### PR TITLE
[libs] Introduce net-backend crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "control-plane-api",
  "libc",
  "log",
+ "net-backend",
  "profiler",
  "rand 0.10.1",
  "signal-hook",
@@ -2379,6 +2380,17 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "net-backend"
+version = "0.12.533"
+dependencies = [
+ "libc",
+ "log",
+ "sys",
+ "sysapi",
+ "syscall",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ members = [
         "src/utils/nanvix-test",
         "src/utils/nanvixd",
         "src/utils/strace",
+        "src/libs/net-backend",
         "src/libs/nanvix-oci",
         "src/libs/nanvix-shim-core",
         "src/libs/nanvix-shim-proto",
@@ -165,6 +166,7 @@ multibin = { path = "src/libs/multibin", default-features = false }
 multiimage = { path = "src/libs/multiimage", default-features = false }
 nanvix = { path = "src/libs/nanvix", default-features = false }
 nanvix-http = { path = "src/libs/nanvix-http", default-features = false }
+net-backend = { path = "src/libs/net-backend", default-features = false }
 nanvix-oci = { path = "src/libs/nanvix-oci" }
 nanvix-registry = { path = "src/libs/nanvix-registry", default-features = false }
 nanvix-sandbox = { path = "src/libs/nanvix-sandbox", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -334,13 +334,14 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
-ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin multiimage profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-sandbox-config nanvix-terminal syscomm user-vm-api
+ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin multiimage net-backend profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-sandbox-config nanvix-terminal syscomm user-vm-api
 # Host rlibs excluded on Windows:
+#  - net-backend: uses libc/__errno_location (Linux-only socket APIs).
 #  - nanvix-http, nanvix-sandbox-cache: depend on Unix-only APIs.
 #  - syscomm: test code references cfg(unix)-gated SocketAddr::Unix variant.
 #  - nanvix-registry: test code uses std::fs::symlink (Unix-only).
 ifeq ($(IS_WINDOWS),yes)
-WINDOWS_EXCLUDED_HOST_RLIBS := nanvix-http nanvix-sandbox-cache syscomm nanvix-registry
+WINDOWS_EXCLUDED_HOST_RLIBS := net-backend nanvix-http nanvix-sandbox-cache syscomm nanvix-registry
 ALL_HOST_RUST_LIBS := $(filter-out $(WINDOWS_EXCLUDED_HOST_RLIBS),$(ALL_HOST_RUST_LIBS))
 endif
 ALL_HOST_UTILS := echo-client mkimage mkramfs strace

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { workspace = true }
 config = { workspace = true }
 control-plane-api = { workspace = true }
 libc = { workspace = true }
+net-backend = { workspace = true }
 profiler = { workspace = true }
 rand = { workspace = true }
 signal-hook = { workspace = true }

--- a/src/daemons/linuxd/src/linux/sys_socket.rs
+++ b/src/daemons/linuxd/src/linux/sys_socket.rs
@@ -7,78 +7,37 @@
 
 use crate::{
     error::WorkerThreadError,
-    syscalls::{
-        SyscallAction,
-        SyscallTable,
-    },
+    syscalls::SyscallTable,
 };
-use ::core::{
-    cmp,
-    mem,
-};
-use ::log::{
-    debug,
-    error,
-    trace,
-    warn,
-};
+use ::log::trace;
+use ::net_backend::error::NetError;
 use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
     ipc::Message,
     pm::ThreadIdentifier,
 };
-use ::sysapi::{
-    netinet_in::message_flags::{
-        MSG_EOR,
-        MSG_NOSIGNAL,
-        MSG_OOB,
-        MSG_PEEK,
-        MSG_WAITALL,
-    },
-    sys_socket::{
-        sockaddr,
-        socklen_t,
-    },
-    sys_types::{
-        c_size_t,
-        c_ssize_t,
-    },
-};
-use ::syscall::{
-    netinet::in_::Protocol,
-    sys::socket::{
-        message::{
-            AcceptSocketRequest,
-            AcceptSocketResponse,
-            BindSocketRequest,
-            BindSocketResponse,
-            ConnectSocketRequest,
-            ConnectSocketResponse,
-            CreateSocketPairRequest,
-            CreateSocketPairResponse,
-            CreateSocketRequest,
-            CreateSocketResponse,
-            GetPeerNameRequest,
-            GetPeerNameResponse,
-            GetSockNameRequest,
-            GetSockNameResponse,
-            ListenSocketRequest,
-            ListenSocketResponse,
-            ReceiveSocketRequest,
-            ReceiveSocketResponse,
-            SendSocketRequest,
-            SendSocketResponse,
-            ShutdownSocketRequest,
-            ShutdownSocketResponse,
-        },
-        AddressFamily,
-        Shutdown,
-        SocketAddr,
-        SocketType,
-    },
+use ::syscall::sys::socket::message::{
+    AcceptSocketRequest,
+    AcceptSocketResponse,
+    BindSocketRequest,
+    BindSocketResponse,
+    ConnectSocketRequest,
+    ConnectSocketResponse,
+    CreateSocketPairRequest,
+    CreateSocketPairResponse,
+    CreateSocketRequest,
+    CreateSocketResponse,
+    GetPeerNameRequest,
+    GetPeerNameResponse,
+    GetSockNameRequest,
+    GetSockNameResponse,
+    ListenSocketRequest,
+    ListenSocketResponse,
+    ReceiveSocketRequest,
+    ReceiveSocketResponse,
+    SendSocketRequest,
+    SendSocketResponse,
+    ShutdownSocketRequest,
+    ShutdownSocketResponse,
 };
 
 //==================================================================================================
@@ -92,47 +51,13 @@ pub fn do_socket<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("socket(): tid={tid:?}, request={request:?}");
 
-    let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
-        Ok(domain) => domain,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-
-    let typ: LibcSocketType = LibcSocketType::from(request.typ);
-
-    let protocol: LibcSocketProtocol = LibcSocketProtocol::from(request.protocol);
-
-    debug!(
-        "libc::socket(): domain={:?}, type={:?}, protocol={protocol:?}",
-        domain.inner(),
-        typ.inner(),
-    );
-    match unsafe {
-        handle_socket(syscall_table, domain.inner() as i32, typ.inner(), protocol.inner())
-    } {
-        -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_socket(): worker thread interrupted while blocked on socket()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::socket(): failed with errno={errno:?}");
-            let error: ErrorCode = match ErrorCode::try_from(errno) {
-                Ok(error) => error,
-                Err(_) => {
-                    let reason: &str = "unknown error code";
-                    warn!("do_socket(): {reason} (errno={errno:?})");
-                    ErrorCode::ValueOutOfRange
-                },
-            };
-            Ok(crate::build_error(tid, error))
-        },
-        sockfd => {
-            debug!("libc::socket(): fd={sockfd:?}");
-            Ok(CreateSocketResponse::build(tid, sockfd))
-        },
+    match syscall_table
+        .net_backend
+        .socket(request.domain, request.typ, request.protocol)
+    {
+        Ok(sockfd) => Ok(CreateSocketResponse::build(tid, sockfd)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -147,49 +72,13 @@ pub fn do_socketpair<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("socketpair(): tid={tid:?}, request={request:?}");
 
-    let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
-        Ok(domain) => domain,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-
-    let typ: LibcSocketType = LibcSocketType::from(request.typ);
-
-    let protocol: LibcSocketProtocol = LibcSocketProtocol::from(request.protocol);
-
-    let mut sv: [libc::c_int; 2] = [0; 2];
-
-    debug!(
-        "libc::socketpair(): domain={:?}, type={:?}, protocol={protocol:?}",
-        domain.inner(),
-        typ.inner(),
-    );
-    match unsafe {
-        handle_socketpair(
-            syscall_table,
-            domain.inner() as i32,
-            typ.inner(),
-            protocol.inner(),
-            sv.as_mut_ptr(),
-        )
-    } {
-        -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_socketpair(): worker thread interrupted while blocked on socketpair()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::socketpair(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => {
-            debug!("libc::socketpair(): fds={sv:?}");
-            Ok(CreateSocketPairResponse::build(tid, sv[0], sv[1]))
-        },
+    match syscall_table
+        .net_backend
+        .socketpair(request.domain, request.typ, request.protocol)
+    {
+        Ok((fd0, fd1)) => Ok(CreateSocketPairResponse::build(tid, fd0, fd1)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -204,37 +93,13 @@ pub fn do_bind<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("bind(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
-        Ok(sockaddr) => sockaddr,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-    let socklen: socklen_t = mem::size_of_val(&sockaddr) as socklen_t;
-
-    debug!(
-        "libc::bind(): sockfd={sockfd:?}, sockaddr.sa_family={:?}, sockaddr.sa_data={:?}, \
-         socklen={socklen:?}",
-        sockaddr.inner().sa_family,
-        sockaddr.inner().sa_data,
-    );
-    match unsafe {
-        handle_bind(syscall_table, sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen)
-    } {
-        -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_bind(): worker thread interrupted while blocked on bind()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::bind(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => Ok(BindSocketResponse::build(tid)),
+    match syscall_table
+        .net_backend
+        .bind(request.sockfd, &request.sockaddr)
+    {
+        Ok(()) => Ok(BindSocketResponse::build(tid)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -249,43 +114,13 @@ pub fn do_connect<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("connect(): tid={tid:?}, request={request:?}");
 
-    let sockfd: libc::c_int = request.sockfd;
-    let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
-        Ok(sockaddr) => sockaddr,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-    let socklen: socklen_t = request.socklen;
-
-    debug!(
-        "libc::connect(): sockfd={sockfd:?}, sockaddr.sa_family={:?}, sockaddr.sa_data={:?}, \
-         socklen={socklen:?}",
-        sockaddr.inner().sa_family,
-        sockaddr.inner().sa_data,
-    );
-
-    match unsafe {
-        handle_connect(
-            syscall_table,
-            sockfd,
-            &sockaddr.inner() as *const libc::sockaddr,
-            socklen as libc::socklen_t,
-        )
-    } {
-        -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_connect(): worker thread interrupted while blocked on connect()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::connect(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => Ok(ConnectSocketResponse::build(tid)),
+    match syscall_table
+        .net_backend
+        .connect(request.sockfd, &request.sockaddr, request.socklen)
+    {
+        Ok(()) => Ok(ConnectSocketResponse::build(tid)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -300,26 +135,13 @@ pub fn do_listen<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("listen(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let backlog: i32 = request.backlog;
-
-    debug!("libc::listen(): sockfd={sockfd:?}, backlog={backlog:?}");
-    match unsafe { handle_listen(syscall_table, sockfd, backlog) } {
-        -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_listen(): worker thread interrupted while blocked on listen()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::listen(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => Ok(ListenSocketResponse::build(tid)),
+    match syscall_table
+        .net_backend
+        .listen(request.sockfd, request.backlog)
+    {
+        Ok(()) => Ok(ListenSocketResponse::build(tid)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -334,37 +156,10 @@ pub fn do_getpeername<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("getpeername(): tid={tid:?}, request={request:?}");
 
-    let sockfd: libc::c_int = request.sockfd;
-    let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
-    let mut address_len: libc::socklen_t =
-        core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
-
-    debug!("libc::getpeername(): sockfd={sockfd:?}");
-    match unsafe { handle_getpeername(syscall_table, sockfd, &mut address, &mut address_len) } {
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!(
-                    "do_getpeername(): worker thread interrupted while blocked on getpeername()"
-                );
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::getpeername(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => {
-            let sockaddr: sockaddr = sockaddr {
-                sa_len: address_len as u8,
-                sa_family: address.sa_family as u8,
-                sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
-            };
-            Ok(GetPeerNameResponse::build(tid, &sockaddr))
-        },
+    match syscall_table.net_backend.getpeername(request.sockfd) {
+        Ok(addr) => Ok(GetPeerNameResponse::build(tid, &addr)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -379,38 +174,10 @@ pub fn do_getsockname<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("getsockname(): tid={tid:?}, request={request:?}");
 
-    let sockfd: libc::c_int = request.sockfd;
-    let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
-    let mut address_len: libc::socklen_t =
-        core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
-
-    debug!("libc::getsockname(): sockfd={sockfd:?}");
-    match unsafe { handle_getsockname(syscall_table, sockfd, &mut address, &mut address_len) } {
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!(
-                    "do_getsockname(): worker thread interrupted while blocked on getsockname()"
-                );
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::getsockname(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            error!("libc::getsockname(): {error:?}");
-            Ok(crate::build_error(tid, error))
-        },
-        _ => {
-            let sockaddr: sockaddr = sockaddr {
-                sa_len: address_len as u8,
-                sa_family: address.sa_family as u8,
-                sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
-            };
-            Ok(GetSockNameResponse::build(tid, &sockaddr))
-        },
+    match syscall_table.net_backend.getsockname(request.sockfd) {
+        Ok(addr) => Ok(GetSockNameResponse::build(tid, &addr)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -425,35 +192,10 @@ pub fn do_accept<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("accept(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
-    let mut address_len: libc::socklen_t =
-        core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
-
-    debug!("libc::accept(): sockfd={sockfd:?}");
-    match unsafe { handle_accept(syscall_table, sockfd, &mut address, &mut address_len) } {
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_accept(): worker thread interrupted while blocked on accept()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::accept(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        sockfd => {
-            let sockaddr: sockaddr = sockaddr {
-                sa_len: address_len as u8,
-                sa_family: address.sa_family as u8,
-                sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
-            };
-            Ok(AcceptSocketResponse::build(tid, sockfd, &sockaddr))
-        },
+    match syscall_table.net_backend.accept(request.sockfd) {
+        Ok((new_sockfd, addr)) => Ok(AcceptSocketResponse::build(tid, new_sockfd, &addr)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -468,46 +210,18 @@ pub fn do_recv<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("recv(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
-        Ok(flags) => flags,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-
-    let recv_len: usize = cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
-
+    let recv_len: usize =
+        core::cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
     let mut buffer: [u8; ReceiveSocketResponse::BUFFER_SIZE] =
         [0; ReceiveSocketResponse::BUFFER_SIZE];
 
-    debug!("libc::recv(): sockfd={sockfd:?}, len={recv_len:?}, flags={:?}", flags.inner());
-    match unsafe {
-        handle_recv(
-            syscall_table,
-            sockfd,
-            buffer.as_mut_ptr() as *mut libc::c_void,
-            recv_len,
-            flags.inner(),
-        )
-    } {
-        count if count >= 0 => {
-            debug!("libc::recv(): count={count:?}");
-            Ok(ReceiveSocketResponse::build(tid, count as c_size_t, buffer))
-        },
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_recv(): worker thread interrupted while blocked on recv()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::recv(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => unreachable!("libc::recv() returned invalid value"),
+    match syscall_table
+        .net_backend
+        .recv(request.sockfd, &mut buffer, recv_len, request.flags)
+    {
+        Ok(count) => Ok(ReceiveSocketResponse::build(tid, count as u32, buffer)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -522,27 +236,13 @@ pub fn do_shutdown<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("shutdown(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let how: LibcShutdownReason = LibcShutdownReason::from(request.how);
-
-    debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
-    match unsafe { handle_shutdown(syscall_table, sockfd, how.inner()) } {
-        0 => Ok(ShutdownSocketResponse::build(tid)),
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_shutdown(): worker thread interrupted while blocked on shutdown()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::shutdown(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        ret => unreachable!("libc::shutdown() returned invalid value {ret:?}"),
+    match syscall_table
+        .net_backend
+        .shutdown(request.sockfd, request.how)
+    {
+        Ok(()) => Ok(ShutdownSocketResponse::build(tid)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }
 
@@ -557,391 +257,14 @@ pub fn do_send<T>(
 ) -> Result<Message, WorkerThreadError> {
     trace!("send(): tid={tid:?}, request={request:?}");
 
-    let sockfd: i32 = request.sockfd;
-    let count: c_size_t = request.count;
-    let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
-        Ok(flags) => flags,
-        Err(e) => return Ok(crate::build_error(tid, e.code)),
-    };
-    let buffer: [u8; SendSocketRequest::BUFFER_SIZE] = request.buffer;
-
-    debug!(
-        "libc::send(): sockfd={sockfd:?}, count={count:?}, flags={:?}, buffer={buffer:?}",
-        flags.inner()
-    );
-    match unsafe {
-        handle_send(
-            syscall_table,
-            sockfd,
-            buffer.as_ptr() as *const libc::c_void,
-            count as usize,
-            flags.inner(),
-        )
-    } {
-        count if count >= 0 => {
-            debug!("libc::send(): count={count:?}");
-            Ok(SendSocketResponse::build(tid, count as c_ssize_t))
-        },
-        -1 => {
-            let errno: libc::c_int = unsafe { *libc::__errno_location() };
-
-            // Check if the thread has been interrupted.
-            if errno == libc::EINTR {
-                error!("do_send(): worker thread interrupted while blocked on send()");
-                return Err(WorkerThreadError::Interrupted);
-            }
-
-            error!("libc::send(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
-        },
-        _ => unreachable!("libc::send() returned invalid value"),
-    }
-}
-
-//==================================================================================================
-
-struct LibcSocketDomain(libc::sa_family_t);
-
-impl LibcSocketDomain {
-    fn inner(&self) -> libc::sa_family_t {
-        self.0
-    }
-
-    fn try_from(domain: AddressFamily) -> Result<Self, Error> {
-        match domain {
-            AddressFamily::Inet => Ok(Self(libc::AF_INET as libc::sa_family_t)),
-            AddressFamily::Inet6 => Ok(Self(libc::AF_INET6 as libc::sa_family_t)),
-            AddressFamily::Unix => Ok(Self(libc::AF_UNIX as libc::sa_family_t)),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid socket domain")),
-        }
-    }
-}
-
-struct LibcSocketType(libc::c_int);
-
-impl LibcSocketType {
-    fn inner(&self) -> libc::c_int {
-        self.0
-    }
-
-    fn from(type_: SocketType) -> Self {
-        match type_ {
-            SocketType::Datagram => Self(libc::SOCK_DGRAM),
-            SocketType::Stream => Self(libc::SOCK_STREAM),
-            SocketType::Raw => Self(libc::SOCK_RAW),
-            SocketType::SeqPacket => Self(libc::SOCK_SEQPACKET),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct LibcSocketProtocol(libc::c_int);
-
-impl LibcSocketProtocol {
-    fn inner(&self) -> libc::c_int {
-        self.0
-    }
-
-    fn from(protocol: Protocol) -> Self {
-        match protocol {
-            Protocol::Ip => Self(libc::IPPROTO_IP),
-            Protocol::Tcp => Self(libc::IPPROTO_TCP),
-            Protocol::Udp => Self(libc::IPPROTO_UDP),
-        }
-    }
-}
-
-struct LibcSocketAddress(libc::sockaddr);
-
-impl LibcSocketAddress {
-    fn inner(&self) -> libc::sockaddr {
-        self.0
-    }
-}
-
-impl TryFrom<sockaddr> for LibcSocketAddress {
-    type Error = Error;
-
-    fn try_from(sockaddr: sockaddr) -> Result<Self, Self::Error> {
-        let domain: i32 = sockaddr.sa_family.into();
-        let domain: AddressFamily = match AddressFamily::try_from(domain) {
-            Ok(domain) => domain,
-            Err(_error) => {
-                return Err(Error::new(
-                    ErrorCode::InvalidArgument,
-                    "failed to convert socket address",
-                ))
-            },
-        };
-        Ok(Self(libc::sockaddr {
-            sa_family: LibcSocketDomain::try_from(domain)?.inner(),
-            sa_data: unsafe { core::mem::transmute::<[u8; 14], [i8; 14]>(sockaddr.sa_data) },
-        }))
-    }
-}
-
-impl TryFrom<SocketAddr> for LibcSocketAddress {
-    type Error = Error;
-
-    fn try_from(sockaddr: SocketAddr) -> Result<Self, Self::Error> {
-        let sockaddr: sockaddr = sockaddr::from(&sockaddr);
-        LibcSocketAddress::try_from(sockaddr)
-    }
-}
-
-struct LibcShutdownReason(libc::c_int);
-
-impl LibcShutdownReason {
-    fn inner(&self) -> libc::c_int {
-        self.0
-    }
-}
-
-impl From<Shutdown> for LibcShutdownReason {
-    fn from(how: Shutdown) -> Self {
-        match how {
-            Shutdown::Read => Self(libc::SHUT_RD),
-            Shutdown::Write => Self(libc::SHUT_WR),
-            Shutdown::ReadWrite => Self(libc::SHUT_RDWR),
-        }
-    }
-}
-
-struct LibcMessageFlags(libc::c_int);
-
-impl LibcMessageFlags {
-    fn inner(&self) -> libc::c_int {
-        self.0
-    }
-
-    fn try_from(flags: i32) -> Result<Self, Error> {
-        let mut flags = flags;
-        let mut libc_flags = 0;
-
-        let flag_mappings: [(i32, libc::c_int); 5] = [
-            (MSG_PEEK, libc::MSG_PEEK),
-            (MSG_OOB, libc::MSG_OOB),
-            (MSG_WAITALL, libc::MSG_WAITALL),
-            (MSG_EOR, libc::MSG_EOR),
-            (MSG_NOSIGNAL, libc::MSG_NOSIGNAL),
-        ];
-
-        for (posix_flag, libc_flag) in &flag_mappings {
-            if flags & posix_flag != 0 {
-                libc_flags |= libc_flag;
-                flags &= !posix_flag;
-            }
-        }
-
-        if flags != 0 {
-            return Err(Error::new(ErrorCode::InvalidArgument, "invalid message flags"));
-        }
-
-        Ok(Self(libc_flags))
-    }
-}
-
-//==================================================================================================
-// System Call Wrappers
-//==================================================================================================
-
-/// Handler for `libc::socket()`.
-unsafe fn handle_socket<T>(
-    syscall_table: &SyscallTable<T>,
-    domain: libc::c_int,
-    type_: libc::c_int,
-    protocol: libc::c_int,
-) -> libc::c_int {
-    match &syscall_table.socket {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, domain, type_, protocol)
-        },
-    }
-}
-
-/// Handler for `libc::socketpair()`.
-unsafe fn handle_socketpair<T>(
-    syscall_table: &SyscallTable<T>,
-    domain: libc::c_int,
-    type_: libc::c_int,
-    protocol: libc::c_int,
-    sv: *mut libc::c_int,
-) -> libc::c_int {
-    match &syscall_table.socketpair {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, domain, type_, protocol, sv)
-        },
-    }
-}
-
-/// Handler for `libc::bind()`.
-unsafe fn handle_bind<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    addr: *const libc::sockaddr,
-    addrlen: libc::socklen_t,
-) -> libc::c_int {
-    match &syscall_table.bind {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
-        },
-    }
-}
-
-/// Handler for `libc::connect()`.
-unsafe fn handle_connect<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    addr: *const libc::sockaddr,
-    addrlen: libc::socklen_t,
-) -> libc::c_int {
-    match &syscall_table.connect {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
-        },
-    }
-}
-
-/// Handler for `libc::listen()`.
-unsafe fn handle_listen<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    backlog: libc::c_int,
-) -> libc::c_int {
-    match &syscall_table.listen {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, backlog)
-        },
-    }
-}
-
-/// Handler for `libc::getpeername()`.
-unsafe fn handle_getpeername<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    match &syscall_table.getpeername {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
-        },
-    }
-}
-
-/// Handler for `libc::getsockname()`.
-unsafe fn handle_getsockname<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    match &syscall_table.getsockname {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
-        },
-    }
-}
-
-/// Handler for `libc::accept()`.
-unsafe fn handle_accept<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    match &syscall_table.accept {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
-        },
-    }
-}
-
-/// Handler for `libc::recv()`.
-unsafe fn handle_recv<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    buf: *mut libc::c_void,
-    len: libc::size_t,
-    flags: libc::c_int,
-) -> libc::ssize_t {
-    match &syscall_table.recv {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, buf, len, flags)
-        },
-    }
-}
-
-/// Handler for `libc::send()`.
-unsafe fn handle_send<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    buf: *const libc::c_void,
-    len: libc::size_t,
-    flags: libc::c_int,
-) -> libc::ssize_t {
-    match &syscall_table.send {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, buf, len, flags)
-        },
-    }
-}
-
-/// Handler for `libc::shutdown()`.
-unsafe fn handle_shutdown<T>(
-    syscall_table: &SyscallTable<T>,
-    sockfd: libc::c_int,
-    how: libc::c_int,
-) -> libc::c_int {
-    match &syscall_table.shutdown {
-        SyscallAction::Block => {
-            unsafe { *libc::__errno_location() = libc::EPERM };
-            -1
-        },
-        SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(&syscall_table.state, sockfd, how)
-        },
+    match syscall_table.net_backend.send(
+        request.sockfd,
+        &request.buffer,
+        request.count as usize,
+        request.flags,
+    ) {
+        Ok(count) => Ok(SendSocketResponse::build(tid, count as i32)),
+        Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
+        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
     }
 }

--- a/src/daemons/linuxd/src/syscalls.rs
+++ b/src/daemons/linuxd/src/syscalls.rs
@@ -2,6 +2,12 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::net_backend::NetBackend;
+
+//==================================================================================================
 // Function Type Aliases
 //==================================================================================================
 
@@ -81,47 +87,6 @@ pub type PipeFn<T> = unsafe fn(&T, *mut libc::c_int) -> libc::c_int;
 
 /// Type alias for `getdents()` system call function.
 pub type GetdentsFn<T> = unsafe fn(&T, libc::c_int, *mut u8, libc::size_t) -> libc::c_long;
-
-/// Type alias for `socket()` system call function.
-pub type SocketFn<T> = unsafe fn(&T, libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
-
-/// Type alias for `socketpair()` system call function.
-pub type SocketpairFn<T> =
-    unsafe fn(&T, libc::c_int, libc::c_int, libc::c_int, *mut libc::c_int) -> libc::c_int;
-
-/// Type alias for `bind()` system call function.
-pub type BindFn<T> =
-    unsafe fn(&T, libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
-
-/// Type alias for `connect()` system call function.
-pub type ConnectFn<T> =
-    unsafe fn(&T, libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
-
-/// Type alias for `listen()` system call function.
-pub type ListenFn<T> = unsafe fn(&T, libc::c_int, libc::c_int) -> libc::c_int;
-
-/// Type alias for `getpeername()` system call function.
-pub type GetpeernameFn<T> =
-    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
-
-/// Type alias for `getsockname()` system call function.
-pub type GetsocknameFn<T> =
-    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
-
-/// Type alias for `accept()` system call function.
-pub type AcceptFn<T> =
-    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
-
-/// Type alias for `recv()` system call function.
-pub type RecvFn<T> =
-    unsafe fn(&T, libc::c_int, *mut libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
-
-/// Type alias for `send()` system call function.
-pub type SendFn<T> =
-    unsafe fn(&T, libc::c_int, *const libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
-
-/// Type alias for `shutdown()` system call function.
-pub type ShutdownFn<T> = unsafe fn(&T, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `select()` system call function.
 pub type SelectFn<T> = unsafe fn(
@@ -1238,331 +1203,6 @@ pub unsafe fn default_getdents<T>(
 }
 
 //==================================================================================================
-// Default Implementations - socket.rs
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Default implementation for `socket()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `domain`: Domain.
-/// - `type_`: Type.
-/// - `protocol`: Protocol.
-///
-/// # Returns
-///
-/// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// This function is safe to call as it does not access any pointers.
-///
-pub unsafe fn default_socket<T>(
-    _state: &T,
-    domain: libc::c_int,
-    type_: libc::c_int,
-    protocol: libc::c_int,
-) -> libc::c_int {
-    libc::socket(domain, type_, protocol)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `socketpair()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `domain`: Domain.
-/// - `type_`: Type.
-/// - `protocol`: Protocol.
-/// - `sv`: Socket pair.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sv` is a valid pointer to writable memory for at least 2 integers.
-///
-pub unsafe fn default_socketpair<T>(
-    _state: &T,
-    domain: libc::c_int,
-    type_: libc::c_int,
-    protocol: libc::c_int,
-    sv: *mut libc::c_int,
-) -> libc::c_int {
-    libc::socketpair(domain, type_, protocol, sv)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `bind()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `addr`: Address.
-/// - `addrlen`: Address length.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor and `addr` is a valid pointer to readable memory of at least `addrlen` bytes.
-///
-pub unsafe fn default_bind<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    addr: *const libc::sockaddr,
-    addrlen: libc::socklen_t,
-) -> libc::c_int {
-    libc::bind(sockfd, addr, addrlen)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `connect()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `addr`: Address.
-/// - `addrlen`: Address length.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor and `addr` is a valid pointer to readable memory of at least `addrlen` bytes.
-///
-pub unsafe fn default_connect<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    addr: *const libc::sockaddr,
-    addrlen: libc::socklen_t,
-) -> libc::c_int {
-    libc::connect(sockfd, addr, addrlen)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `listen()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `backlog`: Backlog.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor.
-///
-pub unsafe fn default_listen<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    backlog: libc::c_int,
-) -> libc::c_int {
-    libc::listen(sockfd, backlog)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `getpeername()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `addr`: Address.
-/// - `addrlen`: Address length.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor, `addr` is a valid pointer to writable memory, and `addrlen` is a valid pointer to writable memory.
-///
-pub unsafe fn default_getpeername<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    libc::getpeername(sockfd, addr, addrlen)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `getsockname()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `addr`: Address.
-/// - `addrlen`: Address length.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor, `addr` is a valid pointer to writable memory, and `addrlen` is a valid pointer to writable memory.
-///
-pub unsafe fn default_getsockname<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    libc::getsockname(sockfd, addr, addrlen)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `accept()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `addr`: Address.
-/// - `addrlen`: Address length.
-///
-/// # Returns
-///
-/// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor, and if `addr` is not NULL, it must be a valid pointer to writable memory and `addrlen` must be a valid pointer to writable memory.
-///
-pub unsafe fn default_accept<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    addr: *mut libc::sockaddr,
-    addrlen: *mut libc::socklen_t,
-) -> libc::c_int {
-    libc::accept(sockfd, addr, addrlen)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `recv()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `buf`: Buffer.
-/// - `len`: Length.
-/// - `flags`: Flags.
-///
-/// # Returns
-///
-/// Upon successful completion, the number of bytes received is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor and `buf` is a valid pointer to writable memory of at least `len` bytes.
-///
-pub unsafe fn default_recv<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    buf: *mut libc::c_void,
-    len: libc::size_t,
-    flags: libc::c_int,
-) -> libc::ssize_t {
-    libc::recv(sockfd, buf, len, flags)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `send()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `buf`: Buffer.
-/// - `len`: Length.
-/// - `flags`: Flags.
-///
-/// # Returns
-///
-/// Upon successful completion, the number of bytes sent is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor and `buf` is a valid pointer to readable memory of at least `len` bytes.
-///
-pub unsafe fn default_send<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    buf: *const libc::c_void,
-    len: libc::size_t,
-    flags: libc::c_int,
-) -> libc::ssize_t {
-    libc::send(sockfd, buf, len, flags)
-}
-
-///
-/// # Description
-///
-/// Default implementation for `shutdown()` system call.
-///
-/// # Parameters
-///
-/// - `_state`: Immutable reference to state (unused in default implementation).
-/// - `sockfd`: Socket file descriptor.
-/// - `how`: How.
-///
-/// # Returns
-///
-/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
-///
-/// # Safety
-///
-/// The caller must ensure that `sockfd` is a valid socket file descriptor.
-///
-pub unsafe fn default_shutdown<T>(
-    _state: &T,
-    sockfd: libc::c_int,
-    how: libc::c_int,
-) -> libc::c_int {
-    libc::shutdown(sockfd, how)
-}
-
-//==================================================================================================
 // Default Implementations - poll.rs
 //==================================================================================================
 
@@ -1674,11 +1314,14 @@ pub enum SyscallAction<F> {
 ///
 /// System call routing table.
 ///
-/// This structure holds the configuration for how system calls should be handled. Each system
-/// call can be either blocked or forwarded to a handler function. The generic type parameter `T`
-/// represents custom state that is passed as a reference to each system call handler, allowing
-/// implementations to maintain context-specific information (e.g., file descriptor tables,
-/// process state, or other runtime data).
+/// This structure holds the configuration for how system calls should be handled. Most system
+/// calls can be either blocked or forwarded to a handler function via [`SyscallAction`]. Socket
+/// operations are handled separately through the [`NetBackend`] field, which provides a
+/// type-safe networking API and is not subject to the block/forward routing mechanism.
+///
+/// The generic type parameter `T` represents custom state that is passed as a reference to each
+/// system call handler, allowing implementations to maintain context-specific information (e.g.,
+/// file descriptor tables, process state, or other runtime data).
 ///
 /// # Type Parameters
 ///
@@ -1688,6 +1331,9 @@ pub enum SyscallAction<F> {
 pub struct SyscallTable<T> {
     /// State that is passed to each system call action function.
     pub state: T,
+
+    /// Networking backend for socket operations.
+    pub net_backend: NetBackend,
 
     // unistd.rs system calls.
     pub chdir: SyscallAction<ChdirFn<T>>,
@@ -1732,19 +1378,6 @@ pub struct SyscallTable<T> {
     // dirent.rs system calls.
     pub getdents: SyscallAction<GetdentsFn<T>>,
 
-    // socket.rs system calls.
-    pub accept: SyscallAction<AcceptFn<T>>,
-    pub bind: SyscallAction<BindFn<T>>,
-    pub connect: SyscallAction<ConnectFn<T>>,
-    pub getpeername: SyscallAction<GetpeernameFn<T>>,
-    pub getsockname: SyscallAction<GetsocknameFn<T>>,
-    pub listen: SyscallAction<ListenFn<T>>,
-    pub recv: SyscallAction<RecvFn<T>>,
-    pub send: SyscallAction<SendFn<T>>,
-    pub shutdown: SyscallAction<ShutdownFn<T>>,
-    pub socket: SyscallAction<SocketFn<T>>,
-    pub socketpair: SyscallAction<SocketpairFn<T>>,
-
     // poll.rs system calls.
     pub poll: SyscallAction<PollFn<T>>,
 
@@ -1772,6 +1405,9 @@ impl<T> SyscallTable<T> {
     pub fn new(state: T) -> Self {
         Self {
             state,
+
+            // Networking backend.
+            net_backend: NetBackend::new(),
 
             // unistd.rs system calls.
             chdir: SyscallAction::Forward(default_chdir),
@@ -1815,19 +1451,6 @@ impl<T> SyscallTable<T> {
 
             // dirent.rs system calls.
             getdents: SyscallAction::Forward(default_getdents),
-
-            // socket.rs system calls.
-            accept: SyscallAction::Forward(default_accept),
-            bind: SyscallAction::Forward(default_bind),
-            connect: SyscallAction::Forward(default_connect),
-            getpeername: SyscallAction::Forward(default_getpeername),
-            getsockname: SyscallAction::Forward(default_getsockname),
-            listen: SyscallAction::Forward(default_listen),
-            recv: SyscallAction::Forward(default_recv),
-            send: SyscallAction::Forward(default_send),
-            shutdown: SyscallAction::Forward(default_shutdown),
-            socket: SyscallAction::Forward(default_socket),
-            socketpair: SyscallAction::Forward(default_socketpair),
 
             // poll.rs system calls.
             poll: SyscallAction::Forward(default_poll),

--- a/src/libs/net-backend/Cargo.toml
+++ b/src/libs/net-backend/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "net-backend"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Platform-agnostic networking backend for Nanvix daemons"
+homepage.workspace = true
+
+[dependencies]
+libc = { workspace = true }
+log = { workspace = true }
+sys = { workspace = true, features = ["std"] }
+sysapi = { workspace = true, features = ["std"] }
+syscall = { workspace = true, features = ["std", "networking"] }
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/src/libs/net-backend/src/error.rs
+++ b/src/libs/net-backend/src/error.rs
@@ -1,0 +1,21 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+
+//==================================================================================================
+// NetError
+//==================================================================================================
+
+/// Errors returned by `NetBackend` operations.
+#[derive(Debug)]
+pub enum NetError {
+    /// The operation was interrupted by a signal (EINTR).
+    Interrupted,
+    /// The operation failed with a specific error code.
+    Errno(ErrorCode),
+}

--- a/src/libs/net-backend/src/io.rs
+++ b/src/libs/net-backend/src/io.rs
@@ -1,0 +1,112 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    error::NetError,
+    types::LibcMessageFlags,
+    NetBackend,
+};
+use ::log::{
+    debug,
+    error,
+    warn,
+};
+use ::sys::error::ErrorCode;
+
+//==================================================================================================
+// I/O Operations
+//==================================================================================================
+
+impl NetBackend {
+    /// Sends data on a connected socket.
+    ///
+    /// Returns the number of bytes sent.
+    pub fn send(
+        &self,
+        sockfd: i32,
+        buf: &[u8],
+        count: usize,
+        flags: i32,
+    ) -> Result<isize, NetError> {
+        // Validate that count does not exceed buffer length to prevent out-of-bounds reads.
+        if count > buf.len() {
+            error!("send(): count ({count}) exceeds buffer length ({})", buf.len());
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        let flags: LibcMessageFlags =
+            LibcMessageFlags::try_from_nanvix(flags).map_err(|e| NetError::Errno(e.code))?;
+
+        debug!("libc::send(): sockfd={sockfd:?}, count={count:?}, flags={:?}", flags.inner());
+
+        match unsafe {
+            libc::send(sockfd, buf.as_ptr() as *const libc::c_void, count, flags.inner())
+        } {
+            count if count >= 0 => {
+                debug!("libc::send(): count={count:?}");
+                Ok(count)
+            },
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::send(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => unreachable!("libc::send() returned invalid value"),
+        }
+    }
+
+    /// Receives data from a connected socket.
+    ///
+    /// Returns the number of bytes received.
+    pub fn recv(
+        &self,
+        sockfd: i32,
+        buf: &mut [u8],
+        count: usize,
+        flags: i32,
+    ) -> Result<isize, NetError> {
+        // Validate that count does not exceed buffer length to prevent out-of-bounds writes.
+        if count > buf.len() {
+            error!("recv(): count ({count}) exceeds buffer length ({})", buf.len());
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        let flags: LibcMessageFlags =
+            LibcMessageFlags::try_from_nanvix(flags).map_err(|e| NetError::Errno(e.code))?;
+
+        debug!("libc::recv(): sockfd={sockfd:?}, len={count:?}, flags={:?}", flags.inner());
+
+        match unsafe {
+            libc::recv(sockfd, buf.as_mut_ptr() as *mut libc::c_void, count, flags.inner())
+        } {
+            count if count >= 0 => {
+                debug!("libc::recv(): count={count:?}");
+                Ok(count)
+            },
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::recv(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => unreachable!("libc::recv() returned invalid value"),
+        }
+    }
+}

--- a/src/libs/net-backend/src/lib.rs
+++ b/src/libs/net-backend/src/lib.rs
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod error;
+pub mod io;
+pub mod query;
+pub mod socket;
+mod types;
+
+//==================================================================================================
+// NetBackend
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Platform-agnostic networking backend.
+///
+/// This struct encapsulates all platform-specific networking logic and provides a clean Rust API
+/// for socket operations. On Linux, it calls libc directly. On Windows, it uses the Winsock2 API.
+///
+/// `NetBackend` is designed to be shared between `linuxd` and the future `networkd` daemon without
+/// code duplication.
+#[derive(Clone, Copy)]
+pub struct NetBackend(());
+
+impl NetBackend {
+    /// Creates a new `NetBackend` instance.
+    pub fn new() -> Self {
+        Self(())
+    }
+}
+
+impl Default for NetBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/libs/net-backend/src/query.rs
+++ b/src/libs/net-backend/src/query.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    error::NetError,
+    NetBackend,
+};
+use ::log::{
+    debug,
+    error,
+    warn,
+};
+use ::sys::error::ErrorCode;
+use ::sysapi::sys_socket::sockaddr;
+
+//==================================================================================================
+// Query Operations
+//==================================================================================================
+
+impl NetBackend {
+    /// Gets the address of the peer connected to a socket.
+    pub fn getpeername(&self, sockfd: i32) -> Result<sockaddr, NetError> {
+        let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
+        let mut address_len: libc::socklen_t =
+            core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
+
+        debug!("libc::getpeername(): sockfd={sockfd:?}");
+
+        match unsafe { libc::getpeername(sockfd, &mut address, &mut address_len) } {
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::getpeername(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => {
+                let mut sa_data: [u8; 14] = [0u8; 14];
+                for (i, &b) in address.sa_data.iter().enumerate() {
+                    sa_data[i] = b as u8;
+                }
+                let addr: sockaddr = sockaddr {
+                    sa_len: address_len as u8,
+                    sa_family: address.sa_family as u8,
+                    sa_data,
+                };
+                Ok(addr)
+            },
+        }
+    }
+
+    /// Gets the local address of a socket.
+    pub fn getsockname(&self, sockfd: i32) -> Result<sockaddr, NetError> {
+        let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
+        let mut address_len: libc::socklen_t =
+            core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
+
+        debug!("libc::getsockname(): sockfd={sockfd:?}");
+
+        match unsafe { libc::getsockname(sockfd, &mut address, &mut address_len) } {
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::getsockname(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => {
+                let mut sa_data: [u8; 14] = [0u8; 14];
+                for (i, &b) in address.sa_data.iter().enumerate() {
+                    sa_data[i] = b as u8;
+                }
+                let addr: sockaddr = sockaddr {
+                    sa_len: address_len as u8,
+                    sa_family: address.sa_family as u8,
+                    sa_data,
+                };
+                Ok(addr)
+            },
+        }
+    }
+}

--- a/src/libs/net-backend/src/socket.rs
+++ b/src/libs/net-backend/src/socket.rs
@@ -1,0 +1,284 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    error::NetError,
+    types::{
+        LibcShutdownReason,
+        LibcSocketAddress,
+        LibcSocketDomain,
+        LibcSocketProtocol,
+        LibcSocketType,
+    },
+    NetBackend,
+};
+use ::log::{
+    debug,
+    error,
+    warn,
+};
+use ::sys::error::ErrorCode;
+use ::sysapi::sys_socket::{
+    sockaddr,
+    socklen_t,
+};
+use ::syscall::{
+    netinet::in_::Protocol,
+    sys::socket::{
+        AddressFamily,
+        Shutdown,
+        SocketType,
+    },
+};
+
+//==================================================================================================
+// Socket Operations
+//==================================================================================================
+
+impl NetBackend {
+    /// Creates a new socket.
+    pub fn socket(
+        &self,
+        domain: AddressFamily,
+        typ: SocketType,
+        protocol: Protocol,
+    ) -> Result<i32, NetError> {
+        let domain: LibcSocketDomain =
+            LibcSocketDomain::try_from_nanvix(domain).map_err(|e| NetError::Errno(e.code))?;
+        let typ: LibcSocketType = LibcSocketType::from_nanvix(typ);
+        let protocol: LibcSocketProtocol = LibcSocketProtocol::from_nanvix(protocol);
+
+        debug!(
+            "libc::socket(): domain={:?}, type={:?}, protocol={protocol:?}",
+            domain.inner(),
+            typ.inner(),
+        );
+
+        match unsafe { libc::socket(domain.inner() as i32, typ.inner(), protocol.inner()) } {
+            -1 => {
+                let errno: i32 = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::socket(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            sockfd => {
+                debug!("libc::socket(): fd={sockfd:?}");
+                Ok(sockfd)
+            },
+        }
+    }
+
+    /// Creates a pair of connected sockets.
+    pub fn socketpair(
+        &self,
+        domain: AddressFamily,
+        typ: SocketType,
+        protocol: Protocol,
+    ) -> Result<(i32, i32), NetError> {
+        let domain: LibcSocketDomain =
+            LibcSocketDomain::try_from_nanvix(domain).map_err(|e| NetError::Errno(e.code))?;
+        let typ: LibcSocketType = LibcSocketType::from_nanvix(typ);
+        let protocol: LibcSocketProtocol = LibcSocketProtocol::from_nanvix(protocol);
+
+        let mut sv: [libc::c_int; 2] = [0; 2];
+
+        debug!(
+            "libc::socketpair(): domain={:?}, type={:?}, protocol={protocol:?}",
+            domain.inner(),
+            typ.inner(),
+        );
+
+        match unsafe {
+            libc::socketpair(domain.inner() as i32, typ.inner(), protocol.inner(), sv.as_mut_ptr())
+        } {
+            -1 => {
+                let errno: i32 = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::socketpair(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => {
+                debug!("libc::socketpair(): fds={sv:?}");
+                Ok((sv[0], sv[1]))
+            },
+        }
+    }
+
+    /// Binds a socket to an address.
+    pub fn bind(&self, sockfd: i32, addr: &sockaddr) -> Result<(), NetError> {
+        let sockaddr: LibcSocketAddress =
+            LibcSocketAddress::try_from(*addr).map_err(|e| NetError::Errno(e.code))?;
+        let socklen: socklen_t = core::mem::size_of::<libc::sockaddr>() as socklen_t;
+
+        debug!(
+            "libc::bind(): sockfd={sockfd:?}, sockaddr.sa_family={:?}, sockaddr.sa_data={:?}, \
+             socklen={socklen:?}",
+            sockaddr.inner().sa_family,
+            sockaddr.inner().sa_data,
+        );
+
+        match unsafe { libc::bind(sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen) } {
+            -1 => {
+                let errno: i32 = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::bind(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => Ok(()),
+        }
+    }
+
+    /// Connects a socket to an address.
+    pub fn connect(
+        &self,
+        sockfd: i32,
+        addr: &sockaddr,
+        socklen: socklen_t,
+    ) -> Result<(), NetError> {
+        // Validate that socklen does not exceed the size of the address structure.
+        if (socklen as usize) > core::mem::size_of::<libc::sockaddr>() {
+            error!(
+                "connect(): socklen ({socklen}) exceeds size of sockaddr ({})",
+                core::mem::size_of::<libc::sockaddr>()
+            );
+            return Err(NetError::Errno(::sys::error::ErrorCode::InvalidArgument));
+        }
+
+        let sockaddr: LibcSocketAddress =
+            LibcSocketAddress::try_from(*addr).map_err(|e| NetError::Errno(e.code))?;
+
+        debug!(
+            "libc::connect(): sockfd={sockfd:?}, sockaddr.sa_family={:?}, sockaddr.sa_data={:?}, \
+             socklen={socklen:?}",
+            sockaddr.inner().sa_family,
+            sockaddr.inner().sa_data,
+        );
+
+        match unsafe {
+            libc::connect(
+                sockfd,
+                &sockaddr.inner() as *const libc::sockaddr,
+                socklen as libc::socklen_t,
+            )
+        } {
+            -1 => {
+                let errno: i32 = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::connect(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => Ok(()),
+        }
+    }
+
+    /// Listens for connections on a socket.
+    pub fn listen(&self, sockfd: i32, backlog: i32) -> Result<(), NetError> {
+        debug!("libc::listen(): sockfd={sockfd:?}, backlog={backlog:?}");
+
+        match unsafe { libc::listen(sockfd, backlog) } {
+            -1 => {
+                let errno: i32 = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::listen(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            _ => Ok(()),
+        }
+    }
+
+    /// Accepts a connection on a socket.
+    ///
+    /// Returns the new socket file descriptor and the peer address.
+    pub fn accept(&self, sockfd: i32) -> Result<(i32, sockaddr), NetError> {
+        let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
+        let mut address_len: libc::socklen_t =
+            core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
+
+        debug!("libc::accept(): sockfd={sockfd:?}");
+
+        match unsafe { libc::accept(sockfd, &mut address, &mut address_len) } {
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::accept(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            new_sockfd => {
+                let mut sa_data: [u8; 14] = [0u8; 14];
+                for (i, &b) in address.sa_data.iter().enumerate() {
+                    sa_data[i] = b as u8;
+                }
+                let addr: sockaddr = sockaddr {
+                    sa_len: address_len as u8,
+                    sa_family: address.sa_family as u8,
+                    sa_data,
+                };
+                Ok((new_sockfd, addr))
+            },
+        }
+    }
+
+    /// Shuts down part of a full-duplex connection.
+    pub fn shutdown(&self, sockfd: i32, how: Shutdown) -> Result<(), NetError> {
+        let how: LibcShutdownReason = LibcShutdownReason::from(how);
+
+        debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
+
+        match unsafe { libc::shutdown(sockfd, how.inner()) } {
+            0 => Ok(()),
+            -1 => {
+                let errno: libc::c_int = unsafe { *libc::__errno_location() };
+                if errno == libc::EINTR {
+                    return Err(NetError::Interrupted);
+                }
+                error!("libc::shutdown(): failed with errno={errno:?}");
+                let error: ErrorCode = ErrorCode::try_from(errno).unwrap_or_else(|_| {
+                    warn!("unknown errno value {errno:?}, mapping to ValueOutOfRange");
+                    ErrorCode::ValueOutOfRange
+                });
+                Err(NetError::Errno(error))
+            },
+            ret => unreachable!("libc::shutdown() returned invalid value {ret:?}"),
+        }
+    }
+}

--- a/src/libs/net-backend/src/types.rs
+++ b/src/libs/net-backend/src/types.rs
@@ -1,0 +1,185 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    netinet_in::message_flags::{
+        MSG_EOR,
+        MSG_NOSIGNAL,
+        MSG_OOB,
+        MSG_PEEK,
+        MSG_WAITALL,
+    },
+    sys_socket::sockaddr,
+};
+use ::syscall::{
+    netinet::in_::Protocol,
+    sys::socket::{
+        AddressFamily,
+        Shutdown,
+        SocketType,
+    },
+};
+
+//==================================================================================================
+// LibcSocketDomain
+//==================================================================================================
+
+pub(crate) struct LibcSocketDomain(libc::sa_family_t);
+
+impl LibcSocketDomain {
+    pub(crate) fn inner(&self) -> libc::sa_family_t {
+        self.0
+    }
+
+    pub(crate) fn try_from_nanvix(domain: AddressFamily) -> Result<Self, Error> {
+        match domain {
+            AddressFamily::Inet => Ok(Self(libc::AF_INET as libc::sa_family_t)),
+            AddressFamily::Inet6 => Ok(Self(libc::AF_INET6 as libc::sa_family_t)),
+            AddressFamily::Unix => Ok(Self(libc::AF_UNIX as libc::sa_family_t)),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid socket domain")),
+        }
+    }
+}
+
+//==================================================================================================
+// LibcSocketType
+//==================================================================================================
+
+pub(crate) struct LibcSocketType(libc::c_int);
+
+impl LibcSocketType {
+    pub(crate) fn inner(&self) -> libc::c_int {
+        self.0
+    }
+
+    pub(crate) fn from_nanvix(type_: SocketType) -> Self {
+        match type_ {
+            SocketType::Datagram => Self(libc::SOCK_DGRAM),
+            SocketType::Stream => Self(libc::SOCK_STREAM),
+            SocketType::Raw => Self(libc::SOCK_RAW),
+            SocketType::SeqPacket => Self(libc::SOCK_SEQPACKET),
+        }
+    }
+}
+
+//==================================================================================================
+// LibcSocketProtocol
+//==================================================================================================
+
+#[derive(Debug)]
+pub(crate) struct LibcSocketProtocol(libc::c_int);
+
+impl LibcSocketProtocol {
+    pub(crate) fn inner(&self) -> libc::c_int {
+        self.0
+    }
+
+    pub(crate) fn from_nanvix(protocol: Protocol) -> Self {
+        match protocol {
+            Protocol::Ip => Self(libc::IPPROTO_IP),
+            Protocol::Tcp => Self(libc::IPPROTO_TCP),
+            Protocol::Udp => Self(libc::IPPROTO_UDP),
+        }
+    }
+}
+
+//==================================================================================================
+// LibcSocketAddress
+//==================================================================================================
+
+pub(crate) struct LibcSocketAddress(libc::sockaddr);
+
+impl LibcSocketAddress {
+    pub(crate) fn inner(&self) -> libc::sockaddr {
+        self.0
+    }
+}
+
+impl TryFrom<sockaddr> for LibcSocketAddress {
+    type Error = Error;
+
+    fn try_from(sockaddr: sockaddr) -> Result<Self, Self::Error> {
+        let domain: i32 = sockaddr.sa_family.into();
+        let domain: AddressFamily = match AddressFamily::try_from(domain) {
+            Ok(domain) => domain,
+            Err(_error) => {
+                return Err(Error::new(
+                    ErrorCode::InvalidArgument,
+                    "failed to convert socket address",
+                ))
+            },
+        };
+        Ok(Self(libc::sockaddr {
+            sa_family: LibcSocketDomain::try_from_nanvix(domain)?.inner(),
+            sa_data: sockaddr.sa_data.map(|b| b as i8),
+        }))
+    }
+}
+
+//==================================================================================================
+// LibcShutdownReason
+//==================================================================================================
+
+pub(crate) struct LibcShutdownReason(libc::c_int);
+
+impl LibcShutdownReason {
+    pub(crate) fn inner(&self) -> libc::c_int {
+        self.0
+    }
+}
+
+impl From<Shutdown> for LibcShutdownReason {
+    fn from(how: Shutdown) -> Self {
+        match how {
+            Shutdown::Read => Self(libc::SHUT_RD),
+            Shutdown::Write => Self(libc::SHUT_WR),
+            Shutdown::ReadWrite => Self(libc::SHUT_RDWR),
+        }
+    }
+}
+
+//==================================================================================================
+// LibcMessageFlags
+//==================================================================================================
+
+pub(crate) struct LibcMessageFlags(libc::c_int);
+
+impl LibcMessageFlags {
+    pub(crate) fn inner(&self) -> libc::c_int {
+        self.0
+    }
+
+    pub(crate) fn try_from_nanvix(flags: i32) -> Result<Self, Error> {
+        let mut flags = flags;
+        let mut libc_flags = 0;
+
+        let flag_mappings: [(i32, libc::c_int); 5] = [
+            (MSG_PEEK, libc::MSG_PEEK),
+            (MSG_OOB, libc::MSG_OOB),
+            (MSG_WAITALL, libc::MSG_WAITALL),
+            (MSG_EOR, libc::MSG_EOR),
+            (MSG_NOSIGNAL, libc::MSG_NOSIGNAL),
+        ];
+
+        for (posix_flag, libc_flag) in &flag_mappings {
+            if flags & posix_flag != 0 {
+                libc_flags |= libc_flag;
+                flags &= !posix_flag;
+            }
+        }
+
+        if flags != 0 {
+            return Err(Error::new(ErrorCode::InvalidArgument, "invalid message flags"));
+        }
+
+        Ok(Self(libc_flags))
+    }
+}


### PR DESCRIPTION
Extract networking socket logic from linuxd into a standalone
`net-backend` library crate under `src/libs/net-backend`. This
decouples the platform-specific socket implementation from the daemon,
enabling reuse by the future `networkd` daemon and simplifying the
linuxd code.

The new crate provides:
- `NetBackend` struct with methods for socket(), socketpair(), bind(),
  connect(), listen(), accept(), getpeername(), getsockname(), send(),
  recv(), and shutdown().
- `NetError` enum that distinguishes EINTR (Interrupted) from other
  errno values, letting callers handle interrupts uniformly.
- Internal type-conversion helpers (LibcSocketDomain, LibcSocketType,
  LibcSocketProtocol, LibcSocketAddress, LibcShutdownReason,
  LibcMessageFlags) moved from linuxd.

In linuxd:
- Replace inline libc wrappers and SyscallAction-based socket dispatch
  with calls to `syscall_table.net_backend.*`.
- Remove all socket-related type aliases, default_* functions, and
  SyscallAction fields from `SyscallTable`.
- `sys_socket.rs` handlers now delegate directly to `NetBackend` and
  pattern-match on `NetError` for clean error propagation.