### PR TITLE
[build] Update hyperlight to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -867,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.15.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=1fba3a5539e5760227a178454fc3967e0058fef8#1fba3a5539e5760227a178454fc3967e0058fef8"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=9749e047750a215dea680707433a12f9b33b0397#9749e047750a215dea680707433a12f9b33b0397"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.15.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=1fba3a5539e5760227a178454fc3967e0058fef8#1fba3a5539e5760227a178454fc3967e0058fef8"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=9749e047750a215dea680707433a12f9b33b0397#9749e047750a215dea680707433a12f9b33b0397"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.15.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=1fba3a5539e5760227a178454fc3967e0058fef8#1fba3a5539e5760227a178454fc3967e0058fef8"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=9749e047750a215dea680707433a12f9b33b0397#9749e047750a215dea680707433a12f9b33b0397"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2467,7 +2467,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3229,7 +3229,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3558,7 +3558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3834,7 +3834,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4685,7 +4685,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,11 +136,11 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1fba3a5539e5760227a178454fc3967e0058fef8", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "9749e047750a215dea680707433a12f9b33b0397", default-features = false, features = [
         "i686-guest",
         "guest-counter",
 ] }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1fba3a5539e5760227a178454fc3967e0058fef8", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "9749e047750a215dea680707433a12f9b33b0397", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
@@ -148,7 +148,7 @@ hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = 
         "i686-guest",
         "guest-counter",
 ] }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1fba3a5539e5760227a178454fc3967e0058fef8", default-features = false, features = [
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "9749e047750a215dea680707433a12f9b33b0397", default-features = false, features = [
         "i686-guest",
         "guest-counter",
 ] }


### PR DESCRIPTION
Automated hyperlight version bump.

| Field | Value |
|-------|-------|
| Repository | [`hyperlight-dev/hyperlight`](https://github.com/hyperlight-dev/hyperlight) |
| Version | `0.15.0` |
| Old ref | `1fba3a5539e5760227a178454fc3967e0058fef8` |
| New rev | `9749e047750a215dea680707433a12f9b33b0397` |

**Files changed:**
- `Cargo.toml` — updated hyperlight crate references
- `Cargo.lock` — regenerated

> Generated by the **Hyperlight Update** workflow.