### PR TITLE
[config] Derive USER_HEAP_CAPACITY from MEMORY_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -408,6 +408,7 @@ dependencies = [
  "compiler_builtins",
  "mmio-tag",
  "rustc-std-workspace-core",
+ "static_assert",
 ]
 
 [[package]]
@@ -730,7 +731,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -851,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1164,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1614,16 +1615,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2449,7 +2440,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3211,7 +3202,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3268,7 +3259,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3540,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3816,7 +3807,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4063,20 +4054,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4667,7 +4658,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/libs/config/Cargo.toml
+++ b/src/libs/config/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = { workspace = true }
 core = { version = "1.0.1", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { workspace = true, optional = true }
 mmio-tag = { workspace = true }
+static_assert = { workspace = true }
 
 [features]
 default = []
@@ -29,6 +30,7 @@ rustc-dep-of-std = [
     "core",
     "cfg-if/rustc-dep-of-std",
     "compiler_builtins/rustc-dep-of-std",
+    "static_assert/rustc-dep-of-std",
 ]
 
 [build-dependencies]

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -240,10 +240,13 @@ pub mod memory_layout {
     /// Maximum capacity of the user heap in bytes. The heap is backed by the unified mmap region
     /// and grows lazily on demand.
     ///
-    /// NOTE: This must be strictly less than the VM's physical memory (`MEMORY_SIZE`) to leave
-    /// room for the kernel, page tables, user stacks, and program text.
+    /// Derived as a quarter of the VM's physical memory (`MEMORY_SIZE`) to leave room for the
+    /// kernel, page tables, user stacks, and program text.
     ///
-    pub const USER_HEAP_CAPACITY: usize = 32 * crate::constants::MEGABYTE;
+    pub const USER_HEAP_CAPACITY: usize = crate::kernel::MEMORY_SIZE / 4;
+
+    // Compile-time assertion: USER_HEAP_CAPACITY must be strictly less than MEMORY_SIZE.
+    static_assert::assert_eq!(USER_HEAP_CAPACITY < crate::kernel::MEMORY_SIZE);
 
     /// RAMFS images larger than this threshold are mounted in-place as read-only
     /// to avoid OOM when copying to the heap on Hyperlight.

--- a/src/tests/stress-rust/src/tests/heap_max_capacity.rs
+++ b/src/tests/stress-rust/src/tests/heap_max_capacity.rs
@@ -101,8 +101,8 @@ pub fn run() -> Result<(), StressError> {
         }
     }
 
-    // Verify we allocated a substantial amount. The heap capacity is 32 MB; even after prior
-    // tests we should be able to claim a meaningful fraction.
+    // Verify we allocated a substantial amount. Even after prior tests we should be able to claim
+    // a meaningful fraction of USER_HEAP_CAPACITY.
     if total_allocated < FILL_BLOCK_SIZE {
         return Err(Error::new(
             ErrorCode::InvalidArgument,


### PR DESCRIPTION
## Summary

Derive `USER_HEAP_CAPACITY` from `MEMORY_SIZE` instead of hardcoding it to 32 MB.

## Changes

- Compute `USER_HEAP_CAPACITY` as `MEMORY_SIZE / 4` so it automatically adapts to the configured VM physical memory.
- Add a compile-time assertion via the `static_assert` crate to guarantee the invariant (heap capacity < memory size) is never violated.
- Add `static_assert` as a dependency of the `config` crate (including `rustc-dep-of-std` feature forwarding).
- Update stale comment in the stress test that referenced the old hardcoded value.

## Testing

- Full build passes (`./z build -- all`).
- Existing `heap_max_capacity` stress test exercises the full `USER_HEAP_CAPACITY` and remains valid since it already references the constant dynamically.

Closes #2262