### PR TITLE
[sys] Prefix kernel call wrappers with `__kcall_` and expose unmangled symbols

### DIFF
--- a/src/benchmarks/snapshot-rust-nostd/src/main.rs
+++ b/src/benchmarks/snapshot-rust-nostd/src/main.rs
@@ -27,6 +27,6 @@ use ::sys::error::Error;
 ///
 #[unsafe(no_mangle)]
 pub fn main() -> Result<(), Error> {
-    ::sys::kcall::pm::snapshot()?;
+    ::sys::kcall::pm::__kcall_snapshot()?;
     Ok(())
 }

--- a/src/benchmarks/vfs-bench-nostd/src/main.rs
+++ b/src/benchmarks/vfs-bench-nostd/src/main.rs
@@ -172,13 +172,13 @@ pub fn main() -> Result<(), Error> {
 ///   negative caching and blocking write operations on the mount.
 fn mount_ramfs(readonly: bool) -> Result<(), Error> {
     // Acquire IO management capability.
-    pm::capctl(Capability::IoManagement, true)?;
+    pm::__kcall_capctl(Capability::IoManagement, true)?;
 
     // Attach RAMFS MMIO region.
-    mm::mmio_alloc(RAMFS_MMIO_TAG)?;
+    mm::__kcall_mmio_alloc(RAMFS_MMIO_TAG)?;
 
     // Get region info.
-    let info: ::sys::mm::MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
+    let info: ::sys::mm::MmioRegionInfo = mm::__kcall_mmio_info(RAMFS_MMIO_TAG)?;
     let total_size: usize = info.size();
 
     // Mount the FAT image directly from the MMIO region.
@@ -189,7 +189,7 @@ fn mount_ramfs(readonly: bool) -> Result<(), Error> {
 
     // Release IO management capability but keep the MMIO region allocated —
     // the mounted FAT references it for the process lifetime.
-    pm::capctl(Capability::IoManagement, false)?;
+    pm::__kcall_capctl(Capability::IoManagement, false)?;
 
     Ok(())
 }

--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -43,12 +43,12 @@ use ::sys::{
 fn handle_page_fault(info: EventInformation) {
     // Terminate process.
     ::syslog::info!("terminating process (pid={:?})", info.pid);
-    if let Err(e) = ::sys::kcall::pm::terminate(info.pid) {
+    if let Err(e) = ::sys::kcall::pm::__kcall_terminate(info.pid) {
         panic!("failed to terminate test daemon (error={:?})", e);
     }
 
     // Acknowledge exception event.
-    if let Err(e) = ::sys::kcall::event::resume(info.id) {
+    if let Err(e) = ::sys::kcall::event::__kcall_resume(info.id) {
         panic!("failed to resume exception event (error={:?})", e);
     }
 }
@@ -89,7 +89,7 @@ fn handle_ipc_request(message: Message) -> Result<bool, Error> {
 
 #[unsafe(no_mangle)]
 pub fn main() {
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(e) => panic!("failed to get pid (error={:?})", e),
     };
@@ -99,7 +99,7 @@ pub fn main() {
 
     // Acquire exception management capability.
     ::syslog::info!("acquiring exception management capability...");
-    if let Err(e) = ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
+    if let Err(e) = ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
         panic!("failed to acquire exception management capability (error={:?})", e);
     }
 
@@ -107,7 +107,7 @@ pub fn main() {
 
     // Subscribe to page faults.
     ::syslog::info!("subscribing to page faults...");
-    if let Err(e) = ::sys::kcall::event::evctrl(
+    if let Err(e) = ::sys::kcall::event::__kcall_evctrl(
         Event::Exception(page_fault_exception),
         EventCtrlRequest::Register,
     ) {
@@ -120,7 +120,7 @@ pub fn main() {
     }
 
     loop {
-        match ::sys::kcall::ipc::recv() {
+        match ::sys::kcall::ipc::__kcall_recv() {
             Ok(message) => match message.message_type {
                 MessageType::Exception => match EventInformation::try_from(message) {
                     Ok(info) => handle_page_fault(info),
@@ -148,7 +148,7 @@ pub fn main() {
     }
 
     // Shutdown memory management daemon.
-    let e = ::sys::kcall::pm::exit(0);
+    let e = ::sys::kcall::pm::__kcall_exit(0);
     ::syslog::error!("failed to shutdown memory management daemon (error={:?})", e);
 
     loop {

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
     cleanup();
 
     // Exits the runtime.
-    let Err(error) = ::sys::kcall::pm::exit(status);
+    let Err(error) = ::sys::kcall::pm::__kcall_exit(status);
     panic!("failed to exit process (error={error:?})");
 }
 
@@ -321,7 +321,7 @@ fn init() {
     #[cfg(any(target_os = "none", target_os = "nanvix"))]
     match sysalloc::tda::alloc() {
         core::prelude::v1::Ok(Some(tda_ptr)) => {
-            if let Err(error) = ::sys::kcall::pm::set_thread_data_area(tda_ptr) {
+            if let Err(error) = ::sys::kcall::pm::__kcall_set_thread_data_area(tda_ptr) {
                 panic!("init(): failed to set thread data area (error={error:?})");
             }
             sysalloc::tda::mark_initialized();
@@ -391,26 +391,27 @@ fn vfs_init_ramfs() {
     }
 
     // Acquire IO management capability.
-    if ::sys::kcall::pm::capctl(Capability::IoManagement, true).is_err() {
+    if ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, true).is_err() {
         ::syslog::warn!("vfs_init_ramfs(): failed to acquire IoManagement capability");
         return;
     }
 
     // Attempt to allocate and mount the RAMFS MMIO region.
     let mounted: bool = (|| -> bool {
-        if ::sys::kcall::mm::mmio_alloc(RAMFS_MMIO_TAG).is_err() {
+        if ::sys::kcall::mm::__kcall_mmio_alloc(RAMFS_MMIO_TAG).is_err() {
             // No RAMFS region available — the guest was simply not launched with `-ramfs`.
             return false;
         }
 
-        let info: ::sys::mm::MmioRegionInfo = match ::sys::kcall::mm::mmio_info(RAMFS_MMIO_TAG) {
-            Ok(i) => i,
-            Err(_) => {
-                // Free the MMIO mapping on failure.
-                let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
-                return false;
-            },
-        };
+        let info: ::sys::mm::MmioRegionInfo =
+            match ::sys::kcall::mm::__kcall_mmio_info(RAMFS_MMIO_TAG) {
+                Ok(i) => i,
+                Err(_) => {
+                    // Free the MMIO mapping on failure.
+                    let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
+                    return false;
+                },
+            };
         let total_size: usize = info.size();
 
         // Mount the MMIO region directly — it is writable.
@@ -428,7 +429,7 @@ fn vfs_init_ramfs() {
                 Err(_) => {
                     ::syslog::warn!("vfs_init_ramfs(): failed to parse multi-image header");
                     if !free_mmio_early {
-                        let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                        let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
                     }
                     return false;
                 },
@@ -439,7 +440,7 @@ fn vfs_init_ramfs() {
                 Err(_) => {
                     ::syslog::warn!("vfs_init_ramfs(): failed to parse multi-image entries");
                     if !free_mmio_early {
-                        let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                        let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
                     }
                     return false;
                 },
@@ -454,14 +455,14 @@ fn vfs_init_ramfs() {
                     total_size
                 );
                 if !free_mmio_early {
-                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                    let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
                 }
                 return false;
             }
             if ::multiimage::validate_entries(entries, header.total_size).is_err() {
                 ::syslog::warn!("vfs_init_ramfs(): multi-image entry validation failed");
                 if !free_mmio_early {
-                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                    let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
                 }
                 return false;
             }
@@ -502,7 +503,7 @@ fn vfs_init_ramfs() {
             {
                 ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
                 if !free_mmio_early {
-                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                    let _ = ::sys::kcall::mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
                 }
                 return false;
             }
@@ -512,7 +513,7 @@ fn vfs_init_ramfs() {
     })();
 
     // Release IO management capability.
-    let _ = ::sys::kcall::pm::capctl(Capability::IoManagement, false);
+    let _ = ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, false);
 
     if mounted {
         ::syslog::info!("vfs_init_ramfs(): mounted RAMFS at {}", RAMFS_MOUNT_PATH);

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 #[trace_libcall]
 pub extern "C" fn pthread_detach(thread: pthread_t) -> c_int {
     match ::sys::pm::ThreadIdentifier::try_from(thread) {
-        Ok(tid) => match ::sys::kcall::pm::detach_thread(tid) {
+        Ok(tid) => match ::sys::kcall::pm::__kcall_detach_thread(tid) {
             Ok(()) => 0,
             Err(error) => {
                 ::syslog::warn!("pthread_detach(): detach_thread failed ({error:?})");

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -62,16 +62,16 @@ impl ProcessDaemon {
     /// Initializes the process manager daemon.
     pub fn init() -> Result<Self, Error> {
         ::syslog::info!("running process manager daemon...");
-        let mypid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+        let mypid: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
         assert_eq!(mypid, crate::PROCD, "process daemon has unexpected pid");
 
         // Acquire process management capabilities.
         ::syslog::info!("acquiring process managemnet capabilities...");
-        ::sys::kcall::pm::capctl(Capability::ProcessManagement, true)?;
+        ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true)?;
 
         // Subscribe to process termination.
         ::syslog::info!("subscribing to process termination...");
-        ::sys::kcall::event::evctrl(
+        ::sys::kcall::event::__kcall_evctrl(
             Event::Scheduling(SchedulingEvent::ProcessTermination),
             EventCtrlRequest::Register,
         )?;
@@ -84,7 +84,7 @@ impl ProcessDaemon {
     /// Runs the process manager daemon.
     pub fn run(&mut self) {
         loop {
-            match ::sys::kcall::ipc::recv() {
+            match ::sys::kcall::ipc::__kcall_recv() {
                 Ok(message) => {
                     ::syslog::info!("received message from={:?}", { message.source });
                     match message.message_type {
@@ -172,12 +172,12 @@ impl ProcessDaemon {
                 ProcessManagementMessageHeader::Signup => {
                     let message: SignupMessage = SignupMessage::from_bytes(message.payload);
                     let message: Message = self.handle_signup(destination, message)?;
-                    ::sys::kcall::ipc::send(&message)?;
+                    ::sys::kcall::ipc::__kcall_send(&message)?;
                 },
                 ProcessManagementMessageHeader::Lookup => {
                     let message: LookupMessage = LookupMessage::from_bytes(message.payload);
                     let message: Message = self.handle_lookup(destination, message)?;
-                    ::sys::kcall::ipc::send(&message)?;
+                    ::sys::kcall::ipc::__kcall_send(&message)?;
                 },
                 // Ignore all other messages.
                 _ => {},
@@ -270,12 +270,13 @@ impl ProcessDaemon {
             ::syslog::info!("shutting down process (pid={:?}, name={:?})", pid, pname);
             let message: Message =
                 message::shutdown_request(*pid, 0).expect("failed to broadcast shutdown message");
-            ::sys::kcall::ipc::send(&message).expect("failed to broadcast shutdown message");
+            ::sys::kcall::ipc::__kcall_send(&message)
+                .expect("failed to broadcast shutdown message");
         }
 
         // Wait for memory daemon to terminate.
         while !self.processes.is_empty() {
-            match ::sys::kcall::ipc::recv() {
+            match ::sys::kcall::ipc::__kcall_recv() {
                 Ok(message) => {
                     if message.message_type == MessageType::ProcessTerminationEvent {
                         // Deserialize process identifier.
@@ -314,7 +315,7 @@ impl Drop for ProcessDaemon {
     fn drop(&mut self) {
         // Unsubscribe from scheduling events.
         ::syslog::info!("unsubscribing from scheduling events...");
-        if let Err(e) = ::sys::kcall::event::evctrl(
+        if let Err(e) = ::sys::kcall::event::__kcall_evctrl(
             Event::Scheduling(SchedulingEvent::ProcessTermination),
             EventCtrlRequest::Unregister,
         ) {
@@ -322,7 +323,7 @@ impl Drop for ProcessDaemon {
         }
 
         ::syslog::info!("shutting down process manager daemon...");
-        if let Err(e) = ::sys::kcall::pm::capctl(Capability::ProcessManagement, false) {
+        if let Err(e) = ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, false) {
             ::syslog::error!("failed to release process management capabilities (error={:?})", e);
         }
     }

--- a/src/libs/proc/src/syscall/lookup.rs
+++ b/src/libs/proc/src/syscall/lookup.rs
@@ -45,14 +45,14 @@ use ::sys::{
 ///
 pub fn lookup(name: &str) -> Result<ProcessIdentifier, Error> {
     // FIXME: this should not be required.
-    let mypid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let mypid: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
 
     // Build lookup message and send it.
     let message: Message = message::lookup_request(name, mypid)?;
-    ::sys::kcall::ipc::send(&message)?;
+    ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait response from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Parse response.
     match message.message_type {

--- a/src/libs/proc/src/syscall/signup.rs
+++ b/src/libs/proc/src/syscall/signup.rs
@@ -46,10 +46,10 @@ use ::sys::{
 pub fn signup(pid: &ProcessIdentifier, name: &str) -> Result<(), Error> {
     // Build signup message and send it.
     let message: Message = message::signup_request(*pid, name)?;
-    ::sys::kcall::ipc::send(&message)?;
+    ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait unblock message from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Parse message.
     match message.message_type {

--- a/src/libs/sys/src/sys/kcall/debug.rs
+++ b/src/libs/sys/src/sys/kcall/debug.rs
@@ -31,7 +31,8 @@ use crate::{
 ///
 /// Upon success, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn debug(buf: *const u8, size: usize) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_debug(buf: *const u8, size: usize) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::Debug.into(), buf as u32, size as u32);
 
     if result == 0 {

--- a/src/libs/sys/src/sys/kcall/event.rs
+++ b/src/libs/sys/src/sys/kcall/event.rs
@@ -24,7 +24,8 @@ use crate::{
 // Resume Event
 //==================================================================================================
 
-pub fn resume(event: EventDescriptor) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_resume(event: EventDescriptor) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Resume.into(), usize::from(event) as u32);
 
     if result == 0 {
@@ -38,7 +39,8 @@ pub fn resume(event: EventDescriptor) -> Result<(), Error> {
 // Controls an Event
 //==================================================================================================
 
-pub fn evctrl(ev: Event, req: EventCtrlRequest) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_evctrl(ev: Event, req: EventCtrlRequest) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::EventCtrl.into(), u32::from(ev), u32::from(req));
 
     if result == 0 {

--- a/src/libs/sys/src/sys/kcall/ipc.rs
+++ b/src/libs/sys/src/sys/kcall/ipc.rs
@@ -24,7 +24,8 @@ use crate::{
 // Send Message
 //==================================================================================================
 
-pub fn send(message: &Message) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_send(message: &Message) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Send.into(), message as *const Message as usize as u32);
 
     if result == 0 {
@@ -38,7 +39,8 @@ pub fn send(message: &Message) -> Result<(), Error> {
 // Receive Message
 //==================================================================================================
 
-pub fn recv() -> Result<Message, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_recv() -> Result<Message, Error> {
     let mut message: Message = Default::default();
 
     let result: i64 =
@@ -75,7 +77,8 @@ pub fn recv() -> Result<Message, Error> {
 /// - [`ErrorCode::InvalidArgument`]: Invalid destination identifiers, self-push, or transfer
 ///   length exceeds `u32::MAX`.
 ///
-pub fn push(
+#[unsafe(no_mangle)]
+pub fn __kcall_push(
     destination_pid: ProcessIdentifier,
     destination_tid: ThreadIdentifier,
     buffer: &[u8],
@@ -127,7 +130,8 @@ pub fn push(
 /// - [`ErrorCode::InvalidArgument`]: Invalid sender identifiers, self-pull, or transfer length
 ///   exceeds `u32::MAX`.
 ///
-pub fn pull(
+#[unsafe(no_mangle)]
+pub fn __kcall_pull(
     sender_pid: ProcessIdentifier,
     sender_tid: ThreadIdentifier,
     buffer: &mut [u8],

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -37,7 +37,8 @@ fn split_tag(tag: u64) -> (u32, u32) {
 // Map Memory Pages
 //==================================================================================================
 
-pub fn mmap(
+#[unsafe(no_mangle)]
+pub fn __kcall_mmap(
     pid: ProcessIdentifier,
     vaddr: VirtualAddress,
     npages: usize,
@@ -64,7 +65,8 @@ pub fn mmap(
 // Unmap Memory Page
 //==================================================================================================
 
-pub fn munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::MemoryUnmap.into(), pid.try_into()?, vaddr.into_raw_value() as u32);
 
@@ -79,7 +81,8 @@ pub fn munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error
 // Change Memory Protection
 //==================================================================================================
 
-pub fn mprotect(
+#[unsafe(no_mangle)]
+pub fn __kcall_mprotect(
     pid: ProcessIdentifier,
     vaddr: VirtualAddress,
     access: AccessPermission,
@@ -117,7 +120,8 @@ pub fn mprotect(
 ///
 /// `Ok(())` on success, or an error describing why the allocation failed.
 ///
-pub fn mmio_alloc(tag: u64) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_alloc(tag: u64) -> Result<(), Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let result: i64 = kcall2!(KcallNumber::AllocMmio.into(), lower, upper);
 
@@ -146,7 +150,8 @@ pub fn mmio_alloc(tag: u64) -> Result<(), Error> {
 ///
 /// `Ok(())` on success, or an error describing why the release failed.
 ///
-pub fn mmio_free(tag: u64) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_free(tag: u64) -> Result<(), Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let result: i64 = kcall2!(KcallNumber::FreeMmio.into(), lower, upper);
 
@@ -175,7 +180,8 @@ pub fn mmio_free(tag: u64) -> Result<(), Error> {
 ///
 /// On success, returns an [`MmioRegionInfo`] structure populated by the kernel.
 ///
-pub fn mmio_info(tag: u64) -> Result<MmioRegionInfo, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_info(tag: u64) -> Result<MmioRegionInfo, Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let mut info: MmioRegionInfo = MmioRegionInfo::default();
     let buffer: *mut MmioRegionInfo = &mut info;

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -46,7 +46,8 @@ use ::core::{
 /// Upon successful completion, the process identifier of the calling process is returned. Upon
 /// failure, an error is returned instead.
 ///
-pub fn getpid() -> Result<ProcessIdentifier, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetPid.into());
 
     // NOTE: errors are unlikely because getpid() always succeeds for a valid calling process.
@@ -71,7 +72,8 @@ pub fn getpid() -> Result<ProcessIdentifier, Error> {
 /// Upon successful completion, the thread identifier of the calling thread is returned. Upon
 /// failure, an error is returned instead.
 ///
-pub fn gettid() -> Result<ThreadIdentifier, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_gettid() -> Result<ThreadIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetTid.into());
 
     // NOTE: errors are unlikely because gettid() always succeeds for a valid calling thread.
@@ -100,7 +102,8 @@ pub fn gettid() -> Result<ThreadIdentifier, Error> {
 /// Upon successful completion, this function does not return. Upon failure, an error is returned
 /// instead.
 ///
-pub fn exit(status: i32) -> Result<!, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_exit(status: i32) -> Result<!, Error> {
     let result: i64 = kcall1!(KcallNumber::Exit.into(), status as u32);
     Err(Error::new(ErrorCode::try_from(result)?, "failed to terminate process"))
 }
@@ -123,7 +126,8 @@ pub fn exit(status: i32) -> Result<!, Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_capctl(capability: Capability, value: bool) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::CapCtl.into(), capability as u32, value as u32);
 
     // NOTE: errors are unlikely because capability control typically succeeds.
@@ -151,7 +155,8 @@ pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Terminate.into(), u32::try_from(pid)?);
 
     // NOTE: errors are unlikely because terminate typically succeeds for a valid process.
@@ -245,7 +250,7 @@ pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
 ///
 #[unsafe(no_mangle)]
 pub extern "C" fn _do_exit_thread(status: usize) -> ! {
-    let _ = exit_thread(status);
+    let _ = __kcall_exit_thread(status);
     unreachable!("failed to exit thread");
 }
 
@@ -264,7 +269,8 @@ pub extern "C" fn _do_exit_thread(status: usize) -> ! {
 /// Upon successful completion, the thread identifier of the new thread is returned. Upon failure,
 /// an error is returned instead.
 ///
-pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
     unsafe extern "C" {
         fn _do_start_thread() -> !;
     }
@@ -307,7 +313,8 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
 /// Upon successful completion, this function does not return. Upon failure, an error is returned
 /// instead.
 ///
-pub fn exit_thread(status: usize) -> Result<!, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_exit_thread(status: usize) -> Result<!, Error> {
     let result: i64 = kcall1!(KcallNumber::ExitThread.into(), status as u32);
 
     Err(Error::new(ErrorCode::try_from(result)?, "failed to terminate thread"))
@@ -331,7 +338,8 @@ pub fn exit_thread(status: usize) -> Result<!, Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
 
@@ -361,7 +369,8 @@ pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Erro
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::DetachThread.into(), i32::from(tid) as u32);
 
     if unlikely(result != 0) {
@@ -390,7 +399,11 @@ pub fn detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_lock_mutex(
+    mutex_addr: MutexAddress,
+    timeout: Option<SystemTime>,
+) -> Result<(), Error> {
     // Attempt to convert the timeout.
     let (seconds, nanoseconds): (u32, u32) = match timeout {
         Some(timeout) => {
@@ -435,7 +448,8 @@ pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Resu
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::MutexUnlock.into(), usize::from(mutex_addr) as u32);
 
     // NOTE: errors are unlikely because unlock typically succeeds for a valid, held mutex.
@@ -465,7 +479,8 @@ pub fn unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
 /// Upon successful completion, the number of threads awakened is returned. Upon failure, an error
 /// is returned instead.
 ///
-pub fn signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize, Error> {
     let result: i64 = kcall4!(
         KcallNumber::CondSignal.into(),
         usize::from(cond_addr) as u32,
@@ -502,7 +517,8 @@ pub fn signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn wait_cond(
+#[unsafe(no_mangle)]
+pub fn __kcall_wait_cond(
     cond_addr: ConditionAddress,
     mutex_addr: MutexAddress,
     timeout: Option<SystemTime>,
@@ -553,7 +569,8 @@ pub fn wait_cond(
 /// Upon successful completion, `gettime()` returns empty. Upon failure, it returns an `Error` to
 /// indicate the error.
 ///
-pub fn gettime(buffer: &mut SystemTime) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_gettime(buffer: &mut SystemTime) -> Result<(), Error> {
     let result: i64 =
         kcall1!(KcallNumber::GetTime.into(), buffer as *mut SystemTime as usize as u32);
 
@@ -582,7 +599,8 @@ pub fn gettime(buffer: &mut SystemTime) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
 ///
-pub fn sleep(timeout: Duration) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_sleep(timeout: Duration) -> Result<(), Error> {
     let seconds: u32 = timeout
         .as_secs()
         .try_into()
@@ -622,7 +640,8 @@ pub fn sleep(timeout: Duration) -> Result<(), Error> {
 /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
-pub fn get_thread_data_area() -> Result<*mut u8, Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_get_thread_data_area() -> Result<*mut u8, Error> {
     let result: i64 = kcall0!(KcallNumber::GetThreadDataArea.into());
 
     // NOTE: errors are unlikely because get_thread_data_area typically succeeds.
@@ -660,7 +679,8 @@ pub fn get_thread_data_area() -> Result<*mut u8, Error> {
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
 ///
-pub fn set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::SetThreadDataArea.into(), user_tda as usize as u32);
 
     // NOTE: errors are unlikely because set_thread_data_area typically succeeds.
@@ -685,7 +705,8 @@ pub fn set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-pub fn snapshot() -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_snapshot() -> Result<(), Error> {
     let result: i64 = kcall0!(KcallNumber::Snapshot.into());
 
     if unlikely(result != 0) {

--- a/src/libs/sys/src/sys/kcall/sched.rs
+++ b/src/libs/sys/src/sys/kcall/sched.rs
@@ -17,7 +17,8 @@ use crate::{
 // Scheduler Yield
 //==================================================================================================
 
-pub fn sched_yield() -> Result<(), Error> {
+#[unsafe(no_mangle)]
+pub fn __kcall_sched_yield() -> Result<(), Error> {
     let result: i64 = kcall0!(KcallNumber::SchedulerYield.into());
 
     if result == 0 {

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -215,7 +215,7 @@ impl OomHandler for NanvixOomHandler {
 ///
 #[allow(static_mut_refs)]
 pub fn init(base: VirtualAddress, capacity: usize) -> Result<(), Error> {
-    let pid: ProcessIdentifier = kcall::pm::getpid()?;
+    let pid: ProcessIdentifier = kcall::pm::__kcall_getpid()?;
 
     let size: usize = PAGE_SIZE;
 

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -166,7 +166,7 @@ impl Heap {
 
         for page in (new_end..old_end).step_by(mem::PAGE_SIZE).rev() {
             let page_addr: VirtualAddress = VirtualAddress::from_raw_value(page);
-            if let Err(error) = kcall::mm::munmap(self.pid, page_addr) {
+            if let Err(error) = kcall::mm::__kcall_munmap(self.pid, page_addr) {
                 ::syslog::warn!(
                     "shrink(): failed to unmap page at {:X?}, stopping (error={:?})",
                     page_addr,
@@ -214,7 +214,7 @@ pub fn map_range(
 
     // Use batch mmap kcall to map all pages in a single kernel transition.
     if let Err(error) =
-        kcall::mm::mmap(pid, VirtualAddress::new(start), npages, AccessPermission::RDWR)
+        kcall::mm::__kcall_mmap(pid, VirtualAddress::new(start), npages, AccessPermission::RDWR)
     {
         ::syslog::warn!(
             "map_range(): batch mmap failed at {:X?}..{:X?}, npages={} (error={:?})",
@@ -251,7 +251,7 @@ pub fn unmap_range(
 
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
-        if let Err(error) = kcall::mm::munmap(pid, vaddr) {
+        if let Err(error) = kcall::mm::__kcall_munmap(pid, vaddr) {
             ::syslog::warn!(
                 "unmap_range(): failed to unmap page at {:X?}, skipping (error={:?})",
                 vaddr,

--- a/src/libs/sysalloc/src/lib.rs
+++ b/src/libs/sysalloc/src/lib.rs
@@ -39,8 +39,8 @@ pub use ::arch::mem::*;
 pub use ::sys::mm::*;
 
 pub use ::sys::kcall::mm::{
-    mmap,
-    munmap,
+    __kcall_mmap,
+    __kcall_munmap,
 };
 
 pub use allocator::*;

--- a/src/libs/sysalloc/src/tda.rs
+++ b/src/libs/sysalloc/src/tda.rs
@@ -251,7 +251,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
 ///
 pub fn cleanup() -> Result<(), sys::error::Error> {
     // Get the base address for thread data area.
-    let tcb_ptr: *mut u8 = match sys::kcall::pm::get_thread_data_area() {
+    let tcb_ptr: *mut u8 = match sys::kcall::pm::__kcall_get_thread_data_area() {
         Ok(ptr) => ptr,
         Err(error) => {
             ::syslog::warn!("cleanup_tda(): {error:?}");
@@ -272,7 +272,7 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
     mark_uninitialized();
 
     // Clear the thread-local storage pointer first to avoid dangling pointers.
-    match sys::kcall::pm::set_thread_data_area(core::ptr::null_mut()) {
+    match sys::kcall::pm::__kcall_set_thread_data_area(core::ptr::null_mut()) {
         Ok(()) => Ok(()),
         Err(error) => {
             ::syslog::warn!("cleanup_tda(): failed to clear tda pointer (error={error:?})");

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -86,7 +86,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
     const MESSAGE_ASSEMBLER_CAPACITY: usize =
         GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request message.
     let request: Message = GetDirectoryEntriesRequest::build(tid, fd, count).map_err(|error| {
@@ -96,7 +96,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
     })?;
 
     // Send request message.
-    ::sys::kcall::ipc::send(&request).map_err(|error| {
+    ::sys::kcall::ipc::__kcall_send(&request).map_err(|error| {
         let reason: &str = "failed to send message";
         warn!("posix_getdents(): {reason} (error={:?})", error);
         Error::new(error.code, reason)
@@ -112,7 +112,7 @@ fn posix_getdents_linuxd(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Err
 
     loop {
         // Wait for response message.
-        let response: Message = ::sys::kcall::ipc::recv().map_err(|error| {
+        let response: Message = ::sys::kcall::ipc::__kcall_recv().map_err(|error| {
             let reason: &str = "failed to receive message";
             warn!("posix_getdents(): {reason} (error={:?})", error);
             Error::new(error.code, reason)

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -85,14 +85,14 @@ fn posix_fadvise_linuxd(
     len: off_t,
     advice: c_int,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileAdvisoryInformationRequest::build(tid, fd, offset, len, advice);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -66,14 +66,14 @@ pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Resu
 /// Forwards a `posix_fallocate` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn posix_fallocate_linuxd(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileSpaceControlRequest::build(tid, fd, offset, len)?;
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -65,14 +65,14 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
 /// Forwards a `fcntl` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fcntl_linuxd(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileControlRequest::build(tid, fd, cmd, arg.unwrap_or(0));
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status == -1 {

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -59,17 +59,17 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
 /// Forwards an `openat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn openat_linuxd(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<c_int, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: OpenAtRequest = OpenAtRequest::new(dirfd, pathname, flags, mode)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -82,17 +82,17 @@ fn renameat_linuxd(
     newdirfd: RawFileDescriptor,
     newpath: &str,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: RenameAtRequest = RenameAtRequest::new(olddirfd, oldpath, newdirfd, newpath)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -66,17 +66,17 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
 /// Forwards an `unlinkat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn unlinkat_linuxd(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: UnlinkAtRequest = UnlinkAtRequest::new(dirfd, pathname, flags)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -159,7 +159,7 @@ fn poll_linuxd(
     fds: &[PollFd],
     timeout: PollTimeout,
 ) -> Result<Vec<(RawFileDescriptor, PollEvents)>, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let events: Vec<i16> = fds.iter().map(|fd| fd.events.0).collect();
@@ -168,7 +168,7 @@ fn poll_linuxd(
     let request: PollRequest = PollRequest::new(&poll_fds, &events, timeout)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
     for request in &requests {
-        ipc::send(request)?;
+        ipc::__kcall_send(request)?;
     }
 
     // Compute maximum number of parts in the response.
@@ -176,7 +176,7 @@ fn poll_linuxd(
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ipc::recv()?;
+        let response: Message = ipc::__kcall_recv()?;
 
         // Check if system call failed.
         if response.status != 0 {

--- a/src/libs/syscall/src/pthread/syscall/cond.rs
+++ b/src/libs/syscall/src/pthread/syscall/cond.rs
@@ -21,8 +21,8 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        signal_cond,
-        wait_cond,
+        __kcall_signal_cond,
+        __kcall_wait_cond,
     },
     pm::{
         ConditionAddress,
@@ -72,7 +72,7 @@ pub fn pthread_cond_broadcast(cond: &pthread_cond_t) -> Result<(), Error> {
     }
 
     let _awakened: usize =
-        signal_cond(ConditionAddress::from(cond as *const pthread_cond_t as usize), true)?;
+        __kcall_signal_cond(ConditionAddress::from(cond as *const pthread_cond_t as usize), true)?;
 
     Ok(())
 }
@@ -136,7 +136,7 @@ pub fn pthread_cond_signal(cond: &pthread_cond_t) -> Result<(), Error> {
     }
 
     let _awakened: usize =
-        signal_cond(ConditionAddress::from(cond as *const pthread_cond_t as usize), false)?;
+        __kcall_signal_cond(ConditionAddress::from(cond as *const pthread_cond_t as usize), false)?;
 
     Ok(())
 }
@@ -157,7 +157,7 @@ pub fn pthread_cond_timedwait(
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::warn!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_cond_timedwait(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -173,12 +173,12 @@ pub fn pthread_cond_timedwait(
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::warn!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_cond_timedwait(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
 
-    wait_cond(
+    __kcall_wait_cond(
         ConditionAddress::from(cond as *const pthread_cond_t as usize),
         MutexAddress::from(mutex as *const pthread_mutex_t as usize),
         timeout,
@@ -197,7 +197,7 @@ pub fn pthread_cond_wait(cond: &pthread_cond_t, mutex: &pthread_mutex_t) -> Resu
             entry.insert(pthread_condattr_t::default());
         } else {
             let reason: &str = "condition variable is not initialized";
-            ::syslog::warn!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_cond_wait(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
@@ -213,12 +213,12 @@ pub fn pthread_cond_wait(cond: &pthread_cond_t, mutex: &pthread_mutex_t) -> Resu
             entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
-            ::syslog::warn!("pthread_wait_cond(): {}", reason);
+            ::syslog::warn!("pthread_cond_wait(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
 
-    wait_cond(
+    __kcall_wait_cond(
         ConditionAddress::from(cond as *const pthread_cond_t as usize),
         MutexAddress::from(mutex as *const pthread_mutex_t as usize),
         None,

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -45,10 +45,10 @@ use ::sys::{
     kcall::{
         arch,
         pm::{
-            create_thread,
-            exit_thread,
-            gettid,
-            join_thread,
+            __kcall_create_thread,
+            __kcall_exit_thread,
+            __kcall_gettid,
+            __kcall_join_thread,
         },
     },
     mm::VirtualAddress,
@@ -123,7 +123,7 @@ pub fn pthread_create(func: extern "C" fn(usize) -> usize, arg: usize) -> Result
         user_tda,
     };
 
-    let thread: pthread_t = create_thread(&mut args)?.try_into()?;
+    let thread: pthread_t = __kcall_create_thread(&mut args)?.try_into()?;
 
     // Store the stack in the global map.
     // NOTE: The stack will be dropped either when the thread is joined or the process exits.
@@ -160,7 +160,7 @@ pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
     };
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
 
     // Remove the stack from the global map.
     // NOTE: The stack will be dropped when this function returns.
@@ -193,7 +193,7 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
         ::syslog::warn!("pthread_exit(): failed to cleanup thread data area ({error:?})");
     }
 
-    exit_thread(retval)
+    __kcall_exit_thread(retval)
 }
 
 ///
@@ -229,7 +229,7 @@ pub fn pthread_self() -> pthread_t {
         // Cache miss: the TDA slot still holds the TDA_TID_UNSET sentinel because tda::alloc()
         // cannot know the child's TID at allocation time. Resolve via kcall and cache for future
         // calls.
-        let real_tid: pthread_t = gettid()
+        let real_tid: pthread_t = __kcall_gettid()
             .expect("pthread_self(): gettid kcall failed (TDA cache-miss path)")
             .try_into()
             .expect("pthread_self(): invalid thread identifier from kernel (TDA cache-miss path)");
@@ -242,7 +242,7 @@ pub fn pthread_self() -> pthread_t {
     }
 
     // Fallback: TDA not yet initialized (early startup).
-    gettid()
+    __kcall_gettid()
         .expect("pthread_self(): gettid kcall failed (early-startup path)")
         .try_into()
         .expect("pthread_self(): invalid thread identifier from kernel (early-startup path)")

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -20,8 +20,8 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        lock_mutex,
-        unlock_mutex,
+        __kcall_lock_mutex,
+        __kcall_unlock_mutex,
     },
     pm::MutexAddress,
     time::SystemTime,
@@ -102,7 +102,7 @@ pub fn pthread_mutex_lock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
         }
     }
 
-    lock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize), None)
+    __kcall_lock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize), None)
 }
 
 pub fn pthread_mutex_timedlock(
@@ -124,7 +124,7 @@ pub fn pthread_mutex_timedlock(
         }
     }
 
-    lock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize), timeout)
+    __kcall_lock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize), timeout)
 }
 
 pub fn pthread_mutex_trylock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
@@ -144,7 +144,7 @@ pub fn pthread_mutex_trylock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
     }
 
     // Try to lock the mutex and parse the result.
-    match lock_mutex(
+    match __kcall_lock_mutex(
         MutexAddress::from(mutex as *const pthread_mutex_t as usize),
         Some(SystemTime::default()),
     ) {
@@ -185,5 +185,5 @@ pub fn pthread_mutex_unlock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
         }
     }
 
-    unlock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize))
+    __kcall_unlock_mutex(MutexAddress::from(mutex as *const pthread_mutex_t as usize))
 }

--- a/src/libs/syscall/src/pthread/syscall/rwlock.rs
+++ b/src/libs/syscall/src/pthread/syscall/rwlock.rs
@@ -24,10 +24,10 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        lock_mutex,
-        signal_cond,
-        unlock_mutex,
-        wait_cond,
+        __kcall_lock_mutex,
+        __kcall_signal_cond,
+        __kcall_unlock_mutex,
+        __kcall_wait_cond,
     },
     pm::{
         ConditionAddress,
@@ -238,7 +238,7 @@ pub fn pthread_rwlock_rdlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
     };
 
     // Protect state.
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
 
     loop {
         let should_wait: bool = {
@@ -253,10 +253,10 @@ pub fn pthread_rwlock_rdlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
         };
 
         if !should_wait {
-            unlock_mutex(mutex_addr)?;
+            __kcall_unlock_mutex(mutex_addr)?;
             break Ok(());
         }
-        wait_cond(readers_cond_addr, mutex_addr, None)?;
+        __kcall_wait_cond(readers_cond_addr, mutex_addr, None)?;
     }
 }
 
@@ -286,7 +286,7 @@ pub fn pthread_rwlock_wrlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
         (mutex_addr, writers_cond_addr)
     };
 
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
 
     {
         let mut runtime: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
@@ -305,10 +305,10 @@ pub fn pthread_rwlock_wrlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
         }
 
         if acquired {
-            unlock_mutex(mutex_addr)?;
+            __kcall_unlock_mutex(mutex_addr)?;
             break Ok(());
         }
-        wait_cond(writers_cond_addr, mutex_addr, None)?;
+        __kcall_wait_cond(writers_cond_addr, mutex_addr, None)?;
     }
 }
 
@@ -344,7 +344,7 @@ pub fn pthread_rwlock_unlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
         (mutex_addr, readers_cond_addr, writers_cond_addr)
     };
 
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
 
     let (wake_readers, wake_writer): (bool, bool) = {
         let mut locked_runtime: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
@@ -374,12 +374,12 @@ pub fn pthread_rwlock_unlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error>
 
     // Wake appropriate waiters while still holding protection mutex so they observe state.
     if wake_writer {
-        let _ = signal_cond(writers_cond_addr, false);
+        let _ = __kcall_signal_cond(writers_cond_addr, false);
     } else if wake_readers {
-        let _ = signal_cond(readers_cond_addr, true); // broadcast to all readers
+        let _ = __kcall_signal_cond(readers_cond_addr, true); // broadcast to all readers
     }
 
-    unlock_mutex(mutex_addr)
+    __kcall_unlock_mutex(mutex_addr)
 }
 
 ///

--- a/src/libs/syscall/src/pthread/syscall/tda.rs
+++ b/src/libs/syscall/src/pthread/syscall/tda.rs
@@ -160,7 +160,7 @@ pub fn pthread_key_delete(key: pthread_key_t) -> Result<(), Error> {
 ///
 pub fn pthread_getspecific(key: pthread_key_t) -> Result<Pointer, Error> {
     // Lookup thread identifier before locking up the table of thread data keys.
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid().unwrap();
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid().unwrap();
 
     // Lookup thread-specific data.
     match THREAD_DATA.lock().get(key as usize) {
@@ -196,7 +196,7 @@ pub fn pthread_getspecific(key: pthread_key_t) -> Result<Pointer, Error> {
 ///
 pub fn pthread_setspecific(key: pthread_key_t, value: Pointer) -> Result<(), Error> {
     // Lookup thread identifier before locking up the table of thread data keys.
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid().unwrap();
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid().unwrap();
 
     // Lookup thread-specific data.
     match THREAD_DATA.lock().get_mut(key as usize) {

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -19,9 +19,9 @@ use ::sys::{
     },
     kcall,
     kcall::mm::{
-        mmap,
-        mprotect,
-        munmap,
+        __kcall_mmap,
+        __kcall_mprotect,
+        __kcall_munmap,
     },
     mm::{
         AccessPermission,
@@ -100,7 +100,7 @@ impl MemorySegment {
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        let pid: ProcessIdentifier = kcall::pm::__kcall_getpid()?;
 
         map_range(
             pid,
@@ -256,7 +256,7 @@ fn map_range(
 
         // Attempt to map page.
         let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
-        if let Err(error) = mmap(pid, vaddr, 1, access) {
+        if let Err(error) = __kcall_mmap(pid, vaddr, 1, access) {
             // Failed to map page, attempt to rollback.
 
             ::syslog::warn!(
@@ -279,7 +279,7 @@ fn map_range(
             return Err(error);
         }
 
-        // NOTE: pages allocated with mmap() are always zeroed.
+        // NOTE: pages allocated with __kcall_mmap() are always zeroed.
     }
 
     Ok(())
@@ -305,7 +305,7 @@ fn unmap_range(
 
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
-        if let Err(error) = munmap(pid, vaddr) {
+        if let Err(error) = __kcall_munmap(pid, vaddr) {
             ::syslog::warn!(
                 "unmap_range(): failed to unmap page at {:X?}, skipping (error={:?})",
                 vaddr,
@@ -339,7 +339,7 @@ fn protect_range(
         debug_assert!(vaddr != end);
 
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
-        if let Err(error) = mprotect(pid, vaddr, prot) {
+        if let Err(error) = __kcall_mprotect(pid, vaddr, prot) {
             ::syslog::warn!(
                 "protect_range(): failed to change protection of page at {:X?}, skipping \
                  (error={:?})",

--- a/src/libs/syscall/src/safe/time.rs
+++ b/src/libs/syscall/src/safe/time.rs
@@ -61,7 +61,7 @@ impl Time {
     ///
     pub fn now() -> Result<Time, Error> {
         let mut now: SystemTime = SystemTime::default();
-        kcall::pm::gettime(&mut now)?;
+        kcall::pm::__kcall_gettime(&mut now)?;
         Ok(Time(now))
     }
 

--- a/src/libs/syscall/src/sched/syscalls/sched_yield.rs
+++ b/src/libs/syscall/src/sched/syscalls/sched_yield.rs
@@ -21,5 +21,5 @@ use ::sys::error::Error;
 /// Upon successful completion, empty is returned. Otherwise an error code is returned instead.
 ///
 pub fn sched_yield() -> Result<(), Error> {
-    sys::kcall::sched::sched_yield()
+    sys::kcall::sched::__kcall_sched_yield()
 }

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -83,15 +83,15 @@ pub fn select(
         ));
     }
 
-    let tid: ThreadIdentifier = pm::gettid()?;
+    let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message =
         SelectRequest::build(tid, nfds, &readfds, &writefds, &errorfds, timeout)?;
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -41,14 +41,14 @@ pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = AcceptSocketRequest::build(tid, sockfd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -39,16 +39,16 @@ pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let sockaddr: sockaddr = sockaddr::from(sockaddr);
 
     // Build request and send it.
     let request: Message = BindSocketRequest::build(tid, sockfd, &sockaddr);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -59,16 +59,16 @@ pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let (sockaddr, socklen): (sockaddr, socklen_t) = From::<&SocketAddr>::from(sockaddr);
 
     // Build request and send it.
     let request: Message = ConnectSocketRequest::build(tid, sockfd, &sockaddr, socklen);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -56,14 +56,14 @@ pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = GetPeerNameRequest::build(tid, sockfd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -56,14 +56,14 @@ pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = GetSockNameRequest::build(tid, sockfd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -35,14 +35,14 @@ pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = ListenSocketRequest::build(tid, sockfd, backlog);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -39,7 +39,7 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
@@ -55,10 +55,10 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
 
         // Build request and send it.
         let request: Message = ReceiveSocketRequest::build(tid, sockfd, recv_len as u32, flags);
-        ::sys::kcall::ipc::send(&request)?;
+        ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -42,7 +42,7 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
@@ -60,10 +60,10 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
         // Build request and send it.
         let request: Message =
             SendSocketRequest::build(tid, sockfd, chunk_size as c_size_t, flags, chunk);
-        ::sys::kcall::ipc::send(&request)?;
+        ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -38,14 +38,14 @@ pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = ShutdownSocketRequest::build(tid, sockfd, how);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -43,14 +43,14 @@ pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Res
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = CreateSocketRequest::build(tid, domain, typ, protocol);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -66,7 +66,7 @@ pub fn socketpair(
         ));
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Check if array of file descriptors has expected length.
     if socket_fds.len() != 2 {
@@ -77,10 +77,10 @@ pub fn socketpair(
 
     // Build request and send it.
     let request: Message = CreateSocketPairRequest::build(tid, domain, typ, protocol);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -63,14 +63,14 @@ pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
 /// Forwards a `fchmod` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fchmod_linuxd(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = FileChmodRequest::build(tid, fd, mode);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -67,17 +67,17 @@ pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(
 /// Forwards a `fchmodat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fchmodat_linuxd(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: FileChmodAtRequest = FileChmodAtRequest::new(dirfd, mode, flag, path)?;
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -88,9 +88,9 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
 /// Forwards a `fstat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fstat_linuxd(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
     let message: Message = FileStatRequest::build(tid, fd);
-    ::sys::kcall::ipc::send(&message)?;
+    ::sys::kcall::ipc::__kcall_send(&message)?;
 
     *buf = crate::sys::stat::syscall::fstatat_response()?;
 

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -68,14 +68,14 @@ fn fstatat_linuxd(
     buf: &mut sys_stat::stat,
     flag: i32,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: FileStatAtRequest = FileStatAtRequest::new(dirfd, path.to_string(), flag)?;
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     *buf = crate::sys::stat::syscall::fstatat_response()?;

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -66,14 +66,14 @@ pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Erro
 /// Forwards a `futimens` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn futimens_linuxd(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = UpdateFileAccessTimeRequest::build(tid, fd, times);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -71,7 +71,7 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
 /// Forwards a `mkdirat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: MakeDirectoryAtRequest =
         MakeDirectoryAtRequest::new(dirfd, pathname.to_string(), mode)?;
@@ -80,11 +80,11 @@ fn mkdirat_linuxd(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Res
 
     // Send request.
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -81,7 +81,7 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -83,7 +83,7 @@ fn utimensat_linuxd(
     times: &[timespec; 2],
     flags: i32,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: UpdateFileAccessTimeAtRequest =
         UpdateFileAccessTimeAtRequest::new(dirfd, pathname.to_string(), flags, times)?;
@@ -92,11 +92,11 @@ fn utimensat_linuxd(
 
     // Send request.
     for request in &requests {
-        sys::kcall::ipc::send(request)?;
+        sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/times/syscall/times.rs
+++ b/src/libs/syscall/src/sys/times/syscall/times.rs
@@ -60,14 +60,14 @@ pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
         return Ok(0);
     }
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = TimesRequest::build(tid)?;
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/time/syscall/clock_gettime.rs
+++ b/src/libs/syscall/src/time/syscall/clock_gettime.rs
@@ -54,7 +54,7 @@ pub fn clock_gettime(clock_id: clockid_t, tp: &mut Option<&mut timespec>) -> Res
         CLOCK_MONOTONIC | CLOCK_REALTIME => {
             // Get system time and store it in the provided timespec structure.
             let mut now: SystemTime = SystemTime::default();
-            ::sys::kcall::pm::gettime(&mut now)?;
+            ::sys::kcall::pm::__kcall_gettime(&mut now)?;
             ::syslog::debug!("clock_gettime(): now={:?}", now);
             if let Some(tp) = tp {
                 tp.tv_sec = now.seconds() as time_t;

--- a/src/libs/syscall/src/time/syscall/nanosleep.rs
+++ b/src/libs/syscall/src/time/syscall/nanosleep.rs
@@ -69,10 +69,10 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
     let duration: Duration = Duration::new(secs, nanos);
 
     let mut now: SystemTime = SystemTime::default();
-    ::sys::kcall::pm::gettime(&mut now)?;
+    ::sys::kcall::pm::__kcall_gettime(&mut now)?;
 
     // Sleep for the requested time.
-    ::sys::kcall::pm::sleep(duration)?;
+    ::sys::kcall::pm::__kcall_sleep(duration)?;
 
     // Store the remaining time in the provided timespec structure.
     if let Some(rem) = rem {
@@ -91,7 +91,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
         };
 
         let mut now: SystemTime = SystemTime::default();
-        ::sys::kcall::pm::gettime(&mut now)?;
+        ::sys::kcall::pm::__kcall_gettime(&mut now)?;
 
         if now > later {
             rem.tv_sec = 0;

--- a/src/libs/syscall/src/unistd/bindings/_exit.rs
+++ b/src/libs/syscall/src/unistd/bindings/_exit.rs
@@ -53,7 +53,7 @@ use ::syslog::trace_libcall;
 #[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _exit(status: c_int) -> ! {
-    match sys::kcall::pm::exit(status) {
+    match sys::kcall::pm::__kcall_exit(status) {
         Ok(_) => unreachable!("process termination should not successfully return"),
         Err(error) => panic!("failed to terminate process (error={error:?})"),
     }

--- a/src/libs/syscall/src/unistd/syscall/_exit.rs
+++ b/src/libs/syscall/src/unistd/syscall/_exit.rs
@@ -26,5 +26,5 @@ use ::sys::error::Error;
 /// instead.
 ///
 pub fn _exit(status: i32) -> Result<!, Error> {
-    ::sys::kcall::pm::exit(status)?;
+    ::sys::kcall::pm::__kcall_exit(status)?;
 }

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -63,17 +63,17 @@ pub fn chdir(path: &str) -> Result<(), Error> {
 /// Forwards a `chdir` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn chdir_linuxd(path: &str) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: ChangeDirectoryRequest = ChangeDirectoryRequest::new(path)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -59,14 +59,14 @@ pub fn close(fd: i32) -> Result<(), Error> {
 /// Forwards a `close` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn close_linuxd(fd: i32) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = CloseRequest::build(tid, fd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -72,17 +72,17 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
 /// Forwards a `faccessat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: FileAccessAtRequest = FileAccessAtRequest::new(dirfd, path, mode, flag)?;
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+        ::sys::kcall::ipc::__kcall_send(&request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -61,14 +61,14 @@ pub fn fchdir(fd: c_int) -> Result<(), Error> {
 /// Forwards a `fchdir` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fchdir_linuxd(fd: c_int) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = FileChdirRequest::build(tid, fd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -66,14 +66,14 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
 /// Forwards a `fchown` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fchown_linuxd(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = FileChownRequest::build(tid, fd, owner, group);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -92,17 +92,17 @@ fn fchownat_linuxd(
     group: gid_t,
     flag: c_int,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: FileChownAtRequest = FileChownAtRequest::new(dirfd, owner, group, flag, path)?;
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -64,14 +64,14 @@ pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
 /// Forwards a `fdatasync` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fdatasync_linuxd(fd: RawFileDescriptor) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileDataSyncRequest::build(tid, fd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -62,14 +62,14 @@ pub fn fsync(fd: c_int) -> Result<(), Error> {
 /// Forwards a `fsync` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn fsync_linuxd(fd: c_int) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileSyncRequest::build(tid, fd);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -71,14 +71,14 @@ pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
 /// Forwards a `ftruncate` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn ftruncate_linuxd(fd: c_int, length: off_t) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileTruncateRequest::build(tid, fd, length);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -64,12 +64,12 @@ fn getcwd_linuxd() -> Result<String, Error> {
 /// Handles the request of the `getcwd()` system call.
 #[cfg(not(feature = "standalone"))]
 fn getcwd_request() -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: Message = GetCurrentWorkingDirectoryRequest::build(tid);
 
     // Send request.
-    ::sys::kcall::ipc::send(&request)
+    ::sys::kcall::ipc::__kcall_send(&request)
 }
 
 /// Handles the response of the `getcwd()` system call.
@@ -82,7 +82,7 @@ fn getcwd_response() -> Result<String, Error> {
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether the system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -53,14 +53,14 @@ pub fn getegid() -> Result<gid_t, Error> {
 /// Forwards a `getegid` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn getegid_linuxd() -> Result<gid_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = GetIdsRequest::build(tid);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -53,14 +53,14 @@ pub fn geteuid() -> Result<uid_t, Error> {
 /// Forwards a `geteuid` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn geteuid_linuxd() -> Result<uid_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = GetIdsRequest::build(tid);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -53,14 +53,14 @@ pub fn getgid() -> Result<gid_t, Error> {
 /// Forwards a `getgid` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn getgid_linuxd() -> Result<gid_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = GetIdsRequest::build(tid);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/getpid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getpid.rs
@@ -20,5 +20,5 @@ use ::sys::{
 /// `getpid()` returns the process ID (PID) of the calling process.
 ///
 pub fn getpid() -> Result<ProcessIdentifier, Error> {
-    ::sys::kcall::pm::getpid()
+    ::sys::kcall::pm::__kcall_getpid()
 }

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -53,14 +53,14 @@ pub fn getuid() -> Result<uid_t, Error> {
 /// Forwards a `getuid` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn getuid_linuxd() -> Result<uid_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = GetIdsRequest::build(tid);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -88,7 +88,7 @@ fn linkat_linuxd(
     newpath: &str,
     flags: c_int,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: LinkAtRequest =
         LinkAtRequest::new(olddirfd, oldpath.to_string(), newdirfd, newpath.to_string(), flags)?;
@@ -97,11 +97,11 @@ fn linkat_linuxd(
 
     // Send request.
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -71,14 +71,14 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
 /// Forwards a `lseek` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = SeekRequest::build(tid, fd, offset, whence);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -46,14 +46,14 @@ pub fn pipe() -> Result<[i32; 2], Error> {
 /// Forwards a `pipe` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn pipe_linuxd() -> Result<[i32; 2], Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = PipeRequest::build(tid);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -92,7 +92,7 @@ fn pread_linuxd(
     buffer: &mut [u8],
     offset: off_t,
 ) -> Result<c_size_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let mut total_read: c_size_t = 0;
     let mut buffer_offset: usize = 0;
@@ -108,10 +108,10 @@ fn pread_linuxd(
             chunk_size as c_size_t,
             offset + buffer_offset as off_t,
         );
-        ::sys::kcall::ipc::send(&request)?;
+        ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -91,7 +91,7 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
     let mut total_written: c_size_t = 0;
     let mut buffer_offset: usize = 0;
 
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     while buffer_offset < buffer.len() {
         let chunk_size: usize =
@@ -108,10 +108,10 @@ fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<
             offset + buffer_offset as off_t,
             chunk,
         );
-        ::sys::kcall::ipc::send(&request)?;
+        ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether the system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -56,17 +56,17 @@ fn read_chunk(
 ) -> Result<c_size_t, Error> {
     // Send metadata-only ReadRequest via IKC message.
     let request: Message = ReadRequest::build(tid, fd, chunk.len() as c_size_t);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Pull data from linuxd via data chunk transfer.
-    let bytes_pulled: usize = ::sys::kcall::ipc::pull(
+    let bytes_pulled: usize = ::sys::kcall::ipc::__kcall_pull(
         ::sys::pm::ProcessIdentifier::KERNEL,
         ::sys::pm::ThreadIdentifier::KERNEL,
         chunk,
     )?;
 
     // Receive response metadata (count, status). The bulk data is already in the buffer.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
@@ -184,7 +184,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
 
 /// Forwards a `read` request via IKC, splitting the buffer into page-aligned chunks.
 fn read_via_ikc(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let mut total_read: c_size_t = 0;
     let mut offset: usize = 0;

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -83,14 +83,14 @@ pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, E
 /// Forwards a `readlinkat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: ReadLinkAtRequest = ReadLinkAtRequest::new(dirfd, path.to_string(), buf.len())?;
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     let capacity: usize =
@@ -99,7 +99,7 @@ fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -70,7 +70,7 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
 /// Forwards a `symlinkat` request to linuxd via IPC.
 #[cfg(not(feature = "standalone"))]
 fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let request: SymbolicLinkAtRequest =
         SymbolicLinkAtRequest::new(target.to_string(), dirfd, linkpath.to_string())?;
@@ -79,11 +79,11 @@ fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Erro
 
     // Send request.
     for request in &requests {
-        ::sys::kcall::ipc::send(request)?;
+        ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -60,17 +60,17 @@ fn write_chunk(
     // Build metadata-only request and send it via IKC message.
     let empty_buf: [u8; WriteRequest::BUFFER_SIZE] = [0u8; WriteRequest::BUFFER_SIZE];
     let request: Message = WriteRequest::build(tid, fd, chunk.len() as c_size_t, empty_buf);
-    ::sys::kcall::ipc::send(&request)?;
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Push actual data to linuxd via data chunk transfer.
-    ::sys::kcall::ipc::push(
+    ::sys::kcall::ipc::__kcall_push(
         ::sys::pm::ProcessIdentifier::KERNEL,
         ::sys::pm::ThreadIdentifier::KERNEL,
         chunk,
     )?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
@@ -160,7 +160,7 @@ fn write_standalone(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Er
 
 /// Forwards a write request via IKC, splitting the buffer into page-aligned chunks.
 fn write_via_ikc(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     let mut total_written: c_size_t = 0;
     let mut offset: usize = 0;

--- a/src/libs/syslog/src/standalone.rs
+++ b/src/libs/syslog/src/standalone.rs
@@ -158,7 +158,7 @@ impl core::fmt::Debug for LogLevel {
 impl fmt::Write for Logger {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let slice: &[u8] = s.as_bytes();
-        let _ = ::sys::kcall::debug::debug(slice.as_ptr(), slice.len());
+        let _ = ::sys::kcall::debug::__kcall_debug(slice.as_ptr(), slice.len());
         Ok(())
     }
 }

--- a/src/tests/stress-rust/src/tests/common.rs
+++ b/src/tests/stress-rust/src/tests/common.rs
@@ -10,7 +10,7 @@ use ::core::{
     ptr,
 };
 use ::sys::{
-    kcall::pm::capctl,
+    kcall::pm::__kcall_capctl,
     pm::{
         Capability,
         MutexAddress,
@@ -70,7 +70,7 @@ impl CapabilityGuard {
     /// Fails if the capability cannot be enabled.
     ///
     pub fn enable(capability: Capability) -> Result<Self, StressError> {
-        capctl(capability, true)?;
+        __kcall_capctl(capability, true)?;
         Ok(Self {
             capability,
             released: false,
@@ -92,7 +92,7 @@ impl CapabilityGuard {
     ///
     pub fn disable(&mut self) -> Result<(), StressError> {
         if !self.released {
-            capctl(self.capability, false)?;
+            __kcall_capctl(self.capability, false)?;
             self.released = true;
         }
         Ok(())
@@ -102,7 +102,7 @@ impl CapabilityGuard {
 impl Drop for CapabilityGuard {
     fn drop(&mut self) {
         if !self.released {
-            let _ = capctl(self.capability, false);
+            let _ = __kcall_capctl(self.capability, false);
             self.released = true;
         }
     }

--- a/src/tests/stress-rust/src/tests/debug_console_spam.rs
+++ b/src/tests/stress-rust/src/tests/debug_console_spam.rs
@@ -7,8 +7,8 @@
 
 use super::common::StressError;
 use ::sys::kcall::{
-    debug::debug as kernel_debug,
-    sched::sched_yield,
+    debug::__kcall_debug as kernel_debug,
+    sched::__kcall_sched_yield,
 };
 
 //==================================================================================================
@@ -44,7 +44,7 @@ pub fn run() -> Result<(), StressError> {
         kernel_debug(payload.as_ptr(), payload.len())?;
 
         if round & 0x7 == 0 {
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
     }
     Ok(())

--- a/src/tests/stress-rust/src/tests/event_registration.rs
+++ b/src/tests/stress-rust/src/tests/event_registration.rs
@@ -16,8 +16,8 @@ use ::sys::{
         ExceptionEvent,
     },
     kcall::{
-        event::evctrl,
-        sched::sched_yield,
+        event::__kcall_evctrl,
+        sched::__kcall_sched_yield,
     },
     pm::Capability,
 };
@@ -53,11 +53,11 @@ pub fn run() -> Result<(), StressError> {
             }
 
             let target: Event = Event::Exception(*ev);
-            evctrl(target, EventCtrlRequest::Register)?;
-            evctrl(target, EventCtrlRequest::Unregister)?;
+            __kcall_evctrl(target, EventCtrlRequest::Register)?;
+            __kcall_evctrl(target, EventCtrlRequest::Unregister)?;
 
             if (cycle + index) & 0x3 == 0 {
-                sched_yield()?;
+                __kcall_sched_yield()?;
             }
         }
     }

--- a/src/tests/stress-rust/src/tests/kcall_hammer.rs
+++ b/src/tests/stress-rust/src/tests/kcall_hammer.rs
@@ -25,13 +25,13 @@ use ::sys::{
     },
     kcall::{
         pm::{
-            create_thread,
-            gettime,
-            join_thread,
-            lock_mutex,
-            unlock_mutex,
+            __kcall_create_thread,
+            __kcall_gettime,
+            __kcall_join_thread,
+            __kcall_lock_mutex,
+            __kcall_unlock_mutex,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ThreadCreateArgs,
@@ -81,14 +81,14 @@ pub fn run() -> Result<(), StressError> {
     for worker_id in 0..KCALL_HAMMER_WORKERS {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, kcall_hammer_worker, worker_id);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
         tids.push(tid);
         stacks.push(stack);
     }
 
     for (tid, stack) in tids.into_iter().zip(stacks) {
         let mut retval: usize = 0;
-        join_thread(tid, &mut retval)?;
+        __kcall_join_thread(tid, &mut retval)?;
         drop(stack);
         if retval == KCALL_HAMMER_FAILURE {
             let code_raw: usize = KCALL_HAMMER_ERROR_CODE.swap(0, Ordering::AcqRel);
@@ -152,15 +152,15 @@ extern "C" fn kcall_hammer_worker(worker_id: usize) -> usize {
 /// `Ok(count)` on success where `count` is the number of iterations completed.
 fn kcall_hammer_worker_impl(worker_id: usize) -> Result<usize, Error> {
     for iteration in 0..KCALL_HAMMER_ITERATIONS {
-        lock_mutex(stress_mutex_addr(), None)?;
+        __kcall_lock_mutex(stress_mutex_addr(), None)?;
         let mut now: SystemTime = SystemTime::default();
-        gettime(&mut now)?;
-        unlock_mutex(stress_mutex_addr())?;
+        __kcall_gettime(&mut now)?;
+        __kcall_unlock_mutex(stress_mutex_addr())?;
 
         KCALL_HAMMER_PROGRESS.fetch_add(1, Ordering::AcqRel);
 
         if (iteration + worker_id) & 0x3 == 0 {
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
     }
 

--- a/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
+++ b/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
@@ -19,11 +19,11 @@ use ::sys::{
     },
     kcall::{
         mm::{
-            mmap,
-            mprotect,
-            munmap,
+            __kcall_mmap,
+            __kcall_mprotect,
+            __kcall_munmap,
         },
-        pm::getpid,
+        pm::__kcall_getpid,
     },
     mm::{
         AccessPermission,
@@ -59,7 +59,7 @@ const MMAP_STRESS_STRIDE_BYTES: usize = 4 * KILOBYTE;
 pub fn run() -> Result<(), StressError> {
     let mut cap_guard: CapabilityGuard = CapabilityGuard::enable(Capability::MemoryManagement)?;
 
-    let pid: ProcessIdentifier = getpid()?;
+    let pid: ProcessIdentifier = __kcall_getpid()?;
 
     // Reserve address space from the unified bump allocator so we don't conflict with the heap
     // region.
@@ -75,11 +75,11 @@ pub fn run() -> Result<(), StressError> {
             AccessPermission::RDONLY
         };
 
-        mmap(pid, addr, 1, perm)?;
+        __kcall_mmap(pid, addr, 1, perm)?;
 
         if perm.is_writable() {
-            mprotect(pid, addr, AccessPermission::RDONLY)?;
-            mprotect(pid, addr, AccessPermission::RDWR)?;
+            __kcall_mprotect(pid, addr, AccessPermission::RDONLY)?;
+            __kcall_mprotect(pid, addr, AccessPermission::RDWR)?;
 
             let raw_addr: usize = usize::from(addr);
             let iteration_byte: u8 = u8::try_from(iteration)
@@ -90,7 +90,7 @@ pub fn run() -> Result<(), StressError> {
             }
         }
 
-        munmap(pid, addr)?;
+        __kcall_munmap(pid, addr)?;
 
         let next_raw: usize = usize::from(addr);
         current_addr = VirtualAddress::from_raw_value(next_raw + MMAP_STRESS_STRIDE_BYTES);

--- a/src/tests/stress-rust/src/tests/mutex_churn.rs
+++ b/src/tests/stress-rust/src/tests/mutex_churn.rs
@@ -25,12 +25,12 @@ use ::sys::{
     },
     kcall::{
         pm::{
-            create_thread,
-            join_thread,
-            lock_mutex,
-            unlock_mutex,
+            __kcall_create_thread,
+            __kcall_join_thread,
+            __kcall_lock_mutex,
+            __kcall_unlock_mutex,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ThreadCreateArgs,
@@ -79,14 +79,14 @@ pub fn run() -> Result<(), StressError> {
     for worker_id in 0..CHURN_WORKERS {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, mutex_churn_worker, worker_id);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
         tids.push(tid);
         stacks.push(stack);
     }
 
     for (tid, stack) in tids.into_iter().zip(stacks) {
         let mut retval: usize = 0;
-        join_thread(tid, &mut retval)?;
+        __kcall_join_thread(tid, &mut retval)?;
         drop(stack);
         if retval == CHURN_WORKER_FAILURE {
             let code_raw: usize = CHURN_ERROR_CODE.swap(0, Ordering::AcqRel);
@@ -147,12 +147,12 @@ extern "C" fn mutex_churn_worker(worker_id: usize) -> usize {
 /// `Ok(count)` on success where `count` is the number of iterations completed.
 fn mutex_churn_worker_impl(worker_id: usize) -> Result<usize, Error> {
     for iteration in 0..CHURN_ITERATIONS {
-        lock_mutex(stress_mutex_addr(), None)?;
+        __kcall_lock_mutex(stress_mutex_addr(), None)?;
         CHURN_TOTAL.fetch_add(1, Ordering::AcqRel);
-        unlock_mutex(stress_mutex_addr())?;
+        __kcall_unlock_mutex(stress_mutex_addr())?;
 
         if (iteration ^ worker_id) & 0x7 == 0 {
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
     }
 

--- a/src/tests/stress-rust/src/tests/parallel_spawners.rs
+++ b/src/tests/stress-rust/src/tests/parallel_spawners.rs
@@ -23,8 +23,8 @@ use ::sys::{
         ErrorCode,
     },
     kcall::{
-        pm::create_thread,
-        sched::sched_yield,
+        pm::__kcall_create_thread,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ThreadCreateArgs,
@@ -72,14 +72,14 @@ pub fn run() -> Result<(), StressError> {
     for worker_id in 0..CONCURRENT_SPAWNERS {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, spawner_worker, worker_id);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
         tids.push(tid);
         stacks.push(stack);
     }
 
     for (tid, stack) in tids.into_iter().zip(stacks) {
         let mut retval: usize = 0;
-        ::sys::kcall::pm::join_thread(tid, &mut retval)?;
+        ::sys::kcall::pm::__kcall_join_thread(tid, &mut retval)?;
         drop(stack);
         if retval == SPAWN_FAILURE {
             let code_raw: usize = SPAWN_ERROR_CODE.swap(0, Ordering::AcqRel);
@@ -143,10 +143,10 @@ fn spawner_worker_impl(worker_id: usize) -> Result<usize, Error> {
         let signature: usize = (worker_id << 8) | child_index;
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, spawn_child_worker, signature);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
 
         let mut retval: usize = 0;
-        ::sys::kcall::pm::join_thread(tid, &mut retval)?;
+        ::sys::kcall::pm::__kcall_join_thread(tid, &mut retval)?;
         drop(stack);
         assert_eq!(retval, signature ^ SPAWN_CHILD_RETURN_TAG, "child returned wrong signature");
         PARALLEL_SPAWNED.fetch_add(1, Ordering::AcqRel);
@@ -191,7 +191,7 @@ extern "C" fn spawn_child_worker(signature: usize) -> usize {
 /// `Ok(tag)` on success where `tag` combines the signature and return marker.
 fn spawn_child_worker_impl(signature: usize) -> Result<usize, Error> {
     for _ in 0..FAN_OUT_SPINS {
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
     Ok(signature ^ SPAWN_CHILD_RETURN_TAG)
 }

--- a/src/tests/stress-rust/src/tests/scheduler_pressure.rs
+++ b/src/tests/stress-rust/src/tests/scheduler_pressure.rs
@@ -26,12 +26,12 @@ use ::sys::{
     },
     kcall::{
         pm::{
-            create_thread,
-            gettime,
-            join_thread,
-            sleep,
+            __kcall_create_thread,
+            __kcall_gettime,
+            __kcall_join_thread,
+            __kcall_sleep,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ThreadCreateArgs,
@@ -108,13 +108,13 @@ pub fn run() -> Result<(), StressError> {
     // Spawn all workers upfront to maximize concurrent scheduling pressure.
     for (worker_id, stack) in stacks.iter().enumerate() {
         let mut args: ThreadCreateArgs = thread_args(stack, scheduler_pressure_worker, worker_id);
-        match create_thread(&mut args) {
+        match __kcall_create_thread(&mut args) {
             Ok(tid) => tids.push(tid),
             Err(e) => {
                 // Join already-spawned threads before returning so their stacks remain valid.
                 for tid in &tids {
                     let mut retval: usize = 0;
-                    let _ = join_thread(*tid, &mut retval);
+                    let _ = __kcall_join_thread(*tid, &mut retval);
                 }
                 return Err(e);
             },
@@ -124,7 +124,7 @@ pub fn run() -> Result<(), StressError> {
     // Join each worker and check for failures. Stacks are kept alive until after the loop.
     for tid in &tids {
         let mut retval: usize = 0;
-        join_thread(*tid, &mut retval)?;
+        __kcall_join_thread(*tid, &mut retval)?;
         if retval == PRESSURE_FAILURE {
             let code_raw: usize = PRESSURE_ERROR_CODE.swap(0, Ordering::Relaxed);
             let code: ErrorCode = error_code_from_usize(code_raw);
@@ -200,11 +200,11 @@ fn scheduler_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
         // Burst of fast kcalls: alternate gettime and yield to saturate the scheduler.
         for iteration in 0..SYSCALLS_PER_ROUND {
             let mut now: SystemTime = SystemTime::default();
-            gettime(&mut now)?;
+            __kcall_gettime(&mut now)?;
 
             // Stagger yields across workers so that ready-queue membership varies each cycle.
             if (iteration + worker_id + round) & 0x3 == 0 {
-                sched_yield()?;
+                __kcall_sched_yield()?;
             }
         }
 
@@ -212,7 +212,7 @@ fn scheduler_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
 
         // Brief sleep to force a sleeping → wakeup → ready transition, exercising the scheduler's
         // thread-selection logic again from a different starting state.
-        sleep(INTER_ROUND_SLEEP)?;
+        __kcall_sleep(INTER_ROUND_SLEEP)?;
     }
 
     Ok(PRESSURE_ROUNDS)

--- a/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
@@ -31,15 +31,15 @@ use ::sys::{
     },
     kcall::{
         mm::{
-            mmap,
-            munmap,
+            __kcall_mmap,
+            __kcall_munmap,
         },
         pm::{
-            create_thread,
-            getpid,
-            join_thread,
+            __kcall_create_thread,
+            __kcall_getpid,
+            __kcall_join_thread,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     mm::{
         AccessPermission,
@@ -114,14 +114,14 @@ pub fn run() -> Result<(), StressError> {
     for worker_id in 0..worker_count {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, scoreboard_pressure_worker, worker_id);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
         tids.push(tid);
         stacks.push(stack);
     }
 
     for (tid, stack) in tids.into_iter().zip(stacks) {
         let mut retval: usize = 0;
-        join_thread(tid, &mut retval)?;
+        __kcall_join_thread(tid, &mut retval)?;
         drop(stack);
 
         if retval == SCOREBOARD_PRESSURE_FAILURE {
@@ -196,7 +196,7 @@ extern "C" fn scoreboard_pressure_worker(worker_id: usize) -> usize {
 /// Propagates failures from kernel calls or address calculations.
 ///
 fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
-    let pid: ProcessIdentifier = getpid()?;
+    let pid: ProcessIdentifier = __kcall_getpid()?;
     let region_base: usize = worker_region_base(worker_id)?;
 
     for iteration in 0..SCOREBOARD_PRESSURE_ITERATIONS {
@@ -204,7 +204,7 @@ fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
         let addr_raw: usize = region_base + page_offset;
         let addr: VirtualAddress = VirtualAddress::from_raw_value(addr_raw);
 
-        mmap(pid, addr, 1, AccessPermission::RDWR)?;
+        __kcall_mmap(pid, addr, 1, AccessPermission::RDWR)?;
         let byte_raw: usize = (worker_id ^ iteration) & SCOREBOARD_PRESSURE_BYTE_MASK;
         let byte: u8 = u8::try_from(byte_raw)
             .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "worker byte overflow"))?;
@@ -212,12 +212,12 @@ fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
             let ptr: *mut u8 = exposed_addr_to_mut_u8(addr_raw);
             ptr.write_volatile(byte);
         }
-        munmap(pid, addr)?;
+        __kcall_munmap(pid, addr)?;
 
         SCOREBOARD_PRESSURE_PROGRESS.fetch_add(1, Ordering::AcqRel);
 
         if (iteration ^ worker_id) & SCOREBOARD_PRESSURE_YIELD_MASK == 0 {
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
     }
 

--- a/src/tests/stress-rust/src/tests/sleep_burst.rs
+++ b/src/tests/stress-rust/src/tests/sleep_burst.rs
@@ -16,8 +16,8 @@ use ::sys::{
         ErrorCode,
     },
     kcall::{
-        pm::sleep,
-        sched::sched_yield,
+        pm::__kcall_sleep,
+        sched::__kcall_sched_yield,
     },
 };
 
@@ -50,10 +50,10 @@ pub fn run() -> Result<(), StressError> {
             .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "round overflow"))?;
         let delay_micros: u64 = SLEEP_BASE_MICROS + (round_u64 & 0xF) * SLEEP_JITTER_MICROS;
         let duration: Duration = Duration::from_micros(delay_micros);
-        sleep(duration)?;
+        __kcall_sleep(duration)?;
 
         if round & 0x3 == 0 {
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
     }
 

--- a/src/tests/stress-rust/src/tests/thread_data_area.rs
+++ b/src/tests/stress-rust/src/tests/thread_data_area.rs
@@ -10,8 +10,8 @@ use super::common::{
     raw_pointer_address,
 };
 use ::sys::kcall::pm::{
-    get_thread_data_area,
-    set_thread_data_area,
+    __kcall_get_thread_data_area,
+    __kcall_set_thread_data_area,
 };
 
 //==================================================================================================
@@ -29,15 +29,15 @@ use ::sys::kcall::pm::{
 /// `Ok(())` on success or an error if thread data area operations fail.
 ///
 pub fn run() -> Result<(), StressError> {
-    let saved_tda: *mut u8 = get_thread_data_area()?;
+    let saved_tda: *mut u8 = __kcall_get_thread_data_area()?;
 
     let inner_result: Result<(), StressError> = (|| {
         let mut scratch: [u8; 64] = [0; 64];
         scratch.fill(0xbc);
         let scratch_ptr: *mut u8 = scratch.as_mut_ptr();
-        set_thread_data_area(scratch_ptr)?;
+        __kcall_set_thread_data_area(scratch_ptr)?;
 
-        let observed: *mut u8 = get_thread_data_area()?;
+        let observed: *mut u8 = __kcall_get_thread_data_area()?;
         let scratch_addr: usize = raw_pointer_address(scratch_ptr);
         let observed_addr: usize = raw_pointer_address(observed);
 
@@ -46,7 +46,7 @@ pub fn run() -> Result<(), StressError> {
         Ok(())
     })();
 
-    let restore_result: Result<(), StressError> = set_thread_data_area(saved_tda);
+    let restore_result: Result<(), StressError> = __kcall_set_thread_data_area(saved_tda);
     inner_result?;
     restore_result
 }

--- a/src/tests/stress-rust/src/tests/thread_fan_out.rs
+++ b/src/tests/stress-rust/src/tests/thread_fan_out.rs
@@ -22,8 +22,8 @@ use ::sys::{
         ErrorCode,
     },
     kcall::{
-        pm::create_thread,
-        sched::sched_yield,
+        pm::__kcall_create_thread,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ThreadCreateArgs,
@@ -67,10 +67,10 @@ pub fn run() -> Result<(), StressError> {
     for round in 0..FAN_OUT_ROUNDS {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, fan_out_worker, round);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
 
         let mut retval: usize = 0;
-        ::sys::kcall::pm::join_thread(tid, &mut retval)?;
+        ::sys::kcall::pm::__kcall_join_thread(tid, &mut retval)?;
         drop(stack);
         if retval == FAN_OUT_FAILURE {
             let code_raw: usize = FAN_OUT_ERROR_CODE.swap(0, Ordering::AcqRel);
@@ -131,7 +131,7 @@ extern "C" fn fan_out_worker(round: usize) -> usize {
 /// `Ok(tag)` on success where `tag` encodes the round value.
 fn fan_out_worker_impl(round: usize) -> Result<usize, Error> {
     for _ in 0..FAN_OUT_SPINS {
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
     FAN_OUT_COMPLETED.fetch_add(1, Ordering::AcqRel);
     Ok(round ^ FAN_OUT_RETURN_TAG)

--- a/src/tests/stress-rust/src/tests/thread_identity.rs
+++ b/src/tests/stress-rust/src/tests/thread_identity.rs
@@ -25,10 +25,10 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        create_thread,
-        getpid,
-        gettid,
-        join_thread,
+        __kcall_create_thread,
+        __kcall_getpid,
+        __kcall_gettid,
+        __kcall_join_thread,
     },
     pm::{
         ProcessIdentifier,
@@ -70,15 +70,15 @@ pub fn run() -> Result<(), StressError> {
     THREAD_IDENTITY_PID.store(0, Ordering::Relaxed);
     THREAD_IDENTITY_TID.store(0, Ordering::Relaxed);
 
-    let main_pid: ProcessIdentifier = getpid()?;
-    let main_tid: ThreadIdentifier = gettid()?;
+    let main_pid: ProcessIdentifier = __kcall_getpid()?;
+    let main_tid: ThreadIdentifier = __kcall_gettid()?;
 
     let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = thread_args(&stack, thread_identity_worker, 0);
-    let tid: ThreadIdentifier = create_thread(&mut args)?;
+    let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
 
     if retval == IDENTITY_FAILURE {
@@ -146,8 +146,8 @@ extern "C" fn thread_identity_worker(_: usize) -> usize {
 ///
 /// `Ok(tag)` on success where `tag` encodes the identity completion marker.
 fn thread_identity_worker_impl() -> Result<usize, Error> {
-    let pid: ProcessIdentifier = getpid()?;
-    let tid: ThreadIdentifier = gettid()?;
+    let pid: ProcessIdentifier = __kcall_getpid()?;
+    let tid: ThreadIdentifier = __kcall_gettid()?;
 
     THREAD_IDENTITY_PID.store(usize::try_from(pid)?, Ordering::Release);
     THREAD_IDENTITY_TID.store(usize::try_from(tid)?, Ordering::Release);

--- a/src/tests/stress-rust/src/tests/zombie_join_pressure.rs
+++ b/src/tests/stress-rust/src/tests/zombie_join_pressure.rs
@@ -26,9 +26,9 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        create_thread,
-        join_thread,
-        sleep,
+        __kcall_create_thread,
+        __kcall_join_thread,
+        __kcall_sleep,
     },
     pm::{
         ThreadCreateArgs,
@@ -110,7 +110,7 @@ fn run_round(_round: usize) -> Result<(), StressError> {
     for _worker_id in 0..WORKERS {
         let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, zombie_join_worker, 0);
-        match create_thread(&mut args) {
+        match __kcall_create_thread(&mut args) {
             Ok(tid) => {
                 tids.push(tid);
                 stacks.push(stack);
@@ -119,7 +119,7 @@ fn run_round(_round: usize) -> Result<(), StressError> {
                 // Join already-spawned threads before propagating the error.
                 for (tid, stack) in tids.into_iter().zip(stacks) {
                     let mut retval: usize = 0;
-                    let _ = join_thread(tid, &mut retval);
+                    let _ = __kcall_join_thread(tid, &mut retval);
                     drop(stack);
                 }
                 return Err(err);
@@ -130,7 +130,7 @@ fn run_round(_round: usize) -> Result<(), StressError> {
     // Join every worker and validate return values.
     for (tid, stack) in tids.into_iter().zip(stacks) {
         let mut retval: usize = 0;
-        join_thread(tid, &mut retval)?;
+        __kcall_join_thread(tid, &mut retval)?;
         drop(stack);
 
         if retval == WORKER_FAILURE {
@@ -190,6 +190,6 @@ extern "C" fn zombie_join_worker(_arg: usize) -> usize {
 /// Worker body: sleeps for [`SLEEP_MICROS`] microseconds and returns [`RETURN_TAG`].
 ///
 fn zombie_join_worker_impl() -> Result<usize, Error> {
-    sleep(Duration::from_micros(SLEEP_MICROS))?;
+    __kcall_sleep(Duration::from_micros(SLEEP_MICROS))?;
     Ok(RETURN_TAG)
 }

--- a/src/tests/test-kernel/src/direction_flag.rs
+++ b/src/tests/test-kernel/src/direction_flag.rs
@@ -141,7 +141,7 @@ fn test_gettime_with_df_set() -> Result<(), Error> {
     let mut time: SystemTime = SystemTime::EPOCH;
 
     set_df();
-    let result: Result<(), Error> = pm::gettime(&mut time);
+    let result: Result<(), Error> = pm::__kcall_gettime(&mut time);
     clear_df();
 
     result?;
@@ -170,7 +170,7 @@ fn test_gettime_with_df_set() -> Result<(), Error> {
 /// leading to a triple fault or data corruption.
 fn test_yield_with_df_set() -> Result<(), Error> {
     set_df();
-    let result: Result<(), Error> = sched::sched_yield();
+    let result: Result<(), Error> = sched::__kcall_sched_yield();
     clear_df();
 
     result
@@ -185,7 +185,7 @@ fn test_debug_with_df_set() -> Result<(), Error> {
     let msg: &[u8] = b"direction_flag: df-test probe";
 
     set_df();
-    let result: Result<(), Error> = debug::debug(msg.as_ptr(), msg.len());
+    let result: Result<(), Error> = debug::__kcall_debug(msg.as_ptr(), msg.len());
     clear_df();
 
     result
@@ -201,7 +201,7 @@ fn test_debug_with_df_set() -> Result<(), Error> {
 fn test_stress_yield_with_df_set() -> Result<(), Error> {
     for i in 0..STRESS_ITERATIONS {
         set_df();
-        let result: Result<(), Error> = sched::sched_yield();
+        let result: Result<(), Error> = sched::__kcall_sched_yield();
         clear_df();
 
         if let Err(e) = result {

--- a/src/tests/test-kernel/src/mmio_ramfs.rs
+++ b/src/tests/test-kernel/src/mmio_ramfs.rs
@@ -65,10 +65,10 @@ pub fn run() -> Result<(), Error> {
     let mut region_attached: bool = false;
 
     let mut result: Result<(), Error> = (|| {
-        pm::capctl(Capability::IoManagement, true)?;
+        pm::__kcall_capctl(Capability::IoManagement, true)?;
         cap_acquired = true;
 
-        match mm::mmio_alloc(RAMFS_MMIO_TAG) {
+        match mm::__kcall_mmio_alloc(RAMFS_MMIO_TAG) {
             Ok(()) => region_attached = true,
             Err(err) if err.code == ErrorCode::NoSuchEntry => {
                 let reason: &'static str =
@@ -79,7 +79,7 @@ pub fn run() -> Result<(), Error> {
             Err(err) => return Err(err),
         }
 
-        let info: MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
+        let info: MmioRegionInfo = mm::__kcall_mmio_info(RAMFS_MMIO_TAG)?;
         validate_info(&info)?;
         dump_ramfs_contents(&info)?;
 
@@ -87,7 +87,7 @@ pub fn run() -> Result<(), Error> {
     })();
 
     if region_attached {
-        if let Err(err) = mm::mmio_free(RAMFS_MMIO_TAG) {
+        if let Err(err) = mm::__kcall_mmio_free(RAMFS_MMIO_TAG) {
             ::syslog::error!("test-kernel: failed to free RAMFS region (error={:?})", err);
             if result.is_ok() {
                 result = Err(err);
@@ -96,7 +96,7 @@ pub fn run() -> Result<(), Error> {
     }
 
     if cap_acquired {
-        if let Err(err) = pm::capctl(Capability::IoManagement, false) {
+        if let Err(err) = pm::__kcall_capctl(Capability::IoManagement, false) {
             ::syslog::error!(
                 "test-kernel: failed to drop IoManagement capability (error={:?})",
                 err

--- a/src/tests/test-kernel/src/rendezvous.rs
+++ b/src/tests/test-kernel/src/rendezvous.rs
@@ -131,7 +131,7 @@ fn spawn_child_thread(
         user_stack_size: USER_THREAD_STACK_SIZE,
         user_tda: None,
     };
-    pm::create_thread(&mut args)
+    pm::__kcall_create_thread(&mut args)
 }
 
 ///
@@ -149,7 +149,7 @@ fn spawn_child_thread(
 ///
 fn join_child_thread(tid: ThreadIdentifier) -> Result<(), Error> {
     let mut retval: usize = 0;
-    pm::join_thread(tid, &mut retval)?;
+    pm::__kcall_join_thread(tid, &mut retval)?;
     if retval != 0 {
         ::syslog::error!("child thread failed (tid={:?}, retval={})", tid, retval);
         return Err(Error::new(ErrorCode::OperationNotPermitted, "child thread reported failure"));
@@ -168,11 +168,11 @@ fn join_child_thread(tid: ThreadIdentifier) -> Result<(), Error> {
 /// A tuple of (pid, main_tid).
 ///
 fn store_caller_ids() -> Result<(ProcessIdentifier, ThreadIdentifier), Error> {
-    let pid: ProcessIdentifier = pm::getpid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
 
-    let main_tid: ThreadIdentifier = pm::gettid()?;
+    let main_tid: ThreadIdentifier = pm::__kcall_gettid()?;
     let main_tid_raw: u32 = u32::try_from(main_tid)?;
     MAIN_TID.store(main_tid_raw, ORDER);
 
@@ -252,7 +252,7 @@ extern "C" fn pusher_thread_basic(_arg: usize) -> usize {
         Err(()) => return 1,
     };
 
-    match ipc::push(pid, main_tid, &TEST_PAYLOAD_16) {
+    match ipc::__kcall_push(pid, main_tid, &TEST_PAYLOAD_16) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -275,7 +275,7 @@ fn test_basic_push_pull() -> Result<(), Error> {
 
     // Pull data from the child thread.
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     // Validate byte count.
     if bytes_transferred != TEST_PAYLOAD_16.len() {
@@ -318,12 +318,12 @@ extern "C" fn pusher_thread_pull_first(_arg: usize) -> usize {
 
     // Yield several times to give the main thread time to call pull() and sleep.
     for _ in 0..5 {
-        if sched::sched_yield().is_err() {
+        if sched::__kcall_sched_yield().is_err() {
             return 1;
         }
     }
 
-    match ipc::push(pid, main_tid, &TEST_PAYLOAD_16) {
+    match ipc::__kcall_push(pid, main_tid, &TEST_PAYLOAD_16) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -346,7 +346,7 @@ fn test_pull_first() -> Result<(), Error> {
 
     // Pull immediately — the child yields multiple times, so we should sleep first.
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     if bytes_transferred != TEST_PAYLOAD_16.len() {
         ::syslog::error!(
@@ -386,7 +386,7 @@ extern "C" fn pusher_thread_one_byte(_arg: usize) -> usize {
     };
 
     let payload: [u8; 1] = [0x42];
-    match ipc::push(pid, main_tid, &payload) {
+    match ipc::__kcall_push(pid, main_tid, &payload) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -407,7 +407,7 @@ fn test_single_byte() -> Result<(), Error> {
     let child_tid: ThreadIdentifier = spawn_child_thread(pusher_thread_one_byte, stack_base)?;
 
     let mut recv_buf: [u8; 1] = [0u8; 1];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     if bytes_transferred != 1 {
         ::syslog::error!(
@@ -449,7 +449,7 @@ extern "C" fn pusher_thread_asymmetric(_arg: usize) -> usize {
         Err(()) => return 1,
     };
 
-    match ipc::push(pid, main_tid, &TEST_PAYLOAD_16) {
+    match ipc::__kcall_push(pid, main_tid, &TEST_PAYLOAD_16) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -472,7 +472,7 @@ fn test_asymmetric_buffers() -> Result<(), Error> {
 
     // Provide only 8 bytes to the pull.
     let mut recv_buf: [u8; 8] = [0u8; 8];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     // The kernel should transfer min(16, 8) = 8 bytes.
     if bytes_transferred != 8 {
@@ -513,7 +513,7 @@ extern "C" fn pusher_thread_zero(_arg: usize) -> usize {
     };
 
     let empty: [u8; 0] = [];
-    match ipc::push(pid, main_tid, &empty) {
+    match ipc::__kcall_push(pid, main_tid, &empty) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -535,7 +535,7 @@ fn test_zero_length() -> Result<(), Error> {
     let child_tid: ThreadIdentifier = spawn_child_thread(pusher_thread_zero, stack_base)?;
 
     let mut recv_buf: [u8; 0] = [];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     if bytes_transferred != 0 {
         ::syslog::error!(
@@ -587,7 +587,7 @@ extern "C" fn pusher_thread_large(_arg: usize) -> usize {
         unsafe { ::core::slice::from_raw_parts_mut(send_ptr, size) };
     fill_pattern(send_buf);
 
-    let result: usize = match ipc::push(pid, main_tid, send_buf) {
+    let result: usize = match ipc::__kcall_push(pid, main_tid, send_buf) {
         Ok(()) => 0,
         Err(_) => 1,
     };
@@ -631,7 +631,7 @@ fn test_large_transfer(size: usize) -> Result<(), Error> {
     // SAFETY: recv_ptr is valid for `size` bytes.
     let recv_buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(recv_ptr, size) };
 
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, recv_buf)?;
 
     if bytes_transferred != size {
         ::syslog::error!(
@@ -691,7 +691,7 @@ extern "C" fn pusher_thread_multi(_arg: usize) -> usize {
             *b = fill_byte;
         }
 
-        if ipc::push(pid, main_tid, &payload).is_err() {
+        if ipc::__kcall_push(pid, main_tid, &payload).is_err() {
             return 1;
         }
     }
@@ -720,7 +720,7 @@ fn test_multi_round() -> Result<(), Error> {
 
     for i in 0..ROUNDS {
         let mut recv_buf: [u8; 16] = [0u8; 16];
-        let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
         if bytes_transferred != 16 {
             ::syslog::error!(
@@ -766,11 +766,11 @@ fn test_multi_round() -> Result<(), Error> {
 fn test_self_push_rejected() -> Result<(), Error> {
     ::syslog::info!("test_self_push_rejected: starting");
 
-    let pid: ProcessIdentifier = pm::getpid()?;
-    let tid: ThreadIdentifier = pm::gettid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
     let payload: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
-    match ipc::push(pid, tid, &payload) {
+    match ipc::__kcall_push(pid, tid, &payload) {
         Err(e) if e.code == ErrorCode::InvalidArgument => {
             // Expected: self-push is rejected.
         },
@@ -804,11 +804,11 @@ fn test_self_push_rejected() -> Result<(), Error> {
 fn test_self_pull_rejected() -> Result<(), Error> {
     ::syslog::info!("test_self_pull_rejected: starting");
 
-    let pid: ProcessIdentifier = pm::getpid()?;
-    let tid: ThreadIdentifier = pm::gettid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
     let mut recv_buf: [u8; 4] = [0u8; 4];
-    match ipc::pull(pid, tid, &mut recv_buf) {
+    match ipc::__kcall_pull(pid, tid, &mut recv_buf) {
         Err(e) if e.code == ErrorCode::InvalidArgument => {
             // Expected: self-pull is rejected.
         },
@@ -846,7 +846,7 @@ extern "C" fn puller_thread_reverse(_arg: usize) -> usize {
     };
 
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    let bytes_transferred: usize = match ipc::pull(pid, main_tid, &mut recv_buf) {
+    let bytes_transferred: usize = match ipc::__kcall_pull(pid, main_tid, &mut recv_buf) {
         Ok(n) => n,
         Err(_) => return 1,
     };
@@ -877,10 +877,10 @@ fn test_reverse_direction() -> Result<(), Error> {
     let child_tid: ThreadIdentifier = spawn_child_thread(puller_thread_reverse, stack_base)?;
 
     // Retrieve our own PID for the push call.
-    let pid: ProcessIdentifier = pm::getpid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
 
     // Push data to the child thread.
-    ipc::push(pid, child_tid, &TEST_PAYLOAD_16)?;
+    ipc::__kcall_push(pid, child_tid, &TEST_PAYLOAD_16)?;
 
     join_child_thread(child_tid)?;
     // SAFETY: stack is no longer in use after join.
@@ -908,13 +908,13 @@ extern "C" fn bidir_child_thread(_arg: usize) -> usize {
 
     // Phase 1: push data to the main thread.
     let outgoing: [u8; 4] = [0xAA, 0xBB, 0xCC, 0xDD];
-    if ipc::push(pid, main_tid, &outgoing).is_err() {
+    if ipc::__kcall_push(pid, main_tid, &outgoing).is_err() {
         return 1;
     }
 
     // Phase 2: pull data from the main thread.
     let mut incoming: [u8; 4] = [0u8; 4];
-    let n: usize = match ipc::pull(pid, main_tid, &mut incoming) {
+    let n: usize = match ipc::__kcall_pull(pid, main_tid, &mut incoming) {
         Ok(n) => n,
         Err(_) => return 1,
     };
@@ -948,7 +948,7 @@ fn test_bidirectional() -> Result<(), Error> {
 
     // Phase 1: pull from the child.
     let mut recv_buf: [u8; 4] = [0u8; 4];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     if bytes_transferred != 4 {
         ::syslog::error!(
@@ -970,7 +970,7 @@ fn test_bidirectional() -> Result<(), Error> {
 
     // Phase 2: push to the child.
     let reply: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
-    ipc::push(pid, child_tid, &reply)?;
+    ipc::__kcall_push(pid, child_tid, &reply)?;
 
     join_child_thread(child_tid)?;
     // SAFETY: stack is no longer in use after join.
@@ -1019,7 +1019,7 @@ extern "C" fn concurrent_pusher_thread(arg: usize) -> usize {
         *b = fill_byte;
     }
 
-    let result: usize = match ipc::push(pid, main_tid, send_buf) {
+    let result: usize = match ipc::__kcall_push(pid, main_tid, send_buf) {
         Ok(()) => 0,
         Err(_) => 1,
     };
@@ -1072,7 +1072,7 @@ fn test_concurrent_push(transfer_size: usize) -> Result<(), Error> {
             user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
-        let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+        let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
         child_tids[i] = Some(tid);
     }
 
@@ -1094,7 +1094,7 @@ fn test_concurrent_push(transfer_size: usize) -> Result<(), Error> {
         let recv_buf: &mut [u8] =
             unsafe { ::core::slice::from_raw_parts_mut(recv_ptr, transfer_size) };
 
-        let bytes_transferred: usize = ipc::pull(pid, child_tid, recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, recv_buf)?;
 
         if bytes_transferred != transfer_size {
             ::syslog::error!(
@@ -1166,7 +1166,7 @@ extern "C" fn concurrent_puller_thread(arg: usize) -> usize {
     // SAFETY: recv_ptr is valid for `size` bytes.
     let recv_buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(recv_ptr, size) };
 
-    let bytes_transferred: usize = match ipc::pull(pid, main_tid, recv_buf) {
+    let bytes_transferred: usize = match ipc::__kcall_pull(pid, main_tid, recv_buf) {
         Ok(n) => n,
         Err(_) => {
             unsafe { ::alloc::alloc::dealloc(recv_ptr, layout) };
@@ -1228,13 +1228,13 @@ fn test_concurrent_pull(transfer_size: usize) -> Result<(), Error> {
             user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
-        let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+        let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
         child_tids[i] = Some(tid);
     }
 
     // Yield to let children register their pull requests.
     for _ in 0..5 {
-        sched::sched_yield()?;
+        sched::__kcall_sched_yield()?;
     }
 
     // Push unique data to each child.
@@ -1260,7 +1260,7 @@ fn test_concurrent_pull(transfer_size: usize) -> Result<(), Error> {
             *b = fill_byte;
         }
 
-        ipc::push(pid, child_tid, send_buf)?;
+        ipc::__kcall_push(pid, child_tid, send_buf)?;
 
         // SAFETY: send_ptr was allocated with send_layout.
         unsafe { ::alloc::alloc::dealloc(send_ptr, send_layout) };
@@ -1366,7 +1366,7 @@ extern "C" fn independent_pair_thread(arg: usize) -> usize {
 
     // Spin-yield until the main thread signals that all partner TIDs are written.
     while !PARTNER_TIDS_READY.load(ORDER) {
-        if sched::sched_yield().is_err() {
+        if sched::__kcall_sched_yield().is_err() {
             return 1;
         }
     }
@@ -1400,7 +1400,7 @@ extern "C" fn independent_pair_thread(arg: usize) -> usize {
         for b in buf.iter_mut() {
             *b = fill_byte;
         }
-        let result: usize = match ipc::push(pid, partner_tid, buf) {
+        let result: usize = match ipc::__kcall_push(pid, partner_tid, buf) {
             Ok(()) => 0,
             Err(_) => 1,
         };
@@ -1420,7 +1420,7 @@ extern "C" fn independent_pair_thread(arg: usize) -> usize {
         // SAFETY: buf_ptr is valid for `size` bytes.
         let buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(buf_ptr, size) };
 
-        let result: usize = match ipc::pull(pid, partner_tid, buf) {
+        let result: usize = match ipc::__kcall_pull(pid, partner_tid, buf) {
             Ok(n) if n == size && buf.iter().all(|&b| b == fill_byte) => 0,
             _ => 1,
         };
@@ -1443,7 +1443,7 @@ fn test_independent_pairs() -> Result<(), Error> {
 
     ::syslog::info!("test_independent_pairs: starting (pairs={})", NUM_PAIRS);
 
-    let pid: ProcessIdentifier = pm::getpid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
     TRANSFER_SIZE.store(TRANSFER as u32, ORDER);
@@ -1472,7 +1472,7 @@ fn test_independent_pairs() -> Result<(), Error> {
             user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
-        let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+        let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
         child_tids[i] = Some(tid);
 
         // Store TID so partner can find it.
@@ -1536,7 +1536,7 @@ extern "C" fn stress_pusher_thread(_arg: usize) -> usize {
         for b in buf.iter_mut() {
             *b = fill_byte;
         }
-        if ipc::push(pid, main_tid, buf).is_err() {
+        if ipc::__kcall_push(pid, main_tid, buf).is_err() {
             unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
             return 1;
         }
@@ -1587,7 +1587,7 @@ fn test_stress_sequential() -> Result<(), Error> {
             *b = 0;
         }
 
-        let bytes_transferred: usize = ipc::pull(pid, child_tid, recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, recv_buf)?;
 
         if bytes_transferred != SIZE {
             ::syslog::error!(
@@ -1661,7 +1661,7 @@ extern "C" fn bidir_large_child_thread(_arg: usize) -> usize {
     let buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(buf_ptr, size) };
     fill_pattern(buf);
 
-    if ipc::push(pid, main_tid, buf).is_err() {
+    if ipc::__kcall_push(pid, main_tid, buf).is_err() {
         unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
         return 1;
     }
@@ -1671,7 +1671,7 @@ extern "C" fn bidir_large_child_thread(_arg: usize) -> usize {
         *b = 0;
     }
 
-    let bytes_transferred: usize = match ipc::pull(pid, main_tid, buf) {
+    let bytes_transferred: usize = match ipc::__kcall_pull(pid, main_tid, buf) {
         Ok(n) => n,
         Err(_) => {
             unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
@@ -1732,7 +1732,7 @@ fn test_large_bidirectional() -> Result<(), Error> {
     // SAFETY: buf_ptr is valid for SIZE bytes.
     let buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(buf_ptr, SIZE) };
 
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, buf)?;
 
     if bytes_transferred != SIZE {
         ::syslog::error!(
@@ -1759,7 +1759,7 @@ fn test_large_bidirectional() -> Result<(), Error> {
         *byte = 0xFF ^ (((i.wrapping_mul(37).wrapping_add(7)) & 0xFF) as u8);
     }
 
-    ipc::push(pid, child_tid, buf)?;
+    ipc::__kcall_push(pid, child_tid, buf)?;
 
     // SAFETY: buf_ptr was allocated with buf_layout and is no longer in use.
     unsafe { ::alloc::alloc::dealloc(buf_ptr, buf_layout) };
@@ -1790,7 +1790,7 @@ extern "C" fn puller_thread_reverse_asymmetric(_arg: usize) -> usize {
     };
 
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    let bytes_transferred: usize = match ipc::pull(pid, main_tid, &mut recv_buf) {
+    let bytes_transferred: usize = match ipc::__kcall_pull(pid, main_tid, &mut recv_buf) {
         Ok(n) => n,
         Err(_) => return 1,
     };
@@ -1824,11 +1824,11 @@ fn test_reverse_asymmetric() -> Result<(), Error> {
     let child_tid: ThreadIdentifier =
         spawn_child_thread(puller_thread_reverse_asymmetric, stack_base)?;
 
-    let pid: ProcessIdentifier = pm::getpid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
 
     // Push only 4 bytes to the child that expects up to 16.
     let payload: [u8; 4] = [0xA1, 0xB2, 0xC3, 0xD4];
-    ipc::push(pid, child_tid, &payload)?;
+    ipc::__kcall_push(pid, child_tid, &payload)?;
 
     join_child_thread(child_tid)?;
     // SAFETY: stack is no longer in use after join.
@@ -1873,7 +1873,7 @@ extern "C" fn mixed_size_pusher_thread(_arg: usize) -> usize {
         let buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(buf_ptr, size) };
         fill_pattern(buf);
 
-        let result: bool = ipc::push(pid, main_tid, buf).is_ok();
+        let result: bool = ipc::__kcall_push(pid, main_tid, buf).is_ok();
 
         // SAFETY: buf_ptr was allocated with the same layout.
         unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
@@ -1917,7 +1917,7 @@ fn test_mixed_transfer_sizes() -> Result<(), Error> {
         // SAFETY: recv_ptr is valid for `size` bytes.
         let recv_buf: &mut [u8] = unsafe { ::core::slice::from_raw_parts_mut(recv_ptr, size) };
 
-        let bytes_transferred: usize = ipc::pull(pid, child_tid, recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, recv_buf)?;
 
         if bytes_transferred != size {
             ::syslog::error!(
@@ -1976,13 +1976,13 @@ extern "C" fn multi_round_bidir_child(_arg: usize) -> usize {
         for b in outgoing.iter_mut() {
             *b = fill_byte;
         }
-        if ipc::push(pid, main_tid, &outgoing).is_err() {
+        if ipc::__kcall_push(pid, main_tid, &outgoing).is_err() {
             return 1;
         }
 
         // Phase B: pull from main, expect complement fill byte.
         let mut incoming: [u8; 16] = [0u8; 16];
-        let n: usize = match ipc::pull(pid, main_tid, &mut incoming) {
+        let n: usize = match ipc::__kcall_pull(pid, main_tid, &mut incoming) {
             Ok(n) => n,
             Err(_) => return 1,
         };
@@ -2025,7 +2025,7 @@ fn test_multi_round_bidirectional() -> Result<(), Error> {
     for i in 0..ROUNDS {
         // Phase A: pull from child.
         let mut recv_buf: [u8; 16] = [0u8; 16];
-        let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
         if bytes_transferred != 16 {
             ::syslog::error!(
@@ -2053,7 +2053,7 @@ fn test_multi_round_bidirectional() -> Result<(), Error> {
         for b in reply.iter_mut() {
             *b = reply_byte;
         }
-        ipc::push(pid, child_tid, &reply)?;
+        ipc::__kcall_push(pid, child_tid, &reply)?;
     }
 
     join_child_thread(child_tid)?;
@@ -2092,7 +2092,7 @@ extern "C" fn stress_pair_thread(arg: usize) -> usize {
 
     // Spin-yield until the main thread signals that all partner TIDs are written.
     while !PARTNER_TIDS_READY.load(ORDER) {
-        if sched::sched_yield().is_err() {
+        if sched::__kcall_sched_yield().is_err() {
             return 1;
         }
     }
@@ -2130,7 +2130,7 @@ extern "C" fn stress_pair_thread(arg: usize) -> usize {
             for b in buf.iter_mut() {
                 *b = fill_byte;
             }
-            if ipc::push(pid, partner_tid, buf).is_err() {
+            if ipc::__kcall_push(pid, partner_tid, buf).is_err() {
                 unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
                 return 1;
             }
@@ -2153,7 +2153,7 @@ extern "C" fn stress_pair_thread(arg: usize) -> usize {
                 *b = 0;
             }
 
-            let n: usize = match ipc::pull(pid, partner_tid, buf) {
+            let n: usize = match ipc::__kcall_pull(pid, partner_tid, buf) {
                 Ok(n) => n,
                 Err(_) => {
                     unsafe { ::alloc::alloc::dealloc(buf_ptr, layout) };
@@ -2194,7 +2194,7 @@ fn test_stress_concurrent_pairs() -> Result<(), Error> {
         TRANSFER
     );
 
-    let pid: ProcessIdentifier = pm::getpid()?;
+    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
     TRANSFER_SIZE.store(TRANSFER as u32, ORDER);
@@ -2223,7 +2223,7 @@ fn test_stress_concurrent_pairs() -> Result<(), Error> {
             user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
-        let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+        let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
         child_tids[i] = Some(tid);
 
         // Store TID so partner can find it.
@@ -2275,7 +2275,7 @@ extern "C" fn cleanup_pusher_thread(_arg: usize) -> usize {
         Err(()) => return 1,
     };
 
-    match ipc::push(pid, main_tid, &CLEANUP_PAYLOAD) {
+    match ipc::__kcall_push(pid, main_tid, &CLEANUP_PAYLOAD) {
         Ok(()) => 0,
         Err(_) => 1,
     }
@@ -2293,7 +2293,7 @@ extern "C" fn cleanup_puller_thread(_arg: usize) -> usize {
     };
 
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    match ipc::pull(pid, main_tid, &mut recv_buf) {
+    match ipc::__kcall_pull(pid, main_tid, &mut recv_buf) {
         Ok(_) => 0,
         Err(_) => 1,
     }
@@ -2325,7 +2325,7 @@ fn test_thread_exit_cleanup() -> Result<(), Error> {
 
             // Pull data from the child thread.
             let mut recv_buf: [u8; 16] = [0u8; 16];
-            let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+            let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
             // Validate byte count and payload.
             if bytes_transferred != 16 {
@@ -2350,11 +2350,11 @@ fn test_thread_exit_cleanup() -> Result<(), Error> {
 
             // Yield to give the child time to call pull() and sleep.
             for _ in 0..5 {
-                sched::sched_yield()?;
+                sched::__kcall_sched_yield()?;
             }
 
             // Push data to the child thread.
-            ipc::push(pid, child_tid, &CLEANUP_PAYLOAD)?;
+            ipc::__kcall_push(pid, child_tid, &CLEANUP_PAYLOAD)?;
 
             join_child_thread(child_tid)?;
         }
@@ -2368,7 +2368,7 @@ fn test_thread_exit_cleanup() -> Result<(), Error> {
     let child_tid: ThreadIdentifier = spawn_child_thread(pusher_thread_basic, stack_base)?;
 
     let mut recv_buf: [u8; 16] = [0u8; 16];
-    let bytes_transferred: usize = ipc::pull(pid, child_tid, &mut recv_buf)?;
+    let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tid, &mut recv_buf)?;
 
     if bytes_transferred != TEST_PAYLOAD_16.len() || recv_buf != TEST_PAYLOAD_16 {
         ::syslog::error!("test_thread_exit_cleanup: final validation failed");
@@ -2417,13 +2417,13 @@ fn test_interleaved_pending_order() -> Result<(), Error> {
 
     // Yield to give all children time to call push() and register their pending entries.
     for _ in 0..10 {
-        sched::sched_yield()?;
+        sched::__kcall_sched_yield()?;
     }
 
     // Pull from children in reverse order (2, 1, 0) to exercise swap_remove on non-last indices.
     for i in (0..NUM_CHILDREN).rev() {
         let mut recv_buf: [u8; 16] = [0u8; 16];
-        let bytes_transferred: usize = ipc::pull(pid, child_tids[i], &mut recv_buf)?;
+        let bytes_transferred: usize = ipc::__kcall_pull(pid, child_tids[i], &mut recv_buf)?;
 
         if bytes_transferred != 16 {
             ::syslog::error!(

--- a/src/tests/test-kernel/src/tls.rs
+++ b/src/tests/test-kernel/src/tls.rs
@@ -155,8 +155,8 @@ fn assert_eq_or_fail(test: &'static str, expected: u32, actual: u32) -> Result<(
 ///
 /// Propagates errors from `get_thread_data_area()` or `set_thread_data_area()`.
 fn setup_tda(tda: &mut TdaBuffer) -> Result<*mut u8, Error> {
-    let original_tda: *mut u8 = pm::get_thread_data_area()?;
-    pm::set_thread_data_area(tda.as_mut_ptr().cast::<u8>())?;
+    let original_tda: *mut u8 = pm::__kcall_get_thread_data_area()?;
+    pm::__kcall_set_thread_data_area(tda.as_mut_ptr().cast::<u8>())?;
     Ok(original_tda)
 }
 
@@ -172,7 +172,7 @@ fn setup_tda(tda: &mut TdaBuffer) -> Result<*mut u8, Error> {
 ///
 /// Propagates errors from `set_thread_data_area()`.
 fn teardown_tda(original_tda: *mut u8) -> Result<(), Error> {
-    pm::set_thread_data_area(original_tda)?;
+    pm::__kcall_set_thread_data_area(original_tda)?;
     Ok(())
 }
 
@@ -252,7 +252,7 @@ fn test_multiple_offsets() -> Result<(), Error> {
 ///
 /// Returns an error if `%gs:0x0` does not reflect the active buffer's value.
 fn test_reassignment() -> Result<(), Error> {
-    let original: *mut u8 = pm::get_thread_data_area()?;
+    let original: *mut u8 = pm::__kcall_get_thread_data_area()?;
 
     let mut tda_a: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
     let mut tda_b: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
@@ -265,19 +265,19 @@ fn test_reassignment() -> Result<(), Error> {
     }
 
     // Point TDA to buffer A and verify.
-    pm::set_thread_data_area(tda_a.as_mut_ptr().cast::<u8>())?;
+    pm::__kcall_set_thread_data_area(tda_a.as_mut_ptr().cast::<u8>())?;
     let val_a: u32 = unsafe { read_gs_offset_0() };
     let mut result: Result<(), Error> = assert_eq_or_fail("reassignment_a", magic_a, val_a);
 
     // Switch TDA to buffer B and verify (only if buffer A succeeded).
     if result.is_ok() {
-        pm::set_thread_data_area(tda_b.as_mut_ptr().cast::<u8>())?;
+        pm::__kcall_set_thread_data_area(tda_b.as_mut_ptr().cast::<u8>())?;
         let val_b: u32 = unsafe { read_gs_offset_0() };
         result = assert_eq_or_fail("reassignment_b", magic_b, val_b);
     }
 
     // Cleanup.
-    pm::set_thread_data_area(original)?;
+    pm::__kcall_set_thread_data_area(original)?;
     result
 }
 
@@ -304,14 +304,14 @@ fn test_clear_and_restore() -> Result<(), Error> {
 
     if result.is_ok() {
         // Clear TDA (set to null).
-        pm::set_thread_data_area(core::ptr::null_mut())?;
+        pm::__kcall_set_thread_data_area(core::ptr::null_mut())?;
 
         // Verify get_thread_data_area() returns null after clearing.
         // NOTE: we intentionally do NOT read %gs:0x0 here because the segment
         // base has been zeroed and the selector set to null, so a %gs-relative
         // read would fault (GP or PF). The getter is the only safe way to
         // verify that the TDA was actually cleared.
-        let cleared_tda: *mut u8 = pm::get_thread_data_area()?;
+        let cleared_tda: *mut u8 = pm::__kcall_get_thread_data_area()?;
         if !cleared_tda.is_null() {
             ::syslog::error!(
                 "test-kernel: tls: clear_restore: TDA not null after clear ({cleared_tda:?})"
@@ -322,7 +322,7 @@ fn test_clear_and_restore() -> Result<(), Error> {
 
     if result.is_ok() {
         // Restore TDA and verify the magic value is accessible again.
-        pm::set_thread_data_area(tda.as_mut_ptr().cast::<u8>())?;
+        pm::__kcall_set_thread_data_area(tda.as_mut_ptr().cast::<u8>())?;
         let after: u32 = unsafe { read_gs_offset_0() };
         result = assert_eq_or_fail("clear_restore_after", TDA_MAGIC, after);
     }
@@ -378,7 +378,7 @@ fn test_get_set_round_trip() -> Result<(), Error> {
     let original: *mut u8 = setup_tda(&mut tda)?;
     let expected_ptr: *mut u8 = tda.as_mut_ptr().cast::<u8>();
 
-    let returned_tda: *mut u8 = pm::get_thread_data_area()?;
+    let returned_tda: *mut u8 = pm::__kcall_get_thread_data_area()?;
     if returned_tda != expected_ptr {
         ::syslog::error!(
             "test-kernel: tls: get_set_round_trip: expected {expected_ptr:?}, got {returned_tda:?}"
@@ -401,7 +401,7 @@ fn test_get_set_round_trip() -> Result<(), Error> {
 ///
 /// Returns an error if any iteration produces a mismatched read.
 fn test_repeated_reassignment() -> Result<(), Error> {
-    let original: *mut u8 = pm::get_thread_data_area()?;
+    let original: *mut u8 = pm::__kcall_get_thread_data_area()?;
 
     let mut tda_a: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
     let mut tda_b: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
@@ -415,14 +415,14 @@ fn test_repeated_reassignment() -> Result<(), Error> {
 
     let mut result: Result<(), Error> = Ok(());
     for _ in 0..REPEAT_ITERATIONS {
-        pm::set_thread_data_area(tda_a.as_mut_ptr().cast::<u8>())?;
+        pm::__kcall_set_thread_data_area(tda_a.as_mut_ptr().cast::<u8>())?;
         let val_a: u32 = unsafe { read_gs_offset_0() };
         if let Err(e) = assert_eq_or_fail("repeated_reassign_a", magic_a, val_a) {
             result = Err(e);
             break;
         }
 
-        pm::set_thread_data_area(tda_b.as_mut_ptr().cast::<u8>())?;
+        pm::__kcall_set_thread_data_area(tda_b.as_mut_ptr().cast::<u8>())?;
         let val_b: u32 = unsafe { read_gs_offset_0() };
         if let Err(e) = assert_eq_or_fail("repeated_reassign_b", magic_b, val_b) {
             result = Err(e);
@@ -430,7 +430,7 @@ fn test_repeated_reassignment() -> Result<(), Error> {
         }
     }
 
-    pm::set_thread_data_area(original)?;
+    pm::__kcall_set_thread_data_area(original)?;
     result
 }
 
@@ -507,7 +507,7 @@ extern "C" fn tda_worker(arg: usize) -> usize {
     let tda_ptr: *mut u8 = arg as *mut u8;
 
     // Install the worker's TDA.
-    if pm::set_thread_data_area(tda_ptr).is_err() {
+    if pm::__kcall_set_thread_data_area(tda_ptr).is_err() {
         return 0;
     }
 
@@ -584,10 +584,10 @@ fn test_tda_survives_create_join() -> Result<(), Error> {
     let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs =
         make_thread_args(&stack, tda_worker, worker_tda.as_mut_ptr() as usize);
-    let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+    let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
 
     let mut retval: usize = 0;
-    pm::join_thread(tid, &mut retval)?;
+    pm::__kcall_join_thread(tid, &mut retval)?;
     drop(stack);
 
     if retval != WORKER_EXIT_STATUS {
@@ -636,10 +636,10 @@ fn test_repeated_create_join() -> Result<(), Error> {
         let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs =
             make_thread_args(&stack, tda_worker_generic, worker_tda.as_mut_ptr() as usize);
-        let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+        let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
 
         let mut retval: usize = 0;
-        pm::join_thread(tid, &mut retval)?;
+        pm::__kcall_join_thread(tid, &mut retval)?;
         drop(stack);
 
         // Check that the worker succeeded.
@@ -669,7 +669,7 @@ fn test_repeated_create_join() -> Result<(), Error> {
 /// verify the value after joining.
 extern "C" fn tda_worker_generic(arg: usize) -> usize {
     let tda_ptr: *mut u8 = arg as *mut u8;
-    if pm::set_thread_data_area(tda_ptr).is_err() {
+    if pm::__kcall_set_thread_data_area(tda_ptr).is_err() {
         return 0;
     }
     let gs_value: u32 = unsafe { read_gs_offset_0() };
@@ -704,10 +704,10 @@ fn test_worker_tda_independence() -> Result<(), Error> {
     let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs =
         make_thread_args(&stack, tda_worker_generic, worker_tda.as_mut_ptr() as usize);
-    let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
+    let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
 
     let mut retval: usize = 0;
-    pm::join_thread(tid, &mut retval)?;
+    pm::__kcall_join_thread(tid, &mut retval)?;
     drop(stack);
 
     // Verify the worker read its own magic (not the main thread's).

--- a/src/tests/test-mmio-fault/src/main.rs
+++ b/src/tests/test-mmio-fault/src/main.rs
@@ -58,13 +58,13 @@ const RAMFS_MMIO_TAG: u64 = u64::from_be_bytes(*b"RAMFS   ");
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
     // Acquire IO management capability.
-    pm::capctl(Capability::IoManagement, true)?;
+    pm::__kcall_capctl(Capability::IoManagement, true)?;
 
     // Allocate the RAMFS MMIO region so its pages are mapped.
-    mm::mmio_alloc(RAMFS_MMIO_TAG)?;
+    mm::__kcall_mmio_alloc(RAMFS_MMIO_TAG)?;
 
     // Query the region's base address and size.
-    let info: ::sys::mm::MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
+    let info: ::sys::mm::MmioRegionInfo = mm::__kcall_mmio_info(RAMFS_MMIO_TAG)?;
     let base_addr: usize = info.base().into_raw_value();
     let size: usize = info.size();
 

--- a/src/tests/testd/src/event/mod.rs
+++ b/src/tests/testd/src/event/mod.rs
@@ -29,7 +29,7 @@ use ::sys::{
 ///
 fn test_subscribe_unsubscribe() -> bool {
     // Acquire exception control capability.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
         Ok(()) => (),
         _ => return false,
     }
@@ -38,14 +38,16 @@ fn test_subscribe_unsubscribe() -> bool {
     let debug_exception: ExceptionEvent = ExceptionEvent::Exception1;
 
     // Attempt to subscribe to event.
-    match ::sys::kcall::event::evctrl(Event::Exception(debug_exception), EventCtrlRequest::Register)
-    {
+    match ::sys::kcall::event::__kcall_evctrl(
+        Event::Exception(debug_exception),
+        EventCtrlRequest::Register,
+    ) {
         Ok(()) => (),
         _ => return false,
     }
 
     // Attempt to unsubscribe from event.
-    match ::sys::kcall::event::evctrl(
+    match ::sys::kcall::event::__kcall_evctrl(
         Event::Exception(debug_exception),
         EventCtrlRequest::Unregister,
     ) {
@@ -54,7 +56,7 @@ fn test_subscribe_unsubscribe() -> bool {
     }
 
     // Release exception control capability.
-    matches!(::sys::kcall::pm::capctl(Capability::ExceptionControl, false), Ok(()))
+    matches!(::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false), Ok(()))
 }
 
 ///
@@ -72,7 +74,10 @@ fn test_subscribe_without_capability() -> bool {
 
     // Attempt to subscribe to event.
     !matches!(
-        ::sys::kcall::event::evctrl(Event::Exception(debug_exception), EventCtrlRequest::Register),
+        ::sys::kcall::event::__kcall_evctrl(
+            Event::Exception(debug_exception),
+            EventCtrlRequest::Register
+        ),
         Ok(())
     )
 }
@@ -88,7 +93,7 @@ fn test_subscribe_without_capability() -> bool {
 ///
 fn test_unsubscribe_without_subscription() -> bool {
     // Acquire exception control capability.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
         Ok(()) => (),
         _ => return false,
     }
@@ -97,14 +102,15 @@ fn test_unsubscribe_without_subscription() -> bool {
     let debug_exception: ExceptionEvent = ExceptionEvent::Exception1;
 
     // Attempt to unsubscribe from event.
-    if let Ok(()) =
-        ::sys::kcall::event::evctrl(Event::Exception(debug_exception), EventCtrlRequest::Unregister)
-    {
+    if let Ok(()) = ::sys::kcall::event::__kcall_evctrl(
+        Event::Exception(debug_exception),
+        EventCtrlRequest::Unregister,
+    ) {
         return false;
     }
 
     // Release exception control capability.
-    matches!(::sys::kcall::pm::capctl(Capability::ExceptionControl, false), Ok(()))
+    matches!(::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false), Ok(()))
 }
 
 ///
@@ -118,7 +124,7 @@ fn test_unsubscribe_without_subscription() -> bool {
 ///
 fn test_unsubscribe_without_capability() -> bool {
     // Acquire exception control capability.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
         Ok(()) => (),
         _ => return false,
     }
@@ -127,21 +133,23 @@ fn test_unsubscribe_without_capability() -> bool {
     let debug_exception: ExceptionEvent = ExceptionEvent::Exception1;
 
     // Subscribe to event.
-    match ::sys::kcall::event::evctrl(Event::Exception(debug_exception), EventCtrlRequest::Register)
-    {
+    match ::sys::kcall::event::__kcall_evctrl(
+        Event::Exception(debug_exception),
+        EventCtrlRequest::Register,
+    ) {
         Ok(()) => (),
         _ => return false,
     }
 
     // Release exception control capability.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, false) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false) {
         Ok(()) => (),
         _ => return false,
     }
 
     // Attempt to unsubscribe from event.
     matches!(
-        ::sys::kcall::event::evctrl(
+        ::sys::kcall::event::__kcall_evctrl(
             Event::Exception(debug_exception),
             EventCtrlRequest::Unregister
         ),

--- a/src/tests/testd/src/main.rs
+++ b/src/tests/testd/src/main.rs
@@ -59,7 +59,7 @@ pub fn main() {
     event::test();
     mm::test();
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(e) => panic!("failed to get process identifier (error={:?})", e),
     };

--- a/src/tests/testd/src/mm/mod.rs
+++ b/src/tests/testd/src/mm/mod.rs
@@ -49,12 +49,12 @@ const _: () = assert!(
 ///
 fn test_mmap_munmap() -> bool {
     // Acquire memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
         Ok(()) => (),
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -62,19 +62,19 @@ fn test_mmap_munmap() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
+    match ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
         Ok(_) => (),
         Err(_) => return false,
     }
 
     // Unmap the page.
-    match ::sys::kcall::mm::munmap(mypid, vaddr) {
+    match ::sys::kcall::mm::__kcall_munmap(mypid, vaddr) {
         Ok(_) => (),
         Err(_) => return false,
     }
 
     // Release memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
         Ok(()) => (),
         _ => return false,
     }
@@ -93,12 +93,12 @@ fn test_mmap_munmap() -> bool {
 ///
 fn test_mmap_write_munmap() -> bool {
     // Acquire memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
         Ok(()) => (),
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -106,7 +106,7 @@ fn test_mmap_write_munmap() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::WRONLY) {
+    match ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::WRONLY) {
         Ok(_) => (),
         Err(_) => return false,
     }
@@ -128,13 +128,13 @@ fn test_mmap_write_munmap() -> bool {
     }
 
     // Unmap the page.
-    match ::sys::kcall::mm::munmap(mypid, vaddr) {
+    match ::sys::kcall::mm::__kcall_munmap(mypid, vaddr) {
         Ok(_) => (),
         Err(_) => return false,
     }
 
     // Release memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
         Ok(()) => (),
         _ => return false,
     }
@@ -153,12 +153,12 @@ fn test_mmap_write_munmap() -> bool {
 ///
 fn test_mmap_munmap_many_times_inplace() -> bool {
     // Acquire memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
         Ok(()) => (),
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -167,20 +167,20 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
         let vaddr: VirtualAddress = USER_MMAP_END;
 
         // Map a page.
-        match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
+        match ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
             Ok(_) => (),
             Err(_) => return false,
         }
 
         // Unmap the page.
-        match ::sys::kcall::mm::munmap(mypid, vaddr) {
+        match ::sys::kcall::mm::__kcall_munmap(mypid, vaddr) {
             Ok(_) => (),
             Err(_) => return false,
         }
     }
 
     // Release memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
         Ok(()) => (),
         _ => return false,
     }
@@ -199,12 +199,12 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
 ///
 fn test_mmap_munmap_many_times_rolling() -> bool {
     // Acquire memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
         Ok(()) => (),
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -216,20 +216,20 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
         // Map a page.
-        match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
+        match ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
             Ok(_) => (),
             Err(_) => return false,
         }
 
         // Unmap the page.
-        match ::sys::kcall::mm::munmap(mypid, vaddr) {
+        match ::sys::kcall::mm::__kcall_munmap(mypid, vaddr) {
             Ok(_) => (),
             Err(_) => return false,
         }
     }
 
     // Release memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
         Ok(()) => (),
         _ => return false,
     }
@@ -248,11 +248,11 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
 ///
 fn test_mmap_munmap_return_zeros() -> bool {
     // Acquire memory management capability.
-    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, true).is_err() {
+    if ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true).is_err() {
         return false;
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -260,7 +260,7 @@ fn test_mmap_munmap_return_zeros() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    if ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::WRONLY).is_err() {
+    if ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::WRONLY).is_err() {
         return false;
     }
 
@@ -272,12 +272,12 @@ fn test_mmap_munmap_return_zeros() -> bool {
     }
 
     // Unmap the page.
-    if ::sys::kcall::mm::munmap(mypid, vaddr).is_err() {
+    if ::sys::kcall::mm::__kcall_munmap(mypid, vaddr).is_err() {
         return false;
     }
 
     // Map the page again to read.
-    if ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY).is_err() {
+    if ::sys::kcall::mm::__kcall_mmap(mypid, vaddr, 1, AccessPermission::RDONLY).is_err() {
         return false;
     }
 
@@ -292,12 +292,12 @@ fn test_mmap_munmap_return_zeros() -> bool {
     }
 
     // Unmap the page.
-    if ::sys::kcall::mm::munmap(mypid, vaddr).is_err() {
+    if ::sys::kcall::mm::__kcall_munmap(mypid, vaddr).is_err() {
         return false;
     }
 
     // Release memory management capability.
-    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, false).is_err() {
+    if ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false).is_err() {
         return false;
     }
 
@@ -321,11 +321,11 @@ fn test_mmap_multi_page() -> bool {
     const NPAGES: usize = 4;
 
     // Acquire memory management capability.
-    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, true).is_err() {
+    if ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true).is_err() {
         return false;
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -333,7 +333,7 @@ fn test_mmap_multi_page() -> bool {
     let base_vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map multiple pages in a single call.
-    if ::sys::kcall::mm::mmap(mypid, base_vaddr, NPAGES, AccessPermission::RDWR).is_err() {
+    if ::sys::kcall::mm::__kcall_mmap(mypid, base_vaddr, NPAGES, AccessPermission::RDWR).is_err() {
         return false;
     }
 
@@ -374,13 +374,13 @@ fn test_mmap_multi_page() -> bool {
     for i in 0..NPAGES {
         let page_addr: usize = base_vaddr.into_raw_value() + i * PAGE_SIZE;
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(page_addr);
-        if ::sys::kcall::mm::munmap(mypid, vaddr).is_err() {
+        if ::sys::kcall::mm::__kcall_munmap(mypid, vaddr).is_err() {
             return false;
         }
     }
 
     // Release memory management capability.
-    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, false).is_err() {
+    if ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false).is_err() {
         return false;
     }
 

--- a/src/tests/testd/src/pm/capability.rs
+++ b/src/tests/testd/src/pm/capability.rs
@@ -22,8 +22,10 @@ use ::sys::pm::Capability;
 ///
 fn test_capctl_exception_control() -> bool {
     // Attempt to acquire and release exception control capability.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
-        Ok(()) => matches!(::sys::kcall::pm::capctl(Capability::ExceptionControl, false), Ok(())),
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
+        Ok(()) => {
+            matches!(::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false), Ok(()))
+        },
         _ => false,
     }
 }
@@ -39,8 +41,10 @@ fn test_capctl_exception_control() -> bool {
 ///
 fn test_capctl_interrupt_control() -> bool {
     // Attempt to acquire and release interrupt control capability.
-    match ::sys::kcall::pm::capctl(Capability::InterruptControl, true) {
-        Ok(()) => matches!(::sys::kcall::pm::capctl(Capability::InterruptControl, false), Ok(())),
+    match ::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, true) {
+        Ok(()) => {
+            matches!(::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, false), Ok(()))
+        },
         _ => false,
     }
 }
@@ -56,8 +60,10 @@ fn test_capctl_interrupt_control() -> bool {
 ///
 fn test_capctl_io_management() -> bool {
     // Attempt to acquire and release I/O management capability.
-    match ::sys::kcall::pm::capctl(Capability::IoManagement, true) {
-        Ok(()) => matches!(::sys::kcall::pm::capctl(Capability::IoManagement, false), Ok(())),
+    match ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, true) {
+        Ok(()) => {
+            matches!(::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, false), Ok(()))
+        },
         _ => false,
     }
 }
@@ -73,8 +79,10 @@ fn test_capctl_io_management() -> bool {
 ///
 fn test_capctl_memory_management() -> bool {
     // Attempt to acquire and release memory management capability.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
-        Ok(()) => matches!(::sys::kcall::pm::capctl(Capability::MemoryManagement, false), Ok(())),
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
+        Ok(()) => {
+            matches!(::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false), Ok(()))
+        },
         _ => false,
     }
 }
@@ -90,8 +98,10 @@ fn test_capctl_memory_management() -> bool {
 ///
 fn test_capctl_process_management() -> bool {
     // Attempt to acquire and release process management capability.
-    match ::sys::kcall::pm::capctl(Capability::ProcessManagement, true) {
-        Ok(()) => matches!(::sys::kcall::pm::capctl(Capability::ProcessManagement, false), Ok(())),
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true) {
+        Ok(()) => {
+            matches!(::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, false), Ok(()))
+        },
         _ => false,
     }
 }
@@ -107,10 +117,10 @@ fn test_capctl_process_management() -> bool {
 ///
 fn test_capctl_invalid_acquire() -> bool {
     // Attempt to acquire exception control capability twice.
-    match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
-        Ok(()) => match ::sys::kcall::pm::capctl(Capability::ExceptionControl, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
+        Ok(()) => match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, true) {
             Ok(()) => return false,
-            _ => match ::sys::kcall::pm::capctl(Capability::ExceptionControl, false) {
+            _ => match ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false) {
                 Ok(()) => (),
                 _ => return false,
             },
@@ -119,10 +129,10 @@ fn test_capctl_invalid_acquire() -> bool {
     }
 
     // Attempt to acquire interrupt control capability twice.
-    match ::sys::kcall::pm::capctl(Capability::InterruptControl, true) {
-        Ok(()) => match ::sys::kcall::pm::capctl(Capability::InterruptControl, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, true) {
+        Ok(()) => match ::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, true) {
             Ok(()) => return false,
-            _ => match ::sys::kcall::pm::capctl(Capability::InterruptControl, false) {
+            _ => match ::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, false) {
                 Ok(()) => (),
                 _ => return false,
             },
@@ -131,10 +141,10 @@ fn test_capctl_invalid_acquire() -> bool {
     }
 
     // Attempt to acquire I/O management capability twice.
-    match ::sys::kcall::pm::capctl(Capability::IoManagement, true) {
-        Ok(()) => match ::sys::kcall::pm::capctl(Capability::IoManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, true) {
+        Ok(()) => match ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, true) {
             Ok(()) => return false,
-            _ => match ::sys::kcall::pm::capctl(Capability::IoManagement, false) {
+            _ => match ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, false) {
                 Ok(()) => (),
                 _ => return false,
             },
@@ -143,10 +153,10 @@ fn test_capctl_invalid_acquire() -> bool {
     }
 
     // Attempt to acquire memory management capability twice.
-    match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
-        Ok(()) => match ::sys::kcall::pm::capctl(Capability::MemoryManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
+        Ok(()) => match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, true) {
             Ok(()) => return false,
-            _ => match ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+            _ => match ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
                 Ok(()) => (),
                 _ => return false,
             },
@@ -155,10 +165,10 @@ fn test_capctl_invalid_acquire() -> bool {
     }
 
     // Attempt to acquire process management capability twice.
-    match ::sys::kcall::pm::capctl(Capability::ProcessManagement, true) {
-        Ok(()) => match ::sys::kcall::pm::capctl(Capability::ProcessManagement, true) {
+    match ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true) {
+        Ok(()) => match ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true) {
             Ok(()) => return false,
-            _ => match ::sys::kcall::pm::capctl(Capability::ProcessManagement, false) {
+            _ => match ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, false) {
                 Ok(()) => (),
                 _ => return false,
             },
@@ -180,27 +190,27 @@ fn test_capctl_invalid_acquire() -> bool {
 ///
 fn test_capctl_invalid_release() -> bool {
     // Attempt to release exception control capability without acquiring it.
-    if let Ok(()) = ::sys::kcall::pm::capctl(Capability::ExceptionControl, false) {
+    if let Ok(()) = ::sys::kcall::pm::__kcall_capctl(Capability::ExceptionControl, false) {
         return false;
     }
 
     // Attempt to release interrupt control capability without acquiring it.
-    if let Ok(()) = ::sys::kcall::pm::capctl(Capability::InterruptControl, false) {
+    if let Ok(()) = ::sys::kcall::pm::__kcall_capctl(Capability::InterruptControl, false) {
         return false;
     }
 
     // Attempt to release I/O management capability without acquiring it.
-    if let Ok(()) = ::sys::kcall::pm::capctl(Capability::IoManagement, false) {
+    if let Ok(()) = ::sys::kcall::pm::__kcall_capctl(Capability::IoManagement, false) {
         return false;
     }
 
     // Attempt to release memory management capability without acquiring it.
-    if let Ok(()) = ::sys::kcall::pm::capctl(Capability::MemoryManagement, false) {
+    if let Ok(()) = ::sys::kcall::pm::__kcall_capctl(Capability::MemoryManagement, false) {
         return false;
     }
 
     // Attempt to release process management capability without acquiring it.
-    if let Ok(()) = ::sys::kcall::pm::capctl(Capability::ProcessManagement, false) {
+    if let Ok(()) = ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, false) {
         return false;
     }
 

--- a/src/tests/testd/src/pm/sched.rs
+++ b/src/tests/testd/src/pm/sched.rs
@@ -15,7 +15,7 @@
 /// If the test passed, `true` is returned. Otherwise, `false` is returned instead.
 ///
 fn test_sched_yield() -> bool {
-    matches!(::sys::kcall::sched::sched_yield(), Ok(()))
+    matches!(::sys::kcall::sched::__kcall_sched_yield(), Ok(()))
 }
 
 //==================================================================================================

--- a/src/tests/thread-rust/src/runtime.rs
+++ b/src/tests/thread-rust/src/runtime.rs
@@ -13,10 +13,10 @@ use ::sys::{
         ErrorCode,
     },
     kcall::pm::{
-        create_thread,
-        detach_thread,
-        gettime,
-        join_thread,
+        __kcall_create_thread,
+        __kcall_detach_thread,
+        __kcall_gettime,
+        __kcall_join_thread,
     },
     pm::{
         ThreadCreateArgs,
@@ -56,7 +56,7 @@ impl KernelThread {
             user_tda: None,
         };
 
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
+        let tid: ThreadIdentifier = __kcall_create_thread(&mut args)?;
 
         Ok(Self {
             tid: Some(tid),
@@ -71,7 +71,7 @@ impl KernelThread {
             .tid
             .take()
             .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "thread handle missing"))?;
-        join_thread(tid, &mut retval)?;
+        __kcall_join_thread(tid, &mut retval)?;
         drop(self.stack.take());
         Ok(retval)
     }
@@ -86,7 +86,7 @@ impl KernelThread {
             .tid
             .take()
             .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "thread handle missing"))?;
-        detach_thread(tid)?;
+        __kcall_detach_thread(tid)?;
         // Intentionally leak the stack — the thread may still be using it.
         if let Some(stack) = self.stack.take() {
             core::mem::forget(stack);
@@ -110,7 +110,7 @@ impl Drop for KernelThread {
 /// Returns the current monotonic system time.
 pub fn monotonic_now() -> Result<SystemTime, Error> {
     let mut now: SystemTime = SystemTime::default();
-    gettime(&mut now)?;
+    __kcall_gettime(&mut now)?;
     Ok(now)
 }
 

--- a/src/tests/thread-rust/src/tests/condvars.rs
+++ b/src/tests/thread-rust/src/tests/condvars.rs
@@ -26,14 +26,14 @@ use ::sys::{
     },
     kcall::{
         pm::{
-            create_thread,
-            join_thread,
-            lock_mutex,
-            signal_cond,
-            unlock_mutex,
-            wait_cond,
+            __kcall_create_thread,
+            __kcall_join_thread,
+            __kcall_lock_mutex,
+            __kcall_signal_cond,
+            __kcall_unlock_mutex,
+            __kcall_wait_cond,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::{
         ConditionAddress,
@@ -102,19 +102,19 @@ fn test_condition_signal() -> Result<(), Error> {
         user_stack_size: stack.size(),
         user_tda: None,
     };
-    let tid = create_thread(&mut args)?;
+    let tid = __kcall_create_thread(&mut args)?;
 
     while WAIT_STATE.load(Ordering::Acquire) == 0 {
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
 
-    lock_mutex(mutex_addr(), None)?;
-    let awakened = signal_cond(cond_addr(), false)?;
+    __kcall_lock_mutex(mutex_addr(), None)?;
+    let awakened = __kcall_signal_cond(cond_addr(), false)?;
     assert_eq!(awakened, 1, "expected to wake exactly one waiter");
-    unlock_mutex(mutex_addr())?;
+    __kcall_unlock_mutex(mutex_addr())?;
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
     assert_eq!(retval, 0, "condition worker returned unexpected code");
     assert_eq!(WAIT_STATE.load(Ordering::Acquire), 2, "worker never completed wait");
@@ -134,10 +134,10 @@ fn test_condition_timeout() -> Result<(), Error> {
         user_stack_size: stack.size(),
         user_tda: None,
     };
-    let tid = create_thread(&mut args)?;
+    let tid = __kcall_create_thread(&mut args)?;
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
     assert_eq!(retval, 1, "condition timeout worker returned unexpected code");
     assert_eq!(WAIT_STATE.load(Ordering::Acquire), 3, "timeout path did not run");
@@ -149,11 +149,11 @@ extern "C" fn condition_wait_worker(_arg: usize) -> usize {
 }
 
 fn condition_wait_worker_impl() -> Result<usize, Error> {
-    lock_mutex(mutex_addr(), None)?;
+    __kcall_lock_mutex(mutex_addr(), None)?;
     WAIT_STATE.store(1, Ordering::Release);
-    wait_cond(cond_addr(), mutex_addr(), None)?;
+    __kcall_wait_cond(cond_addr(), mutex_addr(), None)?;
     WAIT_STATE.store(2, Ordering::Release);
-    unlock_mutex(mutex_addr())?;
+    __kcall_unlock_mutex(mutex_addr())?;
     Ok(0)
 }
 
@@ -163,16 +163,16 @@ extern "C" fn condition_timeout_worker(_arg: usize) -> usize {
 }
 
 fn condition_timeout_worker_impl() -> Result<usize, Error> {
-    lock_mutex(mutex_addr(), None)?;
+    __kcall_lock_mutex(mutex_addr(), None)?;
     WAIT_STATE.store(1, Ordering::Release);
     let deadline = deadline_from_now(Duration::from_millis(100))?;
-    match wait_cond(cond_addr(), mutex_addr(), Some(deadline)) {
+    match __kcall_wait_cond(cond_addr(), mutex_addr(), Some(deadline)) {
         Err(err) => {
             assert_eq!(err.code, ErrorCode::OperationTimedOut, "unexpected error code");
         },
         Ok(_) => panic!("wait_cond() should time out"),
     }
     WAIT_STATE.store(3, Ordering::Release);
-    unlock_mutex(mutex_addr())?;
+    __kcall_unlock_mutex(mutex_addr())?;
     Ok(1)
 }

--- a/src/tests/thread-rust/src/tests/mutexes.rs
+++ b/src/tests/thread-rust/src/tests/mutexes.rs
@@ -25,12 +25,12 @@ use ::sys::{
     },
     kcall::{
         pm::{
-            create_thread,
-            join_thread,
-            lock_mutex,
-            unlock_mutex,
+            __kcall_create_thread,
+            __kcall_join_thread,
+            __kcall_lock_mutex,
+            __kcall_unlock_mutex,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::{
         MutexAddress,
@@ -99,7 +99,7 @@ fn test_mutex_contention() -> Result<(), Error> {
     WORKER_STATE.store(0, Ordering::Relaxed);
 
     let mutex_addr: MutexAddress = test_mutex_addr();
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
 
     let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
@@ -110,17 +110,17 @@ fn test_mutex_contention() -> Result<(), Error> {
         user_stack_size: stack.size(),
         user_tda: None,
     };
-    let tid = create_thread(&mut args)?;
+    let tid = __kcall_create_thread(&mut args)?;
 
     while WORKER_STATE.load(Ordering::Acquire) == 0 {
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
     assert_eq!(WORKER_STATE.load(Ordering::Acquire), 1, "worker should be blocked");
 
-    unlock_mutex(mutex_addr)?;
+    __kcall_unlock_mutex(mutex_addr)?;
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
     assert_eq!(retval, 0, "mutex worker returned unexpected status");
     assert_eq!(WORKER_STATE.load(Ordering::Acquire), 2, "worker never executed critical section");
@@ -131,16 +131,16 @@ fn test_mutex_timeout() -> Result<(), Error> {
     reset_test_mutex();
 
     let mutex_addr: MutexAddress = test_mutex_addr();
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
 
-    match lock_mutex(mutex_addr, Some(SystemTime::EPOCH)) {
+    match __kcall_lock_mutex(mutex_addr, Some(SystemTime::EPOCH)) {
         Err(err) => {
             assert_eq!(err.code, ErrorCode::OperationTimedOut, "unexpected error code");
         },
         Ok(_) => panic!("second lock must time out immediately"),
     }
 
-    unlock_mutex(mutex_addr)?;
+    __kcall_unlock_mutex(mutex_addr)?;
     Ok(())
 }
 
@@ -151,9 +151,9 @@ extern "C" fn mutex_worker(raw_addr: usize) -> usize {
 
 fn mutex_worker_impl(mutex_addr: MutexAddress) -> Result<usize, Error> {
     WORKER_STATE.store(1, Ordering::Release);
-    lock_mutex(mutex_addr, None)?;
+    __kcall_lock_mutex(mutex_addr, None)?;
     WORKER_STATE.store(2, Ordering::Release);
-    unlock_mutex(mutex_addr)?;
+    __kcall_unlock_mutex(mutex_addr)?;
     Ok(0)
 }
 
@@ -190,7 +190,7 @@ fn test_mutex_dynamic_init() -> Result<(), Error> {
             if ready != 0 {
                 break;
             }
-            sched_yield()?;
+            __kcall_sched_yield()?;
         }
 
         let retval = thread.join()?;

--- a/src/tests/thread-rust/src/tests/nowait.rs
+++ b/src/tests/thread-rust/src/tests/nowait.rs
@@ -9,7 +9,10 @@ use crate::runtime::KernelThread;
 use ::core::time::Duration;
 use ::sys::{
     error::Error,
-    kcall::pm::sleep,
+    kcall::pm::{
+        __kcall_exit,
+        __kcall_sleep,
+    },
 };
 
 //==================================================================================================
@@ -29,8 +32,7 @@ const WORKER_SLEEP: Duration = Duration::from_secs(5);
 /// The kernel must cleanly tear down the process, terminating the blocked worker. Because this test
 /// calls `exit()`, it **must be the last test** executed by the binary.
 pub fn run() -> Result<(), Error> {
-    test_exit_with_detached_blocked_thread()?;
-    Ok(())
+    test_exit_with_detached_blocked_thread()
 }
 
 fn test_exit_with_detached_blocked_thread() -> Result<(), Error> {
@@ -39,11 +41,12 @@ fn test_exit_with_detached_blocked_thread() -> Result<(), Error> {
 
     // Exit the process. The kernel will interrupt the sleeping worker and clean up.
     // exit() diverges on success; on failure we propagate the error.
-    ::sys::kcall::pm::exit(0)?;
+    let Err(e) = __kcall_exit(0);
+    Err(e)
 }
 
 extern "C" fn worker_sleep(_arg: usize) -> usize {
     // Block for a long time. The kernel will interrupt this sleep when the process exits.
-    let _ = sleep(WORKER_SLEEP);
+    let _ = __kcall_sleep(WORKER_SLEEP);
     0
 }

--- a/src/tests/thread-rust/src/tests/rwlocks.rs
+++ b/src/tests/thread-rust/src/tests/rwlocks.rs
@@ -110,7 +110,7 @@ fn reader_a_impl() -> Result<usize, Error> {
 
     // Wait until reader B also acquires the read lock.
     while STAGE.load(Ordering::Acquire) < 2 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     unsafe {
@@ -127,7 +127,7 @@ extern "C" fn reader_b_entry(_arg: usize) -> usize {
 fn reader_b_impl() -> Result<usize, Error> {
     // Wait until reader A has acquired.
     while STAGE.load(Ordering::Acquire) < 1 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     // SAFETY: see reader_a_impl.
@@ -144,7 +144,7 @@ fn reader_b_impl() -> Result<usize, Error> {
 
     // Wait until reader A releases before we release.
     while STAGE.load(Ordering::Acquire) < 3 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     unsafe {
@@ -196,7 +196,7 @@ fn test_rwlock_dynamic_init() -> Result<(), Error> {
 
     // Wait until writer is inside.
     while WRITER_INSIDE.load(Ordering::Acquire) == 0 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     // Launch reader which must block until writer releases.
@@ -209,7 +209,7 @@ fn test_rwlock_dynamic_init() -> Result<(), Error> {
             0,
             "reader entered while writer holds lock"
         );
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     let ret_w = writer.join()?;
@@ -243,7 +243,7 @@ fn dyn_writer_impl() -> Result<usize, Error> {
 
     // Hold the lock for a while.
     for _ in 0..4000_u32 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     WRITER_INSIDE.store(0, Ordering::Release);
@@ -271,7 +271,7 @@ fn dyn_reader_impl() -> Result<usize, Error> {
 
     // Hold the read lock briefly.
     for _ in 0..2000_u32 {
-        ::sys::kcall::sched::sched_yield()?;
+        ::sys::kcall::sched::__kcall_sched_yield()?;
     }
 
     READER_INSIDE.store(0, Ordering::Release);

--- a/src/tests/thread-rust/src/tests/scheduler.rs
+++ b/src/tests/thread-rust/src/tests/scheduler.rs
@@ -15,10 +15,10 @@ use ::sys::{
     error::Error,
     kcall::{
         pm::{
-            create_thread,
-            join_thread,
+            __kcall_create_thread,
+            __kcall_join_thread,
         },
-        sched::sched_yield,
+        sched::__kcall_sched_yield,
     },
     pm::ThreadCreateArgs,
 };
@@ -51,7 +51,7 @@ fn test_sched_yield_progress() -> Result<(), Error> {
         user_stack_size: stack.size(),
         user_tda: None,
     };
-    let tid = create_thread(&mut args)?;
+    let tid = __kcall_create_thread(&mut args)?;
 
     // Signal the worker to proceed and yield until it observes the change.
     SCHED_STATE.store(1, Ordering::Release);
@@ -59,12 +59,12 @@ fn test_sched_yield_progress() -> Result<(), Error> {
         if SCHED_STATE.load(Ordering::Acquire) == 2 {
             break;
         }
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
 
     assert_eq!(SCHED_STATE.load(Ordering::Acquire), 2, "worker never observed yield");
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
     assert_eq!(retval, 0, "yield worker returned unexpected status");
     Ok(())
@@ -77,7 +77,7 @@ extern "C" fn yield_worker(_arg: usize) -> usize {
 fn yield_worker_impl() -> Result<usize, Error> {
     // Wait until the main thread tells us to proceed.
     while SCHED_STATE.load(Ordering::Acquire) != 1 {
-        sched_yield()?;
+        __kcall_sched_yield()?;
     }
 
     SCHED_STATE.store(2, Ordering::Release);

--- a/src/tests/thread-rust/src/tests/tda.rs
+++ b/src/tests/thread-rust/src/tests/tda.rs
@@ -9,8 +9,8 @@ use ::core::ptr;
 use ::sys::{
     error::Error,
     kcall::pm::{
-        get_thread_data_area,
-        set_thread_data_area,
+        __kcall_get_thread_data_area,
+        __kcall_set_thread_data_area,
     },
 };
 
@@ -31,16 +31,16 @@ pub fn run() -> Result<(), Error> {
 }
 
 fn test_set_and_restore_tda() -> Result<(), Error> {
-    let original_ptr = get_thread_data_area()?;
+    let original_ptr = __kcall_get_thread_data_area()?;
 
     let new_ptr: *mut u8 = ptr::addr_of_mut!(TEMP_TDA).cast::<u8>();
-    set_thread_data_area(new_ptr)?;
+    __kcall_set_thread_data_area(new_ptr)?;
 
-    let active_ptr = get_thread_data_area()?;
+    let active_ptr = __kcall_get_thread_data_area()?;
     assert_eq!(active_ptr, new_ptr, "TDA pointer mismatch");
 
-    set_thread_data_area(original_ptr)?;
-    let restored = get_thread_data_area()?;
+    __kcall_set_thread_data_area(original_ptr)?;
+    let restored = __kcall_get_thread_data_area()?;
     assert_eq!(restored, original_ptr, "original TDA pointer was not restored");
     Ok(())
 }

--- a/src/tests/thread-rust/src/tests/threads.rs
+++ b/src/tests/thread-rust/src/tests/threads.rs
@@ -15,10 +15,10 @@ use ::core::sync::atomic::{
 use ::sys::{
     error::Error,
     kcall::pm::{
-        create_thread,
-        getpid,
-        gettid,
-        join_thread,
+        __kcall_create_thread,
+        __kcall_getpid,
+        __kcall_gettid,
+        __kcall_join_thread,
     },
     pm::ThreadCreateArgs,
 };
@@ -50,10 +50,10 @@ pub fn run() -> Result<(), Error> {
 }
 
 fn test_identifiers() -> Result<(), Error> {
-    let pid = getpid()?;
+    let pid = __kcall_getpid()?;
     assert!(i32::from(pid) > 0, "process identifier must be positive");
 
-    let tid = gettid()?;
+    let tid = __kcall_gettid()?;
     assert!(i32::from(tid) > 0, "thread identifier must be positive");
     Ok(())
 }
@@ -62,7 +62,7 @@ fn test_create_and_join() -> Result<(), Error> {
     WORKER_STARTED.store(false, Ordering::Relaxed);
     WORKER_TID.store(0, Ordering::Relaxed);
 
-    let main_tid_raw: usize = usize::try_from(gettid()?)?;
+    let main_tid_raw: usize = usize::try_from(__kcall_gettid()?)?;
 
     let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
@@ -73,10 +73,10 @@ fn test_create_and_join() -> Result<(), Error> {
         user_stack_size: stack.size(),
         user_tda: None,
     };
-    let tid = create_thread(&mut args)?;
+    let tid = __kcall_create_thread(&mut args)?;
 
     let mut retval: usize = 0;
-    join_thread(tid, &mut retval)?;
+    __kcall_join_thread(tid, &mut retval)?;
     drop(stack);
     assert_eq!(retval, EXPECTED_EXIT_STATUS, "unexpected worker exit status");
     assert!(WORKER_STARTED.load(Ordering::Acquire), "worker never started execution");
@@ -93,7 +93,7 @@ extern "C" fn worker_thread(arg: usize) -> usize {
 fn worker_thread_impl(arg: usize) -> Result<usize, Error> {
     assert_eq!(arg, EXPECTED_WORKER_ARG, "worker received unexpected argument");
 
-    let tid_raw: usize = usize::try_from(gettid()?)?;
+    let tid_raw: usize = usize::try_from(__kcall_gettid()?)?;
     WORKER_TID.store(tid_raw, Ordering::Release);
     WORKER_STARTED.store(true, Ordering::Release);
 

--- a/src/tests/thread-rust/src/tests/timers.rs
+++ b/src/tests/thread-rust/src/tests/timers.rs
@@ -9,7 +9,7 @@ use crate::runtime::monotonic_now;
 use ::core::time::Duration;
 use ::sys::{
     error::Error,
-    kcall::pm::sleep,
+    kcall::pm::__kcall_sleep,
 };
 
 //==================================================================================================
@@ -33,7 +33,7 @@ fn test_monotonic_clock() -> Result<(), Error> {
 fn test_sleep_elapsed_time() -> Result<(), Error> {
     let before = monotonic_now()?;
     let target = Duration::from_millis(5);
-    sleep(target)?;
+    __kcall_sleep(target)?;
     let after = monotonic_now()?;
 
     match after.checked_sub(&before) {

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -116,15 +116,15 @@ fn test_ramfs_mount() -> Result<(), Error> {
 
     let result: Result<(), Error> = (|| {
         // Acquire IO management capability.
-        pm::capctl(Capability::IoManagement, true)?;
+        pm::__kcall_capctl(Capability::IoManagement, true)?;
         cap_acquired = true;
 
         // Attach RAMFS MMIO region.
-        mm::mmio_alloc(RAMFS_MMIO_TAG)?;
+        mm::__kcall_mmio_alloc(RAMFS_MMIO_TAG)?;
         region_attached = true;
 
         // Get region info.
-        let info: ::sys::mm::MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
+        let info: ::sys::mm::MmioRegionInfo = mm::__kcall_mmio_info(RAMFS_MMIO_TAG)?;
         let total_size: usize = info.size();
 
         ::syslog::info!("vfs-test: ramfs region (size={})", total_size,);
@@ -139,9 +139,9 @@ fn test_ramfs_mount() -> Result<(), Error> {
         }
 
         // Release MMIO region before mounting.
-        mm::mmio_free(RAMFS_MMIO_TAG)?;
+        mm::__kcall_mmio_free(RAMFS_MMIO_TAG)?;
         region_attached = false;
-        pm::capctl(Capability::IoManagement, false)?;
+        pm::__kcall_capctl(Capability::IoManagement, false)?;
         cap_acquired = false;
 
         // Leak the buffer so it lives for the program's lifetime.
@@ -180,10 +180,10 @@ fn test_ramfs_mount() -> Result<(), Error> {
 
     // Cleanup on error.
     if region_attached {
-        let _ = mm::mmio_free(RAMFS_MMIO_TAG);
+        let _ = mm::__kcall_mmio_free(RAMFS_MMIO_TAG);
     }
     if cap_acquired {
-        let _ = pm::capctl(Capability::IoManagement, false);
+        let _ = pm::__kcall_capctl(Capability::IoManagement, false);
     }
 
     result

--- a/src/user/hello-rust-nostd/src/main.rs
+++ b/src/user/hello-rust-nostd/src/main.rs
@@ -23,7 +23,7 @@ use ::sys::{
 #[unsafe(no_mangle)]
 pub fn main() -> Result<(), Error> {
     let msg: &str = "Hello, world from Rust!\n";
-    let _ = debug::debug(msg.as_ptr(), msg.len());
+    let _ = debug::__kcall_debug(msg.as_ptr(), msg.len());
 
     Ok(())
 }


### PR DESCRIPTION
Add `#[unsafe(no_mangle)]` to every user-space kernel call wrapper in
`src/libs/sys/src/sys/kcall/` and rename each function with a `__kcall_`
prefix. This gives each wrapper a stable, linker-visible symbol name
(e.g. `__kcall_getpid`, `__kcall_send`, `__kcall_mmap`) so that
external tooling, debuggers, and profilers can locate kernel call entry
points without relying on Rust's mangling scheme.

## Affected modules and their renamed functions

| Module  | Functions |
|---------|-----------|
| debug   | `debug` |
| event   | `resume`, `evctrl` |
| ipc     | `send`, `recv`, `push`, `pull` |
| mm      | `mmap`, `munmap`, `mprotect`, `mmio_alloc`, `mmio_free`, `mmio_info` |
| pm      | `getpid`, `gettid`, `exit`, `capctl`, `terminate`, `create_thread`, `exit_thread`, `join_thread`, `lock_mutex`, `unlock_mutex`, `signal_cond`, `wait_cond`, `gettime`, `sleep`, `get_thread_data_area`, `set_thread_data_area`, `snapshot` |
| sched   | `sched_yield` |

## Scope

All call sites across libraries (`sys`, `sysalloc`, `syslog`, `syscall`, `proc`,
`nvx`), daemons (`memd`), tests (`testd`, `thread-rust`, `stress-rust`,
`test-kernel`, `test-mmio-fault`, `vfs-test`), benchmarks
(`snapshot-rust-nostd`, `vfs-bench-nostd`), and user applications
(`hello-rust-nostd`) are updated to use the new names.

## Validation

- Full build passes (`z build -- all`)
- Format and lint checks pass (`z build -- format lint`)