### PR TITLE
[syscall] Rename LinuxDaemon* types to SystemCall*

### DIFF
--- a/src/daemons/linuxd/src/assemble.rs
+++ b/src/daemons/linuxd/src/assemble.rs
@@ -33,8 +33,8 @@ use ::syscall::{
         UnlinkAtRequest,
     },
     message::{
-        LinuxDaemonLongMessage,
-        LinuxDaemonMessagePart,
+        SystemCallLongMessage,
+        SystemCallMessagePart,
     },
     poll::message::PollRequest,
     sys::stat::message::{
@@ -59,15 +59,15 @@ use ::syscall::{
 
 impl<T> RequestAssemblerTrait<T> for FileStatAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileStatAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::FileStatAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -82,7 +82,7 @@ impl<T> RequestAssemblerTrait<T> for FileStatAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::FileStatAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -100,15 +100,15 @@ impl<T> RequestAssemblerTrait<T> for FileStatAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for SymbolicLinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::SymbolicLinkAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::SymbolicLinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -123,7 +123,7 @@ impl<T> RequestAssemblerTrait<T> for SymbolicLinkAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::SymbolicLinkAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -141,15 +141,15 @@ impl<T> RequestAssemblerTrait<T> for SymbolicLinkAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for LinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::LinkAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::LinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -164,7 +164,7 @@ impl<T> RequestAssemblerTrait<T> for LinkAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::LinkAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -182,15 +182,15 @@ impl<T> RequestAssemblerTrait<T> for LinkAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for ReadLinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::ReadLinkAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::ReadLinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -205,7 +205,7 @@ impl<T> RequestAssemblerTrait<T> for ReadLinkAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::ReadLinkAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -223,15 +223,15 @@ impl<T> RequestAssemblerTrait<T> for ReadLinkAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for MakeDirectoryAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::MakeDirectoryAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::MakeDirectoryAtRequest(assembler) => {
@@ -248,7 +248,7 @@ impl<T> RequestAssemblerTrait<T> for MakeDirectoryAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::MakeDirectoryAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -266,15 +266,15 @@ impl<T> RequestAssemblerTrait<T> for MakeDirectoryAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for UpdateFileAccessTimeAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::UpdateFileAccessTimeAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::UpdateFileAccessTimeAtRequest(assembler) => {
@@ -293,7 +293,7 @@ impl<T> RequestAssemblerTrait<T> for UpdateFileAccessTimeAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::UpdateFileAccessTimeAtRequest(assembler) => {
                 assembler.take_parts()
@@ -313,15 +313,15 @@ impl<T> RequestAssemblerTrait<T> for UpdateFileAccessTimeAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for FileChownAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileChownAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::FileChownAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -336,7 +336,7 @@ impl<T> RequestAssemblerTrait<T> for FileChownAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::FileChownAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -354,15 +354,15 @@ impl<T> RequestAssemblerTrait<T> for FileChownAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for FileChmodAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileChmodAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::FileChmodAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -377,7 +377,7 @@ impl<T> RequestAssemblerTrait<T> for FileChmodAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::FileChmodAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -395,15 +395,15 @@ impl<T> RequestAssemblerTrait<T> for FileChmodAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for OpenAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::OpenAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::OpenAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -418,7 +418,7 @@ impl<T> RequestAssemblerTrait<T> for OpenAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::OpenAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -436,15 +436,15 @@ impl<T> RequestAssemblerTrait<T> for OpenAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for RenameAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::RenameAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::RenameAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -459,7 +459,7 @@ impl<T> RequestAssemblerTrait<T> for RenameAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::RenameAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -477,15 +477,15 @@ impl<T> RequestAssemblerTrait<T> for RenameAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for UnlinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::UnlinkAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::UnlinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -500,7 +500,7 @@ impl<T> RequestAssemblerTrait<T> for UnlinkAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::UnlinkAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -518,15 +518,15 @@ impl<T> RequestAssemblerTrait<T> for UnlinkAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for ChangeDirectoryRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::ChangeDirectoryRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::ChangeDirectoryRequest(assembler) => {
@@ -543,7 +543,7 @@ impl<T> RequestAssemblerTrait<T> for ChangeDirectoryRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::ChangeDirectoryRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -561,15 +561,15 @@ impl<T> RequestAssemblerTrait<T> for ChangeDirectoryRequest {
 
 impl<T> RequestAssemblerTrait<T> for FileAccessAtRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileAccessAtRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::FileAccessAtRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -584,7 +584,7 @@ impl<T> RequestAssemblerTrait<T> for FileAccessAtRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::FileAccessAtRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),
@@ -602,15 +602,15 @@ impl<T> RequestAssemblerTrait<T> for FileAccessAtRequest {
 
 impl<T> RequestAssemblerTrait<T> for PollRequest {
     fn new_assembler() -> RequestAssemblerType {
-        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::PollRequest(
-            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
         )
     }
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::PollRequest(assembler) => Ok(assembler.add_part(part)?),
@@ -625,7 +625,7 @@ impl<T> RequestAssemblerTrait<T> for PollRequest {
         }
     }
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
         match assembler {
             RequestAssemblerType::PollRequest(assembler) => assembler.take_parts(),
             _ => unreachable!("invalid assembler type"),

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -16,9 +16,9 @@ use ::sys::{
     pm::ThreadIdentifier,
 };
 use ::syscall::message::{
-    LinuxDaemonLongMessage,
-    LinuxDaemonMessagePart,
     MessagePartitioner,
+    SystemCallLongMessage,
+    SystemCallMessagePart,
 };
 
 //==================================================================================================
@@ -38,7 +38,7 @@ impl RequestAssembler {
     pub fn assemble_and_take<S, T: RequestAssemblerTrait<S>>(
         &mut self,
         source: ThreadIdentifier,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<Option<T>, WorkerThreadError> {
         match self.assemble_and_take_internal::<S, T>(source, part) {
             Ok(request) => Ok(request),
@@ -53,7 +53,7 @@ impl RequestAssembler {
     fn assemble_and_take_internal<S, T: RequestAssemblerTrait<S>>(
         &mut self,
         source: ThreadIdentifier,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<Option<T>, WorkerThreadError> {
         let message_complete: bool = {
             match self.assemble_parts::<S, T>(source, part) {
@@ -77,7 +77,7 @@ impl RequestAssembler {
     fn assemble_parts<S, T: RequestAssemblerTrait<S>>(
         &mut self,
         source: ThreadIdentifier,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<bool, WorkerThreadError> {
         let assembler: &mut RequestAssemblerType = self
             .inflight
@@ -96,27 +96,27 @@ impl RequestAssembler {
             .remove(&source)
             .expect("inflight request does exist");
 
-        let parts: Vec<LinuxDaemonMessagePart> = T::take_parts(assembler);
+        let parts: Vec<SystemCallMessagePart> = T::take_parts(assembler);
         Ok(T::from_parts(&parts)?)
     }
 }
 
 #[allow(clippy::enum_variant_names)]
 pub enum RequestAssemblerType {
-    FileStatAtRequest(LinuxDaemonLongMessage),
-    SymbolicLinkAtRequest(LinuxDaemonLongMessage),
-    LinkAtRequest(LinuxDaemonLongMessage),
-    ReadLinkAtRequest(LinuxDaemonLongMessage),
-    MakeDirectoryAtRequest(LinuxDaemonLongMessage),
-    UpdateFileAccessTimeAtRequest(LinuxDaemonLongMessage),
-    FileChownAtRequest(LinuxDaemonLongMessage),
-    FileChmodAtRequest(LinuxDaemonLongMessage),
-    OpenAtRequest(LinuxDaemonLongMessage),
-    RenameAtRequest(LinuxDaemonLongMessage),
-    UnlinkAtRequest(LinuxDaemonLongMessage),
-    ChangeDirectoryRequest(LinuxDaemonLongMessage),
-    FileAccessAtRequest(LinuxDaemonLongMessage),
-    PollRequest(LinuxDaemonLongMessage),
+    FileStatAtRequest(SystemCallLongMessage),
+    SymbolicLinkAtRequest(SystemCallLongMessage),
+    LinkAtRequest(SystemCallLongMessage),
+    ReadLinkAtRequest(SystemCallLongMessage),
+    MakeDirectoryAtRequest(SystemCallLongMessage),
+    UpdateFileAccessTimeAtRequest(SystemCallLongMessage),
+    FileChownAtRequest(SystemCallLongMessage),
+    FileChmodAtRequest(SystemCallLongMessage),
+    OpenAtRequest(SystemCallLongMessage),
+    RenameAtRequest(SystemCallLongMessage),
+    UnlinkAtRequest(SystemCallLongMessage),
+    ChangeDirectoryRequest(SystemCallLongMessage),
+    FileAccessAtRequest(SystemCallLongMessage),
+    PollRequest(SystemCallLongMessage),
 }
 
 pub trait RequestAssemblerTrait<T>
@@ -128,12 +128,12 @@ where
 
     fn add_part(
         assembler: &mut RequestAssemblerType,
-        part: LinuxDaemonMessagePart,
+        part: SystemCallMessagePart,
     ) -> Result<(), WorkerThreadError>;
 
     fn is_complete(assembler: &RequestAssemblerType) -> Result<bool, Error>;
 
-    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart>;
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart>;
 
     fn process_request(
         syscall_table: &SyscallTable<T>,
@@ -159,21 +159,20 @@ mod tests {
     use ::syscall::{
         fcntl::message::OpenAtRequest,
         message::MessagePartitioner,
-        LinuxDaemonMessage,
+        SystemCallMessage,
     };
     use ::tokio::sync::Mutex;
 
-    /// Extracts `LinuxDaemonMessagePart` payloads from the IPC `Message` objects
+    /// Extracts `SystemCallMessagePart` payloads from the IPC `Message` objects
     /// produced by `MessagePartitioner::into_parts()`.
     #[allow(clippy::expect_used)]
-    fn extract_parts(messages: Vec<Message>) -> Vec<LinuxDaemonMessagePart> {
+    fn extract_parts(messages: Vec<Message>) -> Vec<SystemCallMessagePart> {
         messages
             .into_iter()
             .map(|msg| {
-                let daemon_msg: LinuxDaemonMessage =
-                    LinuxDaemonMessage::try_from_bytes(msg.payload)
-                        .expect("valid LinuxDaemonMessage");
-                LinuxDaemonMessagePart::from_bytes(daemon_msg.payload)
+                let daemon_msg: SystemCallMessage = SystemCallMessage::try_from_bytes(msg.payload)
+                    .expect("valid SystemCallMessage");
+                SystemCallMessagePart::from_bytes(daemon_msg.payload)
             })
             .collect()
     }
@@ -190,7 +189,7 @@ mod tests {
         let original: OpenAtRequest =
             OpenAtRequest::new(-100, "/tmp/test.txt", 0x41, 0o644).expect("valid OpenAtRequest");
 
-        let parts: Vec<LinuxDaemonMessagePart> =
+        let parts: Vec<SystemCallMessagePart> =
             extract_parts(original.into_parts(source).expect("valid parts"));
 
         let mut assembler: RequestAssembler = RequestAssembler::default();
@@ -234,13 +233,13 @@ mod tests {
         let source_a: ThreadIdentifier = ThreadIdentifier::from(1_i32);
         let request_a: OpenAtRequest =
             OpenAtRequest::new(-100, "/tmp/a.txt", 0x41, 0o644).expect("valid OpenAtRequest");
-        let parts_a: Vec<LinuxDaemonMessagePart> =
+        let parts_a: Vec<SystemCallMessagePart> =
             extract_parts(request_a.into_parts(source_a).expect("valid parts"));
 
         let source_b: ThreadIdentifier = ThreadIdentifier::from(2_i32);
         let request_b: OpenAtRequest =
             OpenAtRequest::new(-100, "/tmp/b.txt", 0x41, 0o644).expect("valid OpenAtRequest");
-        let parts_b: Vec<LinuxDaemonMessagePart> =
+        let parts_b: Vec<SystemCallMessagePart> =
             extract_parts(request_b.into_parts(source_b).expect("valid parts"));
 
         // Barrier: signal when Thread A has released the lock.

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -94,7 +94,7 @@ use ::syscall::{
         RenameAtRequest,
         UnlinkAtRequest,
     },
-    message::LinuxDaemonMessagePart,
+    message::SystemCallMessagePart,
     poll::message::PollRequest,
     sys::{
         select::message::SelectRequest,
@@ -146,8 +146,8 @@ use ::syscall::{
         WriteRequest,
         WriteResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
     LINUXD,
 };
 use ::syscomm::{
@@ -531,14 +531,14 @@ impl WorkerThreadHandle {
                     break;
                 },
                 sys::ipc::MessageType::Ikc => {
-                    match LinuxDaemonMessage::try_from_bytes(message.payload) {
+                    match SystemCallMessage::try_from_bytes(message.payload) {
                         Ok(message) => {
                             let message: Message = match message.header {
                                 // The system calls are interposed before being forwarded to the
                                 // backend provider.
-                                LinuxDaemonMessageHeader::CloseRequest
-                                | LinuxDaemonMessageHeader::ReadRequest
-                                | LinuxDaemonMessageHeader::WriteRequest => {
+                                SystemCallMessageHeader::CloseRequest
+                                | SystemCallMessageHeader::ReadRequest
+                                | SystemCallMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
                                         &syscall_table,
                                         gateway_reader.clone(),
@@ -564,34 +564,34 @@ impl WorkerThreadHandle {
                                 // The following system calls have their request and response
                                 // data fit in a single message. Thus, they can be immediately
                                 // forwarded to the backend provider.
-                                LinuxDaemonMessageHeader::AcceptSocketRequest
-                                | LinuxDaemonMessageHeader::BindSocketRequest
-                                | LinuxDaemonMessageHeader::ConnectSocketRequest
-                                | LinuxDaemonMessageHeader::CreateSocketPairRequest
-                                | LinuxDaemonMessageHeader::CreateSocketRequest
-                                | LinuxDaemonMessageHeader::FileAdvisoryInformationRequest
-                                | LinuxDaemonMessageHeader::FileChdirRequest
-                                | LinuxDaemonMessageHeader::FileChmodRequest
-                                | LinuxDaemonMessageHeader::FileChownRequest
-                                | LinuxDaemonMessageHeader::FileControlRequest
-                                | LinuxDaemonMessageHeader::FileDataSyncRequest
-                                | LinuxDaemonMessageHeader::FileSpaceControlRequest
-                                | LinuxDaemonMessageHeader::FileSyncRequest
-                                | LinuxDaemonMessageHeader::FileTruncateRequest
-                                | LinuxDaemonMessageHeader::GetIdsRequest
-                                | LinuxDaemonMessageHeader::GetPeerNameRequest
-                                | LinuxDaemonMessageHeader::GetSockNameRequest
-                                | LinuxDaemonMessageHeader::ListenSocketRequest
-                                | LinuxDaemonMessageHeader::PartialReadRequest
-                                | LinuxDaemonMessageHeader::PartialWriteRequest
-                                | LinuxDaemonMessageHeader::ReceiveSocketRequest
-                                | LinuxDaemonMessageHeader::SeekRequest
-                                | LinuxDaemonMessageHeader::SelectRequest
-                                | LinuxDaemonMessageHeader::SendSocketRequest
-                                | LinuxDaemonMessageHeader::ShutdownSocketRequest
-                                | LinuxDaemonMessageHeader::TimesRequest
-                                | LinuxDaemonMessageHeader::PipeRequest
-                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
+                                SystemCallMessageHeader::AcceptSocketRequest
+                                | SystemCallMessageHeader::BindSocketRequest
+                                | SystemCallMessageHeader::ConnectSocketRequest
+                                | SystemCallMessageHeader::CreateSocketPairRequest
+                                | SystemCallMessageHeader::CreateSocketRequest
+                                | SystemCallMessageHeader::FileAdvisoryInformationRequest
+                                | SystemCallMessageHeader::FileChdirRequest
+                                | SystemCallMessageHeader::FileChmodRequest
+                                | SystemCallMessageHeader::FileChownRequest
+                                | SystemCallMessageHeader::FileControlRequest
+                                | SystemCallMessageHeader::FileDataSyncRequest
+                                | SystemCallMessageHeader::FileSpaceControlRequest
+                                | SystemCallMessageHeader::FileSyncRequest
+                                | SystemCallMessageHeader::FileTruncateRequest
+                                | SystemCallMessageHeader::GetIdsRequest
+                                | SystemCallMessageHeader::GetPeerNameRequest
+                                | SystemCallMessageHeader::GetSockNameRequest
+                                | SystemCallMessageHeader::ListenSocketRequest
+                                | SystemCallMessageHeader::PartialReadRequest
+                                | SystemCallMessageHeader::PartialWriteRequest
+                                | SystemCallMessageHeader::ReceiveSocketRequest
+                                | SystemCallMessageHeader::SeekRequest
+                                | SystemCallMessageHeader::SelectRequest
+                                | SystemCallMessageHeader::SendSocketRequest
+                                | SystemCallMessageHeader::ShutdownSocketRequest
+                                | SystemCallMessageHeader::TimesRequest
+                                | SystemCallMessageHeader::PipeRequest
+                                | SystemCallMessageHeader::UpdateFileAccessTimeRequest => {
                                     match Self::handle_short_request_messages(
                                         syscall_table.clone(),
                                         source,
@@ -613,9 +613,9 @@ impl WorkerThreadHandle {
                                 // single message, but their response data is too large to fit in a
                                 // single message. Thus, their response is split into multiple
                                 // messages.
-                                LinuxDaemonMessageHeader::FileStatRequest
-                                | LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest
-                                | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
+                                SystemCallMessageHeader::FileStatRequest
+                                | SystemCallMessageHeader::GetCurrentWorkingDirectoryRequest
+                                | SystemCallMessageHeader::GetDirectoryEntriesRequest => {
                                     match Self::handle_long_response_messages(
                                         uvm_stream.clone(),
                                         &syscall_table,
@@ -638,20 +638,20 @@ impl WorkerThreadHandle {
                                 // The following system calls have request data that is too large to
                                 // fit in a single message. Thus, their request is split into multiple
                                 // messages.
-                                LinuxDaemonMessageHeader::ChangeDirectoryRequestPart
-                                | LinuxDaemonMessageHeader::FileStatAtRequestPart
-                                | LinuxDaemonMessageHeader::FileAccessAtRequestPart
-                                | LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart
-                                | LinuxDaemonMessageHeader::LinkAtRequestPart
-                                | LinuxDaemonMessageHeader::ReadLinkAtRequestPart
-                                | LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart
-                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart
-                                | LinuxDaemonMessageHeader::FileChownAtRequestPart
-                                | LinuxDaemonMessageHeader::FileChmodAtRequestPart
-                                | LinuxDaemonMessageHeader::OpenAtRequestPart
-                                | LinuxDaemonMessageHeader::RenameAtRequestPart
-                                | LinuxDaemonMessageHeader::UnlinkAtRequestPart
-                                | LinuxDaemonMessageHeader::PollRequestPart => {
+                                SystemCallMessageHeader::ChangeDirectoryRequestPart
+                                | SystemCallMessageHeader::FileStatAtRequestPart
+                                | SystemCallMessageHeader::FileAccessAtRequestPart
+                                | SystemCallMessageHeader::SymbolicLinkAtRequestPart
+                                | SystemCallMessageHeader::LinkAtRequestPart
+                                | SystemCallMessageHeader::ReadLinkAtRequestPart
+                                | SystemCallMessageHeader::MakeDirectoryAtRequestPart
+                                | SystemCallMessageHeader::UpdateFileAccessTimeAtRequestPart
+                                | SystemCallMessageHeader::FileChownAtRequestPart
+                                | SystemCallMessageHeader::FileChmodAtRequestPart
+                                | SystemCallMessageHeader::OpenAtRequestPart
+                                | SystemCallMessageHeader::RenameAtRequestPart
+                                | SystemCallMessageHeader::UnlinkAtRequestPart
+                                | SystemCallMessageHeader::PollRequestPart => {
                                     match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
@@ -692,7 +692,7 @@ impl WorkerThreadHandle {
                             };
                         },
                         Err(e) => {
-                            error!("failed to parse Linux daemon message (error={e:?})");
+                            error!("failed to parse system call message (error={e:?})");
                         },
                     }
                 },
@@ -728,17 +728,17 @@ impl WorkerThreadHandle {
         gateway_reader: Arc<Mutex<SocketStreamReader>>,
         gateway_writer: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
         channel_rx: &mut Receiver<VenvCommand>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         cancel_rx: &mut watch::Receiver<bool>,
     ) -> Result<Message, WorkerThreadError> {
         match message.header {
-            LinuxDaemonMessageHeader::CloseRequest => {
+            SystemCallMessageHeader::CloseRequest => {
                 let request: CloseRequest = CloseRequest::from_bytes(message.payload);
                 Self::handle_close_request(syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::ReadRequest => {
+            SystemCallMessageHeader::ReadRequest => {
                 let request: ReadRequest = ReadRequest::from_bytes(message.payload);
                 Self::handle_read_request(
                     syscall_table,
@@ -750,7 +750,7 @@ impl WorkerThreadHandle {
                     cancel_rx,
                 )
             },
-            LinuxDaemonMessageHeader::WriteRequest => {
+            SystemCallMessageHeader::WriteRequest => {
                 let request: WriteRequest = WriteRequest::from_bytes(message.payload);
                 Self::handle_write_request(
                     syscall_table,
@@ -787,125 +787,125 @@ impl WorkerThreadHandle {
     fn handle_short_request_messages<T>(
         syscall_table: Arc<SyscallTable<T>>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
     ) -> Result<Message, WorkerThreadError> {
         match message.header {
-            LinuxDaemonMessageHeader::AcceptSocketRequest => {
+            SystemCallMessageHeader::AcceptSocketRequest => {
                 let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
                 sys_socket::do_accept(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::BindSocketRequest => {
+            SystemCallMessageHeader::BindSocketRequest => {
                 let request: BindSocketRequest = BindSocketRequest::from_bytes(message.payload);
                 sys_socket::do_bind(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::ConnectSocketRequest => {
+            SystemCallMessageHeader::ConnectSocketRequest => {
                 let request: ConnectSocketRequest =
                     ConnectSocketRequest::from_bytes(message.payload);
                 sys_socket::do_connect(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::CreateSocketPairRequest => {
+            SystemCallMessageHeader::CreateSocketPairRequest => {
                 let request: CreateSocketPairRequest =
                     CreateSocketPairRequest::from_bytes(message.payload);
                 sys_socket::do_socketpair(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::CreateSocketRequest => {
+            SystemCallMessageHeader::CreateSocketRequest => {
                 let request: CreateSocketRequest = CreateSocketRequest::from_bytes(message.payload);
                 sys_socket::do_socket(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileAdvisoryInformationRequest => {
+            SystemCallMessageHeader::FileAdvisoryInformationRequest => {
                 let request: FileAdvisoryInformationRequest =
                     FileAdvisoryInformationRequest::from_bytes(message.payload);
                 fcntl::do_posix_fadvise(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileChdirRequest => {
+            SystemCallMessageHeader::FileChdirRequest => {
                 let request: FileChdirRequest = FileChdirRequest::from_bytes(message.payload);
                 unistd::do_fchdir(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileChmodRequest => {
+            SystemCallMessageHeader::FileChmodRequest => {
                 let request: FileChmodRequest = FileChmodRequest::from_bytes(message.payload);
                 fcntl::do_fchmod(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileChownRequest => {
+            SystemCallMessageHeader::FileChownRequest => {
                 let request: FileChownRequest = FileChownRequest::from_bytes(message.payload);
                 unistd::do_fchown(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileControlRequest => {
+            SystemCallMessageHeader::FileControlRequest => {
                 let request: FileControlRequest = FileControlRequest::from_bytes(message.payload);
                 fcntl::do_fcntl(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileDataSyncRequest => {
+            SystemCallMessageHeader::FileDataSyncRequest => {
                 let request: FileDataSyncRequest = FileDataSyncRequest::from_bytes(message.payload);
                 unistd::do_fdatasync(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileSpaceControlRequest => {
+            SystemCallMessageHeader::FileSpaceControlRequest => {
                 let request: FileSpaceControlRequest =
                     FileSpaceControlRequest::from_bytes(message.payload);
                 fcntl::do_posix_fallocate(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileSyncRequest => {
+            SystemCallMessageHeader::FileSyncRequest => {
                 let request: FileSyncRequest = FileSyncRequest::from_bytes(message.payload);
                 unistd::do_fsync(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::FileTruncateRequest => {
+            SystemCallMessageHeader::FileTruncateRequest => {
                 let request: FileTruncateRequest = FileTruncateRequest::from_bytes(message.payload);
                 unistd::do_ftruncate(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::GetIdsRequest => {
+            SystemCallMessageHeader::GetIdsRequest => {
                 let request: GetIdsRequest = GetIdsRequest::from_bytes(message.payload);
                 unistd::do_getids(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::GetPeerNameRequest => {
+            SystemCallMessageHeader::GetPeerNameRequest => {
                 let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(message.payload);
                 sys_socket::do_getpeername(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::GetSockNameRequest => {
+            SystemCallMessageHeader::GetSockNameRequest => {
                 let request: GetSockNameRequest = GetSockNameRequest::from_bytes(message.payload);
                 sys_socket::do_getsockname(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::ListenSocketRequest => {
+            SystemCallMessageHeader::ListenSocketRequest => {
                 let request: ListenSocketRequest = ListenSocketRequest::from_bytes(message.payload);
                 sys_socket::do_listen(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::PartialReadRequest => {
+            SystemCallMessageHeader::PartialReadRequest => {
                 let request: PartialReadRequest = PartialReadRequest::from_bytes(message.payload);
                 unistd::do_pread(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::PartialWriteRequest => {
+            SystemCallMessageHeader::PartialWriteRequest => {
                 let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
                 unistd::do_pwrite(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::ReceiveSocketRequest => {
+            SystemCallMessageHeader::ReceiveSocketRequest => {
                 let request: ReceiveSocketRequest =
                     ReceiveSocketRequest::from_bytes(message.payload);
                 sys_socket::do_recv(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::SeekRequest => {
+            SystemCallMessageHeader::SeekRequest => {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
                 unistd::do_lseek(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::SelectRequest => {
+            SystemCallMessageHeader::SelectRequest => {
                 let request: SelectRequest = SelectRequest::from_bytes(message.payload);
                 sys_select::do_select(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::SendSocketRequest => {
+            SystemCallMessageHeader::SendSocketRequest => {
                 let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
                 sys_socket::do_send(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::ShutdownSocketRequest => {
+            SystemCallMessageHeader::ShutdownSocketRequest => {
                 let request: ShutdownSocketRequest =
                     ShutdownSocketRequest::from_bytes(message.payload);
                 sys_socket::do_shutdown(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::TimesRequest => {
+            SystemCallMessageHeader::TimesRequest => {
                 let request: TimesRequest = TimesRequest::from_bytes(message.payload);
                 sys_times::do_times(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
+            SystemCallMessageHeader::UpdateFileAccessTimeRequest => {
                 let request: UpdateFileAccessTimeRequest =
                     UpdateFileAccessTimeRequest::from_bytes(message.payload);
                 fcntl::do_futimens(&syscall_table, source, request)
             },
-            LinuxDaemonMessageHeader::PipeRequest => {
+            SystemCallMessageHeader::PipeRequest => {
                 let _request = PipeRequest::from_bytes(message.payload);
                 unistd::do_pipe(&syscall_table, source)
             },
@@ -939,10 +939,10 @@ impl WorkerThreadHandle {
         assembler: Arc<Mutex<RequestAssembler>>,
         syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
     ) -> Result<(), WorkerThreadError> {
         match message.header {
-            LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
+            SystemCallMessageHeader::ChangeDirectoryRequestPart => {
                 Self::handle_long_request::<T, ChangeDirectoryRequest>(
                     uvm_stream,
                     assembler,
@@ -951,7 +951,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
+            SystemCallMessageHeader::FileAccessAtRequestPart => {
                 Self::handle_long_request::<T, FileAccessAtRequest>(
                     uvm_stream,
                     assembler,
@@ -960,7 +960,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::FileStatAtRequestPart => {
+            SystemCallMessageHeader::FileStatAtRequestPart => {
                 Self::handle_long_request::<T, FileStatAtRequest>(
                     uvm_stream,
                     assembler,
@@ -969,7 +969,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
+            SystemCallMessageHeader::SymbolicLinkAtRequestPart => {
                 Self::handle_long_request::<T, SymbolicLinkAtRequest>(
                     uvm_stream,
                     assembler,
@@ -978,7 +978,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::LinkAtRequestPart => {
+            SystemCallMessageHeader::LinkAtRequestPart => {
                 Self::handle_long_request::<T, LinkAtRequest>(
                     uvm_stream,
                     assembler,
@@ -987,7 +987,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
+            SystemCallMessageHeader::ReadLinkAtRequestPart => {
                 Self::handle_long_request::<T, ReadLinkAtRequest>(
                     uvm_stream,
                     assembler,
@@ -996,7 +996,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
+            SystemCallMessageHeader::MakeDirectoryAtRequestPart => {
                 Self::handle_long_request::<T, MakeDirectoryAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1005,7 +1005,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
+            SystemCallMessageHeader::UpdateFileAccessTimeAtRequestPart => {
                 Self::handle_long_request::<T, UpdateFileAccessTimeAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1014,7 +1014,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::FileChownAtRequestPart => {
+            SystemCallMessageHeader::FileChownAtRequestPart => {
                 Self::handle_long_request::<T, FileChownAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1023,7 +1023,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
+            SystemCallMessageHeader::FileChmodAtRequestPart => {
                 Self::handle_long_request::<T, FileChmodAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1032,7 +1032,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::OpenAtRequestPart => {
+            SystemCallMessageHeader::OpenAtRequestPart => {
                 Self::handle_long_request::<T, OpenAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1041,7 +1041,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::RenameAtRequestPart => {
+            SystemCallMessageHeader::RenameAtRequestPart => {
                 Self::handle_long_request::<T, RenameAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1050,7 +1050,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
+            SystemCallMessageHeader::UnlinkAtRequestPart => {
                 Self::handle_long_request::<T, UnlinkAtRequest>(
                     uvm_stream,
                     assembler,
@@ -1059,7 +1059,7 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::PollRequestPart => {
+            SystemCallMessageHeader::PollRequestPart => {
                 Self::handle_long_request::<T, PollRequest>(
                     uvm_stream,
                     assembler,
@@ -1096,16 +1096,16 @@ impl WorkerThreadHandle {
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
     ) -> Result<(), WorkerThreadError> {
         match message.header {
-            LinuxDaemonMessageHeader::FileStatRequest => {
+            SystemCallMessageHeader::FileStatRequest => {
                 Self::handle_fstat_request(syscall_table, uvm_stream, source, message)
             },
-            LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest => {
+            SystemCallMessageHeader::GetCurrentWorkingDirectoryRequest => {
                 Self::handle_getcwd_request(uvm_stream, syscall_table, source)
             },
-            LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
+            SystemCallMessageHeader::GetDirectoryEntriesRequest => {
                 Self::handle_getdents_request(syscall_table, uvm_stream, source, message)
             },
             header => {
@@ -1574,7 +1574,7 @@ impl WorkerThreadHandle {
         syscall_table: &SyscallTable<T>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
     ) -> Result<(), WorkerThreadError> {
         let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
         let messages: Vec<Message> = fcntl::do_fstat(syscall_table, source, request)?;
@@ -1639,7 +1639,7 @@ impl WorkerThreadHandle {
         syscall_table: &SyscallTable<T>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
+        message: SystemCallMessage,
     ) -> Result<(), WorkerThreadError> {
         let request: GetDirectoryEntriesRequest =
             GetDirectoryEntriesRequest::from_bytes(message.payload);
@@ -1678,12 +1678,12 @@ impl WorkerThreadHandle {
         assembler: Arc<Mutex<RequestAssembler>>,
         syscall_table: &SyscallTable<S>,
         source: ThreadIdentifier,
-        message: &LinuxDaemonMessage,
+        message: &SystemCallMessage,
     ) -> Result<(), WorkerThreadError>
     where
         T: RequestAssemblerTrait<S>,
     {
-        let part: LinuxDaemonMessagePart = LinuxDaemonMessagePart::from_bytes(message.payload);
+        let part: SystemCallMessagePart = SystemCallMessagePart::from_bytes(message.payload);
 
         trace!("handle_long_request(): source={source:?}, part={part:?}");
 

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -8,13 +8,13 @@
 use crate::{
     dirent::posix_dent,
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::vec::Vec;
 use ::core::mem;
@@ -62,11 +62,11 @@ pub struct GetDirectoryEntriesRequest {
     pub count: u32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetDirectoryEntriesRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetDirectoryEntriesRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetDirectoryEntriesRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<u32>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<u32>();
 
     /// Maximum number of entries in the request.
     pub const MAX_ENTRIES: usize = MAX_ENTRIES;
@@ -86,18 +86,18 @@ impl GetDirectoryEntriesRequest {
         })
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: c_int, count: usize) -> Result<Message, Error> {
         let message: GetDirectoryEntriesRequest = GetDirectoryEntriesRequest::new(fd, count)?;
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::GetDirectoryEntriesRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::GetDirectoryEntriesRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -261,11 +261,11 @@ impl MessagePartitioner for GetDirectoryEntriesResponse {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_response(
+        SystemCallMessagePart::build_response(
             tid,
-            LinuxDaemonMessageHeader::GetDirectoryEntriesResponsePart,
+            SystemCallMessageHeader::GetDirectoryEntriesResponsePart,
             total_parts,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -24,12 +24,12 @@ use {
             GetDirectoryEntriesResponse,
         },
         message::{
-            LinuxDaemonLongMessage,
-            LinuxDaemonMessagePart,
             MessagePartitioner,
+            SystemCallLongMessage,
+            SystemCallMessagePart,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -84,7 +84,7 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
 #[cfg(not(feature = "standalone"))]
 fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error> {
     const MESSAGE_ASSEMBLER_CAPACITY: usize =
-        GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
@@ -103,8 +103,8 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
     })?;
 
     // Create message assembler.
-    let mut assembler: LinuxDaemonLongMessage =
-        LinuxDaemonLongMessage::new(MESSAGE_ASSEMBLER_CAPACITY).map_err(|error| {
+    let mut assembler: SystemCallLongMessage =
+        SystemCallLongMessage::new(MESSAGE_ASSEMBLER_CAPACITY).map_err(|error| {
             let reason: &str = "failed to create message assembler";
             warn!("posix_getdents(): {reason} (error={:?})", error);
             Error::new(error.code, reason)
@@ -135,12 +135,12 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
             }
         } else {
             // System call succeeded, parse response.
-            let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+            let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
             match message.header {
-                LinuxDaemonMessageHeader::GetDirectoryEntriesResponsePart => {
-                    let part: LinuxDaemonMessagePart =
-                        LinuxDaemonMessagePart::from_bytes(message.payload);
+                SystemCallMessageHeader::GetDirectoryEntriesResponsePart => {
+                    let part: SystemCallMessagePart =
+                        SystemCallMessagePart::from_bytes(message.payload);
 
                     // Add part to message assembler and check for errors.
                     if let Err(error) = assembler.add_part(part) {
@@ -154,7 +154,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
                         continue;
                     }
 
-                    let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+                    let parts: Vec<SystemCallMessagePart> = assembler.take_parts();
 
                     match GetDirectoryEntriesResponse::from_parts(&parts) {
                         Ok(response) => break Ok(response.entries),

--- a/src/libs/syscall/src/fcntl/message/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/message/fadvise.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -37,10 +37,10 @@ pub struct FileAdvisoryInformationRequest {
     pub advice: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileAdvisoryInformationRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileAdvisoryInformationRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileAdvisoryInformationRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<off_t>()
         - mem::size_of::<off_t>()
@@ -56,11 +56,11 @@ impl FileAdvisoryInformationRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -73,8 +73,8 @@ impl FileAdvisoryInformationRequest {
     ) -> Message {
         let message: FileAdvisoryInformationRequest =
             FileAdvisoryInformationRequest::new(fd, offset, len, advice);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileAdvisoryInformationRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileAdvisoryInformationRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -99,10 +99,10 @@ pub struct FileAdvisoryInformationResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileAdvisoryInformationResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileAdvisoryInformationResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileAdvisoryInformationResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(ret: i32) -> Self {
         Self {
@@ -111,18 +111,18 @@ impl FileAdvisoryInformationResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileAdvisoryInformationResponse = FileAdvisoryInformationResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileAdvisoryInformationResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileAdvisoryInformationResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/fcntl/message/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/message/fallocate.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -37,10 +37,10 @@ pub struct FileSpaceControlRequest {
     pub len: off_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileSpaceControlRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileSpaceControlRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileSpaceControlRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<off_t>()
         - mem::size_of::<off_t>();
@@ -54,11 +54,11 @@ impl FileSpaceControlRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -69,8 +69,8 @@ impl FileSpaceControlRequest {
         len: off_t,
     ) -> Result<Message, Error> {
         let message: FileSpaceControlRequest = FileSpaceControlRequest::new(fd, offset, len);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileSpaceControlRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileSpaceControlRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -94,10 +94,10 @@ pub struct FileSpaceControlResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileSpaceControlResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileSpaceControlResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileSpaceControlResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(ret: i32) -> Self {
         Self {
@@ -106,18 +106,18 @@ impl FileSpaceControlResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileSpaceControlResponse = FileSpaceControlResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileSpaceControlResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileSpaceControlResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/fcntl/message/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/message/fcntl.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -36,10 +36,10 @@ pub struct FileControlRequest {
     pub arg: c_int,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileControlRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileControlRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileControlRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<i32>()
         - mem::size_of::<c_int>();
@@ -53,18 +53,18 @@ impl FileControlRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32, cmd: i32, arg: c_int) -> Message {
         let message: FileControlRequest = FileControlRequest::new(fd, cmd, arg);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileControlRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileControlRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -89,10 +89,10 @@ pub struct FileControlResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileControlResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileControlResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileControlResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(ret: i32) -> Self {
         Self {
@@ -101,18 +101,18 @@ impl FileControlResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileControlResponse = FileControlResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileControlResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileControlResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -212,11 +212,11 @@ impl MessagePartitioner for OpenAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::OpenAtRequestPart,
+            SystemCallMessageHeader::OpenAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -234,10 +234,10 @@ pub struct OpenAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(OpenAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(OpenAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl OpenAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(ret: i32) -> Self {
         Self {
@@ -246,18 +246,18 @@ impl OpenAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: OpenAtResponse = OpenAtResponse::new(ret);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::OpenAtResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -285,11 +285,11 @@ impl MessagePartitioner for RenameAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::RenameAtRequestPart,
+            SystemCallMessageHeader::RenameAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -307,10 +307,10 @@ pub struct RenameAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(RenameAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(RenameAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl RenameAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -319,20 +319,18 @@ impl RenameAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: RenameAtResponse = RenameAtResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::RenameAtResponse,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::RenameAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -212,11 +212,11 @@ impl MessagePartitioner for UnlinkAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::UnlinkAtRequestPart,
+            SystemCallMessageHeader::UnlinkAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -234,10 +234,10 @@ pub struct UnlinkAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(UnlinkAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(UnlinkAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl UnlinkAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -246,20 +246,18 @@ impl UnlinkAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UnlinkAtResponse = UnlinkAtResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::UnlinkAtResponse,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::UnlinkAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -16,8 +16,8 @@ use sysapi::sys_types::off_t;
 use {
     crate::{
         fcntl::message::FileAdvisoryInformationRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -117,11 +117,11 @@ fn posix_fadvise_linuxd(
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileAdvisoryInformationResponse => Ok(()),
+            SystemCallMessageHeader::FileAdvisoryInformationResponse => Ok(()),
             header => {
                 // Response was not successfully parsed.
                 ::syslog::warn!(

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -12,8 +12,8 @@ use sysapi::sys_types::off_t;
 use {
     crate::{
         fcntl::message::FileSpaceControlRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         error::ErrorCode,
@@ -103,11 +103,11 @@ fn posix_fallocate_linuxd(fd: RawFileDescriptor, offset: off_t, len: off_t) -> R
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileSpaceControlResponse => Ok(()),
+            SystemCallMessageHeader::FileSpaceControlResponse => Ok(()),
             // Response was not parsed.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -17,8 +17,8 @@ use {
             FileControlRequest,
             FileControlResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -106,11 +106,11 @@ fn fcntl_linuxd(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileControlResponse => {
+            SystemCallMessageHeader::FileControlResponse => {
                 let message: FileControlResponse = FileControlResponse::from_bytes(message.payload);
                 let ret: c_int = message.ret;
                 Ok(ret)

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -21,8 +21,8 @@ use {
             OpenAtResponse,
         },
         message::MessagePartitioner,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -105,10 +105,10 @@ fn openat_linuxd(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Resu
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
-                LinuxDaemonMessageHeader::OpenAtResponse => {
+                SystemCallMessageHeader::OpenAtResponse => {
                     // Parse response.
                     let response: OpenAtResponse = OpenAtResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -12,8 +12,8 @@ use {
     crate::{
         fcntl::message::RenameAtRequest,
         message::MessagePartitioner,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -128,9 +128,9 @@ fn renameat_linuxd(
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
-            LinuxDaemonMessageHeader::RenameAtResponse => Ok(()),
+            SystemCallMessageHeader::RenameAtResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
                 ::syslog::warn!(

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -13,8 +13,8 @@ use {
     crate::{
         fcntl::message::UnlinkAtRequest,
         message::MessagePartitioner,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -106,10 +106,10 @@ fn unlinkat_linuxd(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Re
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::UnlinkAtResponse => Ok(()),
+            SystemCallMessageHeader::UnlinkAtResponse => Ok(()),
             // Response was not parsed.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -111,7 +111,7 @@ use ::sys::{
 
 #[derive(Debug, PartialEq, Eq)]
 #[repr(u16)]
-pub enum LinuxDaemonMessageHeader {
+pub enum SystemCallMessageHeader {
     OpenAtRequestPart,
     OpenAtResponse,
     UnlinkAtRequestPart,
@@ -211,12 +211,12 @@ pub enum LinuxDaemonMessageHeader {
     SelectRequest,
     SelectResponse,
 }
-// Manual TryFrom<u16> implementation for LinuxDaemonMessageHeader
-impl TryFrom<u16> for LinuxDaemonMessageHeader {
+// Manual TryFrom<u16> implementation for SystemCallMessageHeader
+impl TryFrom<u16> for SystemCallMessageHeader {
     type Error = ();
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        use LinuxDaemonMessageHeader::*;
+        use SystemCallMessageHeader::*;
         match value {
             x if x == OpenAtRequestPart as u16 => Ok(OpenAtRequestPart),
             x if x == OpenAtResponse as u16 => Ok(OpenAtResponse),
@@ -330,13 +330,13 @@ impl TryFrom<u16> for LinuxDaemonMessageHeader {
 }
 
 #[repr(C, packed)]
-pub struct LinuxDaemonMessage {
+pub struct SystemCallMessage {
     /// Message header.
-    pub header: LinuxDaemonMessageHeader,
+    pub header: SystemCallMessageHeader,
     /// Message payload.
     pub payload: [u8; Self::PAYLOAD_SIZE],
 }
-::static_assert::assert_eq_size!(LinuxDaemonMessage, Message::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SystemCallMessage, Message::PAYLOAD_SIZE);
 
 //==================================================================================================
 // Constants
@@ -345,7 +345,7 @@ pub struct LinuxDaemonMessage {
 ///
 /// # Description
 ///
-/// Process identifier of the Linux Daemon Service
+/// Process identifier of the system call provider.
 ///
 pub const LINUXD: ProcessIdentifier = ProcessIdentifier::KERNEL;
 
@@ -353,21 +353,21 @@ pub const LINUXD: ProcessIdentifier = ProcessIdentifier::KERNEL;
 // Implementations
 //==================================================================================================
 
-impl LinuxDaemonMessage {
+impl SystemCallMessage {
     pub const PAYLOAD_SIZE: usize =
-        Message::PAYLOAD_SIZE - mem::size_of::<LinuxDaemonMessageHeader>();
+        Message::PAYLOAD_SIZE - mem::size_of::<SystemCallMessageHeader>();
 
-    pub fn new(header: LinuxDaemonMessageHeader, payload: [u8; Self::PAYLOAD_SIZE]) -> Self {
+    pub fn new(header: SystemCallMessageHeader, payload: [u8; Self::PAYLOAD_SIZE]) -> Self {
         Self { header, payload }
     }
 
     pub fn try_from_bytes(bytes: [u8; Message::PAYLOAD_SIZE]) -> Result<Self, Error> {
         // Check if message header is valid.
-        let _header: LinuxDaemonMessageHeader =
-            LinuxDaemonMessageHeader::try_from(u16::from_ne_bytes([bytes[0], bytes[1]]))
+        let _header: SystemCallMessageHeader =
+            SystemCallMessageHeader::try_from(u16::from_ne_bytes([bytes[0], bytes[1]]))
                 .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid message header"))?;
 
-        let message: LinuxDaemonMessage = unsafe { mem::transmute(bytes) };
+        let message: SystemCallMessage = unsafe { mem::transmute(bytes) };
 
         Ok(message)
     }

--- a/src/libs/syscall/src/message/long.rs
+++ b/src/libs/syscall/src/message/long.rs
@@ -2,7 +2,7 @@
 // Imports
 //==================================================================================================
 
-use crate::message::LinuxDaemonMessagePart;
+use crate::message::SystemCallMessagePart;
 use ::alloc::vec::Vec;
 use ::sys::error::{
     Error,
@@ -18,18 +18,18 @@ use ::sys::error::{
 ///
 /// This structure represents a long message that is split into multiple parts.
 ///
-pub struct LinuxDaemonLongMessage {
+pub struct SystemCallLongMessage {
     /// Maximum number of parts that the message can contain.
     capacity: usize,
     /// Parts of the message.
-    parts: Vec<LinuxDaemonMessagePart>,
+    parts: Vec<SystemCallMessagePart>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl LinuxDaemonLongMessage {
+impl SystemCallLongMessage {
     ///
     /// # Description
     ///
@@ -68,7 +68,7 @@ impl LinuxDaemonLongMessage {
     ///
     /// Upon success, the function returns empty. Otherwise, it returns an error.
     ///
-    pub fn add_part(&mut self, part: LinuxDaemonMessagePart) -> Result<(), Error> {
+    pub fn add_part(&mut self, part: SystemCallMessagePart) -> Result<(), Error> {
         // Check if we reached the maximum capacity.
         if self.parts.len() == self.capacity {
             return Err(Error::new(ErrorCode::MessageTooLong, "message too long"));
@@ -116,7 +116,7 @@ impl LinuxDaemonLongMessage {
     ///
     /// Returns the parts of the message.
     ///
-    pub fn take_parts(self) -> Vec<LinuxDaemonMessagePart> {
+    pub fn take_parts(self) -> Vec<SystemCallMessagePart> {
         self.parts
     }
 }

--- a/src/libs/syscall/src/message/mod.rs
+++ b/src/libs/syscall/src/message/mod.rs
@@ -23,8 +23,8 @@ use ::sys::{
 // Exports
 //==================================================================================================
 
-pub use long::LinuxDaemonLongMessage;
-pub use part::LinuxDaemonMessagePart;
+pub use long::SystemCallLongMessage;
+pub use part::SystemCallMessagePart;
 
 //==================================================================================================
 // Traits
@@ -95,7 +95,7 @@ where
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error>;
 
     ///
@@ -116,7 +116,7 @@ where
         let bytes: Vec<u8> = self.to_bytes();
         let num_parts: u16 = bytes
             .len()
-            .div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE)
+            .div_ceil(SystemCallMessagePart::PAYLOAD_SIZE)
             .try_into()
             .map_err(|_| {
                 Error::new(
@@ -127,10 +127,10 @@ where
         let mut parts: Vec<Message> = Vec::with_capacity(num_parts as usize);
 
         for (part_number, chunk) in bytes
-            .chunks(LinuxDaemonMessagePart::PAYLOAD_SIZE)
+            .chunks(SystemCallMessagePart::PAYLOAD_SIZE)
             .enumerate()
         {
-            let mut payload = [0; LinuxDaemonMessagePart::PAYLOAD_SIZE];
+            let mut payload = [0; SystemCallMessagePart::PAYLOAD_SIZE];
             payload[..chunk.len()].copy_from_slice(chunk);
             parts.push(Self::new_part(
                 tid,
@@ -159,9 +159,9 @@ where
     /// Upon success, a vector containing the response messages is returned. Upon failure, an error
     /// is returned instead.
     ///
-    fn from_parts(parts: &Vec<LinuxDaemonMessagePart>) -> Result<Self, Error> {
+    fn from_parts(parts: &Vec<SystemCallMessagePart>) -> Result<Self, Error> {
         let mut bytes: Vec<u8> =
-            Vec::with_capacity(parts.len() * LinuxDaemonMessagePart::PAYLOAD_SIZE);
+            Vec::with_capacity(parts.len() * SystemCallMessagePart::PAYLOAD_SIZE);
 
         for part in parts {
             bytes.extend_from_slice(&part.payload[..part.payload_size as usize]);

--- a/src/libs/syscall/src/message/part.rs
+++ b/src/libs/syscall/src/message/part.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -34,10 +34,10 @@ use ::sys::{
 ///
 /// # Description
 ///
-/// This structure represents a part of a Linux Daemon Message.
+/// This structure represents a part of a System Call Message.
 ///
 #[repr(C, packed)]
-pub struct LinuxDaemonMessagePart {
+pub struct SystemCallMessagePart {
     /// Total parts.
     pub total_parts: u16,
     /// Part number.
@@ -47,11 +47,11 @@ pub struct LinuxDaemonMessagePart {
     /// Payload.
     pub payload: [u8; Self::PAYLOAD_SIZE],
 }
-::static_assert::assert_eq_size!(LinuxDaemonMessagePart, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SystemCallMessagePart, SystemCallMessage::PAYLOAD_SIZE);
 
-impl LinuxDaemonMessagePart {
+impl SystemCallMessagePart {
     /// Maximum size of the payload.
-    pub const PAYLOAD_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PAYLOAD_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<u8>()
         - mem::size_of::<u16>()
         - mem::size_of::<u16>();
@@ -76,7 +76,7 @@ impl LinuxDaemonMessagePart {
     ///
     pub fn build_request(
         tid: ThreadIdentifier,
-        header: LinuxDaemonMessageHeader,
+        header: SystemCallMessageHeader,
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
@@ -105,7 +105,7 @@ impl LinuxDaemonMessagePart {
     ///
     pub fn build_response(
         tid: ThreadIdentifier,
-        header: LinuxDaemonMessageHeader,
+        header: SystemCallMessageHeader,
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
@@ -117,7 +117,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Description
     ///
-    /// Converts a byte array into a Linux Daemon Message Part.
+    /// Converts a byte array into a System Call Message Part.
     ///
     /// # Parameters
     ///
@@ -125,22 +125,22 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Returns
     ///
-    /// A Linux Daemon Message Part.
+    /// A System Call Message Part.
     ///
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
     ///
     /// # Description
     ///
-    /// Converts a Linux Daemon Message Part into a byte array.
+    /// Converts a System Call Message Part into a byte array.
     ///
     /// # Returns
     ///
     /// A byte array.
     ///
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -163,7 +163,7 @@ impl LinuxDaemonMessagePart {
     /// Upon success, the message is returned. Upon failure, an error is returned instead.
     fn build(
         tid: ThreadIdentifier,
-        header: LinuxDaemonMessageHeader,
+        header: SystemCallMessageHeader,
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
@@ -178,9 +178,9 @@ impl LinuxDaemonMessagePart {
             ));
         }
 
-        let message: LinuxDaemonMessagePart =
+        let message: SystemCallMessagePart =
             Self::new(total_parts, part_number, payload_size, payload)?;
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(header, message.into_bytes());
+        let message: SystemCallMessage = SystemCallMessage::new(header, message.into_bytes());
         if is_response {
             Ok(Message::new(
                 MessageSender::from(crate::LINUXD),
@@ -203,7 +203,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Description
     ///
-    /// Creates a new part of a Linux Daemon Message.
+    /// Creates a new part of a System Call Message.
     ///
     /// # Parameters
     ///
@@ -232,11 +232,11 @@ impl LinuxDaemonMessagePart {
     }
 }
 
-impl Debug for LinuxDaemonMessagePart {
+impl Debug for SystemCallMessagePart {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "LinuxDaemonMessagePart {{ part_number: {}, total_parts={},  payload_size: {} }}",
+            "SystemCallMessagePart {{ part_number: {}, total_parts={},  payload_size: {} }}",
             { self.part_number },
             { self.total_parts },
             { self.payload_size }

--- a/src/libs/syscall/src/poll/message.rs
+++ b/src/libs/syscall/src/poll/message.rs
@@ -7,12 +7,12 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessageHeader,
+    SystemCallMessageHeader,
 };
 use ::alloc::vec::Vec;
 use ::core::mem;
@@ -229,11 +229,11 @@ impl MessagePartitioner for PollRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::PollRequestPart,
+            SystemCallMessageHeader::PollRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -404,11 +404,11 @@ impl MessagePartitioner for PollResponse {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_response(
+        SystemCallMessagePart::build_response(
             tid,
-            LinuxDaemonMessageHeader::PollResponsePart,
+            SystemCallMessageHeader::PollResponsePart,
             total_parts,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -19,16 +19,16 @@ use ::sysapi::ffi::{
 use {
     crate::{
         message::{
-            LinuxDaemonLongMessage,
-            LinuxDaemonMessagePart,
             MessagePartitioner,
+            SystemCallLongMessage,
+            SystemCallMessagePart,
         },
         poll::message::{
             PollRequest,
             PollResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -172,8 +172,8 @@ fn poll_linuxd(
     }
 
     // Compute maximum number of parts in the response.
-    let capacity: usize = PollResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
-    let mut assembler: LinuxDaemonLongMessage = LinuxDaemonLongMessage::new(capacity)?;
+    let capacity: usize = PollResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
+    let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
         let response: Message = ipc::recv()?;
@@ -196,8 +196,7 @@ fn poll_linuxd(
         }
 
         // Parse system call response.
-        let message: LinuxDaemonMessage = match LinuxDaemonMessage::try_from_bytes(response.payload)
-        {
+        let message: SystemCallMessage = match SystemCallMessage::try_from_bytes(response.payload) {
             Ok(m) => m,
             Err(error) => {
                 ::syslog::warn!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
@@ -206,9 +205,9 @@ fn poll_linuxd(
         };
 
         match message.header {
-            LinuxDaemonMessageHeader::PollResponsePart => {
-                let part: LinuxDaemonMessagePart =
-                    LinuxDaemonMessagePart::from_bytes(message.payload);
+            SystemCallMessageHeader::PollResponsePart => {
+                let part: SystemCallMessagePart =
+                    SystemCallMessagePart::from_bytes(message.payload);
 
                 // Add response part to message assembler and check for errors.
                 if let Err(e) = assembler.add_part(part) {
@@ -223,7 +222,7 @@ fn poll_linuxd(
                     continue;
                 }
 
-                let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+                let parts: Vec<SystemCallMessagePart> = assembler.take_parts();
 
                 // Assemble message.
                 match PollResponse::from_parts(&parts) {

--- a/src/libs/syscall/src/sys/select/message/mod.rs
+++ b/src/libs/syscall/src/sys/select/message/mod.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -49,14 +49,14 @@ pub struct SelectRequest {
     /// Required padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SelectRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SelectRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 // Ensure that the maximum number of file descriptors can be encoded in a `u8`.
 ::static_assert::assert_eq!(FD_SETSIZE < u8::MAX as usize);
 
 impl SelectRequest {
     /// Size of the padding field.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<u8>()
         - mem::size_of::<Option<fd_set>>()
         - mem::size_of::<Option<fd_set>>()
@@ -82,12 +82,12 @@ impl SelectRequest {
     }
 
     /// Deserializes a request from raw bytes.
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
     /// Serializes the request into raw bytes.
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -121,8 +121,8 @@ impl SelectRequest {
 
         let message: SelectRequest =
             SelectRequest::new(nfds_u8, readfds, writefds, errorfds, timeout);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SelectRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::SelectRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -164,11 +164,11 @@ pub struct SelectResponse {
     /// Required padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SelectResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SelectResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SelectResponse {
     /// Size of the padding field.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<u8>()
         - mem::size_of::<Option<fd_set>>()
         - mem::size_of::<Option<fd_set>>()
@@ -191,12 +191,12 @@ impl SelectResponse {
     }
 
     /// Deserializes a response from raw bytes.
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
     /// Serializes the response into raw bytes.
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -209,8 +209,8 @@ impl SelectResponse {
         errorfds: &Option<fd_set>,
     ) -> Message {
         let message: SelectResponse = SelectResponse::new(ready_fds, readfds, writefds, errorfds);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SelectResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::SelectResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -10,8 +10,8 @@ use crate::{
         SelectRequest,
         SelectResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -119,11 +119,11 @@ pub fn select(
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::SelectResponse => {
+            SystemCallMessageHeader::SelectResponse => {
                 let response: SelectResponse = SelectResponse::from_bytes(message.payload);
 
                 for (fd_set, dest) in [

--- a/src/libs/syscall/src/sys/socket/message/accept.rs
+++ b/src/libs/syscall/src/sys/socket/message/accept.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -34,10 +34,10 @@ pub struct AcceptSocketRequest {
     pub sockfd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(AcceptSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(AcceptSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl AcceptSocketRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(sockfd: i32) -> Self {
         Self {
@@ -46,18 +46,18 @@ impl AcceptSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32) -> Message {
         let message: Self = Self::new(sockfd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::AcceptSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::AcceptSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -82,11 +82,11 @@ pub struct AcceptSocketResponse {
     pub sockaddr: sockaddr,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(AcceptSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(AcceptSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl AcceptSocketResponse {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<sockaddr>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<sockaddr>();
 
     pub fn new(sockfd: i32, sockaddr: &sockaddr) -> Self {
         Self {
@@ -96,18 +96,18 @@ impl AcceptSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockfd, sockaddr);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::AcceptSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::AcceptSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/bind.rs
+++ b/src/libs/syscall/src/sys/socket/message/bind.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     sys::socket::sockaddr,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -35,11 +35,11 @@ pub struct BindSocketRequest {
     pub sockaddr: sockaddr,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(BindSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(BindSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl BindSocketRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<sockaddr>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<sockaddr>();
 
     pub fn new(sockfd: c_int, sockaddr: &sockaddr) -> Self {
         Self {
@@ -49,18 +49,18 @@ impl BindSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: c_int, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockfd, sockaddr);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::BindSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::BindSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -95,10 +95,10 @@ impl Debug for BindSocketRequest {
 pub struct BindSocketResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(BindSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(BindSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl BindSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -106,18 +106,18 @@ impl BindSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::BindSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::BindSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/connect.rs
+++ b/src/libs/syscall/src/sys/socket/message/connect.rs
@@ -10,8 +10,8 @@ use crate::{
         sockaddr,
         socklen_t,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -39,10 +39,10 @@ pub struct ConnectSocketRequest {
     pub socklen: socklen_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ConnectSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ConnectSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ConnectSocketRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<c_int>()
         - mem::size_of::<sockaddr>()
         - mem::size_of::<socklen_t>();
@@ -56,11 +56,11 @@ impl ConnectSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -71,8 +71,8 @@ impl ConnectSocketRequest {
         socklen: socklen_t,
     ) -> Message {
         let message: Self = Self::new(sockfd, sockaddr, socklen);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ConnectSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConnectSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -107,23 +107,23 @@ impl Debug for ConnectSocketRequest {
 pub struct ConnectSocketResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ConnectSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ConnectSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ConnectSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::default();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ConnectSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConnectSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/message/getpeername.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     sys::socket::sockaddr,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -35,10 +35,10 @@ pub struct GetPeerNameRequest {
     pub sockfd: c_int,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetPeerNameRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetPeerNameRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetPeerNameRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
 
     pub fn new(sockfd: c_int) -> Self {
         Self {
@@ -47,18 +47,18 @@ impl GetPeerNameRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: c_int) -> Message {
         let message: Self = Self::new(sockfd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::GetPeerNameRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::GetPeerNameRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -81,10 +81,10 @@ pub struct GetPeerNameResponse {
     pub sockaddr: sockaddr,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetPeerNameResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetPeerNameResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetPeerNameResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<sockaddr>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<sockaddr>();
 
     fn new(sockaddr: &sockaddr) -> Self {
         Self {
@@ -93,18 +93,18 @@ impl GetPeerNameResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockaddr);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::GetPeerNameResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::GetPeerNameResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/message/getsockname.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     sys::socket::sockaddr,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -35,10 +35,10 @@ pub struct GetSockNameRequest {
     pub sockfd: c_int,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetSockNameRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetSockNameRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetSockNameRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
 
     pub fn new(sockfd: c_int) -> Self {
         Self {
@@ -47,18 +47,18 @@ impl GetSockNameRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: c_int) -> Message {
         let message: Self = Self::new(sockfd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::GetSockNameRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::GetSockNameRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -81,10 +81,10 @@ pub struct GetSockNameResponse {
     pub sockaddr: sockaddr,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetSockNameResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetSockNameResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetSockNameResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<sockaddr>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<sockaddr>();
 
     pub fn new(sockaddr: &sockaddr) -> Self {
         Self {
@@ -93,18 +93,18 @@ impl GetSockNameResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockaddr);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::GetSockNameResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::GetSockNameResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/listen.rs
+++ b/src/libs/syscall/src/sys/socket/message/listen.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -34,11 +34,11 @@ pub struct ListenSocketRequest {
     pub backlog: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ListenSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ListenSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ListenSocketRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<i32>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<i32>();
 
     pub fn new(sockfd: i32, backlog: i32) -> Self {
         Self {
@@ -48,18 +48,18 @@ impl ListenSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32, backlog: i32) -> Message {
         let message: Self = Self::new(sockfd, backlog);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ListenSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ListenSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -83,10 +83,10 @@ impl ListenSocketRequest {
 pub struct ListenSocketResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ListenSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ListenSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ListenSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -94,18 +94,18 @@ impl ListenSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ListenSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ListenSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -33,10 +33,10 @@ pub struct ReceiveSocketRequest {
     pub flags: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ReceiveSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ReceiveSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ReceiveSocketRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<u32>()
         - mem::size_of::<i32>();
@@ -50,18 +50,18 @@ impl ReceiveSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32, count: u32, flags: i32) -> Message {
         let message: ReceiveSocketRequest = ReceiveSocketRequest::new(sockfd, count, flags);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ReceiveSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ReceiveSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -85,20 +85,20 @@ pub struct ReceiveSocketResponse {
     pub count: c_size_t,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(ReceiveSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ReceiveSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ReceiveSocketResponse {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_size_t>();
+    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_size_t>();
 
     pub fn new(count: c_size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -108,8 +108,8 @@ impl ReceiveSocketResponse {
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: ReceiveSocketResponse = ReceiveSocketResponse::new(count, buffer);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ReceiveSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ReceiveSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -36,10 +36,10 @@ pub struct SendSocketRequest {
     pub flags: i32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(SendSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SendSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SendSocketRequest {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<u32>()
         - mem::size_of::<i32>();
@@ -53,11 +53,11 @@ impl SendSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -69,8 +69,8 @@ impl SendSocketRequest {
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: SendSocketRequest = SendSocketRequest::new(sockfd, count, flags, buffer);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::SendSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::SendSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -95,10 +95,10 @@ pub struct SendSocketResponse {
     pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SendSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SendSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SendSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(count: c_ssize_t) -> Self {
         Self {
@@ -107,18 +107,18 @@ impl SendSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: SendSocketResponse = SendSocketResponse::new(count);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::SendSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::SendSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/message/shutdown.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     sys::socket::Shutdown,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -35,11 +35,11 @@ pub struct ShutdownSocketRequest {
     pub how: Shutdown,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ShutdownSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ShutdownSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ShutdownSocketRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<Shutdown>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<Shutdown>();
 
     pub fn new(sockfd: i32, how: Shutdown) -> Self {
         Self {
@@ -49,18 +49,18 @@ impl ShutdownSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32, how: Shutdown) -> Message {
         let message: Self = Self::new(sockfd, how);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ShutdownSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ShutdownSocketRequest,
             message.into_bytes(),
         );
 
@@ -85,10 +85,10 @@ impl ShutdownSocketRequest {
 pub struct ShutdownSocketResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ShutdownSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ShutdownSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ShutdownSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -96,18 +96,18 @@ impl ShutdownSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ShutdownSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ShutdownSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/socket.rs
+++ b/src/libs/syscall/src/sys/socket/message/socket.rs
@@ -11,8 +11,8 @@ use crate::{
         AddressFamily,
         SocketType,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -40,10 +40,10 @@ pub struct CreateSocketRequest {
     pub protocol: Protocol,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CreateSocketRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CreateSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CreateSocketRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<AddressFamily>()
         - mem::size_of::<SocketType>()
         - mem::size_of::<Protocol>();
@@ -57,11 +57,11 @@ impl CreateSocketRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -72,8 +72,8 @@ impl CreateSocketRequest {
         protocol: Protocol,
     ) -> Message {
         let message: Self = Self::new(domain, typ, protocol);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::CreateSocketRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::CreateSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -98,10 +98,10 @@ pub struct CreateSocketResponse {
     pub sockfd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CreateSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CreateSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CreateSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(sockfd: i32) -> Self {
         Self {
@@ -110,18 +110,18 @@ impl CreateSocketResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd: i32) -> Message {
         let message: Self = Self::new(sockfd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::CreateSocketResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::CreateSocketResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/message/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/message/socketpair.rs
@@ -11,8 +11,8 @@ use crate::{
         AddressFamily,
         SocketType,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -41,10 +41,10 @@ pub struct CreateSocketPairRequest {
     pub protocol: Protocol,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CreateSocketPairRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CreateSocketPairRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CreateSocketPairRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<AddressFamily>()
         - mem::size_of::<SocketType>()
         - mem::size_of::<Protocol>();
@@ -58,11 +58,11 @@ impl CreateSocketPairRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -73,8 +73,8 @@ impl CreateSocketPairRequest {
         protocol: Protocol,
     ) -> Message {
         let message: Self = Self::new(domain, typ, protocol);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::CreateSocketPairRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::CreateSocketPairRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -100,11 +100,11 @@ pub struct CreateSocketPairResponse {
     pub sockfd_1: c_int,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CreateSocketPairResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CreateSocketPairResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CreateSocketPairResponse {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<c_int>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<c_int>();
 
     pub fn new(sockfd_0: c_int, sockfd_1: c_int) -> Self {
         Self {
@@ -114,18 +114,18 @@ impl CreateSocketPairResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, sockfd_0: c_int, sockfd_1: c_int) -> Message {
         let message: Self = Self::new(sockfd_0, sockfd_1);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::CreateSocketPairResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::CreateSocketPairResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -13,8 +13,8 @@ use crate::{
         },
         SocketAddr,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -59,11 +59,11 @@ pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::AcceptSocketResponse => {
+                SystemCallMessageHeader::AcceptSocketResponse => {
                     let response: AcceptSocketResponse =
                         AcceptSocketResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -11,8 +11,8 @@ use crate::{
         sockaddr,
         SocketAddr,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -59,11 +59,11 @@ pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::BindSocketResponse => Ok(()),
+                SystemCallMessageHeader::BindSocketResponse => Ok(()),
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
             },

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -15,8 +15,8 @@ use crate::{
         socklen_t,
         SocketAddr,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -78,11 +78,11 @@ pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
         Err(Error::new(error_code, "connect() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::ConnectSocketResponse => {
+            SystemCallMessageHeader::ConnectSocketResponse => {
                 let _response: ConnectSocketResponse =
                     ConnectSocketResponse::from_bytes(message.payload);
                 Ok(())

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -13,8 +13,8 @@ use crate::{
         },
         SocketAddr,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -73,11 +73,11 @@ pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
         Err(Error::new(error_code, "getpeername() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::GetPeerNameResponse => {
+            SystemCallMessageHeader::GetPeerNameResponse => {
                 let response: GetPeerNameResponse =
                     GetPeerNameResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -13,8 +13,8 @@ use crate::{
         },
         SocketAddr,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -73,11 +73,11 @@ pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
         Err(Error::new(error_code, "getsockname() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::GetSockNameResponse => {
+            SystemCallMessageHeader::GetSockNameResponse => {
                 let response: GetSockNameResponse =
                     GetSockNameResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     sys::socket::message::ListenSocketRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -53,11 +53,11 @@ pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::ListenSocketResponse => Ok(()),
+                SystemCallMessageHeader::ListenSocketResponse => Ok(()),
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
             },

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -10,8 +10,8 @@ use crate::{
         ReceiveSocketRequest,
         ReceiveSocketResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::cmp;
 use ::sys::{
@@ -71,11 +71,11 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
             };
         } else {
             // System call succeeded, parse response.
-            match LinuxDaemonMessage::try_from_bytes(response.payload) {
+            match SystemCallMessage::try_from_bytes(response.payload) {
                 // Response was successfully parsed.
                 Ok(message) => match message.header {
                     // Response was successfully parsed.
-                    LinuxDaemonMessageHeader::ReceiveSocketResponse => {
+                    SystemCallMessageHeader::ReceiveSocketResponse => {
                         // Parse response.
                         let response: ReceiveSocketResponse =
                             ReceiveSocketResponse::from_bytes(message.payload);

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -10,8 +10,8 @@ use crate::{
         SendSocketRequest,
         SendSocketResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::cmp;
 use ::sys::{
@@ -76,11 +76,11 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
             }
         } else {
             // System call succeeded, parse response.
-            match LinuxDaemonMessage::try_from_bytes(response.payload) {
+            match SystemCallMessage::try_from_bytes(response.payload) {
                 // Response was successfully parsed.
                 Ok(message) => match message.header {
                     // Response was successfully parsed.
-                    LinuxDaemonMessageHeader::SendSocketResponse => {
+                    SystemCallMessageHeader::SendSocketResponse => {
                         // Parse response.
                         let response: SendSocketResponse =
                             SendSocketResponse::from_bytes(message.payload);

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -10,8 +10,8 @@ use crate::{
         message::ShutdownSocketRequest,
         Shutdown,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -56,11 +56,11 @@ pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::ShutdownSocketResponse => Ok(()),
+                SystemCallMessageHeader::ShutdownSocketResponse => Ok(()),
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
             },

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -15,8 +15,8 @@ use crate::{
         AddressFamily,
         SocketType,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -61,11 +61,11 @@ pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Res
         }
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::CreateSocketResponse => {
+                SystemCallMessageHeader::CreateSocketResponse => {
                     let response: CreateSocketResponse =
                         CreateSocketResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -15,8 +15,8 @@ use crate::{
         AddressFamily,
         SocketType,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -90,11 +90,11 @@ pub fn socketpair(
         Err(Error::new(error_code, "socketpair() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::CreateSocketPairResponse => {
+            SystemCallMessageHeader::CreateSocketPairResponse => {
                 let response: CreateSocketPairResponse =
                     CreateSocketPairResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/sys/stat/message/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmod.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -41,11 +41,11 @@ pub struct FileChmodRequest {
     /// Padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChmodRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChmodRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChmodRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<mode_t>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>() - mem::size_of::<mode_t>();
 
     fn new(fd: c_int, mode: mode_t) -> Self {
         Self {
@@ -55,20 +55,18 @@ impl FileChmodRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: c_int, mode: mode_t) -> Message {
         let message: FileChmodRequest = FileChmodRequest::new(fd, mode);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChmodRequest,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileChmodRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -90,11 +88,11 @@ impl FileChmodRequest {
 pub struct FileChmodResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChmodResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChmodResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChmodResponse {
     /// Size of padding.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -102,14 +100,14 @@ impl FileChmodResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChmodResponse = FileChmodResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChmodResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileChmodResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -237,11 +237,11 @@ impl MessagePartitioner for FileChmodAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::FileChmodAtRequestPart,
+            SystemCallMessageHeader::FileChmodAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -259,11 +259,11 @@ impl MessagePartitioner for FileChmodAtRequest {
 pub struct FileChmodAtResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChmodAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChmodAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChmodAtResponse {
     /// Size of padding.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -271,14 +271,14 @@ impl FileChmodAtResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChmodAtResponse = FileChmodAtResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChmodAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileChmodAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/stat/message/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstat.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -37,10 +37,10 @@ pub struct FileStatRequest {
     /// Padding.
     pub padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileStatRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileStatRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileStatRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     /// Creates a new request message.
     fn new(fd: i32) -> Self {
@@ -51,21 +51,19 @@ impl FileStatRequest {
     }
 
     /// Creates a new request message from a byte array.
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
     /// Converts the request message to a byte array.
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileStatRequest = FileStatRequest::new(fd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileStatRequest,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileStatRequest, message.into_bytes());
         Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),

--- a/src/libs/syscall/src/sys/stat/message/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstatat.rs
@@ -7,12 +7,12 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessageHeader,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -202,11 +202,11 @@ impl MessagePartitioner for FileStatAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::FileStatAtRequestPart,
+            SystemCallMessageHeader::FileStatAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -396,11 +396,11 @@ impl MessagePartitioner for FileStatAtResponse {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_response(
+        SystemCallMessagePart::build_response(
             tid,
-            LinuxDaemonMessageHeader::FileStatAtResponsePart,
+            SystemCallMessageHeader::FileStatAtResponsePart,
             total_parts,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/sys/stat/message/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/message/futimens.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -32,17 +32,17 @@ pub struct UpdateFileAccessTimeRequest {
     pub times: [timespec; 2],
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(UpdateFileAccessTimeRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(UpdateFileAccessTimeRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl UpdateFileAccessTimeRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - 2 * mem::size_of::<timespec>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - 2 * mem::size_of::<timespec>();
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -52,8 +52,8 @@ impl UpdateFileAccessTimeRequest {
             times: *times,
             _padding: [0; Self::PADDING_SIZE],
         };
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::UpdateFileAccessTimeRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -77,10 +77,10 @@ pub struct UpdateFileAccessTimeResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(UpdateFileAccessTimeResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(UpdateFileAccessTimeResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl UpdateFileAccessTimeResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -89,18 +89,18 @@ impl UpdateFileAccessTimeResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UpdateFileAccessTimeResponse = UpdateFileAccessTimeResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::UpdateFileAccessTimeResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -237,11 +237,11 @@ impl MessagePartitioner for MakeDirectoryAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart,
+            SystemCallMessageHeader::MakeDirectoryAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -259,10 +259,10 @@ pub struct MakeDirectoryAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(MakeDirectoryAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(MakeDirectoryAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl MakeDirectoryAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -271,18 +271,18 @@ impl MakeDirectoryAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: MakeDirectoryAtResponse = MakeDirectoryAtResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::MakeDirectoryAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::MakeDirectoryAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -259,11 +259,11 @@ impl MessagePartitioner for UpdateFileAccessTimeAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart,
+            SystemCallMessageHeader::UpdateFileAccessTimeAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -286,10 +286,10 @@ pub struct UpdateFileAccessTimeAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(UpdateFileAccessTimeAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(UpdateFileAccessTimeAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl UpdateFileAccessTimeAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -298,18 +298,18 @@ impl UpdateFileAccessTimeAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UpdateFileAccessTimeAtResponse = UpdateFileAccessTimeAtResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::UpdateFileAccessTimeAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -15,8 +15,8 @@ use sysapi::sys_types::mode_t;
 use {
     crate::{
         sys::stat::message::FileChmodRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -100,10 +100,10 @@ fn fchmod_linuxd(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileChmodResponse => Ok(()),
+            SystemCallMessageHeader::FileChmodResponse => Ok(()),
             // Invalid response.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -15,8 +15,8 @@ use {
     crate::{
         message::MessagePartitioner,
         sys::stat::message::FileChmodAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -85,10 +85,10 @@ fn fchmodat_linuxd(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Resul
         Err(Error::new(error_code, "fchmodat() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
         match message.header {
-            LinuxDaemonMessageHeader::FileChmodAtResponse => Ok(()),
+            SystemCallMessageHeader::FileChmodAtResponse => Ok(()),
             _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
         }
     }

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -15,8 +15,8 @@ use ::sysapi::time::timespec;
 use {
     crate::{
         sys::stat::message::UpdateFileAccessTimeRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -101,11 +101,11 @@ fn futimens_linuxd(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), E
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeResponse => Ok(()),
+            SystemCallMessageHeader::UpdateFileAccessTimeResponse => Ok(()),
             // Response was not successfully parsed.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -16,8 +16,8 @@ use {
     crate::{
         message::MessagePartitioner,
         sys::stat::message::MakeDirectoryAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::{
         string::ToString,
@@ -117,10 +117,10 @@ fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Res
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
-            LinuxDaemonMessageHeader::MakeDirectoryAtResponse => Ok(()),
+            SystemCallMessageHeader::MakeDirectoryAtResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
                 ::syslog::warn!(

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -25,13 +25,13 @@ mod utimensat;
 use {
     crate::{
         message::{
-            LinuxDaemonLongMessage,
-            LinuxDaemonMessagePart,
             MessagePartitioner,
+            SystemCallLongMessage,
+            SystemCallMessagePart,
         },
         sys::stat::message::FileStatAtResponse,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -76,9 +76,9 @@ pub use utimensat::utimensat;
 ///
 #[cfg(not(feature = "standalone"))]
 fn fstatat_response() -> Result<sys_stat::stat, Error> {
-    let capacity: usize = sys_stat::stat::SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+    let capacity: usize = sys_stat::stat::SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
-    let mut assembler: LinuxDaemonLongMessage = LinuxDaemonLongMessage::new(capacity)?;
+    let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
         let response: Message = ::sys::kcall::ipc::recv()?;
@@ -91,11 +91,11 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
             break Err(Error::new(error_code, "fstatat() failed"));
         } else {
             // System call succeeded, parse response.
-            match LinuxDaemonMessage::try_from_bytes(response.payload) {
+            match SystemCallMessage::try_from_bytes(response.payload) {
                 Ok(message) => match message.header {
-                    LinuxDaemonMessageHeader::FileStatAtResponsePart => {
-                        let part: LinuxDaemonMessagePart =
-                            LinuxDaemonMessagePart::from_bytes(message.payload);
+                    SystemCallMessageHeader::FileStatAtResponsePart => {
+                        let part: SystemCallMessagePart =
+                            SystemCallMessagePart::from_bytes(message.payload);
 
                         if let Err(e) = assembler.add_part(part) {
                             ::syslog::warn!("fstatat(): failed to add part to assembler");
@@ -106,7 +106,7 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
                             continue;
                         }
 
-                        let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+                        let parts: Vec<SystemCallMessagePart> = assembler.take_parts();
 
                         let response: FileStatAtResponse = FileStatAtResponse::from_parts(&parts)?;
                         break Ok(response.stat);

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -12,8 +12,8 @@ use {
     crate::{
         message::MessagePartitioner,
         sys::stat::message::UpdateFileAccessTimeAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::{
         string::ToString,
@@ -130,11 +130,11 @@ fn utimensat_linuxd(
         }
     } else {
         // System call succeeded, parse response.
-        let message = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtResponse => Ok(()),
+            SystemCallMessageHeader::UpdateFileAccessTimeAtResponse => Ok(()),
             // Response was not successfully parsed.
             _ => {
                 let reason: &str = "unexpected message header";

--- a/src/libs/syscall/src/sys/time/message/mod.rs
+++ b/src/libs/syscall/src/sys/time/message/mod.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -33,10 +33,10 @@ use ::sysapi::{
 pub struct TimesRequest {
     pub _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(TimesRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(TimesRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl TimesRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -44,18 +44,18 @@ impl TimesRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Result<Message, Error> {
         let message: TimesRequest = TimesRequest::new();
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -78,11 +78,11 @@ pub struct TimesResponse {
     pub buffer: tms,
     pub _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(TimesResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(TimesResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl TimesResponse {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<clock_t>() - mem::size_of::<tms>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<clock_t>() - mem::size_of::<tms>();
 
     fn new(elapsed: clock_t, buffer: tms) -> Self {
         Self {
@@ -92,18 +92,18 @@ impl TimesResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, elapsed: clock_t, buffer: tms) -> Message {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/sys/times/message/mod.rs
+++ b/src/libs/syscall/src/sys/times/message/mod.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -33,10 +33,10 @@ use sysapi::{
 pub struct TimesRequest {
     pub _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(TimesRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(TimesRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl TimesRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -44,18 +44,18 @@ impl TimesRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Result<Message, Error> {
         let message: TimesRequest = TimesRequest::new();
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -78,11 +78,11 @@ pub struct TimesResponse {
     pub buffer: tms,
     pub _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(TimesResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(TimesResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl TimesResponse {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<clock_t>() - mem::size_of::<tms>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<clock_t>() - mem::size_of::<tms>();
 
     fn new(elapsed: clock_t, buffer: tms) -> Self {
         Self {
@@ -92,18 +92,18 @@ impl TimesResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    pub fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, elapsed: clock_t, buffer: tms) -> Message {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/sys/times/syscall/times.rs
+++ b/src/libs/syscall/src/sys/times/syscall/times.rs
@@ -10,8 +10,8 @@ use crate::{
         TimesRequest,
         TimesResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -82,10 +82,10 @@ pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
         match message.header {
-            LinuxDaemonMessageHeader::TimesResponse => {
+            SystemCallMessageHeader::TimesResponse => {
                 // Parse response.
                 let response: TimesResponse = TimesResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -178,11 +178,11 @@ impl MessagePartitioner for ChangeDirectoryRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::ChangeDirectoryRequestPart,
+            SystemCallMessageHeader::ChangeDirectoryRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -200,10 +200,10 @@ impl MessagePartitioner for ChangeDirectoryRequest {
 pub struct ChangeDirectoryResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ChangeDirectoryResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ChangeDirectoryResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ChangeDirectoryResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -211,14 +211,14 @@ impl ChangeDirectoryResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: ChangeDirectoryResponse = ChangeDirectoryResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::ChangeDirectoryResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ChangeDirectoryResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/close.rs
+++ b/src/libs/syscall/src/unistd/message/close.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt,
@@ -32,10 +32,10 @@ pub struct CloseRequest {
     pub fd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CloseRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CloseRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CloseRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(fd: i32) -> Self {
         Self {
@@ -44,18 +44,18 @@ impl CloseRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: CloseRequest = CloseRequest::new(fd);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::CloseRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -84,10 +84,10 @@ pub struct CloseResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(CloseResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(CloseResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl CloseResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -96,18 +96,18 @@ impl CloseResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: CloseResponse = CloseResponse::new(ret);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::CloseResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -234,11 +234,11 @@ impl MessagePartitioner for FileAccessAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::FileAccessAtRequestPart,
+            SystemCallMessageHeader::FileAccessAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -256,10 +256,10 @@ impl MessagePartitioner for FileAccessAtRequest {
 pub struct FileAccessAtResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileAccessAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileAccessAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileAccessAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -267,14 +267,14 @@ impl FileAccessAtResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileAccessAtResponse = FileAccessAtResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileAccessAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileAccessAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/fchdir.rs
+++ b/src/libs/syscall/src/unistd/message/fchdir.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -36,10 +36,10 @@ pub struct FileChdirRequest {
     /// Padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChdirRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChdirRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChdirRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_int>();
 
     fn new(fd: c_int) -> Self {
         Self {
@@ -48,20 +48,18 @@ impl FileChdirRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: c_int) -> Message {
         let message: FileChdirRequest = FileChdirRequest::new(fd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChdirRequest,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileChdirRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -84,10 +82,10 @@ pub struct FileChdirResponse {
     /// Padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChdirResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChdirResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChdirResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -95,18 +93,18 @@ impl FileChdirResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChdirResponse = FileChdirResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChdirResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileChdirResponse,
             message.into_bytes(),
         );
         Message::new(

--- a/src/libs/syscall/src/unistd/message/fchown.rs
+++ b/src/libs/syscall/src/unistd/message/fchown.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt::Debug,
@@ -44,10 +44,10 @@ pub struct FileChownRequest {
     /// Padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChownRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChownRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChownRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<c_int>()
         - mem::size_of::<uid_t>()
         - mem::size_of::<gid_t>();
@@ -61,20 +61,18 @@ impl FileChownRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: c_int, owner: uid_t, group: gid_t) -> Message {
         let message: FileChownRequest = FileChownRequest::new(fd, owner, group);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChownRequest,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileChownRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -97,10 +95,10 @@ pub struct FileChownResponse {
     /// Padding.
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChownResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChownResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChownResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -108,14 +106,14 @@ impl FileChownResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChownResponse = FileChownResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChownResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileChownResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -264,11 +264,11 @@ impl MessagePartitioner for FileChownAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::FileChownAtRequestPart,
+            SystemCallMessageHeader::FileChownAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -286,10 +286,10 @@ impl MessagePartitioner for FileChownAtRequest {
 pub struct FileChownAtResponse {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileChownAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileChownAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileChownAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -297,14 +297,14 @@ impl FileChownAtResponse {
         }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChownAtResponse = FileChownAtResponse::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileChownAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileChownAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/message/fdatasync.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::{
     fmt,
@@ -32,10 +32,10 @@ pub struct FileDataSyncRequest {
     pub fd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileDataSyncRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileDataSyncRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileDataSyncRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(fd: i32) -> Self {
         Self {
@@ -44,18 +44,18 @@ impl FileDataSyncRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileDataSyncRequest = FileDataSyncRequest::new(fd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileDataSyncRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileDataSyncRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -85,10 +85,10 @@ pub struct FileDataSyncResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileDataSyncResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileDataSyncResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileDataSyncResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -97,18 +97,18 @@ impl FileDataSyncResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileDataSyncResponse = FileDataSyncResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileDataSyncResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileDataSyncResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/fsync.rs
+++ b/src/libs/syscall/src/unistd/message/fsync.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -30,10 +30,10 @@ pub struct FileSyncRequest {
     pub fd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileSyncRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileSyncRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileSyncRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(fd: i32) -> Self {
         Self {
@@ -42,20 +42,18 @@ impl FileSyncRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileSyncRequest = FileSyncRequest::new(fd);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileSyncRequest,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileSyncRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -82,10 +80,10 @@ pub struct FileSyncResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileSyncResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileSyncResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileSyncResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -94,20 +92,18 @@ impl FileSyncResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileSyncResponse = FileSyncResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileSyncResponse,
-            message.into_bytes(),
-        );
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::FileSyncResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/message/ftruncate.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -32,11 +32,11 @@ pub struct FileTruncateRequest {
     pub length: off_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(FileTruncateRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(FileTruncateRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl FileTruncateRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<off_t>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<off_t>();
 
     fn new(fd: i32, length: off_t) -> Self {
         Self {
@@ -46,18 +46,18 @@ impl FileTruncateRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32, length: off_t) -> Message {
         let message: FileTruncateRequest = FileTruncateRequest::new(fd, length);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileTruncateRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileTruncateRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -84,7 +84,7 @@ pub struct FileTruncateResponse {
 }
 
 impl FileTruncateResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -93,18 +93,18 @@ impl FileTruncateResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileTruncateResponse = FileTruncateResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::FileTruncateResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileTruncateResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/getcwd.rs
+++ b/src/libs/syscall/src/unistd/message/getcwd.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::{
@@ -47,7 +47,7 @@ pub struct GetCurrentWorkingDirectoryRequest {
 }
 
 impl GetCurrentWorkingDirectoryRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -55,18 +55,18 @@ impl GetCurrentWorkingDirectoryRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { core::mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { core::mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: GetCurrentWorkingDirectoryRequest = GetCurrentWorkingDirectoryRequest::new();
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            crate::LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            crate::SystemCallMessageHeader::GetCurrentWorkingDirectoryRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -166,11 +166,11 @@ impl MessagePartitioner for GetCurrentWorkingDirectoryResponse {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_response(
+        SystemCallMessagePart::build_response(
             tid,
-            LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryResponsePart,
+            SystemCallMessageHeader::GetCurrentWorkingDirectoryResponsePart,
             total_parts,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/unistd/message/getids.rs
+++ b/src/libs/syscall/src/unistd/message/getids.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -32,10 +32,10 @@ use sysapi::sys_types::{
 pub struct GetIdsRequest {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetIdsRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetIdsRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetIdsRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -43,18 +43,18 @@ impl GetIdsRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: GetIdsRequest = GetIdsRequest::new();
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::GetIdsRequest, message.into_bytes());
         Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -77,10 +77,10 @@ pub struct GetIdsResponse {
     pub egid: gid_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(GetIdsResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(GetIdsResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl GetIdsResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<uid_t>() * 2 // Size of `uid` + `euid`
         - mem::size_of::<gid_t>() * 2; // Size of `gid` + `egid`
 
@@ -94,11 +94,11 @@ impl GetIdsResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -110,8 +110,8 @@ impl GetIdsResponse {
         egid: gid_t,
     ) -> Message {
         let message: GetIdsResponse = GetIdsResponse::new(uid, gid, euid, egid);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::GetIdsResponse, message.into_bytes());
         Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -270,11 +270,11 @@ impl MessagePartitioner for LinkAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::LinkAtRequestPart,
+            SystemCallMessageHeader::LinkAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -292,10 +292,10 @@ pub struct LinkAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(LinkAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(LinkAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl LinkAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     pub fn new(ret: i32) -> Self {
         Self {
@@ -304,18 +304,18 @@ impl LinkAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: LinkAtResponse = LinkAtResponse::new(ret);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::LinkAtResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::LinkAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/lseek.rs
+++ b/src/libs/syscall/src/unistd/message/lseek.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -32,10 +32,10 @@ pub struct SeekRequest {
     pub whence: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SeekRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SeekRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SeekRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<i64>()
         - mem::size_of::<i32>();
@@ -49,18 +49,18 @@ impl SeekRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32, offset: i64, whence: i32) -> Message {
         let message: SeekRequest = SeekRequest::new(fd, offset, whence);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::SeekRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -82,10 +82,10 @@ pub struct SeekResponse {
     pub offset: i64,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SeekResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SeekResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SeekResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i64>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i64>();
 
     fn new(offset: i64) -> Self {
         Self {
@@ -94,18 +94,18 @@ impl SeekResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, offset: i64) -> Message {
         let message: SeekResponse = SeekResponse::new(offset);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::SeekResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/pipe.rs
+++ b/src/libs/syscall/src/unistd/message/pipe.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -28,10 +28,10 @@ use ::sys::{
 pub struct PipeRequest {
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(PipeRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PipeRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PipeRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE;
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE;
 
     fn new() -> Self {
         Self {
@@ -39,18 +39,18 @@ impl PipeRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier) -> Message {
         let message: PipeRequest = PipeRequest::new();
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::PipeRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -73,10 +73,10 @@ pub struct PipeResponse {
     pub write_fd: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(PipeResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PipeResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PipeResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - 2 * mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - 2 * mem::size_of::<i32>();
 
     fn new(read_fd: i32, write_fd: i32) -> Self {
         Self {
@@ -86,18 +86,18 @@ impl PipeResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, read_fd: i32, write_fd: i32) -> Message {
         let message: PipeResponse = PipeResponse::new(read_fd, write_fd);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::PipeResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -37,10 +37,10 @@ pub struct PartialReadRequest {
     pub offset: off_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(PartialReadRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PartialReadRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PartialReadRequest {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
@@ -54,18 +54,18 @@ impl PartialReadRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32, count: c_size_t, offset: off_t) -> Message {
         let message: PartialReadRequest = PartialReadRequest::new(fd, count, offset);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::PartialReadRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PartialReadRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -89,20 +89,20 @@ pub struct PartialReadResponse {
     pub count: i32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(PartialReadResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PartialReadResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PartialReadResponse {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(count: c_ssize_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -112,8 +112,8 @@ impl PartialReadResponse {
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: PartialReadResponse = PartialReadResponse::new(count, buffer);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::PartialReadResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PartialReadResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -37,10 +37,10 @@ pub struct PartialWriteRequest {
     pub offset: off_t,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(PartialWriteRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PartialWriteRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PartialWriteRequest {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
@@ -54,11 +54,11 @@ impl PartialWriteRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -70,8 +70,8 @@ impl PartialWriteRequest {
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: PartialWriteRequest = PartialWriteRequest::new(fd, count, offset, buffer);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::PartialWriteRequest,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PartialWriteRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
@@ -95,10 +95,10 @@ pub struct PartialWriteResponse {
     pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(PartialWriteResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(PartialWriteResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PartialWriteResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(count: c_ssize_t) -> Self {
         Self {
@@ -107,18 +107,18 @@ impl PartialWriteResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: PartialWriteResponse = PartialWriteResponse::new(count);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::PartialWriteResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PartialWriteResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -32,11 +32,11 @@ pub struct ReadRequest {
     pub count: u32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(ReadRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ReadRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ReadRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
     fn new(fd: i32, count: c_size_t) -> Self {
         Self {
@@ -46,18 +46,18 @@ impl ReadRequest {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, fd: i32, count: c_size_t) -> Message {
         let message: ReadRequest = ReadRequest::new(fd, count);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::ReadRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -79,27 +79,27 @@ pub struct ReadResponse {
     pub count: i32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(ReadResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(ReadResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ReadResponse {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Message {
         let message: ReadResponse = ReadResponse::new(count, buffer);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::ReadResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/message/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/readlinkat.rs
@@ -7,12 +7,12 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessageHeader,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -213,11 +213,11 @@ impl MessagePartitioner for ReadLinkAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::ReadLinkAtRequestPart,
+            SystemCallMessageHeader::ReadLinkAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -362,11 +362,11 @@ impl MessagePartitioner for ReadLinkAtResponse {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_response(
+        SystemCallMessagePart::build_response(
             tid,
-            LinuxDaemonMessageHeader::ReadLinkAtResponsePart,
+            SystemCallMessageHeader::ReadLinkAtResponsePart,
             total_parts,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -7,13 +7,13 @@
 
 use crate::{
     message::{
-        LinuxDaemonMessagePart,
         MessageDeserializer,
         MessagePartitioner,
         MessageSerializer,
+        SystemCallMessagePart,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::alloc::{
     string::String,
@@ -224,11 +224,11 @@ impl MessagePartitioner for SymbolicLinkAtRequest {
         total_parts: u16,
         part_number: u16,
         payload_size: u8,
-        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        LinuxDaemonMessagePart::build_request(
+        SystemCallMessagePart::build_request(
             tid,
-            LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart,
+            SystemCallMessageHeader::SymbolicLinkAtRequestPart,
             total_parts,
             part_number,
             payload_size,
@@ -246,10 +246,10 @@ pub struct SymbolicLinkAtResponse {
     pub ret: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SymbolicLinkAtResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(SymbolicLinkAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SymbolicLinkAtResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(ret: i32) -> Self {
         Self {
@@ -258,18 +258,18 @@ impl SymbolicLinkAtResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: SymbolicLinkAtResponse = SymbolicLinkAtResponse::new(ret);
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
-            LinuxDaemonMessageHeader::SymbolicLinkAtResponse,
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::SymbolicLinkAtResponse,
             message.into_bytes(),
         );
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::core::mem;
 use ::sys::{
@@ -35,21 +35,21 @@ pub struct WriteRequest {
     pub count: u32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
-::static_assert::assert_eq_size!(WriteRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(WriteRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl WriteRequest {
     pub const BUFFER_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
     fn new(fd: i32, count: c_size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { fd, count, buffer }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
@@ -60,8 +60,8 @@ impl WriteRequest {
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: WriteRequest = WriteRequest::new(fd, count, buffer);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteRequest, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::WriteRequest, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
@@ -84,10 +84,10 @@ pub struct WriteResponse {
     pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(WriteResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
+::static_assert::assert_eq_size!(WriteResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl WriteResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
     fn new(count: c_ssize_t) -> Self {
         Self {
@@ -96,18 +96,18 @@ impl WriteResponse {
         }
     }
 
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
         unsafe { mem::transmute(bytes) }
     }
 
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
         unsafe { mem::transmute(self) }
     }
 
     pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: WriteResponse = WriteResponse::new(count);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteResponse, message.into_bytes());
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::WriteResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
             MessageReceiver::from(tid),

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -14,8 +14,8 @@ use {
     crate::{
         message::MessagePartitioner,
         unistd::message::ChangeDirectoryRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -97,9 +97,9 @@ fn chdir_linuxd(path: &str) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
-            LinuxDaemonMessageHeader::ChangeDirectoryResponse => Ok(()),
+            SystemCallMessageHeader::ChangeDirectoryResponse => Ok(()),
             header => {
                 let reason: &str = "unexpected message header";
                 ::syslog::warn!("chdir(): {:?} (path={:?}, header={:?})", reason, path, header);

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -16,8 +16,8 @@ use {
             CloseRequest,
             CloseResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -76,11 +76,11 @@ fn close_linuxd(fd: i32) -> Result<(), Error> {
         Err(Error::new(error_code, "close() failed"))
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::CloseResponse => {
+                SystemCallMessageHeader::CloseResponse => {
                     // Parse response.
                     let _: CloseResponse = CloseResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -15,8 +15,8 @@ use {
     crate::{
         message::MessagePartitioner,
         unistd::message::FileAccessAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -103,10 +103,10 @@ fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Resul
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
         match message.header {
-            LinuxDaemonMessageHeader::FileAccessAtResponse => Ok(()),
+            SystemCallMessageHeader::FileAccessAtResponse => Ok(()),
             header => {
                 ::syslog::warn!(
                     "faccessat(): failed to parse response (dirfd={:?}, path={:?}, mode={:?}, \

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -18,8 +18,8 @@ use ::sysapi::sys_types::{
 use {
     crate::{
         unistd::message::FileChownRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -93,10 +93,10 @@ fn fchown_linuxd(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<()
         }
     } else {
         // System call succeeded, parse response.
-        let message = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileChownResponse => Ok(()),
+            SystemCallMessageHeader::FileChownResponse => Ok(()),
             // Invalid response.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -18,8 +18,8 @@ use {
     crate::{
         message::MessagePartitioner,
         unistd::message::FileChownAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -123,10 +123,10 @@ fn fchownat_linuxd(
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
         match message.header {
-            LinuxDaemonMessageHeader::FileChownAtResponse => Ok(()),
+            SystemCallMessageHeader::FileChownAtResponse => Ok(()),
             header => {
                 ::syslog::warn!(
                     "fchownat(): failed to parse response (dirfd={:?}, path={:?}, owner={:?}, \

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -14,8 +14,8 @@ use ::sys::error::{
 use {
     crate::{
         unistd::message::FileDataSyncRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -91,11 +91,11 @@ fn fdatasync_linuxd(fd: RawFileDescriptor) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileDataSyncResponse => Ok(()),
+            SystemCallMessageHeader::FileDataSyncResponse => Ok(()),
             // Invalid response.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -14,8 +14,8 @@ use ::sysapi::ffi::c_int;
 use {
     crate::{
         unistd::message::FileSyncRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -79,10 +79,10 @@ fn fsync_linuxd(fd: c_int) -> Result<(), Error> {
         Err(Error::new(error_code, "fsync() failed"))
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileSyncResponse => Ok(()),
+            SystemCallMessageHeader::FileSyncResponse => Ok(()),
             // Invalid response.
             _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
         }

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -17,8 +17,8 @@ use ::sysapi::{
 use {
     crate::{
         unistd::message::FileTruncateRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -98,11 +98,11 @@ fn ftruncate_linuxd(fd: c_int, length: off_t) -> Result<(), Error> {
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::FileTruncateResponse => Ok(()),
+            SystemCallMessageHeader::FileTruncateResponse => Ok(()),
             // Invalid response.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -11,16 +11,16 @@ use ::sys::error::Error;
 use {
     crate::{
         message::{
-            LinuxDaemonLongMessage,
-            LinuxDaemonMessagePart,
             MessagePartitioner,
+            SystemCallLongMessage,
+            SystemCallMessagePart,
         },
         unistd::message::{
             GetCurrentWorkingDirectoryRequest,
             GetCurrentWorkingDirectoryResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::vec::Vec,
     ::sys::{
@@ -77,9 +77,9 @@ fn getcwd_request() -> Result<(), Error> {
 fn getcwd_response() -> Result<String, Error> {
     // Compute the maximum number of parts in the response.
     let capacity: usize =
-        GetCurrentWorkingDirectoryResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        GetCurrentWorkingDirectoryResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
-    let mut assembler: LinuxDaemonLongMessage = LinuxDaemonLongMessage::new(capacity)?;
+    let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
         let response: Message = ::sys::kcall::ipc::recv()?;
@@ -93,12 +93,12 @@ fn getcwd_response() -> Result<String, Error> {
             }
         } else {
             // System call succeeded, parse response.
-            let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+            let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
 
             match message.header {
-                LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryResponsePart => {
-                    let part: LinuxDaemonMessagePart =
-                        LinuxDaemonMessagePart::from_bytes(message.payload);
+                SystemCallMessageHeader::GetCurrentWorkingDirectoryResponsePart => {
+                    let part: SystemCallMessagePart =
+                        SystemCallMessagePart::from_bytes(message.payload);
 
                     // Add part to message assembler and check for errors.
                     if let Err(e) = assembler.add_part(part) {
@@ -110,7 +110,7 @@ fn getcwd_response() -> Result<String, Error> {
                         continue;
                     }
 
-                    let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+                    let parts: Vec<SystemCallMessagePart> = assembler.take_parts();
 
                     match GetCurrentWorkingDirectoryResponse::from_parts(&parts) {
                         Ok(response) => break Ok(response.cwd),

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -14,8 +14,8 @@ use {
             GetIdsRequest,
             GetIdsResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         error::ErrorCode,
@@ -74,10 +74,10 @@ fn getegid_linuxd() -> Result<gid_t, Error> {
         }
     } else {
         // System call succeeded, parse response
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed
-            LinuxDaemonMessageHeader::GetIdsResponse => {
+            SystemCallMessageHeader::GetIdsResponse => {
                 let response: GetIdsResponse = GetIdsResponse::from_bytes(message.payload);
                 Ok(response.egid)
             },

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -14,8 +14,8 @@ use {
             GetIdsRequest,
             GetIdsResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         error::ErrorCode,
@@ -74,10 +74,10 @@ fn geteuid_linuxd() -> Result<uid_t, Error> {
         }
     } else {
         // System call succeeded, parse response
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed
-            LinuxDaemonMessageHeader::GetIdsResponse => {
+            SystemCallMessageHeader::GetIdsResponse => {
                 let response: GetIdsResponse = GetIdsResponse::from_bytes(message.payload);
                 Ok(response.euid)
             },

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -14,8 +14,8 @@ use {
             GetIdsRequest,
             GetIdsResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         error::ErrorCode,
@@ -74,10 +74,10 @@ fn getgid_linuxd() -> Result<gid_t, Error> {
         }
     } else {
         // System call succeeded, parse response
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed
-            LinuxDaemonMessageHeader::GetIdsResponse => {
+            SystemCallMessageHeader::GetIdsResponse => {
                 let response: GetIdsResponse = GetIdsResponse::from_bytes(message.payload);
                 Ok(response.gid)
             },

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -14,8 +14,8 @@ use {
             GetIdsRequest,
             GetIdsResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         error::ErrorCode,
@@ -74,10 +74,10 @@ fn getuid_linuxd() -> Result<uid_t, Error> {
         }
     } else {
         // System call succeeded, parse response
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed
-            LinuxDaemonMessageHeader::GetIdsResponse => {
+            SystemCallMessageHeader::GetIdsResponse => {
                 let response: GetIdsResponse = GetIdsResponse::from_bytes(message.payload);
                 Ok(response.uid)
             },

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -13,8 +13,8 @@ use {
     crate::{
         message::MessagePartitioner,
         unistd::message::LinkAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::{
         string::ToString,
@@ -139,11 +139,11 @@ fn linkat_linuxd(
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::LinkAtResponse => Ok(()),
+            SystemCallMessageHeader::LinkAtResponse => Ok(()),
             // Response was not successfully parsed.
             header => {
                 let reason: &str = "unexpected message header";

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -27,8 +27,8 @@ use {
             SeekRequest,
             SeekResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -111,11 +111,11 @@ fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<o
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         // Response was successfully parsed.
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::SeekResponse => {
+            SystemCallMessageHeader::SeekResponse => {
                 // Parse response.
                 let response: SeekResponse = SeekResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -16,8 +16,8 @@ use {
             PipeRequest,
             PipeResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::sys::{
         ipc::Message,
@@ -63,11 +63,11 @@ fn pipe_linuxd() -> Result<[i32; 2], Error> {
         Err(Error::new(error_code, "pipe() failed"))
     } else {
         // System call succeeded, parse response.
-        match LinuxDaemonMessage::try_from_bytes(response.payload) {
+        match SystemCallMessage::try_from_bytes(response.payload) {
             // Response was successfully parsed.
             Ok(message) => match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::PipeResponse => {
+                SystemCallMessageHeader::PipeResponse => {
                     // Parse response.
                     let response: PipeResponse = PipeResponse::from_bytes(message.payload);
 

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -27,8 +27,8 @@ use {
             PartialReadRequest,
             PartialReadResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::core::cmp,
     ::sys::{
@@ -134,11 +134,11 @@ fn pread_linuxd(
             }
         } else {
             // System call succeeded, parse response.
-            let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+            let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
             // Response was successfully parsed.
             match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::PartialReadResponse => {
+                SystemCallMessageHeader::PartialReadResponse => {
                     // Parse response.
                     let response: PartialReadResponse =
                         PartialReadResponse::from_bytes(message.payload);

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -27,8 +27,8 @@ use {
             PartialWriteRequest,
             PartialWriteResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::core::cmp,
     ::sys::{
@@ -133,11 +133,11 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
             }
         } else {
             // System call succeeded, parse response.
-            let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+            let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
             // Response was successfully parsed.
             match message.header {
                 // Response was successfully parsed.
-                LinuxDaemonMessageHeader::PartialWriteResponse => {
+                SystemCallMessageHeader::PartialWriteResponse => {
                     // Parse response.
                     let message: PartialWriteResponse =
                         PartialWriteResponse::from_bytes(message.payload);

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -12,8 +12,8 @@ use crate::{
         ReadRequest,
         ReadResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -92,9 +92,9 @@ fn read_chunk(
     }
 
     // Parse response.
-    let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+    let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
     match message.header {
-        LinuxDaemonMessageHeader::ReadResponse => {
+        SystemCallMessageHeader::ReadResponse => {
             let resp: ReadResponse = ReadResponse::from_bytes(message.payload);
             let count: i32 = resp.count;
 

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -14,16 +14,16 @@ use ::sysapi::sys_types::c_ssize_t;
 use {
     crate::{
         message::{
-            LinuxDaemonLongMessage,
-            LinuxDaemonMessagePart,
             MessagePartitioner,
+            SystemCallLongMessage,
+            SystemCallMessagePart,
         },
         unistd::message::{
             ReadLinkAtRequest,
             ReadLinkAtResponse,
         },
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::{
         string::ToString,
@@ -94,9 +94,9 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
     }
 
     let capacity: usize =
-        ReadLinkAtResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        ReadLinkAtResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
-    let mut assembler: LinuxDaemonLongMessage = LinuxDaemonLongMessage::new(capacity)?;
+    let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
         let response: Message = ::sys::kcall::ipc::recv()?;
@@ -127,11 +127,11 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
             }
         } else {
             // System call succeeded, parse response.
-            let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+            let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
             match message.header {
-                LinuxDaemonMessageHeader::ReadLinkAtResponsePart => {
-                    let part: LinuxDaemonMessagePart =
-                        LinuxDaemonMessagePart::from_bytes(message.payload);
+                SystemCallMessageHeader::ReadLinkAtResponsePart => {
+                    let part: SystemCallMessagePart =
+                        SystemCallMessagePart::from_bytes(message.payload);
 
                     if let Err(error) = assembler.add_part(part) {
                         ::syslog::warn!(
@@ -151,7 +151,7 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
                         continue;
                     }
 
-                    let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+                    let parts: Vec<SystemCallMessagePart> = assembler.take_parts();
 
                     match ReadLinkAtResponse::from_parts(&parts) {
                         Ok(response) => {

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -11,8 +11,8 @@ use {
     crate::{
         message::MessagePartitioner,
         unistd::message::SymbolicLinkAtRequest,
-        LinuxDaemonMessage,
-        LinuxDaemonMessageHeader,
+        SystemCallMessage,
+        SystemCallMessageHeader,
     },
     ::alloc::{
         string::ToString,
@@ -116,10 +116,10 @@ fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Erro
         }
     } else {
         // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
         match message.header {
             // Response was successfully parsed.
-            LinuxDaemonMessageHeader::SymbolicLinkAtResponse => Ok(()),
+            SystemCallMessageHeader::SymbolicLinkAtResponse => Ok(()),
             // Response was not successfully parsed.
             header => {
                 ::syslog::warn!(

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -12,8 +12,8 @@ use crate::{
         WriteRequest,
         WriteResponse,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
 use ::sys::{
     error::{
@@ -91,9 +91,9 @@ fn write_chunk(
     }
 
     // Parse response.
-    let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
+    let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
     match message.header {
-        LinuxDaemonMessageHeader::WriteResponse => {
+        SystemCallMessageHeader::WriteResponse => {
             let response: WriteResponse = WriteResponse::from_bytes(message.payload);
             Ok(response.count as c_size_t)
         },

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -63,7 +63,7 @@ async fn forward_message_to_system_vm(
     // Label: uservm::io_thread::system_vm::write()
     profiler::timestamp_message!(
         &mut msg.payload,
-        std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+        std::mem::offset_of!(syscall::SystemCallMessage, payload)
             + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
     );
     // SAFETY: `Message` derives `Clone`; cloning avoids consuming the caller's binding.
@@ -305,7 +305,7 @@ impl IoThread {
 
                                         // Label: uservm::io_thread::system_vm::read()
                                         profiler::timestamp_message!(&mut message.payload,
-                                            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                            std::mem::offset_of!(syscall::SystemCallMessage, payload)
                                                 + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                                         );
 
@@ -425,7 +425,7 @@ impl IoThread {
                                     debug!("input flush completed");
                                     // Messages are no longer buffered, nothing to flush. We should remove this.
                                     if let Err(error) =
-                                        control_tx.send(IoControlCommand::LinuxDaemonFlushed).await
+                                        control_tx.send(IoControlCommand::SystemCallFlushed).await
                                     {
                                         debug!(
                                             "control channel closed while sending flush ack: {error}"

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -728,7 +728,7 @@ pub fn build_input_fn(
                         // Label: uservm::lib::vm_input::vm_exit()
                         profiler::timestamp_message!(
                             &mut msg.payload,
-                            mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                            mem::offset_of!(syscall::SystemCallMessage, payload)
                                 + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                         );
 
@@ -740,7 +740,7 @@ pub fn build_input_fn(
                         // Label: uservm::lib::vm_input::vm_write_bytes()
                         profiler::timestamp_message!(
                             &mut msg.payload,
-                            mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                            mem::offset_of!(syscall::SystemCallMessage, payload)
                                 + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                         );
 
@@ -832,7 +832,7 @@ pub fn build_input_fn(
                 // Label: uservm::lib::vm_input::vm_exit()
                 profiler::timestamp_message!(
                     &mut msg.payload,
-                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                    std::mem::offset_of!(syscall::SystemCallMessage, payload)
                         + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                 );
 
@@ -859,7 +859,7 @@ pub fn build_input_fn(
                 // Label: uservm::lib::vm_input::vm_write_bytes()
                 profiler::timestamp_message!(
                     &mut msg.payload,
-                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                    std::mem::offset_of!(syscall::SystemCallMessage, payload)
                         + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                 );
 
@@ -1027,7 +1027,7 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
                 // Label: uservm::lib::vm_output::send()
                 profiler::timestamp_message!(
                     &mut message.payload,
-                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                    std::mem::offset_of!(syscall::SystemCallMessage, payload)
                         + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
                 );
 
@@ -1109,7 +1109,7 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
         // Label: uservm::lib::vm_output::send()
         profiler::timestamp_message!(
             &mut message.payload,
-            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+            std::mem::offset_of!(syscall::SystemCallMessage, payload)
                 + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
         );
 

--- a/src/uservm/src/memory_thread.rs
+++ b/src/uservm/src/memory_thread.rs
@@ -141,7 +141,7 @@ impl MemoryThread {
                                     IkcFrame::Message(ref mut msg) => {
                                         // Label: uservm::memory_thread::data_rx::recv()
                                         profiler::timestamp_message!(&mut msg.payload,
-                                            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                            std::mem::offset_of!(syscall::SystemCallMessage, payload)
                                                 + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                                         );
                                     },

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -134,7 +134,7 @@ pub enum IoControlCommand {
     _PauseMicroVm,
     _CreateSnapshot(String),
     _ResumeMicroVm,
-    LinuxDaemonFlushed,
+    SystemCallFlushed,
     Shutdown,
 }
 
@@ -495,9 +495,9 @@ impl Orchestrator {
                 }
                 Ok(Continue(()))
             },
-            IoControlCommand::LinuxDaemonFlushed => {
+            IoControlCommand::SystemCallFlushed => {
                 // NOTE: this will be unreachable once the communication is fully implemented
-                // `LinuxDaemonFlushed` should only be sent in the middle of `pause_protocol`.
+                // `SystemCallFlushed` should only be sent in the middle of `pause_protocol`.
                 // In fact, it should already be unreachable, but it cannot be tested ATM.
                 Ok(Continue(()))
             },
@@ -647,7 +647,7 @@ impl Orchestrator {
         self.io_control_tx
             .send(IoControlResponse::FlushInput)
             .await?;
-        self.receive_linux_daemon_flushed().await?;
+        self.receive_system_call_flushed().await?;
         self.state = State::Paused;
         trace!("State: Running -> Paused");
         self.io_control_tx
@@ -659,31 +659,31 @@ impl Orchestrator {
     ///
     /// # Description
     ///
-    /// Attempts to receive a `LinuxDaemonFlushed` message from the control input.
+    /// Attempts to receive a `SystemCallFlushed` message from the control input.
     ///
     /// # Returns
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
-    async fn receive_linux_daemon_flushed(&mut self) -> Result<()> {
+    async fn receive_system_call_flushed(&mut self) -> Result<()> {
         let start: Instant = Instant::now();
         let warn_interval: Duration = Duration::from_millis(TIMEOUT_WARNING_INTERVAL_IN_MS as u64);
         loop {
             match timeout(warn_interval, self.io_control_rx.recv()).await {
-                Ok(Some(IoControlCommand::LinuxDaemonFlushed)) => break,
+                Ok(Some(IoControlCommand::SystemCallFlushed)) => break,
                 Ok(Some(_other)) => {
                     // Ignore unrelated messages during flushing.
                     continue;
                 },
                 Ok(None) => {
                     let reason: String =
-                        "io_control_rx closed while waiting for LinuxDaemonFlushed".to_string();
-                    error!("receive_linux_daemon_flushed(): {reason}");
+                        "io_control_rx closed while waiting for SystemCallFlushed".to_string();
+                    error!("receive_system_call_flushed(): {reason}");
                     anyhow::bail!(reason)
                 },
                 Err(_) => {
                     let elapsed_ms: usize = start.elapsed().as_millis() as usize;
-                    warn!("{}ms have passed waiting for `LinuxDaemonFlushed`", elapsed_ms);
+                    warn!("{}ms have passed waiting for `SystemCallFlushed`", elapsed_ms);
                     continue;
                 },
             }
@@ -874,10 +874,10 @@ mod tests {
             // Allow orchestrator to enter pause_protocol loop.
             sleep(Duration::from_millis(5)).await;
             let _ = vcpu_resp_tx_clone.send(VcpuControlResponse::Paused).await;
-            // Allow orchestrator to send FlushOutput & FlushInput, then provide LinuxDaemonFlushed.
+            // Allow orchestrator to send FlushOutput & FlushInput, then provide SystemCallFlushed.
             sleep(Duration::from_millis(5)).await;
             let _ = io_cmd_tx_clone
-                .send(IoControlCommand::LinuxDaemonFlushed)
+                .send(IoControlCommand::SystemCallFlushed)
                 .await;
         });
 

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -41,8 +41,8 @@ use ::sys::{
     pm::ThreadIdentifier,
 };
 use ::syscall::{
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+    SystemCallMessage,
+    SystemCallMessageHeader,
     unistd::message::{
         ReadRequest,
         ReadResponse,
@@ -331,19 +331,19 @@ async fn standalone_io_handler(
         trace!("standalone io_handler: received frame (type={})", frame.frame_type_byte());
         match frame {
             IkcFrame::Message(msg) => {
-                let ldm: LinuxDaemonMessage = match LinuxDaemonMessage::try_from_bytes(msg.payload)
-                {
-                    Ok(ldm) => ldm,
-                    Err(e) => {
-                        warn!("standalone io_handler: failed to parse message: {e:?}");
-                        continue;
-                    },
-                };
+                let syscall_msg: SystemCallMessage =
+                    match SystemCallMessage::try_from_bytes(msg.payload) {
+                        Ok(syscall_msg) => syscall_msg,
+                        Err(e) => {
+                            warn!("standalone io_handler: failed to parse message: {e:?}");
+                            continue;
+                        },
+                    };
 
-                match ldm.header {
-                    LinuxDaemonMessageHeader::WriteRequest => {
+                match syscall_msg.header {
+                    SystemCallMessageHeader::WriteRequest => {
                         let tid: ThreadIdentifier = extract_tid(msg.source);
-                        let req: WriteRequest = WriteRequest::from_bytes(ldm.payload);
+                        let req: WriteRequest = WriteRequest::from_bytes(syscall_msg.payload);
                         handle_write_request(
                             &mut vm_stdout_rx,
                             &vm_stdin_tx,
@@ -354,9 +354,9 @@ async fn standalone_io_handler(
                         )
                         .await;
                     },
-                    LinuxDaemonMessageHeader::ReadRequest => {
+                    SystemCallMessageHeader::ReadRequest => {
                         let tid: ThreadIdentifier = extract_tid(msg.source);
-                        let req: ReadRequest = ReadRequest::from_bytes(ldm.payload);
+                        let req: ReadRequest = ReadRequest::from_bytes(syscall_msg.payload);
                         handle_read_request(
                             &mut vm_stdout_rx,
                             &vm_stdin_tx,

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -28,7 +28,7 @@ use ::nanvix::{
         pm::ThreadIdentifier,
     },
     syscall::{
-        LinuxDaemonMessage,
+        SystemCallMessage,
         unistd::message::{
             ReadRequest,
             ReadResponse,
@@ -120,16 +120,16 @@ impl Benchmark {
                 },
                 None => anyhow::bail!("warmup: channel closed during ReadRequest"),
             };
-            let warmup_linuxd_msg: LinuxDaemonMessage =
-                LinuxDaemonMessage::try_from_bytes(warmup_read_msg.payload)
-                    .map_err(|_| anyhow::anyhow!("warmup: error parsing LinuxDaemon message"))?;
+            let warmup_syscall_msg: SystemCallMessage =
+                SystemCallMessage::try_from_bytes(warmup_read_msg.payload)
+                    .map_err(|_| anyhow::anyhow!("warmup: error parsing SystemCall message"))?;
             // NOTE: `as_id()` returns `Err(ThreadIdentifier)` when the source is a
             // thread (expected) and `Ok(ProcessIdentifier)` when it is a process.
             let warmup_tid: ThreadIdentifier = match { warmup_read_msg.source }.as_id() {
                 Err(tid) => tid,
                 Ok(pid) => anyhow::bail!("warmup: unexpected message source: {pid:?}"),
             };
-            let _warmup_read_req: ReadRequest = ReadRequest::from_bytes(warmup_linuxd_msg.payload);
+            let _warmup_read_req: ReadRequest = ReadRequest::from_bytes(warmup_syscall_msg.payload);
 
             // Step 2: Receive the bulk pull request from the guest kernel.
             let warmup_pull_header: DataChunkHeader = match vcpu_thread_stdout_rx.recv().await {
@@ -213,12 +213,12 @@ impl Benchmark {
                     anyhow::bail!(reason);
                 },
             };
-            let linuxd_message: LinuxDaemonMessage =
-                match LinuxDaemonMessage::try_from_bytes(ipc_read_message.payload) {
+            let syscall_message: SystemCallMessage =
+                match SystemCallMessage::try_from_bytes(ipc_read_message.payload) {
                     Ok(message) => message,
                     Err(_) => {
                         return Err(anyhow::anyhow!(
-                            "Error parsing IPC message to LinuxDaemon message"
+                            "Error parsing IPC message to SystemCall message"
                         ));
                     },
                 };
@@ -226,7 +226,7 @@ impl Benchmark {
                 Err(tid) => tid,
                 Ok(pid) => return Err(anyhow::anyhow!("unexpected message source: {pid:?}")),
             };
-            let _read_request: ReadRequest = ReadRequest::from_bytes(linuxd_message.payload);
+            let _read_request: ReadRequest = ReadRequest::from_bytes(syscall_message.payload);
 
             // Step 2: Receive the bulk pull request from the guest kernel.
             let pull_header: DataChunkHeader = match vcpu_thread_stdout_rx.recv().await {


### PR DESCRIPTION
Rename messaging types and identifiers to decouple the syscall interface from the Linux daemon implementation detail:

- `LinuxDaemonMessage` → `SystemCallMessage`
- `LinuxDaemonMessageHeader` → `SystemCallMessageHeader`
- `LinuxDaemonMessagePart` → `SystemCallMessagePart`
- `LinuxDaemonLongMessage` → `SystemCallLongMessage`
- `LinuxDaemonFlushed` → `SystemCallFlushed`
- `receive_linux_daemon_flushed()` → `receive_system_call_flushed()`

The syscall messaging protocol is a generic system call transport layer and should not carry naming tied to a specific daemon. This rename clarifies that these types define the wire format between user-space and whatever system call provider is running, making the abstraction reusable regardless of the backend.

**Affected crates:**
- `src/libs/syscall` — core type definitions, message partitioning, and all per-syscall request/response modules
- `src/daemons/linuxd` — request assembler and worker thread dispatch
- `src/uservm` — orchestrator control commands, I/O thread, profiler offset calculations, and standalone/benchmark paths