### PR TITLE
[ci] Expect exit code 4 from smoke test after procd exit propagation

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "In-kernel tests passed."
 
     # Smoke test that boots nanvixd and checks for the kernel magic string,
-    # verifying the multibin initrd (procd, testd, memd).
+    # verifying the multibin initrd (procd, testd, memd, vfsd).
     - name: "Smoke Test (${{ inputs.machine-type }})"
       shell: bash
       env:
@@ -44,36 +44,16 @@ runs:
       run: |
         set -Eeuo pipefail
 
-        MAGIC_STRING="hello, world!"
         TIMEOUT=120
-
-        # Build multibin image from pre-built artifacts.
-        ./bin/mkimage.elf -o nanvix.img \
-            "bin/procd.elf;procd" \
-            "bin/memd.elf;memd" \
-            "bin/testd.elf;testd"
-
+        RELEASE_FLAG=""
         if [[ "${{ inputs.build-type }}" == "release" ]]; then
-          # In release builds, CI sets LOG_LEVEL=error, which suppresses the
-          # debug-level magic string. Validate success by requiring nanvixd to
-          # exit cleanly before timeout.
-          if ! bash scripts/run-nanvixd.sh \
-                "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}"; then
-            echo "::error::Smoke test failed: nanvixd did not exit cleanly within ${TIMEOUT}s."
-            exit 1
-          fi
-        else
-          # In debug builds, assert successful boot by waiting for kernel magic
-          # string in console output.
-          if ! bash scripts/run-nanvixd.sh \
-                "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}" \
-                --wait-for-string "${MAGIC_STRING}"; then
-            echo "::error::Smoke test failed: magic string '${MAGIC_STRING}' not found within ${TIMEOUT}s."
-            exit 1
-          fi
+          RELEASE_FLAG="--release"
         fi
 
-        echo "Smoke test passed."
+        ./z build ${RELEASE_FLAG} -- run-smoke-test \
+            "MACHINE=${{ inputs.machine-type }}" \
+            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}" \
+            "TIMEOUT=${TIMEOUT}"
 
     # Run test binary directly from downloaded artifacts.
     - name: "Integration Test (${{ inputs.machine-type }})"

--- a/Makefile
+++ b/Makefile
@@ -899,6 +899,7 @@ standalone-images-clean:
 test:
 	@$(MAKE) run-unit-tests
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	@$(MAKE) run-smoke-test
 	@$(MAKE) run-nanvix-tests
 endif
 
@@ -960,6 +961,43 @@ NANVIX_TEST_BIN := $(BINARIES_DIR)/nanvix-test.$(HOST_BIN_EXT)
 run-nanvix-tests: all-nanvix
 	@echo "Running integration tests with configuration: $(NANVIX_TEST_CONFIG)"
 	RUST_LOG=$(LOG_LEVEL) $(NANVIX_TEST_BIN) $(NANVIX_TEST_CONFIG)
+
+# Expected VM exit code for the smoke test image.
+# testd deliberately triggers a page fault as its final test; the kernel kills it
+# with ErrorCode::Interrupted (4) and procd propagates that status as the VM exit code.
+SMOKE_TEST_EXPECTED_EXIT_CODE := 4
+
+# Kernel magic string emitted at debug log level during boot.
+SMOKE_TEST_MAGIC_STRING := hello, world!
+
+# Smoke test: boot the system image and verify correct behavior.
+# Only applicable in standalone mode (the smoke image bundles guest daemons).
+# - Release mode (RELEASE=yes): validates VM exits with the expected status code.
+# - Debug mode (RELEASE=no): validates the kernel magic string appears in console output.
+.PHONY: run-smoke-test
+ifeq ($(DEPLOYMENT_MODE),standalone)
+run-smoke-test: image
+ifeq ($(RELEASE),yes)
+	@echo "Running smoke test (expected exit code=$(SMOKE_TEST_EXPECTED_EXIT_CODE))..."
+	@ACTUAL=0; \
+	bash $(SCRIPTS_DIR)/run-nanvixd.sh $(MACHINE) $(IMAGE) $(TIMEOUT) || ACTUAL=$$?; \
+	if [ "$$ACTUAL" -ne "$(SMOKE_TEST_EXPECTED_EXIT_CODE)" ]; then \
+		echo "ERROR: Smoke test failed: expected exit code $(SMOKE_TEST_EXPECTED_EXIT_CODE), got $$ACTUAL."; \
+		exit 1; \
+	fi
+else
+	@echo "Running smoke test (waiting for magic string)..."
+	@if ! bash $(SCRIPTS_DIR)/run-nanvixd.sh $(MACHINE) $(IMAGE) $(TIMEOUT) \
+			--wait-for-string "$(SMOKE_TEST_MAGIC_STRING)"; then \
+		echo "ERROR: Smoke test failed: magic string '$(SMOKE_TEST_MAGIC_STRING)' not found within $(TIMEOUT)s."; \
+		exit 1; \
+	fi
+endif
+	@echo "Smoke test passed."
+else
+run-smoke-test:
+	@echo "Skipping smoke test (DEPLOYMENT_MODE=$(DEPLOYMENT_MODE), requires standalone)."
+endif
 
 #===================================================================================================
 # Build Rules for L2 System VM Snapshot


### PR DESCRIPTION
PR #2349 changed procd to propagate the exit status of the triggering process (testd) instead of always exiting 0. Since testd deliberately triggers a page fault as its final test, the kernel kills it with ErrorCode::Interrupted (4), and procd now propagates that status as the VM exit code.

This broke the CI smoke test, which previously expected a clean exit.

## Changes

- Add `run-smoke-test` Makefile target that boots the system image and validates the VM exit code against `SMOKE_TEST_EXPECTED_EXIT_CODE` (4).
- Include `run-smoke-test` in the `test` target before integration tests.
- Simplify the CI integration-test action to delegate release-mode smoke testing to the new Makefile target via `./z build -- run-smoke-test`.
- Add vfsd to the debug-mode smoke test image (was missing).

## Why this wasn't caught before merge

PR #2349's CI ran in **debug mode** where the smoke test validates by finding the kernel magic string in console output. The magic string is emitted before testd triggers its page fault, so `--wait-for-string` returns success regardless of the final VM exit code. Only the **release mode** path (post-merge CI) checks exit codes, and that's where the failure surfaced.

Closes #2351