### PR TITLE
[kernel] Flush TLB entries after PDE/PTE modifications

### DIFF
--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -167,7 +167,7 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
         Ok(paddr)
     }
 
-    pub fn clean(&mut self) {
+    fn clean(&mut self) {
         for pde in self.entries.iter_mut() {
             *pde = 0;
         }

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -164,6 +164,11 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
         // Write page directory entry.
         self.write_pde(pgtable_address, pde);
 
+        // Invalidate the TLB entry for this page table range so the CPU does not use a
+        // stale PDE pointing to the freed page table.
+        // SAFETY: called from kernel mode after modifying a PDE.
+        unsafe { ::arch::mem::paging::invlpg(pgtable_address.into_raw_value()) };
+
         Ok(paddr)
     }
 

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
@@ -214,6 +214,11 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
         // Write page table entry.
         self.write_pte(page_address, pte);
 
+        // Invalidate the TLB entry so the CPU does not use a stale mapping to the
+        // old frame if this virtual address is re-mapped to a different frame.
+        // SAFETY: called from kernel mode after modifying a PTE.
+        unsafe { ::arch::mem::paging::invlpg(page_address.into_raw_value()) };
+
         self.nmapped -= 1;
 
         Ok(paddr)
@@ -328,6 +333,10 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
 
         // Write page table entry.
         self.write_pte(page_address, pte);
+
+        // Invalidate the TLB entry so the permission change takes effect immediately.
+        // SAFETY: called from kernel mode after modifying a PTE.
+        unsafe { ::arch::mem::paging::invlpg(page_address.into_raw_value()) };
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Add `invlpg` calls after modifying page directory and page table entries that transition from present-to-not-present or change access permissions on present entries. Without these invalidations, the CPU may use stale TLB entries that point to freed page tables/frames or retain old permission bits.

## Changes

- `PageDirectory::unmap()`: PDE P=1→P=0 — prevents use of a stale PDE pointing to a freed page table frame.
- `PageTable::unmap()`: PTE P=1→P=0 — prevents use of a stale mapping to a freed or reallocated physical frame.
- `PageTable::ctrl()`: PTE flags change while P=1 — ensures permission changes take effect immediately.
- `PageDirectory::clean()`: made private to enforce PDE lifecycle through `map()`/`unmap()`.

## Root Cause

Non-deterministic page fault observed in CI (workflow run 25240581238) where `stress-rust` triggered a fault at `0x62404000` with an invalid CR3 value. After `Vmem::unmap()` cleared a PDE for an empty page table, the subsequent `Vmem::map()` re-created the PDE for a new page table, but the CPU resolved the virtual address through a stale TLB entry pointing to the old (freed) page table storage.

## Testing

- Built and tested on both `hyperlight` and `microvm` in `standalone` deployment mode.
- All integration tests pass.

Fixes the CI failure in PR #2242.