### PR TITLE
[kernel] Translate kernel GVA to GPA in user-copy paths

### DIFF
--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -731,8 +731,9 @@ impl Vmem {
 
                 if !dry_run {
                     // Copy memory from user space to kernel space.
+                    let dst_gpa: usize = crate::hal::platform::virt_to_phys(dst.into_raw_value());
                     super::memcpy(
-                        dst.into_raw_value() as *mut u8,
+                        dst_gpa as *mut u8,
                         (src_frame.into_raw_value() + offset) as *const u8,
                         copy_size,
                     )?;
@@ -895,7 +896,8 @@ impl Vmem {
 
                 // Copy memory from kernel space to user space.
                 let dst: *mut u8 = (dst_frame.into_raw_value() + offset) as *mut u8;
-                let src: *const u8 = src.into_raw_value() as *const u8;
+                let src_gpa: usize = crate::hal::platform::virt_to_phys(src.into_raw_value());
+                let src: *const u8 = src_gpa as *const u8;
                 let copy_result: Result<(), Error> = super::memcpy(dst, src, copy_size);
                 if let Err(error) = copy_result {
                     let reason: &str = "failed to perform physical memory copy";

--- a/src/tests/misc-rust/src/tests/argv.rs
+++ b/src/tests/misc-rust/src/tests/argv.rs
@@ -1,0 +1,46 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Regression test for the kernel→user copy path in `create_process()`.
+//!
+//! During process creation the kernel copies the argument string from a heap-allocated `CString`
+//! (kernel GVA) into a freshly-mapped user page (GPA) via `copy_to_user_unaligned`. The
+//! underlying `no_identity_map::memcpy` on Hyperlight expects **GPAs** on both endpoints and
+//! internally translates each GPA→GVA before dereferencing.
+//!
+//! On Hyperlight, after eager copy-on-write pre-faulting, writable kernel pages (heap, BSS, data)
+//! may reside at a low-memory GVA while their actual backing frame lives in the scratch region at
+//! a different GPA. Without the `virt_to_phys()` translation on the kernel-side source address,
+//! `memcpy` receives the raw GVA as if it were a GPA, resolves it to the wrong physical frame,
+//! and copies garbage into user space — corrupting `argv`.
+//!
+//! This test validates that `argv[0]` arrives intact by comparing its first bytes against the
+//! known binary name prefix. A mismatch indicates the kernel-side GVA→GPA translation is missing
+//! or broken.
+//!
+//! On microvm, GVA == GPA (identity-mapped), so the bug does not manifest and this test passes
+//! unconditionally — it serves as a regression guard exclusively for the Hyperlight backend.
+
+use ::core::sync::atomic::Ordering;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+const EXPECTED_ARGV0_PREFIX: &[u8] = b"misc-rust";
+
+#[allow(clippy::as_conversions)]
+pub fn run() -> Result<(), Error> {
+    let argv: *const *const u8 = ::nvx::ARGV.load(Ordering::SeqCst) as *const *const u8;
+    let arg0: *const u8 = unsafe { *argv };
+
+    for (i, &expected) in EXPECTED_ARGV0_PREFIX.iter().enumerate() {
+        let got: u8 = unsafe { *arg0.add(i) };
+        if got != expected {
+            ::syslog::error!("argv[0] byte {i}: expected {expected:#04x}, got {got:#04x}");
+            return Err(Error::new(ErrorCode::InvalidArgument, "argv[0] corrupted"));
+        }
+    }
+
+    Ok(())
+}

--- a/src/tests/misc-rust/src/tests/mod.rs
+++ b/src/tests/misc-rust/src/tests/mod.rs
@@ -7,6 +7,7 @@ use ::sys::error::Error;
 // Modules
 //==================================================================================================
 
+mod argv;
 mod env;
 mod sysinfo;
 mod time;
@@ -18,6 +19,7 @@ mod uid_gid;
 
 /// Runs every miscellaneous system call test.
 pub fn run_all() -> Result<(), Error> {
+    argv::run()?;
     uid_gid::run()?;
     time::run()?;
     sysinfo::run()?;


### PR DESCRIPTION
Fixes the kernel<->user copy paths on on hyperlight i686-guest, where super::memcpy expects GPAs on both endpoints but the kernel side was passing a GVA.

Brings cpython on hyperlight standalone to parity with microvm: the hello test now passes (it failed before with "Hello test did not produce expected output"). Remaining regrtest failures are unrelated