### PR TITLE
[syscall] Downgrade logs from ERROR to WARN

### DIFF
--- a/src/libs/syscall/src/dirent/bindings/opendir.rs
+++ b/src/libs/syscall/src/dirent/bindings/opendir.rs
@@ -73,7 +73,13 @@ pub unsafe extern "C" fn opendir(dirname: *const i8) -> *mut DirectoryStream {
     match dirent::opendir(dirname) {
         Ok(dirp) => Box::into_raw(dirp),
         Err(error) => {
-            ::syslog::error!("opendir(): {error:?} (dirname={dirname:?})");
+            if error.code == ErrorCode::NoSuchEntry
+                || error.code == ErrorCode::OperationNotSupported
+            {
+                ::syslog::warn!("opendir(): {error:?} (dirname={dirname:?})");
+            } else {
+                ::syslog::error!("opendir(): {error:?} (dirname={dirname:?})");
+            }
             *__errno_location() = error.code.get();
             ptr::null_mut()
         },

--- a/src/libs/syscall/src/dirent/bindings/readdir.rs
+++ b/src/libs/syscall/src/dirent/bindings/readdir.rs
@@ -85,11 +85,19 @@ pub unsafe extern "C" fn readdir(dirp: *mut DirectoryStream) -> *mut dirent {
         },
         // Error.
         Err(error) => {
-            ::syslog::error!(
-                "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
-                dirp,
-                error
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
+                    dirp,
+                    error
+                );
+            } else {
+                ::syslog::error!(
+                    "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
+                    dirp,
+                    error
+                );
+            }
             *__errno_location() = error.code.get();
             ptr::null_mut()
         },

--- a/src/libs/syscall/src/fcntl/bindings/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/bindings/fcntl.rs
@@ -36,7 +36,11 @@ pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, args: ...) -> c_int {
     match file::fcntl(fd, &cmd) {
         Ok(ret) => ret,
         Err(error) => {
-            ::syslog::error!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
+            } else {
+                ::syslog::error!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/bindings/open.rs
+++ b/src/libs/syscall/src/fcntl/bindings/open.rs
@@ -77,7 +77,9 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -
     match fcntl::open(pathname, flags, mode) {
         Ok(fd) => fd,
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry {
+            if error.code == ErrorCode::NoSuchEntry
+                || error.code == ErrorCode::OperationNotSupported
+            {
                 ::syslog::warn!(
                     "open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})"
                 );

--- a/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
+++ b/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
@@ -52,10 +52,17 @@ pub unsafe extern "C" fn posix_fadvise(
     match fcntl::posix_fadvise(fd, offset, len, advice) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
-                 advice={advice:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
+                     advice={advice:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
+                     advice={advice:?})"
+                );
+            }
 
             error.code.get()
         },

--- a/src/libs/syscall/src/poll/bindings.rs
+++ b/src/libs/syscall/src/poll/bindings.rs
@@ -80,7 +80,11 @@ pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) ->
             ready.len() as c_int
         },
         Err(error) => unsafe {
-            ::syslog::error!("poll(): failed (error={:?})", error);
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!("poll(): failed (error={:?})", error);
+            } else {
+                ::syslog::error!("poll(): failed (error={:?})", error);
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/select/bindings/mod.rs
+++ b/src/libs/syscall/src/sys/select/bindings/mod.rs
@@ -132,7 +132,11 @@ pub unsafe extern "C" fn select(
     match syscall::select(nfds as usize, read_ref, write_ref, error_ref, &timeout) {
         Ok(ready_fds) => ready_fds as c_int,
         Err(err) => {
-            ::syslog::error!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
+            if err.code == ErrorCode::OperationNotSupported {
+                ::syslog::warn!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
+            } else {
+                ::syslog::error!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
+            }
             // SAFETY: `__errno_location()` returns a valid pointer.
             unsafe {
                 *__errno_location() = err.code.get();

--- a/src/libs/syscall/src/sys/socket/bindings/accept.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/accept.rs
@@ -86,9 +86,15 @@ pub unsafe extern "C" fn accept(
             sockfd
         },
         Err(error) => {
-            ::syslog::error!(
-                "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/bind.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/bind.rs
@@ -80,9 +80,15 @@ pub unsafe extern "C" fn bind(sockfd: c_int, sockaddr: *const sockaddr, len: soc
     match crate::sys::socket::syscall::bind(sockfd, &sockaddr) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/connect.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/connect.rs
@@ -100,9 +100,15 @@ pub unsafe extern "C" fn connect(
     match socket::syscall::connect(sockfd, &sockaddr) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-            );
+            if error.code == ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
@@ -97,9 +97,17 @@ pub unsafe extern "C" fn getpeername(
             0
         },
         Err(error) => {
-            ::syslog::error!(
-                "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
+                     len={len:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
+                     len={len:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/listen.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/listen.rs
@@ -51,7 +51,11 @@ pub unsafe extern "C" fn listen(sockfd: c_int, backlog: c_int) -> c_int {
     match crate::sys::socket::syscall::listen(sockfd, backlog) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
+            } else {
+                ::syslog::error!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/recv.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recv.rs
@@ -126,9 +126,17 @@ pub unsafe extern "C" fn recv(
             },
         },
         Err(error) => {
-            ::syslog::error!(
-                "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                     flags={flags:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                     flags={flags:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/send.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/send.rs
@@ -119,9 +119,17 @@ pub unsafe extern "C" fn send(
             },
         },
         Err(error) => {
-            ::syslog::error!(
-                "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                     flags={flags:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                     flags={flags:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
@@ -73,7 +73,11 @@ pub unsafe extern "C" fn shutdown(sockfd: c_int, how: c_int) -> c_int {
     match socket::syscall::shutdown(sockfd, how) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
+            } else {
+                ::syslog::error!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/socket.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socket.rs
@@ -98,9 +98,15 @@ pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c
     match crate::sys::socket::syscall::socket(domain, typ, protocol) {
         Ok(sockfd) => sockfd,
         Err(error) => {
-            ::syslog::error!(
-                "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
@@ -131,10 +131,17 @@ pub unsafe extern "C" fn socketpair(
     match crate::sys::socket::syscall::socketpair(domain, typ, protocol, socket_fds) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
-                 socket_fds={socket_fds:?})"
-            );
+            if error.code == ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, \
+                     protocol={protocol:?}, socket_fds={socket_fds:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, \
+                     protocol={protocol:?}, socket_fds={socket_fds:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/time/bindings/clock_getres.rs
+++ b/src/libs/syscall/src/time/bindings/clock_getres.rs
@@ -56,12 +56,21 @@ pub unsafe extern "C" fn clock_getres(clock_id: clockid_t, res: *mut timespec) -
         Ok(()) => 0,
         // System call failed.
         Err(error) => {
-            ::syslog::error!(
-                "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
-                clock_id,
-                res,
-                error
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
+                    clock_id,
+                    res,
+                    error
+                );
+            } else {
+                ::syslog::error!(
+                    "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
+                    clock_id,
+                    res,
+                    error
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/time/bindings/clock_gettime.rs
+++ b/src/libs/syscall/src/time/bindings/clock_gettime.rs
@@ -49,12 +49,21 @@ pub unsafe extern "C" fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -
     match crate::time::clock_gettime(clock_id, &mut tp) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
-                clock_id,
-                tp,
-                error
-            );
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
+                    clock_id,
+                    tp,
+                    error
+                );
+            } else {
+                ::syslog::error!(
+                    "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
+                    clock_id,
+                    tp,
+                    error
+                );
+            }
             // Set errno.
             *__errno_location() = error.code.get();
             -1

--- a/src/libs/syscall/src/unistd/bindings/fchown.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchown.rs
@@ -70,7 +70,15 @@ pub unsafe extern "C" fn fchown(fd: c_int, owner: uid_t, group: gid_t) -> c_int 
     match crate::unistd::fchown(fd, owner, group) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})");
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/bindings/ftruncate.rs
@@ -66,7 +66,11 @@ pub unsafe extern "C" fn ftruncate(fd: c_int, length: off_t) -> c_int {
     match crate::unistd::ftruncate(fd, length) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
+            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                ::syslog::warn!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
+            } else {
+                ::syslog::error!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/pwrite.rs
+++ b/src/libs/syscall/src/unistd/bindings/pwrite.rs
@@ -90,10 +90,17 @@ pub unsafe extern "C" fn pwrite(
     match unistd::pwrite(fd, buffer, offset) {
         Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
-            ::syslog::error!(
-                "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
-                 offset={offset:?})"
-            );
+            if error.code == ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
+                     offset={offset:?})"
+                );
+            } else {
+                ::syslog::error!(
+                    "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
+                     offset={offset:?})"
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/write.rs
+++ b/src/libs/syscall/src/unistd/bindings/write.rs
@@ -88,10 +88,17 @@ pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t
     match crate::unistd::syscall::write(fd, buffer) {
         Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
-            ::syslog::error!(
-                "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
-                buffer.as_ptr()
-            );
+            if error.code == ErrorCode::OperationNotSupported {
+                ::syslog::warn!(
+                    "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
+                    buffer.as_ptr()
+                );
+            } else {
+                ::syslog::error!(
+                    "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
+                    buffer.as_ptr()
+                );
+            }
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -107,7 +107,11 @@ pub mod bindings {
         match crate::unistd::close(fd) {
             Ok(()) => 0,
             Err(error) => {
-                ::syslog::error!("close(): failed ({:?})", error);
+                if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                    ::syslog::warn!("close(): failed ({:?})", error);
+                } else {
+                    ::syslog::error!("close(): failed ({:?})", error);
+                }
                 unsafe {
                     *__errno_location() = error.code.get();
                 }

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -119,7 +119,11 @@ pub mod bindings {
                 0
             },
             Err(error) => {
-                ::syslog::error!("pipe(): failed (error={error:?})");
+                if error.code == ::sys::error::ErrorCode::OperationNotSupported {
+                    ::syslog::warn!("pipe(): failed (error={error:?})");
+                } else {
+                    ::syslog::error!("pipe(): failed (error={error:?})");
+                }
                 unsafe {
                     *__errno_location() = error.code.get();
                 }


### PR DESCRIPTION
In standalone deployment mode, many syscalls are unavailable because
there is no linuxd daemon to forward requests to. When CPython or
imported modules attempt to use these syscalls, the kernel returns
`OperationNotSupported`. Programs handle this gracefully by falling back
to alternative code paths and continuing normally.

Previously, all such failures were logged at ERROR level, which
polluted output and could mangle test result display. Since these are
expected limitations of standalone mode — not actual error conditions —
downgrade the log to WARN when the error code is `OperationNotSupported`.
Genuine errors (invalid arguments, I/O failures, etc.) remain at ERROR
level.

Affected syscall bindings:
- `poll`, `select`
- `open`, `fcntl`, `posix_fadvise`
- `close`, `pipe`, `write`, `pwrite`, `fchown`, `ftruncate`
- `readdir`
- `clock_gettime`, `clock_getres`
- `socket`, `connect`, `bind`, `listen`, `accept`, `send`, `recv`,
  `shutdown`, `getpeername`, `socketpair`

## Issues

- Closes #2274 
- Closes #2275