### PR TITLE
[kernel] Widen identity-map visibility for dynamic kernel frames

### DIFF
--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -136,7 +136,7 @@ impl KernelStack {
     ///
     /// The size of the target kernel stack.
     ///
-    fn size(&self) -> usize {
+    pub(crate) fn size(&self) -> usize {
         config::kernel::KSTACK_SIZE
     }
 
@@ -153,7 +153,7 @@ impl KernelStack {
     ///
     /// As stacks grow downwards, the base address is the highest address of the stack.
     ///
-    fn base(&self) -> PageAligned<VirtualAddress> {
+    pub(crate) fn base(&self) -> PageAligned<VirtualAddress> {
         PageAligned::from_raw_value(self.kpages[0].base().into_raw_value()).unwrap()
     }
 
@@ -190,14 +190,18 @@ impl KernelStack {
         let guard_base: usize = self.kpages[0].base().into_raw_value();
         let word_count: usize = ::arch::mem::PAGE_SIZE / ::core::mem::size_of::<u32>();
         let guard_ptr: *mut u32 = guard_base as *mut u32;
-        for i in 0..word_count {
-            // SAFETY: The guard page is within allocated kernel memory and no other references
-            // to this memory exist at this point, so writing through a raw pointer derived from
-            // the page base address is sound.
-            unsafe {
-                guard_ptr.add(i).write_volatile(KSTACK_GUARD_PATTERN);
+        // Switch to the kernel address space so that the identity-mapped guard page
+        // is accessible even when CR3 points to a user page directory.
+        super::virt::with_kernel_address_space(|| {
+            for i in 0..word_count {
+                // SAFETY: The guard page is within allocated kernel memory and no other
+                // references to this memory exist at this point, so writing through a
+                // raw pointer derived from the page base address is sound.
+                unsafe {
+                    guard_ptr.add(i).write_volatile(KSTACK_GUARD_PATTERN);
+                }
             }
-        }
+        });
     }
 
     ///
@@ -243,17 +247,22 @@ impl KernelStack {
 fn check_guard_page(guard_base: usize) -> Result<(), Error> {
     let word_count: usize = ::arch::mem::PAGE_SIZE / ::core::mem::size_of::<u32>();
     let guard_ptr: *const u32 = guard_base as *const u32;
-    for i in 0..word_count {
-        // SAFETY: The caller guarantees that the guard page at `guard_base` is within valid
-        // kernel memory (either allocated kernel pages or the BSS section).
-        let val: u32 = unsafe { guard_ptr.add(i).read_volatile() };
-        if val != KSTACK_GUARD_PATTERN {
-            let reason: &str = "kernel stack guard watermark corrupted (possible stack overflow)";
-            error!("{}", reason);
-            return Err(Error::new(ErrorCode::BadAddress, reason));
+    // Switch to the kernel address space so that the identity-mapped guard page
+    // is accessible even when CR3 points to a user page directory.
+    super::virt::with_kernel_address_space(|| {
+        for i in 0..word_count {
+            // SAFETY: The caller guarantees that the guard page at `guard_base` is within valid
+            // kernel memory (either allocated kernel pages or the BSS section).
+            let val: u32 = unsafe { guard_ptr.add(i).read_volatile() };
+            if val != KSTACK_GUARD_PATTERN {
+                let reason: &str =
+                    "kernel stack guard watermark corrupted (possible stack overflow)";
+                error!("{}", reason);
+                return Err(Error::new(ErrorCode::BadAddress, reason));
+            }
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 ///

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -28,6 +28,9 @@ use ::arch::mem::{
     PAGE_ALIGNMENT,
     PGTAB_ALIGNMENT,
 };
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub(crate) use virt::propagate_kernel_pdes;
+pub(crate) use virt::with_kernel_address_space;
 pub use virt::{
     KernelPage,
     PageTableStorage,

--- a/src/kernel/src/mm/virt/identity_map.rs
+++ b/src/kernel/src/mm/virt/identity_map.rs
@@ -268,7 +268,7 @@ impl Drop for Cr3Guard {
 /// CR3-agnostic. If an interrupt fires while CR3 points to the kernel address space,
 /// the handler will execute in the kernel address space rather than the original one.
 ///
-fn with_kernel_address_space<F, R>(f: F) -> R
+pub(crate) fn with_kernel_address_space<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -529,6 +529,48 @@ fn ensure_pte(
 ///
 /// # Description
 ///
+/// Propagates the kernel PDE at `pde_idx` to the currently-active page directory (if it differs
+/// from the kernel PD and lacks that PDE). This enables kernel code running in a user address
+/// space to access identity-mapped memory without faulting.
+///
+fn propagate_pde_to_current_pd(kernel_pd_paddr: usize, pde_idx: TableIndex) -> Result<(), Error> {
+    // SAFETY: running in supervisor mode.
+    let current_cr3: Cr3Register = unsafe { Cr3Register::read() };
+    let current_pd_paddr: usize = current_cr3.paging_structure_base_address.address() as usize;
+
+    // Nothing to do if we're already in the kernel address space.
+    if current_pd_paddr == kernel_pd_paddr {
+        return Ok(());
+    }
+    if current_pd_paddr == 0 {
+        trace!("propagate_pde_to_current_pd(): CR3 is zero (early boot?), skipping");
+        return Ok(());
+    }
+
+    // Read the kernel PDE.
+    let kernel_pd: Table<PageDirectoryEntry> = unsafe { Table::from_address(kernel_pd_paddr) };
+    let kernel_pde: PageDirectoryEntry = unsafe { kernel_pd.read(pde_idx) }
+        .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "invalid PDE index"))?;
+
+    if !kernel_pde.is_present() {
+        return Ok(());
+    }
+
+    // Only propagate if the current PD doesn't already have a present PDE at this index.
+    let current_pd: Table<PageDirectoryEntry> = unsafe { Table::from_address(current_pd_paddr) };
+    let current_pde: PageDirectoryEntry = unsafe { current_pd.read(pde_idx) }
+        .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "invalid PDE index"))?;
+
+    if !current_pde.is_present() {
+        unsafe { current_pd.write(pde_idx, kernel_pde) };
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
 /// Identity-maps a single page in the kernel page directory.
 ///
 /// If the target PTE is already present, this function is a no-op. If the PDE is absent, a new
@@ -551,7 +593,7 @@ fn ensure_pte(
 ///
 /// If the lazy mapper has not been initialized yet (boot page tables still active), this function
 /// is a no-op and returns success.
-fn identity_map_page(phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Error> {
+pub(crate) fn identity_map_page(phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Error> {
     let phys_addr: usize = phys_addr.into_raw_value();
 
     let pd_paddr: usize = KERNEL_PD_PADDR.load(Ordering::Acquire);
@@ -567,7 +609,84 @@ fn identity_map_page(phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Erro
     let pd: Table<PageDirectoryEntry> = unsafe { Table::from_address(pd_paddr) };
     let pt_paddr: usize = ensure_pt(pd, pde_idx)?;
 
+    // Eagerly propagate the PDE to the currently-active page directory (if different from the
+    // kernel PD). This ensures that kernel code running in a user address space can immediately
+    // access the identity-mapped page without faulting.
+    propagate_pde_to_current_pd(pd_paddr, pde_idx)?;
+
     // SAFETY: the PT is identity-mapped (BSS-backed).
     let pt: Table<PageTableEntry> = unsafe { Table::from_address(pt_paddr) };
     ensure_pte(pt, pte_idx, phys_addr)
+}
+
+///
+/// # Description
+///
+/// Propagates kernel identity-mapping PDEs for the given physical address range into a target page
+/// directory. This ensures that the target PD (typically a user process PD) can access
+/// identity-mapped kernel memory (e.g., kernel stacks) without faulting.
+///
+/// For each page in `[start, start + size)`, copies the corresponding PDE from the kernel PD into
+/// the target PD if the kernel PD has a present PDE and the target PD does not.
+///
+/// # Parameters
+///
+/// - `target_pd_paddr`: Physical address of the target page directory.
+/// - `start`: Page-aligned start of the physical address range.
+/// - `size`: Size of the range in bytes (must be page-aligned and > 0).
+///
+/// # Returns
+///
+/// Upon success, `Ok(())`. Upon failure, an error is returned.
+///
+pub(crate) fn propagate_kernel_pdes(
+    target_pd_paddr: usize,
+    start: usize,
+    size: usize,
+) -> Result<(), Error> {
+    let kernel_pd_paddr: usize = KERNEL_PD_PADDR.load(Ordering::Acquire);
+    if kernel_pd_paddr == 0 {
+        return Ok(());
+    }
+
+    // SAFETY: both PDs are identity-mapped (BSS-backed or in kernel memory).
+    let kernel_pd: Table<PageDirectoryEntry> = unsafe { Table::from_address(kernel_pd_paddr) };
+    let target_pd: Table<PageDirectoryEntry> = unsafe { Table::from_address(target_pd_paddr) };
+
+    // Iterate over all PDE indices covered by [start, start + size).
+    let end: usize = start + size;
+    let mut addr: usize = start;
+    let mut last_pde_idx: Option<TableIndex> = None;
+
+    while addr < end {
+        let pde_idx: TableIndex = paging::pd_index(addr);
+
+        // Skip if we already processed this PDE index.
+        if last_pde_idx == Some(pde_idx) {
+            addr += mem::PAGE_SIZE;
+            continue;
+        }
+        last_pde_idx = Some(pde_idx);
+
+        // Read kernel PDE.
+        let kernel_pde: PageDirectoryEntry = unsafe { kernel_pd.read(pde_idx) }
+            .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "invalid PDE index"))?;
+
+        if !kernel_pde.is_present() {
+            addr += mem::PAGE_SIZE;
+            continue;
+        }
+
+        // Read target PDE — only propagate if not already present.
+        let target_pde: PageDirectoryEntry = unsafe { target_pd.read(pde_idx) }
+            .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "invalid PDE index"))?;
+
+        if !target_pde.is_present() {
+            unsafe { target_pd.write(pde_idx, kernel_pde) };
+        }
+
+        addr += mem::PAGE_SIZE;
+    }
+
+    Ok(())
 }

--- a/src/kernel/src/mm/virt/kpage.rs
+++ b/src/kernel/src/mm/virt/kpage.rs
@@ -5,6 +5,12 @@
 // Imports
 //==================================================================================================
 
+#[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+use crate::hal::mem::{
+    Address,
+    PageAligned,
+    VirtualAddress,
+};
 use crate::{
     hal::mem::PageAddress,
     mm::phys::KernelFrame,

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -19,15 +19,23 @@ pub(in crate::mm) use page_table_allocator::PAGE_TABLE_ALLOCATOR;
 mod vmem;
 
 #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub(crate) use identity_map::identity_map_page;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
 use identity_map::init as identity_map_init;
 #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
 pub(crate) use identity_map::memcpy;
 #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
-use identity_map::memset;
+pub(in crate::mm) use identity_map::memset;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub(crate) use identity_map::propagate_kernel_pdes;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub(crate) use identity_map::with_kernel_address_space;
 #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
 pub(crate) use no_identity_map::memcpy;
 #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
-use no_identity_map::memset;
+pub(in crate::mm) use no_identity_map::memset;
+#[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+pub(crate) use no_identity_map::with_kernel_address_space;
 
 //==================================================================================================
 // Imports

--- a/src/kernel/src/mm/virt/no_identity_map.rs
+++ b/src/kernel/src/mm/virt/no_identity_map.rs
@@ -127,3 +127,12 @@ pub(crate) fn memset(base: *mut u8, value: u8, size: usize) -> Result<(), Error>
 
     Ok(())
 }
+
+/// Executes a closure. On Hyperlight, the host-bootstrapped page tables are always active and the
+/// kernel does not manage its own CR3, so this is a trivial passthrough.
+pub(crate) fn with_kernel_address_space<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    f()
+}


### PR DESCRIPTION
## Summary

Expose identity-mapping helpers and add new functions needed by the unified physical memory allocator. This is preparatory infrastructure — no allocator behavior changes yet.

## Motivation

Part of the physical memory allocator unification (#1270). Once the kpool is removed, kernel frames can be allocated from any physical address. These frames must be identity-mapped before use, and their PDEs must be propagated into user page directories so that context switches don't fault.

## PR Stack

This is **PR 3 of 4** in the kpool removal series:

1. #2305 — `Bitmap::usage()` / `SparseBitmap::usage()` (no dependencies)
2. #2306 — Config: add `kernel_watermark` parameter (no dependencies)
3. **This PR** — Identity-map infrastructure for dynamic kernel frames (no dependencies)
4. #2297 — Unify allocator: delete kpool, add kframe, watermark gating (depends on 1-3)

> **Note:** CI will report dead-code warnings for `identity_map_page`, `propagate_kernel_pdes`, and `propagate_pde_to_current_pd` because their callers are introduced in PR 4. These warnings are expected and will resolve when the stack merges.

## Changes

### Visibility widening
- `identity_map_page` — `fn` → `pub(crate) fn`
- `with_kernel_address_space` — `fn` → `pub(crate) fn`
- `memset` — `use` → `pub(in crate::mm) use`
- `KernelStack::base()`, `KernelStack::size()` — `fn` → `pub(crate) fn`

### New functions
- `propagate_pde_to_current_pd()` — copies a kernel PDE into the active user PD
- `propagate_kernel_pdes()` — copies kernel PDEs for a physical address range into a target PD
- `with_kernel_address_space()` in `no_identity_map.rs` — no-op passthrough for hyperlight

### Behavioral changes
- `kstack.rs` — wraps guard-page write/check in `with_kernel_address_space()` so they work when CR3 points to a user PD

### Re-exports
- `mm::virt::mod.rs` — re-exports `identity_map_page`, `with_kernel_address_space`, `propagate_kernel_pdes`
- `mm::mod.rs` — re-exports `propagate_kernel_pdes`, `with_kernel_address_space`

## Testing

Guard-page operations are now wrapped in `with_kernel_address_space()` which is a no-op when already in the kernel address space — no behavioral change for existing code paths. Existing tests pass.