### PR TITLE
[build] Add .ctors/.dtors sections to x86 user linker script

### DIFF
--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -33,6 +33,24 @@ SECTIONS
 		*(.data*)
 	}
 
+	/* Global constructors. */
+	.ctors : ALIGN(4)
+	{
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*crtend*.o(.ctors))
+	}
+
+	/* Global destructors. */
+	.dtors : ALIGN(4)
+	{
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*crtend*.o(.dtors))
+	}
+
 	/* Uninitialized data section. */
 	.bss :
 	{


### PR DESCRIPTION
## Summary

Add explicit `.ctors` and `.dtors` output sections to `build/user/linker/x86/user.ld` so that global constructors and destructors (e.g., `__attribute__((constructor))`) are collected and ordered correctly in user-space ELF binaries.

## Details

The ordering follows the standard GCC CRT convention:
- `crtbegin` → user objects (excluding `crtend`) → sorted priorities → `crtend`

This ensures `_init()`/`_fini()` from `crti.o` + `crtbegin.o` can iterate the constructor/destructor arrays at startup and exit. `KEEP()` prevents `--gc-sections` from discarding these entries.

Sections are placed between `.data` and `.bss` with 4-byte alignment, matching the pointer size on i386.

## Related

- nanvix/llvm-project#29 — Clang toolchain should override `useInitArrayDefault()` to emit `.ctors`/`.dtors` instead of `.init_array`/`.fini_array`