### PR TITLE
[kernel] Defer detached zombie reap

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -149,6 +149,9 @@ pub struct ProcessManager {
     tm: ThreadManager,
     /// Number of messages buffered (not yet consumed).
     number_buffered_messages: usize,
+    /// Detached-thread zombies whose reaping was deferred because their
+    /// `ContextInformation` was still needed by an in-progress context switch.
+    deferred_reap: Vec<(ProcessIdentifier, ZombieThread)>,
 }
 
 impl ProcessManager {
@@ -180,6 +183,7 @@ impl ProcessManager {
             running: Some(kernel),
             tm,
             number_buffered_messages: 0,
+            deferred_reap: Vec::new(),
         }
     }
 
@@ -1021,23 +1025,29 @@ impl ProcessManager {
         let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
             match running_process.exit_thread(status) {
                 // The calling process still has runnable threads, put it in the list of ready processes.
-                (Ok((join_cond, runnable_process, previous_context)), detached_dropped) => {
+                (Ok((join_cond, runnable_process, previous_context)), deferred_zombie) => {
+                    let pid: ProcessIdentifier = runnable_process.state().pid();
                     self.ready.push_back(runnable_process);
-                    if detached_dropped {
-                        self.tm.on_thread_reaped();
+                    if let Some(zombie) = deferred_zombie {
+                        self.deferred_reap.push((pid, zombie));
                     }
                     (join_cond, previous_context)
                 },
                 // The calling process has only sleeping threads left, put it in the list of suspended processes.
-                (Err(Ok((join_cond, sleeping_process, previous_context))), detached_dropped) => {
+                (Err(Ok((join_cond, sleeping_process, previous_context))), deferred_zombie) => {
+                    let pid: ProcessIdentifier = sleeping_process.state().pid();
                     self.suspended.push_back(sleeping_process);
-                    if detached_dropped {
-                        self.tm.on_thread_reaped();
+                    if let Some(zombie) = deferred_zombie {
+                        self.deferred_reap.push((pid, zombie));
                     }
                     (join_cond, previous_context)
                 },
                 // The calling process has only zombie threads left, put it in the list of zombies processes.
-                (Err(Err((join_cond, zombie_process, previous_context))), _) => {
+                (Err(Err((join_cond, zombie_process, previous_context))), deferred_zombie) => {
+                    debug_assert!(
+                        deferred_zombie.is_none(),
+                        "deferred zombie must be None when no other threads remain"
+                    );
                     self.zombies.push_back(zombie_process);
                     (join_cond, previous_context)
                 },

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -294,6 +294,26 @@ impl ProcessManager {
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
+
+        // Debug-only: detect use-after-free in the detached-thread exit path. With slab
+        // poison-on-free, a freed ContextInformation block is filled with SLAB_POISON_BYTE. If
+        // `from` points to a poisoned block, the zombie thread's ContextInformation was freed
+        // before the context switch — a use-after-free bug.
+        #[cfg(debug_assertions)]
+        {
+            let from_bytes: &[u8] = unsafe {
+                core::slice::from_raw_parts(
+                    from as *const u8,
+                    core::mem::size_of::<ContextInformation>(),
+                )
+            };
+            debug_assert!(
+                !from_bytes.iter().all(|&b| b == slab::SLAB_POISON_BYTE),
+                "BUG: ContextInformation at {:p} freed before context switch (detached-thread UAF)",
+                from,
+            );
+        }
+
         PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.fetch_add(1, ORDER);
         Self::switch(next_pid, next_tid, from, to, user_tda);
 

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -52,6 +52,7 @@ use crate::{
     PERF_SCHED_SOFT_CONTEXT_SWITCHES,
     PERF_SCHED_WAKEUP,
 };
+use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_SIZE;
 use ::config::kernel::SCHEDULER_FREQ;
 use ::core::{
@@ -217,6 +218,9 @@ impl ProcessManager {
     pub unsafe fn exit(status: ExitStatus) -> Result<!, Error> {
         trace!("status={status:?}");
 
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         // Terminate the calling process and select another process to run next.
         let (next_pid, next_tid, from, to, user_tda): (
             ProcessIdentifier,
@@ -266,6 +270,9 @@ impl ProcessManager {
     /// - The processor is running in privileged mode.
     ///
     pub unsafe fn exit_thread(status: ExitStatus) -> Result<!, Error> {
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         // Terminate the calling thread and select another thread to run next.
         let (next_pid, next_tid, from, to, user_tda): (
             ProcessIdentifier,
@@ -321,6 +328,30 @@ impl ProcessManager {
         // reached, it indicates a critical bug and undefined behavior. This is considered
         // unreachable by design.
         core::hint::unreachable_unchecked()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reaps any detached-thread zombies whose cleanup was deferred because
+    /// their `ContextInformation` was still needed by an in-progress context
+    /// switch. This must be called at PM entry points so that deferred zombies
+    /// are cleaned up once the context switch that produced them has completed.
+    ///
+    /// # Safety
+    ///
+    /// This function is safe to call if and only if the following conditions are met:
+    /// - The process manager is initialized.
+    /// - Access to the process manager is synchronized.
+    /// - The memory manager is initialized.
+    /// - Access to the memory manager is synchronized.
+    ///
+    unsafe fn reap_deferred() {
+        let deferred: Vec<(ProcessIdentifier, ZombieThread)> =
+            core::mem::take(&mut Self::get_mut().deferred_reap);
+        for (pid, zombie) in deferred {
+            Self::harvest_zombie_thread(pid, zombie);
+        }
     }
 
     ///
@@ -436,6 +467,9 @@ impl ProcessManager {
     ) -> Result<ExitStatus, SleepError> {
         trace!("pid={:?}, tid={:?}", pid, tid);
 
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         loop {
             let result: Result<ZombieThread, Result<Condvar, Error>> =
                 Self::get_mut().try_join_thread(pid, tid);
@@ -485,6 +519,9 @@ impl ProcessManager {
     ) -> Result<(), Error> {
         trace!("pid={:?}, tid={:?}", pid, tid);
 
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         let result: Result<Option<ZombieThread>, Error> =
             Self::get_mut().do_detach_thread(pid, tid);
 
@@ -528,6 +565,9 @@ impl ProcessManager {
     /// - The processor is running in privileged mode.
     ///
     pub unsafe fn sleep(alarm: Option<SystemTime>) -> Result<(), SleepError> {
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         // Suspend the execution of the calling thread and select another thread to run next.
         let (next_pid, next_tid, from, to, user_tda): (
             ProcessIdentifier,
@@ -617,6 +657,9 @@ impl ProcessManager {
     /// - The processor is running in privileged mode.
     ///
     pub unsafe fn giveup() -> Result<(), Error> {
+        // Reap any detached-thread zombies deferred from a previous context switch.
+        Self::reap_deferred();
+
         REMAINING_QUANTUM.store(0, ORDER);
 
         // Re-schedule the calling thread and select another thread to run next.

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -267,7 +267,7 @@ impl RunningProcess {
                 (Condvar, ZombieProcess, *mut ContextInformation),
             >,
         >,
-        bool, // true if a detached thread was auto-dropped and needs reaping notification.
+        Option<ZombieThread>, // Detached zombie that must be reaped after the context switch.
     ) {
         let is_detached: bool = self.running.is_detached();
         let join_cond: Condvar = self.running.join_cond();
@@ -282,32 +282,33 @@ impl RunningProcess {
 
         let (zombie_thread, ctx) = self.running.exit(status);
 
-        // Determine whether other threads remain. If so, a detached zombie can be dropped
-        // immediately. If this is the last thread, keep the zombie so ZombieProcess can be
-        // constructed (it requires a non-empty zombie list).
+        // Determine whether other threads remain. If so, a detached zombie must NOT be dropped
+        // here — it owns the ContextInformation that `ctx` points to, and the context switch
+        // will write through that pointer. Instead, return it for deferred reaping after the
+        // context switch completes.
         let has_other_threads: bool =
             ready.is_some() || interrupted_threads.is_some() || sleeping_threads.is_some();
 
-        let (zombie_threads, detached_dropped): (Option<NonEmptyVecDeque<ZombieThread>>, bool) =
-            if is_detached && has_other_threads {
-                // Detached thread with other threads still alive — drop the zombie immediately.
-                // The kernel stack is freed via KernelStack::Drop. User stack pages remain mapped
-                // until the process exits and its Vmem is destroyed.
-                // The caller must call ThreadManager::on_thread_reaped() to update the live count.
-                drop(zombie_thread);
-                (existing_zombies, true)
-            } else {
-                (
-                    Some(match existing_zombies {
-                        Some(mut zombie_threads) => {
-                            zombie_threads.push_back(zombie_thread);
-                            zombie_threads
-                        },
-                        None => NonEmptyVecDeque::new(zombie_thread),
-                    }),
-                    false,
-                )
-            };
+        let (zombie_threads, deferred_zombie): (
+            Option<NonEmptyVecDeque<ZombieThread>>,
+            Option<ZombieThread>,
+        ) = if is_detached && has_other_threads {
+            // Return the zombie for deferred reaping. Do NOT drop it here — the context
+            // switch still needs the ContextInformation that lives inside the zombie's
+            // ThreadState.
+            (existing_zombies, Some(zombie_thread))
+        } else {
+            (
+                Some(match existing_zombies {
+                    Some(mut zombie_threads) => {
+                        zombie_threads.push_back(zombie_thread);
+                        zombie_threads
+                    },
+                    None => NonEmptyVecDeque::new(zombie_thread),
+                }),
+                None,
+            )
+        };
 
         if let Some(ready_threads) = ready {
             (
@@ -322,7 +323,7 @@ impl RunningProcess {
                     ),
                     ctx,
                 )),
-                detached_dropped,
+                deferred_zombie,
             )
         } else if let Some(interrupted_threads) = interrupted_threads {
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
@@ -332,7 +333,7 @@ impl RunningProcess {
                 zombie_threads,
             );
 
-            (Ok((join_cond, interrupted_process.resume(), ctx)), detached_dropped)
+            (Ok((join_cond, interrupted_process.resume(), ctx)), deferred_zombie)
         } else if let Some(sleeping_threads) = sleeping_threads {
             (
                 Err(Ok((
@@ -340,7 +341,7 @@ impl RunningProcess {
                     SleepingProcess::new(state, sleeping_threads, zombie_threads),
                     ctx,
                 ))),
-                detached_dropped,
+                deferred_zombie,
             )
         } else {
             match zombie_threads {
@@ -355,7 +356,7 @@ impl RunningProcess {
                             ZombieProcess::new(state, zombie_threads, final_status),
                             ctx,
                         ))),
-                        detached_dropped,
+                        deferred_zombie,
                     )
                 },
                 // Unreachable: zombie_threads is None only when is_detached && has_other_threads,

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -37,6 +37,16 @@ include!("lib.spec.rs");
 include!("lib.proof.rs");
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Slab poison byte used in debug builds to fill freed blocks and make use-after-free bugs more
+/// likely to cause a crash and easier to diagnose. This is not used in release builds to avoid
+/// the performance overhead of filling freed blocks.
+#[cfg(all(debug_assertions, not(verus_keep_ghost)))]
+pub const SLAB_POISON_BYTE: u8 = 0xDE;
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -358,6 +368,13 @@ impl Slab {
 
         // Free the block.
         self.index.clear(index)?;
+
+        // Poison the freed block so that any use-after-free dereference through a stale pointer
+        // reads a recognizable garbage pattern instead of silently reusing stale data.
+        #[cfg(all(debug_assertions, not(verus_keep_ghost)))]
+        unsafe {
+            core::ptr::write_bytes(ptr as *mut u8, SLAB_POISON_BYTE, self.block_size);
+        }
 
         proof! { self.lemma_deallocate_ok(old(self), index, ptr); }
 

--- a/src/tests/test-kernel/src/detach.rs
+++ b/src/tests/test-kernel/src/detach.rs
@@ -1,0 +1,150 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # Detached-Thread Use-After-Free Regression Test
+//!
+//! Stress-tests the detached thread exit path to verify that the kernel does
+//! not use-after-free the `ContextInformation` owned by a detached zombie
+//! thread. In debug builds, the kernel's `exit_thread` code path contains a
+//! `debug_assert!` (paired with slab poison-on-free) that fires if the
+//! `ContextInformation` is freed before the context switch. This test
+//! exercises the code path by spawning many detached threads that exit
+//! immediately, triggering a deterministic kernel panic if the bug is present.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::alloc::Layout;
+use ::arch::mem::PAGE_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
+use ::core::sync::atomic::{
+    AtomicUsize,
+    Ordering,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        pm,
+        sched,
+    },
+    mm::VirtualAddress,
+    pm::{
+        ThreadCreateArgs,
+        ThreadIdentifier,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of detached threads to attempt spawning in the stress test.
+///
+/// The system-wide thread limit (`MAX_THREADS`) includes the caller's own thread, so the actual
+/// number of workers that can be created is at most `MAX_THREADS - 1`. The spawn loop tolerates
+/// hitting the limit early and uses the actual spawned count for the completion wait condition.
+const MAX_DETACHED_THREADS: usize = ::config::kernel::MAX_THREADS - 1;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+static WORKERS_FINISHED: AtomicUsize = AtomicUsize::new(0);
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+fn alloc_thread_stack() -> Result<(*mut u8, Layout, VirtualAddress), Error> {
+    let layout: Layout = Layout::from_size_align(USER_THREAD_STACK_SIZE, PAGE_SIZE)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "bad stack layout"))?;
+    let stack_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack_ptr.is_null() {
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate thread stack"));
+    }
+    let stack_base: VirtualAddress = VirtualAddress::from_raw_value(stack_ptr as usize);
+    Ok((stack_ptr, layout, stack_base))
+}
+
+fn spawn_detached_thread(
+    entry: extern "C" fn(usize) -> usize,
+    stack_base: VirtualAddress,
+) -> Result<ThreadIdentifier, Error> {
+    let mut args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: ThreadCreateArgs::NULL_USER_FN,
+        user_fn_arg0: entry as *const () as usize,
+        user_fn_arg1: 0,
+        user_stack_base: stack_base,
+        user_stack_size: USER_THREAD_STACK_SIZE,
+        user_tda: None,
+    };
+    let tid: ThreadIdentifier = pm::__kcall_create_thread(&mut args)?;
+    pm::__kcall_detach_thread(tid)?;
+    Ok(tid)
+}
+
+//==================================================================================================
+// Test
+//==================================================================================================
+
+/// Executes detached-thread regression tests.
+pub fn run() -> Result<(), Error> {
+    test_detach_and_exit_stress()
+}
+
+/// Stress-tests detached thread exit to trigger use-after-free.
+///
+/// Spawns multiple detached threads that exit immediately. Each detached-thread
+/// exit exercises the code path where `ContextInformation` is freed. In debug
+/// builds, the kernel's `exit_thread` path contains a `debug_assert!` that
+/// verifies the `ContextInformation` has not been freed (slab-poisoned) before
+/// the context switch saves registers through the `from` pointer. If the UAF
+/// bug is present, the assertion fires and the kernel panics.
+fn test_detach_and_exit_stress() -> Result<(), Error> {
+    WORKERS_FINISHED.store(0, Ordering::Relaxed);
+
+    let mut spawned: usize = 0;
+    for _ in 0..MAX_DETACHED_THREADS {
+        let (stack_ptr, layout, stack_base) = match alloc_thread_stack() {
+            Ok(v) => v,
+            Err(_) => break,
+        };
+        match spawn_detached_thread(worker_fast, stack_base) {
+            Ok(_tid) => spawned += 1,
+            Err(_) => {
+                // Thread limit reached — free the unused stack and stop spawning.
+                unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
+                break;
+            },
+        }
+
+        // Yield to let the detached worker run and exit. The context switch
+        // back to us is where the UAF would corrupt memory.
+        sched::__kcall_sched_yield()?;
+        sched::__kcall_sched_yield()?;
+
+        // The stack is intentionally leaked: the detached thread may still be
+        // using it if the yields above did not schedule it. The kernel will
+        // reclaim the memory when the process exits.
+        let _ = (stack_ptr, layout);
+    }
+
+    assert!(spawned > 0, "failed to spawn any detached worker threads");
+
+    // Wait for all workers to finish. The test harness (nanvix-test) enforces
+    // an external timeout, so an unbounded loop is safe here.
+    while WORKERS_FINISHED.load(Ordering::Acquire) < spawned {
+        sched::__kcall_sched_yield()?;
+    }
+
+    Ok(())
+}
+
+extern "C" fn worker_fast(_arg: usize) -> usize {
+    WORKERS_FINISHED.fetch_add(1, Ordering::Release);
+    0
+}

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -22,6 +22,7 @@ use ::sys::error::{
 //==================================================================================================
 
 mod demand_paging;
+mod detach;
 mod direction_flag;
 mod mmio_ramfs;
 mod rendezvous;
@@ -51,6 +52,8 @@ const EXIT_CODE: i32 = 13;
 ///
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
+    detach::run()?;
+
     mmio_ramfs::run()?;
 
     tls::run()?;


### PR DESCRIPTION
## Summary

Fix a use-after-free bug in detached thread cleanup by deferring zombie reaping.

## Changes

- **[slab]** Poison freed blocks in debug builds
- **[kernel]** Assert `ContextInformation` is live
- **[tests]** Add detached-thread UAF regression test
- **[kernel]** Defer detached zombie reap