### PR TITLE
[syscall] Downgrade NoSuchEntry syscall logs from ERROR to WARN

### DIFF
--- a/src/libs/posix/src/sys/stat/mod.rs
+++ b/src/libs/posix/src/sys/stat/mod.rs
@@ -292,12 +292,21 @@ pub unsafe extern "C" fn lstat(pathname: *const c_char, statbuf: *mut sys_stat::
     match stat::lstat(pathname, statbuf) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
-                pathname,
-                statbuf,
-                error
-            );
+            if error.code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!(
+                    "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
+                    pathname,
+                    statbuf,
+                    error
+                );
+            } else {
+                ::syslog::error!(
+                    "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
+                    pathname,
+                    statbuf,
+                    error
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/bindings/open.rs
+++ b/src/libs/syscall/src/fcntl/bindings/open.rs
@@ -77,7 +77,15 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -
     match fcntl::open(pathname, flags, mode) {
         Ok(fd) => fd,
         Err(error) => {
-            ::syslog::trace!("open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})");
+            if error.code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!(
+                    "open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
@@ -76,9 +76,17 @@ pub unsafe extern "C" fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: 
         Ok(()) => 0,
         // System call failed.
         Err(error) => {
-            ::syslog::error!(
-                "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?})"
-            );
+            if error.code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!(
+                    "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, \
+                     flags={flags:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, \
+                     flags={flags:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/syscall/open.rs
+++ b/src/libs/syscall/src/fcntl/syscall/open.rs
@@ -43,7 +43,7 @@ pub fn open(pathname: &str, flags: c_int, mode: mode_t) -> Result<c_int, Error> 
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::debug!("open(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("open(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -46,7 +46,7 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::debug!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }
@@ -74,17 +74,30 @@ fn openat_linuxd(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Resu
     // Check whether system call succeeded or not.
     if response.status != 0 {
         // System call failed, parse error code and return it.
-        ::syslog::error!(
-            "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, error={:?})",
-            dirfd,
-            pathname,
-            flags,
-            mode,
-            { response.status }
-        );
         match ErrorCode::try_from(response.status) {
             // Succeeded to parse error code.
             Ok(error_code) => {
+                if error_code == ErrorCode::NoSuchEntry {
+                    ::syslog::warn!(
+                        "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, \
+                         error={:?})",
+                        dirfd,
+                        pathname,
+                        flags,
+                        mode,
+                        error_code
+                    );
+                } else {
+                    ::syslog::error!(
+                        "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, \
+                         error={:?})",
+                        dirfd,
+                        pathname,
+                        flags,
+                        mode,
+                        error_code
+                    );
+                }
                 // Return error.
                 Err(Error::new(error_code, "openat() failed"))
             },

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -87,7 +87,11 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
         if response.status != 0 {
             // System call failed, parse error code and return it.
             let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-            ::syslog::error!("fstatat(): failed (error={:?})", error_code);
+            if error_code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!("fstatat(): failed (error={:?})", error_code);
+            } else {
+                ::syslog::error!("fstatat(): failed (error={:?})", error_code);
+            }
             break Err(Error::new(error_code, "fstatat() failed"));
         } else {
             // System call succeeded, parse response.

--- a/src/libs/syscall/src/unistd/bindings/faccessat.rs
+++ b/src/libs/syscall/src/unistd/bindings/faccessat.rs
@@ -92,10 +92,17 @@ pub unsafe extern "C" fn faccessat(
     match crate::unistd::faccessat(dirfd, path, mode, flag) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
-                 flag={flag:?})"
-            );
+            if error.code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!(
+                    "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
+                     flag={flag:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
+                     flag={flag:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/readlinkat.rs
@@ -109,10 +109,17 @@ pub unsafe extern "C" fn readlinkat(
     match unistd::readlinkat(dirfd, path, buf) {
         Ok(bytes_read) => bytes_read,
         Err(error) => {
-            ::syslog::trace!(
-                "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
-                 bufsize={bufsize:?})"
-            );
+            if error.code == ErrorCode::NoSuchEntry {
+                ::syslog::warn!(
+                    "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
+                     bufsize={bufsize:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
+                     bufsize={bufsize:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -86,17 +86,31 @@ fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Resul
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
-            "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, error_code={:?})",
-            dirfd,
-            path,
-            mode,
-            flag,
-            { response.status },
-        );
-
         match ErrorCode::try_from(response.status) {
-            Ok(error_code) => Err(Error::new(error_code, "failed")),
+            Ok(error_code) => {
+                if error_code == ErrorCode::NoSuchEntry {
+                    ::syslog::warn!(
+                        "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, \
+                         error_code={:?})",
+                        dirfd,
+                        path,
+                        mode,
+                        flag,
+                        error_code,
+                    );
+                } else {
+                    ::syslog::error!(
+                        "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, \
+                         error_code={:?})",
+                        dirfd,
+                        path,
+                        mode,
+                        flag,
+                        error_code,
+                    );
+                }
+                Err(Error::new(error_code, "failed"))
+            },
             Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "failed to parse error code")),
         }
     } else {

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -103,15 +103,28 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
 
         // Check whether system call succeeded or not.
         if response.status != 0 {
-            ::syslog::error!(
-                "readlinkat(): system call failed (dirfd={:?}, path={:?}, error_code={:?})",
-                dirfd,
-                path,
-                { response.status }
-            );
             // System call failed, parse error code and return.
             match ErrorCode::try_from(response.status) {
-                Ok(error_code) => break Err(Error::new(error_code, "system call failed")),
+                Ok(error_code) => {
+                    if error_code == ErrorCode::NoSuchEntry {
+                        ::syslog::warn!(
+                            "readlinkat(): system call failed (dirfd={:?}, path={:?}, \
+                             error_code={:?})",
+                            dirfd,
+                            path,
+                            error_code
+                        );
+                    } else {
+                        ::syslog::error!(
+                            "readlinkat(): system call failed (dirfd={:?}, path={:?}, \
+                             error_code={:?})",
+                            dirfd,
+                            path,
+                            error_code
+                        );
+                    }
+                    break Err(Error::new(error_code, "system call failed"));
+                },
                 Err(error) => {
                     ::syslog::error!(
                         "readlinkat(): failed to parse error code (dirfd={:?}, path={:?}, \


### PR DESCRIPTION
## Summary

Programs routinely call `lstat()`, `stat()`, `access()`, `open()`, `readlink()`, and `unlink()` to probe whether paths exist. When the path does not exist, the kernel returns `ENOENT` — the normal POSIX "no" answer. Previously, these benign failures were logged at ERROR level, flooding kernel logs with ~800+ noise lines per CPython test run and obscuring real errors.

## Changes

Downgrade `NoSuchEntry` (ENOENT) failures to WARN in the following paths:
- `posix::sys::stat::lstat()` binding
- `syscall fstatat_response()` (linuxd IPC path for stat/lstat/fstatat)
- `faccessat()` binding and linuxd IPC path
- `openat()` linuxd IPC path
- `unlinkat()` binding
- `readlinkat()` binding and linuxd IPC path

Also standardize standalone VFS failure logs (previously a mix of trace, debug, and warn) to WARN level for consistency:
- `lstat()`, `stat()`, `fstat()`, `fstatat()` VFS paths
- `faccessat()`, `open()`, `openat()` VFS paths
- `unlinkat()`, `unlink()` VFS paths
- `open()` binding

Genuine errors (permission denied, I/O errors, etc.) remain at ERROR.

Closes #2269