### PR TITLE
[utils] Remove hyperlight support from test and bench utilities

### DIFF
--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -37,7 +37,6 @@ standalone = ["nanvix/standalone", "nanvixd/standalone"]
 gdb = ["microvm", "nanvix/gdb"]
 # Enables fine-grained time profiling.
 profile-time = ["nanvixd/profile-time", "nanvix/profile-time"]
-hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 whp = ["nanvix/whp"]
 

--- a/src/utils/nanvix-test/Cargo.toml
+++ b/src/utils/nanvix-test/Cargo.toml
@@ -32,7 +32,6 @@ default = ["microvm", "multi-process"]
 single-process = ["nanvix/single-process", "nanvixd/single-process"]
 multi-process = ["nanvix/multi-process", "nanvixd/multi-process"]
 standalone = ["nanvix/standalone", "nanvixd/standalone"]
-hyperlight = ["nanvix/hyperlight", "nanvixd/hyperlight"]
 microvm = ["nanvix/microvm", "nanvixd/microvm"]
 whp = ["nanvix/whp", "nanvixd/whp"]
 

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -8,10 +8,7 @@
 use crate::{
     DEFAULT_TENANT_ID,
     config::RunnerConfig,
-    executor::{
-        DEFAULT_EXIT_CODE_SKIP_VALIDATION,
-        WorkloadSpec,
-    },
+    executor::WorkloadSpec,
     log_layout::{
         GuestLogTracker,
         RunnerLogPaths,
@@ -176,45 +173,10 @@ pub(crate) async fn test_with_http_executor(
             log_layout.persist_program_output(iteration, payload.as_slice())?;
 
             // Explicitly terminate the User VM to get the exit code.
-            // FIXME (#1010): On hyperlight, SIGKILL terminates nanvixd before we can send the kill
-            // request, causing a connection error. When skip_exit_code_validation is true, we
-            // tolerate termination failures since we cannot reliably get the exit code anyway.
-            let exit_code: i32 = match user_vm.terminate().await {
-                Ok(code) => code,
-                Err(error) => {
-                    if workload.skip_exit_code_validation() {
-                        warn!(
-                            "test_with_http_executor(): termination failed but skipping \
-                             validation (program={}, iteration={}, error={})",
-                            program_path, iteration, error
-                        );
-                        DEFAULT_EXIT_CODE_SKIP_VALIDATION
-                    } else {
-                        return Err(error);
-                    }
-                },
-            };
+            let exit_code: i32 = user_vm.terminate().await?;
 
-            // Validate exit code unless skip_exit_code_validation() is set.
-            // FIXME (#1010): Remove skip_exit_code_validation() once graceful hyperlight interrupt
-            // is implemented. Currently hyperlight uses SIGKILL which prevents clean exit.
-            if !workload.skip_exit_code_validation() && exit_code != workload.expected_exit_code() {
-                let expected: i32 = workload.expected_exit_code();
-                let reason: String = format!(
-                    "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
-                    expected, exit_code, program_path, iteration
-                );
-                error!("test_with_http_executor(): {reason}");
-                return Err(::anyhow::anyhow!(reason));
-            }
-
-            // When termination succeeds on hyperlight, still validate the exit code
-            // — but only if the test explicitly declared an expected exit code.
-            if workload.skip_exit_code_validation()
-                && exit_code != DEFAULT_EXIT_CODE_SKIP_VALIDATION
-                && workload.has_explicit_expected_exit_code()
-                && exit_code != workload.expected_exit_code()
-            {
+            // Validate exit code.
+            if exit_code != workload.expected_exit_code() {
                 let expected: i32 = workload.expected_exit_code();
                 let reason: String = format!(
                     "exit code mismatch (expected={}, actual={}, program={}, iteration={})",

--- a/src/utils/nanvix-test/src/executor/mod.rs
+++ b/src/utils/nanvix-test/src/executor/mod.rs
@@ -17,17 +17,6 @@ pub mod terminal;
 use ::anyhow::Result;
 
 //==================================================================================================
-// Constants
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Exit code used when we failed to retrieve the exit code and need to skip validation.
-///
-const DEFAULT_EXIT_CODE_SKIP_VALIDATION: i32 = -2;
-
-//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -74,15 +63,6 @@ pub struct WorkloadSpec<'a> {
     /// Optional expected exit code that the workload must produce.
     ///
     expected_exit_code: Option<i32>,
-    ///
-    /// # Description
-    ///
-    /// Indicates whether exit code validation should be skipped. This is used on hyperlight where
-    /// the User VM is terminated via SIGKILL and cannot reliably report exit codes.
-    ///
-    /// FIXME (#1010): Remove this workaround once graceful hyperlight interrupt is implemented.
-    ///
-    skip_exit_code_validation: bool,
 }
 
 impl<'a> WorkloadSpec<'a> {
@@ -100,7 +80,6 @@ impl<'a> WorkloadSpec<'a> {
     /// - `expect_empty_output`: Indicates whether the workload should produce an empty stdout
     ///   payload.
     /// - `expected_exit_code`: Optional exit code that the workload must produce.
-    /// - `skip_exit_code_validation`: Indicates whether exit code validation should be skipped.
     ///
     /// # Return Value
     ///
@@ -112,7 +91,6 @@ impl<'a> WorkloadSpec<'a> {
         expected_output: Option<&'a str>,
         expect_empty_output: bool,
         expected_exit_code: Option<i32>,
-        skip_exit_code_validation: bool,
     ) -> Self {
         Self {
             program_path,
@@ -121,7 +99,6 @@ impl<'a> WorkloadSpec<'a> {
             expected_output,
             expect_empty_output,
             expected_exit_code,
-            skip_exit_code_validation,
         }
     }
 
@@ -200,32 +177,6 @@ impl<'a> WorkloadSpec<'a> {
             None => 0,
         }
     }
-
-    ///
-    /// # Description
-    ///
-    /// Returns `true` when the test explicitly declared an expected exit code.
-    ///
-    /// # Return Value
-    ///
-    /// Returns `true` if `expected_exit_code` was set in the test configuration; otherwise `false`.
-    ///
-    pub const fn has_explicit_expected_exit_code(&self) -> bool {
-        self.expected_exit_code.is_some()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Indicates whether exit code validation should be skipped.
-    ///
-    /// # Return Value
-    ///
-    /// Returns `true` if exit code validation should be skipped; otherwise returns `false`.
-    ///
-    pub const fn skip_exit_code_validation(&self) -> bool {
-        self.skip_exit_code_validation
-    }
 }
 
 //==================================================================================================
@@ -295,50 +246,27 @@ mod tests {
     #[test]
     fn workload_spec_expected_exit_code_some() {
         let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(0), false);
+            WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(0));
         assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_none() {
-        let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, false, None, false);
+        let spec: WorkloadSpec = WorkloadSpec::new("./bin/test.elf", None, None, None, false, None);
         assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_nonzero() {
         let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(13), false);
+            WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(13));
         assert_eq!(spec.expected_exit_code(), 13);
-    }
-
-    #[test]
-    fn workload_spec_skip_exit_code_validation() {
-        let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(0), true);
-        assert!(spec.skip_exit_code_validation());
-        assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_negative() {
         let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, false, Some(-1), false);
+            WorkloadSpec::new("./bin/test.elf", None, None, None, false, Some(-1));
         assert_eq!(spec.expected_exit_code(), -1);
-    }
-
-    #[test]
-    fn workload_spec_has_explicit_expected_exit_code_some() {
-        let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, false, Some(0), false);
-        assert!(spec.has_explicit_expected_exit_code());
-    }
-
-    #[test]
-    fn workload_spec_has_explicit_expected_exit_code_none() {
-        let spec: WorkloadSpec =
-            WorkloadSpec::new("./bin/test.elf", None, None, None, false, None, false);
-        assert!(!spec.has_explicit_expected_exit_code());
     }
 }

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     config::RunnerConfig,
-    executor::{
-        DEFAULT_EXIT_CODE_SKIP_VALIDATION,
-        WorkloadSpec,
-    },
+    executor::WorkloadSpec,
     log_layout::{
         GuestLogTracker,
         RunnerLogPaths,
@@ -213,26 +210,7 @@ pub async fn test_with_terminal_executor(
         .await?;
 
         // Wait for the nanvixd process to exit and get its exit code.
-        // FIXME (#1010): On hyperlight, SIGKILL terminates nanvixd without a clean exit, causing
-        // wait_exit_code() to fail. When skip_exit_code_validation is true, we tolerate this
-        // failure since we cannot reliably get the exit code anyway.
-        let exit_code: i32 = match nanvixd.wait_exit_code().await {
-            Ok(code) => code,
-            Err(error) => {
-                if workload.skip_exit_code_validation() {
-                    warn!(
-                        "test_with_terminal_executor(): wait_exit_code failed but skipping \
-                         validation (program={}, iteration={}, error={})",
-                        workload.program_path(),
-                        iteration,
-                        error
-                    );
-                    DEFAULT_EXIT_CODE_SKIP_VALIDATION
-                } else {
-                    return Err(error);
-                }
-            },
-        };
+        let exit_code: i32 = nanvixd.wait_exit_code().await?;
 
         if let Err(error) = write(&stdout_file_path, &stdout_bytes) {
             let reason: String = format!(
@@ -275,29 +253,8 @@ pub async fn test_with_terminal_executor(
             return Err(::anyhow::anyhow!(reason));
         }
 
-        // Validate exit code unless skip_exit_code_validation() is set.
-        // FIXME (#1010): Remove skip_exit_code_validation() once graceful hyperlight interrupt
-        // is implemented. Currently hyperlight uses SIGKILL which prevents clean exit.
-        if !workload.skip_exit_code_validation() && exit_code != workload.expected_exit_code() {
-            let expected: i32 = workload.expected_exit_code();
-            let reason: String = format!(
-                "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
-                expected,
-                exit_code,
-                workload.program_path(),
-                iteration
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        }
-
-        // When wait_exit_code succeeds on hyperlight, still validate the exit code
-        // — but only if the test explicitly declared an expected exit code.
-        if workload.skip_exit_code_validation()
-            && exit_code != DEFAULT_EXIT_CODE_SKIP_VALIDATION
-            && workload.has_explicit_expected_exit_code()
-            && exit_code != workload.expected_exit_code()
-        {
+        // Validate exit code.
+        if exit_code != workload.expected_exit_code() {
             let expected: i32 = workload.expected_exit_code();
             let reason: String = format!(
                 "exit code mismatch (expected={}, actual={}, program={}, iteration={})",

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -243,10 +243,7 @@ async fn run() -> Result<()> {
     .await;
     warning::fail_if_triggered("prepare_runner_environment")?;
 
-    // Detect machine type at compile time based on enabled Cargo features.
-    #[cfg(feature = "hyperlight")]
-    let machine: &str = "hyperlight";
-    #[cfg(feature = "microvm")]
+    // Machine type used for filtering tests.
     let machine: &str = "microvm";
 
     for test_config in selected_tests {
@@ -361,7 +358,6 @@ async fn run() -> Result<()> {
                     expected_output.as_deref(),
                     expect_empty_output,
                     expected_exit_code,
-                    machine == "hyperlight",
                 );
 
                 test_with_http_executor(
@@ -415,7 +411,6 @@ async fn run() -> Result<()> {
                     expected_output.as_deref(),
                     expect_empty_output,
                     expected_exit_code,
-                    machine == "hyperlight",
                 );
 
                 test_with_terminal_executor(

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -32,7 +32,6 @@ standalone = ["nanvix/standalone"]
 gdb = ["nanvix/gdb"]
 # Enables fine-grained time profiling.
 profile-time = ["nanvix/profile-time"]
-hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 whp = ["nanvix/whp"]
 

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -328,7 +328,7 @@ async fn async_main() -> Result<ExitCode> {
 /// # Parameters
 ///
 /// - `args`: The parsed command-line arguments.
-/// - `machine`: The target machine type (e.g., `"microvm"`, `"hyperlight"`).
+/// - `machine`: The target machine type (e.g., `"microvm"`).
 /// - `deployment`: The deployment type (e.g., `"single-process"`, `"multi-process"`).
 ///
 /// # Returns


### PR DESCRIPTION
Remove all hyperlight-specific code paths, features, and workarounds
from nanvix-test, nanvix-bench, and nanvixd:

- Remove the `hyperlight` Cargo feature from nanvix-test, nanvix-bench,
  and nanvixd.
- Remove `skip_exit_code_validation` field and
  `has_explicit_expected_exit_code()` method from `WorkloadSpec`.
- Remove `DEFAULT_EXIT_CODE_SKIP_VALIDATION` constant.
- Simplify exit-code validation in both HTTP and terminal executors to a
  single unconditional check, replacing the dual-path logic that
  tolerated termination failures on hyperlight.
- Remove compile-time `#[cfg(feature = "hyperlight")]` machine-type
  detection in nanvix-test; `machine` is now unconditionally `"microvm"`.
- Drop the `machine == "hyperlight"` argument from `WorkloadSpec::new()`
  call sites.
- Remove associated unit tests and update remaining tests to match the
  simplified constructor signature.
- Update nanvixd doc comment to reflect the removal.

This eliminates all FIXME #1010 workarounds that were added for
hyperlight's SIGKILL-based termination behavior.