### PR TITLE
[config] Double maximum user heap capacity

### DIFF
--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -240,10 +240,11 @@ pub mod memory_layout {
     /// Maximum capacity of the user heap in bytes. The heap is backed by the unified mmap region
     /// and grows lazily on demand.
     ///
-    /// Derived as a quarter of the VM's physical memory (`MEMORY_SIZE`) to leave room for the
-    /// kernel, page tables, user stacks, and program text.
+    /// Derived as half of the VM's physical memory (`MEMORY_SIZE`) to leave room for the kernel,
+    /// page tables, user stacks, and program text while still allowing large single-operation
+    /// allocations.
     ///
-    pub const USER_HEAP_CAPACITY: usize = crate::kernel::MEMORY_SIZE / 4;
+    pub const USER_HEAP_CAPACITY: usize = crate::kernel::MEMORY_SIZE / 2;
 
     // Compile-time assertion: USER_HEAP_CAPACITY must be strictly less than MEMORY_SIZE.
     static_assert::assert_eq!(USER_HEAP_CAPACITY < crate::kernel::MEMORY_SIZE);


### PR DESCRIPTION
Raise `USER_HEAP_CAPACITY` from `MEMORY_SIZE/4` to `MEMORY_SIZE/2` so that user processes can perform large single-operation allocations (e.g. 20M-element `itertools.tee` buffers) without hitting the heap cap.

The heap is demand-paged from the unified mmap region, so this change only increases the virtual reservation limit — physical frames are still committed lazily on fault. The existing compile-time assertion (`USER_HEAP_CAPACITY < MEMORY_SIZE`) continues to hold.

**Trade-off:** at full commit the remaining physical budget for the kernel, page tables, RAMFS, and scratch regions drops from 75% to 50% of `MEMORY_SIZE`. At the default 256 MB configuration this leaves 128 MB for non-heap use, which is sufficient for typical workloads. Configurations running at 128 MB with large RAMFS images should be validated for OOM margin.