### PR TITLE
[kernel] F: Defer detached zombie reap

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -149,6 +149,9 @@ pub struct ProcessManager {
     tm: ThreadManager,
     /// Number of messages buffered (not yet consumed).
     number_buffered_messages: usize,
+    /// Detached-thread zombies whose reaping was deferred because their
+    /// `ContextInformation` was still needed by an in-progress context switch.
+    deferred_reap: Vec<(ProcessIdentifier, ZombieThread)>,
 }
 
 impl ProcessManager {
@@ -180,6 +183,7 @@ impl ProcessManager {
             running: Some(kernel),
             tm,
             number_buffered_messages: 0,
+            deferred_reap: Vec::new(),
         }
     }
 
@@ -1021,18 +1025,20 @@ impl ProcessManager {
         let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
             match running_process.exit_thread(status) {
                 // The calling process still has runnable threads, put it in the list of ready processes.
-                (Ok((join_cond, runnable_process, previous_context)), detached_dropped) => {
+                (Ok((join_cond, runnable_process, previous_context)), deferred_zombie) => {
+                    let pid: ProcessIdentifier = runnable_process.state().pid();
                     self.ready.push_back(runnable_process);
-                    if detached_dropped {
-                        self.tm.on_thread_reaped();
+                    if let Some(zombie) = deferred_zombie {
+                        self.deferred_reap.push((pid, zombie));
                     }
                     (join_cond, previous_context)
                 },
                 // The calling process has only sleeping threads left, put it in the list of suspended processes.
-                (Err(Ok((join_cond, sleeping_process, previous_context))), detached_dropped) => {
+                (Err(Ok((join_cond, sleeping_process, previous_context))), deferred_zombie) => {
+                    let pid: ProcessIdentifier = sleeping_process.state().pid();
                     self.suspended.push_back(sleeping_process);
-                    if detached_dropped {
-                        self.tm.on_thread_reaped();
+                    if let Some(zombie) = deferred_zombie {
+                        self.deferred_reap.push((pid, zombie));
                     }
                     (join_cond, previous_context)
                 },

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -52,6 +52,7 @@ use crate::{
     PERF_SCHED_SOFT_CONTEXT_SWITCHES,
     PERF_SCHED_WAKEUP,
 };
+use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_SIZE;
 use ::config::kernel::SCHEDULER_FREQ;
 use ::core::{
@@ -217,6 +218,9 @@ impl ProcessManager {
     pub unsafe fn exit(status: ExitStatus) -> Result<!, Error> {
         trace!("status={status:?}");
 
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         // Terminate the calling process and select another process to run next.
         let (next_pid, next_tid, from, to, user_tda): (
             ProcessIdentifier,
@@ -266,6 +270,9 @@ impl ProcessManager {
     /// - The processor is running in privileged mode.
     ///
     pub unsafe fn exit_thread(status: ExitStatus) -> Result<!, Error> {
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         // Terminate the calling thread and select another thread to run next.
         let (next_pid, next_tid, from, to, user_tda): (
             ProcessIdentifier,
@@ -301,6 +308,30 @@ impl ProcessManager {
         // reached, it indicates a critical bug and undefined behavior. This is considered
         // unreachable by design.
         core::hint::unreachable_unchecked()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reaps any detached-thread zombies whose cleanup was deferred because
+    /// their `ContextInformation` was still needed by an in-progress context
+    /// switch. This must be called at PM entry points so that deferred zombies
+    /// are cleaned up once the context switch that produced them has completed.
+    ///
+    /// # Safety
+    ///
+    /// This function is safe to call if and only if the following conditions are met:
+    /// - The process manager is initialized.
+    /// - Access to the process manager is synchronized.
+    /// - The memory manager is initialized.
+    /// - Access to the memory manager is synchronized.
+    ///
+    unsafe fn reap_deferred() {
+        let deferred: Vec<(ProcessIdentifier, ZombieThread)> =
+            core::mem::take(&mut Self::get_mut().deferred_reap);
+        for (pid, zombie) in deferred {
+            Self::harvest_zombie_thread(pid, zombie);
+        }
     }
 
     ///
@@ -416,6 +447,9 @@ impl ProcessManager {
     ) -> Result<ExitStatus, SleepError> {
         trace!("pid={:?}, tid={:?}", pid, tid);
 
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         loop {
             let result: Result<ZombieThread, Result<Condvar, Error>> =
                 Self::get_mut().try_join_thread(pid, tid);
@@ -464,6 +498,9 @@ impl ProcessManager {
         tid: ThreadIdentifier,
     ) -> Result<(), Error> {
         trace!("pid={:?}, tid={:?}", pid, tid);
+
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
 
         let result: Result<Option<ZombieThread>, Error> =
             Self::get_mut().do_detach_thread(pid, tid);

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -267,7 +267,7 @@ impl RunningProcess {
                 (Condvar, ZombieProcess, *mut ContextInformation),
             >,
         >,
-        bool, // true if a detached thread was auto-dropped and needs reaping notification.
+        Option<ZombieThread>, // Detached zombie that must be reaped after the context switch.
     ) {
         let is_detached: bool = self.running.is_detached();
         let join_cond: Condvar = self.running.join_cond();
@@ -282,32 +282,33 @@ impl RunningProcess {
 
         let (zombie_thread, ctx) = self.running.exit(status);
 
-        // Determine whether other threads remain. If so, a detached zombie can be dropped
-        // immediately. If this is the last thread, keep the zombie so ZombieProcess can be
-        // constructed (it requires a non-empty zombie list).
+        // Determine whether other threads remain. If so, a detached zombie must NOT be dropped
+        // here — it owns the ContextInformation that `ctx` points to, and the context switch
+        // will write through that pointer. Instead, return it for deferred reaping after the
+        // context switch completes.
         let has_other_threads: bool =
             ready.is_some() || interrupted_threads.is_some() || sleeping_threads.is_some();
 
-        let (zombie_threads, detached_dropped): (Option<NonEmptyVecDeque<ZombieThread>>, bool) =
-            if is_detached && has_other_threads {
-                // Detached thread with other threads still alive — drop the zombie immediately.
-                // The kernel stack is freed via KernelStack::Drop. User stack pages remain mapped
-                // until the process exits and its Vmem is destroyed.
-                // The caller must call ThreadManager::on_thread_reaped() to update the live count.
-                drop(zombie_thread);
-                (existing_zombies, true)
-            } else {
-                (
-                    Some(match existing_zombies {
-                        Some(mut zombie_threads) => {
-                            zombie_threads.push_back(zombie_thread);
-                            zombie_threads
-                        },
-                        None => NonEmptyVecDeque::new(zombie_thread),
-                    }),
-                    false,
-                )
-            };
+        let (zombie_threads, deferred_zombie): (
+            Option<NonEmptyVecDeque<ZombieThread>>,
+            Option<ZombieThread>,
+        ) = if is_detached && has_other_threads {
+            // Return the zombie for deferred reaping. Do NOT drop it here — the context
+            // switch still needs the ContextInformation that lives inside the zombie's
+            // ThreadState.
+            (existing_zombies, Some(zombie_thread))
+        } else {
+            (
+                Some(match existing_zombies {
+                    Some(mut zombie_threads) => {
+                        zombie_threads.push_back(zombie_thread);
+                        zombie_threads
+                    },
+                    None => NonEmptyVecDeque::new(zombie_thread),
+                }),
+                None,
+            )
+        };
 
         if let Some(ready_threads) = ready {
             (
@@ -322,7 +323,7 @@ impl RunningProcess {
                     ),
                     ctx,
                 )),
-                detached_dropped,
+                deferred_zombie,
             )
         } else if let Some(interrupted_threads) = interrupted_threads {
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
@@ -332,7 +333,7 @@ impl RunningProcess {
                 zombie_threads,
             );
 
-            (Ok((join_cond, interrupted_process.resume(), ctx)), detached_dropped)
+            (Ok((join_cond, interrupted_process.resume(), ctx)), deferred_zombie)
         } else if let Some(sleeping_threads) = sleeping_threads {
             (
                 Err(Ok((
@@ -340,7 +341,7 @@ impl RunningProcess {
                     SleepingProcess::new(state, sleeping_threads, zombie_threads),
                     ctx,
                 ))),
-                detached_dropped,
+                deferred_zombie,
             )
         } else {
             match zombie_threads {
@@ -355,7 +356,7 @@ impl RunningProcess {
                             ZombieProcess::new(state, zombie_threads, final_status),
                             ctx,
                         ))),
-                        detached_dropped,
+                        deferred_zombie,
                     )
                 },
                 // Unreachable: zombie_threads is None only when is_detached && has_other_threads,

--- a/src/tests/thread-rust/src/tests/detach.rs
+++ b/src/tests/thread-rust/src/tests/detach.rs
@@ -1,0 +1,89 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::runtime::KernelThread;
+use ::core::sync::atomic::{
+    AtomicUsize,
+    Ordering,
+};
+use ::sys::{
+    error::Error,
+    kcall::sched::__kcall_sched_yield,
+};
+use ::sysapi::unistd::STDOUT_FILENO;
+use ::syscall::unistd;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+static WORKERS_FINISHED: AtomicUsize = AtomicUsize::new(0);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Executes detached-thread tests.
+pub fn run() -> Result<(), Error> {
+    test_detach_and_exit_stress()?;
+    Ok(())
+}
+
+/// Stress-tests detached thread exit to trigger use-after-free.
+///
+/// Spawns multiple detached threads that exit immediately. Each detached-thread exit frees a
+/// `ContextInformation` slab slot (128 bytes); if the bug is present, the subsequent context
+/// switch writes CPU state through a dangling pointer into that freed slot.
+///
+/// NOTE: This test exercises the exact code path that was buggy but cannot deterministically
+/// trigger a crash in isolation. The original bug manifested under heavy allocation pressure
+/// (e.g., CPython's thread-heavy workload) where the freed slab slot was reused by a different
+/// object type (VecDeque nodes, BTreeMap entries) before the context switch wrote to it. In this
+/// simpler test, the freed slot is typically reused by the next iteration's `ContextInformation`
+/// allocation and re-initialized, masking the corruption. The test remains valuable as a
+/// regression test that exercises the spawn→detach→exit→continue pattern and will catch any
+/// future breakage of that path.
+fn test_detach_and_exit_stress() -> Result<(), Error> {
+    const ITERATIONS: usize = 50;
+
+    WORKERS_FINISHED.store(0, Ordering::Relaxed);
+
+    for _ in 0..ITERATIONS {
+        let handle: KernelThread = KernelThread::spawn(worker_fast, 0)?;
+        handle.detach()?;
+
+        // Yield to let the detached worker run and exit. The context switch back to us is where
+        // the UAF would corrupt memory.
+        __kcall_sched_yield()?;
+        __kcall_sched_yield()?;
+    }
+
+    // Wait for all workers to finish.
+    for _ in 0..2000u32 {
+        if WORKERS_FINISHED.load(Ordering::Acquire) >= ITERATIONS {
+            break;
+        }
+        __kcall_sched_yield()?;
+    }
+
+    assert!(
+        WORKERS_FINISHED.load(Ordering::Acquire) >= ITERATIONS,
+        "not all detached workers finished"
+    );
+
+    // Exercise the event manager via a write syscall. If any scheduler data structure was
+    // corrupted by the UAF, this will likely panic.
+    let msg: &[u8] = b"";
+    unistd::write(STDOUT_FILENO, msg)?;
+
+    Ok(())
+}
+
+extern "C" fn worker_fast(_arg: usize) -> usize {
+    WORKERS_FINISHED.fetch_add(1, Ordering::Release);
+    0
+}

--- a/src/tests/thread-rust/src/tests/mod.rs
+++ b/src/tests/thread-rust/src/tests/mod.rs
@@ -10,6 +10,7 @@ use ::sys::error::Error;
 mod attributes;
 mod cond_timedwait;
 mod condvars;
+mod detach;
 mod identity;
 mod mutex_timedlock;
 mod mutexes;
@@ -30,6 +31,7 @@ pub fn run_all() -> Result<(), Error> {
     threads::run()?;
     identity::run()?;
     attributes::run()?;
+    detach::run()?;
     mutexes::run()?;
     mutex_timedlock::run()?;
     condvars::run()?;


### PR DESCRIPTION
## Summary

Fixes a use-after-free in the detached-thread exit path that caused kernel panics (VecDeque assertion failures, slab corruption) when detached threads exited while other threads remained.

## Root Cause

`RunningProcess::exit_thread()` immediately dropped the `ZombieThread` for detached threads, freeing the `Box<ContextInformation>` that the returned `ctx` pointer still referenced. The subsequent context switch wrote CPU state through the dangling pointer, corrupting whatever reused the freed slab slot.

## Fix

- Changed `exit_thread()` return type from `bool` (detached_dropped flag) to `Option<ZombieThread>` (deferred zombie).
- Added a `deferred_reap` list to `ProcessManager` that holds detached zombies until after the context switch completes.
- Added `reap_deferred()` calls at PM entry points (`exit`, `exit_thread`, `join_thread`, `detach_thread`) to harvest deferred zombies safely.

## Testing

- Added integration test `detach::test_detach_and_exit` in thread-rust that exercises the exact code path.
- Full test suite passes (`make test`).

Closes #2344