### PR TITLE
[kernel] Copy host page tables into BSS-owned storage on Hyperlight

### DIFF
--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -193,46 +193,4 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
         let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
         Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
     }
-
-    ///
-    /// # Description
-    ///
-    /// Returns a raw pointer to the first entry in the page directory.
-    ///
-    /// # Returns
-    ///
-    /// A raw pointer to the first entry in the page directory.
-    ///
-    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
-    pub fn as_ptr(&self) -> *const PteWord {
-        self.entries.as_ptr()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Merges non-zero entries from `old_pd` into this page directory.
-    ///
-    /// For each PDE index, if `self` has a not-present entry and `old_pd` has a present
-    /// entry, the old entry is copied verbatim. Existing present entries in `self` are never
-    /// overwritten.
-    ///
-    /// This is used on platforms that provide a root virtual address space via platform-provided
-    /// page tables to inherit host-built page table mappings.
-    ///
-    /// # Safety
-    ///
-    /// - `old_pd` must point to a valid, page-aligned array of `PAGE_TABLE_LENGTH` PDE words.
-    /// - `self` and `old_pd` must not point to overlapping paging structures.
-    /// - The caller must ensure that the pointed-to memory remains valid for the duration of this
-    ///   call.
-    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
-    pub unsafe fn inherit_from(&mut self, old_pd: *const PteWord) {
-        use ::arch::mem::PAGE_TABLE_LENGTH;
-        for i in 0..PAGE_TABLE_LENGTH {
-            if !PresentFlag::is_set(self.entries[i]) && PresentFlag::is_set(*old_pd.add(i)) {
-                self.entries[i] = *old_pd.add(i);
-            }
-        }
-    }
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -250,11 +250,23 @@ static KERNEL_PADDING: [u8; 2 * 1024 * 1024] = [0u8; 2 * 1024 * 1024];
 // Constants
 //==================================================================================================
 
-/// Number of page tables needed for identity-mapping physical memory regions.
 ///
-/// On Hyperlight the host page tables are used directly; only a small number of
-/// page table slots are needed for process creation.
-pub const NUM_PAGE_TABLES: usize = 4;
+/// # Description
+///
+/// Number of page tables needed for copying the host-provided paging structures into BSS.
+///
+/// On Hyperlight the host builds the page tables before guest entry. During kernel init the
+/// contents are copied into BSS-backed slots so the kernel owns all paging structures. The host
+/// page directory has present entries for two discontiguous GVA regions:
+///   - **Snapshot** (low GVA): identity-mapped kernel image and initrd, spanning at most
+///     `MEMORY_SIZE / PGTAB_SIZE + 1` page tables.
+///   - **Scratch** (high GVA): mapped near the top of the 32-bit address space, spanning at
+///     most `MEMORY_SIZE / PGTAB_SIZE + 1` page tables.
+///
+/// The `+1` accounts for the fact that each region is misaligned with respect to page table
+/// boundaries.
+///
+pub const NUM_PAGE_TABLES: usize = 2 * (MEMORY_SIZE / mem::PGTAB_SIZE + 1);
 
 //==================================================================================================
 // Structures

--- a/src/kernel/src/mm/platform_vas.rs
+++ b/src/kernel/src/mm/platform_vas.rs
@@ -3,9 +3,11 @@
 
 //! Memory manager initialization when `platform-root-virtual-address-space-bootstrap` is enabled.
 //!
-//! The platform provides the root virtual address space — host-built page tables are used
-//! directly and the kernel does not create its own identity map or switch CR3. Only a root
-//! [`Vmem`] descriptor is created so the process manager can clone it for user processes.
+//! The host builds the initial page tables before guest entry. During kernel init this module
+//! walks the host page directory (from CR3), copies every page table into a BSS-backed slot
+//! owned by the kernel, and constructs a root [`Vmem`] descriptor. After initialization the
+//! kernel switches CR3 to its own page directory (backed by the BSS page-table allocator) so
+//! that all paging structures are fully owned and modifiable by the kernel.
 
 use crate::{
     collections::Bitmap,
@@ -17,6 +19,7 @@ use crate::{
             MemoryRegionType,
             PageAligned,
             PageTableAddress,
+            PageTableAligned,
             PhysicalAddress,
             TruncatedMemoryRegion,
             VirtualAddress,
@@ -28,11 +31,23 @@ use ::alloc::{
     collections::LinkedList,
     vec::Vec,
 };
+use ::arch::mem::{
+    self,
+    paging::{
+        PresentFlag,
+        PteWord,
+    },
+    PAGE_TABLE_LENGTH,
+};
 use ::sparse_bitmap::SparseBitmap;
-use ::sys::error::Error;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 use super::{
     phys,
+    virt::PAGE_TABLE_ALLOCATOR,
     KernelPage,
     PageTableStorage,
     PhysMemRegion,
@@ -168,10 +183,60 @@ pub fn init(
     #[cfg(feature = "test")]
     phys::test();
 
-    // On Hyperlight the host-built page tables are used directly — the kernel does not create
-    // its own identity map or switch CR3.
+    // Walk the host page directory and copy each page table into a BSS-allocated slot so the kernel
+    // owns all paging structures. This ensures the kernel can find and modify PTEs for MMIO
+    // permission changes without depending on host page table memory.
     let kernel_pages: LinkedList<KernelPage> = LinkedList::new();
-    let kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
-        LinkedList::new();
+    let kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> = {
+        let mut page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
+            LinkedList::new();
+
+        let host_pd_ptr: *const PteWord = crate::hal::platform::get_root_pd_ptr();
+
+        // SAFETY: The host page directory is mapped and readable after CoW pre-faulting.
+        // This runs during single-threaded boot initialization. Each BSS slot returned by
+        // alloc_as() is fully initialized via copy_nonoverlapping before any read, so
+        // assume_init_mut() is sound (the contents are overwritten, not read as zeroes).
+        unsafe {
+            for i in 0..PAGE_TABLE_LENGTH {
+                let pde: PteWord = *host_pd_ptr.add(i);
+                if !PresentFlag::is_set(pde) {
+                    continue;
+                }
+
+                let pt_gpa: usize = (pde & crate::hal::platform::PTE_ADDR_MASK_U32) as usize;
+                let pt_gva: usize = crate::hal::platform::gpa_to_gva(pt_gpa);
+                let pt_vaddr: usize = i * mem::PGTAB_SIZE;
+                let pt_addr: PageTableAddress =
+                    PageTableAddress::new(PageTableAligned::from_raw_value(pt_vaddr)?);
+
+                // Allocate a BSS slot and copy the host page table contents into it.
+                let bss_slot: &'static mut [PteWord; PAGE_TABLE_LENGTH] = PAGE_TABLE_ALLOCATOR
+                    .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
+                    .map_err(|e| {
+                        error!("page table BSS allocation failed: {}", e);
+                        Error::new(
+                            ErrorCode::OutOfMemory,
+                            "BSS page table allocation failed during host PT copy",
+                        )
+                    })?
+                    .assume_init_mut();
+
+                let host_pt_ptr: *const PteWord = pt_gva as *const PteWord;
+                core::ptr::copy_nonoverlapping(
+                    host_pt_ptr,
+                    bss_slot.as_mut_ptr(),
+                    PAGE_TABLE_LENGTH,
+                );
+
+                let storage: PageTableStorage = PageTableStorage::Bss(bss_slot);
+                let page_table: PageTable<PageTableStorage> = PageTable::from_existing(storage);
+                page_tables.push_back((pt_addr, page_table));
+            }
+        }
+
+        page_tables
+    };
+
     VirtMemoryManager::init(kernel_pages, kernel_page_tables)
 }

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -14,6 +14,8 @@ mod manager;
 #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
 mod no_identity_map;
 mod page_table_allocator;
+#[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+pub(in crate::mm) use page_table_allocator::PAGE_TABLE_ALLOCATOR;
 mod vmem;
 
 #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
@@ -56,19 +58,9 @@ pub use vmem::Vmem;
 
 pub enum PageTableStorage {
     /// Boot-time BSS-backed storage, allocated via `PAGE_TABLE_ALLOCATOR`.
-    #[cfg_attr(
-        feature = "platform-root-virtual-address-space-bootstrap",
-        allow(dead_code)
-    )]
     Bss(&'static mut [PteWord; PAGE_TABLE_LENGTH]),
     /// Runtime storage backed by a kernel page from the page pool.
     KernelPage(KernelPage),
-    /// Host-built page table inherited from a pre-existing address space.
-    #[cfg_attr(
-        not(feature = "platform-root-virtual-address-space-bootstrap"),
-        allow(dead_code)
-    )]
-    Inherited(*mut PteWord),
 }
 
 impl Deref for PageTableStorage {
@@ -81,7 +73,6 @@ impl Deref for PageTableStorage {
                 let base: *const PteWord = page.base().into_raw_value() as *const PteWord;
                 unsafe { core::slice::from_raw_parts(base, PAGE_TABLE_LENGTH) }
             },
-            Self::Inherited(ptr) => unsafe { core::slice::from_raw_parts(*ptr, PAGE_TABLE_LENGTH) },
         }
     }
 }
@@ -93,9 +84,6 @@ impl DerefMut for PageTableStorage {
             Self::KernelPage(page) => {
                 let base: *mut PteWord = page.base().into_raw_value() as *mut PteWord;
                 unsafe { core::slice::from_raw_parts_mut(base, PAGE_TABLE_LENGTH) }
-            },
-            Self::Inherited(ptr) => unsafe {
-                core::slice::from_raw_parts_mut(*ptr, PAGE_TABLE_LENGTH)
             },
         }
     }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -119,57 +119,8 @@ impl Vmem {
             kpage_tables.push_back(Rc::new(RefCell::new((vaddr, page_table))));
         }
 
-        // On Hyperlight, inherit host-built page directory entries so that scratch-region
-        // mappings (I/O buffers, boot stack, kernel data/BSS/kpool) remain accessible.
-        // The host PD (in CR3) has the correct GVA→scratch GPA mappings after eager
-        // pre-faulting. Inheriting them into the root PD enables Vmem::clone to propagate
-        // these mappings to user-process PDs.
-        // On microvm, register the kernel PD for lazy identity mapping and set CR3.
-        #[cfg(all(
-            feature = "hyperlight",
-            feature = "platform-root-virtual-address-space-bootstrap"
-        ))]
-        {
-            use ::arch::mem::paging::PresentFlag;
-
-            let host_pd_ptr: *const PteWord = crate::hal::platform::get_root_pd_ptr();
-            unsafe {
-                pgdir.inherit_from(host_pd_ptr);
-            }
-
-            // Wrap each inherited host-built page table as a tracked kernel page table so that
-            // kctrl() can find and modify PTEs for MMIO permission changes.
-            // Walk the host PD and create an Inherited PageTableStorage for every present PDE
-            // that was not already registered by the kernel (i.e., not in kpage_tables).
-            unsafe {
-                for i in 0..PAGE_TABLE_LENGTH {
-                    let pde: PteWord = *host_pd_ptr.add(i);
-                    if !PresentFlag::is_set(pde) {
-                        continue;
-                    }
-
-                    let pt_gpa: usize = (pde & crate::hal::platform::PTE_ADDR_MASK_U32) as usize;
-                    let pt_gva: usize = crate::hal::platform::gpa_to_gva(pt_gpa);
-                    let pt_vaddr: usize = i * mem::PGTAB_SIZE;
-                    let pt_addr: PageTableAddress =
-                        PageTableAddress::new(PageTableAligned::from_raw_value(pt_vaddr)?);
-
-                    // Skip if already tracked (e.g., registered by the kernel's own init path).
-                    let already_tracked: bool = kpage_tables
-                        .iter()
-                        .any(|entry| entry.borrow().0.into_raw_value() == pt_vaddr);
-                    if already_tracked {
-                        continue;
-                    }
-
-                    let storage: PageTableStorage =
-                        PageTableStorage::Inherited(pt_gva as *mut PteWord);
-                    let page_table: PageTable<PageTableStorage> = PageTable::from_existing(storage);
-                    kpage_tables.push_back(Rc::new(RefCell::new((pt_addr, page_table))));
-                }
-            }
-        }
-
+        // On platforms that do not bootstrap the root virtual address space, register the kernel
+        // page directory for lazy identity mapping and set CR3.
         #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
         {
             use crate::hal::mem::PageDirectoryAddress;
@@ -228,14 +179,6 @@ impl Vmem {
             // FIXME: do not be so open about permissions.
             pgdir.map(entry.borrow().0, page_table_address, false, AccessPermission::RDWR)?;
             kernel_page_tables.push_back(entry.clone());
-        }
-
-        // On platforms that provide a root virtual address space via platform-provided page tables,
-        // inherit the entries from the source page directory so that the kernel retains access to
-        // host-provided mappings after the CR3 switch.
-        #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
-        unsafe {
-            pgdir.inherit_from(from.pgdir.as_ptr());
         }
 
         // Store root pages.


### PR DESCRIPTION
## Summary

On Hyperlight, the kernel previously depended on host-allocated scratch memory for paging structures — either pointing directly at host page table memory (`PageTableStorage::Inherited`) or using `PageDirectory::inherit_from()` to merge host PDEs. This PR replaces that with a clean ownership model where the kernel copies all host page tables into BSS-backed slots at boot.

## Changes

- **`platform_vas::init()`**: Walk host PD entries (from CR3), allocate BSS slots via `PAGE_TABLE_ALLOCATOR`, copy host page table contents, and wrap them as `PageTableStorage::Bss` with `PageTable::from_existing()`.
- **`hyperlight/mod.rs`**: Update `NUM_PAGE_TABLES` from a hardcoded `4` to `2 * (MEMORY_SIZE / PGTAB_SIZE + 1)`, accounting for page tables in both the snapshot region (low GVA) and scratch region (high GVA), plus misalignment.
- **`virt/mod.rs`**: Remove `PageTableStorage::Inherited` variant and its `Deref`/`DerefMut` arms. Add cfg-gated `pub(in crate::mm)` re-export of `PAGE_TABLE_ALLOCATOR`.
- **`vmem.rs`**: Remove `inherit_from()` calls from `Vmem::new()` and `Vmem::clone()` — all PDEs are now populated by the `pgdir.map()` loop from BSS-copied page tables.
- **`page_directory.rs`**: Remove dead `inherit_from()` method and `as_ptr()`.

## Testing

- Build passes: `hyperlight` and `microvm`
- Lint passes: both platforms
- Integration tests pass: `hyperlight/standalone` and `microvm/standalone`

Closes #2240.