### PR TITLE
[memd] Move process manager signup before page fault subscription

### DIFF
--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -103,6 +103,13 @@ pub fn main() {
         panic!("failed to acquire exception management capability (error={:?})", e);
     }
 
+    // Signup to the process manager daemon.
+    // NOTE: this must happen before subscribing to page faults so that no
+    // exception messages arrive during the synchronous signup handshake.
+    if let Err(e) = ::proc::signup(&mypid, myname) {
+        panic!("failed to signup to process manager daemon (error={:?})", e);
+    }
+
     let page_fault_exception: ExceptionEvent = ExceptionEvent::Exception14;
 
     // Subscribe to page faults.
@@ -112,11 +119,6 @@ pub fn main() {
         EventCtrlRequest::Register,
     ) {
         panic!("failed to subscribe to page faults (error={:?})", e);
-    }
-
-    // Signup to the process manager daemon.
-    if let Err(e) = ::proc::signup(&mypid, myname) {
-        panic!("failed to signup to process manager daemon (error={:?})", e);
     }
 
     loop {


### PR DESCRIPTION
## Summary

Move `proc::signup()` before the page fault subscription in memd to prevent exception messages from arriving during the synchronous signup handshake.

## Problem

If a page fault is delivered while memd is still registering with the process manager, the handshake can deadlock or receive an unexpected message type.

## Fix

Reorder the initialization sequence so that `proc::signup()` completes before subscribing to page faults. This ensures the IPC channel is quiescent until memd enters its main event loop.