### PR TITLE
[nanvixd] Add -kernel-args flag to nanvixd standalone mode

### DIFF
--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -26,6 +26,9 @@ Run a hello-world application and see its output on the terminal:
 - [Running Containers](#running-containers)
   - [Building a Nanvix OCI image](#building-a-nanvix-oci-image)
   - [Importing and running with `ctr`](#importing-and-running-with-ctr)
+  - [Enabling Host Networking](#enabling-host-networking)
+  - [Mounting a Host Directory](#mounting-a-host-directory)
+  - [Passing Kernel Arguments](#passing-kernel-arguments)
 - [HTTP Mode](#http-mode)
   - [Starting the Server](#starting-the-server)
   - [Spawning an Application (NEW)](#spawning-an-application-new)
@@ -36,6 +39,7 @@ Run a hello-world application and see its output on the terminal:
   - [HTTP Error Codes](#http-error-codes)
 - [Logging](#logging)
 - [Expert Mode: Standalone User VM](#expert-mode-standalone-user-vm)
+  - [Recognised Kernel Arguments](#recognised-kernel-arguments)
 
 ---
 
@@ -140,6 +144,16 @@ To make a host directory accessible to the guest at `/mnt`, use the `-mount` fla
 The guest can then read and write files under `/mnt/` which map to the host directory.
 See [host-mount.md](host-mount.md) for the design and protocol details.
 
+### Passing Kernel Arguments
+
+To pass kernel arguments (written to guest control registers), use the `-kernel-args` flag:
+
+```bash
+./bin/nanvixd.elf -kernel-args snapshot -console-file /dev/stdout -- ./bin/snapshot-rust-nostd.elf
+```
+
+See [Recognised Kernel Arguments](#recognised-kernel-arguments) below for available tokens.
+
 Everything after `--` is forwarded to the application as arguments:
 
 ```bash
@@ -172,9 +186,10 @@ To include a literal `;` in any section, escape it as `\;`:
 # args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
 ```
 
-> **Note:** Kernel arguments are passed independently via the `-kernel-args` flag on the UserVM
-> (see [Expert Mode: Standalone User VM](#expert-mode-standalone-user-vm)). They are no longer
-> embedded in the initrd arguments string.
+> **Note:** Kernel arguments can be passed via `-kernel-args` on `nanvixd` (see
+> [Passing Kernel Arguments](#passing-kernel-arguments)) or directly on the UserVM (see
+> [Expert Mode: Standalone User VM](#expert-mode-standalone-user-vm)). They are not embedded in
+> the initrd arguments string.
 
 ## HTTP Mode
 

--- a/doc/run-windows.md
+++ b/doc/run-windows.md
@@ -20,8 +20,12 @@ Run a guest application via `nanvixd` in standalone interactive mode:
 - [Creating Multibinary Images](#creating-multibinary-images)
 - [Using `z.ps1 run`](#using-zps1-run)
 - [Running nanvixd Directly](#running-nanvixd-directly)
+  - [Enabling Host Networking](#enabling-host-networking)
+  - [Mounting a Host Directory](#mounting-a-host-directory)
+  - [Passing Kernel Arguments](#passing-kernel-arguments)
 - [Logging](#logging)
 - [Expert Mode: Standalone UserVM](#expert-mode-standalone-uservm)
+  - [Recognised Kernel Arguments](#recognised-kernel-arguments)
 - [Benchmarking](#benchmarking)
   - [Quick Start](#quick-start-1)
 
@@ -105,6 +109,16 @@ To make a host directory accessible to the guest at `/mnt`, use the `-mount` fla
 The guest can then read and write files under `/mnt/` which map to the host directory.
 See [host-mount.md](host-mount.md) for the design and protocol details.
 
+### Passing Kernel Arguments
+
+To pass kernel arguments (written to guest control registers), use the `-kernel-args` flag:
+
+```powershell
+.\bin\nanvixd.exe -kernel-args snapshot -- .\bin\snapshot-rust-nostd.elf
+```
+
+See [Recognised Kernel Arguments](#recognised-kernel-arguments) below for available tokens.
+
 Everything after `--` is forwarded to the application as arguments:
 
 ```powershell
@@ -137,9 +151,10 @@ To include a literal `;` in any section, escape it as `\;`:
 # args: ["arg1", "with;semicolon", "arg2"]   env: ["VAR1=foo"]
 ```
 
-> **Note:** Kernel arguments are passed independently via the `-kernel-args` flag on the UserVM
-> (see [Expert Mode: Standalone UserVM](#expert-mode-standalone-uservm)). They are no longer
-> embedded in the initrd arguments string.
+> **Note:** Kernel arguments can be passed via `-kernel-args` on `nanvixd` (see
+> [Passing Kernel Arguments](#passing-kernel-arguments)) or directly on the UserVM (see
+> [Expert Mode: Standalone UserVM](#expert-mode-standalone-uservm)). They are not embedded in
+> the initrd arguments string.
 
 ## Logging
 

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -223,7 +223,7 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
             state.config.kernel_binary_path().to_string(),
             Some(message.program.clone()),
             initrd_args,
-            None,
+            state.config.kernel_args().map(|s| s.to_string()),
             state.config.ramfs_filename().map(|s| s.to_string()),
             state.config.console_file().map(|s| s.to_string()),
             state.config.snapshot_path().map(|s| s.to_string()),

--- a/src/libs/nanvix-sandbox-config/src/standalone.rs
+++ b/src/libs/nanvix-sandbox-config/src/standalone.rs
@@ -37,6 +37,8 @@ pub struct StandaloneConfig {
     snapshot_path: Option<String>,
     /// Optional host directory to mount on the guest.
     mount_directory: Option<String>,
+    /// Optional kernel arguments written to guest control registers.
+    kernel_args: Option<String>,
     /// Networking mode (disabled or enabled).
     networking_mode: NetworkingMode,
     /// Optional GDB server port for debugging the guest.
@@ -61,6 +63,7 @@ impl StandaloneConfig {
     /// - `console_file`: Optional file path for guest stderr capture.
     /// - `snapshot_path`: Optional snapshot path for restoring VM state instead of cold-booting.
     /// - `mount_directory`: Optional host directory to mount on the guest.
+    /// - `kernel_args`: Optional kernel arguments written to guest control registers.
     /// - `networking_mode`: Networking mode for host networking.
     /// - `gdb_port`: Optional GDB server port.
     ///
@@ -70,6 +73,7 @@ impl StandaloneConfig {
         console_file: Option<String>,
         snapshot_path: Option<String>,
         mount_directory: Option<String>,
+        kernel_args: Option<String>,
         networking_mode: NetworkingMode,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> Self {
@@ -79,6 +83,7 @@ impl StandaloneConfig {
             console_file,
             snapshot_path,
             mount_directory,
+            kernel_args,
             networking_mode,
             #[cfg(feature = "gdb")]
             gdb_port,
@@ -108,6 +113,11 @@ impl StandaloneConfig {
     /// Returns the optional host directory to mount on the guest.
     pub fn mount_directory(&self) -> Option<&str> {
         self.mount_directory.as_deref()
+    }
+
+    /// Returns the optional kernel arguments string.
+    pub fn kernel_args(&self) -> Option<&str> {
+        self.kernel_args.as_deref()
     }
 
     /// Returns the networking mode.

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -120,7 +120,7 @@ impl Terminal {
             self.config.kernel_binary_path().to_string(),
             Some(guest_binary_path.to_string()),
             initrd_args,
-            None,
+            self.config.kernel_args().map(|s| s.to_string()),
             self.config.ramfs_filename().map(|s| s.to_string()),
             self.config.console_file().map(|s| s.to_string()),
             self.config.snapshot_path().map(|s| s.to_string()),

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -83,6 +83,8 @@ pub struct Args {
     snapshot_path: Option<String>,
     /// Optional host directory to mount on the guest (standalone mode only).
     mount_directory: Option<String>,
+    /// Optional kernel arguments written to guest control registers (standalone mode only).
+    kernel_args: Option<String>,
     /// Optional GDB server port: when set, the uservm starts a GDB RSP server on this TCP port.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -134,6 +136,8 @@ impl Args {
     pub const OPT_SNAPSHOT: &'static str = "-snapshot";
     /// Command-line option for host directory to mount on the guest (standalone mode only).
     pub const OPT_MOUNT_DIRECTORY: &'static str = "-mount";
+    /// Command-line option for kernel arguments (standalone mode only).
+    pub const OPT_KERNEL_ARGS: &'static str = "-kernel-args";
     /// Command-line option for GDB server port (standalone mode only).
     #[cfg(feature = "gdb")]
     pub const OPT_GDB_PORT: &'static str = "-gdb-port";
@@ -186,6 +190,7 @@ impl Args {
         let mut tmp_directory: String = DEFAULT_TMP_DIRECTORY.to_string();
         let mut snapshot_path: Option<String> = None;
         let mut mount_directory: Option<String> = None;
+        let mut kernel_args: Option<String> = None;
         #[cfg(feature = "gdb")]
         let mut gdb_port: Option<u16> = None;
         let mut networking_mode: NetworkingMode = NetworkingMode::Disabled;
@@ -314,6 +319,17 @@ impl Args {
                     }
                     mount_directory = Some(args[i].clone());
                 },
+                Self::OPT_KERNEL_ARGS => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_KERNEL_ARGS
+                        ));
+                    }
+                    kernel_args = Some(args[i].clone());
+                },
                 // Set GDB server port (standalone mode only).
                 #[cfg(feature = "gdb")]
                 Self::OPT_GDB_PORT => {
@@ -384,6 +400,12 @@ impl Args {
             anyhow::bail!("{} is only supported in standalone builds", Self::OPT_MOUNT_DIRECTORY);
         }
 
+        // Reject -kernel-args in non-standalone builds.
+        #[cfg(not(feature = "standalone"))]
+        if kernel_args.is_some() {
+            anyhow::bail!("{} is only supported in standalone builds", Self::OPT_KERNEL_ARGS);
+        }
+
         // Determine operation mode: HTTP mode is active if -http-addr is provided,
         // interactive mode is active if `--` separator with program name is provided.
         #[cfg(unix)]
@@ -440,6 +462,7 @@ impl Args {
             tmp_directory,
             snapshot_path,
             mount_directory,
+            kernel_args,
             #[cfg(feature = "gdb")]
             gdb_port,
             networking_mode,
@@ -496,6 +519,8 @@ Options:
              (standalone mode only).
   {mount} <host-dir>                       Mount a host directory on the guest at /mnt (standalone \
              mode only).
+  {kernel_args} <args>                      Pass kernel arguments to guest control registers \
+             (standalone mode only).
   {allow_host_networking}                   Enable host networking for the guest (disabled when \
              omitted).{gdb_port_line}
 ",
@@ -518,6 +543,7 @@ Options:
             tmp_dir = Self::OPT_TMP_DIRECTORY,
             snapshot = Self::OPT_SNAPSHOT,
             mount = Self::OPT_MOUNT_DIRECTORY,
+            kernel_args = Self::OPT_KERNEL_ARGS,
             allow_host_networking = Self::OPT_ALLOW_HOST_NETWORKING,
             gdb_port_line = if cfg!(feature = "gdb") {
                 "\n  -gdb-port <port>                         GDB server port (standalone mode \
@@ -631,6 +657,19 @@ Options:
     ///
     pub fn mount_directory(&self) -> Option<&str> {
         self.mount_directory.as_deref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the optional kernel arguments string.
+    ///
+    /// # Returns
+    ///
+    /// The kernel arguments string, if present.
+    ///
+    pub fn kernel_args(&self) -> Option<&str> {
+        self.kernel_args.as_deref()
     }
 
     ///

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -202,6 +202,7 @@ async fn async_main() -> Result<ExitCode> {
         args.console_file().clone(),
         args.snapshot_path().map(|s| s.to_string()),
         args.mount_directory().map(|s| s.to_string()),
+        args.kernel_args().map(|s| s.to_string()),
         args.networking_mode(),
         #[cfg(feature = "gdb")]
         args.gdb_port(),


### PR DESCRIPTION
## Summary

Add a `-kernel-args` command-line option to `nanvixd` that passes kernel arguments through to guest control registers in standalone mode.

## Changes

- **`src/utils/nanvixd/src/args.rs`** — Parse new `-kernel-args <value>` option.
- **`src/libs/nanvix-sandbox-config/src/standalone.rs`** — Add `kernel_args` field to `StandaloneConfig` with constructor parameter and accessor.
- **`src/libs/nanvix-http/src/client/standalone.rs`** / **`src/libs/nanvix-terminal/src/standalone.rs`** — Wire `kernel_args` from config into sandbox launch, replacing hardcoded `None`.
- **`doc/run-linux.md`** / **`doc/run-windows.md`** — Document the flag with usage examples and update the existing kernel-arguments note.
