### PR TITLE
[ci] Detect offline runners and migrate jobs to GitHub-hosted

### DIFF
--- a/.github/actions/check-runners/action.yml
+++ b/.github/actions/check-runners/action.yml
@@ -1,0 +1,81 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Check Self-Hosted Runners"
+description: "Check whether self-hosted runners matching a given OS and name
+  prefix are online.  Call once per OS to get per-platform availability."
+
+# NOTE: The /repos/{owner}/{repo}/actions/runners endpoint requires the
+# 'administration:read' permission, which is NOT available to the default
+# GITHUB_TOKEN.  If the call fails (403), the action conservatively assumes
+# runners are available and outputs 'true'.  To enable automatic
+# skip-when-offline behaviour, store a fine-grained PAT with
+# 'Administration: Read' as the RUNNER_ADMIN_TOKEN secret and pass it via
+# the github-token input.
+
+inputs:
+  github-token:
+    description: "Token with administration:read scope for listing runners.
+      Falls back to assuming runners are available when the token lacks
+      sufficient permissions."
+    required: true
+  os:
+    description: "Runner OS label to match (e.g. 'Linux' or 'Windows')."
+    required: true
+  runner-name-prefix:
+    description: "Only consider runners whose name starts with this prefix
+      (e.g. 'Prometheus').  Leave empty to consider all self-hosted runners."
+    required: false
+    default: ""
+
+outputs:
+  available:
+    description: "'true' if at least one matching self-hosted runner is online, 'false' otherwise"
+    value: ${{ steps.check.outputs.available }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Check Runner Availability"
+      id: check
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        CHECK_OS: ${{ inputs.os }}
+        RUNNER_NAME_PREFIX: ${{ inputs.runner-name-prefix }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        org="${GITHUB_REPOSITORY_OWNER}"
+        api_err_file=$(mktemp)
+
+        # Try org-level runners first (most common for shared self-hosted
+        # runners), then fall back to repo-level.
+        if runners_json=$(gh api --paginate "orgs/${org}/actions/runners" 2>"${api_err_file}"); then
+          echo "Queried org-level runners for '${org}'."
+        elif runners_json=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runners" 2>"${api_err_file}"); then
+          echo "Queried repo-level runners for '${GITHUB_REPOSITORY}'."
+        else
+          api_err=$(cat "${api_err_file}")
+          echo "::warning::Could not query runner status (${api_err:-unknown error}) — assuming runners are available."
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          rm -f "${api_err_file}"
+          exit 0
+        fi
+        rm -f "${api_err_file}"
+
+        count=$(echo "${runners_json}" | jq --arg os "${CHECK_OS}" --arg prefix "${RUNNER_NAME_PREFIX}" \
+          '[ .runners[]
+            | select(
+                .status == "online"
+                and (.labels | map(.name) | contains(["self-hosted", $os]))
+                and ($prefix == "" or (.name | startswith($prefix)))
+              )
+          ] | length')
+        if [ "${count}" -gt 0 ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "${CHECK_OS} self-hosted runners online: ${count}"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::No ${CHECK_OS} self-hosted runners are online — dependent jobs will be skipped."
+        fi

--- a/.github/actions/setup-kvm/action.yml
+++ b/.github/actions/setup-kvm/action.yml
@@ -11,6 +11,22 @@ runs:
       shell: bash
       run: |
         echo "[INFO] Configuring KVM access..."
-        sudo usermod -aG kvm "$(whoami)"
-        sudo chmod 666 /dev/kvm
+        if [[ ! -e /dev/kvm ]]; then
+          echo "::error::/dev/kvm not found — KVM is not available."
+          exit 1
+        fi
+        # In containers we typically run as root and sudo/usermod may not
+        # be available.  Only adjust permissions when needed.
+        if [[ -w /dev/kvm ]]; then
+          echo "[INFO] /dev/kvm is already writable — no changes needed."
+        elif command -v sudo &>/dev/null; then
+          sudo chmod 666 /dev/kvm
+          echo "[INFO] Set /dev/kvm permissions via sudo."
+        else
+          chmod 666 /dev/kvm 2>/dev/null || {
+            echo "::error::Cannot make /dev/kvm writable (no sudo, chmod failed)."
+            exit 1
+          }
+          echo "[INFO] Set /dev/kvm permissions directly."
+        fi
         echo "[INFO] KVM is ready."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,37 @@ jobs:
     uses: nanvix/nanvix/.github/workflows/branch-up-to-date.yml@dev
     secrets: inherit
 
+  # Check whether self-hosted runners are online so that benchmark jobs can be
+  # gracefully skipped when no runners are available instead of queuing
+  # indefinitely.  See .github/actions/check-runners/action.yml for details.
+  check-runners:
+    name: "Check Self-Hosted Runners"
+    if: github.repository == 'nanvix/nanvix'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      benchmark-linux: ${{ steps.check-linux.outputs.available }}
+      benchmark-windows: ${{ steps.check-windows.outputs.available }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Check Linux Runners"
+        id: check-linux
+        uses: ./.github/actions/check-runners
+        with:
+          github-token: ${{ secrets.RUNNER_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          os: "Linux"
+          runner-name-prefix: "prometheus"
+
+      - name: "Check Windows Runners"
+        id: check-windows
+        uses: ./.github/actions/check-runners
+        with:
+          github-token: ${{ secrets.RUNNER_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          os: "Windows"
+          runner-name-prefix: "WIN"
+
   # ==========================================================================================
   # Stage 1: Source Checks (GitHub-Hosted Runners)
   # ==========================================================================================
@@ -345,42 +376,26 @@ jobs:
           '["release"]') }}
         machine-type: [ microvm ]
         deployment-type: [ standalone, single-process, multi-process ]
-    runs-on:
-      group: Test
-      labels: [ self-hosted, Linux ]
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
+      options: --privileged
     permissions:
       contents: read
+      packages: read
+    env:
+      # The CI container runs as root without USER set; nanvixd uses it as
+      # fallback tenant-id and fails when the variable is missing.
+      USER: root
 
     steps:
-      - name: "Pre-Checkout Cleanup"
-        shell: bash
-        run: |
-          # Previous runs may leave root-owned files that prevent
-          # actions/checkout from resetting the workspace. The cleanup
-          # composite action cannot run before checkout, so perform a direct cleanup
-          # of the images directory without executing any workspace scripts.
-          if [[ -d "${GITHUB_WORKSPACE}/images" ]]; then
-            echo "Removing images directory before checkout..."
-            sudo rm -rf "${GITHUB_WORKSPACE}/images"
-          fi
-
       - uses: actions/checkout@v6
 
-      - name: "Isolate Cargo Home"
-        shell: bash
-        run: |
-          # Isolate Cargo home per job to prevent concurrent git-cache races on
-          # self-hosted runners that share the same filesystem.  Symlink the
-          # toolchain bin/ directory so that the Makefile can still resolve
-          # $CARGO_HOME/bin/cargo.
-          mkdir -p "$RUNNER_TEMP/.cargo"
-          ln -sfn "$HOME/.cargo/bin" "$RUNNER_TEMP/.cargo/bin"
-          echo "CARGO_HOME=$RUNNER_TEMP/.cargo" >> "$GITHUB_ENV"
+      - name: "Setup"
+        uses: ./.github/actions/native-setup
 
-      - name: "Pre-Cleanup Dangling Resources"
-        uses: ./.github/actions/cleanup
-        with:
-          phase: pre
+      - name: "Setup KVM"
+        uses: ./.github/actions/setup-kvm
 
       - name: "Prepare Test Artifacts"
         uses: ./.github/actions/prepare-test-artifacts
@@ -396,9 +411,6 @@ jobs:
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
 
-      - name: "Link Toolchain"
-        uses: ./.github/actions/link-toolchain
-
       - name: "Shim Integration Test"
         shell: bash
         env:
@@ -408,12 +420,6 @@ jobs:
           echo "Running shim integration tests with NANVIX_DIR=${NANVIX_DIR}"
           cargo test --locked --no-default-features \
             -p containerd-shim-nanvix-v1 --test integration -- --nocapture --test-threads=1
-
-      - name: "Post-Cleanup Dangling Resources"
-        if: always()
-        uses: ./.github/actions/cleanup
-        with:
-          phase: post
 
       - name: "Upload logs in case of failures"
         if: failure() || cancelled()
@@ -783,7 +789,7 @@ jobs:
   # A finalize job aggregates results after the benchmark completes.
   benchmark:
     name: "Benchmark (${{ matrix.machine-type }})"
-    needs: [ precheck ]
+    needs: [ precheck, check-runners ]
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -804,8 +810,10 @@ jobs:
       contents: read
 
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # Skips gracefully when check-runners reports no Linux self-hosted runners.
     if: |
       !cancelled() &&
+      needs.check-runners.outputs.benchmark-linux != 'false' &&
       github.repository == 'nanvix/nanvix' && (
         github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
@@ -942,7 +950,7 @@ jobs:
   # exclusion steps are omitted.
   windows-benchmark:
     name: "Windows Benchmark (${{ matrix.machine-type }})"
-    needs: [ precheck ]
+    needs: [ precheck, check-runners ]
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -959,10 +967,12 @@ jobs:
       contents: read
 
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # Skips gracefully when check-runners reports no Windows self-hosted runners.
     # Fork PRs are excluded to prevent untrusted code from running on
     # self-hosted runners.
     if: |
       !cancelled() &&
+      needs.check-runners.outputs.benchmark-windows != 'false' &&
       github.repository == 'nanvix/nanvix' && (
         github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
@@ -1298,16 +1308,22 @@ jobs:
   release-archive:
     name: "Release Archive (${{ matrix.target-arch }}, ${{ matrix.machine-type }},
       ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
-    needs: [ ci-test, benchmark-finalize, windows-benchmark-finalize ]
+    needs: [ ci-test, benchmark-finalize, windows-benchmark-finalize, check-runners ]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # Benchmark finalize may be skipped when self-hosted runners are offline;
+    # release proceeds if check-runners confirmed no runners were available.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
-      needs.benchmark-finalize.result == 'success' &&
-      needs.windows-benchmark-finalize.result == 'success'
+      (needs.benchmark-finalize.result == 'success' ||
+        (needs.benchmark-finalize.result == 'skipped' &&
+          needs.check-runners.outputs.benchmark-linux == 'false')) &&
+      (needs.windows-benchmark-finalize.result == 'success' ||
+        (needs.windows-benchmark-finalize.result == 'skipped' &&
+          needs.check-runners.outputs.benchmark-windows == 'false'))
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1358,16 +1374,23 @@ jobs:
         ci-test,
         benchmark-finalize,
         windows-benchmark-finalize,
+        check-runners,
       ]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # Benchmark finalize may be skipped when self-hosted runners are offline;
+    # release proceeds if check-runners confirmed no runners were available.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
-      needs.benchmark-finalize.result == 'success' &&
-      needs.windows-benchmark-finalize.result == 'success' &&
+      (needs.benchmark-finalize.result == 'success' ||
+        (needs.benchmark-finalize.result == 'skipped' &&
+          needs.check-runners.outputs.benchmark-linux == 'false')) &&
+      (needs.windows-benchmark-finalize.result == 'success' ||
+        (needs.windows-benchmark-finalize.result == 'skipped' &&
+          needs.check-runners.outputs.benchmark-windows == 'false')) &&
       needs.windows-integration-test.result == 'success'
     timeout-minutes: 60
     strategy:
@@ -1426,25 +1449,12 @@ jobs:
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.release-archive.result == 'success' &&
       needs.windows-release-archive.result == 'success'
-    runs-on:
-      group: Test
-      labels: [ self-hosted, Linux ]
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: "Isolate Cargo Home"
-        shell: bash
-        run: |
-          # Isolate Cargo home per job to prevent concurrent git-cache races on
-          # self-hosted runners that share the same filesystem.  Symlink the
-          # toolchain bin/ directory so that the Makefile can still resolve
-          # $CARGO_HOME/bin/cargo.
-          mkdir -p "$RUNNER_TEMP/.cargo"
-          ln -sfn "$HOME/.cargo/bin" "$RUNNER_TEMP/.cargo/bin"
-          echo "CARGO_HOME=$RUNNER_TEMP/.cargo" >> "$GITHUB_ENV"
 
       - name: "Publish Release"
         uses: ./.github/actions/publish-release
@@ -1465,6 +1475,7 @@ jobs:
         benchmark-finalize,
         windows-benchmark,
         windows-benchmark-finalize,
+        check-runners,
         release-archive,
         windows-release-archive,
         publish-release,

--- a/src/libs/nanvix-terminal/src/multi_process.rs
+++ b/src/libs/nanvix-terminal/src/multi_process.rs
@@ -361,6 +361,14 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
     fn get_current_user_name() -> Result<String> {
         let username: String = ::std::env::var("USER")
             .or_else(|_| ::std::env::var("USERNAME"))
+            .or_else(|_| {
+                ::std::process::Command::new("whoami")
+                    .output()
+                    .ok()
+                    .and_then(|o| String::from_utf8(o.stdout).ok())
+                    .map(|s| s.trim().to_string())
+                    .ok_or(::std::env::VarError::NotPresent)
+            })
             .map_err(|error| ::anyhow::anyhow!("failed to get current user name: {}", error))?;
         Ok(username)
     }

--- a/src/libs/nanvix-terminal/src/single_process.rs
+++ b/src/libs/nanvix-terminal/src/single_process.rs
@@ -353,6 +353,14 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
     fn get_current_user_name() -> Result<String> {
         let username: String = ::std::env::var("USER")
             .or_else(|_| ::std::env::var("USERNAME"))
+            .or_else(|_| {
+                ::std::process::Command::new("whoami")
+                    .output()
+                    .ok()
+                    .and_then(|o| String::from_utf8(o.stdout).ok())
+                    .map(|s| s.trim().to_string())
+                    .ok_or(::std::env::VarError::NotPresent)
+            })
             .map_err(|error| ::anyhow::anyhow!("failed to get current user name: {}", error))?;
         Ok(username)
     }


### PR DESCRIPTION
## Summary

Add a **check-runners** composite action that queries the GitHub API for online self-hosted runners before benchmark jobs start. When no runners are available, benchmark jobs are gracefully skipped instead of queuing indefinitely.

Migrate **ci-test** and **publish-release** jobs from self-hosted runners to GitHub-hosted `ubuntu-24.04` with the CI container image, removing self-hosted workarounds.

## Changes

- **New**: `.github/actions/check-runners/action.yml` — composite action that checks runner availability via the GitHub API
- **ci.yml**: add `check-runners` job with `RUNNER_ADMIN_TOKEN` fallback to `GITHUB_TOKEN`
- **ci.yml**: migrate `ci-test` to `ubuntu-24.04` + `ghcr.io/nanvix/ci` container
- **ci.yml**: migrate `publish-release` to `ubuntu-24.04`
- **ci.yml**: update benchmark, release, and checks job conditions to handle skipped benchmarks

## Setup Required

The check-runners action requires a fine-grained PAT with `Administration: Read` scope stored as the `RUNNER_ADMIN_TOKEN` repository secret. Without it, the action conservatively assumes runners are available (no behavior change).