### PR TITLE
[linuxd] Fallible `SyscallTable::new()`

### DIFF
--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -108,7 +108,7 @@ pub async fn main() -> Result<()> {
     info!("Listening to user VMs on: {user_vm_sockaddr:?}");
 
     let linuxd: LinuxDaemon<()> = match LinuxDaemon::init(
-        Arc::new(SyscallTable::default()),
+        Arc::new(SyscallTable::new(())?),
         tenant_id.as_deref().unwrap_or_default(),
         control_plane_sockaddr,
         args.control_plane_socket_type(),

--- a/src/daemons/linuxd/src/syscalls.rs
+++ b/src/daemons/linuxd/src/syscalls.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use ::net_backend::NetBackend;
+use ::net_backend::{
+    error::NetError,
+    NetBackend,
+};
 
 //==================================================================================================
 // Function Type Aliases
@@ -1400,15 +1403,18 @@ impl<T> SyscallTable<T> {
     ///
     /// # Returns
     ///
-    /// A new syscall table.
+    /// Upon success, a new syscall table is returned. Upon failure, a `NetError` is returned.
     ///
-    pub fn new(state: T) -> Self {
-        Self {
+    /// # Errors
+    ///
+    /// Returns `NetError` if platform networking initialization fails.
+    ///
+    pub fn new(state: T) -> Result<Self, NetError> {
+        Ok(Self {
             state,
 
             // Networking backend.
-            net_backend: NetBackend::new()
-                .expect("platform networking initialization should succeed"),
+            net_backend: NetBackend::new()?,
 
             // unistd.rs system calls.
             chdir: SyscallAction::Forward(default_chdir),
@@ -1461,12 +1467,6 @@ impl<T> SyscallTable<T> {
 
             // times.rs system calls.
             times: SyscallAction::Forward(default_times),
-        }
-    }
-}
-
-impl Default for SyscallTable<()> {
-    fn default() -> Self {
-        Self::new(())
+        })
     }
 }

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/linuxd.rs
@@ -132,9 +132,18 @@ impl LinuxDaemon {
 
         // Create a new Linux Daemon instance.
         let syscall_table: ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>> =
-            args.syscall_table().unwrap_or_else(|| {
-                ::std::sync::Arc::new(::linuxd::syscalls::SyscallTable::new(T::default()))
-            });
+            match args.syscall_table() {
+                Some(table) => table,
+                None => {
+                    let table: ::linuxd::syscalls::SyscallTable<T> =
+                        ::linuxd::syscalls::SyscallTable::new(T::default()).map_err(|e| {
+                            let reason: &str = "failed to initialize syscall table";
+                            error!("spawn(): {reason} (error={e:?})");
+                            anyhow::Error::new(e).context(reason)
+                        })?;
+                    ::std::sync::Arc::new(table)
+                },
+            };
 
         let linuxd: EmbeddedLinuxd<T> = EmbeddedLinuxd::init(
             syscall_table,
@@ -145,8 +154,9 @@ impl LinuxDaemon {
             args.l2(),
         )
         .map_err(|e| {
-            error!("spawn(): failed to initialize linuxd (error={e:?})");
-            anyhow::anyhow!("failed to initialize linuxd")
+            let reason: &str = "failed to initialize linuxd";
+            error!("spawn(): {reason} (error={e:?})");
+            anyhow::anyhow!("{reason}")
         })?;
 
         // Spawn a task to run the Linux Daemon.

--- a/src/libs/net-backend/src/error.rs
+++ b/src/libs/net-backend/src/error.rs
@@ -19,3 +19,14 @@ pub enum NetError {
     /// The operation failed with a specific error code.
     Errno(ErrorCode),
 }
+
+impl core::fmt::Display for NetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NetError::Interrupted => write!(f, "operation interrupted (EINTR)"),
+            NetError::Errno(code) => write!(f, "network error: {code}"),
+        }
+    }
+}
+
+impl std::error::Error for NetError {}


### PR DESCRIPTION
## Summary

Follow-up to #2315. Changes `SyscallTable::new()` to return `Result<Self, NetError>` instead of panicking via `.expect()` when platform networking initialization fails.

## Changes

- **syscalls.rs**: Change `new()` signature to `Result<Self, NetError>`. Remove `Default` impl since `new()` is now fallible.
- **error.rs**: Implement `Display` and `std::error::Error` for `NetError` so it integrates with `anyhow` error chains.
- **main.rs**: Replace `SyscallTable::default()` with `SyscallTable::new(())?` to propagate initialization errors.
- **linuxd.rs** (nanvix-sandbox): Replace `unwrap_or_else` closure with `match` + `map_err` to propagate errors via `?`.

## Motivation

The reviewer on #2315 flagged that `SyscallTable::new()` should not panic on `NetBackend::new()` failure. This PR propagates the error to callers, which already use `anyhow::Result` and can handle it gracefully.

## Testing

- All 46 `net-backend` unit tests pass.
- Full workspace build passes on Windows.
- Pre-commit checks pass.