### PR TITLE
[build] Update hyperlight to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=798dab14c9ef9c5efa15dc80231d2d2e1e916826#798dab14c9ef9c5efa15dc80231d2d2e1e916826"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=798dab14c9ef9c5efa15dc80231d2d2e1e916826#798dab14c9ef9c5efa15dc80231d2d2e1e916826"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=798dab14c9ef9c5efa15dc80231d2d2e1e916826#798dab14c9ef9c5efa15dc80231d2d2e1e916826"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2006,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cd3e9eb685089c784f5769b1197d348c7274bc20d4e1349650f63b91b6d0af"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -2452,7 +2452,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3201,7 +3201,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3271,7 +3271,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3825,7 +3825,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4739,7 +4739,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4874,15 +4874,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,11 +137,11 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "798dab14c9ef9c5efa15dc80231d2d2e1e916826", default-features = false, features = [
         "i686-guest",
         "guest-counter",
 ] }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "798dab14c9ef9c5efa15dc80231d2d2e1e916826", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
@@ -149,7 +149,7 @@ hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = 
         "i686-guest",
         "guest-counter",
 ] }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "798dab14c9ef9c5efa15dc80231d2d2e1e916826", default-features = false, features = [
         "i686-guest",
         "guest-counter",
 ] }


### PR DESCRIPTION
Automated hyperlight version bump.

| Field | Value |
|-------|-------|
| Repository | [`hyperlight-dev/hyperlight`](https://github.com/hyperlight-dev/hyperlight) |
| Version | `0.14.0` |
| Old ref | `94ee495638385eaffc5f0c8f69fe7d768047b3b6` |
| New rev | `798dab14c9ef9c5efa15dc80231d2d2e1e916826` |

**Files changed:**
- `Cargo.toml` — updated hyperlight crate references
- `Cargo.lock` — regenerated

> Generated by the **Hyperlight Update** workflow.