### PR TITLE
[config] Add `kernel_watermark` configuration parameter

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -31,6 +31,14 @@ kpool_size = 4194304
 # - Must not cause kpool_base + kpool_size to exceed memory_size.
 kpool_base = 0x00800000
 
+# Kernel watermark (in frames).
+# User-side allocations are rejected when fulfilling them would leave fewer than this many free
+# frames in the system. Kernel allocations are never gated by this watermark.
+# Constraints:
+# - Must be non-zero.
+# - Recommended: 32-64 frames (128-256 KB), sized to cover worst-case kernel cleanup operations.
+kernel_watermark = 64
+
 #==================================================================================================
 # Stack Configuration
 #==================================================================================================

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -119,6 +119,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kpool_base"), "kpool_base");
     constants.push_str(&format!("pub const KPOOL_BASE_RAW: usize = {val:#x};\n"));
 
+    let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "kernel_watermark"),
+        "kernel_watermark",
+    );
+    constants.push_str(&format!("pub const KERNEL_WATERMARK: usize = {val};\n"));
+
     let val: usize =
         parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kstack_size"), "kstack_size");
     constants.push_str(&format!("pub const KSTACK_SIZE: usize = {val};\n"));
@@ -285,6 +291,13 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         kredzone_size,
         WORD_SIZE,
     );
+
+    // kernel_watermark must be non-zero.
+    let kernel_watermark: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "kernel_watermark"),
+        "kernel_watermark",
+    );
+    assert!(kernel_watermark > 0, "kernel_watermark must be non-zero");
 
     // Write the generated file.
     fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");


### PR DESCRIPTION
## Summary

Add a `kernel_watermark` parameter to `kernel_config.toml` that defines the minimum number of free frames reserved for kernel use. The constant is generated in the config crate and validated non-zero at build time.

This is purely additive — existing `kpool_base` and `kpool_size` fields are preserved.

## Motivation

Part of the physical memory allocator unification (#1270). The unified allocator uses this watermark to gate user-side allocations: requests are rejected when fulfilling them would leave fewer than `KERNEL_WATERMARK` free frames. Kernel allocations bypass the watermark.

## PR Stack

This is **PR 2 of 4** in the kpool removal series:

1. #2305 — `Bitmap::usage()` / `SparseBitmap::usage()` (no dependencies)
2. **This PR** — Config: add `kernel_watermark` parameter (no dependencies)
3. #TBD — Identity-map infrastructure for dynamic kernel frames (no dependencies)
4. #2297 — Unify allocator: delete kpool, add kframe, watermark gating (depends on 1-3)

## Changes

- `build/kernel_config.toml` — add `kernel_watermark = 64`
- `src/libs/config/build.rs` — generate `KERNEL_WATERMARK` constant, add non-zero assertion

## Testing

Purely additive, no behavioral change. Existing tests pass.