### PR TITLE
[kernel] Add system-wide thread count cap

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -83,6 +83,21 @@ ipc_message_size = 64
 ikc_poll_batch_size = 8
 
 #==================================================================================================
+# Thread Limits
+#==================================================================================================
+
+# Maximum number of threads that may exist system-wide at the same time (including the kernel
+# thread). When this limit is reached, create_thread and create_process return OutOfMemory instead
+# of proceeding with allocations that could exhaust the kernel heap.
+# A thread slot is considered occupied from creation until the zombie is joined or harvested.
+# Constraints:
+# - Must be at least 1 (the kernel thread always exists).
+# Notes:
+# - Each thread consumes at least one kernel stack (kstack_size bytes). At the default kstack_size
+#   of 64 KiB, 32 threads imply up to ~2 MiB of kernel-stack reservation.
+max_threads = 32
+
+#==================================================================================================
 # Synchronization Limits
 #==================================================================================================
 

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1899,6 +1899,9 @@ impl ProcessManager {
                 // Frames allocated to the user stack are freed when we exit this scope.
                 // Frames allocated to the kernel stack are freed when we exit this scope.
             }
+
+            // Notify the thread manager that this thread has been reaped.
+            self.tm.on_thread_reaped();
         }
 
         Ok(Some((state.pid(), status)))

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -392,6 +392,9 @@ impl ProcessManager {
                         // Frames allocated to the kernel stack are freed when we exit this scope.
                     }
 
+                    // Notify the thread manager that this thread has been reaped.
+                    Self::get_mut().tm.on_thread_reaped();
+
                     break Ok(status);
                 },
 

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -147,6 +147,9 @@ impl<'a> ThreadRefMut<'a> {
 pub struct ThreadManager {
     /// Next thread identifier to be assigned.
     next_id: ThreadIdentifier,
+    /// Number of threads that have been created but not yet reaped (joined or harvested).
+    /// Initialized to 1 to account for the kernel thread created in [`ThreadManager::new()`].
+    live_count: usize,
 }
 
 impl ThreadManager {
@@ -175,6 +178,7 @@ impl ThreadManager {
             kernel,
             Self {
                 next_id: From::<i32>::from(1),
+                live_count: 1,
             },
         )
     }
@@ -200,6 +204,17 @@ impl ThreadManager {
     ///   `create_thread` calls can exhaust the identifier space.
     ///
     pub(crate) fn try_next_tid(&self) -> Result<(ThreadIdentifier, ThreadIdentifier), Error> {
+        // Reject if the system-wide thread cap would be exceeded.
+        if self.live_count >= ::config::kernel::MAX_THREADS {
+            let reason: &str = "system-wide thread limit reached";
+            error!(
+                "{reason} (live_count={}, max_threads={})",
+                self.live_count,
+                ::config::kernel::MAX_THREADS
+            );
+            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        }
+
         let id: ThreadIdentifier = self.next_id;
         let raw_id: i32 = <i32>::from(self.next_id);
         let next_raw_id: i32 = match raw_id.checked_add(1) {
@@ -224,6 +239,25 @@ impl ThreadManager {
     ///
     pub(crate) fn commit_next_tid(&mut self, next_tid: ThreadIdentifier) {
         self.next_id = next_tid;
+        self.live_count += 1;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Notifies the thread manager that a thread has been reaped (joined or harvested as a zombie).
+    /// This decrements the live thread count, freeing a slot for future thread creation.
+    ///
+    pub(crate) fn on_thread_reaped(&mut self) {
+        // Use a runtime assert (not debug_assert) so that an accounting bug in release builds
+        // panics instead of silently wrapping usize and permanently breaking admission control.
+        // The kernel thread is never reaped, so live_count must be at least 2 here (the kernel
+        // thread plus the thread being reaped).
+        assert!(
+            self.live_count > 1,
+            "live_count underflow: kernel thread must always remain counted"
+        );
+        self.live_count -= 1;
     }
 
     ///

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -177,6 +177,10 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     );
     constants.push_str(&format!("pub const KLOG_BUFFER_SIZE: usize = {val};\n"));
 
+    let val: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "max_threads"), "max_threads");
+    constants.push_str(&format!("pub const MAX_THREADS: usize = {val};\n"));
+
     constants.push_str("}\n");
 
     //==============================================================================================
@@ -235,6 +239,11 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         "kernel_watermark",
     );
     assert!(kernel_watermark > 0, "kernel_watermark must be non-zero");
+
+    // max_threads must be at least 1 (the kernel thread always exists).
+    let max_threads: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "max_threads"), "max_threads");
+    assert!(max_threads >= 1, "max_threads must be at least 1");
 
     // Write the generated file.
     fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");


### PR DESCRIPTION
## Summary

Add a configurable system-wide maximum thread count (`MAX_THREADS`) to the kernel. When the limit is reached, `create_thread` and `create_process` return `OutOfMemory` instead of proceeding with allocations that can exhaust the kernel heap and crash the guest.

## Design

**Harvest-based accounting** — threads count toward the cap from creation (`commit_next_tid`) until their zombie is reaped (`join_thread` or `harvest_zombies`). This ensures zombie threads still holding kernel resources (kernel stacks, page-table bookkeeping) are correctly included, and avoids fragile accounting across `terminate()`/`do_exit()` paths.

## Changes

- **`build/kernel_config.toml`**: Add `max_threads = 32` with documentation.
- **`src/libs/config/build.rs`**: Parse and emit `config::kernel::MAX_THREADS` constant; add build-time assertion (`>= 1`).
- **`src/kernel/src/pm/thread/mod.rs`**: Add `live_count` field to `ThreadManager`; admission check in `try_next_tid()` returns `OutOfMemory`; increment in `commit_next_tid()`; new `on_thread_reaped()` decrement method.
- **`src/kernel/src/pm/process/manager/unsafe.rs`**: Decrement on `join_thread()` zombie harvest.
- **`src/kernel/src/pm/process/manager/mod.rs`**: Decrement on `harvest_zombies()` zombie harvest.

## Testing

- Build passes (`z.ps1 build -- all`).
- All Windows standalone integration tests pass (`z.ps1 build -- run-nanvix-tests`).
- Format check passes.

## Related Issues

- Closes #2329
- Closes #1270