### PR TITLE
[tests] Remove hyperlight from tests

### DIFF
--- a/.github/skills/test-development/SKILL.md
+++ b/.github/skills/test-development/SKILL.md
@@ -38,7 +38,7 @@ Libraries with unit tests are listed in
 
 ### System Integration Tests
 
-System tests are available on `microvm` and `hyperlight` machines. On Linux, all deployment
+System tests are available on `microvm` machines. On Linux, all deployment
 modes are supported (`nanvixd` + kernel + guest). On Windows, only standalone mode is supported.
 
 ```bash

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -19,7 +19,7 @@ integration tests, and the combined test suite exposed through the `z` utility.
 ./z build -- run-unit-tests
 ```
 
-## System Integration Tests (microvm and hyperlight only)
+## System Integration Tests (microvm only)
 
 ```bash
 ./z build -- run-nanvix-tests
@@ -47,7 +47,7 @@ On Windows, unit tests can be run natively through `z.ps1`:
 ```
 
 System integration tests are also available on Windows for standalone mode
-(`DEPLOYMENT_MODE=standalone`) on both `microvm` and `hyperlight` machines:
+(`DEPLOYMENT_MODE=standalone`) on `microvm` machines:
 
 ```powershell
 .\z.ps1 build -- run-nanvix-tests

--- a/doc/test.md
+++ b/doc/test.md
@@ -11,7 +11,7 @@ This document guides you through testing Nanvix.
 - [Table of Contents](#table-of-contents)
 - [Running Full CI Pipeline](#running-full-ci-pipeline)
 - [Running Unit Tests](#running-unit-tests)
-- [Running System Integration Tests (MicroVM and Hyperlight Only)](#running-system-integration-tests-microvm-and-hyperlight-only)
+- [Running System Integration Tests (MicroVM Only)](#running-system-integration-tests-microvm-only)
   - [Test Modes](#test-modes)
 - [Running All Tests](#running-all-tests)
 
@@ -31,9 +31,9 @@ build parameters.
 ./z build -- run-unit-tests
 ```
 
-## Running System Integration Tests (MicroVM and Hyperlight Only)
+## Running System Integration Tests (MicroVM Only)
 
-> ℹ️ System integration tests are available on `microvm` and `hyperlight`
+> ℹ️ System integration tests are available on `microvm`
 machines on both Linux and Windows. On Windows, only standalone mode (`DEPLOYMENT_MODE=standalone`)
 is supported.
 
@@ -81,6 +81,5 @@ The `nanvix-test.elf` utility supports two execution modes:
 ./z build -- test
 ```
 
-On `microvm` and `hyperlight` machines,
 `./z build -- test` runs both unit tests and system
-integration tests. On other machines, only unit tests are executed.
+integration tests.

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -40,7 +40,6 @@ PADDING=60
 # Counters for passed and failed steps.
 passed_count=0
 failed_count=0
-skipped_count=0
 
 # Total elapsed time.
 total_elapsed_time=0
@@ -172,32 +171,6 @@ is_machine_independent() {
 
 #
 # Description
-#   Checks if a machine/deployment combination should be excluded.
-#
-# Arguments
-#   $1 - Machine type.
-#   $2 - Deployment type.
-#
-# Returns
-#   0 if excluded (should skip), 1 otherwise.
-#
-# Usage Example
-#   if is_excluded "hyperlight" "standalone"; then
-#
-is_excluded() {
-    local machine="${1}"
-    local deployment="${2}"
-
-    # Hyperlight does not support the -ramfs flag required by standalone mode.
-    if [[ "${machine}" == "hyperlight" ]] && [[ "${deployment}" == "standalone" ]]; then
-        return 0
-    fi
-
-    return 1
-}
-
-#
-# Description
 #   Runs a single pipeline step and reports the result.
 #
 # Arguments
@@ -310,12 +283,6 @@ main() {
     for build_type in "${BUILD_TYPES[@]}"; do
         for machine in "${MACHINE_TYPES[@]}"; do
             for deployment in "${DEPLOYMENT_TYPES[@]}"; do
-                # Check if this machine/deployment combination is excluded.
-                if is_excluded "${machine}" "${deployment}"; then
-                    ((++skipped_count))
-                    continue
-                fi
-
                 for step in "${STEP_TYPES[@]}"; do
                     # Check if this step is machine-independent.
                     if is_machine_independent "${step}"; then
@@ -341,7 +308,6 @@ main() {
     total_milliseconds=$((total_elapsed_time % 1000))
     print_info "(pipeline) Total Passed: ${passed_count}"
     print_info "(pipeline) Total Failed: ${failed_count}"
-    print_info "(pipeline) Total Skipped (excluded): ${skipped_count}"
     print_info "(pipeline) Total Time: ${total_seconds}.${total_milliseconds}s"
 
     # Exit with error if there are failed steps.

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -4,13 +4,13 @@
 # Licensed under the MIT License.
 
 #
-# Runs Nanvix via nanvixd (microvm / hyperlight).
+# Runs Nanvix via nanvixd (microvm).
 #
 # Usage:
 #   run-nanvixd.sh <machine> <image> [timeout] [--wait-for-string <string>]
 #
 # Arguments:
-#   machine  Machine type (microvm or hyperlight).
+#   machine  Machine type (microvm).
 #   image    Path to the multibin system image.
 #   timeout  Timeout in seconds (default: 120).
 #
@@ -103,9 +103,9 @@ function check_args
 {
 	# Validate machine type.
 	case "${MACHINE}" in
-		microvm | hyperlight) ;;
+		microvm) ;;
 		*)
-			print_error "Unsupported machine type: '${MACHINE}'. Expected 'microvm' or 'hyperlight'."
+			print_error "Unsupported machine type: '${MACHINE}'. Expected 'microvm'."
 			usage
 			;;
 	esac

--- a/test/test.toml
+++ b/test/test.toml
@@ -114,7 +114,7 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
-runs_on = ["microvm"]            # FIXME: #1643 — kernel heap exhaustion under Hyperlight
+runs_on = ["microvm"]
 
 #===================================================================================================
 # Terminal Executor Tests (Interactive Mode)
@@ -187,4 +187,4 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
-runs_on = ["microvm"]            # FIXME: #1643 — kernel heap exhaustion under Hyperlight
+runs_on = ["microvm"]


### PR DESCRIPTION
Drop hyperlight from the supported machine matrix, leaving microvm as the only machine type. The Rust-side hyperlight crate dependencies and feature gates are intentionally kept; this changeset targets only the scripting, CI pipeline, and documentation layers.

### Changes

- **pipeline.sh**: Remove `hyperlight` from `MACHINE_TYPES` array and delete the now-unnecessary `is_excluded()` function and its call-site.
- **run-nanvixd.sh**: Remove hyperlight from the accepted machine-type case branch and update usage text.
- **test.toml**: Remove FIXME comments referencing #1643 (kernel heap exhaustion under Hyperlight) since the hyperlight path no longer exists.
- **docs** (`test.md`, `test/SKILL.md`, `test-development/SKILL.md`): Update section headings and prose to reflect microvm-only support.