### PR TITLE
[libs] Add `usage()` method to `Bitmap` and `SparseBitmap`

### DIFF
--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -216,6 +216,27 @@ impl Bitmap {
     ///
     /// # Description
     ///
+    /// Returns the number of bits currently set (allocated) in the bitmap.
+    ///
+    /// # Returns
+    ///
+    /// The number of set bits.
+    ///
+    #[verus_spec(result =>
+        requires
+            self.inv(),
+        ensures
+            result as int == self@.usage(),
+            0 <= result as int,
+            result as int <= self@.num_bits,
+    )]
+    pub fn usage(&self) -> usize {
+        self.usage
+    }
+
+    ///
+    /// # Description
+    ///
     /// Allocates a bit in the bitmap.
     ///
     /// # Returns

--- a/src/libs/sparse-bitmap/src/lib.rs
+++ b/src/libs/sparse-bitmap/src/lib.rs
@@ -364,6 +364,20 @@ impl SparseBitmap {
     ///
     /// # Description
     ///
+    /// Returns the total number of bits currently set (allocated) across
+    /// all chunks.
+    ///
+    /// # Returns
+    ///
+    /// The sum of per-chunk usage counts.
+    ///
+    pub fn usage(&self) -> usize {
+        self.chunks.iter().map(|c| c.bitmap.usage()).sum()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Locates the chunk whose covered range contains `index`, if any.
     /// Binary-searches the offset-sorted chunks in O(log n). Callers
     /// that only need a yes/no coverage answer can use


### PR DESCRIPTION
## Summary

Add a public `usage()` method to both `Bitmap` and `SparseBitmap` that returns the number of currently set (allocated) bits. `SparseBitmap` aggregates usage across all chunks.

These accessors enable callers to query allocator utilization without exposing internal fields.

## Motivation

Part of the physical memory allocator unification (#1270). The unified allocator needs `usage()` to compute free frame counts for watermark gating.

## PR Stack

This is **PR 1 of 4** in the kpool removal series:

1. **This PR** — `Bitmap::usage()` / `SparseBitmap::usage()` (no dependencies)
2. #TBD — Config: add `kernel_watermark` parameter (no dependencies)
3. #TBD — Identity-map infrastructure for dynamic kernel frames (no dependencies)
4. #2297 — Unify allocator: delete kpool, add kframe, watermark gating (depends on 1-3)

## Changes

- `src/libs/bitmap/src/lib.rs` — add `pub fn usage() -> usize`
- `src/libs/sparse-bitmap/src/lib.rs` — add `pub fn usage() -> usize`

## Testing

Purely additive, no behavioral change. Existing tests pass.