### PR TITLE
[ci] Use CI container and native-setup action

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,24 +7,15 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
 
     permissions:
       contents: read
+      packages: read
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: "Free Disk Space"
-        uses: ./.github/actions/free-disk-space
-        with:
-          remove-hostedtoolcache: "false"
-
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup default nightly
-
-      - name: Pull Nanvix Docker Image
-        run: |
-          docker pull nanvix/toolchain:latest-minimal
+      - name: "Setup"
+        uses: ./.github/actions/native-setup


### PR DESCRIPTION
Replace ad-hoc setup steps in the Copilot setup workflow with the project's standard CI container image (`ghcr.io/nanvix/ci:ubuntu-24.04`) and the reusable `native-setup` action.

This removes the manual Rust installation, disk-space cleanup, and Docker image pull steps, aligning the Copilot workflow with the existing CI infrastructure. The container image already includes all required tooling, so individual setup steps are redundant.

### Changes

- Run the job inside the `ghcr.io/nanvix/ci:ubuntu-24.04` container.
- Add `packages: read` permission for GHCR access.
- Replace free-disk-space, Rust install, and Docker pull steps with the `native-setup` composite action.