### PR TITLE
[kernel] Add kernel arguments to command-line format

### DIFF
--- a/.github/skills/user-app-development/SKILL.md
+++ b/.github/skills/user-app-development/SKILL.md
@@ -34,6 +34,13 @@ Nanvix.  User applications are programs that run inside the Nanvix guest environ
     -console-file /dev/stdout \
     -- ./bin/echo-rust-nostd.elf \
     "arg1 arg2;VAR1=foo VAR2=bar"
+
+# Pass arguments, environment variables, and kernel arguments.
+# Format: "<app args>;<env vars>;<kernel args>"
+./bin/nanvixd.elf \
+    -console-file /dev/stdout \
+    -- ./bin/echo-rust-nostd.elf \
+    "arg1 arg2;VAR1=foo;feature1 feature2"
 ```
 
 ### HTTP Mode (for multi-application scenarios)

--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -20,7 +20,6 @@ Run a hello-world application and see its output on the terminal:
 ## Table of Contents
 
 - [Quick Start](#quick-start)
-- [Table of Contents](#table-of-contents)
 - [Interactive Mode](#interactive-mode)
   - [Shim Configuration](#shim-configuration)
 - [Running Containers](#running-containers)
@@ -104,11 +103,17 @@ Everything after `--` is forwarded to the application as arguments:
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf arg1 arg2
 ```
 
-Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the first unescaped semicolon becomes command-line arguments; everything after it becomes
-environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Arguments, environment variables, and kernel arguments are packed into a single string separated
+by `;`. The format is `<app args>;<env vars>;<kernel args>`:
+
+- Everything before the first unescaped `;` becomes command-line arguments.
+- Everything between the first and second unescaped `;` becomes environment variables as
+  space-separated `KEY=VALUE` pairs.
+- Everything after the second unescaped `;` becomes kernel arguments — a space-separated string
+  that the kernel uses to enable/disable internal features.
+
 Use an empty string when neither is needed. To pass only environment variables, start the string
-with `;`:
+with `;`. To pass only kernel arguments, use `;;`:
 
 ```bash
 # Arguments and environment variables.
@@ -116,14 +121,20 @@ with `;`:
 
 # Environment variables only.
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf ";VAR1=foo"
+
+# All three components.
+./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf "arg1 arg2;VAR1=foo;feature1 feature2"
+
+# Kernel arguments only.
+./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf ";;feature1 feature2"
 ```
 
-To include a literal `;` in the argument portion, escape it as `\;`:
+To include a literal `;` in any section, escape it as `\;`:
 
 ```bash
 # Argument containing a literal semicolon.
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/echo-rust-nostd.elf "arg1 with\;semicolon arg2;VAR1=foo"
-# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
+# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]   kernel_args: []
 ```
 
 ## HTTP Mode
@@ -217,13 +228,16 @@ All requests are `POST` to `http://<host:port>/`. The message type is specified 
 | `tenant_id`    | string | yes      | Tenant identifier for resource isolation.|
 | `app_name`     | string | yes      | Application name for identification.     |
 | `program`      | string | yes      | Path to the program binary to execute.   |
-| `program_args` | string | yes      | Arguments and environment variables.     |
+| `program_args` | string | yes      | Arguments, environment variables, and kernel arguments. |
 
-Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the first unescaped semicolon becomes command-line arguments; everything after it becomes
-environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Arguments, environment variables, and kernel arguments are packed into a single string separated
+by `;`. The format is `<app args>;<env vars>;<kernel args>`. Everything before the first unescaped
+semicolon becomes command-line arguments; everything between the first and second unescaped
+semicolon becomes environment variables as space-separated `KEY=VALUE` pairs; everything after the
+second unescaped semicolon becomes kernel arguments — a space-separated string that the kernel uses
+to enable/disable internal features (e.g., `"arg1 arg2;VAR1=foo;feature1 feature2"`).
 Use an empty string when neither is needed. To pass only environment variables, start the string
-with `;`. To include a literal `;` in the argument portion, escape it as `\;`.
+with `;`. To include a literal `;` in any section, escape it as `\;`.
 
 **Success response (200):**
 

--- a/doc/run-windows.md
+++ b/doc/run-windows.md
@@ -16,11 +16,13 @@ Run a guest application via `nanvixd` in standalone interactive mode:
 
 ## Table of Contents
 
+- [Quick Start](#quick-start)
 - [Using `z.ps1 run`](#using-zps1-run)
 - [Running nanvixd Directly](#running-nanvixd-directly)
 - [Logging](#logging)
 - [Expert Mode: Standalone UserVM](#expert-mode-standalone-uservm)
 - [Benchmarking](#benchmarking)
+  - [Quick Start](#quick-start-1)
 
 ---
 
@@ -66,11 +68,17 @@ Everything after `--` is forwarded to the application as arguments:
 .\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf arg1 arg2
 ```
 
-Arguments and environment variables are packed into a single string separated by `;`. Everything
-before the first unescaped semicolon becomes command-line arguments; everything after it becomes
-environment variables as space-separated `KEY=VALUE` pairs (e.g., `"arg1 arg2;VAR1=foo VAR2=bar"`).
+Arguments, environment variables, and kernel arguments are packed into a single string separated
+by `;`. The format is `<app args>;<env vars>;<kernel args>`:
+
+- Everything before the first unescaped `;` becomes command-line arguments.
+- Everything between the first and second unescaped `;` becomes environment variables as
+  space-separated `KEY=VALUE` pairs.
+- Everything after the second unescaped `;` becomes kernel arguments — a space-separated string
+  that the kernel uses to enable/disable internal features.
+
 Use an empty string when neither is needed. To pass only environment variables, start the string
-with `;`:
+with `;`. To pass only kernel arguments, use `;;`:
 
 ```powershell
 # Arguments and environment variables.
@@ -78,14 +86,20 @@ with `;`:
 
 # Environment variables only.
 .\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf ";VAR1=foo"
+
+# All three components.
+.\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf "arg1 arg2;VAR1=foo;feature1 feature2"
+
+# Kernel arguments only.
+.\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf ";;feature1 feature2"
 ```
 
-To include a literal `;` in the argument portion, escape it as `\;`:
+To include a literal `;` in any section, escape it as `\;`:
 
 ```powershell
 # Argument containing a literal semicolon.
 .\bin\nanvixd.exe -- .\bin\echo-rust-nostd.elf "arg1 with\;semicolon arg2;VAR1=foo"
-# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
+# args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]   kernel_args: []
 ```
 
 ## Logging

--- a/src/kernel/src/hal/platform/bootinfo.rs
+++ b/src/kernel/src/hal/platform/bootinfo.rs
@@ -41,6 +41,8 @@ pub struct BootInfo {
     pub ioaddresses: IoMemoryAllocator,
     /// Kernel modules.
     pub kernel_modules: LinkedList<KernelModule>,
+    /// Kernel arguments shared by all modules in the initrd.
+    pub kernel_args: &'static str,
 }
 
 //==================================================================================================
@@ -61,6 +63,7 @@ impl BootInfo {
     /// - `mmio_regions`: Memory-mapped I/O regions.
     /// - `ioaddresses`: I/O memory allocator with pre-registered MMIO regions.
     /// - `kernel_modules`: Kernel modules.
+    /// - `kernel_args`: Kernel arguments shared by all modules.
     ///
     /// # Returns
     ///
@@ -73,6 +76,7 @@ impl BootInfo {
         mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
         ioaddresses: IoMemoryAllocator,
         kernel_modules: LinkedList<KernelModule>,
+        kernel_args: &'static str,
     ) -> Self {
         Self {
             madt,
@@ -81,6 +85,7 @@ impl BootInfo {
             mmio_regions,
             ioaddresses,
             kernel_modules,
+            kernel_args,
         }
     }
 }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -526,6 +526,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     let initrd_base: usize = info & !((1 << nzeros) - 1);
 
     let mut kernel_modules: LinkedList<KernelModule> = LinkedList::new();
+    let mut kernel_args: &'static str = "";
 
     // Register initrd as a kernel module.
     if initrd_size != 0 {
@@ -565,7 +566,9 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             && image_data[..multibin::MAGIC.len()] == multibin::MAGIC
         {
             info!("parse_bootinfo(): multibinary initrd detected");
-            kernel_modules.extend(crate::multibin::parse(image_data, initrd_base)?);
+            let (modules, kargs) = crate::multibin::parse(image_data, initrd_base)?;
+            kernel_modules.extend(modules);
+            kernel_args = kargs;
         } else {
             // Single ELF binary with length-prefixed args after the initrd.
             info!("parse_bootinfo(): single-binary initrd detected");
@@ -622,25 +625,45 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             }
 
             // SAFETY: the cmdline bytes reside in bootloader-provided memory that persists for the
-            // kernel's lifetime, so the resulting &'static str is sound.
-            let cmdline: &'static str = unsafe {
-                let bytes: &'static [u8] = core::slice::from_raw_parts(
-                    initrd_cmdline_base as *const u8,
+            // kernel's lifetime. We use a mutable reference so that `compact_semicolon_escapes`
+            // can unescape `\;` in the kernel-args tail in place.
+            let cmdline_bytes: &'static mut [u8] = unsafe {
+                core::slice::from_raw_parts_mut(
+                    initrd_cmdline_base as *mut u8,
                     cmdline_len.as_usize(),
-                );
-                match core::str::from_utf8(bytes) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        let reason: &str = "invalid UTF-8 in command line";
-                        error!("invalid UTF-8 in command line");
-                        return Err(Error::new(ErrorCode::InvalidArgument, reason));
-                    },
-                }
+                )
+            };
+
+            // Validate UTF-8 before any mutation.
+            if core::str::from_utf8(cmdline_bytes).is_err() {
+                let reason: &str = "invalid UTF-8 in command line";
+                error!("invalid UTF-8 in command line");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+
+            // Find the kernel args boundary (second unescaped `;`) using a temporary view.
+            let kargs_pos: Option<usize> = {
+                let s: &str = core::str::from_utf8(cmdline_bytes).unwrap();
+                ::cmdline::find_kernel_args_start(s)
+            };
+
+            // Separate kernel arguments from the per-module command line so that kernel args are
+            // stored once in BootInfo rather than per-module. Unescape `\;` in the kernel-args
+            // tail so that escaping rules are consistent with `split_cmdline`.
+            let module_cmdline: &'static str = if let Some(pos) = kargs_pos {
+                let (module_bytes, rest) = cmdline_bytes.split_at_mut(pos);
+                // rest[0] is the `;` separator — skip it.
+                let kargs_bytes: &'static mut [u8] = &mut rest[1..];
+                kernel_args = ::cmdline::compact_semicolon_escapes(kargs_bytes);
+                core::str::from_utf8(module_bytes)
+                    .expect("cmdline: invalid UTF-8 in module cmdline")
+            } else {
+                core::str::from_utf8(cmdline_bytes).expect("cmdline: invalid UTF-8 in command line")
             };
 
             info!(
                 "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
-                initrd_base, total_bytes, cmdline_len, cmdline
+                initrd_base, total_bytes, cmdline_len, module_cmdline
             );
 
             // Module size must cover the ELF binary AND the trailing cmdline area
@@ -651,7 +674,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             let module: KernelModule = KernelModule::new(
                 PhysicalAddress::from_raw_value(initrd_base)?,
                 module_size,
-                cmdline,
+                module_cmdline,
             );
             kernel_modules.push_back(module);
         }
@@ -664,6 +687,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         LinkedList::new(),
         IoMemoryAllocator::new(),
         kernel_modules,
+        kernel_args,
     ))
 }
 

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -230,7 +230,7 @@ fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &mut LinkedList<KernelModule
             // SAFETY: module pages are mapped read-write; `iter_mut` yields exclusive access
             // so no other reference aliases the cmdline bytes.
             let cmdline_buf: &mut [u8] = unsafe { kmod.cmdline_bytes_mut() };
-            let (args, env): (&str, &str) = ::cmdline::split_cmdline(cmdline_buf);
+            let (args, env, _): (&str, &str, &str) = ::cmdline::split_cmdline(cmdline_buf);
             // Capture compacted length before create_process borrows args/env.
             let compacted_len: usize = args.len() + env.len();
 
@@ -293,6 +293,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
         IoMemoryAllocator,
         LinkedList<KernelModule>,
+        &'static str,
     );
     let (
         madt,
@@ -301,6 +302,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         mut mmio_regions,
         mut ioaddresses,
         mut kernel_modules,
+        kernel_args,
     ): KernelArgs = match kargs.parse() {
         Ok(bootinfo) => (
             bootinfo.madt,
@@ -309,11 +311,16 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             bootinfo.mmio_regions,
             bootinfo.ioaddresses,
             bootinfo.kernel_modules,
+            bootinfo.kernel_args,
         ),
         Err(err) => {
             panic!("failed to parse kernel arguments: {:?}", err);
         },
     };
+
+    if !kernel_args.is_empty() {
+        info!("kernel args: {:?}", kernel_args);
+    }
 
     info!("parsing kernel image...");
     let kimage: KernelImage = match KernelImage::new() {

--- a/src/kernel/src/multibin.rs
+++ b/src/kernel/src/multibin.rs
@@ -25,10 +25,18 @@ use ::sys::{
 ///
 /// # Description
 ///
-/// Parses a multibinary image and returns a list of kernel modules.
+/// Parses a multibinary image and returns a list of kernel modules plus the shared kernel
+/// arguments.
 ///
 /// Each entry in the multibinary image becomes a [`KernelModule`] whose physical address is
-/// computed as `initrd_base + entry.offset`.
+/// computed as `initrd_base + entry.offset`. Kernel arguments are stored once in the image
+/// header and apply to the entire image rather than to individual modules.
+///
+/// **Note:** Kernel arguments from the multibinary header are stored verbatim and do not
+/// undergo `\;` unescape processing. The `\;` escape convention applies only to the packed
+/// command-line string format used in the single-binary initrd path. Because multibinary
+/// kernel args are structurally separated by the image header, semicolon escaping is not
+/// needed.
 ///
 /// # Parameters
 ///
@@ -37,9 +45,12 @@ use ::sys::{
 ///
 /// # Returns
 ///
-/// A [`Vec`] of [`KernelModule`]s on success, or an [`Error`] if the image is malformed.
+/// A tuple `(modules, kernel_args)` on success, or an [`Error`] if the image is malformed.
 ///
-pub fn parse(image_data: &'static [u8], initrd_base: usize) -> Result<Vec<KernelModule>, Error> {
+pub fn parse(
+    image_data: &'static [u8],
+    initrd_base: usize,
+) -> Result<(Vec<KernelModule>, &'static str), Error> {
     let parsed: multibin::ParseResult = multibin::parse(image_data).map_err(|e| {
         error!("parse(): failed to parse multibinary image: {:?}", e);
         e
@@ -51,6 +62,22 @@ pub fn parse(image_data: &'static [u8], initrd_base: usize) -> Result<Vec<Kernel
         image_data.len(),
         parsed.count()
     );
+
+    // Extract kernel arguments from the image header.
+    let kernel_args: &str = if parsed.kernel_args_size() > 0 {
+        let ka_bytes: &[u8] = &image_data
+            [parsed.kernel_args_offset()..parsed.kernel_args_offset() + parsed.kernel_args_size()];
+        match core::str::from_utf8(ka_bytes) {
+            Ok(s) => s,
+            Err(_) => {
+                let reason: &str = "invalid UTF-8 in multibinary kernel args";
+                error!("parse(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        }
+    } else {
+        ""
+    };
 
     let mut modules: Vec<KernelModule> = Vec::new();
 
@@ -92,5 +119,5 @@ pub fn parse(image_data: &'static [u8], initrd_base: usize) -> Result<Vec<Kernel
         modules.push(module);
     }
 
-    Ok(modules)
+    Ok((modules, kernel_args))
 }

--- a/src/libs/cmdline/src/lib.rs
+++ b/src/libs/cmdline/src/lib.rs
@@ -20,9 +20,13 @@ extern crate alloc;
 ///
 /// Splits a packed command-line buffer in place, resolving `\;` escapes to literal `;`.
 ///
-/// A lone `;` separates arguments from environment variables. The sequence `\;` is compacted to a
-/// literal `;`. A backslash not followed by `;` is kept verbatim. Only the first unescaped `;`
-/// acts as the separator.
+/// The format is `<app args>;<env vars>;<kernel args>`. The first unescaped `;` separates
+/// application arguments from environment variables; the second unescaped `;` separates
+/// environment variables from kernel arguments. Kernel arguments are a space-separated string
+/// that the kernel uses to enable/disable internal features.
+///
+/// The sequence `\;` is compacted to a literal `;`. A backslash not followed by `;` is kept
+/// verbatim.
 ///
 /// Because unescaping only ever shortens the content, the compaction is performed in place with no
 /// heap allocation.
@@ -39,8 +43,8 @@ extern crate alloc;
 ///
 /// # Returns
 ///
-/// A tuple `(args, env)` as string slices into the compacted buffer.
-pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str) {
+/// A tuple `(args, env, kernel_args)` as string slices into the compacted buffer.
+pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str, &str) {
     let len: usize = buf.len();
     let mut r: usize = 0;
     let mut w: usize = 0;
@@ -52,16 +56,39 @@ pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str) {
             w += 1;
             r += 2;
         } else if buf[r] == b';' {
-            // First unescaped `;` → separator.
+            // First unescaped `;` → separator between args and env.
             let args_end: usize = w;
             r += 1;
 
-            // Phase 2: compact env immediately after args.
+            // Phase 2: compact env, stop at the second unescaped `;`.
             while r < len {
                 if buf[r] == b'\\' && r + 1 < len && buf[r + 1] == b';' {
                     buf[w] = b';';
                     w += 1;
                     r += 2;
+                } else if buf[r] == b';' {
+                    // Second unescaped `;` → separator between env and kernel args.
+                    let env_end: usize = w;
+                    r += 1;
+
+                    // Phase 3: compact kernel args after env.
+                    while r < len {
+                        if buf[r] == b'\\' && r + 1 < len && buf[r + 1] == b';' {
+                            buf[w] = b';';
+                            w += 1;
+                            r += 2;
+                        } else {
+                            buf[w] = buf[r];
+                            w += 1;
+                            r += 1;
+                        }
+                    }
+
+                    let buf: &[u8] = buf;
+                    let args: &str = unwrap_utf8(&buf[..args_end]);
+                    let env: &str = unwrap_utf8(&buf[args_end..env_end]);
+                    let kernel_args: &str = unwrap_utf8(&buf[env_end..w]);
+                    return (args, env, kernel_args);
                 } else {
                     buf[w] = buf[r];
                     w += 1;
@@ -69,10 +96,11 @@ pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str) {
                 }
             }
 
+            // No second separator — no kernel args.
             let buf: &[u8] = buf;
             let args: &str = unwrap_utf8(&buf[..args_end]);
             let env: &str = unwrap_utf8(&buf[args_end..w]);
-            return (args, env);
+            return (args, env, "");
         } else {
             buf[w] = buf[r];
             w += 1;
@@ -82,12 +110,86 @@ pub fn split_cmdline(buf: &mut [u8]) -> (&str, &str) {
 
     // No separator found — entire buffer is args.
     let args: &str = unwrap_utf8(&buf[..w]);
-    (args, "")
+    (args, "", "")
 }
 
 /// Converts a byte slice to `&str`, panicking on invalid UTF-8.
 fn unwrap_utf8(bytes: &[u8]) -> &str {
     core::str::from_utf8(bytes).expect("cmdline: invalid UTF-8 after compaction")
+}
+
+///
+/// # Description
+///
+/// Finds the byte offset of the second unescaped `;` in a command-line string.
+///
+/// This is used to locate the boundary between `<args>;<env>` and `<kernel_args>` without
+/// modifying the buffer. The sequence `\;` is treated as an escaped literal and is not counted
+/// as a separator.
+///
+/// # Parameters
+///
+/// - `s`: The command-line string to scan.
+///
+/// # Returns
+///
+/// `Some(offset)` where `offset` is the byte index of the second unescaped `;`, or `None` if
+/// fewer than two unescaped semicolons are present.
+pub fn find_kernel_args_start(s: &str) -> Option<usize> {
+    let bytes: &[u8] = s.as_bytes();
+    let mut semicolons: usize = 0;
+    let mut i: usize = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b';' {
+            i += 2;
+        } else if bytes[i] == b';' {
+            semicolons += 1;
+            if semicolons == 2 {
+                return Some(i);
+            }
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+///
+/// # Description
+///
+/// Compacts `\;` escape sequences to literal `;` in a byte buffer, in place.
+///
+/// This is used to unescape a single section of a command-line string (e.g., the kernel
+/// arguments tail) without performing a full `split_cmdline` parse.
+///
+/// # Panics
+///
+/// Panics if the compacted buffer is not valid UTF-8.
+///
+/// # Parameters
+///
+/// - `buf`: Mutable byte slice to compact in place. Must contain valid UTF-8.
+///
+/// # Returns
+///
+/// A `&str` slice into the compacted portion of `buf`.
+pub fn compact_semicolon_escapes(buf: &mut [u8]) -> &str {
+    let len: usize = buf.len();
+    let mut r: usize = 0;
+    let mut w: usize = 0;
+    while r < len {
+        if buf[r] == b'\\' && r + 1 < len && buf[r + 1] == b';' {
+            buf[w] = b';';
+            w += 1;
+            r += 2;
+        } else {
+            buf[w] = buf[r];
+            w += 1;
+            r += 1;
+        }
+    }
+    unwrap_utf8(&buf[..w])
 }
 
 //==================================================================================================
@@ -99,100 +201,206 @@ mod tests {
     use super::*;
 
     /// Helper: copies the input into a mutable buffer and calls `split_cmdline`.
-    fn split(input: &str) -> (::alloc::string::String, ::alloc::string::String) {
+    fn split(
+        input: &str,
+    ) -> (::alloc::string::String, ::alloc::string::String, ::alloc::string::String) {
         let mut buf: ::alloc::vec::Vec<u8> = input.as_bytes().to_vec();
-        let (args, env) = split_cmdline(&mut buf);
-        (::alloc::string::String::from(args), ::alloc::string::String::from(env))
+        let (args, env, kargs) = split_cmdline(&mut buf);
+        (
+            ::alloc::string::String::from(args),
+            ::alloc::string::String::from(env),
+            ::alloc::string::String::from(kargs),
+        )
     }
 
     #[test]
     fn args_only() {
-        let (args, env) = split("arg1 arg2");
+        let (args, env, kargs) = split("arg1 arg2");
         assert_eq!(args, "arg1 arg2", "args mismatch");
         assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn args_and_env() {
-        let (args, env) = split("arg1 arg2;VAR1=foo VAR2=bar");
+        let (args, env, kargs) = split("arg1 arg2;VAR1=foo VAR2=bar");
         assert_eq!(args, "arg1 arg2", "args mismatch");
         assert_eq!(env, "VAR1=foo VAR2=bar", "env mismatch");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn env_only() {
-        let (args, env) = split(";VAR1=foo");
+        let (args, env, kargs) = split(";VAR1=foo");
         assert_eq!(args, "", "args should be empty");
         assert_eq!(env, "VAR1=foo", "env mismatch");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn empty_string() {
-        let (args, env) = split("");
+        let (args, env, kargs) = split("");
         assert_eq!(args, "", "args should be empty");
         assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn escaped_semicolon_in_args() {
-        let (args, env) = split("arg1 with\\;semicolon arg2;VAR1=foo");
+        let (args, env, kargs) = split("arg1 with\\;semicolon arg2;VAR1=foo");
         assert_eq!(args, "arg1 with;semicolon arg2", "escaped \\; should become ;");
         assert_eq!(env, "VAR1=foo", "env mismatch");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn escaped_semicolon_in_env() {
-        let (args, env) = split("arg1;VAR=a\\;b");
+        let (args, env, kargs) = split("arg1;VAR=a\\;b");
         assert_eq!(args, "arg1", "args mismatch");
         assert_eq!(env, "VAR=a;b", "escaped \\; in env should become ;");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn multiple_escaped_semicolons() {
-        let (args, env) = split("a\\;b\\;c;VAR=d\\;e");
+        let (args, env, kargs) = split("a\\;b\\;c;VAR=d\\;e");
         assert_eq!(args, "a;b;c", "multiple escaped semicolons");
         assert_eq!(env, "VAR=d;e", "env escaped semicolon");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn escaped_only_no_separator() {
-        let (args, env) = split("a\\;b");
+        let (args, env, kargs) = split("a\\;b");
         assert_eq!(args, "a;b", "escaped semicolon without separator");
         assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn backslash_before_non_semicolon() {
-        let (args, env) = split("C:\\path\\file;VAR=x");
+        let (args, env, kargs) = split("C:\\path\\file;VAR=x");
         assert_eq!(args, "C:\\path\\file", "lone backslashes preserved");
         assert_eq!(env, "VAR=x", "env mismatch");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn backslash_at_end() {
-        let (args, env) = split("trail\\");
+        let (args, env, kargs) = split("trail\\");
         assert_eq!(args, "trail\\", "trailing backslash preserved");
         assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn backslash_semicolon_then_separator() {
-        let (args, env) = split("a\\;;VAR=x");
+        let (args, env, kargs) = split("a\\;;VAR=x");
         assert_eq!(args, "a;", "backslash-semicolon then separator");
         assert_eq!(env, "VAR=x", "env after separator");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn backward_compatible_no_semicolons() {
-        let (args, env) = split("hello world");
+        let (args, env, kargs) = split("hello world");
         assert_eq!(args, "hello world", "plain args unchanged");
         assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "", "kernel args should be empty");
     }
 
     #[test]
     fn backward_compatible_with_separator() {
-        let (args, env) = split("prog;HOME=/tmp");
+        let (args, env, kargs) = split("prog;HOME=/tmp");
         assert_eq!(args, "prog", "args before separator");
         assert_eq!(env, "HOME=/tmp", "env after separator");
+        assert_eq!(kargs, "", "kernel args should be empty");
+    }
+
+    #[test]
+    fn all_three_components() {
+        let (args, env, kargs) = split("arg1 arg2;VAR1=foo;feature1 feature2");
+        assert_eq!(args, "arg1 arg2", "args mismatch");
+        assert_eq!(env, "VAR1=foo", "env mismatch");
+        assert_eq!(kargs, "feature1 feature2", "kernel args mismatch");
+    }
+
+    #[test]
+    fn kernel_args_only() {
+        let (args, env, kargs) = split(";;feature1");
+        assert_eq!(args, "", "args should be empty");
+        assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "feature1", "kernel args mismatch");
+    }
+
+    #[test]
+    fn args_and_kernel_args_no_env() {
+        let (args, env, kargs) = split("arg1;;feature1 feature2");
+        assert_eq!(args, "arg1", "args mismatch");
+        assert_eq!(env, "", "env should be empty");
+        assert_eq!(kargs, "feature1 feature2", "kernel args mismatch");
+    }
+
+    #[test]
+    fn env_and_kernel_args_no_app_args() {
+        let (args, env, kargs) = split(";VAR=x;feature1");
+        assert_eq!(args, "", "args should be empty");
+        assert_eq!(env, "VAR=x", "env mismatch");
+        assert_eq!(kargs, "feature1", "kernel args mismatch");
+    }
+
+    #[test]
+    fn escaped_semicolon_in_kernel_args() {
+        let (args, env, kargs) = split("arg1;VAR=x;feat\\;ure1 feature2");
+        assert_eq!(args, "arg1", "args mismatch");
+        assert_eq!(env, "VAR=x", "env mismatch");
+        assert_eq!(kargs, "feat;ure1 feature2", "escaped \\; in kernel args should become ;");
+    }
+
+    #[test]
+    fn empty_kernel_args_with_trailing_separator() {
+        let (args, env, kargs) = split("arg1;VAR=x;");
+        assert_eq!(args, "arg1", "args mismatch");
+        assert_eq!(env, "VAR=x", "env mismatch");
+        assert_eq!(kargs, "", "kernel args should be empty");
+    }
+
+    // ── find_kernel_args_start tests ─────────────────────────────────────────
+
+    #[test]
+    fn find_kargs_no_semicolons() {
+        assert_eq!(find_kernel_args_start("hello world"), None);
+    }
+
+    #[test]
+    fn find_kargs_one_semicolon() {
+        assert_eq!(find_kernel_args_start("arg1;VAR=foo"), None);
+    }
+
+    #[test]
+    fn find_kargs_two_semicolons() {
+        // "arg1;VAR=foo;feature1"
+        //  0123456789012345678901
+        //              ^ position 12
+        assert_eq!(find_kernel_args_start("arg1;VAR=foo;feature1"), Some(12));
+    }
+
+    #[test]
+    fn find_kargs_escaped_semicolons_skipped() {
+        // "a\\;b;VAR=x;feat" — the `\;` at position 1 is escaped, not a separator.
+        // First real `;` is at position 4, second at position 10.
+        assert_eq!(find_kernel_args_start("a\\;b;VAR=x;feat"), Some(10));
+    }
+
+    #[test]
+    fn find_kargs_empty_sections() {
+        // ";;feature1" — two separators at positions 0 and 1.
+        assert_eq!(find_kernel_args_start(";;feature1"), Some(1));
+    }
+
+    #[test]
+    fn find_kargs_all_escaped() {
+        // "a\\;b\\;c" — no real separators.
+        assert_eq!(find_kernel_args_start("a\\;b\\;c"), None);
     }
 }

--- a/src/libs/multibin/src/lib.rs
+++ b/src/libs/multibin/src/lib.rs
@@ -15,7 +15,7 @@
 pub const MAGIC: [u8; 4] = *b"NVMB";
 
 /// Current format version.
-pub const VERSION: u32 = 1;
+pub const VERSION: u32 = 2;
 
 /// Size of the image header in bytes.
 pub const HEADER_SIZE: usize = core::mem::size_of::<MultibinHeader>();
@@ -44,6 +44,10 @@ pub struct MultibinHeader {
     pub version: u32,
     /// Number of entries in the image.
     pub num_entries: u32,
+    /// Byte offset from the start of the image to the kernel arguments string.
+    pub kernel_args_offset: u32,
+    /// Length of the kernel arguments string in bytes.
+    pub kernel_args_size: u32,
     /// Reserved for future use — must be zero.
     pub reserved: u32,
 }
@@ -101,6 +105,10 @@ pub struct ParseResult {
     entries: [ParsedEntry; MAX_ENTRIES],
     /// Number of valid entries.
     count: usize,
+    /// Byte offset from the start of the image to the kernel arguments string.
+    kernel_args_offset: usize,
+    /// Length of the kernel arguments string in bytes.
+    kernel_args_size: usize,
 }
 
 impl ParseResult {
@@ -144,6 +152,24 @@ impl ParseResult {
             result: self,
             index: 0,
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the byte offset of the kernel arguments string within the image.
+    ///
+    pub fn kernel_args_offset(&self) -> usize {
+        self.kernel_args_offset
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the length of the kernel arguments string in bytes.
+    ///
+    pub fn kernel_args_size(&self) -> usize {
+        self.kernel_args_size
     }
 }
 
@@ -234,12 +260,25 @@ pub fn parse(data: &[u8]) -> Result<ParseResult, error::Error> {
     let num_entries: u32 = read_u32(data, 8);
     let num_entries_usize: usize = num_entries as usize;
 
-    // Validate reserved field is zero.
-    let reserved: u32 = read_u32(data, 12);
+    // Parse kernel arguments.
+    let kernel_args_offset: usize = read_u32(data, 12) as usize;
+    let kernel_args_size: usize = read_u32(data, 16) as usize;
+    let reserved: u32 = read_u32(data, 20);
     if reserved != 0 {
         return Err(error::Error::new(
             error::ErrorCode::InvalidArgument,
             "multibinary reserved field is non-zero",
+        ));
+    }
+    // Validate kernel args region is within bounds.
+    if kernel_args_size > 0
+        && kernel_args_offset
+            .checked_add(kernel_args_size)
+            .is_none_or(|end| end > data.len())
+    {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary kernel args out of bounds",
         ));
     }
 
@@ -311,6 +350,8 @@ pub fn parse(data: &[u8]) -> Result<ParseResult, error::Error> {
     Ok(ParseResult {
         entries,
         count: num_entries_usize,
+        kernel_args_offset,
+        kernel_args_size,
     })
 }
 
@@ -338,6 +379,7 @@ pub mod builder {
     ///
     pub struct MultibinBuilder {
         entries: Vec<BuildEntry>,
+        kernel_args: Vec<u8>,
     }
 
     impl MultibinBuilder {
@@ -349,6 +391,7 @@ pub mod builder {
         pub fn new() -> Self {
             Self {
                 entries: Vec::new(),
+                kernel_args: Vec::new(),
             }
         }
 
@@ -384,6 +427,22 @@ pub mod builder {
         ///
         /// # Description
         ///
+        /// Sets the kernel arguments string for the image.
+        ///
+        /// Kernel arguments are stored once in the image header and apply to all entries.
+        ///
+        /// # Parameters
+        ///
+        /// - `kernel_args`: Kernel arguments string (UTF-8).
+        ///
+        pub fn set_kernel_args(&mut self, kernel_args: &str) -> &mut Self {
+            self.kernel_args = kernel_args.as_bytes().to_vec();
+            self
+        }
+
+        ///
+        /// # Description
+        ///
         /// Builds the multibinary image.
         ///
         /// # Returns
@@ -410,6 +469,10 @@ pub mod builder {
                 cursor += entry.cmdline.len();
             }
 
+            // Lay out kernel arguments string after per-entry cmdlines.
+            let kernel_args_offset: usize = cursor;
+            cursor += self.kernel_args.len();
+
             // Align to page boundary for first binary.
             let first_binary_offset: usize = align_up(cursor, PAGE_SIZE)?;
 
@@ -427,11 +490,22 @@ pub mod builder {
             // Build the image.
             let mut image: Vec<u8> = std::vec![0u8; total_size];
 
+            // Validate kernel args offset and size fit in u32.
+            if kernel_args_offset > u32::MAX as usize || self.kernel_args.len() > u32::MAX as usize
+            {
+                return Err(error::Error::new(
+                    error::ErrorCode::InvalidArgument,
+                    "multibinary kernel args offset or size exceeds u32",
+                ));
+            }
+
             // Write header.
             image[0..4].copy_from_slice(&MAGIC);
-            image[4..8].copy_from_slice(&(VERSION).to_le_bytes());
+            image[4..8].copy_from_slice(&VERSION.to_le_bytes());
             image[8..12].copy_from_slice(&(num_entries as u32).to_le_bytes());
-            image[12..16].copy_from_slice(&0u32.to_le_bytes());
+            image[12..16].copy_from_slice(&(kernel_args_offset as u32).to_le_bytes());
+            image[16..20].copy_from_slice(&(self.kernel_args.len() as u32).to_le_bytes());
+            image[20..24].copy_from_slice(&0u32.to_le_bytes()); // reserved
 
             // Write entry descriptors.
             for i in 0..num_entries {
@@ -459,6 +533,12 @@ pub mod builder {
             for (i, entry) in self.entries.iter().enumerate() {
                 let off: usize = cmdline_offsets[i];
                 image[off..off + entry.cmdline.len()].copy_from_slice(&entry.cmdline);
+            }
+
+            // Write kernel arguments string.
+            if !self.kernel_args.is_empty() {
+                image[kernel_args_offset..kernel_args_offset + self.kernel_args.len()]
+                    .copy_from_slice(&self.kernel_args);
             }
 
             // Write binary data.
@@ -532,6 +612,41 @@ mod tests {
         // Validate page alignment of binary data.
         assert_eq!(e0.offset % PAGE_SIZE, 0);
         assert_eq!(e1.offset % PAGE_SIZE, 0);
+
+        // No kernel args by default.
+        assert_eq!(result.kernel_args_size(), 0);
+    }
+
+    #[test]
+    fn test_round_trip_with_kernel_args() {
+        let mut builder: builder::MultibinBuilder = builder::MultibinBuilder::new();
+        builder
+            .add(vec![0x7f, b'E', b'L', b'F', 1, 2, 3, 4], "testd")
+            .unwrap();
+        builder
+            .add(vec![0x7f, b'E', b'L', b'F', 5, 6, 7, 8], "procd;ENV=1")
+            .unwrap();
+        builder.set_kernel_args("snapshot verbose");
+
+        let image: Vec<u8> = builder.build().expect("build should succeed");
+
+        // Parse the image back.
+        let result: ParseResult = parse(&image).expect("parse should succeed");
+        assert_eq!(result.count(), 2);
+        let ka_off: usize = result.kernel_args_offset();
+        let ka_size: usize = result.kernel_args_size();
+        assert_eq!(
+            core::str::from_utf8(&image[ka_off..ka_off + ka_size]).unwrap(),
+            "snapshot verbose"
+        );
+
+        // Per-entry cmdlines should not contain kernel args.
+        let e0: &ParsedEntry = result.get(0).expect("entry 0 should exist");
+        assert_eq!(
+            core::str::from_utf8(&image[e0.cmdline_offset..e0.cmdline_offset + e0.cmdline_size])
+                .unwrap(),
+            "testd"
+        );
     }
 
     #[test]

--- a/src/utils/mkimage/src/main.rs
+++ b/src/utils/mkimage/src/main.rs
@@ -35,8 +35,9 @@ fn main() {
         process::exit(1);
     }
 
-    // Parse -o <output> flag.
+    // Parse -o <output> and -k <kernel_args> flags.
     let mut output_path: Option<&str> = None;
+    let mut kernel_args: Option<&str> = None;
     let mut entry_args: Vec<&str> = Vec::new();
     let mut i: usize = 1;
 
@@ -48,6 +49,14 @@ fn main() {
                     process::exit(1);
                 }
                 output_path = Some(&args[i + 1]);
+                i += 2;
+            },
+            "-k" => {
+                if i + 1 >= args.len() {
+                    eprintln!("{}: error: -k requires a kernel arguments string", PROGRAM_NAME);
+                    process::exit(1);
+                }
+                kernel_args = Some(&args[i + 1]);
                 i += 2;
             },
             "-h" | "--help" => {
@@ -113,6 +122,12 @@ fn main() {
         }
     }
 
+    // Set kernel arguments if provided.
+    if let Some(kargs) = kernel_args {
+        eprintln!("{}: kernel args: '{}'", PROGRAM_NAME, kargs);
+        builder.set_kernel_args(kargs);
+    }
+
     let image: Vec<u8> = match builder.build() {
         Ok(image) => image,
         Err(err) => {
@@ -145,7 +160,8 @@ fn main() {
 ///
 fn usage() {
     eprintln!(
-        "Usage: {} -o <output.img> <binary.elf;cmdline> [<binary.elf;cmdline> ...]",
+        "Usage: {} -o <output.img> [-k <kernel_args>] <binary.elf;cmdline> [<binary.elf;cmdline> \
+         ...]",
         PROGRAM_NAME
     );
     eprintln!();
@@ -154,6 +170,13 @@ fn usage() {
     eprintln!("Each entry is specified as 'path/to/binary.elf;cmdline' where the");
     eprintln!("semicolon separates the file path from the command line string.");
     eprintln!();
+    eprintln!("Options:");
+    eprintln!("  -o <output>       Output image file path (required).");
+    eprintln!("  -k <kernel_args>  Kernel arguments shared by all binaries in the image.");
+    eprintln!();
     eprintln!("Example:");
-    eprintln!("  {} -o nanvix.img procd.elf;procd memd.elf;memd testd.elf;testd", PROGRAM_NAME);
+    eprintln!(
+        "  {} -o nanvix.img -k snapshot procd.elf;procd memd.elf;memd testd.elf;testd",
+        PROGRAM_NAME
+    );
 }


### PR DESCRIPTION
## Summary

Extend the packed command-line format from `<args>;<env>` to `<args>;<env>;<kernel_args>`, allowing the kernel to receive feature flags and configuration through the existing command-line mechanism.

## Changes

**cmdline library**
- `split_cmdline()` returns a 3-tuple `(args, env, kernel_args)` with escape handling in all three phases.
- New `find_kernel_args_start()` for read-only scanning of the second unescaped `;`.
- Comprehensive tests for all section combinations and edge cases.

**multibin library**
- Bump image format from V1 to V2: `MultibinHeader` gains `kernel_args_offset` and `kernel_args_size` fields.
- Builder: `set_kernel_args()` method with `u32` overflow validation.
- Parser: expose `kernel_args_offset()` / `kernel_args_size()` on `ParseResult` with bounds checking.
- Round-trip test for kernel args in multibin images.

**kernel**
- `BootInfo` carries `kernel_args: &'static str` shared by all modules.
- Both single-binary and multibinary initrd paths extract and strip kernel args.
- `kmain` destructures and logs `kernel_args`.

**mkimage**
- New `-k <kernel_args>` flag for shared kernel arguments.

**docs**
- Updated run-linux.md, run-windows.md, and user-app-development SKILL with the three-section format and examples.