### PR TITLE
[kernel] Page-align hyperlight initrd module size

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -1451,6 +1451,12 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         // must span from initrd_base to the end of the cmdline payload.
         let module_size: usize =
             INITRD_SIZE_BYTES + initrd_size + CmdlineArgsLen::WIRE_SIZE + cmdline_len.as_usize();
+        let module_size: usize =
+            ::sys::mm::align_up(module_size, PAGE_ALIGNMENT).ok_or_else(|| {
+                let reason: &str = "initrd module size align_up overflow";
+                error!("parse_bootinfo(): {reason}");
+                Error::new(ErrorCode::BadFile, reason)
+            })?;
 
         let module: KernelModule =
             KernelModule::new(PhysicalAddress::from_raw_value(initrd_base)?, module_size, cmdline);


### PR DESCRIPTION
Page-align the hyperlight initrd `module_size` at the producer (`parse_bootinfo`) instead of relying on `kmain` to round it up at the consumer.

- #2219 added page alignment in `kmain`'s module-region registration loop.
- #2252 extended `module_size` to cover all four host-placed components (`INITRD_SIZE_BYTES + initrd_size + WIRE_SIZE + cmdline_len`) and fixed the spill-page fault that escaped in 0.12.521.

`module_size` covers every host-placed byte, but its end is not page aligned (e.g. `0x117002` for `echo-cpp`). The frame allocator gets the right pages today only because `kmain` does `align_up`. This PR makes the page-aligned size explicit at the source so the property is local to where the size is computed.
