### PR TITLE
[libs] Demote error logs to warn level in guest libraries

### DIFF
--- a/src/libs/libc_stdlib/src/aligned_alloc.rs
+++ b/src/libs/libc_stdlib/src/aligned_alloc.rs
@@ -18,7 +18,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::error;
+use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn aligned_alloc(alignment: c_size_t, size: c_size_t) -> *
     if size == 0 {
         // Zero-size allocations have implementation-defined behavior,
         // thus log a warning message and return null.
-        error!("aligned_alloc(): zero-size allocation (alignment={alignment:?}, size={size:?})");
+        warn!("aligned_alloc(): zero-size allocation (alignment={alignment:?}, size={size:?})");
         set_errno(EINVAL);
         return null_mut();
     }
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn aligned_alloc(alignment: c_size_t, size: c_size_t) -> *
     if alignment == 0 {
         // Zero-size alignments have implementation-defined behavior,
         // thus log a warning message and return null.
-        error!("aligned_alloc(): zero-size alignment (alignment={alignment:?}, size={size:?})");
+        warn!("aligned_alloc(): zero-size alignment (alignment={alignment:?}, size={size:?})");
         set_errno(EINVAL);
         return null_mut();
     }
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn aligned_alloc(alignment: c_size_t, size: c_size_t) -> *
     // Allocate memory and check for errors.
     let ptr: *mut u8 = BlockHeader::alloc(size as usize, Some(alignment as usize));
     if ptr.is_null() {
-        error!("aligned_alloc(): allocation failed (alignment={alignment:?}, size={size:?})");
+        warn!("aligned_alloc(): allocation failed (alignment={alignment:?}, size={size:?})");
         set_errno(ENOMEM);
         return null_mut();
     }

--- a/src/libs/libc_stdlib/src/block_header.rs
+++ b/src/libs/libc_stdlib/src/block_header.rs
@@ -17,10 +17,7 @@ use ::core::{
         null_mut,
     },
 };
-use ::syslog::{
-    error,
-    warn,
-};
+use ::syslog::warn;
 
 //==================================================================================================
 // Constants
@@ -98,21 +95,21 @@ impl BlockHeader {
 
         // Validate alignment invariants so that free() can trust the header.
         if !alignment.is_power_of_two() || alignment > MAX_ALIGNMENT {
-            error!("alloc(): invalid alignment (alignment={alignment:?}, size={size:?})");
+            warn!("alloc(): invalid alignment (alignment={alignment:?}, size={size:?})");
             return null_mut();
         }
 
         // Compute size for underlying allocation (header_size + padding_size + requested_size).
         let alloc_size: usize = {
             let Some(alloc_size) = size.checked_add(BLOCK_HEADER_SIZE) else {
-                error!(
+                warn!(
                     "alloc(): overflow when computing allocation size (size={size:?}, \
                      alignment={alignment:?})"
                 );
                 return null_mut();
             };
             let Some(alloc_size) = alloc_size.checked_add(alignment - 1) else {
-                error!(
+                warn!(
                     "alloc(): overflow when computing allocation size (size={size:?}, \
                      alignment={alignment:?})"
                 );
@@ -123,7 +120,7 @@ impl BlockHeader {
             // (LlistNode, 8 bytes) are always naturally aligned when placed at
             // the base of a freed chunk.
             let Some(rounded) = alloc_size.checked_add(UNDERLYING_ALIGNMENT - 1) else {
-                error!(
+                warn!(
                     "alloc(): overflow when rounding allocation size (size={size:?}, \
                      alignment={alignment:?})"
                 );
@@ -136,7 +133,7 @@ impl BlockHeader {
         let layout: Layout = match Layout::from_size_align(alloc_size, UNDERLYING_ALIGNMENT) {
             Ok(layout) => layout,
             Err(error) => {
-                error!("alloc(): {error:?} (alignment={alignment:?}, size={size:?})");
+                warn!("alloc(): {error:?} (alignment={alignment:?}, size={size:?})");
                 return null_mut();
             },
         };
@@ -144,9 +141,7 @@ impl BlockHeader {
         // Perform allocation and check for errors.
         let base: *mut u8 = alloc(layout);
         if base.is_null() {
-            error!(
-                "alloc(): underlying allocation failed (alignment={alignment:?}, size={size:?})"
-            );
+            warn!("alloc(): underlying allocation failed (alignment={alignment:?}, size={size:?})");
             return null_mut();
         }
 
@@ -196,7 +191,7 @@ impl BlockHeader {
         // Allocate new block and check for errors.
         let new_ptr: *mut u8 = BlockHeader::alloc(new_size, Some(header_ref.alignment));
         if new_ptr.is_null() {
-            error!("realloc(): allocation failed (user_ptr={user_ptr:?}, new_size={new_size:?})");
+            warn!("realloc(): allocation failed (user_ptr={user_ptr:?}, new_size={new_size:?})");
             return null_mut();
         }
 
@@ -255,7 +250,7 @@ impl BlockHeader {
             && valid_underlying_alignment;
 
         if !valid {
-            error!(
+            warn!(
                 "BlockHeader::free(): corrupted header detected, leaking (user_ptr={user_ptr:p}, \
                  header={header:?})"
             );
@@ -266,9 +261,7 @@ impl BlockHeader {
         {
             Ok(layout) => layout,
             Err(error) => {
-                error!(
-                    "BlockHeader::free(): corrupted header (error={error:?}, header={header:?})"
-                );
+                warn!("BlockHeader::free(): corrupted header (error={error:?}, header={header:?})");
                 return Err(());
             },
         };

--- a/src/libs/libc_stdlib/src/calloc.rs
+++ b/src/libs/libc_stdlib/src/calloc.rs
@@ -18,7 +18,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::error;
+use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn calloc(nmemb: c_size_t, size: c_size_t) -> *mut c_void 
     if nmemb == 0 || size == 0 {
         // Zero-size allocations have implementation-defined behavior,
         // thus log a warning message and return null.
-        error!("calloc(): zero-size allocation (nmemb={nmemb:?}, size={size:?})");
+        warn!("calloc(): zero-size allocation (nmemb={nmemb:?}, size={size:?})");
         set_errno(EINVAL);
         return null_mut();
     }
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn calloc(nmemb: c_size_t, size: c_size_t) -> *mut c_void 
     let total: usize = match nmemb.checked_mul(size) {
         Some(t) => t,
         None => {
-            error!("calloc(): size overflow (nmemb={nmemb:?}, size={size:?})");
+            warn!("calloc(): size overflow (nmemb={nmemb:?}, size={size:?})");
             set_errno(ENOMEM);
             return null_mut();
         },
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn calloc(nmemb: c_size_t, size: c_size_t) -> *mut c_void 
     // Allocate memory and check for errors.
     let ptr: *mut u8 = BlockHeader::alloc(total, None);
     if ptr.is_null() {
-        error!("calloc(): allocation failed (nmemb={nmemb:?}, size={size:?})");
+        warn!("calloc(): allocation failed (nmemb={nmemb:?}, size={size:?})");
         set_errno(ENOMEM);
         return null_mut();
     }

--- a/src/libs/libc_stdlib/src/malloc.rs
+++ b/src/libs/libc_stdlib/src/malloc.rs
@@ -18,10 +18,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::{
-    error,
-    warn,
-};
+use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -66,7 +63,7 @@ pub unsafe extern "C" fn malloc(size: c_size_t) -> *mut c_void {
     // Allocate memory and check for errors.
     let ptr: *mut u8 = BlockHeader::alloc(size as usize, None);
     if ptr.is_null() {
-        error!("malloc(): allocation failed (size={size:?})");
+        warn!("malloc(): allocation failed (size={size:?})");
         set_errno(ENOMEM);
         return null_mut();
     }

--- a/src/libs/libc_stdlib/src/posix_memalign.rs
+++ b/src/libs/libc_stdlib/src/posix_memalign.rs
@@ -17,7 +17,7 @@ use ::sysapi::{
     },
     sys_types::c_size_t,
 };
-use ::syslog::error;
+use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn posix_memalign(
 ) -> c_int {
     // Check if `memptr` is null.
     if memptr.is_null() {
-        error!("posix_memalign(): null storage (alignment={alignment:?}, size={size:?})");
+        warn!("posix_memalign(): null storage (alignment={alignment:?}, size={size:?})");
         return EINVAL;
     }
 
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn posix_memalign(
     if size == 0 {
         // Zero-size allocations have implementation-defined behavior,
         // thus log a warning message and return error.
-        error!("posix_memalign(): zero-size allocation (alignment={alignment:?}, size={size:?})");
+        warn!("posix_memalign(): zero-size allocation (alignment={alignment:?}, size={size:?})");
         return EINVAL;
     }
 
@@ -79,20 +79,20 @@ pub unsafe extern "C" fn posix_memalign(
     if alignment == 0 {
         // Zero-size alignments have implementation-defined behavior,
         // thus log a warning message and return error.
-        error!("posix_memalign(): zero-size alignment (alignment={alignment:?}, size={size:?})");
+        warn!("posix_memalign(): zero-size alignment (alignment={alignment:?}, size={size:?})");
         return EINVAL;
     }
 
     // Check for invalid alignment.
     if !alignment.is_multiple_of(size_of::<*mut c_void>()) || !alignment.is_power_of_two() {
-        error!("posix_memalign(): invalid alignment (alignment={alignment:?}, size={size:?})");
+        warn!("posix_memalign(): invalid alignment (alignment={alignment:?}, size={size:?})");
         return EINVAL;
     }
 
     // Allocate memory and check for errors.
     let ptr: *mut u8 = BlockHeader::alloc(size, Some(alignment));
     if ptr.is_null() {
-        error!("posix_memalign(): allocation failed (alignment={alignment:?}, size={size:?})");
+        warn!("posix_memalign(): allocation failed (alignment={alignment:?}, size={size:?})");
         return ENOMEM;
     }
 

--- a/src/libs/libc_stdlib/src/realloc.rs
+++ b/src/libs/libc_stdlib/src/realloc.rs
@@ -17,7 +17,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::error;
+use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, size: c_size_t) -> *mut c_voi
     // Reallocate memory and check for errors.
     let new_ptr: *mut u8 = BlockHeader::realloc(ptr.cast::<u8>(), size as usize);
     if new_ptr.is_null() {
-        error!("realloc(): reallocation failed (ptr={ptr:?}, size={size:?})");
+        warn!("realloc(): reallocation failed (ptr={ptr:?}, size={size:?})");
         set_errno(ENOMEM);
         return null_mut();
     }

--- a/src/libs/posix/src/dlfcn/mod.rs
+++ b/src/libs/posix/src/dlfcn/mod.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn dladdr(addr: *const c_void, dlip: *mut DlInfo) -> i32 {
     if addr.is_null() {
         let reason: &str = "addr is null";
         DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dladdr(): {}", reason);
+        ::syslog::warn!("dladdr(): {}", reason);
         return -1;
     }
 
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn dladdr(addr: *const c_void, dlip: *mut DlInfo) -> i32 {
     if dlip.is_null() {
         let reason: &str = "info is null";
         DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dladdr(): {}", reason);
+        ::syslog::warn!("dladdr(): {}", reason);
         return -1;
     }
 
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn dladdr(addr: *const c_void, dlip: *mut DlInfo) -> i32 {
         Ok(()) => 0,
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);
-            ::syslog::error!("dladdr(): {:?}", error);
+            ::syslog::warn!("dladdr(): {:?}", error);
             -1
         },
     }
@@ -237,7 +237,7 @@ pub unsafe extern "C" fn dlclose(handle: *mut c_void) -> i32 {
     if handle.is_null() {
         let reason: &str = "handle is null";
         DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlclose(): {}", reason);
+        ::syslog::warn!("dlclose(): {}", reason);
         return -1;
     }
 
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn dlclose(handle: *mut c_void) -> i32 {
         Ok(()) => 0,
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);
-            ::syslog::error!("dlclose(): {:?}", error);
+            ::syslog::warn!("dlclose(): {:?}", error);
             -1
         },
     }
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
         Ok(pathname) => pathname,
         Err(error) => {
             let reason: String = alloc::format!("invalid filename (error={error:?})");
-            ::syslog::error!("dlopen(): {}", reason);
+            ::syslog::warn!("dlopen(): {}", reason);
             DL_LAST_ERROR.lock().set(&reason);
             return ptr::null_mut();
         },
@@ -338,7 +338,7 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
         None => {
             let reason: String = alloc::format!("invalid mode (mode={mode:#x})");
             DL_LAST_ERROR.lock().set(&reason);
-            ::syslog::error!("dlopen(): {}", reason);
+            ::syslog::warn!("dlopen(): {}", reason);
             return ptr::null_mut();
         },
     };
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
         Ok(handle) => handle.as_mut_ptr(),
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);
-            ::syslog::error!("dlopen(): {:?}", error);
+            ::syslog::warn!("dlopen(): {:?}", error);
             ptr::null_mut()
         },
     }
@@ -393,7 +393,7 @@ pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *m
     if symbol.is_null() {
         let reason: &str = "symbol is null";
         DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlsym(): {}", reason);
+        ::syslog::warn!("dlsym(): {}", reason);
         return ptr::null_mut();
     }
 
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *m
         Ok(symbol) => symbol,
         Err(error) => {
             let reason: String = alloc::format!("invalid symbol (error={error:?})");
-            ::syslog::error!("dlsym(): {}", reason);
+            ::syslog::warn!("dlsym(): {}", reason);
             DL_LAST_ERROR.lock().set(&reason);
             return ptr::null_mut();
         },
@@ -420,7 +420,7 @@ pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *m
         Ok(symbol) => symbol.into_raw_value() as *mut c_void,
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);
-            ::syslog::error!("dlsym(): {:?}", error);
+            ::syslog::warn!("dlsym(): {:?}", error);
             ptr::null_mut()
         },
     }

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -72,13 +72,13 @@ pub unsafe extern "C" fn pthread_attr_getdetachstate(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_getdetachstate(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_getdetachstate(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `detachstate` is not valid.
     if detachstate.is_null() {
-        ::syslog::error!("pthread_attr_getdetachstate(): invalid detach state pointer");
+        ::syslog::warn!("pthread_attr_getdetachstate(): invalid detach state pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -123,13 +123,13 @@ pub unsafe extern "C" fn pthread_attr_getguardsize(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_getguardsize(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_getguardsize(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `guardsize` is not valid.
     if guardsize.is_null() {
-        ::syslog::error!("pthread_attr_getguardsize(): invalid guard size pointer");
+        ::syslog::warn!("pthread_attr_getguardsize(): invalid guard size pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -174,13 +174,13 @@ pub unsafe extern "C" fn pthread_attr_getschedparam(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_getschedparam(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_getschedparam(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `param` is not valid.
     if param.is_null() {
-        ::syslog::error!("pthread_attr_getschedparam(): invalid sched param pointer");
+        ::syslog::warn!("pthread_attr_getschedparam(): invalid sched param pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -225,13 +225,13 @@ pub unsafe extern "C" fn pthread_attr_getstackaddr(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_getstackaddr(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_getstackaddr(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `stackaddr` is not valid.
     if stackaddr.is_null() {
-        ::syslog::error!("pthread_attr_getstackaddr(): invalid stack address pointer");
+        ::syslog::warn!("pthread_attr_getstackaddr(): invalid stack address pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -276,13 +276,13 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_getstacksize(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_getstacksize(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `stacksize` is not valid.
     if stacksize.is_null() {
-        ::syslog::error!("pthread_attr_getstacksize(): invalid stack size pointer");
+        ::syslog::warn!("pthread_attr_getstacksize(): invalid stack size pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -425,7 +425,7 @@ pub unsafe extern "C" fn pthread_attr_setdetachstate(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_setdetachstate(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_setdetachstate(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -468,7 +468,7 @@ pub unsafe extern "C" fn pthread_attr_setguardsize(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_setguardsize(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_setguardsize(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -512,13 +512,13 @@ pub unsafe extern "C" fn pthread_attr_setschedparam(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_setschedparam(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_setschedparam(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `param` is not valid.
     if param.is_null() {
-        ::syslog::error!("pthread_attr_setschedparam(): invalid sched param pointer");
+        ::syslog::warn!("pthread_attr_setschedparam(): invalid sched param pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -563,7 +563,7 @@ pub unsafe extern "C" fn pthread_attr_setstack(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_setstack(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_setstack(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -606,7 +606,7 @@ pub unsafe extern "C" fn pthread_attr_setstackaddr(
 ) -> c_int {
     // Check if `attr` is not valid.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_setstackaddr(): invalid attribute pointer");
+        ::syslog::warn!("pthread_attr_setstackaddr(): invalid attribute pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -646,7 +646,7 @@ pub unsafe extern "C" fn pthread_attr_setstackaddr(
 pub unsafe extern "C" fn pthread_setcanceltype(_type_: c_int, oldtype: *mut c_int) -> c_int {
     // Check if `oldtype` is not valid.
     if oldtype.is_null() {
-        ::syslog::error!("pthread_setcanceltype(): invalid old type pointer");
+        ::syslog::warn!("pthread_setcanceltype(): invalid old type pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/posix/src/pthread/mutex.rs
+++ b/src/libs/posix/src/pthread/mutex.rs
@@ -116,13 +116,13 @@ pub unsafe extern "C" fn pthread_mutex_timedlock(
 ) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_timedlock(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_timedlock(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `abstime` is not valid.
     if abstime.is_null() {
-        ::syslog::error!("pthread_mutex_timedlock(): invalid abstime pointer");
+        ::syslog::warn!("pthread_mutex_timedlock(): invalid abstime pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn pthread_mutex_timedlock(
         match SystemTime::new((*abstime).tv_sec as u64, (*abstime).tv_nsec as u32) {
             Some(timeout) => timeout,
             None => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "pthread_mutex_timedlock(): invalid timeout (abstime={:?})",
                     abstime
                 );
@@ -142,7 +142,7 @@ pub unsafe extern "C" fn pthread_mutex_timedlock(
     match pthread::pthread_mutex_timedlock(&mut *mutex, Some(timeout)) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pthread_mutex_timedlock(): failed to lock mutex (abstime={:?}, error={:?})",
                 abstime,
                 error
@@ -182,14 +182,14 @@ pub unsafe extern "C" fn pthread_mutex_timedlock(
 pub unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_trylock(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_trylock(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     match pthread::pthread_mutex_trylock(&mut *mutex) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("pthread_mutex_trylock(): failed to lock mutex (error={:?})", error);
+            ::syslog::warn!("pthread_mutex_trylock(): failed to lock mutex (error={:?})", error);
             error.code.get()
         },
     }

--- a/src/libs/posix/src/sys/stat/mod.rs
+++ b/src/libs/posix/src/sys/stat/mod.rs
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn fchmod(fd: c_int, mode: mode_t) -> c_int {
     match stat::fchmod(fd, mode) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("fchmod(): {:?} (fd={}, mode={})", error, fd, mode);
+            ::syslog::warn!("fchmod(): {:?} (fd={}, mode={})", error, fd, mode);
             *__errno_location() = error.code.get();
             -1
         },
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn fchmodat(
     let pathname: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "fchmodat(): invalid pathname (dirfd={:?}, mode={:?}, flag={:?}, error={:?})",
                 dirfd,
                 mode,
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn fchmodat(
     match stat::fchmodat(dirfd, pathname, mode, flag) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "fchmodat(): failed (dirfd={}, pathname={:?}, mode={}, flag={}, error={:?})",
                 dirfd,
                 pathname,
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn fchmodat(
 pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
     // Check if `times` is invalid.
     if times.is_null() {
-        ::syslog::error!("futimens(): fd={}, times={:p}", fd, times);
+        ::syslog::warn!("futimens(): fd={}, times={:p}", fd, times);
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -203,7 +203,7 @@ pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
     let times: &[timespec; 2] = match slice::from_raw_parts(times, 2).try_into() {
         Ok(array) => array,
         Err(_) => {
-            ::syslog::error!("futimens(): invalid times array");
+            ::syslog::warn!("futimens(): invalid times array");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -213,12 +213,7 @@ pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
     match stat::futimens(fd, times) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
-                "futimens(): failed (fd={}, times={:?}, error={:?})",
-                fd,
-                times,
-                error
-            );
+            ::syslog::warn!("futimens(): failed (fd={}, times={:?}, error={:?})", fd, times, error);
             *__errno_location() = error.code.get();
             -1
         },
@@ -281,7 +276,7 @@ pub unsafe extern "C" fn lstat(pathname: *const c_char, statbuf: *mut sys_stat::
     let pathname: &str = match ffi::CStr::from_ptr(pathname).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!("lstat(): invalid pathname");
+            ::syslog::warn!("lstat(): invalid pathname");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -292,21 +287,12 @@ pub unsafe extern "C" fn lstat(pathname: *const c_char, statbuf: *mut sys_stat::
     match stat::lstat(pathname, statbuf) {
         Ok(_) => 0,
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry {
-                ::syslog::warn!(
-                    "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
-                    pathname,
-                    statbuf,
-                    error
-                );
-            } else {
-                ::syslog::error!(
-                    "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
-                    pathname,
-                    statbuf,
-                    error
-                );
-            }
+            ::syslog::warn!(
+                "lstat(): failed (pathname={}, statbuf={:p}, error={:?})",
+                pathname,
+                statbuf,
+                error
+            );
             *__errno_location() = error.code.get();
             -1
         },
@@ -371,7 +357,7 @@ pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mo
     let pathname: &str = match ffi::CStr::from_ptr(pathname).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!("mkdirat(): invalid pathname");
+            ::syslog::warn!("mkdirat(): invalid pathname");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -381,7 +367,7 @@ pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mo
     match stat::mkdirat(dirfd, pathname, mode) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mkdirat(): failed (dirfd={}, pathname={:?}, mode={}, error={:?})",
                 dirfd,
                 pathname,
@@ -466,7 +452,7 @@ pub unsafe extern "C" fn utimensat(
     let pathname: &str = match ffi::CStr::from_ptr(filename).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "utimensat(): invalid pathname (dirfd={}, times={:p}, flags={})",
                 dirfd,
                 times,
@@ -479,7 +465,7 @@ pub unsafe extern "C" fn utimensat(
 
     // Check if `times` is invalid.
     if times.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "utimensat(): invalid times (dirfd={}, pathname={:?}, times={:p}, flags={})",
             dirfd,
             pathname,
@@ -494,7 +480,7 @@ pub unsafe extern "C" fn utimensat(
     let times: &[timespec; 2] = match slice::from_raw_parts(times, 2).try_into() {
         Ok(array) => array,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "futimens(): invalid times array (dirfd={}, pathname={:?}, times={:p}, flags={})",
                 dirfd,
                 pathname,
@@ -509,7 +495,7 @@ pub unsafe extern "C" fn utimensat(
     match stat::utimensat(dirfd, pathname, times, flags) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "utimensat(): failed (dirfd={}, pathname={}, times={:?}, flags={}, error={:?})",
                 dirfd,
                 pathname,

--- a/src/libs/posix/src/sys/time/utimes.rs
+++ b/src/libs/posix/src/sys/time/utimes.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) -> c_int {
     // Check if `times` is invalid.
     if times.is_null() {
-        ::syslog::error!("utimes(): invalid times (filename={:?}, times={:?})", filename, times);
+        ::syslog::warn!("utimes(): invalid times (filename={:?}, times={:?})", filename, times);
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -63,11 +63,7 @@ pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) 
     let times: &[timeval; 2] = match slice::from_raw_parts(times, 2).try_into() {
         Ok(times) => times,
         Err(_) => {
-            ::syslog::error!(
-                "utimes(): invalid times (filename={:?}, times={:?})",
-                filename,
-                times
-            );
+            ::syslog::warn!("utimes(): invalid times (filename={:?}, times={:?})", filename, times);
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -77,7 +73,7 @@ pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) 
     let times_0: timespec = match times[0].try_into() {
         Ok(timespec) => timespec,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "utimes(): failed to convert times[0] (filename={filename:?}, times={times:?}, \
                  error={error:?})",
             );
@@ -90,7 +86,7 @@ pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) 
     let times_1: timespec = match times[1].try_into() {
         Ok(timespec) => timespec,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "utimes(): failed to convert times[1] (filename={filename:?}, times={times:?}, \
                  error={error:?})",
             );

--- a/src/libs/posix/src/sys/times/mod.rs
+++ b/src/libs/posix/src/sys/times/mod.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn times(buffer: *mut tms) -> clock_t {
         Ok(clock) => clock,
         // System call failed.
         Err(error) => {
-            ::syslog::error!("times(): failed (buffer={:?}, error={:?})", buffer, error);
+            ::syslog::warn!("times(): failed (buffer={:?}, error={:?})", buffer, error);
             *__errno_location() = error.code.get();
             -1 as clock_t
         },

--- a/src/libs/posix/src/sys/uio/mod.rs
+++ b/src/libs/posix/src/sys/uio/mod.rs
@@ -66,14 +66,14 @@ pub unsafe extern "C" fn pwritev(
 ) -> c_ssize_t {
     // Check if number of elements in the vector is valid.
     if iovcnt < 0 {
-        ::syslog::error!("pwritev(): invalid iovcnt {iovcnt}");
+        ::syslog::warn!("pwritev(): invalid iovcnt {iovcnt}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
 
     // Check if vector base is invalid.
     if iov.is_null() {
-        ::syslog::error!("pwritev(): invalid iov {iov:?}");
+        ::syslog::warn!("pwritev(): invalid iov {iov:?}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn pwritev(
 
             // Check if iov is invalid.
             if iov.is_null() {
-                ::syslog::error!("pwritev(): invalid iov {iov:?}");
+                ::syslog::warn!("pwritev(): invalid iov {iov:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov"));
             }
 
@@ -102,13 +102,13 @@ pub unsafe extern "C" fn pwritev(
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {
-                ::syslog::error!("pwritev(): invalid iov_base {iov_base:?}");
+                ::syslog::warn!("pwritev(): invalid iov_base {iov_base:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_base"));
             }
 
             // Check if `iov_len` is invalid.
             if iov_len == 0 {
-                ::syslog::error!("pwritev(): invalid iov_len {iov_len}");
+                ::syslog::warn!("pwritev(): invalid iov_len {iov_len}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_len"));
             }
 
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn pwritev(
                         count
                     },
                     Err(error) => {
-                        ::syslog::error!("pwritev(): write failed (errno={:?})", error);
+                        ::syslog::warn!("pwritev(): write failed (errno={:?})", error);
                         *__errno_location() = error.code.get();
                         return Err(error);
                     },
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn pwritev(
                 Ok(count) => count as c_ssize_t,
                 // Real write failed.
                 Err(error) => {
-                    ::syslog::error!("pwritev(): write failed (errno={:?})", error);
+                    ::syslog::warn!("pwritev(): write failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
                     -1
                 },
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn pwritev(
         },
         // Dry-mode run failed because some other error.
         Err(error) => {
-            ::syslog::error!("pwritev(): dry-run failed (errno={:?})", error);
+            ::syslog::warn!("pwritev(): dry-run failed (errno={:?})", error);
             *__errno_location() = error.code.get();
             -1
         },
@@ -197,14 +197,14 @@ pub unsafe extern "C" fn preadv(
 ) -> c_ssize_t {
     // Check if number of elements in the vector is valid.
     if (iovcnt < 0) || (iovcnt > IOV_MAX as i32) {
-        ::syslog::error!("preadv(): invalid iovcnt {iovcnt}");
+        ::syslog::warn!("preadv(): invalid iovcnt {iovcnt}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
 
     // Check if vector base is invalid.
     if iov.is_null() {
-        ::syslog::error!("preadv(): invalid iov {iov:?}");
+        ::syslog::warn!("preadv(): invalid iov {iov:?}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn preadv(
 
             // Check if base address is invalid.
             if iov.is_null() {
-                ::syslog::error!("preadv(): invalid iov {iov:?}");
+                ::syslog::warn!("preadv(): invalid iov {iov:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov"));
             }
 
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn preadv(
 
             // Check if base address is invalid.
             if iov_base.is_null() {
-                ::syslog::error!("preadv(): invalid iov_base {iov_base:?}");
+                ::syslog::warn!("preadv(): invalid iov_base {iov_base:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_base"));
             }
 
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn preadv(
                         count as c_size_t
                     },
                     Err(error) => {
-                        ::syslog::error!("preadv(): read failed (errno={:?})", error);
+                        ::syslog::warn!("preadv(): read failed (errno={:?})", error);
                         *__errno_location() = error.code.get();
                         return Err(error);
                     },
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn preadv(
             match do_preadv(false) {
                 Ok(count) => count as c_ssize_t,
                 Err(error) => {
-                    ::syslog::error!("preadv(): read failed (errno={:?})", error);
+                    ::syslog::warn!("preadv(): read failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
                     -1
                 },
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn preadv(
         },
         // Dry-run failed because some other error.
         Err(error) => {
-            ::syslog::error!("preadv(): dry-run failed (errno={:?})", error);
+            ::syslog::warn!("preadv(): dry-run failed (errno={:?})", error);
             *__errno_location() = error.code.get();
             -1
         },
@@ -314,14 +314,14 @@ pub unsafe extern "C" fn preadv(
 pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssize_t {
     // Check if number of elements in the vector is valid.
     if (iovcnt < 0) || (iovcnt > IOV_MAX as i32) {
-        ::syslog::error!("readv(): invalid iovcnt {iovcnt}");
+        ::syslog::warn!("readv(): invalid iovcnt {iovcnt}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
 
     // Check if vector base is invalid.
     if iov.is_null() {
-        ::syslog::error!("readv(): invalid iov {iov:?}");
+        ::syslog::warn!("readv(): invalid iov {iov:?}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -340,7 +340,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 
             // Check if base address is invalid.
             if iov.is_null() {
-                ::syslog::error!("readv(): invalid iov {iov:?}");
+                ::syslog::warn!("readv(): invalid iov {iov:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov"));
             }
 
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 
             // Check if base address is invalid.
             if iov_base.is_null() {
-                ::syslog::error!("readv(): invalid iov_base {iov_base:?}");
+                ::syslog::warn!("readv(): invalid iov_base {iov_base:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_base"));
             }
 
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
             match do_readv(false) {
                 Ok(count) => count as c_ssize_t,
                 Err(error) => {
-                    ::syslog::error!("readv(): read failed (errno={:?})", error);
+                    ::syslog::warn!("readv(): read failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
                     -1
                 },
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
         },
         // Dry-run failed because some other error.
         Err(error) => {
-            ::syslog::error!("readv(): dry-run failed (errno={:?})", error);
+            ::syslog::warn!("readv(): dry-run failed (errno={:?})", error);
             *__errno_location() = error.code.get();
             -1
         },
@@ -425,14 +425,14 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> c_ssize_t {
     // Check if number of elements in the vector is valid.
     if iovcnt < 0 {
-        ::syslog::error!("writev(): invalid iovcnt {iovcnt}");
+        ::syslog::warn!("writev(): invalid iovcnt {iovcnt}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
 
     // Check if vector base is invalid.
     if iov.is_null() {
-        ::syslog::error!("writev(): invalid iov {iov:?}");
+        ::syslog::warn!("writev(): invalid iov {iov:?}");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
 
             // Check if iov is invalid.
             if iov.is_null() {
-                ::syslog::error!("writev(): invalid iov {iov:?}");
+                ::syslog::warn!("writev(): invalid iov {iov:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov"));
             }
 
@@ -460,13 +460,13 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {
-                ::syslog::error!("writev(): invalid iov_base {iov_base:?}");
+                ::syslog::warn!("writev(): invalid iov_base {iov_base:?}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_base"));
             }
 
             // Check if `iov_len` is invalid.
             if iov_len == 0 {
-                ::syslog::error!("writev(): invalid iov_len {iov_len}");
+                ::syslog::warn!("writev(): invalid iov_len {iov_len}");
                 return Err(Error::new(ErrorCode::InvalidArgument, "invalid iov_len"));
             }
 
@@ -478,7 +478,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
                 match unistd::syscall::write(fd, buffer) {
                     Ok(count) => count,
                     Err(error) => {
-                        ::syslog::error!("writev(): write failed (errno={:?})", error);
+                        ::syslog::warn!("writev(): write failed (errno={:?})", error);
                         *__errno_location() = error.code.get();
                         return Err(error);
                     },
@@ -500,7 +500,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
                 Ok(count) => count as c_ssize_t,
                 // Real write failed.
                 Err(error) => {
-                    ::syslog::error!("writev(): write failed (errno={:?})", error);
+                    ::syslog::warn!("writev(): write failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
                     -1
                 },
@@ -508,7 +508,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
         },
         // Dry-mode run failed because some other error.
         Err(error) => {
-            ::syslog::error!("writev(): dry-run failed (errno={:?})", error);
+            ::syslog::warn!("writev(): dry-run failed (errno={:?})", error);
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/posix/src/sys/utsname/mod.rs
+++ b/src/libs/posix/src/sys/utsname/mod.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn uname(name: *mut utsname::utsname) -> c_int {
     // Check if name is not valid.
     if name.is_null() {
-        ::syslog::error!("uname(): name is null");
+        ::syslog::warn!("uname(): name is null");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }

--- a/src/libs/posix/src/utime.rs
+++ b/src/libs/posix/src/utime.rs
@@ -49,7 +49,7 @@ mod bindings {
     pub unsafe extern "C" fn utime(filename: *const c_char, times: *const utimbuf) -> c_int {
         // Check if `times` is invalid.
         if times.is_null() {
-            ::syslog::error!("utime(): invalid times (filename={:?}, times={:?})", filename, times);
+            ::syslog::warn!("utime(): invalid times (filename={:?}, times={:?})", filename, times);
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         }

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -298,7 +298,7 @@ fn try_reclaim(talc: &mut Talc<NanvixOomHandler>) {
         let (_, acme) = match allocated_span.get_base_acme() {
             Some(pair) => pair,
             None => {
-                ::syslog::error!("try_reclaim(): non-empty span returned None from get_base_acme");
+                ::syslog::warn!("try_reclaim(): non-empty span returned None from get_base_acme");
                 return;
             },
         };
@@ -306,14 +306,14 @@ fn try_reclaim(talc: &mut Talc<NanvixOomHandler>) {
         let relative_end: usize = match raw_end.checked_sub(base_raw) {
             Some(v) => v,
             None => {
-                ::syslog::error!("try_reclaim(): acme precedes heap base");
+                ::syslog::warn!("try_reclaim(): acme precedes heap base");
                 return;
             },
         };
         match mm::align_up(relative_end, PAGE_ALIGNMENT) {
             Some(v) => v,
             None => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "try_reclaim(): align_up overflow (relative_end={:X?})",
                     relative_end
                 );

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -46,25 +46,25 @@ impl Heap {
 
         // Check if base address is page-aligned.
         if !base.is_aligned(PAGE_ALIGNMENT) {
-            ::syslog::error!("new(): unaligned base address {:X?}", base);
+            ::syslog::warn!("new(): unaligned base address {:X?}", base);
             return Err(Error::new(ErrorCode::BadAddress, "unaligned base address"));
         }
 
         // Check if size is zero.
         if size == 0 {
-            ::syslog::error!("new(): zero size");
+            ::syslog::warn!("new(): zero size");
             return Err(Error::new(ErrorCode::BadAddress, "zero size"));
         }
 
         // Check if capacity is zero.
         if capacity == 0 {
-            ::syslog::error!("new(): zero capacity");
+            ::syslog::warn!("new(): zero capacity");
             return Err(Error::new(ErrorCode::BadAddress, "zero capacity"));
         }
 
         // Check if capacity is smaller than size.
         if capacity < size {
-            ::syslog::error!("new(): capacity is too small");
+            ::syslog::warn!("new(): capacity is too small");
             return Err(Error::new(ErrorCode::BadAddress, "capacity is too small"));
         }
 
@@ -98,19 +98,19 @@ impl Heap {
 
         // Check if increment is page-aligned.
         if !mm::is_aligned(increment, PAGE_ALIGNMENT) {
-            ::syslog::error!("grow(): unaligned increment");
+            ::syslog::warn!("grow(): unaligned increment");
             return Err(Error::new(ErrorCode::BadAddress, "unaligned increment"));
         }
 
         // Check if increment is zero.
         if increment == 0 {
-            ::syslog::error!("grow(): zero increment");
+            ::syslog::warn!("grow(): zero increment");
             return Err(Error::new(ErrorCode::BadAddress, "zero increment"));
         }
 
         // Check if increment would exceed capacity.
         if self.size + increment > self.capacity {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "grow(): exceeds capacity (self.size={:X?}, increment={:X?}, self.capacity={:X?})",
                 self.size,
                 increment,
@@ -146,7 +146,7 @@ impl Heap {
 
         // Check if new size is page-aligned.
         if !mm::is_aligned(new_size, PAGE_ALIGNMENT) {
-            ::syslog::error!("shrink(): unaligned new_size");
+            ::syslog::warn!("shrink(): unaligned new_size");
             return Err(Error::new(ErrorCode::BadAddress, "unaligned new_size"));
         }
 
@@ -167,7 +167,7 @@ impl Heap {
         for page in (new_end..old_end).step_by(mem::PAGE_SIZE).rev() {
             let page_addr: VirtualAddress = VirtualAddress::from_raw_value(page);
             if let Err(error) = kcall::mm::munmap(self.pid, page_addr) {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "shrink(): failed to unmap page at {:X?}, stopping (error={:?})",
                     page_addr,
                     error
@@ -204,7 +204,7 @@ pub fn map_range(
     // against invalid ranges where the end address wraps around the address space.
     if start > end {
         let reason: &str = "map_range(): start address is greater than end address";
-        ::syslog::error!("{reason}");
+        ::syslog::warn!("{reason}");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -216,7 +216,7 @@ pub fn map_range(
     if let Err(error) =
         kcall::mm::mmap(pid, VirtualAddress::new(start), npages, AccessPermission::RDWR)
     {
-        ::syslog::error!(
+        ::syslog::warn!(
             "map_range(): batch mmap failed at {:X?}..{:X?}, npages={} (error={:?})",
             start,
             end,
@@ -252,7 +252,7 @@ pub fn unmap_range(
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
         if let Err(error) = kcall::mm::munmap(pid, vaddr) {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "unmap_range(): failed to unmap page at {:X?}, skipping (error={:?})",
                 vaddr,
                 error

--- a/src/libs/sysalloc/src/tda.rs
+++ b/src/libs/sysalloc/src/tda.rs
@@ -154,7 +154,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     let allocation_alignment: usize = max(tls_alignment, core::mem::align_of::<*mut u8>());
     let allocation_padding_size: usize = align_up(tls_size, allocation_alignment.try_into()?)
         .ok_or_else(|| {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "alloc(): align_up overflow (tls_size={tls_size}, \
                  allocation_alignment={allocation_alignment})"
             );
@@ -177,7 +177,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     // Check if thread-local storage has an invalid alignment.
     if !tls_start_addr.is_multiple_of(tls_alignment) {
         let reason: &'static str = "tls start address is not page-aligned";
-        ::syslog::error!(
+        ::syslog::warn!(
             "alloc(): {reason} (tls_start_addr={tls_start_addr:x?}, tls_alignment={tls_alignment})",
         );
         return Err(Error::new(ErrorCode::ValueOutOfRange, reason));
@@ -188,7 +188,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
         Ok(layout) => layout,
         Err(_error) => {
             let reason: &'static str = "invalid layout for thread-local storage";
-            ::syslog::error!(
+            ::syslog::warn!(
                 "alloc(): {reason} (allocation_size={allocation_size}, \
                  allocation_alignment={allocation_alignment})",
             );
@@ -201,7 +201,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     let allocation: *mut u8 = unsafe { crate::alloc(layout) };
     if allocation.is_null() {
         let reason: &'static str = "out of memory";
-        ::syslog::error!("init(): {reason}");
+        ::syslog::warn!("init(): {reason}");
         return Err(Error::new(ErrorCode::OutOfMemory, reason));
     }
 
@@ -225,7 +225,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     // Compute pointer to thread-local storage.
     // SAFETY: `tda_ptr` is non-null and pointer arithmetic is within bounds.
     let tls_aligned_size: usize = align_up(tls_size, PAGE_ALIGNMENT).ok_or_else(|| {
-        ::syslog::error!("alloc(): align_up overflow (tls_size={tls_size}, tda_ptr={tda_ptr:?})");
+        ::syslog::warn!("alloc(): align_up overflow (tls_size={tls_size}, tda_ptr={tda_ptr:?})");
         Error::new(ErrorCode::OutOfMemory, "align_up overflow")
     })?;
     let tls_ptr: *mut u8 = unsafe { tda_ptr.sub(tls_aligned_size) };
@@ -254,7 +254,7 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
     let tcb_ptr: *mut u8 = match sys::kcall::pm::get_thread_data_area() {
         Ok(ptr) => ptr,
         Err(error) => {
-            ::syslog::error!("cleanup_tda(): {error:?}");
+            ::syslog::warn!("cleanup_tda(): {error:?}");
             return Err(error);
         },
     };
@@ -275,7 +275,7 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
     match sys::kcall::pm::set_thread_data_area(core::ptr::null_mut()) {
         Ok(()) => Ok(()),
         Err(error) => {
-            ::syslog::error!("cleanup_tda(): failed to clear tda pointer (error={error:?})");
+            ::syslog::warn!("cleanup_tda(): failed to clear tda pointer (error={error:?})");
             Err(error)
         },
     }
@@ -309,7 +309,7 @@ fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
     let allocation_alignment: usize = max(tls_alignment, core::mem::align_of::<*mut u8>());
     let allocation_padding_size: usize = align_up(tls_size, allocation_alignment.try_into()?)
         .ok_or_else(|| {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "dealloc(): align_up overflow (tls_size={tls_size}, \
                  allocation_alignment={allocation_alignment})"
             );
@@ -330,7 +330,7 @@ fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
         Ok(layout) => layout,
         Err(_error) => {
             let reason: &'static str = "invalid layout";
-            ::syslog::error!(
+            ::syslog::warn!(
                 "cleanup(): {reason} (allocation_size={allocation_size}, \
                  allocation_align={allocation_alignment})",
             );

--- a/src/libs/sysalloc/src/vaddr.rs
+++ b/src/libs/sysalloc/src/vaddr.rs
@@ -69,14 +69,14 @@ pub fn reserve(length: usize) -> Result<VirtualAddress, Error> {
     // Reject zero-length reservations.
     if length == 0 {
         let reason: &str = "length must be greater than zero";
-        ::syslog::error!("vaddr::reserve(): {reason} (length={length})");
+        ::syslog::warn!("vaddr::reserve(): {reason} (length={length})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
     // Align up length to page size.
     let length: usize = mm::align_up(length, PAGE_ALIGNMENT).ok_or_else(|| {
         let reason: &str = "align_up overflow";
-        ::syslog::error!("vaddr::reserve(): {reason} (length={length})");
+        ::syslog::warn!("vaddr::reserve(): {reason} (length={length})");
         Error::new(ErrorCode::InvalidArgument, reason)
     })?;
 
@@ -86,14 +86,14 @@ pub fn reserve(length: usize) -> Result<VirtualAddress, Error> {
     let base_raw: usize = locked_next.into_raw_value();
     let new_base_raw: usize = base_raw.checked_add(length).ok_or_else(|| {
         let reason: &str = "address overflow when reserving virtual address space";
-        ::syslog::error!("vaddr::reserve(): {reason} (length={length})");
+        ::syslog::warn!("vaddr::reserve(): {reason} (length={length})");
         Error::new(ErrorCode::OutOfMemory, reason)
     })?;
 
     // Check if we have enough space.
     if new_base_raw > MMAP_END_RAW {
         let reason: &str = "not enough virtual address space for reservation";
-        ::syslog::error!("vaddr::reserve(): {reason} (length={length})");
+        ::syslog::warn!("vaddr::reserve(): {reason} (length={length})");
         return Err(Error::new(ErrorCode::OutOfMemory, reason));
     }
 

--- a/src/libs/syscall/src/dirent/bindings/closedir.rs
+++ b/src/libs/syscall/src/dirent/bindings/closedir.rs
@@ -56,7 +56,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn closedir(dirp: *mut DirectoryStream) -> c_int {
     // Check if directory stream is invalid.
     if dirp.is_null() {
-        ::syslog::error!("closedir(): invalid directory stream (dirp={dirp:?})");
+        ::syslog::warn!("closedir(): invalid directory stream (dirp={dirp:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn closedir(dirp: *mut DirectoryStream) -> c_int {
         Ok(()) => 0,
         Err(error) => {
             // We failed, but ownership of `dirp` is now dropped and memory will be freed.
-            ::syslog::error!("closedir(): {error:?} (dirp={dirp:?})");
+            ::syslog::warn!("closedir(): {error:?} (dirp={dirp:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/dirent/bindings/dirfd.rs
+++ b/src/libs/syscall/src/dirent/bindings/dirfd.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn dirfd(dirp: *mut DirectoryStream) -> c_int {
     // Check if directory stream is invalid.
     if dirp.is_null() {
-        ::syslog::error!("dirfd(): invalid directory stream");
+        ::syslog::warn!("dirfd(): invalid directory stream");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }

--- a/src/libs/syscall/src/dirent/bindings/opendir.rs
+++ b/src/libs/syscall/src/dirent/bindings/opendir.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn opendir(dirname: *const i8) -> *mut DirectoryStream {
     // Check if `dirname` is null.
     if dirname.is_null() {
-        ::syslog::error!("opendir(): null dirname (dirname={dirname:?})");
+        ::syslog::warn!("opendir(): null dirname (dirname={dirname:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return ptr::null_mut();
     }
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn opendir(dirname: *const i8) -> *mut DirectoryStream {
     let dirname: &str = match ffi::CStr::from_ptr(dirname).to_str() {
         Ok(dirname) => dirname,
         Err(_) => {
-            ::syslog::error!("opendir(): invalid dirname (dirname={dirname:?})");
+            ::syslog::warn!("opendir(): invalid dirname (dirname={dirname:?})");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return ptr::null_mut();
         },
@@ -73,13 +73,7 @@ pub unsafe extern "C" fn opendir(dirname: *const i8) -> *mut DirectoryStream {
     match dirent::opendir(dirname) {
         Ok(dirp) => Box::into_raw(dirp),
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry
-                || error.code == ErrorCode::OperationNotSupported
-            {
-                ::syslog::warn!("opendir(): {error:?} (dirname={dirname:?})");
-            } else {
-                ::syslog::error!("opendir(): {error:?} (dirname={dirname:?})");
-            }
+            ::syslog::warn!("opendir(): {error:?} (dirname={dirname:?})");
             *__errno_location() = error.code.get();
             ptr::null_mut()
         },

--- a/src/libs/syscall/src/dirent/bindings/readdir.rs
+++ b/src/libs/syscall/src/dirent/bindings/readdir.rs
@@ -65,7 +65,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn readdir(dirp: *mut DirectoryStream) -> *mut dirent {
     // Check if directory stream is invalid.
     if dirp.is_null() {
-        ::syslog::error!("readdir(): invalid directory stream (dirp={dirp:?})");
+        ::syslog::warn!("readdir(): invalid directory stream (dirp={dirp:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return ptr::null_mut();
     }
@@ -85,19 +85,11 @@ pub unsafe extern "C" fn readdir(dirp: *mut DirectoryStream) -> *mut dirent {
         },
         // Error.
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
-                    dirp,
-                    error
-                );
-            } else {
-                ::syslog::error!(
-                    "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
-                    dirp,
-                    error
-                );
-            }
+            ::syslog::warn!(
+                "readdir(): failed to read directory entry (dirp={:?}, error={:?})",
+                dirp,
+                error
+            );
             *__errno_location() = error.code.get();
             ptr::null_mut()
         },

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -13,8 +13,8 @@ use ::sys::error::{
 };
 use ::sysapi::ffi::c_int;
 use ::syslog::{
-    error,
     trace,
+    warn,
 };
 #[cfg(not(feature = "standalone"))]
 use {
@@ -65,7 +65,7 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_getdents(fd, count).map_err(|e| {
                 let code: ErrorCode = e.into();
-                error!("posix_getdents(): VFS getdents failed (fd={fd}, error={e})");
+                warn!("posix_getdents(): VFS getdents failed (fd={fd}, error={e})");
                 Error::new(code, "vfs getdents failed")
             });
         }
@@ -91,14 +91,14 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
     // Build request message.
     let request: Message = GetDirectoryEntriesRequest::build(tid, fd, count).map_err(|error| {
         let reason: &str = "failed to build message";
-        error!("posix_getdents(): {reason} (error={:?})", error);
+        warn!("posix_getdents(): {reason} (error={:?})", error);
         Error::new(error.code, reason)
     })?;
 
     // Send request message.
     ::sys::kcall::ipc::send(&request).map_err(|error| {
         let reason: &str = "failed to send message";
-        error!("posix_getdents(): {reason} (error={:?})", error);
+        warn!("posix_getdents(): {reason} (error={:?})", error);
         Error::new(error.code, reason)
     })?;
 
@@ -106,7 +106,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
     let mut assembler: LinuxDaemonLongMessage =
         LinuxDaemonLongMessage::new(MESSAGE_ASSEMBLER_CAPACITY).map_err(|error| {
             let reason: &str = "failed to create message assembler";
-            error!("posix_getdents(): {reason} (error={:?})", error);
+            warn!("posix_getdents(): {reason} (error={:?})", error);
             Error::new(error.code, reason)
         })?;
 
@@ -114,7 +114,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
         // Wait for response message.
         let response: Message = ::sys::kcall::ipc::recv().map_err(|error| {
             let reason: &str = "failed to receive message";
-            error!("posix_getdents(): {reason} (error={:?})", error);
+            warn!("posix_getdents(): {reason} (error={:?})", error);
             Error::new(error.code, reason)
         })?;
 
@@ -124,12 +124,12 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
             match ErrorCode::try_from(response.status) {
                 Ok(error_code) => {
                     let reason: &str = "system call failed";
-                    error!("posix_getdents(): {reason} (error_code={error_code:?})");
+                    warn!("posix_getdents(): {reason} (error_code={error_code:?})");
                     break Err(Error::new(error_code, reason));
                 },
                 Err(_) => {
                     let reason: &str = "failed to parse error code";
-                    error!("posix_getdents(): {reason} (response.status={})", { response.status });
+                    warn!("posix_getdents(): {reason} (response.status={})", { response.status });
                     break Err(Error::new(ErrorCode::InvalidMessage, reason));
                 },
             }
@@ -145,7 +145,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
                     // Add part to message assembler and check for errors.
                     if let Err(error) = assembler.add_part(part) {
                         let reason: &str = "failed to assemble message";
-                        error!("posix_getdents(): {reason} (error={:?})", error);
+                        warn!("posix_getdents(): {reason} (error={:?})", error);
                         break Err(error);
                     }
 
@@ -159,14 +159,14 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
                     match GetDirectoryEntriesResponse::from_parts(&parts) {
                         Ok(response) => break Ok(response.entries),
                         Err(error) => {
-                            error!("posix_getdents(): invalid message (error={:?})", error);
+                            warn!("posix_getdents(): invalid message (error={:?})", error);
                             break Err(error);
                         },
                     }
                 },
                 header => {
                     let reason: &str = "unexpected message type";
-                    error!("posix_getdents(): {reason} (header={header:?})");
+                    warn!("posix_getdents(): {reason} (header={header:?})");
                     break Err(Error::new(ErrorCode::InvalidMessage, reason));
                 },
             }

--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -38,7 +38,7 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
     // Check if dynamic library file is opened.
     if !registry.contains_key(handle) {
         let reason: &str = "dynamic library file not open";
-        ::syslog::error!("dlclose(): {}", reason);
+        ::syslog::warn!("dlclose(): {}", reason);
         return Err(Error::new(ErrorCode::BadFile, reason));
     }
 

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -100,7 +100,7 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
                 .filter(|h| !handles_before.contains(h))
                 .copied()
                 .collect();
-            ::syslog::error!(
+            ::syslog::warn!(
                 "dlopen(): rolling back {} entries after failure (error={:?})",
                 new_handles.len(),
                 e
@@ -247,7 +247,7 @@ fn resolve_all_symbols(
                 Some(f) => f,
                 None => {
                     // Handle came from dlfiles.keys(), so this should not happen.
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "resolve_all_symbols(): handle {:?} missing from registry",
                         handle
                     );

--- a/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
@@ -32,7 +32,7 @@ pub fn dlsym(handle: &DlHandle, symbol: &str) -> Result<VirtualAddress, Error> {
             Some(addr) => Ok(VirtualAddress::from_raw_value(addr)),
             None => {
                 let reason: &str = "symbol not found in global scope";
-                ::syslog::error!("dlsym(): {}", reason);
+                ::syslog::warn!("dlsym(): {}", reason);
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         };
@@ -47,14 +47,14 @@ pub fn dlsym(handle: &DlHandle, symbol: &str) -> Result<VirtualAddress, Error> {
                 Some((base, offset)) => Ok(VirtualAddress::from_raw_value(base + offset)),
                 None => {
                     let reason: &str = "symbol not found";
-                    ::syslog::error!("dlsym(): {}", reason);
+                    ::syslog::warn!("dlsym(): {}", reason);
                     Err(Error::new(ErrorCode::NoSuchEntry, reason))
                 },
             }
         },
         None => {
             let reason: &str = "dynamic library file not open";
-            ::syslog::error!("dlinfo(): {}", reason);
+            ::syslog::warn!("dlinfo(): {}", reason);
             Err(Error::new(ErrorCode::BadFile, reason))
         },
     }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -141,7 +141,7 @@ impl DynamicLibrary {
             Ok(cstr) => cstr,
             Err(_) => {
                 let reason: &str = "failed to convert filename to C string";
-                ::syslog::error!("open(): {}", reason);
+                ::syslog::warn!("open(): {}", reason);
                 return Err(Error::new(ErrorCode::BadFile, reason));
             },
         };
@@ -152,7 +152,7 @@ impl DynamicLibrary {
         // Check if file is not a regular file.
         if attr.file_type() != FileType::RegularFile {
             let reason: &str = "file is not a regular file";
-            ::syslog::error!("open(): {}", reason);
+            ::syslog::warn!("open(): {}", reason);
             return Err(Error::new(ErrorCode::BadFile, reason));
         }
 
@@ -167,7 +167,7 @@ impl DynamicLibrary {
                 // Check if ELF file is not a dynamic library.
                 if !elf.is_lib {
                     let reason: &str = "file is not a dynamic library";
-                    ::syslog::error!("load(): {}", reason);
+                    ::syslog::warn!("load(): {}", reason);
                     return Err(Error::new(ErrorCode::BadFile, reason));
                 }
 
@@ -201,7 +201,7 @@ impl DynamicLibrary {
                             // Check if program headers overlap.
                             if base < end_address.into_raw_value() {
                                 let reason: &str = "program headers overlap";
-                                ::syslog::error!("load(): {} (phdr={:#x?}", reason, phdr);
+                                ::syslog::warn!("load(): {} (phdr={:#x?}", reason, phdr);
                                 return Err(Error::new(ErrorCode::BadFile, reason));
                             }
 
@@ -211,7 +211,7 @@ impl DynamicLibrary {
                                 mm::align_up(offset + phdr.p_memsz as usize, PAGE_ALIGNMENT)
                                     .ok_or_else(|| {
                                         let reason: &str = "align_up overflow";
-                                        ::syslog::error!(
+                                        ::syslog::warn!(
                                             "load(): {reason} (p_memsz={}, vaddr={:#x}, \
                                              base={:#x})",
                                             phdr.p_memsz,
@@ -223,7 +223,7 @@ impl DynamicLibrary {
                             let end_raw: usize =
                                 base.into_raw_value().checked_add(capacity).ok_or_else(|| {
                                     let reason: &str = "end_address overflow";
-                                    ::syslog::error!(
+                                    ::syslog::warn!(
                                         "load(): {reason} (base={:#x}, capacity={capacity})",
                                         base.into_raw_value()
                                     );
@@ -264,7 +264,7 @@ impl DynamicLibrary {
                         section_headers.insert(section_name.to_string(), section.clone())
                     {
                         let reason: &str = "duplicate section header";
-                        ::syslog::error!("load(): {} (section.name={:?})", reason, section_name);
+                        ::syslog::warn!("load(): {} (section.name={:?})", reason, section_name);
                         return Err(Error::new(ErrorCode::BadFile, reason));
                     }
                 }
@@ -274,7 +274,7 @@ impl DynamicLibrary {
                     Some(dynsym) => dynsym,
                     None => {
                         let reason: &str = "missing dynamic symbol table";
-                        ::syslog::error!("load(): {}", reason);
+                        ::syslog::warn!("load(): {}", reason);
                         return Err(Error::new(ErrorCode::BadFile, reason));
                     },
                 };
@@ -282,7 +282,7 @@ impl DynamicLibrary {
                     Some(dynstr) => dynstr,
                     None => {
                         let reason: &str = "missing dynamic string table";
-                        ::syslog::error!("load(): {}", reason);
+                        ::syslog::warn!("load(): {}", reason);
                         return Err(Error::new(ErrorCode::BadFile, reason));
                     },
                 };
@@ -305,7 +305,7 @@ impl DynamicLibrary {
             },
             Err(error) => {
                 let reason: &str = "failed to parse ELF file";
-                ::syslog::error!("load(): {} (error={:?})", reason, error);
+                ::syslog::warn!("load(): {} (error={:?})", reason, error);
                 Err(Error::new(ErrorCode::IoErr, reason))
             },
         }
@@ -347,7 +347,7 @@ impl DynamicLibrary {
                 let aligned_end: usize =
                     mm::align_up(unaligned_end, PAGE_ALIGNMENT).ok_or_else(|| {
                         let reason: &str = "align_up overflow in compute_load_size";
-                        ::syslog::error!("compute_load_size(): {reason}");
+                        ::syslog::warn!("compute_load_size(): {reason}");
                         Error::new(ErrorCode::BadFile, reason)
                     })?;
                 if aligned_end > max_end {
@@ -357,7 +357,7 @@ impl DynamicLibrary {
         }
         if max_end == 0 {
             let reason: &str = "no loadable segments found";
-            ::syslog::error!("compute_load_size(): {}", reason);
+            ::syslog::warn!("compute_load_size(): {}", reason);
             return Err(Error::new(ErrorCode::BadFile, reason));
         }
         Ok(max_end - min_base)
@@ -551,7 +551,7 @@ impl DynamicLibrary {
             Ok(sym)
         } else {
             let reason: &str = "invalid symbol index";
-            ::syslog::error!("get_symbol(): {} (rel={:?})", reason, rel);
+            ::syslog::warn!("get_symbol(): {} (rel={:?})", reason, rel);
             Err(Error::new(ErrorCode::BadFile, reason))
         }
     }
@@ -562,7 +562,7 @@ impl DynamicLibrary {
             Some((base, symbol_value)) => base + symbol_value,
             None => {
                 let reason: &str = "symbol not found";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "get_symbol_value(): {} (symbol_name={:?}, symbol={:?})",
                     reason,
                     symbol_name,
@@ -643,7 +643,7 @@ impl DynamicLibrary {
                 // R_386_RELATIVE relocation must have a zero symbol index.
                 if rel.symbol_index() != 0 {
                     let reason: &str = "invalid R_386_RELATIVE relocation";
-                    ::syslog::error!("resolve(): {} (rel={:?})", reason, rel);
+                    ::syslog::warn!("resolve(): {} (rel={:?})", reason, rel);
                     return Err(Error::new(ErrorCode::BadFile, reason));
                 }
 
@@ -690,7 +690,7 @@ impl DynamicLibrary {
 
             relocation_entry_type => {
                 let reason: &str = "unsupported relocation type";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "resolve(): {} (relocation_type={:?}, rel={:?})",
                     reason,
                     relocation_entry_type,
@@ -874,12 +874,12 @@ impl DynamicLibrary {
             },
             Some(Some(_)) => {
                 let reason: &str = "dependency already loaded";
-                ::syslog::error!("load_dependency(): {}", reason);
+                ::syslog::warn!("load_dependency(): {}", reason);
                 Err(Error::new(ErrorCode::BadFile, reason))
             },
             None => {
                 let reason: &str = "dependency not listed";
-                ::syslog::error!("load_dependency(): {}", reason);
+                ::syslog::warn!("load_dependency(): {}", reason);
                 Err(Error::new(ErrorCode::BadFile, reason))
             },
         }

--- a/src/libs/syscall/src/fcntl/bindings/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/bindings/fcntl.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, args: ...) -> c_int {
     let cmd: FileControlRequest = match FileControlRequest::try_from((cmd, args)) {
         Ok(cmd) => cmd,
         Err(error) => {
-            ::syslog::error!("fcntl(): invalid command ({error:?}, fd={fd:?}, cmd={cmd:?})");
+            ::syslog::warn!("fcntl(): invalid command ({error:?}, fd={fd:?}, cmd={cmd:?})");
             *__errno_location() = error.code.get();
             return -1;
         },
@@ -36,11 +36,7 @@ pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, args: ...) -> c_int {
     match file::fcntl(fd, &cmd) {
         Ok(ret) => ret,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
-            } else {
-                ::syslog::error!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
-            }
+            ::syslog::warn!("fcntl(): failed ({error:?}, fd={fd:?}, cmd={cmd:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/bindings/open.rs
+++ b/src/libs/syscall/src/fcntl/bindings/open.rs
@@ -77,17 +77,7 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -
     match fcntl::open(pathname, flags, mode) {
         Ok(fd) => fd,
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry
-                || error.code == ErrorCode::OperationNotSupported
-            {
-                ::syslog::warn!(
-                    "open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})"
-                );
-            }
+            ::syslog::warn!("open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
+++ b/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
@@ -52,17 +52,10 @@ pub unsafe extern "C" fn posix_fadvise(
     match fcntl::posix_fadvise(fd, offset, len, advice) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
-                     advice={advice:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
-                     advice={advice:?})"
-                );
-            }
+            ::syslog::warn!(
+                "posix_fadvise(): failed (fd={fd:?}, offset={offset:?}, len={len:?}, \
+                 advice={advice:?})"
+            );
 
             error.code.get()
         },

--- a/src/libs/syscall/src/fcntl/bindings/posix_fallocate.rs
+++ b/src/libs/syscall/src/fcntl/bindings/posix_fallocate.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -
     match fcntl::posix_fallocate(fd, offset, len) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "posix_fallocate(): {error:?} (fd={fd:?}, offset={offset:?}, len={len:?})",
             );
             error.code.get()

--- a/src/libs/syscall/src/fcntl/bindings/renameat.rs
+++ b/src/libs/syscall/src/fcntl/bindings/renameat.rs
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn renameat(
 ) -> c_int {
     // Check if `oldpath` is null.
     if oldpath.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "renameat(): oldpath is null (olddirfd={olddirfd:?}, newdirfd={newdirfd:?}, \
              oldpath={oldpath:?}, newpath={newpath:?})"
         );
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn renameat(
 
     // Check if `newpath` is null.
     if newpath.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "renameat(): newpath is null (olddirfd={olddirfd:?}, newdirfd={newdirfd:?}, \
              oldpath={oldpath:?}, newpath={newpath:?})"
         );
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn renameat(
     let old_pathname: &str = match ffi::CStr::from_ptr(oldpath).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "renameat(): invalid old pathname (olddirfd={olddirfd:?}, newdirfd={newdirfd:?}, \
                  oldpath={oldpath:?}, newpath={newpath:?})"
             );
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn renameat(
     let new_pathname: &str = match ffi::CStr::from_ptr(newpath).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "renameat(): invalid new pathname (olddirfd={olddirfd:?}, newdirfd={newdirfd:?}, \
                  oldpath={old_pathname:?}, newpath={newpath:?})"
             );
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn renameat(
         Ok(()) => 0,
         // System call failed.
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "renameat(): {error:?} (olddirfd={olddirfd:?}, oldpath={old_pathname:?}, \
                  newdirfd={newdirfd:?}, newpath={new_pathname:?}, error={error:?})"
             );

--- a/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
@@ -50,7 +50,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: c_int) -> c_int {
     // Check if `pathname` is null.
     if pathname.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "unlinkat(): null pathname (dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: 
     let path: &str = match ffi::CStr::from_ptr(pathname).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "unlinkat(): invalid pathname (dirfd={dirfd:?}, pathname={pathname:?}, \
                  flags={flags:?})"
             );
@@ -76,17 +76,9 @@ pub unsafe extern "C" fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: 
         Ok(()) => 0,
         // System call failed.
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry {
-                ::syslog::warn!(
-                    "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, \
-                     flags={flags:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, \
-                     flags={flags:?})"
-                );
-            }
+            ::syslog::warn!(
+                "unlinkat(): {error:?} (dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -104,7 +104,7 @@ impl RenameAtRequest {
         // Check if `oldpath` is too long.
         if oldpath.len() > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!(
+            ::syslog::warn!(
                 "renameat(): oldpath is too long (olddirfd={:?}, oldpath={:?}, newdirfd={:?}, \
                  newpath={:?})",
                 olddirfd,
@@ -118,7 +118,7 @@ impl RenameAtRequest {
         // Check if `newpath` is too long.
         if newpath.len() > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!(
+            ::syslog::warn!(
                 "renameat(): newpath is too long (olddirfd={:?}, oldpath={:?}, newdirfd={:?}, \
                  newpath={:?})",
                 olddirfd,
@@ -169,14 +169,14 @@ impl MessageDeserializer for RenameAtRequest {
         // Check if the message is too short.
         if bytes.len() < Self::OFFSET_OLDPATH {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too short (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too short (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too short"));
         }
 
         // Check if the message is too long.
         if bytes.len() > Self::MAX_SIZE {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too long (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too long (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too long"));
         }
 
@@ -216,14 +216,14 @@ impl MessageDeserializer for RenameAtRequest {
         // Check if the message is too short.
         if bytes.len() < Self::OFFSET_OLDPATH + oldpath_len as usize {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too short (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too short (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too short"));
         }
 
         // Check if `oldpath` is too long.
         if oldpath_len as usize > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!(
+            ::syslog::warn!(
                 "try_from_bytes(): oldpath is too long (olddirfd={:?}, oldpath={:?}, \
                  newdirfd={:?}, newpath={:?})",
                 olddirfd,
@@ -243,14 +243,14 @@ impl MessageDeserializer for RenameAtRequest {
         // Check if the message is too short.
         if bytes.len() < Self::OFFSET_OLDPATH + oldpath_len as usize + newpath_len as usize {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too short (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too short (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too short"));
         }
 
         // Check if `newpath` is too long.
         if newpath_len as usize > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!(
+            ::syslog::warn!(
                 "try_from_bytes(): newpath is too long (olddirfd={:?}, oldpath={:?}, \
                  newdirfd={:?}, newpath={:?})",
                 olddirfd,

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -97,7 +97,7 @@ impl UnlinkAtRequest {
         // Check if pathname is too long.
         if pathname.len() > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!(
+            ::syslog::warn!(
                 "new(): pathname is too long (dirfd={:?}, pathname={:?}, flags={:?})",
                 dirfd,
                 pathname,
@@ -140,14 +140,14 @@ impl MessageDeserializer for UnlinkAtRequest {
         // Check if the message is too short.
         if bytes.len() < Self::OFFSET_OF_PATHNAME {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too short (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too short (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too short"));
         }
 
         // Check if the message is too long.
         if bytes.len() > Self::MAX_SIZE {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too long (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too long (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too long"));
         }
 
@@ -180,14 +180,14 @@ impl MessageDeserializer for UnlinkAtRequest {
         // Check if the message is too short.
         if bytes.len() < Self::OFFSET_OF_PATHNAME + pathname_len {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message is too short (len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message is too short (len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "message is too short"));
         }
 
         // Check if `pathname` is too long.
         if pathname_len > NAME_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): pathname is too long (len={:?})", pathname_len);
+            ::syslog::warn!("try_from_bytes(): pathname is too long (len={:?})", pathname_len);
             return Err(Error::new(ErrorCode::InvalidArgument, "pathname is too long"));
         }
 

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -52,7 +52,7 @@ pub fn posix_fadvise(
     len: off_t,
     advice: c_int,
 ) -> Result<(), Error> {
-    ::syslog::error!(
+    ::syslog::trace!(
         "posix_fadvise(): fd={:?}, offset={:?}, len={:?}, advice={:?}",
         fd,
         offset,
@@ -96,7 +96,7 @@ fn posix_fadvise_linuxd(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "posix_fadvise(): failed (fd={:?}, offset={:?}, len={:?}, advice={:?}, status={:?})",
             fd,
             offset,
@@ -111,7 +111,7 @@ fn posix_fadvise_linuxd(
             Ok(error_code) => Err(Error::new(error_code, "posix_fadvise() failed")),
             // Error code was not successfully parsed.
             Err(error) => {
-                ::syslog::error!("posix_fadvise(): invalid error code (error={:?})", error);
+                ::syslog::warn!("posix_fadvise(): invalid error code (error={:?})", error);
                 Err(Error::new(ErrorCode::TryAgain, "posix_fadvise(): failed"))
             },
         }
@@ -124,7 +124,7 @@ fn posix_fadvise_linuxd(
             LinuxDaemonMessageHeader::FileAdvisoryInformationResponse => Ok(()),
             header => {
                 // Response was not successfully parsed.
-                ::syslog::error!(
+                ::syslog::warn!(
                     "posix_fadvise(): unexpected message header (fd={:?}, offset={:?}, len={:?}, \
                      advice={:?}, header={:?})",
                     fd,

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -77,7 +77,7 @@ fn posix_fallocate_linuxd(fd: RawFileDescriptor, offset: off_t, len: off_t) -> R
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "posix_fallocate(): failed (fd={:?}, offset={:?}, len={:?}, status={:?})",
             fd,
             offset,
@@ -91,7 +91,7 @@ fn posix_fallocate_linuxd(fd: RawFileDescriptor, offset: off_t, len: off_t) -> R
             Ok(error_code) => Err(Error::new(error_code, "posix_fallocate() failed")),
             // Error was not parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "posix_fallocate(): failed (fd={:?}, offset={:?}, len={:?}, error={:?})",
                     fd,
                     offset,
@@ -110,7 +110,7 @@ fn posix_fallocate_linuxd(fd: RawFileDescriptor, offset: off_t, len: off_t) -> R
             LinuxDaemonMessageHeader::FileSpaceControlResponse => Ok(()),
             // Response was not parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "posix_fallocate(): invalid response (fd={:?}, offset={:?}, len={:?}, \
                      header={:?})",
                     fd,

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -76,7 +76,7 @@ fn fcntl_linuxd(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
 
     // Check whether system call succeeded or not.
     if response.status == -1 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "fcntl(): failed (fd={:?}, cmd={:?}, arg={:?}, status={:?})",
             fd,
             cmd,
@@ -93,7 +93,7 @@ fn fcntl_linuxd(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
             },
             // Error code was not successfully parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fcntl(): failed to parse error code (fd={:?}, cmd={:?}, arg={:?}, error={:?})",
                     fd,
                     cmd,
@@ -117,7 +117,7 @@ fn fcntl_linuxd(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
             },
             // Response was not successfully parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fcntl(): invalid response (fd={:?}, cmd={:?}, arg={:?}, header={:?})",
                     fd,
                     cmd,

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -77,33 +77,21 @@ fn openat_linuxd(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Resu
         match ErrorCode::try_from(response.status) {
             // Succeeded to parse error code.
             Ok(error_code) => {
-                if error_code == ErrorCode::NoSuchEntry {
-                    ::syslog::warn!(
-                        "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, \
-                         error={:?})",
-                        dirfd,
-                        pathname,
-                        flags,
-                        mode,
-                        error_code
-                    );
-                } else {
-                    ::syslog::error!(
-                        "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, \
-                         error={:?})",
-                        dirfd,
-                        pathname,
-                        flags,
-                        mode,
-                        error_code
-                    );
-                }
+                ::syslog::warn!(
+                    "openat(): failed (dirfd={:?}, pathname={:?}, flags={:?}, mode={:?}, \
+                     error={:?})",
+                    dirfd,
+                    pathname,
+                    flags,
+                    mode,
+                    error_code
+                );
                 // Return error.
                 Err(Error::new(error_code, "openat() failed"))
             },
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "openat(): failed to parse error code (dirfd={:?}, pathname={:?}, flags={:?}, \
                      mode={:?}, error={:?})",
                     dirfd,

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -96,7 +96,7 @@ fn renameat_linuxd(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "renameat(): failed (olddirfd={:?}, oldpath={:?}, newdirfd={:?}, newpath={:?}, \
              error_code={:?})",
             olddirfd,
@@ -114,7 +114,7 @@ fn renameat_linuxd(
             },
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "renameat(): failed to parse error code (olddirfd={:?}, oldpath={:?}, \
                      newdirfd={:?}, newpath={:?}, error={:?})",
                     olddirfd,
@@ -133,7 +133,7 @@ fn renameat_linuxd(
             LinuxDaemonMessageHeader::RenameAtResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "renameat(): {:?} (olddirfd={:?}, oldpath={:?}, newdirfd={:?}, newpath={:?}, \
                      header={:?})",
                     reason,

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -80,7 +80,7 @@ fn unlinkat_linuxd(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Re
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "unlinkat(): failed (dirfd={}, pathname={}, flags={}, error_code={})",
             dirfd,
             pathname,
@@ -93,7 +93,7 @@ fn unlinkat_linuxd(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Re
             Ok(error_code) => Err(Error::new(error_code, "unlinkat() failed")),
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "unlinkat(): failed to parse error code (dirfd={:?}, pathname={:?}, \
                      flags={:?}, error={:?})",
                     dirfd,
@@ -112,7 +112,7 @@ fn unlinkat_linuxd(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Re
             LinuxDaemonMessageHeader::UnlinkAtResponse => Ok(()),
             // Response was not parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "unlinkat(): failed to parse response (dirfd={:?}, pathname={:?}, flags={:?}, \
                      header={:?})",
                     dirfd,

--- a/src/libs/syscall/src/poll/bindings.rs
+++ b/src/libs/syscall/src/poll/bindings.rs
@@ -80,11 +80,7 @@ pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) ->
             ready.len() as c_int
         },
         Err(error) => unsafe {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!("poll(): failed (error={:?})", error);
-            } else {
-                ::syslog::error!("poll(): failed (error={:?})", error);
-            }
+            ::syslog::warn!("poll(): failed (error={:?})", error);
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -186,7 +186,7 @@ fn poll_linuxd(
                     break Err(Error::new(error_code, reason));
                 },
                 Err(error) => {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "poll(): failed to parse error code (fds={fds:?}, timeout={timeout:?}, \
                          error={error:?})"
                     );
@@ -200,7 +200,7 @@ fn poll_linuxd(
         {
             Ok(m) => m,
             Err(error) => {
-                ::syslog::error!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
+                ::syslog::warn!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
                 break Err(error);
             },
         };
@@ -212,7 +212,7 @@ fn poll_linuxd(
 
                 // Add response part to message assembler and check for errors.
                 if let Err(e) = assembler.add_part(part) {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "poll(): failed to assemble response (fds={fds:?}, timeout={timeout:?})"
                     );
                     break Err(e);
@@ -240,14 +240,14 @@ fn poll_linuxd(
                         break Ok(ready);
                     },
                     Err(error) => {
-                        ::syslog::error!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
+                        ::syslog::warn!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
                         break Err(error);
                     },
                 }
             },
             _ => {
                 let reason: &'static str = "unexpected message header";
-                ::syslog::error!("poll(): {reason} (fds={fds:?}, timeout={timeout:?})");
+                ::syslog::warn!("poll(): {reason} (fds={fds:?}, timeout={timeout:?})");
                 break Err(Error::new(ErrorCode::InvalidMessage, reason));
             },
         }

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
@@ -61,7 +61,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_int {
     // Check if `attr` is points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_destroy(): invalid pointer to thread attributes object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_in
 
     // Check if `attr` points to a misaligned address.
     if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_destroy(): misaligned pointer to thread attributes object \
              (attr={attr:p})"
         );

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_getstack.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_getstack.rs
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
 ) -> c_int {
     // Check if `attr` points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): invalid pointer to thread attributes object (attr={attr:p}, \
              stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
     }
     // Check if `attr` is misaligned.
     if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): misaligned pointer to thread attributes object \
              (attr={attr:p}, stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
 
     // Check if `stackaddr` points to an invalid address.
     if stackaddr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): invalid pointer to stack address (attr={attr:p}, \
              stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
 
     // Check if `stackaddr` is misaligned.
     if !(stackaddr as usize).is_multiple_of(core::mem::align_of::<*mut c_void>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): misaligned pointer to stack address (attr={attr:p}, \
              stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
 
     // Check if `stacksize` points to an invalid address.
     if stacksize.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): invalid pointer to stack size (attr={attr:p}, \
              stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn pthread_attr_getstack(
 
     // Check if `stacksize` is misaligned.
     if !(stacksize as usize).is_multiple_of(core::mem::align_of::<c_size_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_getstack(): misaligned pointer to stack size (attr={attr:p}, \
              stackaddr={stackaddr:p}, stacksize={stacksize:p})"
         );

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
@@ -64,7 +64,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int {
     // Check if `attr` is points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_init(): invalid pointer to thread attributes object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int {
 
     // Check if `attr` points to a misaligned address.
     if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_attr_init(): misaligned pointer to thread attributes object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_broadcast.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_broadcast.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_cond_broadcast(cond: *const pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_broadcast(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_broadcast(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_destroy.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_destroy(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_destroy(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_init.rs
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn pthread_cond_init(
 ) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_init(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_init(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_signal.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_signal.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_cond_signal(cond: *const pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_signal(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_signal(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_timedwait.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_timedwait.rs
@@ -56,19 +56,19 @@ pub unsafe extern "C" fn pthread_cond_timedwait(
 ) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_timedwait(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_timedwait(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_cond_timedwait(): invalid mutex pointer");
+        ::syslog::warn!("pthread_cond_timedwait(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `abstime` is not valid.
     if abstime.is_null() {
-        ::syslog::error!("pthread_cond_timedwait(): invalid absolute time pointer");
+        ::syslog::warn!("pthread_cond_timedwait(): invalid absolute time pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn pthread_cond_timedwait(
         match SystemTime::new((*abstime).tv_sec as u64, (*abstime).tv_nsec as u32) {
             Some(timeout) => timeout,
             None => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "pthread_cond_timedwait(): invalid timeout (cond={:?}, mutex={:?}, \
                      abstime={:?})",
                     cond,
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn pthread_cond_timedwait(
     match crate::pthread::pthread_cond_timedwait(&*cond, &*mutex, Some(timeout)) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pthread_cond_timedwait(): failed to wait on condition variable (cond={:?}, \
                  mutex={:?}, abstime={:?}, error={:?})",
                 cond,

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_wait.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_wait.rs
@@ -50,13 +50,13 @@ pub unsafe extern "C" fn pthread_cond_wait(
 ) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {
-        ::syslog::error!("pthread_cond_wait(): invalid condition variable pointer");
+        ::syslog::warn!("pthread_cond_wait(): invalid condition variable pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_cond_wait(): invalid mutex pointer");
+        ::syslog::warn!("pthread_cond_wait(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
@@ -45,7 +45,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> c_int {
     // Check if pointer to cond attribute object is valid.
     if attr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_condattr_init(): invalid pointer to cond attribute object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn pthread_condattr_init(attr: *mut pthread_condattr_t) ->
 
     // Check if pointer to cond attribute object is properly aligned.
     if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_condattr_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_condattr_init(): misaligned pointer to cond attribute object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();

--- a/src/libs/syscall/src/pthread/bindings/pthread_create.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_create.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn pthread_create(
 ) -> c_int {
     // Check if `thread` is not valid.
     if thread.is_null() {
-        ::syslog::error!("pthread_create(): invalid thread pointer");
+        ::syslog::warn!("pthread_create(): invalid thread pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
@@ -57,7 +57,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_getattr_np(thread: pthread_t, attr: *mut pthread_attr_t) -> c_int {
     // Check if `attr` points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_getattr_np(): invalid pointer to thread attributes object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn pthread_getattr_np(thread: pthread_t, attr: *mut pthrea
 
     // Check if `attr` points to a misaligned address.
     if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_getattr_np(): misaligned pointer to thread attributes object (attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();

--- a/src/libs/syscall/src/pthread/bindings/pthread_key_create.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_key_create.rs
@@ -28,13 +28,13 @@ pub unsafe extern "C" fn pthread_key_create(
 ) -> c_int {
     // Check if storage location for the key is valid.
     if key_ptr.is_null() {
-        ::syslog::error!("pthread_key_create(): invalid storage location for thread key");
+        ::syslog::warn!("pthread_key_create(): invalid storage location for thread key");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if destructor is not null.
     if destructor.is_some() {
-        ::syslog::error!("pthread_key_create(): destructors are not supported");
+        ::syslog::warn!("pthread_key_create(): destructors are not supported");
         return ErrorCode::OperationNotSupported.get();
     }
 
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn pthread_key_create(
             0
         },
         None => {
-            ::syslog::error!("pthread_key_create(): failed to create key");
+            ::syslog::warn!("pthread_key_create(): failed to create key");
             ErrorCode::OutOfMemory.get()
         },
     }

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_destroy.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_mutex_destroy(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_destroy(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_destroy(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_init.rs
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn pthread_mutex_init(
 ) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_init(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_init(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_lock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_lock.rs
@@ -42,14 +42,14 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_mutex_lock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_lock(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_lock(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 
     match crate::pthread::pthread_mutex_lock(&mut *mutex) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!("pthread_mutex_lock(): failed to lock mutex (error={:?})", error);
+            ::syslog::warn!("pthread_mutex_lock(): failed to lock mutex (error={:?})", error);
             error.code.get()
         },
     }

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_unlock.rs
@@ -42,7 +42,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {
-        ::syslog::error!("pthread_mutex_unlock(): invalid mutex pointer");
+        ::syslog::warn!("pthread_mutex_unlock(): invalid mutex pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
@@ -43,19 +43,19 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {
-        ::syslog::error!("pthread_rwlock_destroy(): invalid read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_destroy(): invalid read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `rwlock` is unaligned.
     if !(rwlock as usize).is_multiple_of(align_of::<pthread_rwlock_t>()) {
-        ::syslog::error!("pthread_rwlock_destroy(): unaligned read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_destroy(): unaligned read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Attempt to destroy the read-write lock and check for errors.
     if let Err(error) = crate::pthread::pthread_rwlock_destroy(&mut *rwlock) {
-        ::syslog::error!("pthread_rwlock_destroy(): {error:?} (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_destroy(): {error:?} (rwlock={rwlock:p})");
         return error.code.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn pthread_rwlock_init(
 ) -> c_int {
     // Check if `rwlock` is invalid.
     if rwlock.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_rwlock_init(): invalid read-write lock (rwlock={rwlock:p}, attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn pthread_rwlock_init(
 
     // Check if `rwlock` is unaligned.
     if !(rwlock as usize).is_multiple_of(align_of::<pthread_rwlock_t>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pthread_rwlock_init(): unaligned read-write lock (rwlock={rwlock:p}, attr={attr:p})"
         );
         return ErrorCode::InvalidArgument.get();
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn pthread_rwlock_init(
     if !attr.is_null() {
         // Check if `attr` is unaligned.
         if !(attr as usize).is_multiple_of(align_of::<pthread_rwlockattr_t>()) {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pthread_rwlock_init(): unaligned read-write lock attribute (rwlock={rwlock:p}, \
                  attr={attr:p})"
             );
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn pthread_rwlock_init(
 
     // Attempt to initialize read-write lock and check for errors.
     if let Err(error) = crate::pthread::pthread_rwlock_init(&mut *rwlock, &attr) {
-        ::syslog::error!("pthread_rwlock_init(): {error:?} (rwlock={rwlock:p}, attr={attr:?})");
+        ::syslog::warn!("pthread_rwlock_init(): {error:?} (rwlock={rwlock:p}, attr={attr:?})");
         return error.code.get();
     }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
@@ -43,13 +43,13 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {
-        ::syslog::error!("pthread_rwlock_rdlock(): invalid read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_rdlock(): invalid read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `rwlock` is unaligned.
     if !(rwlock as usize).is_multiple_of(align_of::<pthread_rwlock_t>()) {
-        ::syslog::error!("pthread_rwlock_rdlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_rdlock(): unaligned read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut pthread_rwlock_t) ->
     match crate::pthread::pthread_rwlock_rdlock(&mut *rwlock) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("pthread_rwlock_rdlock(): {error:?} (rwlock={rwlock:p})");
+            ::syslog::warn!("pthread_rwlock_rdlock(): {error:?} (rwlock={rwlock:p})");
             error.code.get()
         },
     }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
@@ -43,13 +43,13 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {
-        ::syslog::error!("pthread_rwlock_unlock(): invalid read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_unlock(): invalid read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `rwlock` is unaligned.
     if !(rwlock as usize).is_multiple_of(align_of::<pthread_rwlock_t>()) {
-        ::syslog::error!("pthread_rwlock_unlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_unlock(): unaligned read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut pthread_rwlock_t) ->
     match crate::pthread::pthread_rwlock_unlock(&mut *rwlock) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("pthread_rwlock_unlock(): {error:?} (rwlock={rwlock:p})");
+            ::syslog::warn!("pthread_rwlock_unlock(): {error:?} (rwlock={rwlock:p})");
             error.code.get()
         },
     }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
@@ -43,13 +43,13 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {
-        ::syslog::error!("pthread_rwlock_wrlock(): invalid read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_wrlock(): invalid read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
     // Check if `rwlock` is unaligned.
     if !(rwlock as usize).is_multiple_of(align_of::<pthread_rwlock_t>()) {
-        ::syslog::error!("pthread_rwlock_wrlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        ::syslog::warn!("pthread_rwlock_wrlock(): unaligned read-write lock (rwlock={rwlock:p})");
         return ErrorCode::InvalidArgument.get();
     }
 
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut pthread_rwlock_t) ->
     match crate::pthread::pthread_rwlock_wrlock(&mut *rwlock) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("pthread_rwlock_wrlock(): {error:?} (rwlock={rwlock:p})");
+            ::syslog::warn!("pthread_rwlock_wrlock(): {error:?} (rwlock={rwlock:p})");
             error.code.get()
         },
     }

--- a/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
@@ -40,7 +40,7 @@ use ::syslog::trace_libcall;
 pub unsafe extern "C" fn pthread_setcancelstate(state: c_int, oldstate: *mut c_int) -> c_int {
     // Check if `oldstate` is not valid.
     if oldstate.is_null() {
-        ::syslog::error!("pthread_setcancelstate(): invalid old state pointer");
+        ::syslog::warn!("pthread_setcancelstate(): invalid old state pointer");
         return ErrorCode::InvalidArgument.get();
     }
 

--- a/src/libs/syscall/src/pthread/syscall/cond.rs
+++ b/src/libs/syscall/src/pthread/syscall/cond.rs
@@ -66,7 +66,7 @@ pub fn pthread_cond_broadcast(cond: &pthread_cond_t) -> Result<(), Error> {
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::error!("pthread_cond_broadcast(): {}", reason);
+            ::syslog::warn!("pthread_cond_broadcast(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -92,7 +92,7 @@ pub fn pthread_cond_init(
     } else {
         // Condition variable is already initialized.
         let reason: &str = "condition variable is already initialized";
-        ::syslog::error!("pthread_cond_init(): {}", reason);
+        ::syslog::warn!("pthread_cond_init(): {}", reason);
         Err(Error::new(ErrorCode::ResourceBusy, reason))
     }
 }
@@ -108,7 +108,7 @@ pub fn pthread_cond_destroy(cond: &mut pthread_cond_t) -> Result<(), Error> {
             return Ok(());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::error!("pthread_cond_destroy(): {}", reason);
+            ::syslog::warn!("pthread_cond_destroy(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -130,7 +130,7 @@ pub fn pthread_cond_signal(cond: &pthread_cond_t) -> Result<(), Error> {
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::error!("pthread_cond_signal(): {}", reason);
+            ::syslog::warn!("pthread_cond_signal(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -157,7 +157,7 @@ pub fn pthread_cond_timedwait(
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::error!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_wait_cond(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -173,7 +173,7 @@ pub fn pthread_cond_timedwait(
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_wait_cond(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -197,7 +197,7 @@ pub fn pthread_cond_wait(cond: &pthread_cond_t, mutex: &pthread_mutex_t) -> Resu
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::error!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_wait_cond(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -213,7 +213,7 @@ pub fn pthread_cond_wait(cond: &pthread_cond_t, mutex: &pthread_mutex_t) -> Resu
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_wait_cond(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -154,7 +154,7 @@ pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
     let tid: ThreadIdentifier = match thread.try_into() {
         Ok(tid) => tid,
         Err(error) => {
-            ::syslog::error!("pthread_join(): {error:?} (thread={thread:?})");
+            ::syslog::warn!("pthread_join(): {error:?} (thread={thread:?})");
             return Err(error);
         },
     };

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -60,7 +60,7 @@ pub fn pthread_mutex_init(
         Ok(())
     } else {
         let reason: &str = "mutex is not initialized";
-        ::syslog::error!("pthread_mutex_init(): {}", reason);
+        ::syslog::warn!("pthread_mutex_init(): {}", reason);
         Err(Error::new(ErrorCode::InvalidArgument, reason))
     }
 }
@@ -76,7 +76,7 @@ pub fn pthread_mutex_destroy(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
             return Ok(());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_mutex_destroy(): {}", reason);
+            ::syslog::warn!("pthread_mutex_destroy(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -97,7 +97,7 @@ pub fn pthread_mutex_lock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_mutex_lock(): {}", reason);
+            ::syslog::warn!("pthread_mutex_lock(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -119,7 +119,7 @@ pub fn pthread_mutex_timedlock(
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_mutex_timedlock(): {}", reason);
+            ::syslog::warn!("pthread_mutex_timedlock(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -138,7 +138,7 @@ pub fn pthread_mutex_trylock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_mutex_trylock(): {}", reason);
+            ::syslog::warn!("pthread_mutex_trylock(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -154,11 +154,11 @@ pub fn pthread_mutex_trylock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
         Err(error) => {
             // Check if we have to interpose the error.
             if error.code == ErrorCode::OperationTimedOut {
-                ::syslog::error!("pthread_mutex_trylock(): mutex is already locked");
+                ::syslog::warn!("pthread_mutex_trylock(): mutex is already locked");
                 // Mutex is already locked.
                 Err(Error::new(ErrorCode::ResourceBusy, "mutex is already locked"))
             } else {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "pthread_mutex_trylock(): failed to lock mutex (error={:?})",
                     error
                 );
@@ -180,7 +180,7 @@ pub fn pthread_mutex_unlock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::error!("pthread_mutex_unlock(): {}", reason);
+            ::syslog::warn!("pthread_mutex_unlock(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_destroy.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_destroy.rs
@@ -50,7 +50,7 @@ pub fn pthread_attr_destroy(attr: &mut pthread_attr_t) -> Result<(), Error> {
     // Check if `attr` references a thread attributes object that was not initialized.
     if attr.is_initialized == 0 {
         let reason: &'static str = "thread attributes object was not initialized";
-        ::syslog::error!("pthread_attr_destroy(): {reason} (attr={:p})", attr as *const _);
+        ::syslog::warn!("pthread_attr_destroy(): {reason} (attr={:p})", attr as *const _);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_getstack.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_getstack.rs
@@ -57,7 +57,7 @@ pub fn pthread_attr_getstack(
     // Ensure the attributes object is initialized.
     if attr.is_initialized == 0 {
         let reason: &'static str = "thread attributes object was not initialized";
-        ::syslog::error!("pthread_attr_getstack(): {reason} (attr={:p})", attr as *const _);
+        ::syslog::warn!("pthread_attr_getstack(): {reason} (attr={:p})", attr as *const _);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_init.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_init.rs
@@ -53,7 +53,7 @@ pub fn pthread_attr_init(attr: &mut pthread_attr_t) -> Result<(), Error> {
     // Check if `attr` references a thread attributes object that was already initialized.
     if attr.is_initialized != 0 {
         let reason: &'static str = "thread attributes object was already initialized";
-        ::syslog::error!("pthread_attr_init(): {reason} (attr={:p})", attr as *const _);
+        ::syslog::warn!("pthread_attr_init(): {reason} (attr={:p})", attr as *const _);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 

--- a/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
@@ -49,7 +49,7 @@ pub fn pthread_getattr_np(thread: pthread_t, attr: &mut pthread_attr_t) -> Resul
     // Check if `attr` references a thread attributes object that was already initialized.
     if attr.is_initialized != 0 {
         let reason: &'static str = "thread attributes object was already initialized";
-        ::syslog::error!("pthread_getattr_np(): {reason} (attr={:p})", attr as *const _);
+        ::syslog::warn!("pthread_getattr_np(): {reason} (attr={:p})", attr as *const _);
         return Err(Error::new(ErrorCode::ResourceBusy, reason));
     }
 

--- a/src/libs/syscall/src/pthread/syscall/rwlock.rs
+++ b/src/libs/syscall/src/pthread/syscall/rwlock.rs
@@ -164,7 +164,7 @@ pub fn pthread_rwlock_init(
         Ok(())
     } else {
         let reason: &str = "read-write lock is already initialized";
-        ::syslog::error!("pthread_rwlock_init(): {reason}");
+        ::syslog::warn!("pthread_rwlock_init(): {reason}");
         Err(Error::new(ErrorCode::InvalidArgument, reason))
     }
 }
@@ -191,7 +191,7 @@ pub fn pthread_rwlock_destroy(rwlock: &mut pthread_rwlock_t) -> Result<(), Error
         let locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> = runtime.lock();
         if locked_runtime_rwlock.readers != 0 || locked_runtime_rwlock.writer_active {
             let reason: &str = "read-write lock is busy";
-            ::syslog::error!("pthread_rwlock_destroy(): {}", reason);
+            ::syslog::warn!("pthread_rwlock_destroy(): {}", reason);
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
     } else {
@@ -200,7 +200,7 @@ pub fn pthread_rwlock_destroy(rwlock: &mut pthread_rwlock_t) -> Result<(), Error
             return Ok(());
         } else {
             let reason: &str = "read-write lock is not initialized";
-            ::syslog::error!("pthread_rwlock_destroy(): {reason}");
+            ::syslog::warn!("pthread_rwlock_destroy(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -360,7 +360,7 @@ pub fn pthread_rwlock_unlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
             // Must be a reader.
             if locked_runtime.readers == 0 {
                 let reason: &str = "unlock on unlocked read-write lock";
-                ::syslog::error!("pthread_rwlock_unlock(): {reason}");
+                ::syslog::warn!("pthread_rwlock_unlock(): {reason}");
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             }
             locked_runtime.readers -= 1;
@@ -407,7 +407,7 @@ fn get_runtime_rwlock(rwlock: &pthread_rwlock_t) -> Result<ReadWriteLock, Error>
             ))));
         } else {
             let reason: &str = "read-write lock is not initialized";
-            ::syslog::error!("lazy_register_rwlock(): {reason}");
+            ::syslog::warn!("lazy_register_rwlock(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }

--- a/src/libs/syscall/src/pthread/syscall/tda.rs
+++ b/src/libs/syscall/src/pthread/syscall/tda.rs
@@ -138,7 +138,7 @@ pub fn pthread_key_delete(key: pthread_key_t) -> Result<(), Error> {
         },
         None => {
             let reason: &str = "key not found";
-            ::syslog::error!("pthread_key_delete(): {:?}", reason);
+            ::syslog::warn!("pthread_key_delete(): {:?}", reason);
             Err(Error::new(ErrorCode::NoSuchEntry, reason))
         },
     }
@@ -174,7 +174,7 @@ pub fn pthread_getspecific(key: pthread_key_t) -> Result<Pointer, Error> {
         // Key not found.
         Some(None) | None => {
             let reason: &str = "key not found";
-            ::syslog::error!("pthread_getspecific(): {:?}", reason);
+            ::syslog::warn!("pthread_getspecific(): {:?}", reason);
             Err(Error::new(ErrorCode::NoSuchEntry, reason))
         },
     }
@@ -208,7 +208,7 @@ pub fn pthread_setspecific(key: pthread_key_t, value: Pointer) -> Result<(), Err
         // Key not found.
         Some(None) | None => {
             let reason: &str = "key not found";
-            ::syslog::error!("pthread_setspecific(): {:?}", reason);
+            ::syslog::warn!("pthread_setspecific(): {:?}", reason);
             Err(Error::new(ErrorCode::NoSuchEntry, reason))
         },
     }

--- a/src/libs/syscall/src/safe/dir/mod.rs
+++ b/src/libs/syscall/src/safe/dir/mod.rs
@@ -313,7 +313,7 @@ struct DirectoryInner {
 impl Drop for DirectoryInner {
     fn drop(&mut self) {
         if let Err(error) = closedir(&self.dir) {
-            ::syslog::error!("DirectoryInner::drop(): {error:?}");
+            ::syslog::warn!("DirectoryInner::drop(): {error:?}");
         }
     }
 }

--- a/src/libs/syscall/src/safe/fs/path.rs
+++ b/src/libs/syscall/src/safe/fs/path.rs
@@ -54,7 +54,7 @@ impl FileSystemPath {
         // Check if path is empty.
         if name.is_empty() {
             let reason: &str = "empty path";
-            ::syslog::error!("new(): {reason}");
+            ::syslog::warn!("new(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
@@ -63,7 +63,7 @@ impl FileSystemPath {
             Ok(cstr) => cstr,
             Err(_) => {
                 let reason: &str = "invalid path";
-                ::syslog::error!("new(): {reason}");
+                ::syslog::warn!("new(): {reason}");
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             },
         };
@@ -71,7 +71,7 @@ impl FileSystemPath {
         // Check if path is too long.
         if name_cstr.as_bytes().len() > PATH_MAX {
             let reason: &str = "path is too long";
-            ::syslog::error!("new(): {reason}");
+            ::syslog::warn!("new(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
@@ -108,13 +108,13 @@ impl FileSystemPath {
                 Ok(name) => FileSystemPath::new(&name),
                 Err(_) => {
                     let reason: &str = "invalid UTF-8 sequence in path";
-                    ::syslog::error!("try_from_bytes(): {reason}");
+                    ::syslog::warn!("try_from_bytes(): {reason}");
                     Err(Error::new(ErrorCode::InvalidArgument, reason))
                 },
             },
             Err(_) => {
                 let reason: &str = "invalid path bytes";
-                ::syslog::error!("try_from_bytes(): {reason}");
+                ::syslog::warn!("try_from_bytes(): {reason}");
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
         }
@@ -140,7 +140,7 @@ impl FileSystemPath {
         // Check if the other path is empty.
         if other.name.is_empty() {
             let reason: &str = "cannot join with an empty path";
-            ::syslog::error!("join(): {reason}");
+            ::syslog::warn!("join(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
@@ -148,7 +148,7 @@ impl FileSystemPath {
         let joined_length: usize = self.name.len() + other.name.len() + 1; // +1 for the separator
         if joined_length > PATH_MAX {
             let reason: &str = "resulting path is too long";
-            ::syslog::error!("join(): {reason}");
+            ::syslog::warn!("join(): {reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -82,21 +82,21 @@ impl MemorySegment {
         // Check if base address is not page-aligned.
         if !base.is_aligned(PAGE_ALIGNMENT) {
             let reason: &str = "unaligned base address";
-            ::syslog::error!("new(): {}", reason);
+            ::syslog::warn!("new(): {}", reason);
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
         // Check if capacity is zero.
         if capacity == 0 {
             let reason: &str = "zero capacity";
-            ::syslog::error!("new(): {}", reason);
+            ::syslog::warn!("new(): {}", reason);
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
         // Check if capacity is page-aligned.
         if !capacity.is_multiple_of(PAGE_SIZE) {
             let reason: &str = "unaligned capacity";
-            ::syslog::error!("new(): {}", reason);
+            ::syslog::warn!("new(): {}", reason);
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -167,7 +167,7 @@ impl MemorySegment {
         // Check if bytes exceed capacity.
         if offset + bytes.len() > self.capacity {
             let reason: &str = "bytes exceed capacity";
-            ::syslog::error!("load(): {}", reason);
+            ::syslog::warn!("load(): {}", reason);
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -259,7 +259,7 @@ fn map_range(
         if let Err(error) = mmap(pid, vaddr, 1, access) {
             // Failed to map page, attempt to rollback.
 
-            ::syslog::error!(
+            ::syslog::warn!(
                 "map_range(): failed to map page at {:X?}, rolling back (error={:?})",
                 vaddr,
                 error
@@ -306,7 +306,7 @@ fn unmap_range(
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
         if let Err(error) = munmap(pid, vaddr) {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "unmap_range(): failed to unmap page at {:X?}, skipping (error={:?})",
                 vaddr,
                 error
@@ -340,7 +340,7 @@ fn protect_range(
 
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
         if let Err(error) = mprotect(pid, vaddr, prot) {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "protect_range(): failed to change protection of page at {:X?}, skipping \
                  (error={:?})",
                 vaddr,

--- a/src/libs/syscall/src/safe/mem/stack.rs
+++ b/src/libs/syscall/src/safe/mem/stack.rs
@@ -70,7 +70,7 @@ impl Stack {
             Ok(layout) => layout,
             Err(error) => {
                 let reason: &str = "failed to create user stack layout";
-                ::syslog::error!("new(): {reason:?} (error={error:?}, size={size:?})");
+                ::syslog::warn!("new(): {reason:?} (error={error:?}, size={size:?})");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             },
         };
@@ -80,7 +80,7 @@ impl Stack {
             ptr if !ptr.is_null() => VirtualAddress::from_raw_value(ptr as usize),
             _ => {
                 let reason: &str = "failed to allocate user stack";
-                ::syslog::error!("new(): {reason:?} (size={size:?})");
+                ::syslog::warn!("new(): {reason:?} (size={size:?})");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             },
         };
@@ -123,9 +123,7 @@ impl Drop for Stack {
         let layout: Layout = match Layout::from_size_align(self.size, align_of::<usize>()) {
             Ok(layout) => layout,
             Err(error) => {
-                ::syslog::error!(
-                    "drop(): failed to create stack layout for drop (error={error:?})"
-                );
+                ::syslog::warn!("drop(): failed to create stack layout for drop (error={error:?})");
                 return;
             },
         };

--- a/src/libs/syscall/src/safe/sys/mod.rs
+++ b/src/libs/syscall/src/safe/sys/mod.rs
@@ -60,7 +60,7 @@ impl System {
             Ok(name) => name,
             Err(_error) => {
                 let reason: &str = "failed to convert system name";
-                ::syslog::error!("system_name(): {}", reason);
+                ::syslog::warn!("system_name(): {}", reason);
                 return Err(Error::new(sys::error::ErrorCode::ValueOutOfRange, reason));
             },
         };

--- a/src/libs/syscall/src/sys/mman/bindings/mmap.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/mmap.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn mmap(
 ) -> *mut u8 {
     // Check if mapping length is invalid.
     if length == 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mmap(): invalid mapping length (addr={addr:?}, length={length}), prot={prot}, \
              flags={flags}, fd={fd}, offset={offset})"
         );
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn mmap(
     let length: usize = match TryFrom::try_from(length) {
         Ok(length) => length,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mmap(): invalid mapping length (addr={addr:?}, length={length}), prot={prot}, \
                  flags={flags}, fd={fd}, offset={offset}), error={error:?}"
             );
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn mmap(
     let flags: MemoryMapFlags = match TryFrom::try_from(flags) {
         Ok(flags) => flags,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mmap(): invalid flags (addr={addr:?}, length={length}, prot={prot}, \
                  flags={flags}, fd={fd}, offset={offset}), error={error:?}"
             );
@@ -135,7 +135,7 @@ pub unsafe extern "C" fn mmap(
 
     // Check for unsupported flags.
     if flags.is_shared() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mmap(): shared memory mapping is not supported (addr={addr:?}, length={length}, \
              prot={prot}, flags={flags:?}, fd={fd}, offset={offset})"
         );
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn mmap(
         }
         return MAP_FAILED;
     } else if flags.is_fixed() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mmap(): fixed memory mapping is not supported (addr={addr:?}, length={length}, \
              prot={prot}, flags={flags:?}, fd={fd}, offset={offset})"
         );
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn mmap(
         }
         return MAP_FAILED;
     } else if !flags.is_anonymous() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mmap(): non-anonymous memory mapping is not supported (addr={addr:?}, \
              length={length}, prot={prot}, flags={flags:?}, fd={fd}, offset={offset})"
         );
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn mmap(
         }
         return MAP_FAILED;
     } else if flags.is_anonymous() && fd != -1 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mmap(): anonymous memory mapping with file descriptor is not supported \
              (addr={addr:?}, length={length}, prot={prot}, flags={flags:?}, fd={fd}, \
              offset={offset})"
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn mmap(
     let prot: MemoryMapProtectionFlags = match TryFrom::try_from(prot) {
         Ok(prot) => prot,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mmap(): invalid protection flags (addr={addr:?}, length={length}, prot={prot}, \
                  flags={flags:?}, fd={fd}, offset={offset}), error={error:?}"
             );
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn mmap(
             virt_addr.into_raw_value() as *mut u8
         },
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mmap(): failed (addr={addr:?}, length={length}, prot={prot:?}, flags={flags:?}, \
                  fd={fd}, offset={offset}), error={error:?}"
             );

--- a/src/libs/syscall/src/sys/mman/bindings/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/mprotect.rs
@@ -35,7 +35,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn mprotect(addr: *mut c_char, length: c_size_t, prot: c_int) -> isize {
     // Check if address is invalid.
     if addr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mprotect(): invalid base address (addr={addr:?}, length={length}, prot={prot})"
         );
         unsafe {
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn mprotect(addr: *mut c_char, length: c_size_t, prot: c_i
     let length: usize = match usize::try_from(length) {
         Ok(length) => length,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mprotect(): invalid length (addr={addr:?}, length={length}, prot={prot})"
             );
             unsafe {
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn mprotect(addr: *mut c_char, length: c_size_t, prot: c_i
     let prot: MemoryMapProtectionFlags = match MemoryMapProtectionFlags::try_from(prot) {
         Ok(prot) => prot,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mprotect(): invalid protection flags (addr={addr:?}, length={length}, \
                  prot={prot})"
             );
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn mprotect(addr: *mut c_char, length: c_size_t, prot: c_i
             0
         },
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "mprotect(): failed (addr={addr:?}, length={length}, prot={prot:?}), \
                  error={error:?}"
             );

--- a/src/libs/syscall/src/sys/mman/bindings/munmap.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/munmap.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn munmap(addr: *mut c_void, length: c_size_t) -> isize {
     // Check if address is invalid.
     if addr.is_null() {
-        ::syslog::error!("munmap(): invalid base address (addr={addr:?}, length={length})");
+        ::syslog::warn!("munmap(): invalid base address (addr={addr:?}, length={length})");
         unsafe {
             *__errno_location() = ErrorCode::InvalidArgument.get();
         }
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn munmap(addr: *mut c_void, length: c_size_t) -> isize {
 
     // Check if mapping length is invalid.
     if length == 0 {
-        ::syslog::error!("munmap(): invalid mapping length (addr={addr:?}, length={length})");
+        ::syslog::warn!("munmap(): invalid mapping length (addr={addr:?}, length={length})");
         unsafe {
             *__errno_location() = ErrorCode::InvalidArgument.get();
         }
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn munmap(addr: *mut c_void, length: c_size_t) -> isize {
     let length: usize = match TryFrom::try_from(length) {
         Ok(length) => length,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "munmap(): invalid mapping length (addr={addr:?}, length={length}), \
                  error={error:?}"
             );
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn munmap(addr: *mut c_void, length: c_size_t) -> isize {
             0
         },
         Err(error) => {
-            ::syslog::error!("munmap(): failed (addr={addr:?}, length={length}), error={error:?}");
+            ::syslog::warn!("munmap(): failed (addr={addr:?}, length={length}), error={error:?}");
             unsafe {
                 *__errno_location() = error.code.get();
             }

--- a/src/libs/syscall/src/sys/mman/syscalls/mmap.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mmap.rs
@@ -50,7 +50,7 @@ pub fn mmap(length: usize, prot: MemoryMapProtectionFlags) -> Result<VirtualAddr
     let aligned_length: usize = ::sys::mm::align_up(length, ::arch::mem::PAGE_ALIGNMENT)
         .ok_or_else(|| {
             let reason: &str = "align_up overflow";
-            ::syslog::error!("mmap(): {reason} (length={length})");
+            ::syslog::warn!("mmap(): {reason} (length={length})");
             Error::new(ErrorCode::InvalidArgument, reason)
         })?;
 

--- a/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
@@ -73,7 +73,7 @@ pub fn mprotect(
     // Check if base address is page-aligned.
     if !base.is_aligned(PAGE_ALIGNMENT) {
         let reason: &'static str = "base address is not page-aligned";
-        ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+        ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -81,12 +81,12 @@ pub fn mprotect(
     let end: VirtualAddress = match base.into_raw_value().checked_add(len) {
         Some(end) if end > USER_MMAP_END_RAW => {
             let reason: &'static str = "invalid end address";
-            ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+            ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         },
         None => {
             let reason: &'static str = "address overflow";
-            ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+            ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         },
         Some(end) => VirtualAddress::from_raw_value(end),
@@ -95,7 +95,7 @@ pub fn mprotect(
     // Check if length is page-aligned.
     if !len.is_multiple_of(usize::from(PAGE_ALIGNMENT)) {
         let reason: &'static str = "length is not page-aligned";
-        ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+        ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -133,7 +133,7 @@ pub fn mprotect(
                 segment
             } else {
                 let reason: &'static str = "memory segment not found";
-                ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+                ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             };
 
@@ -151,7 +151,7 @@ pub fn mprotect(
         },
         None => {
             let reason: &'static str = "memory segment not found";
-            ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+            ::syslog::warn!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
             Err(Error::new(ErrorCode::OutOfMemory, reason))
         },
     }

--- a/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
@@ -58,14 +58,14 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
     // Check if the base address is valid.
     if base < USER_MMAP_BASE || base >= USER_MMAP_END {
         let reason: &str = "invalid base address";
-        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
     // Check if base address is page-aligned.
     if !base.is_aligned(PAGE_ALIGNMENT) {
         let reason: &str = "base address is not page-aligned";
-        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -73,12 +73,12 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
     let end: VirtualAddress = match base.into_raw_value().checked_add(length) {
         Some(end) if end > USER_MMAP_END_RAW => {
             let reason: &str = "invalid end address";
-            syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+            syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
         None => {
             let reason: &str = "end address overflow";
-            syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+            syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
         Some(base_end) => VirtualAddress::from_raw_value(base_end),
@@ -87,7 +87,7 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
     // Check if length is page-aligned.
     if !length.is_multiple_of(usize::from(PAGE_ALIGNMENT)) {
         let reason: &str = "length is not page-aligned";
-        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -144,7 +144,7 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
         },
         None => {
             let reason: &str = "segment not found";
-            syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+            syslog::warn!("munmap(): {reason} (base={base:?}, length={length})");
             Err(Error::new(ErrorCode::InvalidArgument, reason))
         },
     }

--- a/src/libs/syscall/src/sys/select/bindings/mod.rs
+++ b/src/libs/syscall/src/sys/select/bindings/mod.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn select(
 ) -> c_int {
     // Check if `nfds` is not valid.
     if nfds < 0 || nfds as usize > FD_SETSIZE {
-        ::syslog::error!(
+        ::syslog::warn!(
             "select(): invalid nfds (nfds={nfds:?}, readfds={readfds:?}, writefds={writefds:?}, \
              errorfds={errorfds:?})"
         );
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn select(
     } else {
         // Check if pointer is misaligned.
         if !(readfds as usize).is_multiple_of(core::mem::align_of::<fd_set>()) {
-            ::syslog::error!("select(): misaligned readfds pointer (readfds={readfds:?})");
+            ::syslog::warn!("select(): misaligned readfds pointer (readfds={readfds:?})");
             // SAFETY: `__errno_location()` returns a valid pointer.
             unsafe {
                 *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn select(
     } else {
         // Check if pointer is misaligned.
         if !(writefds as usize).is_multiple_of(core::mem::align_of::<fd_set>()) {
-            ::syslog::error!("select(): misaligned writefds pointer (writefds={writefds:?})");
+            ::syslog::warn!("select(): misaligned writefds pointer (writefds={writefds:?})");
             // SAFETY: `__errno_location()` returns a valid pointer.
             unsafe {
                 *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn select(
     } else {
         // Check if pointer is misaligned.
         if !(errorfds as usize).is_multiple_of(core::mem::align_of::<fd_set>()) {
-            ::syslog::error!("select(): misaligned errorfds pointer (errorfds={errorfds:?})");
+            ::syslog::warn!("select(): misaligned errorfds pointer (errorfds={errorfds:?})");
             // SAFETY: `__errno_location()` returns a valid pointer.
             unsafe {
                 *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -135,7 +135,7 @@ pub unsafe extern "C" fn select(
             if err.code == ErrorCode::OperationNotSupported {
                 ::syslog::warn!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
             } else {
-                ::syslog::error!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
+                ::syslog::warn!("select(): syscall failed (nfds={nfds:?}, error={err:?})");
             }
             // SAFETY: `__errno_location()` returns a valid pointer.
             unsafe {

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -95,7 +95,7 @@ pub fn select(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "select(): failed (nfds={:?}, timeout={:?}, status={:?})",
             nfds,
             timeout,
@@ -108,7 +108,7 @@ pub fn select(
             Ok(error_code) => Err(Error::new(error_code, "select() failed")),
             // Error was not parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "select(): {error:?} (nfds={:?}, timeout={:?}, status={:?})",
                     nfds,
                     timeout,
@@ -141,7 +141,7 @@ pub fn select(
             // Response was not parsed.
             header => {
                 let reason: &'static str = "invalid response";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "select(): {reason} (header={header:?}, nfds={:?}, timeout={:?}, status={:?})",
                     nfds,
                     timeout,

--- a/src/libs/syscall/src/sys/socket/bindings/accept.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/accept.rs
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn accept(
 ) -> c_int {
     // Check if sockaddr and len is invalid.
     if !sockaddr.is_null() && len.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "accept(): invalid length pointer (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
              len={len:?})"
         );
@@ -86,15 +86,9 @@ pub unsafe extern "C" fn accept(
             sockfd
         },
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            }
+            ::syslog::warn!(
+                "accept(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/bind.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/bind.rs
@@ -56,7 +56,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn bind(sockfd: c_int, sockaddr: *const sockaddr, len: socklen_t) -> c_int {
     // Check if sock address is invalid.
     if sockaddr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "bind(): invalid socket address (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
              len={len:?})"
         );
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn bind(sockfd: c_int, sockaddr: *const sockaddr, len: soc
     let sockaddr: SocketAddr = match SocketAddr::try_from(unsafe { &*sockaddr }) {
         Ok(sockaddr) => sockaddr,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
             );
             *__errno_location() = error.code.get();
@@ -80,15 +80,9 @@ pub unsafe extern "C" fn bind(sockfd: c_int, sockaddr: *const sockaddr, len: soc
     match crate::sys::socket::syscall::bind(sockfd, &sockaddr) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            }
+            ::syslog::warn!(
+                "bind(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/connect.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/connect.rs
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn connect(
     // Check if `sockaddr` is valid.
     if sockaddr.is_null() {
         let reason: &str = "invalid socket address";
-        ::syslog::error!(
+        ::syslog::warn!(
             "connect(): {reason} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn connect(
     // Check if `len` is valid.
     if len == 0 {
         let reason: &str = "invalid socket address length";
-        ::syslog::error!(
+        ::syslog::warn!(
             "connect(): {reason} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn connect(
     let sockaddr: SocketAddr = match TryFrom::<&sockaddr>::try_from(&*sockaddr) {
         Ok(sockaddr) => sockaddr,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
             );
             *__errno_location() = error.code.get();
@@ -100,15 +100,9 @@ pub unsafe extern "C" fn connect(
     match socket::syscall::connect(sockfd, &sockaddr) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
-                );
-            }
+            ::syslog::warn!(
+                "connect(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn getpeername(
 ) -> c_int {
     // Check if the address is valid.
     if sockaddr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "getpeername(): invalid socket address (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
              len={len:?})"
         );
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn getpeername(
 
     // Check if the length is valid.
     if len.is_null() || (*len as usize) < mem::size_of::<sockaddr>() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "getpeername(): invalid length (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -97,17 +97,9 @@ pub unsafe extern "C" fn getpeername(
             0
         },
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
-                     len={len:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
-                     len={len:?})"
-                );
-            }
+            ::syslog::warn!(
+                "getpeername(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getsockname.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn getsockname(
 ) -> c_int {
     // Check if the address is valid.
     if sockaddr.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "getsockname(): invalid socket address (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
              len={len:?})"
         );
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn getsockname(
 
     // Check if the length is valid.
     if len.is_null() || *len < mem::size_of::<sockaddr>() as socklen_t {
-        ::syslog::error!(
+        ::syslog::warn!(
             "getsockname(): invalid socket address length (sockfd={sockfd:?}, \
              sockaddr={sockaddr:?}, len={len:?})"
         );
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn getsockname(
             0
         },
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "getsockname(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?})"
             );
             *__errno_location() = error.code.get();

--- a/src/libs/syscall/src/sys/socket/bindings/listen.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/listen.rs
@@ -51,11 +51,7 @@ pub unsafe extern "C" fn listen(sockfd: c_int, backlog: c_int) -> c_int {
     match crate::sys::socket::syscall::listen(sockfd, backlog) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
-            } else {
-                ::syslog::error!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
-            }
+            ::syslog::warn!("listen(): {error:?} (sockfd={sockfd:?}, backlog={backlog:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/recv.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recv.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn recv(
 ) -> c_ssize_t {
     // Check if `buf` is valid.
     if buf.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "recv(): invalid buffer (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn recv(
 
     // Check if `len` is valid.
     if len == 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "recv(): invalid buffer length (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
              flags={flags:?})"
         );
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn recv(
 
     // Check if `flags` is valid.
     if flags != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "recv(): unsupported flags (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
              flags={flags:?})"
         );
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn recv(
     let len: usize = match len.try_into() {
         Ok(len) => len,
         Err(_error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "recv(): failed to convert length (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
                  flags={flags:?})"
             );
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn recv(
         Ok(bytes_received) => match bytes_received.try_into() {
             Ok(bytes_received) => bytes_received,
             Err(_error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "recv(): failed to convert bytes received (sockfd={sockfd:?}, buf={buf:?}, \
                      len={len:?}, flags={flags:?})"
                 );
@@ -126,17 +126,9 @@ pub unsafe extern "C" fn recv(
             },
         },
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
-                     flags={flags:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
-                     flags={flags:?})"
-                );
-            }
+            ::syslog::warn!(
+                "recv(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/send.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/send.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn send(
 ) -> c_ssize_t {
     // Check if `buf` is valid.
     if buf.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "send(): invalid buffer (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn send(
 
     // Check if `flags` is valid.
     if flags != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "send(): unsupported flags (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
              flags={flags:?})"
         );
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn send(
     let len: usize = match len.try_into() {
         Ok(len) => len,
         Err(_error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "send(): failed to convert length (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
                  flags={flags:?})"
             );
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn send(
         Ok(bytes_sent) => match bytes_sent.try_into() {
             Ok(bytes_sent) => bytes_sent,
             Err(_error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "send(): failed to convert bytes sent (sockfd={sockfd:?}, buf={buf:?}, \
                      len={len:?}, flags={flags:?})"
                 );
@@ -119,17 +119,9 @@ pub unsafe extern "C" fn send(
             },
         },
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
-                     flags={flags:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
-                     flags={flags:?})"
-                );
-            }
+            ::syslog::warn!(
+                "send(): {error:?} (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn shutdown(sockfd: c_int, how: c_int) -> c_int {
     let how: Shutdown = match Shutdown::try_from(how) {
         Ok(how) => how,
         Err(_error) => {
-            ::syslog::error!("shutdown(): invalid shutdown mode (sockfd={sockfd:?}, how={how:?})");
+            ::syslog::warn!("shutdown(): invalid shutdown mode (sockfd={sockfd:?}, how={how:?})");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -73,11 +73,7 @@ pub unsafe extern "C" fn shutdown(sockfd: c_int, how: c_int) -> c_int {
     match socket::syscall::shutdown(sockfd, how) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
-            } else {
-                ::syslog::error!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
-            }
+            ::syslog::warn!("shutdown(): {error:?} (sockfd={sockfd:?}, how={how:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/socket.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socket.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c
     let domain: AddressFamily = match AddressFamily::try_from(domain) {
         Ok(domain) => domain,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
             );
             *__errno_location() = error.code.get();
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c
     let typ: SocketType = match SocketType::try_from(typ) {
         Ok(typ) => typ,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
             );
             *__errno_location() = error.code.get();
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c
     let protocol: Protocol = match Protocol::try_from(protocol) {
         Ok(protocol) => protocol,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
             );
             *__errno_location() = error.code.get();
@@ -98,15 +98,9 @@ pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c
     match crate::sys::socket::syscall::socket(domain, typ, protocol) {
         Ok(sockfd) => sockfd,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
-                );
-            }
+            ::syslog::warn!(
+                "socket(): {error:?} (domain={domain:?}, type={typ:?}, protocol={protocol:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
@@ -70,14 +70,14 @@ pub unsafe extern "C" fn socketpair(
 ) -> c_int {
     // Check if `socket_fds` is invalid.
     if socket_fds.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "socketpair(): invalid sockets array (domain={domain:?}, typ={typ:?}, \
              protocol={protocol:?}, socket_fds={socket_fds:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     } else if !(socket_fds as usize).is_multiple_of(::core::mem::size_of::<c_int>()) {
-        ::syslog::error!(
+        ::syslog::warn!(
             "socketpair(): invalid sockets array alignment (domain={domain:?}, typ={typ:?}, \
              protocol={protocol:?}, socket_fds={socket_fds:?})"
         );
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn socketpair(
     let domain: AddressFamily = match domain.try_into() {
         Ok(domain) => domain,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
                  socket_fds={socket_fds:?})"
             );
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn socketpair(
     let typ: SocketType = match typ.try_into() {
         Ok(typ) => typ,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
                  socket_fds={socket_fds:?})"
             );
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn socketpair(
     let protocol: Protocol = match protocol.try_into() {
         Ok(protocol) => protocol,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
                  socket_fds={socket_fds:?})"
             );
@@ -131,17 +131,10 @@ pub unsafe extern "C" fn socketpair(
     match crate::sys::socket::syscall::socketpair(domain, typ, protocol, socket_fds) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, \
-                     protocol={protocol:?}, socket_fds={socket_fds:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, \
-                     protocol={protocol:?}, socket_fds={socket_fds:?})"
-                );
-            }
+            ::syslog::warn!(
+                "socketpair(): {error:?} (domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
+                 socket_fds={socket_fds:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -74,7 +74,7 @@ pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("connect(): failed ({:?})", error_code);
+        ::syslog::warn!("connect(): failed ({:?})", error_code);
         Err(Error::new(error_code, "connect() failed"))
     } else {
         // System call succeeded, parse response.

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -69,7 +69,7 @@ pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("getpeername(): failed ({:?})", error_code);
+        ::syslog::warn!("getpeername(): failed ({:?})", error_code);
         Err(Error::new(error_code, "getpeername() failed"))
     } else {
         // System call succeeded, parse response.

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -69,7 +69,7 @@ pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("getsockname(): failed ({:?})", error_code);
+        ::syslog::warn!("getsockname(): failed ({:?})", error_code);
         Err(Error::new(error_code, "getsockname() failed"))
     } else {
         // System call succeeded, parse response.

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -71,7 +71,7 @@ pub fn socketpair(
     // Check if array of file descriptors has expected length.
     if socket_fds.len() != 2 {
         let reason: &str = "array of file descriptors must have length 2";
-        ::syslog::error!("socketpair(): failed ({:?})", reason);
+        ::syslog::warn!("socketpair(): failed ({:?})", reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -86,7 +86,7 @@ pub fn socketpair(
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("socketpair(): failed ({:?})", error_code);
+        ::syslog::warn!("socketpair(): failed ({:?})", error_code);
         Err(Error::new(error_code, "socketpair() failed"))
     } else {
         // System call succeeded, parse response.

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -74,13 +74,13 @@ fn fchmod_linuxd(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("fchmod(): syscall failed (fd={:?}, mode={:o}, status={:?})", fd, mode, {
+        ::syslog::warn!("fchmod(): syscall failed (fd={:?}, mode={:o}, status={:?})", fd, mode, {
             response.status
         });
         // System call failed, parse error code and return it.
         match ErrorCode::try_from(response.status) {
             Ok(error_code) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fchmod(): syscall failed (fd={:?}, mode={:o}, error_code={:?})",
                     fd,
                     mode,
@@ -89,7 +89,7 @@ fn fchmod_linuxd(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
                 Err(Error::new(error_code, "system call failed"))
             },
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fchmod(): syscall failed (fd={:?}, mode={:o}, error={:?})",
                     fd,
                     mode,
@@ -106,7 +106,7 @@ fn fchmod_linuxd(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
             LinuxDaemonMessageHeader::FileChmodResponse => Ok(()),
             // Invalid response.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fchmod(): invalid response (fd={:?}, mode={:o}, header={:?})",
                     fd,
                     mode,

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -44,7 +44,7 @@ use {
 ///
 #[allow(unreachable_code)]
 pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Error> {
-    ::syslog::error!("futimens(): fd={:?}, times={:?}", fd, times);
+    ::syslog::warn!("futimens(): fd={:?}, times={:?}", fd, times);
 
     // In standalone mode, forward operation to virtual file system (VFS).
     #[cfg(feature = "standalone")]
@@ -77,7 +77,7 @@ fn futimens_linuxd(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), E
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("futimens(): failed (fd={:?}, times={:?}, status={:?})", fd, times, {
+        ::syslog::warn!("futimens(): failed (fd={:?}, times={:?}, status={:?})", fd, times, {
             response.status
         });
 
@@ -90,7 +90,7 @@ fn futimens_linuxd(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), E
             },
             // Error code was not successfully parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "futimens(): failed to parse error code (fd={:?}, times={:?}, error={:?})",
                     fd,
                     times,
@@ -108,7 +108,7 @@ fn futimens_linuxd(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), E
             LinuxDaemonMessageHeader::UpdateFileAccessTimeResponse => Ok(()),
             // Response was not successfully parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "futimens(): invalid response (fd={:?}, times={:?}, header={:?})",
                     fd,
                     times,

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -88,7 +88,7 @@ fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Res
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "mkdirat(): failed (dirfd={:?}, pathname={:?}, mode={:?}, error_code={:?})",
             dirfd,
             pathname,
@@ -104,7 +104,7 @@ fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Res
             },
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "mkdirat(): failed to parse error code (dirfd={:?}, pathname={:?}, mode={:?}, \
                      error={:?})",
                     dirfd,
@@ -123,7 +123,7 @@ fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Res
             LinuxDaemonMessageHeader::MakeDirectoryAtResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "mkdirat(): {:?} (dirfd={:?}, pathname={:?}, mode={:?}, header={:?})",
                     reason,
                     dirfd,

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -87,11 +87,7 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
         if response.status != 0 {
             // System call failed, parse error code and return it.
             let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-            if error_code == ErrorCode::NoSuchEntry {
-                ::syslog::warn!("fstatat(): failed (error={:?})", error_code);
-            } else {
-                ::syslog::error!("fstatat(): failed (error={:?})", error_code);
-            }
+            ::syslog::warn!("fstatat(): failed (error={:?})", error_code);
             break Err(Error::new(error_code, "fstatat() failed"));
         } else {
             // System call succeeded, parse response.
@@ -102,7 +98,7 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
                             LinuxDaemonMessagePart::from_bytes(message.payload);
 
                         if let Err(e) = assembler.add_part(part) {
-                            ::syslog::error!("fstatat(): failed to add part to assembler");
+                            ::syslog::warn!("fstatat(): failed to add part to assembler");
                             break Err(e);
                         }
 

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -101,7 +101,7 @@ fn utimensat_linuxd(
     // Check whether system call succeeded or not.
     if response.status != 0 {
         // System call failed, parse error code and return it.
-        ::syslog::error!(
+        ::syslog::warn!(
             "utimensat(): failed (dirfd={:?}, pathname={:?}, times={:?}, flags={:?}, \
              error_code={:?})",
             dirfd,
@@ -116,7 +116,7 @@ fn utimensat_linuxd(
             Ok(error_code) => Err(Error::new(error_code, "utimensat() failed")),
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "utimensat(): failed to convert error code (dirfd={:?}, pathname={:?}, \
                      times={:?}, flags={:?}, error={:?})",
                     dirfd,
@@ -138,7 +138,7 @@ fn utimensat_linuxd(
             // Response was not successfully parsed.
             _ => {
                 let reason: &str = "unexpected message header";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "utimensat(): failed (dirfd={:?}, pathname={:?}, times={:?}, flags={:?}, \
                      reason={:?})",
                     dirfd,

--- a/src/libs/syscall/src/sys/times/syscall/times.rs
+++ b/src/libs/syscall/src/sys/times/syscall/times.rs
@@ -71,12 +71,12 @@ pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("times(): failed (buffer={:?}, status={:?})", buffer, { response.status });
+        ::syslog::warn!("times(): failed (buffer={:?}, status={:?})", buffer, { response.status });
         // System call failed, parse error code and return it.
         match ErrorCode::try_from(response.status) {
             Ok(error_code) => Err(Error::new(error_code, "times() failed")),
             Err(error) => {
-                ::syslog::error!("times(): failed to parse error code (error={:?})", error);
+                ::syslog::warn!("times(): failed to parse error code (error={:?})", error);
                 Err(Error::new(ErrorCode::TryAgain, "times() failed"))
             },
         }
@@ -101,7 +101,7 @@ pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
                 Ok(elapsed)
             },
             header => {
-                ::syslog::error!("times(): failed (buffer={:?}, header={:?})", buffer, header);
+                ::syslog::warn!("times(): failed (buffer={:?}, header={:?})", buffer, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "times() failed"))
             },
         }

--- a/src/libs/syscall/src/sys/utsname/syscall.rs
+++ b/src/libs/syscall/src/sys/utsname/syscall.rs
@@ -46,7 +46,7 @@ fn encode_str<const N: usize>(string: &str) -> Result<[c_char; N], Error> {
         // Failure.
         Err(error) => {
             let reason: &str = "failed to convert string";
-            ::syslog::error!("encode_str(): {} (error={:?})", reason, error);
+            ::syslog::warn!("encode_str(): {} (error={:?})", reason, error);
             return Err(Error::new(ErrorCode::ValueOutOfRange, reason));
         },
     };
@@ -54,7 +54,7 @@ fn encode_str<const N: usize>(string: &str) -> Result<[c_char; N], Error> {
     // Check if string is too long.
     if c_string.as_bytes_with_nul().len() > N {
         let reason: &str = "string is too long";
-        ::syslog::error!("encode_str(): {} (string={:?})", reason, string);
+        ::syslog::warn!("encode_str(): {} (string={:?})", reason, string);
         return Err(Error::new(ErrorCode::ValueOutOfRange, reason));
     }
 

--- a/src/libs/syscall/src/time/bindings/clock_getres.rs
+++ b/src/libs/syscall/src/time/bindings/clock_getres.rs
@@ -56,21 +56,12 @@ pub unsafe extern "C" fn clock_getres(clock_id: clockid_t, res: *mut timespec) -
         Ok(()) => 0,
         // System call failed.
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
-                    clock_id,
-                    res,
-                    error
-                );
-            } else {
-                ::syslog::error!(
-                    "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
-                    clock_id,
-                    res,
-                    error
-                );
-            }
+            ::syslog::warn!(
+                "clock_getres(): failed (clock_id={:?}, res={:?}, error={:?})",
+                clock_id,
+                res,
+                error
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/time/bindings/clock_gettime.rs
+++ b/src/libs/syscall/src/time/bindings/clock_gettime.rs
@@ -49,21 +49,12 @@ pub unsafe extern "C" fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -
     match crate::time::clock_gettime(clock_id, &mut tp) {
         Ok(_) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
-                    clock_id,
-                    tp,
-                    error
-                );
-            } else {
-                ::syslog::error!(
-                    "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
-                    clock_id,
-                    tp,
-                    error
-                );
-            }
+            ::syslog::warn!(
+                "clock_gettime(): failed (clock_id={:?}, tp={:?}, error={:?})",
+                clock_id,
+                tp,
+                error
+            );
             // Set errno.
             *__errno_location() = error.code.get();
             -1

--- a/src/libs/syscall/src/time/bindings/nanosleep.rs
+++ b/src/libs/syscall/src/time/bindings/nanosleep.rs
@@ -23,7 +23,7 @@ use sysapi::errno::__errno_location;
 pub unsafe extern "C" fn nanosleep(req: *const timespec, rem: *mut timespec) -> c_int {
     // Check if `req` is valid.
     if req.is_null() {
-        ::syslog::error!("nanosleep(): invalid req pointer");
+        ::syslog::warn!("nanosleep(): invalid req pointer");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn nanosleep(req: *const timespec, rem: *mut timespec) -> 
     match crate::time::nanosleep(req, &mut rem) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "nanosleep(): failed (req={:?}, rem={:?}, error={:?})",
                 req,
                 rem,

--- a/src/libs/syscall/src/time/syscall/clock_getres.rs
+++ b/src/libs/syscall/src/time/syscall/clock_getres.rs
@@ -46,7 +46,7 @@ use sysapi::{
 /// Upon successful completion, `clock_getres()` returns empty. Otherwise, it returns an error.
 ///
 pub fn clock_getres(clock_id: clockid_t, res: &mut Option<&mut timespec>) -> Result<(), Error> {
-    ::syslog::error!("clock_getres(): clock_id={:?}, res={:?}", clock_id, res);
+    ::syslog::trace!("clock_getres(): clock_id={:?}, res={:?}", clock_id, res);
 
     match clock_id {
         // Check if the clock ID is valid.
@@ -59,12 +59,12 @@ pub fn clock_getres(clock_id: clockid_t, res: &mut Option<&mut timespec>) -> Res
         },
         CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID => {
             let reason: &str = "unsupported clock id";
-            ::syslog::error!("clock_getres(): {} (clock_id={:?}, res={:?})", reason, clock_id, res);
+            ::syslog::warn!("clock_getres(): {} (clock_id={:?}, res={:?})", reason, clock_id, res);
             Err(Error::new(ErrorCode::OperationNotSupported, "clock_getres() failed"))
         },
         clock_id => {
             let reason: &str = "invalid clock id";
-            ::syslog::error!("clock_getres(): {} (clock_id={:?}, res={:?})", reason, clock_id, res);
+            ::syslog::warn!("clock_getres(): {} (clock_id={:?}, res={:?})", reason, clock_id, res);
             Err(Error::new(ErrorCode::InvalidArgument, "clock_getres() failed"))
         },
     }

--- a/src/libs/syscall/src/time/syscall/clock_gettime.rs
+++ b/src/libs/syscall/src/time/syscall/clock_gettime.rs
@@ -65,13 +65,13 @@ pub fn clock_gettime(clock_id: clockid_t, tp: &mut Option<&mut timespec>) -> Res
         },
         CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID => {
             let reason: &str = "unsupported clock id";
-            ::syslog::error!("clock_gettime(): {} (clock_id={:?}, tp={:x?})", reason, clock_id, tp);
+            ::syslog::warn!("clock_gettime(): {} (clock_id={:?}, tp={:x?})", reason, clock_id, tp);
             Err(Error::new(ErrorCode::OperationNotSupported, reason))
         },
 
         clock_id => {
             let reason: &str = "invalid clock id";
-            ::syslog::error!("clock_gettime(): {} (clock_id={:?}, tp={:x?})", reason, clock_id, tp);
+            ::syslog::warn!("clock_gettime(): {} (clock_id={:?}, tp={:x?})", reason, clock_id, tp);
             Err(Error::new(ErrorCode::InvalidArgument, reason))
         },
     }

--- a/src/libs/syscall/src/time/syscall/nanosleep.rs
+++ b/src/libs/syscall/src/time/syscall/nanosleep.rs
@@ -39,7 +39,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
     // Check if the requested time is valid.
     if req.tv_sec < 0 || req.tv_nsec < 0 || req.tv_nsec >= 1_000_000_000 {
         let reason: &str = "invalid sleep time";
-        ::syslog::error!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
+        ::syslog::warn!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
             req.tv_nsec
         });
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -49,7 +49,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
         Ok(secs) => secs,
         Err(_) => {
             let reason: &str = "invalid sleep time";
-            ::syslog::error!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
+            ::syslog::warn!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
                 req.tv_nsec
             });
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -59,7 +59,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
         Ok(nanos) => nanos,
         Err(_) => {
             let reason: &str = "invalid sleep time";
-            ::syslog::error!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
+            ::syslog::warn!("nanosleep(): {} (tv_sec={}, tv_nsec={})", reason, { req.tv_sec }, {
                 req.tv_nsec
             });
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -80,7 +80,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
             Some(later) => later,
             None => {
                 let reason: &str = "invalid sleep time";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "nanosleep(): {} (tv_sec={}, tv_nsec={})",
                     reason,
                     { req.tv_sec },

--- a/src/libs/syscall/src/unistd/bindings/chdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/chdir.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
     // Check if `path` is invalid.
     if path.is_null() {
-        ::syslog::error!("chdir(): path is null (path={path:?})");
+        ::syslog::warn!("chdir(): path is null (path={path:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
     let path: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!("chdir(): invalid path (path={path:?})");
+            ::syslog::warn!("chdir(): invalid path (path={path:?})");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
     match crate::unistd::chdir(path) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("chdir(): {error:?} (path={path:?})");
+            ::syslog::warn!("chdir(): {error:?} (path={path:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/faccessat.rs
+++ b/src/libs/syscall/src/unistd/bindings/faccessat.rs
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn faccessat(
 ) -> c_int {
     // Check if `path` is invalid.
     if path.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "faccessat(): null path pointer (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
              flag={flag:?})"
         );
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn faccessat(
     let path: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "faccessat(): invalid path (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
                  flag={flag:?})"
             );
@@ -92,17 +92,10 @@ pub unsafe extern "C" fn faccessat(
     match crate::unistd::faccessat(dirfd, path, mode, flag) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry {
-                ::syslog::warn!(
-                    "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
-                     flag={flag:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
-                     flag={flag:?})"
-                );
-            }
+            ::syslog::warn!(
+                "faccessat(): {error:?} (dirfd={dirfd:?}, path={path:?}, mode={mode:?}, \
+                 flag={flag:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/fchdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchdir.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn fchdir(fd: c_int) -> c_int {
     match unistd::fchdir(fd) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("fchdir(): {error:?} (fd={fd:?})");
+            ::syslog::warn!("fchdir(): {error:?} (fd={fd:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/fchown.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchown.rs
@@ -70,15 +70,7 @@ pub unsafe extern "C" fn fchown(fd: c_int, owner: uid_t, group: gid_t) -> c_int 
     match crate::unistd::fchown(fd, owner, group) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})"
-                );
-            }
+            ::syslog::warn!("fchown(): {error:?} (fd={fd:?}, owner={owner:?}, group={group:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/fchownat.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchownat.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn fchownat(
 ) -> c_int {
     // Check if `path` is invalid.
     if path.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "fchownat(): null path pointer (dirfd={dirfd:?}, path={path:?}, owner={owner:?}, \
              group={group:?}, flag={flag:?})"
         );
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn fchownat(
     let pathname: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(_error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "fchownat(): invalid pathname (dirfd={dirfd:?}, path={path:?}, owner={owner:?}, \
                  group={group:?}, flag={flag:?})"
             );
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn fchownat(
     match crate::unistd::fchownat(dirfd, pathname, owner, group, flag) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "fchownat(): {error:?} (dirfd={dirfd:?}, path={pathname:?}, owner={owner:?}, \
                  group={group:?}, flag={flag:?})"
             );

--- a/src/libs/syscall/src/unistd/bindings/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/bindings/fdatasync.rs
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn fdatasync(fd: c_int) -> c_int {
     match crate::unistd::fdatasync(fd) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("fdatasync(): {error:?} (fd={fd:?})");
+            ::syslog::warn!("fdatasync(): {error:?} (fd={fd:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/fsync.rs
+++ b/src/libs/syscall/src/unistd/bindings/fsync.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn fsync(fd: c_int) -> c_int {
     match crate::unistd::fsync(fd) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!("fsync(): {error:?} (fd={fd:?})");
+            ::syslog::warn!("fsync(): {error:?} (fd={fd:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/bindings/ftruncate.rs
@@ -66,11 +66,7 @@ pub unsafe extern "C" fn ftruncate(fd: c_int, length: off_t) -> c_int {
     match crate::unistd::ftruncate(fd, length) {
         Ok(()) => 0,
         Err(error) => {
-            if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                ::syslog::warn!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
-            } else {
-                ::syslog::error!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
-            }
+            ::syslog::warn!("ftruncate(): {error:?} (fd={fd:?}, length={length:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/getcwd.rs
+++ b/src/libs/syscall/src/unistd/bindings/getcwd.rs
@@ -71,14 +71,14 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char {
     // Check if the buffer is valid.
     if buf.is_null() {
-        ::syslog::error!("getcwd(): invalid buffer (buf={buf:?}, size={size:?})");
+        ::syslog::warn!("getcwd(): invalid buffer (buf={buf:?}, size={size:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return core::ptr::null_mut();
     }
 
     // Check if the buffer size is invalid.
     if size == 0 {
-        ::syslog::error!("getcwd(): buffer size is zero (buf={buf:?}, size={size:?})");
+        ::syslog::warn!("getcwd(): buffer size is zero (buf={buf:?}, size={size:?})");
         *__errno_location() = ErrorCode::ValueOutOfRange.get();
         return core::ptr::null_mut();
     }
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char
             let cstr: CString = match CString::new(cwd) {
                 Ok(cstr) => cstr,
                 Err(_) => {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "getcwd(): invalid current working directory (buf={buf:?}, size={size:?})"
                     );
                     *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char
 
             // Check if the buffer is large enough.
             if buf.len() < cwd.len() {
-                ::syslog::error!("getcwd(): buffer is too small (buf={buf:?}, size={size:?})");
+                ::syslog::warn!("getcwd(): buffer is too small (buf={buf:?}, size={size:?})");
                 *__errno_location() = ErrorCode::ValueOutOfRange.get();
                 return core::ptr::null_mut();
             }
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char
         },
         // Failure.
         Err(error) => {
-            ::syslog::error!("getcwd(): {error:?} (buf={buf:?}, size={size:?})");
+            ::syslog::warn!("getcwd(): {error:?} (buf={buf:?}, size={size:?})");
             *__errno_location() = error.code.get();
             core::ptr::null_mut()
         },

--- a/src/libs/syscall/src/unistd/bindings/getentropy.rs
+++ b/src/libs/syscall/src/unistd/bindings/getentropy.rs
@@ -91,7 +91,7 @@ fn prng() -> i32 {
 pub unsafe extern "C" fn getentropy(buffer: *mut c_void, length: size_t) -> c_int {
     // Check if buffer is null.
     if buffer.is_null() {
-        ::syslog::error!("getentropy(): invalid buffer (buffer={buffer:?}, length={length:?})");
+        ::syslog::warn!("getentropy(): invalid buffer (buffer={buffer:?}, length={length:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }

--- a/src/libs/syscall/src/unistd/bindings/gethostname.rs
+++ b/src/libs/syscall/src/unistd/bindings/gethostname.rs
@@ -69,13 +69,13 @@ pub unsafe extern "C" fn gethostname(name: *mut c_char, namelen: c_size_t) -> c_
     let buf: &mut [u8] = {
         // Check if the buffer is invalid.
         if name.is_null() {
-            ::syslog::error!("gethostname(): invalid buffer (name={name:?}, namelen={namelen:?})");
+            ::syslog::warn!("gethostname(): invalid buffer (name={name:?}, namelen={namelen:?})");
             return -1;
         }
 
         // Check if `namelen` is invalid.
         if namelen == 0 || namelen as usize >= isize::MAX as usize {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "gethostname(): invalid buffer size (name={name:?}, namelen={namelen:?})"
             );
             return -1;
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn gethostname(name: *mut c_char, namelen: c_size_t) -> c_
         Ok(s) => s,
         // Failure.
         Err(_error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "gethostname(): failed to convert string (name={name:?}, namelen={namelen:?})",
             );
             return -1;

--- a/src/libs/syscall/src/unistd/bindings/linkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/linkat.rs
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn linkat(
     let oldpath: &str = {
         // Check if `oldpath` is invalid.
         if oldpath.is_null() {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "linkat(): invalid oldpath (olddirfd={olddirfd:?}, oldpath={oldpath:?}, \
                  newdirfd={newdirfd:?}, newpath={newpath:?}, flags={flags:?})"
             );
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn linkat(
         match ffi::CStr::from_ptr(oldpath).to_str() {
             Ok(pathname) => pathname,
             Err(_error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "linkat(): invalid oldpath (olddirfd={olddirfd:?}, oldpath={oldpath:?}, \
                      newdirfd={newdirfd:?}, newpath={newpath:?}, flags={flags:?})"
                 );
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn linkat(
     let newpath: &str = {
         // Check if `newpath` is invalid.
         if newpath.is_null() {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "linkat(): invalid newpath (olddirfd={olddirfd:?}, oldpath={oldpath:?}, \
                  newdirfd={newdirfd:?}, newpath={newpath:?}, flags={flags:?})"
             );
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn linkat(
         match ffi::CStr::from_ptr(newpath).to_str() {
             Ok(pathname) => pathname,
             Err(_error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "linkat(): invalid newpath (olddirfd={olddirfd:?}, oldpath={oldpath:?}, \
                      newdirfd={newdirfd:?}, newpath={newpath:?}, flags={flags:?})"
                 );
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn linkat(
     match unistd::linkat(olddirfd, oldpath, newdirfd, newpath, flags) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "linkat(): {error:?} (olddirfd={olddirfd:?}, oldpath={oldpath:?}, \
                  newdirfd={newdirfd:?}, newpath={newpath:?}, flags={flags:?})"
             );

--- a/src/libs/syscall/src/unistd/bindings/pread.rs
+++ b/src/libs/syscall/src/unistd/bindings/pread.rs
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn pread(
 ) -> c_ssize_t {
     // Check if buffer is invalid.
     if buffer.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pread(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
              offset={offset:?})"
         );
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn pread(
     match unistd::pread(fd, buffer, offset) {
         Ok(bytes_read) => bytes_read as c_ssize_t,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pread(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
                  offset={offset:?})"
             );

--- a/src/libs/syscall/src/unistd/bindings/pwrite.rs
+++ b/src/libs/syscall/src/unistd/bindings/pwrite.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn pwrite(
 ) -> c_ssize_t {
     // Check if buffer is invalid.
     if buffer.is_null() {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pwrite(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
              offset={offset:?})"
         );
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn pwrite(
 
     // Check if count is invalid.
     if count == 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "pwrite(): invalid count (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
              offset={offset:?})"
         );
@@ -90,17 +90,10 @@ pub unsafe extern "C" fn pwrite(
     match unistd::pwrite(fd, buffer, offset) {
         Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
-            if error.code == ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
-                     offset={offset:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
-                     offset={offset:?})"
-                );
-            }
+            ::syslog::warn!(
+                "pwrite(): {error:?}, (fd={fd:?}, buffer={buffer:?}, count={count:?}, \
+                 offset={offset:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/read.rs
+++ b/src/libs/syscall/src/unistd/bindings/read.rs
@@ -65,7 +65,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -> c_ssize_t {
     // Check if buffer is invalid.
     if buffer.is_null() {
-        ::syslog::error!("read(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");
+        ::syslog::warn!("read(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -
     match crate::unistd::read(fd, buffer) {
         Ok(bytes_read) => bytes_read as c_ssize_t,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "read(): failed (error={error:?}, fd={fd:?}, buffer={:?}, count={count:?})",
                 buffer.as_ptr()
             );

--- a/src/libs/syscall/src/unistd/bindings/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/readlinkat.rs
@@ -109,17 +109,10 @@ pub unsafe extern "C" fn readlinkat(
     match unistd::readlinkat(dirfd, path, buf) {
         Ok(bytes_read) => bytes_read,
         Err(error) => {
-            if error.code == ErrorCode::NoSuchEntry {
-                ::syslog::warn!(
-                    "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
-                     bufsize={bufsize:?})"
-                );
-            } else {
-                ::syslog::error!(
-                    "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
-                     bufsize={bufsize:?})"
-                );
-            }
+            ::syslog::warn!(
+                "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
+                 bufsize={bufsize:?})"
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/rmdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/rmdir.rs
@@ -23,7 +23,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn rmdir(path: *const c_char) -> c_int {
     // Validate the path pointer.
     if path.is_null() {
-        ::syslog::error!("rmdir(): path is null (path={path:?})");
+        ::syslog::warn!("rmdir(): path is null (path={path:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }

--- a/src/libs/syscall/src/unistd/bindings/setegid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setegid.rs
@@ -44,18 +44,18 @@ use ::syslog::trace_libcall;
 #[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setegid(gid: gid_t) -> c_int {
-    ::syslog::error!("setegid(): gid={gid:?}");
+    ::syslog::trace!("setegid(): gid={gid:?}");
 
     // Check whether `gid` equals to the effective group ID of the calling process.
     match unistd::getegid() {
         Ok(egid) if gid == egid => 0,
         Ok(egid) => {
-            ::syslog::error!("setegid(): operation not permitted (gid={gid:?}, egid={egid:?})");
+            ::syslog::warn!("setegid(): operation not permitted (gid={gid:?}, egid={egid:?})");
             *__errno_location() = ErrorCode::OperationNotPermitted.get();
             -1
         },
         Err(error) => {
-            ::syslog::error!("setegid(): {error:?} (gid={gid:?})");
+            ::syslog::warn!("setegid(): {error:?} (gid={gid:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/seteuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/seteuid.rs
@@ -44,18 +44,18 @@ use ::syslog::trace_libcall;
 #[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn seteuid(uid: uid_t) -> c_int {
-    ::syslog::error!("seteuid(): uid={uid:?}");
+    ::syslog::trace!("seteuid(): uid={uid:?}");
 
     // Check whether `uid` equals to the effective user ID of the calling process.
     match unistd::geteuid() {
         Ok(euid) if uid == euid => 0,
         Ok(euid) => {
-            ::syslog::error!("seteuid(): operation not permitted (uid={uid:?}, euid={euid:?})");
+            ::syslog::warn!("seteuid(): operation not permitted (uid={uid:?}, euid={euid:?})");
             *__errno_location() = ErrorCode::OperationNotPermitted.get();
             -1
         },
         Err(error) => {
-            ::syslog::error!("seteuid(): {error:?} (uid={uid:?})");
+            ::syslog::warn!("seteuid(): {error:?} (uid={uid:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/setgid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setgid.rs
@@ -44,18 +44,18 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setgid(gid: gid_t) -> c_int {
-    ::syslog::error!("setgid(): gid={gid:?}");
+    ::syslog::trace!("setgid(): gid={gid:?}");
 
     // Check whether `gid` equals to the real group ID of the calling process.
     match unistd::getgid() {
         Ok(rgid) if gid == rgid => 0,
         Ok(rgid) => {
-            ::syslog::error!("setgid(): operation not permitted (gid={gid:?}, rgid={rgid:?})");
+            ::syslog::warn!("setgid(): operation not permitted (gid={gid:?}, rgid={rgid:?})");
             *__errno_location() = ErrorCode::OperationNotPermitted.get();
             -1
         },
         Err(error) => {
-            ::syslog::error!("setgid(): {error:?} (gid={gid:?})");
+            ::syslog::warn!("setgid(): {error:?} (gid={gid:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/setuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setuid.rs
@@ -44,18 +44,18 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setuid(uid: uid_t) -> c_int {
-    ::syslog::error!("setuid(): uid={uid:?}");
+    ::syslog::trace!("setuid(): uid={uid:?}");
 
     // Check whether `uid` equals to the real user ID of the calling process.
     match unistd::getuid() {
         Ok(ruid) if uid == ruid => 0,
         Ok(ruid) => {
-            ::syslog::error!("setuid(): operation not permitted (uid={uid:?}, ruid={ruid:?})");
+            ::syslog::warn!("setuid(): operation not permitted (uid={uid:?}, ruid={ruid:?})");
             *__errno_location() = ErrorCode::OperationNotPermitted.get();
             -1
         },
         Err(error) => {
-            ::syslog::error!("setuid(): {error:?} (uid={uid:?})");
+            ::syslog::warn!("setuid(): {error:?} (uid={uid:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/symlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/symlink.rs
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char)
     let target: &str = {
         // Check if `target` is invalid.
         if target.is_null() {
-            syslog::error!(
+            syslog::warn!(
                 "symlink(): target path is null (target={target:?}, linkpath={linkpath:?})"
             );
             *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char)
         match ffi::CStr::from_ptr(target).to_str() {
             Ok(pathname) => pathname,
             Err(_) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "symlink(): invalid target (target={target:?}, linkpath={linkpath:?})"
                 );
                 *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -71,9 +71,7 @@ pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char)
     let linkpath: &str = {
         // Check if `linkpath` is invalid.
         if linkpath.is_null() {
-            syslog::error!(
-                "symlink(): linkpath is null (target={target:?}, linkpath={linkpath:?})"
-            );
+            syslog::warn!("symlink(): linkpath is null (target={target:?}, linkpath={linkpath:?})");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         }
@@ -81,7 +79,7 @@ pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char)
         match ffi::CStr::from_ptr(linkpath).to_str() {
             Ok(pathname) => pathname,
             Err(_) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "symlink(): invalid linkpath (target={target:?}, linkpath={linkpath:?})"
                 );
                 *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -94,7 +92,7 @@ pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char)
     match unistd::symlink(target, linkpath) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("symlink(): {error:?} (target={target}, linkpath={linkpath})");
+            ::syslog::warn!("symlink(): {error:?} (target={target}, linkpath={linkpath})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/symlinkat.rs
@@ -53,13 +53,13 @@ pub unsafe extern "C" fn symlinkat(
     dirfd: c_int,
     linkpath: *const c_char,
 ) -> c_int {
-    ::syslog::error!("symlinkat(): target={target:?}, dirfd={dirfd}, linkpath={linkpath:?}",);
+    ::syslog::trace!("symlinkat(): target={target:?}, dirfd={dirfd}, linkpath={linkpath:?}",);
 
     // Attempt to convert `target`.
     let target: &str = {
         // Check if `target` is invalid.
         if target.is_null() {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "symlinkat(): target is null (target={target:?}, dirfd={dirfd}, \
                  linkpath={linkpath:?})"
             );
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn symlinkat(
         match ffi::CStr::from_ptr(target).to_str() {
             Ok(pathname) => pathname,
             Err(_) => {
-                ::syslog::error!("symlinkat(): invalid target");
+                ::syslog::warn!("symlinkat(): invalid target");
                 *__errno_location() = ErrorCode::InvalidArgument.get();
                 return -1;
             },
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn symlinkat(
     let linkpath: &str = {
         // Check if `linkpath` is invalid.
         if linkpath.is_null() {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "symlinkat(): linkpath is null (target={target:?}, dirfd={dirfd}, \
                  linkpath={linkpath:?})"
             );
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn symlinkat(
         match ffi::CStr::from_ptr(linkpath).to_str() {
             Ok(pathname) => pathname,
             Err(_) => {
-                ::syslog::error!("symlinkat(): invalid linkpath");
+                ::syslog::warn!("symlinkat(): invalid linkpath");
                 *__errno_location() = ErrorCode::InvalidArgument.get();
                 return -1;
             },
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn symlinkat(
     match unistd::symlinkat(target, dirfd, linkpath) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "symlinkat(): {error:?} (target={target:?}, dirfd={dirfd}, linkpath={linkpath:?})"
             );
             *__errno_location() = error.code.get();

--- a/src/libs/syscall/src/unistd/bindings/unlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/unlink.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
     let path: &str = {
         // Check if `path` is invalid.
         if path.is_null() {
-            ::syslog::error!("unlink(): path is null (path={path:?})");
+            ::syslog::warn!("unlink(): path is null (path={path:?})");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         }
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
         match ffi::CStr::from_ptr(path).to_str() {
             Ok(pathname) => pathname,
             Err(_) => {
-                ::syslog::error!("unlink(): invalid path (path={path:?})");
+                ::syslog::warn!("unlink(): invalid path (path={path:?})");
                 *__errno_location() = ErrorCode::InvalidArgument.get();
                 return -1;
             },
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
     match unistd::unlink(path) {
         Ok(()) => 0,
         Err(error) => {
-            ::syslog::error!("unlink(): {error:?} (path={path:?})");
+            ::syslog::warn!("unlink(): {error:?} (path={path:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/bindings/write.rs
+++ b/src/libs/syscall/src/unistd/bindings/write.rs
@@ -67,14 +67,14 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t) -> c_ssize_t {
     // Check if buffer is invalid.
     if buffer.is_null() {
-        ::syslog::error!("write(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");
+        ::syslog::warn!("write(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");
         *__errno_location() = ErrorCode::InvalidArgument.get();
         return -1;
     }
 
     // Check if count is invalid.
     if count == 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "write(): invalid write count (fd={fd:?}, buffer={buffer:?}, count={count:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -88,17 +88,10 @@ pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t
     match crate::unistd::syscall::write(fd, buffer) {
         Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
-            if error.code == ErrorCode::OperationNotSupported {
-                ::syslog::warn!(
-                    "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
-                    buffer.as_ptr()
-                );
-            } else {
-                ::syslog::error!(
-                    "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
-                    buffer.as_ptr()
-                );
-            }
+            ::syslog::warn!(
+                "write(): {error:?} (fd={fd:?}, buffer={:?}, count={count:?})",
+                buffer.as_ptr()
+            );
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -80,7 +80,7 @@ impl ChangeDirectoryRequest {
         // Check if path is too long.
         if path.len() > PATH_MAX {
             #[cfg(target_os = "none")]
-            ::syslog::error!("new(): path too long (path.len={:?})", path.len());
+            ::syslog::warn!("new(): path too long (path.len={:?})", path.len());
             return Err(Error::new(ErrorCode::InvalidArgument, "path too long"));
         }
 
@@ -129,7 +129,7 @@ impl MessageDeserializer for ChangeDirectoryRequest {
         // Check if message is too short.
         if bytes.len() < Self::OFFSET_OF_PATH {
             #[cfg(target_os = "none")]
-            ::syslog::error!("try_from_bytes(): message too short (bytes.len={:?})", bytes.len());
+            ::syslog::warn!("try_from_bytes(): message too short (bytes.len={:?})", bytes.len());
             return Err(Error::new(ErrorCode::InvalidMessage, "message too short"));
         }
 

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -77,7 +77,7 @@ fn chdir_linuxd(path: &str) -> Result<(), Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("chdir(): failed (path={:?}, error_code={:?})", path, { response.status });
+        ::syslog::warn!("chdir(): failed (path={:?}, error_code={:?})", path, { response.status });
         // System call failed, parse error code and return.
         match ErrorCode::try_from(response.status) {
             // Succeeded to parse error code.
@@ -87,7 +87,7 @@ fn chdir_linuxd(path: &str) -> Result<(), Error> {
             },
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "chdir(): failed to parse error code (path={:?}, error={:?})",
                     path,
                     error
@@ -102,7 +102,7 @@ fn chdir_linuxd(path: &str) -> Result<(), Error> {
             LinuxDaemonMessageHeader::ChangeDirectoryResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
-                ::syslog::error!("chdir(): {:?} (path={:?}, header={:?})", reason, path, header);
+                ::syslog::warn!("chdir(): {:?} (path={:?}, header={:?})", reason, path, header);
                 Err(Error::new(ErrorCode::InvalidMessage, reason))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -72,7 +72,7 @@ fn close_linuxd(fd: i32) -> Result<(), Error> {
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("close(): failed (error={})", error_code);
+        ::syslog::warn!("close(): failed (error={})", error_code);
         Err(Error::new(error_code, "close() failed"))
     } else {
         // System call succeeded, parse response.
@@ -107,11 +107,7 @@ pub mod bindings {
         match crate::unistd::close(fd) {
             Ok(()) => 0,
             Err(error) => {
-                if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                    ::syslog::warn!("close(): failed ({:?})", error);
-                } else {
-                    ::syslog::error!("close(): failed ({:?})", error);
-                }
+                ::syslog::warn!("close(): failed ({:?})", error);
                 unsafe {
                     *__errno_location() = error.code.get();
                 }

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -88,28 +88,16 @@ fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Resul
     if response.status != 0 {
         match ErrorCode::try_from(response.status) {
             Ok(error_code) => {
-                if error_code == ErrorCode::NoSuchEntry {
-                    ::syslog::warn!(
-                        "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, \
-                         error_code={:?})",
-                        dirfd,
-                        path,
-                        mode,
-                        flag,
-                        error_code,
-                    );
-                } else {
-                    ::syslog::error!(
-                        "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, \
-                         error_code={:?})",
-                        dirfd,
-                        path,
-                        mode,
-                        flag,
-                        error_code,
-                    );
-                }
-                Err(Error::new(error_code, "failed"))
+                ::syslog::warn!(
+                    "faccessat(): failed (dirfd={:?}, path={:?}, mode={:?}, flag={:?}, \
+                     error_code={:?})",
+                    dirfd,
+                    path,
+                    mode,
+                    flag,
+                    error_code,
+                );
+                Err(Error::new(error_code, "faccessat() failed"))
             },
             Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "failed to parse error code")),
         }
@@ -120,7 +108,7 @@ fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Resul
         match message.header {
             LinuxDaemonMessageHeader::FileAccessAtResponse => Ok(()),
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "faccessat(): failed to parse response (dirfd={:?}, path={:?}, mode={:?}, \
                      flag={:?}, header={:?})",
                     dirfd,

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -72,14 +72,14 @@ fn fchdir_linuxd(fd: c_int) -> Result<(), Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("fchdir(): failed (fd={:?}, error_code={:?})", fd, { response.status });
+        ::syslog::warn!("fchdir(): failed (fd={:?}, error_code={:?})", fd, { response.status });
         // System call failed, parse error code and return.
         match ErrorCode::try_from(response.status) {
             // Succeeded to parse error code.
             Ok(error_code) => Err(Error::new(error_code, "fchdir() failed")),
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!("fchdir(): failed to convert error code (error={:?})", error);
+                ::syslog::warn!("fchdir(): failed to convert error code (error={:?})", error);
                 Err(Error::new(ErrorCode::TryAgain, "fchdir() failed"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -77,7 +77,7 @@ fn fchown_linuxd(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<()
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "fchown(): failed (fd={:?}, owner={:?}, group={:?}, status={:?})",
             fd,
             owner,
@@ -99,7 +99,7 @@ fn fchown_linuxd(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<()
             LinuxDaemonMessageHeader::FileChownResponse => Ok(()),
             // Invalid response.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fchown(): invalid response (fd={:?}, owner={:?}, group={:?}, header={:?})",
                     fd,
                     owner,

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -71,7 +71,7 @@ pub fn fchownat(
     {
         ::nvx::vfs::fd::vfs_fchownat(dirfd, path, owner, group, flag).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!(
+            ::syslog::warn!(
                 "fchownat(): VFS fchownat failed (dirfd={dirfd:?}, path={path:?}, error={e})"
             );
             Error::new(code, "vfs fchownat failed")
@@ -106,7 +106,7 @@ fn fchownat_linuxd(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "fchownat(): failed (dirfd={:?}, path={:?}, owner={:?}, group={:?}, flag={:?}, \
              error_code={:?})",
             dirfd,
@@ -128,7 +128,7 @@ fn fchownat_linuxd(
         match message.header {
             LinuxDaemonMessageHeader::FileChownAtResponse => Ok(()),
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fchownat(): failed to parse response (dirfd={:?}, path={:?}, owner={:?}, \
                      group={:?}, flag={:?}, header={:?})",
                     dirfd,

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -75,7 +75,7 @@ fn fdatasync_linuxd(fd: RawFileDescriptor) -> Result<(), Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!("fdatasync(): fd={:?}, status={:?}", fd, { response.status });
+        ::syslog::warn!("fdatasync(): fd={:?}, status={:?}", fd, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // Error code was successfully parsed.
@@ -98,7 +98,7 @@ fn fdatasync_linuxd(fd: RawFileDescriptor) -> Result<(), Error> {
             LinuxDaemonMessageHeader::FileDataSyncResponse => Ok(()),
             // Invalid response.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "fdatasync(): fd={:?}, status={:?}, header={:?}",
                     fd,
                     { response.status },

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -75,7 +75,7 @@ fn fsync_linuxd(fd: c_int) -> Result<(), Error> {
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("fsync(): failed ({:?})", error_code);
+        ::syslog::warn!("fsync(): failed ({:?})", error_code);
         Err(Error::new(error_code, "fsync() failed"))
     } else {
         // System call succeeded, parse response.

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -82,7 +82,7 @@ fn ftruncate_linuxd(fd: c_int, length: off_t) -> Result<(), Error> {
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "ftruncate(): system call failed: fd={}, length={}, status={}",
             fd,
             length,
@@ -105,7 +105,7 @@ fn ftruncate_linuxd(fd: c_int, length: off_t) -> Result<(), Error> {
             LinuxDaemonMessageHeader::FileTruncateResponse => Ok(()),
             // Invalid response.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "ftruncate(): invalid response: fd={}, length={}, header={:?}",
                     fd,
                     length,

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -64,7 +64,7 @@ fn getegid_linuxd() -> Result<gid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getegid(): failed (tid={:?}, status={:?})", tid, { response.status });
+        ::syslog::warn!("getegid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -83,11 +83,7 @@ fn getegid_linuxd() -> Result<gid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!(
-                    "getegid(): invalid response (tid={:?}, header={:?})",
-                    tid,
-                    header
-                );
+                ::syslog::warn!("getegid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -64,7 +64,7 @@ fn geteuid_linuxd() -> Result<uid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("geteuid(): failed (tid={:?}, status={:?})", tid, { response.status });
+        ::syslog::warn!("geteuid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -83,11 +83,7 @@ fn geteuid_linuxd() -> Result<uid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!(
-                    "geteuid(): invalid response (tid={:?}, header={:?})",
-                    tid,
-                    header
-                );
+                ::syslog::warn!("geteuid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -64,7 +64,7 @@ fn getgid_linuxd() -> Result<gid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getgid(): failed (tid={:?}, status={:?})", tid, { response.status });
+        ::syslog::warn!("getgid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -83,7 +83,7 @@ fn getgid_linuxd() -> Result<gid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!("getgid(): invalid response (tid={:?}, header={:?})", tid, header);
+                ::syslog::warn!("getgid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -64,7 +64,7 @@ fn getuid_linuxd() -> Result<uid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getuid(): failed (tid={:?}, status={:?})", tid, { response.status });
+        ::syslog::warn!("getuid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -83,7 +83,7 @@ fn getuid_linuxd() -> Result<uid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!("getuid(): invalid response (tid={:?}, header={:?})", tid, header);
+                ::syslog::warn!("getuid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -105,7 +105,7 @@ fn linkat_linuxd(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "linkat(): failed (olddirfd={}, oldpath={}, newdirfd={}, newpath={}, flags={}, \
              error={})",
             olddirfd,
@@ -124,7 +124,7 @@ fn linkat_linuxd(
             },
             // Error code was not successfully parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "linkat(): failed to parse error code (olddirfd={}, oldpath={}, newdirfd={}, \
                      newpath={}, flags={}, error={:?})",
                     olddirfd,
@@ -147,7 +147,7 @@ fn linkat_linuxd(
             // Response was not successfully parsed.
             header => {
                 let reason: &str = "unexpected message header";
-                ::syslog::error!(
+                ::syslog::warn!(
                     "linkat(): {:?} (olddirfd={}, oldpath={}, newdirfd={}, newpath={}, flags={}, \
                      header={:?})",
                     reason,

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -82,7 +82,7 @@ fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<o
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "lseek(): failed (fd={}, offset={}, whence={}, error={})",
             fd,
             offset,
@@ -99,7 +99,7 @@ fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<o
             },
             // Error code was not successfully parsed.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "lseek(): failed to parse error code (fd={}, offset={}, whence={}, error={:?})",
                     fd,
                     offset,
@@ -123,7 +123,7 @@ fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<o
             },
             // Response was not successfully parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "lseek(): failed to parse response (fd={}, offset={}, whence={}, header={:?})",
                     fd,
                     offset,

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -59,7 +59,7 @@ fn pipe_linuxd() -> Result<[i32; 2], Error> {
     if response.status != 0 {
         // System call failed, parse error code and return it.
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
-        ::syslog::error!("pipe(): failed (error={})", error_code);
+        ::syslog::warn!("pipe(): failed (error={})", error_code);
         Err(Error::new(error_code, "pipe() failed"))
     } else {
         // System call succeeded, parse response.
@@ -119,11 +119,7 @@ pub mod bindings {
                 0
             },
             Err(error) => {
-                if error.code == ::sys::error::ErrorCode::OperationNotSupported {
-                    ::syslog::warn!("pipe(): failed (error={error:?})");
-                } else {
-                    ::syslog::error!("pipe(): failed (error={error:?})");
-                }
+                ::syslog::warn!("pipe(): failed (error={error:?})");
                 unsafe {
                     *__errno_location() = error.code.get();
                 }

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -72,11 +72,11 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         }
         if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
             let reason: &str = "illegal seek on stdio";
-            ::syslog::error!("pread(): {reason} (fd={fd})");
+            ::syslog::warn!("pread(): {reason} (fd={fd})");
             return Err(Error::new(ErrorCode::IllegalSeek, reason));
         }
         let reason: &str = "pread: fd is not a VFS fd in standalone mode";
-        ::syslog::error!("pread(): {reason} (fd={fd})");
+        ::syslog::warn!("pread(): {reason} (fd={fd})");
         Err(Error::new(ErrorCode::BadFile, reason))
     }
 
@@ -115,7 +115,7 @@ fn pread_linuxd(
 
         // Check whether system call succeeded or not.
         if response.status != 0 {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pread(): failed (fd={}, buffer.len={}, offset={}, error_code={})",
                 fd,
                 buffer.len(),
@@ -128,7 +128,7 @@ fn pread_linuxd(
                 Ok(error_code) => return Err(Error::new(error_code, "pread() failed")),
                 // System call failed, return unknown error.
                 Err(error) => {
-                    ::syslog::error!("pread(): failed to convert error code (error={:?})", error);
+                    ::syslog::warn!("pread(): failed to convert error code (error={:?})", error);
                     return Err(Error::new(ErrorCode::TryAgain, "pread() failed"));
                 },
             }
@@ -160,7 +160,7 @@ fn pread_linuxd(
                     }
                 },
                 header => {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "pread(): failed to parse response (fd={}, buffer.len={}, offset={}, \
                          header={:?})",
                         fd,

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -72,11 +72,11 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         }
         if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
             let reason: &str = "illegal seek on stdio";
-            ::syslog::error!("pwrite(): {reason} (fd={fd})");
+            ::syslog::warn!("pwrite(): {reason} (fd={fd})");
             return Err(Error::new(ErrorCode::IllegalSeek, reason));
         }
         let reason: &str = "pwrite not available in standalone mode";
-        ::syslog::error!("pwrite(): {reason} (fd={fd})");
+        ::syslog::warn!("pwrite(): {reason} (fd={fd})");
         Err(Error::new(ErrorCode::OperationNotSupported, reason))
     }
 
@@ -115,7 +115,7 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
 
         // Check whether the system call succeeded or not.
         if response.status != 0 {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "pwrite(): failed (fd={}, buffer.len={}, error_code={})",
                 fd,
                 buffer.len(),
@@ -127,7 +127,7 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
                 Ok(error_code) => return Err(Error::new(error_code, "pwritev() failed")),
                 // Error code was not parsed.
                 Err(error) => {
-                    ::syslog::error!("pwrite(): failed to convert error code (error={:?})", error);
+                    ::syslog::warn!("pwrite(): failed to convert error code (error={:?})", error);
                     return Err(Error::new(ErrorCode::TryAgain, "pwritev() failed"));
                 },
             }
@@ -148,7 +148,7 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
                 },
                 // Response was not expected.
                 header => {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "pwrite(): failed to parse response (fd={}, buffer.len={}, header={:?})",
                         fd,
                         buffer.len(),

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -70,7 +70,7 @@ fn read_chunk(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "read_chunk(): failed (fd={:?}, chunk.len={:?}, error_code={:?})",
             fd,
             chunk.len(),
@@ -80,7 +80,7 @@ fn read_chunk(
         match ErrorCode::try_from(response.status) {
             Ok(error_code) => return Err(Error::new(error_code, "read() failed")),
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "read_chunk(): failed (fd={:?}, chunk.len={:?}, error_code={:?})",
                     fd,
                     chunk.len(),
@@ -100,7 +100,7 @@ fn read_chunk(
 
             // Guard against a negative count that would wrap when cast to usize.
             if count < 0 {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "read_chunk(): linuxd returned negative count (fd={:?}, count={:?})",
                     fd,
                     count
@@ -114,7 +114,7 @@ fn read_chunk(
             // Sanity-check: the number of bytes reported by linuxd should match the bytes
             // actually pulled via the data chunk transfer.
             if (count as usize) != bytes_pulled {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "read_chunk(): byte count mismatch (resp.count={:?}, bytes_pulled={:?})",
                     count,
                     bytes_pulled
@@ -128,7 +128,7 @@ fn read_chunk(
             Ok(count as c_size_t)
         },
         header => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "read_chunk(): failed to parse response (fd={:?}, chunk.len={:?}, header={:?})",
                 fd,
                 chunk.len(),

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -106,27 +106,16 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
             // System call failed, parse error code and return.
             match ErrorCode::try_from(response.status) {
                 Ok(error_code) => {
-                    if error_code == ErrorCode::NoSuchEntry {
-                        ::syslog::warn!(
-                            "readlinkat(): system call failed (dirfd={:?}, path={:?}, \
-                             error_code={:?})",
-                            dirfd,
-                            path,
-                            error_code
-                        );
-                    } else {
-                        ::syslog::error!(
-                            "readlinkat(): system call failed (dirfd={:?}, path={:?}, \
-                             error_code={:?})",
-                            dirfd,
-                            path,
-                            error_code
-                        );
-                    }
+                    ::syslog::warn!(
+                        "readlinkat(): system call failed (dirfd={:?}, path={:?}, error_code={:?})",
+                        dirfd,
+                        path,
+                        error_code
+                    );
                     break Err(Error::new(error_code, "system call failed"));
                 },
                 Err(error) => {
-                    ::syslog::error!(
+                    ::syslog::warn!(
                         "readlinkat(): failed to parse error code (dirfd={:?}, path={:?}, \
                          error_code={:?})",
                         dirfd,
@@ -145,7 +134,7 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
                         LinuxDaemonMessagePart::from_bytes(message.payload);
 
                     if let Err(error) = assembler.add_part(part) {
-                        ::syslog::error!(
+                        ::syslog::warn!(
                             "readlinkat(): failed to add part (dirfd={:?}, path={:?}, \
                              error_code={:?})",
                             dirfd,
@@ -171,7 +160,7 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
                             break Ok(response.buffer.len() as i32);
                         },
                         Err(error) => {
-                            ::syslog::error!(
+                            ::syslog::warn!(
                                 "readlinkat(): failed to assemble response (dirfd={:?}, \
                                  path={:?}, error_code={:?})",
                                 dirfd,
@@ -187,7 +176,7 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
                 },
                 header => {
                     break {
-                        ::syslog::error!(
+                        ::syslog::warn!(
                             "readlinkat(): failed to parse response (dirfd={:?}, path={:?}, \
                              header={:?})",
                             dirfd,

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -57,9 +57,7 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
     {
         ::nvx::vfs::fd::vfs_symlinkat(target, dirfd, linkpath).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!(
-                "symlinkat(): VFS symlinkat failed (linkpath={linkpath:?}, error={e})"
-            );
+            ::syslog::warn!("symlinkat(): VFS symlinkat failed (linkpath={linkpath:?}, error={e})");
             Error::new(code, "vfs symlinkat failed")
         })
     }
@@ -89,7 +87,7 @@ fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Erro
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "symlinkat(): failed (target={:?}, dirfd={:?}, linkpath={:?}, error_code={:?})",
             target,
             dirfd,
@@ -105,7 +103,7 @@ fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Erro
             },
             // Failed to parse error code, return generic error.
             Err(error) => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "symlinkat(): failed to parse error code (target={:?}, dirfd={:?}, \
                      linkpath={:?}, error={:?})",
                     target,
@@ -124,7 +122,7 @@ fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Erro
             LinuxDaemonMessageHeader::SymbolicLinkAtResponse => Ok(()),
             // Response was not successfully parsed.
             header => {
-                ::syslog::error!(
+                ::syslog::warn!(
                     "symlinkat(): failed to parse response (target={:?}, dirfd={:?}, \
                      linkpath={:?}, header={:?})",
                     target,

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -74,7 +74,7 @@ fn write_chunk(
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
-        ::syslog::error!(
+        ::syslog::warn!(
             "write_chunk(): failed (fd={:?}, chunk.len={:?}, error_code={:?})",
             fd,
             chunk.len(),
@@ -84,7 +84,7 @@ fn write_chunk(
         match ErrorCode::try_from(response.status) {
             Ok(error_code) => return Err(Error::new(error_code, "write() failed")),
             Err(error) => {
-                ::syslog::error!("write_chunk(): failed to convert error code (error={:?})", error);
+                ::syslog::warn!("write_chunk(): failed to convert error code (error={:?})", error);
                 return Err(Error::new(ErrorCode::TryAgain, "write() failed"));
             },
         }
@@ -98,7 +98,7 @@ fn write_chunk(
             Ok(response.count as c_size_t)
         },
         header => {
-            ::syslog::error!(
+            ::syslog::warn!(
                 "write_chunk(): failed to parse response (fd={:?}, chunk.len={:?}, header={:?})",
                 fd,
                 chunk.len(),


### PR DESCRIPTION
## Summary

Demote all `error!()` log calls to `warn!()` in guest-side libraries (libc_stdlib, posix, sysalloc, syscall). The kernel remains the only component that emits error-level logs, making it easier to identify true kernel faults versus recoverable failures in user-space library code.

## Rationale

These libraries report errors back to callers via return codes; the log messages are diagnostic and do not indicate unrecoverable system faults, so `warn` severity is more appropriate.

## Affected Crates

- `src/libs/libc_stdlib` (aligned_alloc, block_header, calloc, malloc, posix_memalign, realloc)
- `src/libs/posix` (dlfcn, pthread, sys/stat, sys/time, sys/times, sys/uio, sys/utsname, utime)
- `src/libs/sysalloc` (allocator, heap, tda, vaddr)
- `src/libs/syscall` (dirent, dlfcn, fcntl, poll, pthread, safe, sys/mman, sys/select, sys/socket, sys/stat, sys/times, sys/utsname, time, unistd)

## Testing

- `z.ps1 build -- all-nanvixd` passes with zero errors and zero unused-import warnings.