### PR TITLE
[build] Standalone as default mode

### DIFF
--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -59,7 +59,7 @@ Set these as environment variables or pass them after `--` in the `z` command:
 |                  | `info`, `warn`,          |                 |
 |                  | `error`, `panic`         |                 |
 | `PROFILER`       | `yes`, `no`              | `no`            |
-| `DEPLOYMENT_MODE`| `standalone`,            | `multi-process` |
+| `DEPLOYMENT_MODE`| `standalone`,            | `standalone`    |
 |                  | `single-process`,        |                 |
 |                  | `multi-process`, `l2`    |                 |
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export TIMESTAMP_MSG ?= no
 export HOST_CPU ?=
 
 # Deployment mode: standalone, single-process, multi-process, l2
-export DEPLOYMENT_MODE ?= multi-process
+export DEPLOYMENT_MODE ?= standalone
 
 # Validate DEPLOYMENT_MODE.
 VALID_DEPLOYMENT_MODES := standalone single-process multi-process l2

--- a/doc/build-linux.md
+++ b/doc/build-linux.md
@@ -76,7 +76,7 @@ Available build parameters:
 
 | Parameter         | Default         | Values                                                             |
 |-------------------|-----------------|--------------------------------------------------------------------|
-| `DEPLOYMENT_MODE` | `multi-process` | `standalone`, `single-process`, `multi-process`, `l2`              |
+| `DEPLOYMENT_MODE` | `standalone`    | `standalone`, `single-process`, `multi-process`, `l2`              |
 | `LOG_LEVEL`       | `error`         | `trace`, `debug`, `info`, `warn`, `error`, `panic`                 |
 | `MACHINE`         | `microvm`       | `hyperlight`, `microvm`, `qemu-pc`, `qemu-isapc`, `qemu-baremetal` |
 | `PROFILER`        | `no`            | `yes`, `no`                                                        |

--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -31,7 +31,7 @@ uservm = { workspace = true }
 user-vm-api = { workspace = true }
 
 [features]
-default = ["microvm", "multi-process"]
+default = ["microvm", "standalone"]
 single-process = [
     "nanvix-sandbox-config",
     "nanvix-sandbox-config/single-process",

--- a/src/libs/nanvix-http/src/client/mod.rs
+++ b/src/libs/nanvix-http/src/client/mod.rs
@@ -7,8 +7,14 @@
 //! It deserializes messages, routes them to appropriate handlers (NEW, KILL), and constructs
 //! JSON responses. The implementation uses Hyper's Service trait for async request handling.
 
-#[cfg(all(feature = "single-process", feature = "standalone"))]
-compile_error!("features `single-process` and `standalone` are mutually exclusive");
+#[cfg(all(feature = "standalone", feature = "multi-process"))]
+compile_error!("features `standalone` and `multi-process` are mutually exclusive");
+
+#[cfg(all(feature = "standalone", feature = "single-process"))]
+compile_error!("features `standalone` and `single-process` are mutually exclusive");
+
+#[cfg(all(feature = "single-process", feature = "multi-process"))]
+compile_error!("features `single-process` and `multi-process` are mutually exclusive");
 
 //==================================================================================================
 // Modules

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -8,8 +8,14 @@
 //! graceful shutdown on interrupt signals, and maintains the sandbox cache for all active
 //! instances.
 
-#[cfg(all(feature = "single-process", feature = "standalone"))]
-compile_error!("features `single-process` and `standalone` are mutually exclusive");
+#[cfg(all(feature = "standalone", feature = "multi-process"))]
+compile_error!("features `standalone` and `multi-process` are mutually exclusive");
+
+#[cfg(all(feature = "standalone", feature = "single-process"))]
+compile_error!("features `standalone` and `single-process` are mutually exclusive");
+
+#[cfg(all(feature = "single-process", feature = "multi-process"))]
+compile_error!("features `single-process` and `multi-process` are mutually exclusive");
 
 //==================================================================================================
 // Imports

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -32,7 +32,7 @@ user-vm-api = { workspace = true }
 uservm = { workspace = true }
 
 [features]
-default = ["microvm", "multi-process"]
+default = ["microvm", "standalone"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into the sandbox.
 single-process = [

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -37,10 +37,15 @@
 //!
 //! ## Deployment Modes
 //!
-//! ### Multi-Process Mode (default)
+//! ### Standalone Mode (default)
 //!
-//! Linux Daemon and User VM run as separate OS processes. This is the production mode
-//! used by Nanvix Daemon for isolation and robustness.
+//! The sandbox runs as a self-contained unit without external Linux Daemon or User VM
+//! processes. This is the simplest deployment mode and the default for development.
+//!
+//! ### Multi-Process Mode
+//!
+//! Linux Daemon and User VM run as separate OS processes. This mode is used by Nanvix
+//! Daemon for isolation and robustness in production deployments.
 //!
 //! ### Single-Process Mode
 //!

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -23,7 +23,7 @@ user-vm-api = { workspace = true }
 uservm = { workspace = true, optional = true }
 
 [features]
-default = ["microvm", "multi-process"]
+default = ["microvm", "standalone"]
 single-process = [
     "nanvix-sandbox-config",
     "nanvix-sandbox-config/single-process",

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -21,8 +21,14 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 
-#[cfg(all(feature = "single-process", feature = "standalone"))]
-compile_error!("features `single-process` and `standalone` are mutually exclusive");
+#[cfg(all(feature = "standalone", feature = "multi-process"))]
+compile_error!("features `standalone` and `multi-process` are mutually exclusive");
+
+#[cfg(all(feature = "standalone", feature = "single-process"))]
+compile_error!("features `standalone` and `single-process` are mutually exclusive");
+
+#[cfg(all(feature = "single-process", feature = "multi-process"))]
+compile_error!("features `single-process` and `multi-process` are mutually exclusive");
 
 //==================================================================================================
 // Modules

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
 
 [features]
-default = ["microvm", "multi-process"]
+default = ["microvm", "standalone"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into Nanvix Daemon (nanvixd).
 single-process = ["nanvix/single-process"]

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -16,6 +16,15 @@
 // The following lints are allowed in tests to facilitate testing of error conditions.
 #![cfg_attr(not(test), forbid(clippy::expect_used))]
 
+#[cfg(all(feature = "standalone", feature = "multi-process"))]
+compile_error!("features `standalone` and `multi-process` are mutually exclusive");
+
+#[cfg(all(feature = "standalone", feature = "single-process"))]
+compile_error!("features `standalone` and `single-process` are mutually exclusive");
+
+#[cfg(all(feature = "single-process", feature = "multi-process"))]
+compile_error!("features `single-process` and `multi-process` are mutually exclusive");
+
 //==================================================================================================
 // Imports
 //==================================================================================================

--- a/z.py
+++ b/z.py
@@ -41,7 +41,7 @@ VALID_MESSAGE_FORMATS: tuple[str, ...] = ("json", "json-diagnostic-rendered-ansi
 
 DEFAULT_MACHINE = "microvm"
 DEFAULT_TARGET = "x86"
-DEFAULT_DEPLOYMENT_MODE_LINUX = "multi-process"
+DEFAULT_DEPLOYMENT_MODE_LINUX = "standalone"
 DEFAULT_DEPLOYMENT_MODE_WINDOWS = "standalone"
 DEFAULT_LOG_LEVEL_DEBUG = "trace"
 DEFAULT_LOG_LEVEL_RELEASE = "warn"


### PR DESCRIPTION
## Summary

Set standalone as the default deployment mode, replacing multi-process.

## Motivation

Standalone mode is the most common and straightforward deployment scenario for development and testing. Making it the default reduces friction for new users and simplifies the typical workflow, especially on Windows where standalone interactive mode is the only supported deployment option.

## Changes

- **Makefile**: Updated `DEPLOYMENT_MODE` default from `multi-process` to `standalone`
- **z.py**: Updated `DEFAULT_DEPLOYMENT_MODE_LINUX` from `multi-process` to `standalone`
- **Cargo.toml** (nanvix-terminal, nanvix-http, nanvixd, nanvix-sandbox): Changed default feature from `multi-process` to `standalone`
- **doc/build-linux.md**: Updated parameter table to reflect new default
- **.github/skills/build/SKILL.md**: Updated parameter table to reflect new default

## Testing

- Build passes with default standalone mode
- Format check passes
- Lint check passes
- Pre-commit hooks pass for all 6 configurations (standalone/single-process/multi-process × microvm/hyperlight)

Closes #2181