### PR TITLE
Handle stdout errors gracefully in standalone terminal I/O bridge

### DIFF
--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -22,7 +22,10 @@ use ::log::{
     warn,
 };
 use ::nanvix_sandbox_config::StandaloneConfig;
-use ::std::io::Read;
+use ::std::io::{
+    ErrorKind,
+    Read,
+};
 use ::tokio::{
     io::{
         self,
@@ -189,16 +192,32 @@ impl Terminal {
         // --- Output path (current task): guest output → host stdout ---
         // TODO (#1706): Flush conditionally based on tty semantics instead of every chunk.
         let mut stdout: Stdout = io::stdout();
+        let mut io_error: Option<::std::io::Error> = None;
         while let Some(data) = output_rx.recv().await {
-            stdout.write_all(&data).await?;
-            stdout.flush().await?;
+            if let Err(e) = stdout.write_all(&data).await {
+                if e.kind() != ErrorKind::BrokenPipe {
+                    error!("failed to write to stdout: {e}");
+                    io_error = Some(e);
+                }
+                break;
+            }
+            if let Err(e) = stdout.flush().await {
+                if e.kind() != ErrorKind::BrokenPipe {
+                    error!("failed to flush stdout: {e}");
+                    io_error = Some(e);
+                }
+                break;
+            }
         }
 
         // Abort the input task immediately — the stdin thread blocks on read() and cannot be
         // interrupted portably, so waiting provides no benefit.
         input_handle.abort();
 
-        Ok(())
+        match io_error {
+            Some(e) => Err(e.into()),
+            None => Ok(()),
+        }
     }
 
     ///

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -30,7 +30,6 @@ use ::tokio::{
         Stdout,
     },
     sync::mpsc,
-    time,
 };
 use ::uservm::standalone::{
     StandaloneVmHandle,
@@ -46,9 +45,6 @@ const IO_BUFFER_SIZE: usize = 4096;
 
 /// Capacity of the bounded channel between the stdin reader thread and the async input task.
 const STDIN_CHANNEL_CAPACITY: usize = 4096;
-
-/// Maximum time to wait for the input task to shut down gracefully before aborting it.
-const INPUT_SHUTDOWN_TIMEOUT: ::std::time::Duration = ::std::time::Duration::from_secs(1);
 
 //==================================================================================================
 // Structures
@@ -169,7 +165,7 @@ impl Terminal {
         } = io;
 
         // --- Input path (independent task): host stdin → guest input ---
-        let mut input_handle: ::tokio::task::JoinHandle<()> = ::tokio::spawn(async move {
+        let input_handle: ::tokio::task::JoinHandle<()> = ::tokio::spawn(async move {
             let (stdin_tx, mut stdin_rx): (mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) =
                 mpsc::channel(STDIN_CHANNEL_CAPACITY);
 
@@ -198,14 +194,9 @@ impl Terminal {
             stdout.flush().await?;
         }
 
-        // Wait briefly for the input task to shut down; abort if it does not complete in time.
-        if time::timeout(INPUT_SHUTDOWN_TIMEOUT, &mut input_handle)
-            .await
-            .is_err()
-        {
-            warn!("input task did not shut down in time, aborting");
-            input_handle.abort();
-        }
+        // Abort the input task immediately — the stdin thread blocks on read() and cannot be
+        // interrupted portably, so waiting provides no benefit.
+        input_handle.abort();
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Handle stdout I/O errors gracefully in the standalone terminal's `bridge_io()` output loop, ensuring proper cleanup of the stdin forwarding task regardless of how the loop exits.

## Problem

Previously, `bridge_io()` used the `?` operator on `stdout.write_all()` and `stdout.flush()`, which propagated any I/O error via early return. This skipped `input_handle.abort()`, leaving the stdin forwarding task running after the output path had already failed.

## Changes

- Capture the first non-`BrokenPipe` I/O error and break out of the output loop instead of returning early.
- Treat `BrokenPipe` as a graceful exit (the reader closed the pipe), breaking without recording an error.
- Always reach `input_handle.abort()` before returning, ensuring the stdin task is cleaned up.
- Propagate the recorded error, if any, after cleanup.