### PR TITLE
[kernel] Support escaping in command-line args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmdline"
-version = "0.13.6"
+version = "0.13.8"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmdline"
+version = "0.13.6"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "cmdline-len-rust"
 version = "0.13.8"
 dependencies = [
@@ -1446,6 +1454,7 @@ dependencies = [
  "build-utils",
  "bump-allocator",
  "cfg-if",
+ "cmdline",
  "config",
  "elf",
  "mmio-tag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/cache",
+        "src/libs/cmdline",
         "src/libs/multibin",
         "src/libs/multiimage",
         "src/libs/mmio-tag",
@@ -143,6 +144,7 @@ libc = "0.2.186"
 linuxd = { path = "src/daemons/linuxd", default-features = false }
 log = "0.4.29"
 cache = { path = "src/libs/cache", default-features = false }
+cmdline = { path = "src/libs/cmdline", default-features = false }
 mkramfs = { path = "src/utils/mkramfs" }
 multibin = { path = "src/libs/multibin", default-features = false }
 multiimage = { path = "src/libs/multiimage", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -317,8 +317,8 @@ export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache config elf error fat32 type-safe nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache config elf error fat32 type-safe proc raw-array nanvix-slab sorted-vec static_assert libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe proc raw-array nanvix-slab sorted-vec static_assert libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -19,7 +19,13 @@ Run a hello-world application and see its output on the terminal:
 
 ## Table of Contents
 
+- [Quick Start](#quick-start)
+- [Table of Contents](#table-of-contents)
 - [Interactive Mode](#interactive-mode)
+  - [Shim Configuration](#shim-configuration)
+- [Running Containers](#running-containers)
+  - [Building a Nanvix OCI image](#building-a-nanvix-oci-image)
+  - [Importing and running with `ctr`](#importing-and-running-with-ctr)
 - [HTTP Mode](#http-mode)
   - [Starting the Server](#starting-the-server)
   - [Spawning an Application (NEW)](#spawning-an-application-new)
@@ -99,9 +105,10 @@ Everything after `--` is forwarded to the application as arguments:
 ```
 
 Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the semicolon becomes command-line arguments; everything after it becomes environment
-variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`). Use an empty
-string when neither is needed. To pass only environment variables, start the string with `;`:
+before the first unescaped semicolon becomes command-line arguments; everything after it becomes
+environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Use an empty string when neither is needed. To pass only environment variables, start the string
+with `;`:
 
 ```bash
 # Arguments and environment variables.
@@ -109,6 +116,14 @@ string when neither is needed. To pass only environment variables, start the str
 
 # Environment variables only.
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf ";VAR1=foo"
+```
+
+To include a literal `;` in the argument portion, escape it as `\;`:
+
+```bash
+# Argument containing a literal semicolon.
+./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf "arg1 with\;semicolon arg2;VAR1=foo"
+# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
 ```
 
 ## HTTP Mode
@@ -205,9 +220,10 @@ All requests are `POST` to `http://<host:port>/`. The message type is specified 
 | `program_args` | string | yes      | Arguments and environment variables.     |
 
 Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the semicolon becomes command-line arguments; everything after it becomes environment
-variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`). Use an empty
-string when neither is needed. To pass only environment variables, start the string with `;`.
+before the first unescaped semicolon becomes command-line arguments; everything after it becomes
+environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Use an empty string when neither is needed. To pass only environment variables, start the string
+with `;`. To include a literal `;` in the argument portion, escape it as `\;`.
 
 **Success response (200):**
 

--- a/doc/run-windows.md
+++ b/doc/run-windows.md
@@ -67,9 +67,10 @@ Everything after `--` is forwarded to the application as arguments:
 ```
 
 Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the semicolon becomes command-line arguments; everything after it becomes environment
-variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`). Use an empty
-string when neither is needed. To pass only environment variables, start the string with `;`:
+before the first unescaped semicolon becomes command-line arguments; everything after it becomes
+environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Use an empty string when neither is needed. To pass only environment variables, start the string
+with `;`:
 
 ```powershell
 # Arguments and environment variables.
@@ -77,6 +78,14 @@ string when neither is needed. To pass only environment variables, start the str
 
 # Environment variables only.
 .\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf ";VAR1=foo"
+```
+
+To include a literal `;` in the argument portion, escape it as `\;`:
+
+```powershell
+# Argument containing a literal semicolon.
+.\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf "arg1 with\;semicolon arg2;VAR1=foo"
+# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
 ```
 
 ## Logging

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -19,6 +19,7 @@ arch = { workspace = true }
 bitmap = { workspace = true }
 bump-allocator = { workspace = true }
 cfg-if = { workspace = true }
+cmdline = { workspace = true }
 config = { workspace = true, optional = true }
 elf = { workspace = true }
 mmio-tag = { workspace = true }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -50,16 +50,14 @@ use crate::{
     },
     pm::ProcessManager,
 };
-use ::alloc::{
-    collections::LinkedList,
-    vec::Vec,
-};
+use ::alloc::collections::LinkedList;
 use ::bitmap::Bitmap;
 use ::core::sync::atomic::{
     AtomicUsize,
     Ordering,
 };
 use ::sys::{
+    error::Error,
     pm::ProcessIdentifier,
     ExitStatus,
 };
@@ -207,30 +205,42 @@ fn test() {
 /// # Parameters
 ///
 /// - `mm`: A reference to the virtual memory manager to use.
-/// - `kmods`: A reference to the list of kernel modules to spawn.
+/// - `kmods`: A mutable reference to the list of kernel modules to spawn.
 ///
 /// # Returns
 ///
 /// The number of servers that were successfully spawned.
 ///
-fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &LinkedList<KernelModule>) -> usize {
+fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &mut LinkedList<KernelModule>) -> usize {
     // SAFETY: the process manager is initialized, this is a single-core system, interrupts are
     // disabled, and the resulting `&mut ProcessManager` does not alias `mm`.
     let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
 
     let mut count: usize = 0;
     // Spawn all servers.
-    for kmod in kmods.iter() {
+    for kmod in kmods.iter_mut() {
+        info!("spawning server: {:?}", kmod.cmdline());
+
         // SAFETY: `kmod.start()` points to a valid, page-aligned ELF image loaded by the
         // bootloader that remains in memory for the lifetime of the kernel.
         let elf: &Elf32Fhdr = unsafe { Elf32Fhdr::from_address(kmod.start().into_raw_value()) };
         let pid: ProcessIdentifier = {
-            // Split command line into arguments an environment variables using ";" as the delimiter.
-            let cmdline: Vec<&str> = kmod.cmdline().split(';').collect();
-            let args: &&str = cmdline.first().unwrap_or(&"");
-            let env: &&str = cmdline.get(1).unwrap_or(&"");
+            // Split command line into arguments and environment variables in place.
+            // A single `;` separates args from env; `\;` is a literal `;`.
+            // SAFETY: module pages are mapped read-write; `iter_mut` yields exclusive access
+            // so no other reference aliases the cmdline bytes.
+            let cmdline_buf: &mut [u8] = unsafe { kmod.cmdline_bytes_mut() };
+            let (args, env): (&str, &str) = ::cmdline::split_cmdline(cmdline_buf);
+            // Capture compacted length before create_process borrows args/env.
+            let compacted_len: usize = args.len() + env.len();
 
-            match pm.create_process(mm, elf, args, env) {
+            let result: Result<ProcessIdentifier, Error> = pm.create_process(mm, elf, args, env);
+
+            // Update the tracked length so that a subsequent cmdline() call returns the
+            // compacted content without stale trailing bytes.
+            kmod.set_cmdline_len(compacted_len);
+
+            match result {
                 Ok(pid) => {
                     count += 1;
                     pid
@@ -242,7 +252,7 @@ fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &LinkedList<KernelModule>) -
             }
         };
 
-        info!("server {} spawned, pid={:?}", kmod.cmdline(), pid);
+        info!("server spawned, pid={:?}", pid);
     }
 
     count
@@ -284,20 +294,26 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         IoMemoryAllocator,
         LinkedList<KernelModule>,
     );
-    let (madt, mem_lower, mut memory_regions, mut mmio_regions, mut ioaddresses, kernel_modules):
-        KernelArgs = match kargs.parse() {
-            Ok(bootinfo) => (
-                bootinfo.madt,
-                bootinfo.mem_lower,
-                bootinfo.memory_regions,
-                bootinfo.mmio_regions,
-                bootinfo.ioaddresses,
-                bootinfo.kernel_modules,
-            ),
-            Err(err) => {
-                panic!("failed to parse kernel arguments: {:?}", err);
-            },
-        };
+    let (
+        madt,
+        mem_lower,
+        mut memory_regions,
+        mut mmio_regions,
+        mut ioaddresses,
+        mut kernel_modules,
+    ): KernelArgs = match kargs.parse() {
+        Ok(bootinfo) => (
+            bootinfo.madt,
+            bootinfo.mem_lower,
+            bootinfo.memory_regions,
+            bootinfo.mmio_regions,
+            bootinfo.ioaddresses,
+            bootinfo.kernel_modules,
+        ),
+        Err(err) => {
+            panic!("failed to parse kernel arguments: {:?}", err);
+        },
+    };
 
     info!("parsing kernel image...");
     let kimage: KernelImage = match KernelImage::new() {
@@ -362,7 +378,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         let aligned_size: usize = page_end - page_start;
         let typ: MemoryRegionType = MemoryRegionType::Reserved;
         if let Ok(region) =
-            MemoryRegion::new(name, start, aligned_size, typ, AccessPermission::RDONLY)
+            MemoryRegion::new(name, start, aligned_size, typ, AccessPermission::RDWR)
         {
             memory_regions.push_back(region);
         }
@@ -480,7 +496,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
 
     // SAFETY: the memory manager is initialized and access is synchronized.
     let status: ExitStatus =
-        if spawn_servers(unsafe { VirtMemoryManager::get_mut() }, &kernel_modules) > 0 {
+        if spawn_servers(unsafe { VirtMemoryManager::get_mut() }, &mut kernel_modules) > 0 {
             // Enable timer interrupts, if they are supported.
             // SAFETY: the hardware abstraction layer is initialized and access is synchronized.
             if let Some(intman) = unsafe { Hal::get_mut() }.intman() {

--- a/src/kernel/src/kmod.rs
+++ b/src/kernel/src/kmod.rs
@@ -22,9 +22,18 @@ pub struct KernelModule {
     region_base: PhysicalAddress,
     /// Total size of the memory region from `region_base` that must be mapped.
     region_size: usize,
-    /// Command line.
-    cmdline: &'static str,
+    /// Pointer to the command-line bytes in bootloader-provided RAM.
+    /// Stored as raw parts instead of `&'static str` so that `cmdline_bytes_mut()` can hand out
+    /// `&mut [u8]` without aliasing a live `&str`.
+    cmdline_ptr: *const u8,
+    /// Length of the command-line byte region.
+    cmdline_len: usize,
 }
+
+// SAFETY: the raw pointer originates from a `&'static str` whose referent lives for the entire
+// program and is only accessed from a single core with interrupts disabled.
+unsafe impl Send for KernelModule {}
+unsafe impl Sync for KernelModule {}
 
 impl KernelModule {
     /// Creates a new kernel module whose mapped region matches the ELF extent.
@@ -34,7 +43,8 @@ impl KernelModule {
             size,
             region_base: start,
             region_size: size,
-            cmdline,
+            cmdline_ptr: cmdline.as_ptr(),
+            cmdline_len: cmdline.len(),
         }
     }
 
@@ -51,7 +61,8 @@ impl KernelModule {
             size,
             region_base,
             region_size,
-            cmdline,
+            cmdline_ptr: cmdline.as_ptr(),
+            cmdline_len: cmdline.len(),
         }
     }
 
@@ -76,8 +87,39 @@ impl KernelModule {
     }
 
     /// Gets the command line of the module.
+    ///
+    /// # Safety (internal)
+    ///
+    /// Uses `from_utf8_unchecked` because `cmdline_ptr`/`cmdline_len` originate from a
+    /// `&'static str` supplied at construction time, guaranteeing valid UTF-8.
     pub fn cmdline(&self) -> &str {
-        self.cmdline
+        // SAFETY: the raw parts were extracted from a `&'static str` in the constructor.
+        unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                self.cmdline_ptr,
+                self.cmdline_len,
+            ))
+        }
+    }
+
+    /// Returns a mutable byte slice over the command-line region.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no shared reference to the same command-line bytes is live.
+    /// The underlying memory must be mapped read-write.
+    pub unsafe fn cmdline_bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.cmdline_ptr as *mut u8, self.cmdline_len) }
+    }
+
+    /// Shrinks the effective command-line length after in-place compaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` exceeds the current length.
+    pub fn set_cmdline_len(&mut self, new_len: usize) {
+        assert!(new_len <= self.cmdline_len, "cannot grow cmdline length");
+        self.cmdline_len = new_len;
     }
 }
 
@@ -86,7 +128,9 @@ impl core::fmt::Debug for KernelModule {
         write!(
             f,
             "kernel_module {{ start: {:?}, size: {:?}, cmdline: {:?} }}",
-            self.start, self.size, self.cmdline
+            self.start,
+            self.size,
+            self.cmdline()
         )
     }
 }

--- a/src/libs/cmdline/Cargo.toml
+++ b/src/libs/cmdline/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "cmdline"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+description = "Command-line argument and environment variable parsing for Nanvix"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+core = { version = "1.0.1", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { workspace = true, optional = true }
+
+[dev-dependencies]
+
+[features]
+default = []
+std = []
+rustc-dep-of-std = ["core", "compiler_builtins"]
+
+[lints]
+workspace = true

--- a/src/libs/cmdline/src/lib.rs
+++ b/src/libs/cmdline/src/lib.rs
@@ -1,0 +1,198 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![deny(clippy::all)]
+
+#[cfg(test)]
+extern crate alloc;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Splits a packed command-line buffer in place, resolving `\;` escapes to literal `;`.
+///
+/// A lone `;` separates arguments from environment variables. The sequence `\;` is compacted to a
+/// literal `;`. A backslash not followed by `;` is kept verbatim. Only the first unescaped `;`
+/// acts as the separator.
+///
+/// Because unescaping only ever shortens the content, the compaction is performed in place with no
+/// heap allocation.
+///
+/// # Panics
+///
+/// Panics if the compacted buffer is not valid UTF-8. This cannot happen when the original input
+/// was valid UTF-8 because the compaction only removes ASCII `\` bytes that precede ASCII `;`.
+///
+/// # Parameters
+///
+/// - `buf`: Mutable byte slice containing the packed command line. Modified in place.
+///   Must contain valid UTF-8.
+///
+/// # Returns
+///
+/// A tuple `(args, env)` as string slices into the compacted buffer.
+pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str) {
+    let len: usize = buf.len();
+    let mut r: usize = 0;
+    let mut w: usize = 0;
+
+    // Phase 1: compact args, stop at the first unescaped `;`.
+    while r < len {
+        if buf[r] == b'\\' && r + 1 < len && buf[r + 1] == b';' {
+            buf[w] = b';';
+            w += 1;
+            r += 2;
+        } else if buf[r] == b';' {
+            // First unescaped `;` → separator.
+            let args_end: usize = w;
+            r += 1;
+
+            // Phase 2: compact env immediately after args.
+            while r < len {
+                if buf[r] == b'\\' && r + 1 < len && buf[r + 1] == b';' {
+                    buf[w] = b';';
+                    w += 1;
+                    r += 2;
+                } else {
+                    buf[w] = buf[r];
+                    w += 1;
+                    r += 1;
+                }
+            }
+
+            let buf: &[u8] = buf;
+            let args: &str = unwrap_utf8(&buf[..args_end]);
+            let env: &str = unwrap_utf8(&buf[args_end..w]);
+            return (args, env);
+        } else {
+            buf[w] = buf[r];
+            w += 1;
+            r += 1;
+        }
+    }
+
+    // No separator found — entire buffer is args.
+    let args: &str = unwrap_utf8(&buf[..w]);
+    (args, "")
+}
+
+/// Converts a byte slice to `&str`, panicking on invalid UTF-8.
+fn unwrap_utf8(bytes: &[u8]) -> &str {
+    core::str::from_utf8(bytes).expect("cmdline: invalid UTF-8 after compaction")
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: copies the input into a mutable buffer and calls `split_cmdline`.
+    fn split(input: &str) -> (::alloc::string::String, ::alloc::string::String) {
+        let mut buf: ::alloc::vec::Vec<u8> = input.as_bytes().to_vec();
+        let (args, env) = split_cmdline(&mut buf);
+        (::alloc::string::String::from(args), ::alloc::string::String::from(env))
+    }
+
+    #[test]
+    fn args_only() {
+        let (args, env) = split("arg1 arg2");
+        assert_eq!(args, "arg1 arg2", "args mismatch");
+        assert_eq!(env, "", "env should be empty");
+    }
+
+    #[test]
+    fn args_and_env() {
+        let (args, env) = split("arg1 arg2;VAR1=foo VAR2=bar");
+        assert_eq!(args, "arg1 arg2", "args mismatch");
+        assert_eq!(env, "VAR1=foo VAR2=bar", "env mismatch");
+    }
+
+    #[test]
+    fn env_only() {
+        let (args, env) = split(";VAR1=foo");
+        assert_eq!(args, "", "args should be empty");
+        assert_eq!(env, "VAR1=foo", "env mismatch");
+    }
+
+    #[test]
+    fn empty_string() {
+        let (args, env) = split("");
+        assert_eq!(args, "", "args should be empty");
+        assert_eq!(env, "", "env should be empty");
+    }
+
+    #[test]
+    fn escaped_semicolon_in_args() {
+        let (args, env) = split("arg1 with\\;semicolon arg2;VAR1=foo");
+        assert_eq!(args, "arg1 with;semicolon arg2", "escaped \\; should become ;");
+        assert_eq!(env, "VAR1=foo", "env mismatch");
+    }
+
+    #[test]
+    fn escaped_semicolon_in_env() {
+        let (args, env) = split("arg1;VAR=a\\;b");
+        assert_eq!(args, "arg1", "args mismatch");
+        assert_eq!(env, "VAR=a;b", "escaped \\; in env should become ;");
+    }
+
+    #[test]
+    fn multiple_escaped_semicolons() {
+        let (args, env) = split("a\\;b\\;c;VAR=d\\;e");
+        assert_eq!(args, "a;b;c", "multiple escaped semicolons");
+        assert_eq!(env, "VAR=d;e", "env escaped semicolon");
+    }
+
+    #[test]
+    fn escaped_only_no_separator() {
+        let (args, env) = split("a\\;b");
+        assert_eq!(args, "a;b", "escaped semicolon without separator");
+        assert_eq!(env, "", "env should be empty");
+    }
+
+    #[test]
+    fn backslash_before_non_semicolon() {
+        let (args, env) = split("C:\\path\\file;VAR=x");
+        assert_eq!(args, "C:\\path\\file", "lone backslashes preserved");
+        assert_eq!(env, "VAR=x", "env mismatch");
+    }
+
+    #[test]
+    fn backslash_at_end() {
+        let (args, env) = split("trail\\");
+        assert_eq!(args, "trail\\", "trailing backslash preserved");
+        assert_eq!(env, "", "env should be empty");
+    }
+
+    #[test]
+    fn backslash_semicolon_then_separator() {
+        let (args, env) = split("a\\;;VAR=x");
+        assert_eq!(args, "a;", "backslash-semicolon then separator");
+        assert_eq!(env, "VAR=x", "env after separator");
+    }
+
+    #[test]
+    fn backward_compatible_no_semicolons() {
+        let (args, env) = split("hello world");
+        assert_eq!(args, "hello world", "plain args unchanged");
+        assert_eq!(env, "", "env should be empty");
+    }
+
+    #[test]
+    fn backward_compatible_with_separator() {
+        let (args, env) = split("prog;HOME=/tmp");
+        assert_eq!(args, "prog", "args before separator");
+        assert_eq!(env, "HOME=/tmp", "env after separator");
+    }
+}


### PR DESCRIPTION
Add `\;` escape sequence so that guest applications can receive literal
semicolons in their command-line arguments.  Previously, `;` was
unconditionally used as the separator between arguments and environment
variables, making it impossible to pass a literal `;` to an application.

Introduce a new `cmdline` library crate (`src/libs/cmdline`) that
performs zero-allocation, in-place splitting of the packed command-line
buffer.  The `split_cmdline(buf: &mut [u8]) -> (&str, &str)` function
uses a read/write cursor to compact `\;` escapes into literal `;`
characters directly in the bootloader-provided RAM, avoiding any heap
allocation in the kernel.

Escape rules:
  - `\;`  → literal `;`
  - `\`   before any other character → kept verbatim
  - first unescaped `;` → separator between args and env vars

Changes:
- Add `src/libs/cmdline` crate with `split_cmdline()` and 13 unit tests.
- Add `KernelModule::cmdline_bytes_mut()` for in-place mutation of the
  command-line region in `src/kernel/src/kmod.rs`.
- Update `spawn_servers()` in `src/kernel/src/kmain.rs` to use the new
  crate instead of `str::split(';')`, taking `&mut LinkedList<KernelModule>`
  and logging the cmdline before mutation.
- Register the crate in workspace `Cargo.toml`, kernel `Cargo.toml`,
  and `Makefile` (build + test lists).
- Update `doc/run-linux.md` and `doc/run-windows.md` with escape
  examples and clarified "first unescaped semicolon" wording.

Closes #2335