### PR TITLE
[slab] Add free_addrs postcondition to from_raw_parts

### DIFF
--- a/src/libs/slab/src/lib.proof.rs
+++ b/src/libs/slab/src/lib.proof.rs
@@ -223,6 +223,9 @@ impl Slab {
                 &&& slab@.end_addr <= addr as usize + len
                 &&& slab@.allocated_addrs == Set::<usize>::empty()
                 &&& slab.inv()
+                &&& forall|i: int| 0 <= i < (slab@.end_addr - slab@.start_addr) / block_size as int
+                    ==> #[trigger] slab@.free_addrs.contains(
+                        (slab@.start_addr + i * block_size as int) as usize)
             })
     {
         assert(size_of::<u8>() == 1);
@@ -343,6 +346,15 @@ impl Slab {
         }
 
         assert(slab@.allocated_addrs.disjoint(slab@.free_addrs));
+
+        // Prove that every valid block index maps to a free address.
+        assert forall|i: int| 0 <= i < (slab@.end_addr - slab@.start_addr) / block_size as int
+            implies #[trigger] slab@.free_addrs.contains(
+                (slab@.start_addr + i * block_size as int) as usize) by {
+            assert(!slab.index@.is_bit_set(i));
+            let free_bits = Set::<int>::new(|j: int| 0 <= j < slab.num_data_blocks() && !slab.index@.is_bit_set(j));
+            assert(free_bits.contains(i));
+        }
     }
 
     /// Proves that the address mapping is injective: distinct block indices

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -113,6 +113,9 @@ impl Slab {
                      &&& slab@.start_addr >= addr as usize
                      &&& slab@.end_addr <= addr as usize + len
                      &&& slab@.allocated_addrs == Set::<usize>::empty()
+                     &&& forall|i: int| 0 <= i < (slab@.end_addr - slab@.start_addr) / block_size as int
+                         ==> #[trigger] slab@.free_addrs.contains(
+                             (slab@.start_addr + i * block_size as int) as usize)
                  },
                  Err(e) => {
                      &&& e.code == ErrorCode::InvalidArgument


### PR DESCRIPTION
## Summary

`Slab::from_raw_parts` previously did not specify the initial state of `free_addrs` in its postcondition — only `allocated_addrs == Set::empty()` was guaranteed. This gap was originally identified by Tianyu.

Since `kheap` already relies heavily on `free_addrs` in its specs and proofs, removing `free_addrs` from `SlabView` would require significant rewrites. Instead, this PR strengthens the `from_raw_parts` postcondition to specify that all valid block addresses are initially in `free_addrs`.