### PR TITLE
[kernel] Implement thread detach support

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -118,6 +118,8 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::MemoryCopy => pm::mcopy(pid, arg0, arg1, arg2, arg3),
         // Handle `create_thread()` locally.
         KcallNumber::CreateThread => pm::create_thread(pid, arg0),
+        // Handle `detach_thread()` locally.
+        KcallNumber::DetachThread => pm::detach_thread(pid, arg0),
         // Handle `send()` locally.
         KcallNumber::Send => ipc::send(pid, tid, arg0),
         // SAFETY: The calling thread is not the kernel and no resources are held.

--- a/src/kernel/src/pm/kcall/detach_thread.rs
+++ b/src/kernel/src/pm/kcall/detach_thread.rs
@@ -1,0 +1,62 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    kcall::KcallResult,
+    pm::ProcessManager,
+};
+use ::sys::pm::{
+    ProcessIdentifier,
+    ThreadIdentifier,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Detaches a thread. A detached thread is automatically harvested when it exits, without
+/// requiring another thread to join it.
+///
+/// # Parameters
+///
+/// - `pid`: Process identifier of the calling process.
+/// - `arg0`: Thread identifier of the thread to detach.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, an error code is returned instead.
+///
+/// # Safety
+///
+/// This function is safe to call if and only if the following conditions are met:
+/// - The process manager is initialized.
+/// - Access to the process manager is synchronized.
+/// - The memory manager is initialized.
+/// - Access to the memory manager is synchronized.
+///
+pub fn detach_thread(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    let tid: ThreadIdentifier = match ThreadIdentifier::try_from(arg0) {
+        Ok(tid) => tid,
+        Err(error) => {
+            error!("{error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
+
+    // SAFETY: the process manager and virtual memory manager are initialized and access is
+    // synchronized.
+    match unsafe { ProcessManager::detach_thread(pid, tid) } {
+        Ok(()) => KcallResult::ok(),
+        Err(error) => {
+            error!("detach_thread(): failed (pid={pid:?}, tid={tid:?}, error={error:?})");
+            KcallResult::Error(error.code.into())
+        },
+    }
+}

--- a/src/kernel/src/pm/kcall/mod.rs
+++ b/src/kernel/src/pm/kcall/mod.rs
@@ -7,6 +7,7 @@
 
 mod capctl;
 mod create_thread;
+mod detach_thread;
 mod get_thread_data_area;
 mod gettime;
 mod join_thread;
@@ -28,6 +29,7 @@ mod wait_cond;
 
 pub use capctl::capctl;
 pub use create_thread::create_thread;
+pub use detach_thread::detach_thread;
 pub use get_thread_data_area::get_thread_data_area;
 pub use gettime::gettime;
 pub use join_thread::join_thread;

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1021,17 +1021,23 @@ impl ProcessManager {
         let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
             match running_process.exit_thread(status) {
                 // The calling process still has runnable threads, put it in the list of ready processes.
-                Ok((join_cond, runnable_process, previous_context)) => {
+                (Ok((join_cond, runnable_process, previous_context)), detached_dropped) => {
                     self.ready.push_back(runnable_process);
+                    if detached_dropped {
+                        self.tm.on_thread_reaped();
+                    }
                     (join_cond, previous_context)
                 },
                 // The calling process has only sleeping threads left, put it in the list of suspended processes.
-                Err(Ok((join_cond, sleeping_process, previous_context))) => {
+                (Err(Ok((join_cond, sleeping_process, previous_context))), detached_dropped) => {
                     self.suspended.push_back(sleeping_process);
+                    if detached_dropped {
+                        self.tm.on_thread_reaped();
+                    }
                     (join_cond, previous_context)
                 },
                 // The calling process has only zombie threads left, put it in the list of zombies processes.
-                Err(Err((join_cond, zombie_process, previous_context))) => {
+                (Err(Err((join_cond, zombie_process, previous_context))), _) => {
                     self.zombies.push_back(zombie_process);
                     (join_cond, previous_context)
                 },
@@ -1261,6 +1267,38 @@ impl ProcessManager {
                 error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Err(Err(Error::new(ErrorCode::OperationNotPermitted, reason)))
             },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Detaches a thread in the calling process. A detached thread is auto-harvested when it exits.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Process identifier of the calling process.
+    /// - `tid`: Thread identifier of the thread to detach.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns `Ok(None)` if the thread was marked detached, or `Ok(Some(zombie))` if
+    /// the thread was already a zombie and should be harvested immediately. On failure, returns an
+    /// error.
+    ///
+    fn do_detach_thread(
+        &mut self,
+        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Result<Option<ZombieThread>, Error> {
+        match self.find_process_mut(pid) {
+            Ok(ProcessRefMut::Running(process)) => process.detach_thread(tid),
+            Ok(_process_ref) => {
+                let reason: &str = "process is not running";
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
+                Err(Error::new(ErrorCode::OperationNotPermitted, reason))
+            },
+            Err(error) => Err(error),
         }
     }
 

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -22,7 +22,10 @@ use crate::{
     pm::{
         process::{
             manager::ProcessManager,
-            state::RunningProcess,
+            state::{
+                ProcessRefMut,
+                RunningProcess,
+            },
         },
         sync::{
             condvar::Condvar,
@@ -303,6 +306,82 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Harvests a zombie thread by reclaiming its kernel and user stacks, unmapping user-stack
+    /// pages from the process address space, and notifying the thread manager.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Process identifier that owns the zombie thread.
+    /// - `zombie_thread`: The zombie thread to harvest.
+    ///
+    /// # Safety
+    ///
+    /// This function is safe to call if and only if the following conditions are met:
+    /// - The process manager is initialized.
+    /// - Access to the process manager is synchronized.
+    /// - The memory manager is initialized.
+    /// - Access to the memory manager is synchronized.
+    ///
+    unsafe fn harvest_zombie_thread(pid: ProcessIdentifier, zombie_thread: ZombieThread) {
+        // If the zombie has no user stack (kernel-only thread), the kernel stack is
+        // reclaimed via KernelStack::Drop and no page unmapping is needed.
+        if let (Some(_kernel_stack), Some(user_stack)) = zombie_thread.harvest() {
+            // Traverse pages belonging to user stack.
+            let base: usize = user_stack.base().into_raw_value();
+            let top: usize = user_stack.top().into_raw_value();
+            // Resolve the process vmem once before the loop.
+            let mut process_ref: ProcessRefMut<'_> = match Self::get_mut().find_process_mut(pid) {
+                Ok(process) => process,
+                Err(error) => {
+                    // Unexpected failure — log but continue since the address space will be
+                    // reclaimed when it is destroyed.
+                    error!("failed to find process (pid={pid:?}, error={error:?})",);
+                    return;
+                },
+            };
+            let vmem: &mut Vmem = process_ref.state_mut().vmem_mut();
+            // TODO: Use an iterator for this.
+            for raw_addr in (base..top).step_by(PAGE_SIZE) {
+                let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(raw_addr)
+                {
+                    Ok(vaddr) => vaddr,
+                    Err(_) => {
+                        // SAFETY: the following condition is unreachable, because
+                        // pages in the user stack are always page-aligned.
+                        unreachable!("address conversion should succeed")
+                    },
+                };
+                // Attempt to unmap page.
+                match VirtMemoryManager::get_mut().try_unmap_upage(vmem, vaddr) {
+                    Ok(true) => {
+                        // Page was present and has been successfully unmapped.
+                    },
+                    Ok(false) => {
+                        // Page was never mapped (not demand-paged). Skip silently.
+                    },
+                    Err(error) => {
+                        // Unexpected failure — log but continue since the
+                        // address space will be reclaimed when it is destroyed.
+                        warn!(
+                            "harvest_zombie_thread(): failed to unmap page (vaddr={:?}, \
+                             error={:?})",
+                            vaddr, error
+                        );
+                    },
+                }
+            }
+
+            // Frames allocated to the user stack are freed when we exit this scope.
+            // Frames allocated to the kernel stack are freed when we exit this scope.
+        }
+
+        // Notify the thread manager that this thread has been reaped.
+        Self::get_mut().tm.on_thread_reaped();
+    }
+
+    ///
+    /// # Description
+    ///
     /// Joins a thread.
     ///
     /// # Parameters
@@ -344,57 +423,7 @@ impl ProcessManager {
             match result {
                 Ok(zombie_thread) => {
                     let status: ExitStatus = zombie_thread.status();
-
-                    // Harvest zombie thread.
-                    if let (Some(_kernel_stack), Some(user_stack)) = zombie_thread.harvest() {
-                        // Traverse pages belonging to user stack.
-                        let base: usize = user_stack.base().into_raw_value();
-                        let top: usize = user_stack.top().into_raw_value();
-                        // TODO: Use an iterator for this.
-                        for raw_addr in (base..top).step_by(PAGE_SIZE) {
-                            let vaddr: PageAligned<VirtualAddress> =
-                                match PageAligned::from_raw_value(raw_addr) {
-                                    Ok(vaddr) => vaddr,
-                                    Err(_) => {
-                                        // SAFETY: the following condition is unreachable, because
-                                        // pages in the user stack are always page-aligned.
-                                        unreachable!("address conversion should succeed")
-                                    },
-                                };
-                            // Attempt to unmap page.
-                            match VirtMemoryManager::get_mut().try_unmap_upage(
-                                Self::get_mut()
-                                    .find_process_mut(pid)
-                                    .map_err(SleepError::Generic)?
-                                    .state_mut()
-                                    .vmem_mut(),
-                                vaddr,
-                            ) {
-                                Ok(true) => {
-                                    // Page was present and has been successfully unmapped.
-                                },
-                                Ok(false) => {
-                                    // Page was never mapped (not demand-paged). Skip silently.
-                                },
-                                Err(error) => {
-                                    // Unexpected failure — log but continue since the
-                                    // address space will be reclaimed when it is destroyed.
-                                    warn!(
-                                        "harvest_zombies(): failed to unmap page (vaddr={:?}, \
-                                         error={:?})",
-                                        vaddr, error
-                                    );
-                                },
-                            }
-                        }
-
-                        // Frames allocated to the user stack are freed when we exit this scope.
-                        // Frames allocated to the kernel stack are freed when we exit this scope.
-                    }
-
-                    // Notify the thread manager that this thread has been reaped.
-                    Self::get_mut().tm.on_thread_reaped();
-
+                    Self::harvest_zombie_thread(pid, zombie_thread);
                     break Ok(status);
                 },
 

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -439,6 +439,49 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Detaches a thread in the calling process. A detached thread is automatically harvested when
+    /// it exits, without requiring another thread to join it.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Process identifier of the calling process.
+    /// - `tid`: Thread identifier of the thread to detach.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+    ///
+    /// # Safety
+    ///
+    /// This function is safe to call if and only if the following conditions are met:
+    /// - The process manager is initialized.
+    /// - Access to the process manager is synchronized.
+    /// - The memory manager is initialized.
+    /// - Access to the memory manager is synchronized.
+    ///
+    pub unsafe fn detach_thread(
+        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Result<(), Error> {
+        trace!("pid={:?}, tid={:?}", pid, tid);
+
+        let result: Result<Option<ZombieThread>, Error> =
+            Self::get_mut().do_detach_thread(pid, tid);
+
+        match result {
+            Ok(Some(zombie_thread)) => {
+                // Thread was already a zombie — harvest it immediately.
+                Self::harvest_zombie_thread(pid, zombie_thread);
+                Ok(())
+            },
+            Ok(None) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Suspends the execution of the calling thread until it is woken up by another thread or until
     /// the specified alarm time is reached.
     ///

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -257,58 +257,112 @@ impl RunningProcess {
     ///
     #[allow(clippy::type_complexity)]
     pub fn exit_thread(
-        mut self,
+        self,
         status: ExitStatus,
-    ) -> Result<
-        (Condvar, RunnableProcess, *mut ContextInformation),
+    ) -> (
         Result<
-            (Condvar, SleepingProcess, *mut ContextInformation),
-            (Condvar, ZombieProcess, *mut ContextInformation),
+            (Condvar, RunnableProcess, *mut ContextInformation),
+            Result<
+                (Condvar, SleepingProcess, *mut ContextInformation),
+                (Condvar, ZombieProcess, *mut ContextInformation),
+            >,
         >,
-    > {
+        bool, // true if a detached thread was auto-dropped and needs reaping notification.
+    ) {
+        let is_detached: bool = self.running.is_detached();
         let join_cond: Condvar = self.running.join_cond();
 
-        let (zombie_thread, ctx) = self.running.exit(status);
-        let zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie.take() {
-            Some(mut zombie_threads) => {
-                zombie_threads.push_back(zombie_thread);
-                zombie_threads
-            },
-            None => NonEmptyVecDeque::new(zombie_thread),
-        };
+        // Extract all fields from self before running.exit() consumes self.running.
+        let mut state: Box<ProcessState> = self.state;
+        let ready: Option<NonEmptyVecDeque<ReadyThread>> = self.ready;
+        let interrupted_threads: Option<NonEmptyVecDeque<InterruptedThread>> =
+            self.interrupted_threads;
+        let sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>> = self.sleeping_threads;
+        let existing_zombies: Option<NonEmptyVecDeque<ZombieThread>> = self.zombie;
 
-        if let Some(ready_threads) = self.ready.take() {
-            Ok((
-                join_cond,
-                RunnableProcess::from_state(
-                    self.state,
-                    ready_threads,
-                    self.interrupted_threads.take(),
-                    self.sleeping_threads.take(),
-                    Some(zombie_threads),
-                ),
-                ctx,
-            ))
-        } else if let Some(interrupted_threads) = self.interrupted_threads.take() {
+        let (zombie_thread, ctx) = self.running.exit(status);
+
+        // Determine whether other threads remain. If so, a detached zombie can be dropped
+        // immediately. If this is the last thread, keep the zombie so ZombieProcess can be
+        // constructed (it requires a non-empty zombie list).
+        let has_other_threads: bool =
+            ready.is_some() || interrupted_threads.is_some() || sleeping_threads.is_some();
+
+        let (zombie_threads, detached_dropped): (Option<NonEmptyVecDeque<ZombieThread>>, bool) =
+            if is_detached && has_other_threads {
+                // Detached thread with other threads still alive — drop the zombie immediately.
+                // The kernel stack is freed via KernelStack::Drop. User stack pages remain mapped
+                // until the process exits and its Vmem is destroyed.
+                // The caller must call ThreadManager::on_thread_reaped() to update the live count.
+                drop(zombie_thread);
+                (existing_zombies, true)
+            } else {
+                (
+                    Some(match existing_zombies {
+                        Some(mut zombie_threads) => {
+                            zombie_threads.push_back(zombie_thread);
+                            zombie_threads
+                        },
+                        None => NonEmptyVecDeque::new(zombie_thread),
+                    }),
+                    false,
+                )
+            };
+
+        if let Some(ready_threads) = ready {
+            (
+                Ok((
+                    join_cond,
+                    RunnableProcess::from_state(
+                        state,
+                        ready_threads,
+                        interrupted_threads,
+                        sleeping_threads,
+                        zombie_threads,
+                    ),
+                    ctx,
+                )),
+                detached_dropped,
+            )
+        } else if let Some(interrupted_threads) = interrupted_threads {
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
-                self.state,
-                self.sleeping_threads.take(),
+                state,
+                sleeping_threads,
                 interrupted_threads,
-                Some(zombie_threads),
+                zombie_threads,
             );
 
-            Ok((join_cond, interrupted_process.resume(), ctx))
-        } else if let Some(sleeping_threads) = self.sleeping_threads.take() {
-            Err(Ok((
-                join_cond,
-                SleepingProcess::new(self.state, sleeping_threads, Some(zombie_threads)),
-                ctx,
-            )))
+            (Ok((join_cond, interrupted_process.resume(), ctx)), detached_dropped)
+        } else if let Some(sleeping_threads) = sleeping_threads {
+            (
+                Err(Ok((
+                    join_cond,
+                    SleepingProcess::new(state, sleeping_threads, zombie_threads),
+                    ctx,
+                ))),
+                detached_dropped,
+            )
         } else {
-            // Use pending exit status if set (from a prior exit() call), otherwise use current
-            // thread's status.
-            let final_status: ExitStatus = self.state.take_pending_exit_status().unwrap_or(status);
-            Err(Err((join_cond, ZombieProcess::new(self.state, zombie_threads, final_status), ctx)))
+            match zombie_threads {
+                Some(zombie_threads) => {
+                    // Use pending exit status if set (from a prior exit() call), otherwise use
+                    // current thread's status.
+                    let final_status: ExitStatus =
+                        state.take_pending_exit_status().unwrap_or(status);
+                    (
+                        Err(Err((
+                            join_cond,
+                            ZombieProcess::new(state, zombie_threads, final_status),
+                            ctx,
+                        ))),
+                        detached_dropped,
+                    )
+                },
+                // Unreachable: zombie_threads is None only when is_detached && has_other_threads,
+                // which guarantees at least one of the ready/interrupted/sleeping branches above
+                // would match.
+                None => unreachable!("no zombie threads and no other threads"),
+            }
         }
     }
 
@@ -412,6 +466,15 @@ impl RunningProcess {
         }
 
         // Search for thread in zombie threads.
+        if let Some(zombie_threads) = &self.zombie {
+            for zombie_thread in zombie_threads.iter() {
+                if zombie_thread.id() == tid && zombie_thread.is_detached() {
+                    let reason: &str = "cannot join a detached thread";
+                    error!("{reason} (tid={tid:?})");
+                    return Err(Err(Error::new(ErrorCode::InvalidArgument, reason)));
+                }
+            }
+        }
         if let Some(zombie_threads) = self.zombie.take() {
             match zombie_threads.remove_if(|thread| thread.id() == tid) {
                 Ok((zombie_threads, zombie_thread)) => {
@@ -428,6 +491,11 @@ impl RunningProcess {
         if let Some(ready_threads) = &mut self.ready {
             for ready_thread in ready_threads.iter() {
                 if ready_thread.id() == tid {
+                    if ready_thread.is_detached() {
+                        let reason: &str = "cannot join a detached thread";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Err(Error::new(ErrorCode::InvalidArgument, reason)));
+                    }
                     let join_cond: Condvar = ready_thread.join_cond();
                     return Err(Ok(join_cond));
                 }
@@ -438,6 +506,11 @@ impl RunningProcess {
         if let Some(sleeping_threads) = &mut self.sleeping_threads {
             for sleeping_thread in sleeping_threads.iter() {
                 if sleeping_thread.id() == tid {
+                    if sleeping_thread.is_detached() {
+                        let reason: &str = "cannot join a detached thread";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Err(Error::new(ErrorCode::InvalidArgument, reason)));
+                    }
                     let join_cond: Condvar = sleeping_thread.join_cond();
                     return Err(Ok(join_cond));
                 }
@@ -448,6 +521,11 @@ impl RunningProcess {
         if let Some(interrupted_threads) = &mut self.interrupted_threads {
             for interrupted_thread in interrupted_threads.iter() {
                 if interrupted_thread.id() == tid {
+                    if interrupted_thread.is_detached() {
+                        let reason: &str = "cannot join a detached thread";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Err(Error::new(ErrorCode::InvalidArgument, reason)));
+                    }
                     let join_cond: Condvar = interrupted_thread.join_cond();
                     return Err(Ok(join_cond));
                 }
@@ -457,6 +535,96 @@ impl RunningProcess {
         let reason: &str = "thread not found";
         error!("{:?} (state={:?})", reason, self.state());
         Err(Err(Error::new(ErrorCode::NoSuchProcess, reason)))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Detaches a thread so that it will be auto-harvested when it exits. If the thread is already
+    /// a zombie, it is removed from the zombie queue and returned for immediate harvesting.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread to detach.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns `Ok(None)` if the thread was marked detached, or `Ok(Some(zombie))` if
+    /// the thread was already a zombie and should be harvested. On failure, returns an error.
+    ///
+    pub fn detach_thread(&mut self, tid: ThreadIdentifier) -> Result<Option<ZombieThread>, Error> {
+        // Detach the running (calling) thread.
+        if self.running.id() == tid {
+            if self.running.is_detached() {
+                let reason: &str = "thread is already detached";
+                error!("{reason} (tid={tid:?})");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+            self.running.set_detached();
+            return Ok(None);
+        }
+
+        // Search in zombie threads — if found, remove and return for immediate harvest.
+        if let Some(zombie_threads) = self.zombie.take() {
+            match zombie_threads.remove_if(|thread| thread.id() == tid) {
+                Ok((zombie_threads, zombie_thread)) => {
+                    self.zombie = NonEmptyVecDeque::from(zombie_threads);
+                    return Ok(Some(zombie_thread));
+                },
+                Err(zombie_threads) => {
+                    self.zombie = Some(zombie_threads);
+                },
+            }
+        }
+
+        // Search in ready threads.
+        if let Some(ready_threads) = &mut self.ready {
+            for ready_thread in ready_threads.iter_mut() {
+                if ready_thread.id() == tid {
+                    if ready_thread.is_detached() {
+                        let reason: &str = "thread is already detached";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                    }
+                    ready_thread.set_detached();
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Search in sleeping threads.
+        if let Some(sleeping_threads) = &mut self.sleeping_threads {
+            for sleeping_thread in sleeping_threads.iter_mut() {
+                if sleeping_thread.id() == tid {
+                    if sleeping_thread.is_detached() {
+                        let reason: &str = "thread is already detached";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                    }
+                    sleeping_thread.set_detached();
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Search in interrupted threads.
+        if let Some(interrupted_threads) = &mut self.interrupted_threads {
+            for interrupted_thread in interrupted_threads.iter_mut() {
+                if interrupted_thread.id() == tid {
+                    if interrupted_thread.is_detached() {
+                        let reason: &str = "thread is already detached";
+                        error!("{reason} (tid={tid:?})");
+                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                    }
+                    interrupted_thread.set_detached();
+                    return Ok(None);
+                }
+            }
+        }
+
+        let reason: &str = "thread not found";
+        error!("{reason} (tid={tid:?})");
+        Err(Error::new(ErrorCode::NoSuchProcess, reason))
     }
 
     ///

--- a/src/kernel/src/pm/thread/interrupted.rs
+++ b/src/kernel/src/pm/thread/interrupted.rs
@@ -127,4 +127,26 @@ impl InterruptedThread {
     pub fn join_cond(&self) -> Condvar {
         self.state.join_cond()
     }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the interrupted thread is detached.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the thread is detached, `false` otherwise.
+    ///
+    pub fn is_detached(&self) -> bool {
+        self.state.is_detached()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the interrupted thread as detached.
+    ///
+    pub fn set_detached(&mut self) {
+        self.state.set_detached();
+    }
 }

--- a/src/kernel/src/pm/thread/ready.rs
+++ b/src/kernel/src/pm/thread/ready.rs
@@ -205,6 +205,28 @@ impl ReadyThread {
     ///
     /// # Description
     ///
+    /// Returns whether the ready thread is detached.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the thread is detached, `false` otherwise.
+    ///
+    pub fn is_detached(&self) -> bool {
+        self.state.is_detached()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the ready thread as detached.
+    ///
+    pub fn set_detached(&mut self) {
+        self.state.set_detached();
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns the admission time of the ready thread.
     ///
     /// # Returns

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -160,6 +160,28 @@ impl RunningThread {
     ///
     /// # Description
     ///
+    /// Returns whether the running thread is detached.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the thread is detached, `false` otherwise.
+    ///
+    pub fn is_detached(&self) -> bool {
+        self.state.is_detached()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the running thread as detached.
+    ///
+    pub fn set_detached(&mut self) {
+        self.state.set_detached();
+    }
+
+    ///
+    /// # Description
+    ///
     /// Terminates the running thread with the specified exit status.
     ///
     /// # Parameters

--- a/src/kernel/src/pm/thread/sleeping.rs
+++ b/src/kernel/src/pm/thread/sleeping.rs
@@ -147,6 +147,28 @@ impl SleepingThread {
     ///
     /// # Description
     ///
+    /// Returns whether the sleeping thread is detached.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the thread is detached, `false` otherwise.
+    ///
+    pub fn is_detached(&self) -> bool {
+        self.state.is_detached()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the sleeping thread as detached.
+    ///
+    pub fn set_detached(&mut self) {
+        self.state.set_detached();
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns the alarm time of the sleeping thread.
     ///
     /// # Returns

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -65,6 +65,8 @@ pub struct ThreadState {
     interrupt_reason: Option<InterruptReason>,
     /// FPU state.
     fpu_state: Pin<Box<FpuState>>,
+    /// Whether the thread is detached (will be auto-harvested on exit).
+    detached: bool,
 }
 
 //==================================================================================================
@@ -107,6 +109,7 @@ impl ThreadState {
             locked_mutexes: BTreeMap::new(),
             interrupt_reason: None,
             fpu_state: Box::pin(fpu_state),
+            detached: false,
         }
     }
 
@@ -217,6 +220,24 @@ impl ThreadState {
     ///
     pub(super) fn take_interrupt_reason(&mut self) -> Option<InterruptReason> {
         self.interrupt_reason.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the thread is detached.
+    ///
+    pub(super) fn is_detached(&self) -> bool {
+        self.detached
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the thread as detached. A detached thread is auto-harvested when it exits.
+    ///
+    pub(super) fn set_detached(&mut self) {
+        self.detached = true;
     }
 
     ///

--- a/src/kernel/src/pm/thread/zombie.rs
+++ b/src/kernel/src/pm/thread/zombie.rs
@@ -123,4 +123,17 @@ impl ZombieThread {
     pub fn status(&self) -> ExitStatus {
         self.status
     }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the zombie thread was detached.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the thread is detached, `false` otherwise.
+    ///
+    pub fn is_detached(&self) -> bool {
+        self.state.is_detached()
+    }
 }

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -299,10 +299,20 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub extern "C" fn pthread_detach(_thread: pthread_t) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/502
-    ::syslog::debug!("pthread_detach(): not implemented");
-    ErrorCode::OperationNotSupported.get()
+pub extern "C" fn pthread_detach(thread: pthread_t) -> c_int {
+    match ::sys::pm::ThreadIdentifier::try_from(thread) {
+        Ok(tid) => match ::sys::kcall::pm::detach_thread(tid) {
+            Ok(()) => 0,
+            Err(error) => {
+                ::syslog::warn!("pthread_detach(): detach_thread failed ({error:?})");
+                error.code.get()
+            },
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_detach(): invalid thread id ({error:?})");
+            ErrorCode::InvalidArgument.get()
+        },
+    }
 }
 
 //==================================================================================================

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -344,6 +344,34 @@ pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Erro
 }
 
 //==================================================================================================
+// Detach Thread
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Detaches a thread. A detached thread is automatically harvested when it exits, without requiring
+/// another thread to join it.
+///
+/// # Parameters
+///
+/// - `tid`: Thread identifier of the thread to detach.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+pub fn detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
+    let result: i64 = kcall1!(KcallNumber::DetachThread.into(), i32::from(tid) as u32);
+
+    if unlikely(result != 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to detach thread"))
+    } else {
+        Ok(())
+    }
+}
+
+//==================================================================================================
 // Lock Mutex
 //==================================================================================================
 

--- a/src/libs/sys/src/sys/number.rs
+++ b/src/libs/sys/src/sys/number.rs
@@ -85,6 +85,8 @@ pub enum KcallNumber {
     Pull = KcallNumber::NR_PULL_SYSCALL,
     /// Creates a snapshot of the virtual machine.
     Snapshot = KcallNumber::NR_SNAPSHOT_SYSCALL,
+    /// Detaches a thread so it is auto-harvested on exit.
+    DetachThread = KcallNumber::NR_DETACH_THREAD_SYSCALL,
     /// Invalid kernel call.
     Invalid = KcallNumber::NR_INVALID_SYSCALL,
 }
@@ -127,6 +129,7 @@ impl KcallNumber {
     const NR_PUSH_SYSCALL: u32 = 33;
     const NR_PULL_SYSCALL: u32 = 34;
     const NR_SNAPSHOT_SYSCALL: u32 = 35;
+    const NR_DETACH_THREAD_SYSCALL: u32 = 36;
     const NR_INVALID_SYSCALL: u32 = u32::MAX;
 }
 
@@ -170,6 +173,7 @@ impl From<u32> for KcallNumber {
             Self::NR_PUSH_SYSCALL => KcallNumber::Push,
             Self::NR_PULL_SYSCALL => KcallNumber::Pull,
             Self::NR_SNAPSHOT_SYSCALL => KcallNumber::Snapshot,
+            Self::NR_DETACH_THREAD_SYSCALL => KcallNumber::DetachThread,
             _ => KcallNumber::Invalid,
         }
     }
@@ -215,6 +219,7 @@ impl From<KcallNumber> for u32 {
             KcallNumber::Push => KcallNumber::NR_PUSH_SYSCALL,
             KcallNumber::Pull => KcallNumber::NR_PULL_SYSCALL,
             KcallNumber::Snapshot => KcallNumber::NR_SNAPSHOT_SYSCALL,
+            KcallNumber::DetachThread => KcallNumber::NR_DETACH_THREAD_SYSCALL,
             KcallNumber::Invalid => KcallNumber::NR_INVALID_SYSCALL,
         }
     }

--- a/src/tests/thread-rust/src/main.rs
+++ b/src/tests/thread-rust/src/main.rs
@@ -39,11 +39,14 @@ use ::syscall::unistd;
 pub fn main() -> Result<(), Error> {
     tests::run_all()?;
 
-    // Magic string for CI harness.
+    // Magic string for CI harness — emitted before the nowait test because it exits the process.
     {
         let magic_string: &[u8] = b"ok";
         unistd::write(STDOUT_FILENO, magic_string)?;
     }
+
+    // The nowait test exits the process with detached blocked threads. It must run last.
+    tests::run_nowait()?;
 
     Ok(())
 }

--- a/src/tests/thread-rust/src/runtime.rs
+++ b/src/tests/thread-rust/src/runtime.rs
@@ -14,6 +14,7 @@ use ::sys::{
     },
     kcall::pm::{
         create_thread,
+        detach_thread,
         gettime,
         join_thread,
     },
@@ -74,12 +75,30 @@ impl KernelThread {
         drop(self.stack.take());
         Ok(retval)
     }
+
+    /// Detaches the thread so it is auto-harvested when it exits.
+    ///
+    /// The caller's `Stack` handle is intentionally leaked because the thread may still be
+    /// using it. The kernel will unmap the thread's stack pages once the detached thread
+    /// terminates (and, in the worst case, on process teardown).
+    pub fn detach(mut self) -> Result<(), Error> {
+        let tid: ThreadIdentifier = self
+            .tid
+            .take()
+            .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "thread handle missing"))?;
+        detach_thread(tid)?;
+        // Intentionally leak the stack — the thread may still be using it.
+        if let Some(stack) = self.stack.take() {
+            core::mem::forget(stack);
+        }
+        Ok(())
+    }
 }
 
 impl Drop for KernelThread {
     fn drop(&mut self) {
         if self.tid.is_some() {
-            panic!("KernelThread dropped without joining");
+            panic!("KernelThread dropped without joining or detaching");
         }
     }
 }

--- a/src/tests/thread-rust/src/tests/mod.rs
+++ b/src/tests/thread-rust/src/tests/mod.rs
@@ -13,16 +13,13 @@ mod condvars;
 mod identity;
 mod mutex_timedlock;
 mod mutexes;
+mod nowait;
 mod rwlocks;
 mod scheduler;
 mod tda;
 mod thread_local;
 mod threads;
 mod timers;
-
-// TODO: Port nowait.c (tests that a process can exit while worker threads are blocked). The C test
-// relies on process-exit semantics that cannot be safely reproduced with the current KernelThread
-// abstraction (dropping without joining panics).
 
 //==================================================================================================
 // Standalone Functions
@@ -43,4 +40,10 @@ pub fn run_all() -> Result<(), Error> {
     tda::run()?;
     scheduler::run()?;
     Ok(())
+}
+
+/// Runs the nowait test, which exits the process. Must be called after all other tests and after
+/// the success marker has been emitted.
+pub fn run_nowait() -> Result<(), Error> {
+    nowait::run()
 }

--- a/src/tests/thread-rust/src/tests/nowait.rs
+++ b/src/tests/thread-rust/src/tests/nowait.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::runtime::KernelThread;
+use ::core::time::Duration;
+use ::sys::{
+    error::Error,
+    kcall::pm::sleep,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Sleep duration long enough that the worker will still be blocked when the main thread exits.
+const WORKER_SLEEP: Duration = Duration::from_secs(5);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Verifies that a process can exit while a detached worker thread is still blocked.
+///
+/// This test spawns a worker that sleeps for a long time, detaches it, and then exits the process.
+/// The kernel must cleanly tear down the process, terminating the blocked worker. Because this test
+/// calls `exit()`, it **must be the last test** executed by the binary.
+pub fn run() -> Result<(), Error> {
+    test_exit_with_detached_blocked_thread()?;
+    Ok(())
+}
+
+fn test_exit_with_detached_blocked_thread() -> Result<(), Error> {
+    let handle: KernelThread = KernelThread::spawn(worker_sleep, 0)?;
+    handle.detach()?;
+
+    // Exit the process. The kernel will interrupt the sleeping worker and clean up.
+    // exit() diverges on success; on failure we propagate the error.
+    ::sys::kcall::pm::exit(0)?;
+}
+
+extern "C" fn worker_sleep(_arg: usize) -> usize {
+    // Block for a long time. The kernel will interrupt this sleep when the process exits.
+    let _ = sleep(WORKER_SLEEP);
+    0
+}


### PR DESCRIPTION
## Summary

Add full thread detach support across the kernel, syscall layer, POSIX library, and test suite. A detached thread is automatically harvested when it exits, without requiring another thread to join it.

## Changes

### Kernel (`src/kernel`)
- **`harvest_zombie_thread` helper** — Extract duplicated zombie-harvesting logic (stack reclamation, page unmapping, thread manager notification) from `join_thread` and `detach_thread` into a shared helper.
- **`DetachThread` kcall (number 36)** — New kernel call that marks a thread as detached. Adds a `detached: bool` field to `ThreadState` with `is_detached()`/`set_detached()` accessors on all thread state wrappers (`ReadyThread`, `RunningThread`, `SleepingThread`, `InterruptedThread`, `ZombieThread`).
- **`RunningProcess::detach_thread()`** — Searches all thread queues; marks the thread as detached or, if already a zombie, removes and returns it for immediate harvesting.
- **`exit_thread()` rework** — Auto-harvests detached threads on exit: when a detached thread exits and other threads remain, its zombie is dropped immediately.
- **Join guards** — `try_join_thread()` rejects joining a detached thread in all states with `InvalidArgument`.
- Supports `pthread_detach(pthread_self())` (detaching the calling thread).

### Syscall wrapper (`src/libs/sys`)
- Add `detach_thread()` in `sys::kcall::pm`.

### POSIX library (`src/libs/posix`)
- Replace the stubbed `pthread_detach()` (returned `OperationNotSupported`) with a working implementation.

### Tests (`src/tests/thread-rust`)
- Add `KernelThread::detach()` to the test runtime.
- Add `nowait` test: spawns a long-sleeping worker, detaches it, and exits the process — verifying the kernel tears down the process cleanly with a blocked detached thread.

## Closes

- https://github.com/nanvix/nanvix/issues/502