### PR TITLE
[kernel] Gate SLAB_POISON_BYTE debug_assert under not(verus_keep_ghost)

### DIFF
--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -306,7 +306,7 @@ impl ProcessManager {
         // poison-on-free, a freed ContextInformation block is filled with SLAB_POISON_BYTE. If
         // `from` points to a poisoned block, the zombie thread's ContextInformation was freed
         // before the context switch — a use-after-free bug.
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, not(verus_keep_ghost)))]
         {
             let from_bytes: &[u8] = unsafe {
                 core::slice::from_raw_parts(


### PR DESCRIPTION
Gate the `debug_assert!` referencing `slab::SLAB_POISON_BYTE` with `not(verus_keep_ghost)` to match the constant's own cfg gate, fixing a compilation error during Verus verification.