### PR TITLE
[ci] Fix Benchmark Build Deployment Mode

### DIFF
--- a/.github/actions/benchmark-build/action.yml
+++ b/.github/actions/benchmark-build/action.yml
@@ -33,5 +33,5 @@ runs:
           VERBOSE=yes \
           RELEASE=yes \
           ${SCCACHE:+"SCCACHE=${SCCACHE}"} \
-          DEPLOYMENT_MODE=l2 \
+          DEPLOYMENT_MODE=multi-process \
           ${TIMESTAMP_MSG_FLAG}

--- a/.github/skills/test-development/SKILL.md
+++ b/.github/skills/test-development/SKILL.md
@@ -53,6 +53,8 @@ modes are supported (`nanvixd` + kernel + guest). On Windows, only standalone mo
 
 Test configurations:
 
+- `test/test-standalone.toml` — Standalone mode (Linux).
+- `test/test-standalone-windows.toml` — Standalone mode (Windows).
 - `test/test-single_process.toml` — Single-process mode.
 - `test/test-multi_process.toml` — Multi-process mode.
 - `test/test-l2.toml` — L2 VM mode.

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -27,6 +27,7 @@ integration tests, and the combined test suite exposed through the `z` utility.
 
 Test configurations are auto-selected based on deployment mode:
 
+- Standalone: `test/test-standalone.toml` (Linux), `test/test-standalone-windows.toml` (Windows)
 - Single-process: `test/test-single_process.toml`
 - L2 VM: `test/test-l2.toml`
 - Multi-process: `test/test-multi_process.toml`

--- a/doc/test.md
+++ b/doc/test.md
@@ -52,6 +52,8 @@ The system integration tests can be run directly using:
 The appropriate test configuration is automatically selected based on the
 deployment mode:
 
+- **Standalone mode** (`DEPLOYMENT_MODE=standalone`): Uses `test/test-standalone.toml` on Linux and
+  `test/test-standalone-windows.toml` on Windows
 - **Single-process mode** (`DEPLOYMENT_MODE=single-process`): Uses `test/test-single_process.toml`
 - **L2 VM mode** (`DEPLOYMENT_MODE=l2`): Uses `test/test-l2.toml`
 - **Multi-process mode** (default): Uses `test/test-multi_process.toml`


### PR DESCRIPTION
## Summary

Fix the benchmark-build CI action that was incorrectly using `DEPLOYMENT_MODE=l2`, causing the `generate-l2-initramfs.sh` script to run during benchmark builds and fail on self-hosted runners (e.g., job 74288584900 in workflow run 25338141941).

## Changes

- **benchmark-build action**: Switch `DEPLOYMENT_MODE=l2` → `DEPLOYMENT_MODE=multi-process`. This builds `linuxd` (needed for HTTP-mode benchmarks like `concurrent` and `round-trip-latency`) without triggering L2 snapshot/initramfs generation.
- **pipeline.sh**: Remove `l2` from the local pipeline matrix since it requires infrastructure (cloud-hypervisor, network namespaces) not available in standard dev environments. L2 remains a valid `DEPLOYMENT_MODE` for manual builds.
- **Skill docs**: Add missing standalone test config entry; update CI skill to clarify L2 is excluded from CI/pipeline/benchmarks.

## Context

The `DEPLOYMENT_MODE=l2` build path triggers `snapshot.mk` which runs `generate-l2-initramfs.sh` (requires `mmdebstrap`, sudo, network access) and `generate-l2-snapshot.sh`. The standard benchmarks don't need these artifacts — they invoke nanvixd directly in standalone fashion regardless of compiled deployment mode.