### PR TITLE
[uservm] E: Batch RIP+RAX for PMIO reads

### DIFF
--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -818,7 +818,7 @@ impl Vmm {
                             // PIT channel 2 output: return gate/OUT2 status.
                             0x61 => {
                                 let value: u8 = pit_ch2.read_speaker();
-                                Self::set_guest_rax(self.partition_handle, value as u64);
+                                self.vcpu.blocking_lock().set_rip_and_rax(value as u64);
                                 continue;
                             },
                             // Other legacy ports: return zero.
@@ -834,7 +834,7 @@ impl Vmm {
                             | 0x3F8..=0x3FF
                             | 0xCF8
                             | 0xCFC..=0xCFF => {
-                                Self::set_guest_rax(self.partition_handle, 0);
+                                self.vcpu.blocking_lock().set_rip_and_rax(0);
                                 continue;
                             },
                             _ => {},
@@ -842,6 +842,8 @@ impl Vmm {
                     }
 
                     // Slow path: application-level I/O (stdout, stdin, VMM port).
+                    // Flush any deferred RIP advance for reads that reach the slow path.
+                    self.vcpu.blocking_lock().flush_pending_rip();
 
                     let exit_status: Option<u16> = match self
                         .inner
@@ -1274,33 +1276,6 @@ impl Vmm {
             Err(error) => {
                 warn!("handle_shutdown(): failed to notify orchestrator thread (error={error:?})");
             },
-        }
-    }
-
-    /// Sets the guest vCPU's RAX register. Used to return data for
-    /// emulated PmioIn instructions (RIP is already advanced by the
-    /// vCPU exit handler).
-    fn set_guest_rax(
-        partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
-        value: u64,
-    ) {
-        use windows::Win32::System::Hypervisor::{
-            WHV_REGISTER_NAME,
-            WHV_REGISTER_VALUE,
-            WHvSetVirtualProcessorRegisters,
-        };
-        const WHV_X64_REGISTER_RAX: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0);
-        let reg_names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RAX];
-        let mut reg_values: [WHV_REGISTER_VALUE; 1] = [unsafe { std::mem::zeroed() }];
-        reg_values[0].Reg64 = value;
-        unsafe {
-            let _ = WHvSetVirtualProcessorRegisters(
-                partition,
-                0,
-                reg_names.as_ptr(),
-                1,
-                reg_values.as_ptr(),
-            );
         }
     }
 

--- a/src/uservm/src/vmm/microvm/whp/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/vcpu/mod.rs
@@ -169,6 +169,8 @@ pub struct VirtualProcessor {
     online: bool,
     /// Exit status code.
     exit_status: u16,
+    /// Deferred RIP value for PMIO reads (batched with RAX write).
+    pending_new_rip: Option<u64>,
 }
 
 // SAFETY: `VirtualProcessor` only stores a `WHV_PARTITION_HANDLE` (an opaque OS handle) and
@@ -249,6 +251,7 @@ impl VirtualProcessor {
             index,
             online: false,
             exit_status: 0,
+            pending_new_rip: None,
         })
     }
 
@@ -656,7 +659,8 @@ impl VirtualProcessor {
                     VirtualProcessorExitContext::Pmio(exit::PmioAccess::PmioOut(port, value, width))
                 } else {
                     let data: Vec<u8> = vec![0u8; access_size as usize];
-                    self.advance_rip(exit_context);
+                    // Defer RIP advance for reads — batched with RAX write.
+                    self.pending_new_rip = Some(Self::next_rip(exit_context));
                     VirtualProcessorExitContext::Pmio(exit::PmioAccess::PmioIn(port, data))
                 }
             },
@@ -680,13 +684,17 @@ impl VirtualProcessor {
         }
     }
 
-    /// Advances the instruction pointer past the current instruction after handling a VM exit.
-    fn advance_rip(&mut self, exit_context: &WHV_RUN_VP_EXIT_CONTEXT) {
+    /// Computes the RIP value after the current instruction from the exit context.
+    fn next_rip(exit_context: &WHV_RUN_VP_EXIT_CONTEXT) -> u64 {
         // InstructionLength is packed in the lower 4 bits of VpContext._bitfield
         // (the InstructionLengthCr8 byte), NOT in ExecutionState._bitfield.
         let instruction_length: u64 = u64::from(exit_context.VpContext._bitfield & 0xF);
-        let current_rip: u64 = exit_context.VpContext.Rip;
-        let new_rip: u64 = current_rip + instruction_length;
+        exit_context.VpContext.Rip + instruction_length
+    }
+
+    /// Advances the instruction pointer past the current instruction after handling a VM exit.
+    fn advance_rip(&mut self, exit_context: &WHV_RUN_VP_EXIT_CONTEXT) {
+        let new_rip: u64 = Self::next_rip(exit_context);
 
         let reg_names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];
         let mut reg_values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
@@ -695,6 +703,52 @@ impl VirtualProcessor {
         unsafe {
             if let Err(e) = whp_set_registers(self.partition, self.index, &reg_names, &reg_values) {
                 warn!("advance_rip(): failed to advance RIP (error={e:?})");
+            }
+        }
+    }
+
+    /// Sets RAX and flushes any deferred RIP advance in a single WHvSet call.
+    pub fn set_rip_and_rax(&mut self, rax_value: u64) {
+        if let Some(new_rip) = self.pending_new_rip.take() {
+            let reg_names: [WHV_REGISTER_NAME; 2] = [WHV_X64_REGISTER_RIP, WHV_X64_REGISTER_RAX];
+            let mut reg_values: [WHV_REGISTER_VALUE; 2] =
+                [unsafe { mem::zeroed() }, unsafe { mem::zeroed() }];
+            reg_values[0].Reg64 = new_rip;
+            reg_values[1].Reg64 = rax_value;
+            unsafe {
+                if let Err(e) =
+                    whp_set_registers(self.partition, self.index, &reg_names, &reg_values)
+                {
+                    warn!("set_rip_and_rax(): failed (error={e:?})");
+                }
+            }
+        } else {
+            // No pending RIP — just set RAX.
+            let reg_names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RAX];
+            let mut reg_values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+            reg_values[0].Reg64 = rax_value;
+            unsafe {
+                if let Err(e) =
+                    whp_set_registers(self.partition, self.index, &reg_names, &reg_values)
+                {
+                    warn!("set_rip_and_rax(): failed to set RAX (error={e:?})");
+                }
+            }
+        }
+    }
+
+    /// Flushes any deferred RIP advance (for exits handled without setting RAX).
+    pub fn flush_pending_rip(&mut self) {
+        if let Some(new_rip) = self.pending_new_rip.take() {
+            let reg_names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];
+            let mut reg_values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+            reg_values[0].Reg64 = new_rip;
+            unsafe {
+                if let Err(e) =
+                    whp_set_registers(self.partition, self.index, &reg_names, &reg_values)
+                {
+                    warn!("flush_pending_rip(): failed (error={e:?})");
+                }
             }
         }
     }


### PR DESCRIPTION
For PMIO read exits, the VMM previously made two separate `WHvSetVirtualProcessorRegisters` calls: one to advance RIP (in the vCPU exit handler) and another to set RAX (in the run loop).

This change defers the RIP advance for PMIO reads and batches it with the RAX write into a single `WHvSetVirtualProcessorRegisters` call, halving the number of hypervisor round-trips per read exit.

### Changes

- Add `pending_new_rip: Option<u64>` to `VirtualProcessor`.
- In `run()`, defer RIP advance for PMIO reads instead of calling `advance_rip()`.
- Add `set_rip_and_rax()`: batches RIP + RAX into one `WHvSet` call.
- Add `flush_pending_rip()`: flushes deferred RIP for slow-path exits that do not set RAX.
- Replace `set_guest_rax()` call sites with `set_rip_and_rax()`.
- Remove the now-unused `set_guest_rax()` method from `Vmm`.

Supersedes the batching portion of #1935 (rebased on latest `dev`).