### PR TITLE
[ci] Serialize benchmark finalize jobs to prevent push conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1222,10 +1222,14 @@ jobs:
   # from the Linux and GitHub-hosted baselines.
   windows-benchmark-finalize:
     name: "Windows Benchmark Finalize"
-    needs: [ windows-benchmark ]
+    needs: [ windows-benchmark, benchmark-finalize ]
     # NOTE: needs.windows-benchmark.result is the aggregate result across all
     # matrix legs. It is 'success' only when every leg succeeds.
-    if: ${{ !cancelled() && needs.windows-benchmark.result == 'success' }}
+    # Depends on benchmark-finalize to serialize pushes to dev and avoid
+    # rebase conflicts on append-only CSV files within the same pipeline run.
+    # Uses always() so this job is not skipped when benchmark-finalize is
+    # skipped or fails (e.g., a Linux benchmark leg fails).
+    if: ${{ always() && !cancelled() && needs.windows-benchmark.result == 'success' }}
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
The `benchmark-finalize` and `windows-benchmark-finalize` jobs both push
commits to `dev` via `benchmark-persist`. Because they previously ran in
parallel (independent `needs` graphs), they could race: both would see the
same remote HEAD, commit their respective CSV appends, and the loser's
`git push` would fail. The retry loop's `git pull --rebase` would then
encounter merge conflicts at the EOF of append-only CSV files, since both
sides added rows at the same position.

Add `benchmark-finalize` as a dependency of `windows-benchmark-finalize`
so their pushes are serialized within a single pipeline run. The two jobs
write to separate directories (`data/baremetal/` vs `data/windows-baremetal/`),
so once serialized the rebase is always conflict-free.