### PR TITLE
[nvx] Initialize environment table

### DIFF
--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -38,6 +38,16 @@ use ::core::sync::atomic::{
 use ::alloc::vec::Vec;
 
 //==================================================================================================
+// External Functions
+//==================================================================================================
+
+#[cfg(feature = "staticlib")]
+unsafe extern "C" {
+    /// Initializes the environment table from a null-terminated array of "KEY=VALUE" C strings.
+    fn __nanvix_env_init(envp: *const *const core::ffi::c_char);
+}
+
+//==================================================================================================
 // Global Variables
 //==================================================================================================
 
@@ -162,6 +172,14 @@ pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
     let mut env: Vec<*mut i8> = unsafe { parse_envp(envp) };
     unsafe {
         environ = env.as_mut_ptr();
+    }
+
+    // Populate the environment table used by getenv()/setenv()/unsetenv().
+    // The `environ` pointer is a null-terminated array of "KEY=VALUE" C strings,
+    // which is exactly the format expected by __nanvix_env_init().
+    #[cfg(feature = "staticlib")]
+    unsafe {
+        __nanvix_env_init(environ as *const *const core::ffi::c_char);
     }
 
     cfg_if::cfg_if! {

--- a/src/libs/syscall/src/stdlib/bindings/env_init.rs
+++ b/src/libs/syscall/src/stdlib/bindings/env_init.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use ::libc_stdlib::env_table;
-use ::sysapi::ffi::{
-    c_char,
-    c_int,
-};
+use ::sysapi::ffi::c_char;
 
 //==================================================================================================
 // Standalone Functions
@@ -27,10 +24,6 @@ use ::sysapi::ffi::{
 /// - `envp`: A pointer to a null-terminated array of null-terminated `KEY=VALUE` C strings. If
 ///   null, the environment table is left empty.
 ///
-/// # Returns
-///
-/// Always returns `0`.
-///
 /// # Note
 ///
 /// In standalone mode, tilde expansion (`~` → `$HOME`) is performed client-side by the syscall
@@ -46,7 +39,6 @@ use ::sysapi::ffi::{
 /// - Each string in the array remains valid for the duration of this call.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __nanvix_env_init(envp: *const *const c_char) -> c_int {
+pub unsafe extern "C" fn __nanvix_env_init(envp: *const *const c_char) {
     env_table::init_from_raw(envp);
-    0
 }


### PR DESCRIPTION
The environment table used by `getenv()`/`setenv()`/`unsetenv()` was never populated during process startup in the staticlib configuration. This caused those functions to operate on an empty table, even though the kernel-provided environment variables were already parsed into the `environ` pointer.

Call `__nanvix_env_init()` in `_start()` after building the environ array to propagate the raw `"KEY=VALUE"` C strings into the environment table managed by the syscall library. The call is gated behind `cfg(feature = "staticlib")`, matching the feature where the symbol is linked in. The return value is checked and triggers a panic on failure.