### PR TITLE
[build] Reduce build check noise

### DIFF
--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -35,7 +35,7 @@ all-guest-binaries-$(1): init all-guest-staticlibs
 	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(1).elf $(BINARIES_DIR)/$(1).elf
 
 check-guest-binaries-$(1):
-	$(GUEST_CARGO_CHECK_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1))
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1))
 
 format-guest-binaries-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1)
@@ -117,16 +117,16 @@ endif
 
 check-guest-binaries:
 ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
-	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES)
 endif
 ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
-	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES)
 endif
 ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
-	$(GUEST_CARGO_CHECK_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
 endif
 ifneq ($(filter c-bindings-rust,$(ALL_GUEST_BINARIES)),)
-	$(GUEST_CARGO_CHECK_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) -p c-bindings-rust $(GUEST_BINARY_CARGO_FEATURES)
 endif
 
 # Batched format: single cargo invocation for all guest binaries.

--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -4,7 +4,7 @@
 # Per-package rules retained for direct invocation (e.g., make check-guest-rlib-<pkg>).
 define GUEST_RLIB_RULES
 check-guest-rlib-$(1):
-	$(GUEST_CARGO_CHECK_CMD) -p $(1)
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
 
 format-guest-rlib-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1)
@@ -40,7 +40,7 @@ _GUEST_RLIB_PKGS := $(foreach pkg,$(ALL_GUEST_RUST_LIBS),-p $(pkg))
 _GUEST_RLIB_LINT_TEST_PKGS := $(foreach pkg,$(ALL_GUEST_RUST_LIBS_TEST_LIST),-p $(pkg))
 
 check-guest-rlibs:
-	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_RLIB_PKGS)
+	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_RLIB_PKGS)
 
 format-guest-rlibs:
 	$(GUEST_CARGO_FMT_CMD) $(_GUEST_RLIB_PKGS)

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -17,8 +17,8 @@ all-guest-staticlib-$(1): init
 	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$(1).a $(LIBRARIES_DIR)/lib$(1).a
 
 check-guest-staticlib-$(1):
-	$(GUEST_CARGO_CHECK_CMD) -p $(1)
-	$(GUEST_CARGO_CHECK_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
 
 format-guest-staticlib-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1)
@@ -49,8 +49,8 @@ all-guest-staticlibs: init
 	done
 
 check-guest-staticlibs:
-	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS)
-	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS)
+	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
 
 format-guest-staticlibs:
 	$(GUEST_CARGO_FMT_CMD) $(_GUEST_STATICLIB_PKGS)

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -17,7 +17,7 @@ all-host-binaries-$(1): init
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/$(1)$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/$(1).$(HOST_BIN_EXT)
 
 check-host-binaries-$(1):
-	$(HOST_CARGO_CHECK_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1)
+	@$(HOST_CARGO_CHECK_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1)
 
 format-host-binaries-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1)
@@ -61,7 +61,7 @@ endif
 
 check-host-binaries: $(foreach pkg,$(_HOST_BINS_WITH_FEATURES),check-host-binaries-$(pkg))
 ifneq ($(_HOST_BINS_PLAIN_PKGS),)
-	$(HOST_CARGO_CHECK_CMD) $(_HOST_BINS_PLAIN_PKGS)
+	@$(HOST_CARGO_CHECK_CMD) $(_HOST_BINS_PLAIN_PKGS)
 endif
 
 # Batched format: single cargo invocation for all host binaries.

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -40,7 +40,7 @@ HOST_RLIBS_CARGO_FEATURES = $(if $(filter $(1),$(USERVM_DEPENDENT_RLIBS)),$(ALL_
 # Per-package rules retained for direct invocation (e.g., make check-host-rlib-<pkg>).
 define HOST_RLIB_RULES
 check-host-rlib-$(1):
-	$(HOST_CARGO_CHECK_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)
+	@$(HOST_CARGO_CHECK_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)
 
 format-host-rlib-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1)
@@ -74,13 +74,13 @@ _HOST_RLIBS_MULTI_PKGS := $(foreach pkg,$(_HOST_RLIBS_MULTI),-p $(pkg))
 
 check-host-rlibs:
 ifneq ($(_HOST_RLIBS_PLAIN_PKGS),)
-	$(HOST_CARGO_CHECK_CMD) $(_HOST_RLIBS_PLAIN_PKGS)
+	@$(HOST_CARGO_CHECK_CMD) $(_HOST_RLIBS_PLAIN_PKGS)
 endif
 ifneq ($(_HOST_RLIBS_USERVM_PKGS),)
-	$(HOST_CARGO_CHECK_CMD) $(ALL_HOST_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_USERVM_PKGS)
+	@$(HOST_CARGO_CHECK_CMD) $(ALL_HOST_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_USERVM_PKGS)
 endif
 ifneq ($(_HOST_RLIBS_MULTI_PKGS),)
-	$(HOST_CARGO_CHECK_CMD) $(MULTI_PROCESS_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_MULTI_PKGS)
+	@$(HOST_CARGO_CHECK_CMD) $(MULTI_PROCESS_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_MULTI_PKGS)
 endif
 
 # Batched format: single cargo invocation for all host rlibs.

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -24,7 +24,7 @@ ifeq ($(PROFILER),yes)
 endif
 
 check-kernel:
-	$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_CARGO_FEATURES) -p kernel
+	@$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_CARGO_FEATURES) -p kernel
 
 format-kernel:
 	$(KERNEL_CARGO_FMT_CMD) -p kernel
@@ -65,7 +65,7 @@ run-kernel-tests: all-test-kernel all-uservm
 		--kernel-args "test_magic=0xDEADBEEF"
 
 check-test-kernel:
-	$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_TEST_CARGO_FEATURES) -p kernel
+	@$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_TEST_CARGO_FEATURES) -p kernel
 
 clean-test-kernel:
 	$(RM_CMD) $(BINARIES_DIR)/kernel-test.elf

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -18,7 +18,7 @@ all-nanvix-bench: init
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvix-bench$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/nanvix-bench.$(HOST_BIN_EXT)
 
 check-nanvix-bench:
-	$(HOST_CARGO_CHECK_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench
+	@$(HOST_CARGO_CHECK_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench
 
 format-nanvix-bench:
 	$(HOST_CARGO_FMT_CMD) -p nanvix-bench

--- a/build/make/nanvix-shim.mk
+++ b/build/make/nanvix-shim.mk
@@ -15,7 +15,7 @@ all-nanvix-shim: init
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/containerd-shim-nanvix-v1 $(BINARIES_DIR)/containerd-shim-nanvix-v1
 
 check-nanvix-shim:
-	$(HOST_CARGO_CHECK_CMD) $(SHIM_CARGO_PACKAGES)
+	@$(HOST_CARGO_CHECK_CMD) $(SHIM_CARGO_PACKAGES)
 
 format-nanvix-shim:
 	$(HOST_CARGO_FMT_CMD) -p nanvix-oci

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -15,7 +15,7 @@ all-nanvix-test: init
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvix-test$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/nanvix-test.$(HOST_BIN_EXT)
 
 check-nanvix-test:
-	$(HOST_CARGO_CHECK_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test
+	@$(HOST_CARGO_CHECK_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test
 
 format-nanvix-test:
 	$(HOST_CARGO_FMT_CMD) -p nanvix-test

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -52,7 +52,7 @@ endif
 endif
 
 check-nanvixd:
-	$(HOST_CARGO_CHECK_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
+	@$(HOST_CARGO_CHECK_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
 
 format-nanvixd:
 	$(HOST_CARGO_FMT_CMD) -p nanvixd

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -14,7 +14,7 @@ all-uservm: init
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/uservm$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/uservm.$(HOST_BIN_EXT)
 
 check-uservm:
-	$(HOST_CARGO_CHECK_CMD) $(USERVM_CARGO_FEATURES) -p uservm
+	@$(HOST_CARGO_CHECK_CMD) $(USERVM_CARGO_FEATURES) -p uservm
 
 format-uservm:
 	$(HOST_CARGO_FMT_CMD) -p uservm

--- a/z.py
+++ b/z.py
@@ -93,7 +93,7 @@ def _supports_color() -> bool:
     if sys.platform == "win32":
         # Windows Terminal and modern consoles support ANSI.
         return True
-    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+    return hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
 
 
 _COLOR = _supports_color()
@@ -109,13 +109,13 @@ def print_error(msg: str) -> None:
 
 
 def print_success(msg: str) -> None:
-    """Print success message to stdout."""
-    print(f"{_c(_GREEN, '[OK]')}    {msg}")
+    """Print success message to stderr."""
+    print(f"{_c(_GREEN, '[OK]')}    {msg}", file=sys.stderr)
 
 
 def print_info(msg: str) -> None:
-    """Print info message to stdout."""
-    print(f"{_c(_CYAN, '[INFO]')}  {msg}")
+    """Print info message to stderr."""
+    print(f"{_c(_CYAN, '[INFO]')}  {msg}", file=sys.stderr)
 
 
 def print_warning(msg: str) -> None:


### PR DESCRIPTION
## Summary

Reduce terminal noise during `./z check` runs by suppressing Make command echo and routing all diagnostic output to stderr.

## Changes

- **Suppress cargo check echo in Make recipes** — Prefix all `cargo check` invocations in `.mk` files with `@` so Make does not print the full command before running it. This keeps terminal output focused on compiler diagnostics.
- **Redirect `print_success()` and `print_info()` to stderr** — These now write to `sys.stderr`, matching the existing behavior of `print_error()` and `print_warning()`. This keeps stdout clean for machine-parseable output.

## Affected Files

- 11 Makefile includes under `build/make/`
- `z.py`