### PR TITLE
[build] Fix missing socket symbols in libposix.a

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics

--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -61,10 +61,13 @@ endef
 $(foreach target,$(ALL_GUEST_BINARIES),$(eval $(call GUEST_BINARY_RULES,$(target))))
 
 # Batched build/check/lint grouping: split guest binaries by feature set.
-# - Regular: all except test-kernel (and standalone-capable in standalone mode).
+# - Regular: all except test-kernel and c-bindings-rust (and standalone-capable in standalone mode).
 # - Standalone: standalone-capable binaries (only in standalone mode).
 # - test-kernel: always separate (unique features).
-_GUEST_BINS_COMMON := $(filter-out test-kernel,$(ALL_GUEST_BINARIES))
+# - c-bindings-rust: built separately to avoid Cargo feature unification masking
+#   missing symbols (it validates that all expected C symbols link without
+#   features contributed by sibling crates like network-rust).
+_GUEST_BINS_COMMON := $(filter-out test-kernel c-bindings-rust,$(ALL_GUEST_BINARIES))
 
 ifeq ($(DEPLOYMENT_MODE),standalone)
 _GUEST_BINS_STANDALONE := $(filter $(STANDALONE_GUEST_BINARIES),$(_GUEST_BINS_COMMON))
@@ -89,6 +92,9 @@ ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
 endif
 ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
 	$(GUEST_CARGO_BUILD_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
+endif
+ifneq ($(filter c-bindings-rust,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_BUILD_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES)
 endif
 	@for pkg in $(ALL_GUEST_BINARIES); do \
 		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$$pkg.elf $(BINARIES_DIR)/$$pkg.elf; \
@@ -123,6 +129,9 @@ endif
 ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
 	$(GUEST_CARGO_CHECK_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
 endif
+ifneq ($(filter c-bindings-rust,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CHECK_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES)
+endif
 
 # Batched format: single cargo invocation for all guest binaries.
 _GUEST_BINS_FMT_PKGS := $(foreach pkg,$(ALL_GUEST_BINARIES),-p $(pkg))
@@ -145,6 +154,9 @@ endif
 ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
 	$(GUEST_CARGO_CLIPPY_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
 endif
+ifneq ($(filter c-bindings-rust,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CLIPPY_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+endif
 
 rust-lint-check-guest-binaries:
 ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
@@ -155,4 +167,7 @@ ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
 endif
 ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
 	$(GUEST_CARGO_CLIPPY_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES) -- -D warnings
+endif
+ifneq ($(filter c-bindings-rust,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CLIPPY_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES) -- -D warnings
 endif

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -43,7 +43,6 @@ pub use ::sysalloc;
 pub mod errno;
 
 /// Definitions for internet operations.
-#[cfg(feature = "networking")]
 pub mod arpa;
 
 /// Format of directory entries
@@ -65,7 +64,6 @@ pub mod fcntl;
 pub mod message;
 
 /// Internet protocols for network stack.
-#[cfg(feature = "networking")]
 pub mod netinet;
 
 /// Posix threads.

--- a/src/libs/syscall/src/sys/mod.rs
+++ b/src/libs/syscall/src/sys/mod.rs
@@ -5,8 +5,7 @@
 // Re-exports
 //==================================================================================================
 
-// Re-export constants that socket2 expects to find directly in sys module
-#[cfg(feature = "networking")]
+// Re-export constants that socket2 expects to find directly in sys module.
 pub use crate::{
     netinet::in_::bindings::{
         ipproto::IPPROTO_IPV6,
@@ -30,7 +29,6 @@ pub mod mman;
 pub mod select;
 
 /// Sockets.
-#[cfg(feature = "networking")]
 pub mod socket;
 
 /// File status.
@@ -46,7 +44,6 @@ pub mod times;
 pub mod uio;
 
 /// Definitions for UNIX domain sockets.
-#[cfg(feature = "networking")]
 pub mod un;
 
 /// System name structure.

--- a/src/tests/c-bindings-rust/src/main.rs
+++ b/src/tests/c-bindings-rust/src/main.rs
@@ -132,6 +132,289 @@ const _: () = assert!(size_of::<timespec>() == size_of::<time_t>() + size_of::<c
 const _: () = assert!(size_of::<sched_param>() == size_of::<c_int>());
 
 //==================================================================================================
+// Link-Time Symbol Presence Check
+//==================================================================================================
+
+// Force the linker to resolve all #[no_mangle] extern "C" symbols exported by the syscall crate.
+// If any symbol is accidentally removed (e.g., by a feature gate), linking this binary will fail.
+//
+// Symbols are declared as opaque statics (not functions) to avoid ABI signature mismatches that
+// could trigger LLVM LTO type-mismatch failures. The linker only needs to resolve the symbol
+// address; the actual calling convention is irrelevant here.
+unsafe extern "C" {
+    static __errno_location: u8;
+    static _exit: u8;
+    static accept: u8;
+    static access: u8;
+    static bind: u8;
+    static chdir: u8;
+    static chown: u8;
+    static chroot: u8;
+    static clock_getres: u8;
+    static clock_gettime: u8;
+    static close: u8;
+    static closedir: u8;
+    static connect: u8;
+    static dirfd: u8;
+    static dup: u8;
+    static dup2: u8;
+    static execv: u8;
+    static execve: u8;
+    static faccessat: u8;
+    static fchdir: u8;
+    static fchown: u8;
+    static fchownat: u8;
+    static fcntl: u8;
+    static fdatasync: u8;
+    static fork: u8;
+    static fstat: u8;
+    static fsync: u8;
+    static ftruncate: u8;
+    static getcwd: u8;
+    static getegid: u8;
+    static getentropy: u8;
+    static geteuid: u8;
+    static getgid: u8;
+    static gethostname: u8;
+    static getpeername: u8;
+    static getpid: u8;
+    static getsockname: u8;
+    static getsockopt: u8;
+    static gettimeofday: u8;
+    static getuid: u8;
+    static isatty: u8;
+    static kill: u8;
+    static lchown: u8;
+    static link: u8;
+    static linkat: u8;
+    static listen: u8;
+    static lseek: u8;
+    static mmap: u8;
+    static mprotect: u8;
+    static munmap: u8;
+    static nanosleep: u8;
+    static open: u8;
+    static opendir: u8;
+    static pipe: u8;
+    static poll: u8;
+    static posix_fadvise: u8;
+    static posix_fallocate: u8;
+    static pread: u8;
+    static pthread_atfork: u8;
+    static pthread_attr_destroy: u8;
+    static pthread_attr_getstack: u8;
+    static pthread_attr_init: u8;
+    static pthread_attr_setstacksize: u8;
+    static pthread_cond_broadcast: u8;
+    static pthread_cond_destroy: u8;
+    static pthread_cond_init: u8;
+    static pthread_cond_signal: u8;
+    static pthread_cond_timedwait: u8;
+    static pthread_cond_wait: u8;
+    static pthread_condattr_init: u8;
+    static pthread_condattr_setclock: u8;
+    static pthread_create: u8;
+    static pthread_getattr_np: u8;
+    static pthread_getschedparam: u8;
+    static pthread_getspecific: u8;
+    static pthread_join: u8;
+    static pthread_key_create: u8;
+    static pthread_kill: u8;
+    static pthread_mutex_destroy: u8;
+    static pthread_mutex_init: u8;
+    static pthread_mutex_lock: u8;
+    static pthread_mutex_unlock: u8;
+    static pthread_rwlock_destroy: u8;
+    static pthread_rwlock_init: u8;
+    static pthread_rwlock_rdlock: u8;
+    static pthread_rwlock_unlock: u8;
+    static pthread_rwlock_wrlock: u8;
+    static pthread_self: u8;
+    static pthread_setcancelstate: u8;
+    static pthread_setspecific: u8;
+    static pthread_sigmask: u8;
+    static pwrite: u8;
+    static read: u8;
+    static readdir: u8;
+    static readlink: u8;
+    static readlinkat: u8;
+    static recv: u8;
+    static recvfrom: u8;
+    static recvmsg: u8;
+    static renameat: u8;
+    static rmdir: u8;
+    static sched_yield: u8;
+    static select: u8;
+    static sem_destroy: u8;
+    static sem_init: u8;
+    static sem_post: u8;
+    static sem_wait: u8;
+    static send: u8;
+    static sendmsg: u8;
+    static sendto: u8;
+    static setegid: u8;
+    static seteuid: u8;
+    static setgid: u8;
+    static setgroups: u8;
+    static setsockopt: u8;
+    static setuid: u8;
+    static shutdown: u8;
+    static sleep: u8;
+    static socket: u8;
+    static socketpair: u8;
+    static stat: u8;
+    static symlink: u8;
+    static symlinkat: u8;
+    static sysconf: u8;
+    static unlink: u8;
+    static unlinkat: u8;
+    static usleep: u8;
+    static waitpid: u8;
+    static write: u8;
+}
+
+/// Wrapper to make raw pointers usable in statics (extern statics are inherently immutable).
+#[repr(transparent)]
+struct SymAddr(*const u8);
+
+// SAFETY: These are addresses of extern symbols resolved at link time; they are never mutated.
+unsafe impl Sync for SymAddr {}
+
+/// Force the linker to retain all syscall symbols by referencing their addresses.
+#[used]
+static SYSCALL_SYMBOLS: [SymAddr; 129] = [
+    SymAddr(&raw const __errno_location),
+    SymAddr(&raw const _exit),
+    SymAddr(&raw const accept),
+    SymAddr(&raw const access),
+    SymAddr(&raw const bind),
+    SymAddr(&raw const chdir),
+    SymAddr(&raw const chown),
+    SymAddr(&raw const chroot),
+    SymAddr(&raw const clock_getres),
+    SymAddr(&raw const clock_gettime),
+    SymAddr(&raw const close),
+    SymAddr(&raw const closedir),
+    SymAddr(&raw const connect),
+    SymAddr(&raw const dirfd),
+    SymAddr(&raw const dup),
+    SymAddr(&raw const dup2),
+    SymAddr(&raw const execv),
+    SymAddr(&raw const execve),
+    SymAddr(&raw const faccessat),
+    SymAddr(&raw const fchdir),
+    SymAddr(&raw const fchown),
+    SymAddr(&raw const fchownat),
+    SymAddr(&raw const fcntl),
+    SymAddr(&raw const fdatasync),
+    SymAddr(&raw const fork),
+    SymAddr(&raw const fstat),
+    SymAddr(&raw const fsync),
+    SymAddr(&raw const ftruncate),
+    SymAddr(&raw const getcwd),
+    SymAddr(&raw const getegid),
+    SymAddr(&raw const getentropy),
+    SymAddr(&raw const geteuid),
+    SymAddr(&raw const getgid),
+    SymAddr(&raw const gethostname),
+    SymAddr(&raw const getpeername),
+    SymAddr(&raw const getpid),
+    SymAddr(&raw const getsockname),
+    SymAddr(&raw const getsockopt),
+    SymAddr(&raw const gettimeofday),
+    SymAddr(&raw const getuid),
+    SymAddr(&raw const isatty),
+    SymAddr(&raw const kill),
+    SymAddr(&raw const lchown),
+    SymAddr(&raw const link),
+    SymAddr(&raw const linkat),
+    SymAddr(&raw const listen),
+    SymAddr(&raw const lseek),
+    SymAddr(&raw const mmap),
+    SymAddr(&raw const mprotect),
+    SymAddr(&raw const munmap),
+    SymAddr(&raw const nanosleep),
+    SymAddr(&raw const open),
+    SymAddr(&raw const opendir),
+    SymAddr(&raw const pipe),
+    SymAddr(&raw const poll),
+    SymAddr(&raw const posix_fadvise),
+    SymAddr(&raw const posix_fallocate),
+    SymAddr(&raw const pread),
+    SymAddr(&raw const pthread_atfork),
+    SymAddr(&raw const pthread_attr_destroy),
+    SymAddr(&raw const pthread_attr_getstack),
+    SymAddr(&raw const pthread_attr_init),
+    SymAddr(&raw const pthread_attr_setstacksize),
+    SymAddr(&raw const pthread_cond_broadcast),
+    SymAddr(&raw const pthread_cond_destroy),
+    SymAddr(&raw const pthread_cond_init),
+    SymAddr(&raw const pthread_cond_signal),
+    SymAddr(&raw const pthread_cond_timedwait),
+    SymAddr(&raw const pthread_cond_wait),
+    SymAddr(&raw const pthread_condattr_init),
+    SymAddr(&raw const pthread_condattr_setclock),
+    SymAddr(&raw const pthread_create),
+    SymAddr(&raw const pthread_getattr_np),
+    SymAddr(&raw const pthread_getschedparam),
+    SymAddr(&raw const pthread_getspecific),
+    SymAddr(&raw const pthread_join),
+    SymAddr(&raw const pthread_key_create),
+    SymAddr(&raw const pthread_kill),
+    SymAddr(&raw const pthread_mutex_destroy),
+    SymAddr(&raw const pthread_mutex_init),
+    SymAddr(&raw const pthread_mutex_lock),
+    SymAddr(&raw const pthread_mutex_unlock),
+    SymAddr(&raw const pthread_rwlock_destroy),
+    SymAddr(&raw const pthread_rwlock_init),
+    SymAddr(&raw const pthread_rwlock_rdlock),
+    SymAddr(&raw const pthread_rwlock_unlock),
+    SymAddr(&raw const pthread_rwlock_wrlock),
+    SymAddr(&raw const pthread_self),
+    SymAddr(&raw const pthread_setcancelstate),
+    SymAddr(&raw const pthread_setspecific),
+    SymAddr(&raw const pthread_sigmask),
+    SymAddr(&raw const pwrite),
+    SymAddr(&raw const read),
+    SymAddr(&raw const readdir),
+    SymAddr(&raw const readlink),
+    SymAddr(&raw const readlinkat),
+    SymAddr(&raw const recv),
+    SymAddr(&raw const recvfrom),
+    SymAddr(&raw const recvmsg),
+    SymAddr(&raw const renameat),
+    SymAddr(&raw const rmdir),
+    SymAddr(&raw const sched_yield),
+    SymAddr(&raw const select),
+    SymAddr(&raw const sem_destroy),
+    SymAddr(&raw const sem_init),
+    SymAddr(&raw const sem_post),
+    SymAddr(&raw const sem_wait),
+    SymAddr(&raw const send),
+    SymAddr(&raw const sendmsg),
+    SymAddr(&raw const sendto),
+    SymAddr(&raw const setegid),
+    SymAddr(&raw const seteuid),
+    SymAddr(&raw const setgid),
+    SymAddr(&raw const setgroups),
+    SymAddr(&raw const setsockopt),
+    SymAddr(&raw const setuid),
+    SymAddr(&raw const shutdown),
+    SymAddr(&raw const sleep),
+    SymAddr(&raw const socket),
+    SymAddr(&raw const socketpair),
+    SymAddr(&raw const stat),
+    SymAddr(&raw const symlink),
+    SymAddr(&raw const symlinkat),
+    SymAddr(&raw const sysconf),
+    SymAddr(&raw const unlink),
+    SymAddr(&raw const unlinkat),
+    SymAddr(&raw const usleep),
+    SymAddr(&raw const waitpid),
+    SymAddr(&raw const write),
+];
+
+//==================================================================================================
 // Main Function
 //==================================================================================================
 

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -115,12 +115,6 @@ program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
 
-[[tests]]
-executor = "http"
-program = "./bin/c-bindings-rust.elf"
-input = "[]"
-expected_output = "ok"
-
 #===================================================================================================
 # Terminal Executor Tests (Interactive Mode)
 #===================================================================================================
@@ -190,11 +184,6 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
-expected_output = "ok"
-
-[[tests]]
-executor = "terminal"
-program = "./bin/c-bindings-rust.elf"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -114,12 +114,6 @@ program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
 
-[[tests]]
-executor = "http"
-program = "./bin/c-bindings-rust.elf"
-input = "[]"
-expected_output = "ok"
-
 #===================================================================================================
 # Terminal Executor Tests (Interactive Mode)
 #===================================================================================================
@@ -189,11 +183,6 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
-expected_output = "ok"
-
-[[tests]]
-executor = "terminal"
-program = "./bin/c-bindings-rust.elf"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test.toml
+++ b/test/test.toml
@@ -116,12 +116,6 @@ input = "[]"
 expected_output = "ok"
 runs_on = ["microvm"]            # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
-[[tests]]
-executor = "http"
-program = "./bin/c-bindings-rust.elf"
-input = "[]"
-expected_output = "ok"
-
 #===================================================================================================
 # Terminal Executor Tests (Interactive Mode)
 #===================================================================================================
@@ -194,8 +188,3 @@ executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
 runs_on = ["microvm"]            # FIXME: #1643 — kernel heap exhaustion under Hyperlight
-
-[[tests]]
-executor = "terminal"
-program = "./bin/c-bindings-rust.elf"
-expected_output = "ok"


### PR DESCRIPTION
## Summary

Fixes #2301.

Removes the `#[cfg(feature = "networking")]` gate from socket-related module declarations in the `syscall` crate, restoring `getsockname`, `getpeername`, `shutdown`, and all other socket symbols to `libposix.a` unconditionally.

Also adds a link-time regression test that prevents this class of bug from recurring.

## Root Cause

Commit e36befb15 ("[syscall] E: Gate networking modules", v0.12.533) added `#[cfg(feature = "networking")]` around the `sys::socket`, `sys::un`, `netinet`, and `arpa` modules. The `posix` crate (which produces `libposix.a`) did not enable this feature, so all socket C bindings were silently compiled out. The CI build never caught it because Cargo feature unification with `network-rust` (which enables `networking`) masked the absence when building in a batch.

## Changes

1. **Remove networking module gates** (`src/libs/syscall/src/lib.rs`, `src/libs/syscall/src/sys/mod.rs`)
   - Socket modules are now always compiled. The existing `#[cfg(feature = "standalone")]` gates inside each syscall function already return `ENOTSUP` when no IPC backend is available.

2. **Add link-time symbol presence test** (`src/tests/c-bindings-rust/src/main.rs`)
   - References all 129 `#[no_mangle] extern "C"` symbols via a `#[used]` static array, forcing the linker to resolve them.

3. **Isolate c-bindings-rust build** (`build/make/generic-guest-binaries.mk`)
   - Build `c-bindings-rust` in its own cargo invocation to prevent feature unification from masking missing symbols.

4. **Remove c-bindings-rust from runtime test configs** (`test/*.toml`)
   - The binary is a compile-time assertion; running it in the VM adds no coverage beyond printing "ok".

## Validation

- `./z build -- all` passes.
- `./z build -- all-guest-binaries-c-bindings-rust` passes (isolated build).
- Temporarily re-adding the `networking` gate causes immediate link failure with all expected undefined symbols.