### PR TITLE
[kernel] Use static str in KernelModule

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -115,10 +115,6 @@ use crate::{
 use ::alloc::{
     collections::linked_list::LinkedList,
     format,
-    string::{
-        String,
-        ToString,
-    },
     vec,
 };
 use ::arch::{
@@ -1429,10 +1425,9 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
 
         let initrd_base: usize = current_data_start;
 
-        kernel_modules.extend(crate::multibin::parse(
-            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_size) },
-            initrd_base,
-        )?);
+        let initrd_data: &'static [u8] =
+            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_size) };
+        kernel_modules.extend(crate::multibin::parse(initrd_data, initrd_base)?);
     } else {
         // Single-binary format: parse old size-header + args layout.
         info!("parse_bootinfo(): single-binary initrd detected");
@@ -1444,9 +1439,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
 
         info!(
             "initrd_base={:#010x}, initrd_size={:#010x}, cmdline={:?}",
-            initrd_base,
-            initrd_size,
-            cmdline.as_str()
+            initrd_base, initrd_size, cmdline
         );
 
         let module: KernelModule =
@@ -1901,8 +1894,8 @@ pub fn init(
     // frame is booked without overlapping with individually-registered sub-regions
     // (kernel text/data/rodata/bss, PEB, heap padding, kpool, initrd modules from kmain).
     //
-    // The two gaps are:
-    //   1. The initrd header page — multibinary descriptors before the first module payload.
+    // The gaps are:
+    //   1. kpool-initrd gap — alignment padding between kpool end and init_data start.
     //   2. The snapshot tail — host budget padding after the last module.
     //
     // When no init_data is present, the entire range from kpool_end to snapshot_end is a gap.
@@ -1925,30 +1918,12 @@ pub fn init(
                 memory_regions.push_back(gap_region);
             }
 
-            // For multibinary (NVMB) format, the first page of the init_data blob contains
-            // the header and entry descriptors. Module payloads start at page-aligned offsets
-            // after this header, leaving the header page as a gap not covered by any module
-            // region. For single-binary format, the module payload starts at byte 8 within
-            // the first page (after the size header), and kmain page-aligns downward so the
-            // first page IS part of the module — no gap to register.
-            let init_data_slice: &[u8] = unsafe {
-                core::slice::from_raw_parts(
-                    init_data_start as *const u8,
-                    init_data_size.min(multibin::MAGIC.len()),
-                )
-            };
-            let is_multibinary: bool = init_data_slice.len() >= multibin::MAGIC.len()
-                && init_data_slice[..multibin::MAGIC.len()] == multibin::MAGIC;
-            if is_multibinary {
-                let initrd_header_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-                    "initrd header",
-                    VirtualAddress::from_raw_value(init_data_start),
-                    mem::PAGE_SIZE,
-                    MemoryRegionType::Reserved,
-                    AccessPermission::RDONLY,
-                )?;
-                memory_regions.push_back(initrd_header_region);
-            }
+            // For multibinary (NVMB) format, the module region registered by kmain now
+            // covers the entire image (including the header page), so no separate gap
+            // registration is needed here. For single-binary format, the module payload
+            // starts at byte 8 within the first page (after the size header), and kmain
+            // page-aligns downward so the first page IS part of the module — no gap to
+            // register either.
 
             // Snapshot tail: padding between the end of init_data and snapshot_end.
             // The host allocates a full snapshot budget that may extend beyond the last module.
@@ -2312,7 +2287,7 @@ unsafe fn build_physical_memory_layout(
 unsafe fn parse_initrd_image(
     init_data_start: usize,
     total_allocation_size: usize,
-) -> Result<(usize, usize, (u8, String)), Error> {
+) -> Result<(usize, usize, (u8, &'static str)), Error> {
     // Check if allocation is too small to hold the initrd header.
     if total_allocation_size < INITRD_SIZE_BYTES {
         let reason: &str = "insufficient initrd allocation size";
@@ -2371,7 +2346,7 @@ unsafe fn parse_initrd_image(
     );
 
     // Read initrd command line.
-    let initrd_cmdline: (u8, String) =
+    let initrd_cmdline: (u8, &'static str) =
         read_initrd_cmdline(current_initrd_start, actual_initrd_size, total_allocation_size)?;
 
     // The ELF payload sits INITRD_SIZE_BYTES past the page-aligned init_data_start,
@@ -2415,7 +2390,7 @@ unsafe fn read_initrd_cmdline(
     initrd_start: usize,
     initrd_size: usize,
     total_allocation_size: usize,
-) -> Result<(u8, String), Error> {
+) -> Result<(u8, &'static str), Error> {
     let args_section_size: usize =
         total_allocation_size.saturating_sub(::config::hyperlight::INITRD_SIZE_BYTES + initrd_size);
 
@@ -2465,11 +2440,11 @@ unsafe fn read_initrd_cmdline(
         return Err(Error::new(ErrorCode::BadFile, reason));
     }
 
-    let args_bytes: &[u8] =
+    let args_bytes: &'static [u8] =
         core::slice::from_raw_parts(args_bytes_offset as *const u8, args_payload_size);
 
     // Convert arguments to UTF-8 string and check for errors.
-    let args_str: &str = match core::str::from_utf8(args_bytes) {
+    let args_str: &'static str = match core::str::from_utf8(args_bytes) {
         Ok(value) => value,
         Err(_) => {
             let reason: &str = "invalid UTF-8 in initrd arguments";
@@ -2478,5 +2453,5 @@ unsafe fn read_initrd_cmdline(
         },
     };
 
-    Ok((args_len, args_str.to_string()))
+    Ok((args_len, args_str))
 }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -57,7 +57,6 @@ use crate::{
 };
 use ::alloc::{
     collections::LinkedList,
-    string::ToString,
     vec,
 };
 use ::arch::{
@@ -574,7 +573,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             );
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
-        let image_data: &[u8] =
+        let image_data: &'static [u8] =
             unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_bytes) };
 
         // Detect initrd format by checking for NVMB multibinary magic.
@@ -589,17 +588,59 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             let initrd_cmdline_len_base: usize = initrd_base + total_bytes;
             let initrd_cmdline_base: usize = initrd_cmdline_len_base + core::mem::size_of::<u8>();
 
+            // Validate that the length field fits within the known initrd allocation.
+            let cmdline_len_end: usize =
+                match initrd_cmdline_len_base.checked_add(core::mem::size_of::<u8>()) {
+                    Some(end) => end,
+                    None => {
+                        let reason: &str = "cmdline length field address overflow";
+                        error!("parse_bootinfo(): {}", reason);
+                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                    },
+                };
+            if cmdline_len_end > ::config::memory_layout::USER_MMAP_BASE_RAW {
+                let reason: &str = "cmdline length field exceeds memory bounds";
+                error!("parse_bootinfo(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+
             let cmdline_len: u8 = unsafe { *(initrd_cmdline_len_base as *const u8) };
-            let cmdline_bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(initrd_cmdline_base as *const u8, cmdline_len as usize)
-            };
-            let cmdline: &str = match core::str::from_utf8(cmdline_bytes) {
-                Ok(s) => s,
-                Err(_) => {
-                    let reason: &str = "invalid UTF-8 in command line";
-                    error!("invalid UTF-8 in command line");
+
+            // Validate that the cmdline payload fits within memory bounds.
+            let cmdline_end: usize = match initrd_cmdline_base.checked_add(cmdline_len as usize) {
+                Some(end) => end,
+                None => {
+                    let reason: &str = "cmdline payload address overflow";
+                    error!("parse_bootinfo(): {}", reason);
                     return Err(Error::new(ErrorCode::InvalidArgument, reason));
                 },
+            };
+            if cmdline_end > ::config::memory_layout::USER_MMAP_BASE_RAW {
+                let reason: &str = "cmdline payload exceeds memory bounds";
+                error!(
+                    "parse_bootinfo(): {} (cmdline_end={:#010x}, mmap_base={:#010x})",
+                    reason,
+                    cmdline_end,
+                    ::config::memory_layout::USER_MMAP_BASE_RAW
+                );
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+
+            // SAFETY: the cmdline bytes reside in bootloader-provided memory that persists for the
+            // kernel's lifetime, so the resulting &'static str is sound.
+            let cmdline: &'static str = unsafe {
+                let bytes: &'static [u8] = core::slice::from_raw_parts(
+                    initrd_cmdline_base as *const u8,
+                    cmdline_len as usize,
+                );
+                match core::str::from_utf8(bytes) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        let reason: &str = "invalid UTF-8 in command line";
+                        error!("invalid UTF-8 in command line");
+                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                    },
+                }
             };
 
             info!(
@@ -607,10 +648,15 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
                 initrd_base, total_bytes, cmdline_len, cmdline
             );
 
+            // Module size must cover the ELF binary AND the trailing cmdline area
+            // (length field + payload) so that the HAL maps the entire region.
+            let module_size: usize =
+                total_bytes + core::mem::size_of::<u8>() + cmdline_len as usize;
+
             let module: KernelModule = KernelModule::new(
                 PhysicalAddress::from_raw_value(initrd_base)?,
-                total_bytes,
-                cmdline.to_string(),
+                module_size,
+                cmdline,
             );
             kernel_modules.push_back(module);
         }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -327,10 +327,20 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     memory_regions.push_back(kimage.kpool());
 
     // Add kernel modules to list of memory regions.
+    // Track which page-aligned region bases have already been registered to avoid
+    // booking the same frames twice (multibinary modules share a single image region).
+    let mut registered_bases: [usize; ::multibin::MAX_ENTRIES] =
+        [usize::MAX; ::multibin::MAX_ENTRIES];
+    let mut registered_count: usize = 0;
     for module in kernel_modules.iter() {
-        let name: &str = module.cmdline();
-        let raw_start: usize = module.start().into_virtual_address().into_raw_value();
-        let size: usize = module.size();
+        // Use only the program name (first token) as the region name to avoid large
+        // heap allocations when the full command line is very long.
+        let name: &str = module
+            .cmdline()
+            .split_once(' ')
+            .map_or(module.cmdline(), |(n, _)| n);
+        let raw_start: usize = module.region_base().into_virtual_address().into_raw_value();
+        let size: usize = module.region_size();
         // Page-align the region: round start down and end up to page boundaries.
         // The module payload may start at an offset within a page (e.g., after a size header).
         let page_start: usize = ::sys::mm::align_down(raw_start, ::sys::mm::Alignment::Align4096);
@@ -342,6 +352,23 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             Some(v) => v,
             None => panic!("kernel module region end overflows address space"),
         };
+
+        // Skip if this exact page-aligned base was already registered.
+        let mut already_registered: bool = false;
+        for base in registered_bases.iter().take(registered_count) {
+            if *base == page_start {
+                already_registered = true;
+                break;
+            }
+        }
+        if already_registered {
+            continue;
+        }
+        if registered_count < registered_bases.len() {
+            registered_bases[registered_count] = page_start;
+            registered_count += 1;
+        }
+
         let start: VirtualAddress = VirtualAddress::from_raw_value(page_start);
         let aligned_size: usize = page_end - page_start;
         let typ: MemoryRegionType = MemoryRegionType::Reserved;

--- a/src/kernel/src/kmod.rs
+++ b/src/kernel/src/kmod.rs
@@ -6,44 +6,78 @@
 //==================================================================================================
 
 use crate::hal::mem::PhysicalAddress;
-use ::alloc::string::String;
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
 pub struct KernelModule {
-    /// Start address.
+    /// Start address of the ELF binary data.
     start: PhysicalAddress,
-    /// Size.
+    /// Size of the ELF binary data.
     size: usize,
+    /// Base address of the memory region that must be mapped for this module.
+    /// For multibinary images this covers the full image (including the header
+    /// where cmdline strings reside); for single-binary modules it equals `start`.
+    region_base: PhysicalAddress,
+    /// Total size of the memory region from `region_base` that must be mapped.
+    region_size: usize,
     /// Command line.
-    cmdline: String,
+    cmdline: &'static str,
 }
 
 impl KernelModule {
-    /// Creates a new kernel module.
-    pub fn new(start: PhysicalAddress, size: usize, cmdline: String) -> Self {
+    /// Creates a new kernel module whose mapped region matches the ELF extent.
+    pub fn new(start: PhysicalAddress, size: usize, cmdline: &'static str) -> Self {
         Self {
             start,
             size,
+            region_base: start,
+            region_size: size,
             cmdline,
         }
     }
 
-    /// Gets the start address of the module.
+    /// Creates a new kernel module with an explicit memory region base and size.
+    pub fn new_with_region(
+        start: PhysicalAddress,
+        size: usize,
+        region_base: PhysicalAddress,
+        region_size: usize,
+        cmdline: &'static str,
+    ) -> Self {
+        Self {
+            start,
+            size,
+            region_base,
+            region_size,
+            cmdline,
+        }
+    }
+
+    /// Gets the start address of the ELF binary.
     pub fn start(&self) -> PhysicalAddress {
         self.start
     }
 
-    /// Gets the size of the module.
+    /// Gets the size of the ELF binary.
     pub fn size(&self) -> usize {
         self.size
     }
 
+    /// Gets the base address of the memory region to map.
+    pub fn region_base(&self) -> PhysicalAddress {
+        self.region_base
+    }
+
+    /// Gets the size of the memory region to map.
+    pub fn region_size(&self) -> usize {
+        self.region_size
+    }
+
     /// Gets the command line of the module.
     pub fn cmdline(&self) -> &str {
-        &self.cmdline
+        self.cmdline
     }
 }
 

--- a/src/kernel/src/multibin.rs
+++ b/src/kernel/src/multibin.rs
@@ -9,10 +9,7 @@ use crate::{
     hal::mem::PhysicalAddress,
     kmod::KernelModule,
 };
-use ::alloc::{
-    string::ToString,
-    vec::Vec,
-};
+use ::alloc::vec::Vec;
 use ::sys::{
     error::{
         Error,
@@ -42,7 +39,7 @@ use ::sys::{
 ///
 /// A [`Vec`] of [`KernelModule`]s on success, or an [`Error`] if the image is malformed.
 ///
-pub fn parse(image_data: &[u8], initrd_base: usize) -> Result<Vec<KernelModule>, Error> {
+pub fn parse(image_data: &'static [u8], initrd_base: usize) -> Result<Vec<KernelModule>, Error> {
     let parsed: multibin::ParseResult = multibin::parse(image_data).map_err(|e| {
         error!("parse(): failed to parse multibinary image: {:?}", e);
         e
@@ -82,10 +79,15 @@ pub fn parse(image_data: &[u8], initrd_base: usize) -> Result<Vec<KernelModule>,
             entry_phys_addr, entry.size, cmdline
         );
 
-        let module: KernelModule = KernelModule::new(
+        // Each module's mapped region covers the entire multibinary image so that
+        // the header pages (containing cmdline strings) remain accessible after
+        // the kernel switches to the new page table.
+        let module: KernelModule = KernelModule::new_with_region(
             PhysicalAddress::from_raw_value(entry_phys_addr)?,
             entry.size,
-            cmdline.to_string(),
+            PhysicalAddress::from_raw_value(initrd_base)?,
+            image_data.len(),
+            cmdline,
         );
         modules.push(module);
     }


### PR DESCRIPTION
Refactor KernelModule to store &'static str instead of heap-allocated String for the command line. Add region_base/region_size fields to track the full mapped region independently of the ELF binary extent.

Key changes:
- KernelModule::new() uses &'static str for cmdline
- new_with_region() constructor for multibinary modules
- Platform parsers return &'static str from guest memory
- kmain deduplicates overlapping page-aligned regions
- Region name uses only the program name (first token)

This eliminates heap allocations during boot for large cmdlines and prepares for the u16 wire-format change.