### PR TITLE
[vfs] Add home directory support and tilde expansion

### DIFF
--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -98,9 +98,11 @@ pub use crate::{
     },
     state::{
         create_mount,
+        home,
         init,
         is_initialized,
         mount_image,
+        set_home,
         unmount,
         MAX_FAT_SIZE,
         MIN_FAT_SIZE,

--- a/src/libs/vfs/src/mount.rs
+++ b/src/libs/vfs/src/mount.rs
@@ -146,6 +146,8 @@ pub struct Vfs {
     mounts: Vec<Mount>,
     /// Current working directory (always absolute, never ends with "/").
     cwd: String,
+    /// Home directory (always absolute). Defaults to "/".
+    home: String,
 }
 
 //==================================================================================================
@@ -158,6 +160,7 @@ impl Vfs {
         Self {
             mounts: Vec::new(),
             cwd: String::from("/"),
+            home: String::from("/"),
         }
     }
 
@@ -214,6 +217,33 @@ impl Vfs {
         &self.cwd
     }
 
+    /// Gets the home directory.
+    #[inline]
+    pub fn home(&self) -> &str {
+        &self.home
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the home directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The new home directory path. Must be absolute.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Fat32Error::InvalidPath`] if the path is not absolute.
+    ///
+    pub fn set_home(&mut self, path: &str) -> Result<(), Fat32Error> {
+        if !path.starts_with('/') {
+            return Err(Fat32Error::InvalidPath);
+        }
+        self.home = self.normalize_path(path)?;
+        Ok(())
+    }
+
     /// Changes the current working directory.
     ///
     /// # Parameters
@@ -255,12 +285,21 @@ impl Vfs {
             return Err(Fat32Error::InvalidPath);
         }
 
-        let abs_path: String = if path.starts_with('/') {
-            String::from(path)
-        } else if self.cwd == "/" {
-            alloc::format!("/{}", path)
+        // Expand tilde prefix.
+        let expanded: String = if path == "~" {
+            self.home.clone()
+        } else if let Some(rest) = path.strip_prefix("~/") {
+            alloc::format!("{}/{}", self.home, rest)
         } else {
-            alloc::format!("{}/{}", self.cwd, path)
+            String::from(path)
+        };
+
+        let abs_path: String = if expanded.starts_with('/') {
+            expanded
+        } else if self.cwd == "/" {
+            alloc::format!("/{}", expanded)
+        } else {
+            alloc::format!("{}/{}", self.cwd, expanded)
         };
 
         let mut components: Vec<&str> = Vec::new();
@@ -666,6 +705,7 @@ mod tests {
     fn default_vfs() {
         let vfs: Vfs = Vfs::default();
         assert_eq!(vfs.cwd(), "/");
+        assert_eq!(vfs.home(), "/");
         assert_eq!(vfs.mount_count(), 0);
     }
 
@@ -704,5 +744,123 @@ mod tests {
     fn mount_readonly_flag() {
         let (mount, _buf) = make_readonly_mount("/data");
         assert!(mount.readonly(), "read-only mount should return true");
+    }
+
+    // -- Home directory tests ----------------------------------------------------
+
+    /// Tests that the default home directory is "/".
+    #[test]
+    fn default_home() {
+        let vfs: Vfs = Vfs::new();
+        assert_eq!(vfs.home(), "/", "default home should be /");
+    }
+
+    /// Tests set_home() and home() round-trip.
+    #[test]
+    fn set_home_roundtrip() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/data/home").expect("set_home should succeed");
+        assert_eq!(vfs.home(), "/data/home");
+    }
+
+    /// Tests that set_home() rejects relative paths.
+    #[test]
+    fn set_home_relative_fails() {
+        let mut vfs: Vfs = Vfs::new();
+        let err: Fat32Error = vfs.set_home("relative").expect_err("should fail");
+        assert_eq!(err, Fat32Error::InvalidPath, "relative path should be rejected");
+    }
+
+    /// Tests that set_home() normalizes the path (strips trailing slashes).
+    #[test]
+    fn set_home_normalizes_trailing_slash() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/data/home/")
+            .expect("set_home should succeed");
+        assert_eq!(vfs.home(), "/data/home");
+    }
+
+    /// Tests that set_home() normalizes dot-dot components.
+    #[test]
+    fn set_home_normalizes_dotdot() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/data/home/../other")
+            .expect("set_home should succeed");
+        assert_eq!(vfs.home(), "/data/other");
+    }
+
+    /// Tests that set_home() rejects paths that escape root via "..".
+    #[test]
+    fn set_home_rejects_escape_root() {
+        let mut vfs: Vfs = Vfs::new();
+        let err: Fat32Error = vfs.set_home("/..").expect_err("should fail");
+        assert_eq!(err, Fat32Error::InvalidPath);
+    }
+
+    // -- Tilde expansion tests ---------------------------------------------------
+
+    /// Tests that "~" alone expands to the home directory.
+    #[test]
+    fn normalize_tilde_alone() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/home/user").expect("set_home should succeed");
+        let result: String = vfs.normalize_path("~").expect("should succeed");
+        assert_eq!(result, "/home/user");
+    }
+
+    /// Tests that "~/foo/bar" expands correctly.
+    #[test]
+    fn normalize_tilde_subpath() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/home/user").expect("set_home should succeed");
+        let result: String = vfs.normalize_path("~/foo/bar").expect("should succeed");
+        assert_eq!(result, "/home/user/foo/bar");
+    }
+
+    /// Tests that "~" with default home ("/") resolves to "/".
+    #[test]
+    fn normalize_tilde_default_home() {
+        let vfs: Vfs = Vfs::new();
+        let result: String = vfs.normalize_path("~").expect("should succeed");
+        assert_eq!(result, "/");
+    }
+
+    /// Tests that "~/file.txt" with default home resolves to "/file.txt".
+    #[test]
+    fn normalize_tilde_subpath_default_home() {
+        let vfs: Vfs = Vfs::new();
+        let result: String = vfs.normalize_path("~/file.txt").expect("should succeed");
+        assert_eq!(result, "/file.txt");
+    }
+
+    /// Tests that paths not starting with "~" are unaffected.
+    #[test]
+    fn normalize_no_tilde() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/home/user").expect("set_home should succeed");
+        let result: String = vfs
+            .normalize_path("/data/file.txt")
+            .expect("should succeed");
+        assert_eq!(result, "/data/file.txt");
+    }
+
+    /// Tests that "~user" is NOT expanded (treated as relative path).
+    #[test]
+    fn normalize_tilde_user_not_expanded() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/home/user").expect("set_home should succeed");
+        let result: String = vfs.normalize_path("~other").expect("should succeed");
+        assert_eq!(result, "/~other", "~user should not be expanded");
+    }
+
+    /// Tests tilde expansion with ".." components.
+    #[test]
+    fn normalize_tilde_with_dotdot() {
+        let mut vfs: Vfs = Vfs::new();
+        vfs.set_home("/home/user").expect("set_home should succeed");
+        let result: String = vfs
+            .normalize_path("~/docs/../file.txt")
+            .expect("should succeed");
+        assert_eq!(result, "/home/user/file.txt");
     }
 }

--- a/src/libs/vfs/src/state.rs
+++ b/src/libs/vfs/src/state.rs
@@ -154,6 +154,41 @@ pub fn is_initialized() -> bool {
     VFS_STATE.lock().is_some()
 }
 
+///
+/// # Description
+///
+/// Sets the home directory.
+///
+/// # Parameters
+///
+/// - `path`: The new home directory path. Must be absolute.
+///
+/// # Errors
+///
+/// - [`Fat32Error::NotInitialized`] if `init()` has not been called.
+/// - [`Fat32Error::InvalidPath`] if the path is not absolute.
+///
+pub fn set_home(path: &str) -> Result<(), Fat32Error> {
+    let mut state = VFS_STATE.lock();
+    let vfs: &mut Vfs = state.as_mut().ok_or(Fat32Error::NotInitialized)?;
+    vfs.set_home(path)
+}
+
+///
+/// # Description
+///
+/// Returns the current home directory.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::NotInitialized`] if `init()` has not been called.
+///
+pub fn home() -> Result<String, Fat32Error> {
+    let state = VFS_STATE.lock();
+    let vfs: &Vfs = state.as_ref().ok_or(Fat32Error::NotInitialized)?;
+    Ok(String::from(vfs.home()))
+}
+
 /// Mounts an existing FAT image from a memory region.
 ///
 /// # Parameters


### PR DESCRIPTION
## Summary

Add a home directory concept to the VFS layer and expand tilde (`~`) prefixes during path normalization, enabling POSIX-style `~/...` shorthand in all path resolution.

## Changes

- Add `home` field to `Vfs` struct, defaulting to `"/"`.
- Add `home()` getter and `set_home()` method with absolute-path validation on the `Vfs` struct.
- Expand `~` and `~/...` prefixes in `normalize_path()` before making the path absolute. `~user` forms are intentionally ignored (Nanvix is single-user).
- Add `set_home()` and `home()` global accessors through `VFS_STATE` in `state.rs`.
- Re-export `set_home` and `home` from the crate root.

## Testing

- Default home value
- `set_home()`/`home()` round-trip
- Relative path rejection
- Tilde-alone expansion
- Tilde-subpath expansion
- Default-home tilde
- No-tilde passthrough
- `~user` non-expansion
- Tilde with `..` components

Closes #2279