### PR TITLE
[syscall] Lower open log to DEBUG

### DIFF
--- a/src/libs/syscall/src/fcntl/syscall/open.rs
+++ b/src/libs/syscall/src/fcntl/syscall/open.rs
@@ -43,7 +43,7 @@ pub fn open(pathname: &str, flags: c_int, mode: mode_t) -> Result<c_int, Error> 
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::warn!("open(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::debug!("open(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -46,7 +46,7 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::warn!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::debug!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }


### PR DESCRIPTION
## Summary

Lowers the log level in `open()` and `openat()` VFS failure paths from WARN to DEBUG in standalone mode.

## Problem

`resolve_library_path()` probes multiple search directories by calling `FileSystem::open_regular_file()`. Each failed probe triggered a WARN-level log entry, producing N-1 spurious warnings per bare library name lookup that obscure real errors.

## Fix


## Affected Files

- `src/libs/syscall/src/fcntl/syscall/open.rs`
- `src/libs/syscall/src/fcntl/syscall/openat.rs`

Closes #2138