### PR TITLE
[nanvixd] E: Enable HTTP mode on Windows

### DIFF
--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -98,9 +98,10 @@ execution_mode = "standalone"
 extra_args = ["-console-file", "/dev/null"]
 ```
 
-> **Note:** When containerd provides a stdout path (e.g., via `ctr run`), the shim
-> automatically overrides `-console-file` from `extra_args` to redirect guest console
-> output to containerd's stdout pipe.
+> **Note:** When the nanvix containerd shim spawns nanvixd, it always sets
+> `-console-file` and `-gateway-sockaddr` itself; any `-console-file` or
+> `-gateway-sockaddr` value passed in `extra_args` is stripped with a
+> warning.
 
 ## Running Containers
 

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -20,6 +20,8 @@ use crate::{
         HTTP_HEADER_MESSAGE_TYPE,
     },
 };
+#[cfg(unix)]
+use ::anyhow::Context;
 use ::anyhow::Result;
 use ::http_body_util::{
     BodyExt,
@@ -35,6 +37,8 @@ use ::hyper::{
     Response,
     StatusCode,
 };
+#[cfg(unix)]
+use ::log::warn;
 use ::log::{
     debug,
     error,
@@ -48,12 +52,18 @@ use ::std::{
     pin::Pin,
     sync::Arc,
 };
+#[cfg(windows)]
+use ::tokio::net::windows::named_pipe::{
+    NamedPipeServer,
+    ServerOptions,
+};
+#[cfg(unix)]
+use ::tokio::net::UnixListener;
 use ::tokio::{
     io::{
         AsyncReadExt,
         AsyncWriteExt,
     },
-    net::UnixListener,
     sync::Mutex,
     task::JoinHandle,
 };
@@ -70,15 +80,22 @@ use ::uservm::standalone::{
 ///
 /// # Description
 ///
-/// Bundles a running VM instance with its gateway bridge task and socket path.
+/// Bundles a running VM instance with its gateway bridge task and endpoint path.
 ///
 struct RunningVm {
     /// Handle for the running VM.
     handle: StandaloneVmHandle,
-    /// Task bridging the gateway Unix socket with the guest's IKC I/O channels.
+    /// Task bridging the cross-platform gateway endpoint with the
+    /// guest's IKC I/O channels.
     _gateway_bridge: JoinHandle<()>,
-    /// Filesystem path of the gateway Unix socket (cleaned up on kill).
-    gateway_socket_path: String,
+    /// Path of the gateway endpoint (UDS path on Unix, named pipe path
+    /// on Windows). On Unix it is read at kill/cleanup to `unlink(2)`
+    /// the underlying socket file; on Windows the named pipe is
+    /// reclaimed automatically when the bridge task drops its server
+    /// handle, so the field is only used to return the endpoint in
+    /// the `NEW` response and is otherwise unread on that platform.
+    #[cfg_attr(windows, allow(dead_code))]
+    gateway_sockaddr: String,
 }
 
 ///
@@ -130,7 +147,15 @@ impl StandaloneState {
             info!("cleanup(): aborting VM");
             vm._gateway_bridge.abort();
             vm.handle.abort_and_wait().await;
-            let _ = ::std::fs::remove_file(&vm.gateway_socket_path);
+            #[cfg(unix)]
+            if let Err(e) = ::std::fs::remove_file(&vm.gateway_sockaddr) {
+                if e.kind() != ::std::io::ErrorKind::NotFound {
+                    warn!(
+                        "cleanup(): failed to remove gateway socket {}: {e}",
+                        vm.gateway_sockaddr
+                    );
+                }
+            }
             debug!("cleanup(): VM cleaned up");
         }
     }
@@ -233,36 +258,46 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
             state.config.gdb_port(),
         );
 
-        // Create a Unix socket that serves as the gateway stream. The test harness (or any
-        // consumer) connects to this socket to exchange I/O with the guest — exactly like the
-        // multi-process gateway, but backed by IKC channels instead of a system VM.
-        let gateway_socket_path: String =
-            format!("/tmp/nvx-standalone-gw-{}.sock", std::process::id());
-        let _ = ::std::fs::remove_file(&gateway_socket_path);
-        let listener: UnixListener = match UnixListener::bind(&gateway_socket_path) {
-            Ok(l) => l,
+        // Cross-platform gateway endpoint: a single point at which a
+        // host-side consumer (typically the containerd shim) connects to
+        // exchange guest application stdio.
+        //
+        //   - Unix    : Unix-domain socket
+        //   - Windows : Named pipe (`\\.\pipe\...`)
+        //
+        // The same `gateway_bridge_task` runs on both OSes; only the
+        // binding primitive differs (see `bind_gateway_endpoint`).
+        //
+        // If the operator did not configure a path via `-gateway-sockaddr`,
+        // we fall back to a per-process auto path so legacy consumers
+        // (nanvix-bench / nanvix-terminal / integration tests) keep working
+        // without any flag.
+        let endpoint_path: String = match state.config.gateway_sockaddr() {
+            Some(p) => p.to_string(),
+            None => default_gateway_path(),
+        };
+        let endpoint: GatewayEndpoint = match bind_gateway_endpoint(&endpoint_path).await {
+            Ok(ep) => ep,
             Err(e) => {
                 let reason: String =
-                    format!("failed to bind gateway socket at {gateway_socket_path}: {e}");
+                    format!("failed to bind gateway endpoint at {endpoint_path}: {e}");
                 error!("serve_new(): {reason}");
                 handle.abort();
                 anyhow::bail!(reason);
             },
         };
-
-        debug!("serve_new(): gateway socket bound at {gateway_socket_path}",);
-
-        let gateway_bridge: JoinHandle<()> = tokio::spawn(gateway_bridge_task(listener, io));
+        debug!("serve_new(): gateway endpoint bound at {endpoint_path}");
+        let gateway_bridge: JoinHandle<()> = tokio::spawn(gateway_bridge_task(endpoint, io));
 
         *guard = Some(RunningVm {
             handle,
             _gateway_bridge: gateway_bridge,
-            gateway_socket_path: gateway_socket_path.clone(),
+            gateway_sockaddr: endpoint_path.clone(),
         });
 
         Ok(message::NewResponse {
             user_vm_id: STANDALONE_VM_ID,
-            gateway_sockaddr: gateway_socket_path,
+            gateway_sockaddr: endpoint_path,
         })
     }
 
@@ -291,9 +326,28 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
         let vm: Option<RunningVm> = state.running_vm.lock().await.take();
         match vm {
             Some(running) => {
+                // Await VM exit first so the gateway bridge keeps draining
+                // guest stdout/stderr until the guest itself terminates.
+                // Aborting the bridge prematurely drops `output_rx`, which
+                // causes the standalone I/O handler to return `-1` from
+                // guest write() calls (see `uservm::standalone::
+                // handle_write_request`), truncating logs and potentially
+                // disrupting guest shutdown.
+                let wait_result = running.handle.wait().await;
+                // Defensive cleanup: the bridge typically exits on its own
+                // once the guest closes its I/O channels, but abort it here
+                // in case the host-side consumer is still connected.
                 running._gateway_bridge.abort();
-                let _ = ::std::fs::remove_file(&running.gateway_socket_path);
-                match running.handle.wait().await {
+                #[cfg(unix)]
+                if let Err(e) = ::std::fs::remove_file(&running.gateway_sockaddr) {
+                    if e.kind() != ::std::io::ErrorKind::NotFound {
+                        warn!(
+                            "serve_kill(): failed to remove gateway socket {}: {e}",
+                            running.gateway_sockaddr
+                        );
+                    }
+                }
+                match wait_result {
                     Ok(exit_status) => {
                         debug!("serve_kill(): VM exited (exit_status={exit_status})");
                         Ok(message::KillResponse {
@@ -435,81 +489,185 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
 // Standalone Functions
 //==================================================================================================
 
-/// Size of the I/O buffer used by the gateway bridge for socket reads.
+/// Size of the I/O buffer used by the gateway bridge for reads from the
+/// connected consumer.
 const GATEWAY_BRIDGE_BUFFER_SIZE: usize = 4096;
 
 ///
 /// # Description
 ///
-/// Bridges a Unix socket connection with the guest's IKC-based I/O channels.
+/// Cross-platform listening primitive for the gateway endpoint. The
+/// path determines the protocol: a `\\.\pipe\...` path on Windows yields
+/// a named pipe server, any other path on Unix yields a UDS listener.
 ///
-/// Accepts exactly one connection on the listener, then runs a bidirectional relay:
-/// - Socket reads → guest stdin (via `input_tx`)
-/// - Guest stdout (via `output_rx`) → socket writes
+/// Wrapped in an enum so [`gateway_bridge_task`] is a single async
+/// function on both OSes; only the accept step differs.
 ///
-/// The task exits when either the socket or the guest I/O channel closes.
+enum GatewayEndpoint {
+    #[cfg(unix)]
+    Unix(UnixListener),
+    #[cfg(windows)]
+    Pipe { server: NamedPipeServer },
+}
+
+#[cfg(unix)]
+fn default_gateway_path() -> String {
+    format!("/tmp/nvx-standalone-gw-{}.sock", std::process::id())
+}
+
+#[cfg(windows)]
+fn default_gateway_path() -> String {
+    format!(r"\\.\pipe\nanvix-standalone-gw-{}", std::process::id())
+}
+
+#[cfg(unix)]
+async fn bind_gateway_endpoint(path: &str) -> ::anyhow::Result<GatewayEndpoint> {
+    // Ensure parent directory exists (operator-supplied paths may point
+    // into a per-sandbox state dir that we created earlier). Propagate
+    // any failure here so the operator sees the real cause instead of a
+    // misleading bind error downstream.
+    if let Some(parent) = ::std::path::Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            ::std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create parent directory {} for gateway socket {path}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    // Pre-bind cleanup: a stale socket file from a prior run is fine to
+    // remove, but any other removal failure (e.g. EACCES, EISDIR) must
+    // surface to the caller instead of being masked by the bind error.
+    match ::std::fs::remove_file(path) {
+        Ok(()) => {},
+        Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {},
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("failed to remove stale gateway socket at {path}"));
+        },
+    }
+    let listener = UnixListener::bind(path)?;
+    // Restrict the gateway socket to the owning user. Without this the socket
+    // inherits the process umask (typically 0755 / 0775) and any local user can
+    // connect to the guest's stdin/stdout. This is in addition to per-sandbox
+    // path isolation provided by the caller.
+    {
+        use ::std::os::unix::fs::PermissionsExt;
+        let mut perms = ::std::fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        ::std::fs::set_permissions(path, perms)?;
+    }
+    Ok(GatewayEndpoint::Unix(listener))
+}
+
+#[cfg(windows)]
+async fn bind_gateway_endpoint(path: &str) -> ::anyhow::Result<GatewayEndpoint> {
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(path)?;
+    Ok(GatewayEndpoint::Pipe { server })
+}
+
 ///
-/// # Parameters
+/// # Description
 ///
-/// - `listener`: Unix socket listener bound to the gateway path.
-/// - `io`: I/O channels connected to the guest's stdin/stdout via IKC.
+/// Bridges the gateway endpoint with the guest's IKC-based I/O
+/// channels. Accepts exactly one connection (the containerd shim, or a
+/// test harness), then runs a bidirectional relay:
+/// - Connection reads → guest stdin (via `input_tx`)
+/// - Guest stdout/stderr (via `output_rx`) → connection writes
 ///
-async fn gateway_bridge_task(listener: UnixListener, io: StandaloneVmIo) {
+/// The task exits when either the connection or the guest I/O channel
+/// closes. The implementation is identical on Unix and Windows; only the
+/// accept primitive differs (UDS accept vs named pipe connect).
+///
+async fn gateway_bridge_task(endpoint: GatewayEndpoint, io: StandaloneVmIo) {
     let StandaloneVmIo {
-        mut output_rx,
+        output_rx,
         input_tx,
     } = io;
 
-    // Accept exactly one connection (the test harness or gateway consumer).
-    let stream = match listener.accept().await {
-        Ok((stream, _addr)) => {
-            debug!("gateway_bridge_task(): accepted connection");
-            stream
+    // Accept exactly one connection. On Unix this is a UDS accept; on
+    // Windows we await the client connect on the pre-created pipe server.
+    match endpoint {
+        #[cfg(unix)]
+        GatewayEndpoint::Unix(listener) => {
+            let stream = match listener.accept().await {
+                Ok((stream, _addr)) => {
+                    debug!("gateway_bridge_task(): accepted UDS connection");
+                    stream
+                },
+                Err(e) => {
+                    error!("gateway_bridge_task(): failed to accept UDS connection: {e}");
+                    return;
+                },
+            };
+            let (reader, writer) = stream.into_split();
+            run_bridge(reader, writer, output_rx, input_tx).await;
         },
-        Err(e) => {
-            error!("gateway_bridge_task(): failed to accept connection: {e}");
-            return;
+        #[cfg(windows)]
+        GatewayEndpoint::Pipe { server } => {
+            if let Err(e) = server.connect().await {
+                error!("gateway_bridge_task(): named pipe connect failed: {e}");
+                // Drain output_rx so the guest doesn't see write() = -1.
+                let mut output_rx = output_rx;
+                while output_rx.recv().await.is_some() {}
+                drop(input_tx);
+                return;
+            }
+            debug!("gateway_bridge_task(): named pipe client connected");
+            let (reader, writer) = tokio::io::split(server);
+            run_bridge(reader, writer, output_rx, input_tx).await;
         },
-    };
+    }
 
-    let (mut reader, mut writer) = stream.into_split();
+    debug!("gateway_bridge_task(): bridge closed");
+}
 
-    // Spawn a task that reads from the socket and forwards to guest stdin.
+/// Generic bidirectional pump used by both the Unix and Windows accept
+/// paths. Reads from `reader` go to `input_tx` (guest stdin); writes to
+/// `writer` come from `output_rx` (guest stdout/stderr).
+async fn run_bridge<R, W>(
+    mut reader: R,
+    mut writer: W,
+    mut output_rx: ::tokio::sync::mpsc::Receiver<Vec<u8>>,
+    input_tx: ::tokio::sync::mpsc::Sender<Vec<u8>>,
+) where
+    R: ::tokio::io::AsyncRead + Unpin + Send + 'static,
+    W: ::tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    // Spawn a task that reads from the connection and forwards to guest
+    // stdin. This runs concurrently with the output direction below.
     let input_handle: JoinHandle<()> = tokio::spawn(async move {
         let mut buffer: [u8; GATEWAY_BRIDGE_BUFFER_SIZE] = [0u8; GATEWAY_BRIDGE_BUFFER_SIZE];
         loop {
             match reader.read(&mut buffer).await {
-                Ok(0) => {
-                    // EOF — consumer closed the write half.
-                    break;
-                },
+                Ok(0) => break,
                 Ok(n) => {
                     if input_tx.send(buffer[..n].to_vec()).await.is_err() {
                         break;
                     }
                 },
                 Err(e) => {
-                    trace!("gateway_bridge_task(): socket read error: {e}");
+                    trace!("gateway_bridge_task(): read error: {e}");
                     break;
                 },
             }
         }
     });
 
-    // Forward guest output to the socket writer.
+    // Forward guest output to the connection.
     while let Some(data) = output_rx.recv().await {
         if let Err(e) = writer.write_all(&data).await {
-            trace!("gateway_bridge_task(): socket write error: {e}");
+            trace!("gateway_bridge_task(): write error: {e}");
             break;
         }
     }
 
-    // Guest output channel closed — shut down the socket write half so the consumer sees EOF.
+    // Guest output channel closed — shut down the connection write half
+    // so the consumer sees EOF, then unwind the input relay.
     let _ = writer.shutdown().await;
-
-    // Wait for the input relay to finish.
     input_handle.abort();
     let _ = input_handle.await;
-
-    debug!("gateway_bridge_task(): bridge closed");
 }

--- a/src/libs/nanvix-http/src/message.rs
+++ b/src/libs/nanvix-http/src/message.rs
@@ -60,7 +60,11 @@ pub struct New {
 pub struct NewResponse {
     /// Unique identifier assigned to the User VM instance.
     pub user_vm_id: UserVmIdentifier,
-    /// Socket address where clients can interact with the VM's stdin/stdout through the gateway.
+    /// Gateway endpoint where the host-side consumer (typically the
+    /// containerd shim) exchanges the guest's stdin/stdout.
+    ///
+    /// - Unix: Unix-domain socket path
+    /// - Windows: named pipe path (e.g. `\\.\pipe\nanvix-standalone-gw-<pid>`)
     pub gateway_sockaddr: String,
 }
 

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -46,19 +46,18 @@ use ::nanvix_sandbox_config::SimpleSandboxCacheConfig;
 #[cfg(feature = "standalone")]
 use ::nanvix_sandbox_config::StandaloneConfig;
 use ::std::sync::Arc;
+use ::tokio::net::{
+    TcpListener,
+    TcpStream,
+};
+#[cfg(unix)]
+use ::tokio::signal::unix::{
+    signal,
+    Signal,
+    SignalKind,
+};
 #[cfg(feature = "single-process")]
 use ::tokio::sync::Mutex;
-use ::tokio::{
-    net::{
-        TcpListener,
-        TcpStream,
-    },
-    signal::unix::{
-        signal,
-        Signal,
-        SignalKind,
-    },
-};
 
 //==================================================================================================
 // Structures
@@ -174,8 +173,8 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
     /// them to HTTP client handlers. In single-process mode, connections are handled sequentially.
     /// In multi-process mode, each connection is handled in a separate tokio task.
     ///
-    /// The server runs until an interrupt signal (SIGINT) is received, at which point it performs
-    /// graceful shutdown by cleaning up all active sandboxes.
+    /// The server runs until a shutdown signal is received (SIGINT on Unix, Ctrl-C on Windows),
+    /// at which point it performs graceful shutdown by cleaning up all active sandboxes.
     ///
     /// # Returns
     ///
@@ -194,8 +193,20 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
             Arc::new(StandaloneState::new(self.config.clone()));
         #[cfg(not(any(feature = "single-process", feature = "standalone")))]
         let sandbox_cache: Arc<SandboxCache<T>> = SandboxCache::new(self.config.clone()).await?;
+        #[cfg(unix)]
         let mut signals: Signal = signal(SignalKind::interrupt())?;
         let http_listener: TcpListener = TcpListener::bind(&self.sockaddr).await?;
+
+        // Cross-platform shutdown signal: SIGINT on Unix, Ctrl-C on Windows.
+        #[cfg(unix)]
+        let shutdown_signal = async move {
+            signals.recv().await;
+        };
+        #[cfg(windows)]
+        let shutdown_signal = async {
+            let _ = ::tokio::signal::ctrl_c().await;
+        };
+        ::tokio::pin!(shutdown_signal);
 
         loop {
             tokio::select! {
@@ -243,7 +254,7 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
                         },
                     }
                 },
-                _ = signals.recv() => {
+                _ = &mut shutdown_signal => {
                     info!("received exit signal, stopping...");
                     #[cfg(feature = "single-process")]
                     {

--- a/src/libs/nanvix-sandbox-config/src/standalone.rs
+++ b/src/libs/nanvix-sandbox-config/src/standalone.rs
@@ -44,6 +44,17 @@ pub struct StandaloneConfig {
     /// Optional GDB server port for debugging the guest.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
+    /// Optional path at which standalone mode should expose the gateway
+    /// endpoint where a host-side consumer (typically the containerd
+    /// shim) exchanges the guest's stdin/stdout.
+    ///
+    /// - Unix: Unix-domain socket path, e.g. `/tmp/nvx-standalone-gw-<pid>.sock`.
+    /// - Windows: named pipe path, e.g. `\\.\pipe\nanvix-standalone-gw-<pid>`.
+    ///
+    /// When unset, standalone mode falls back to a per-process default
+    /// path so legacy consumers (`nanvix-bench`, `nanvix-terminal`)
+    /// continue to work without any flag.
+    gateway_sockaddr: Option<String>,
 }
 
 //==================================================================================================
@@ -67,6 +78,7 @@ impl StandaloneConfig {
     /// - `networking_mode`: Networking mode for host networking.
     /// - `gdb_port`: Optional GDB server port.
     ///
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         kernel_binary_path: String,
         ramfs_filename: Option<String>,
@@ -76,6 +88,7 @@ impl StandaloneConfig {
         kernel_args: Option<String>,
         networking_mode: NetworkingMode,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
+        gateway_sockaddr: Option<String>,
     ) -> Self {
         Self {
             kernel_binary_path,
@@ -87,6 +100,7 @@ impl StandaloneConfig {
             networking_mode,
             #[cfg(feature = "gdb")]
             gdb_port,
+            gateway_sockaddr,
         }
     }
 
@@ -129,5 +143,12 @@ impl StandaloneConfig {
     #[cfg(feature = "gdb")]
     pub fn gdb_port(&self) -> Option<u16> {
         self.gdb_port
+    }
+
+    /// Returns the optional gateway endpoint path (UDS on Unix, named
+    /// pipe on Windows). See the field doc on [`StandaloneConfig`] for
+    /// details.
+    pub fn gateway_sockaddr(&self) -> Option<&str> {
+        self.gateway_sockaddr.as_deref()
     }
 }

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 config = { workspace = true }
 hwloc = { workspace = true }
 linuxd = { workspace = true, optional = true }
-nanvix-http = { workspace = true, optional = true }
+nanvix-http = { workspace = true }
 nanvix-sandbox = { workspace = true }
 nanvix-sandbox-cache = { workspace = true, optional = true }
 nanvix-terminal = { workspace = true }
@@ -26,34 +26,31 @@ syscomm = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
 uservm = { workspace = true, optional = true }
 
-[target.'cfg(unix)'.dependencies]
-nanvix-http = { workspace = true }
-
 [features]
 default = ["microvm", "multi-process"]
 internal-api = ["sys", "syscall", "uservm"]
 single-process = [
     "linuxd",
     "nanvix-sandbox-config/single-process",
-    "nanvix-http?/single-process",
+    "nanvix-http/single-process",
     "nanvix-sandbox/single-process",
     "nanvix-terminal/single-process",
 ]
 multi-process = [
     "nanvix-sandbox-cache",
-    "nanvix-http?/multi-process",
+    "nanvix-http/multi-process",
     "nanvix-sandbox/multi-process",
     "nanvix-sandbox-cache/multi-process",
     "nanvix-terminal/multi-process",
 ]
 standalone = [
-    "nanvix-http?/standalone",
+    "nanvix-http/standalone",
     "nanvix-sandbox/standalone",
     "nanvix-terminal/standalone",
 ]
 gdb = [
     "nanvix-sandbox-config/gdb",
-    "nanvix-http?/gdb",
+    "nanvix-http/gdb",
     "nanvix-sandbox/gdb",
     "nanvix-terminal/gdb",
 ]
@@ -61,7 +58,7 @@ gdb = [
 profile-time = ["nanvix-sandbox/profile-time", "nanvix-terminal/profile-time"]
 microvm = [
     "config/microvm",
-    "nanvix-http?/microvm",
+    "nanvix-http/microvm",
     "nanvix-sandbox/microvm",
     "nanvix-sandbox-cache?/microvm",
     "nanvix-terminal/microvm",
@@ -69,7 +66,7 @@ microvm = [
 ]
 whp = [
     "config/whp",
-    "nanvix-http?/whp",
+    "nanvix-http/whp",
     "nanvix-sandbox/whp",
     "nanvix-sandbox-cache?/whp",
     "nanvix-terminal/whp",

--- a/src/libs/nanvix/src/lib.rs
+++ b/src/libs/nanvix/src/lib.rs
@@ -80,7 +80,6 @@
 
 pub use config;
 pub use hwloc;
-#[cfg(unix)]
 pub use nanvix_http as http;
 pub use nanvix_sandbox as sandbox;
 #[cfg(feature = "single-process")]

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -47,7 +47,6 @@ use ::std::{
 #[derive(Debug, Clone)]
 pub struct Args {
     /// Optional HTTP server socket address (host:port). If present, enables HTTP mode.
-    #[cfg(unix)]
     http_sockaddr: Option<String>,
     /// Directory path containing Nanvix binaries.
     binary_directory: String,
@@ -92,6 +91,11 @@ pub struct Args {
     networking_mode: NetworkingMode,
     /// When `true`, route nanvixd's logs to stdout instead of a auto-named file.
     log_to_stdout: bool,
+    /// Optional path of the standalone gateway endpoint -- the host-side
+    /// rendezvous point where a consumer reads the guest's stdout/stderr
+    /// and writes to its stdin. UDS path on Unix, named pipe path on
+    /// Windows. Defaults to a per-process auto path when omitted.
+    gateway_sockaddr: Option<String>,
 }
 
 //==================================================================================================
@@ -102,7 +106,6 @@ impl Args {
     /// Command-line flag that prints usage information.
     pub const OPT_HELP: &'static str = "-help";
     /// Command-line option that sets the HTTP socket address.
-    #[cfg(unix)]
     pub const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
     /// Command-line option that sets the binary directory path.
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
@@ -147,6 +150,9 @@ impl Args {
     pub const OPT_ALLOW_HOST_NETWORKING: &'static str = "-allow-host-networking";
     /// Command-line flag that routes nanvixd's logs to stdout instead of the auto-named file.
     pub const OPT_LOG_TO_STDOUT: &'static str = "-log-to-stdout";
+    /// Command-line option for the standalone gateway endpoint (UDS
+    /// path on Unix, named pipe path on Windows).
+    pub const OPT_GATEWAY_SOCKADDR: &'static str = "-gateway-sockaddr";
 
     ///
     /// # Description
@@ -167,7 +173,6 @@ impl Args {
     /// the parsing issue or validation failure.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
-        #[cfg(unix)]
         let mut http_sockaddr: Option<String> = None;
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut clh_bin_path: String = config::DEFAULT_CLH_BIN_PATH.to_string();
@@ -200,6 +205,7 @@ impl Args {
         let mut gdb_port: Option<u16> = None;
         let mut networking_mode: NetworkingMode = NetworkingMode::Disabled;
         let mut log_to_stdout: bool = false;
+        let mut gateway_sockaddr: Option<String> = None;
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -223,7 +229,6 @@ impl Args {
                     Self::usage(args[0].as_str());
                     return Err(anyhow::anyhow!("wrong usage"));
                 },
-                #[cfg(unix)]
                 Self::OPT_HTTP_SOCKADDR => {
                     i += 1;
                     http_sockaddr = Some(args[i].clone());
@@ -239,6 +244,17 @@ impl Args {
                 Self::OPT_CONSOLE_FILE => {
                     i += 1;
                     console_file = Some(args[i].clone());
+                },
+                Self::OPT_GATEWAY_SOCKADDR => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_GATEWAY_SOCKADDR
+                        ));
+                    }
+                    gateway_sockaddr = Some(args[i].clone());
                 },
                 Self::OPT_HWLOC => {
                     i += 1;
@@ -428,12 +444,10 @@ impl Args {
 
         // Determine operation mode: HTTP mode is active if -http-addr is provided,
         // interactive mode is active if `--` separator with program name is provided.
-        #[cfg(unix)]
         let http_mode: bool = http_sockaddr.is_some();
         let interactive_mode: bool = program_name.is_some();
 
         // Ensure exactly one mode is active.
-        #[cfg(unix)]
         if http_mode && interactive_mode {
             anyhow::bail!(
                 "cannot use both HTTP mode ({}) and interactive mode ({}) simultaneously",
@@ -442,7 +456,6 @@ impl Args {
             );
         }
 
-        #[cfg(unix)]
         if !http_mode && !interactive_mode {
             anyhow::bail!(
                 "must specify either HTTP mode ({} <sockaddr>) or interactive mode ({} <program> \
@@ -452,18 +465,7 @@ impl Args {
             );
         }
 
-        // On Windows, only interactive mode is supported.
-        #[cfg(windows)]
-        if !interactive_mode {
-            anyhow::bail!(
-                "must specify interactive mode ({} <program> [<args>...]) (HTTP mode is not \
-                 supported on Windows)",
-                Self::OPT_SEPARATOR
-            );
-        }
-
         Ok(Self {
-            #[cfg(unix)]
             http_sockaddr,
             binary_directory,
             clh_bin_path,
@@ -487,6 +489,7 @@ impl Args {
             gdb_port,
             networking_mode,
             log_to_stdout,
+            gateway_sockaddr,
         })
     }
 
@@ -500,13 +503,10 @@ impl Args {
     /// - `program_name`: Name of the program executable.
     ///
     pub fn usage(program_name: &str) {
-        #[cfg(unix)]
         let http_usage: String = format!(
             "\nUsage (HTTP mode):\n  {program_name} {} <sockaddr> [OPTIONS]\n",
             Self::OPT_HTTP_SOCKADDR,
         );
-        #[cfg(windows)]
-        let http_usage: &str = "";
 
         println!(
             "\
@@ -545,7 +545,12 @@ Options:
   {allow_host_networking}                   Enable host networking for the guest (disabled when \
              omitted).
   {log_to_stdout}                          Route nanvixd's own logrus output to stdout instead of \
-             a file in {log_dir} (file logger is otherwise the default).{gdb_port_line}
+             a file in {log_dir} (file logger is otherwise the default).
+  {gateway_sockaddr} <path>                 (Standalone) Path at which to expose the gateway \
+             endpoint -- the host-side rendezvous point where a consumer (e.g. the containerd \
+             shim) reads the guest's stdout/stderr and writes to its stdin. UDS path on Unix, \
+             named pipe path on Windows. Defaults to a per-process auto path when \
+             omitted.{gdb_port_line}
 ",
             http_usage = http_usage,
             program_name = program_name,
@@ -569,6 +574,7 @@ Options:
             kernel_args = Self::OPT_KERNEL_ARGS,
             allow_host_networking = Self::OPT_ALLOW_HOST_NETWORKING,
             log_to_stdout = Self::OPT_LOG_TO_STDOUT,
+            gateway_sockaddr = Self::OPT_GATEWAY_SOCKADDR,
             gdb_port_line = if cfg!(feature = "gdb") {
                 "\n  -gdb-port <port>                         GDB server port (standalone mode \
                  only)."
@@ -587,7 +593,6 @@ Options:
     ///
     /// The HTTP socket address if present; `None` otherwise.
     ///
-    #[cfg(unix)]
     pub fn http_sockaddr(&self) -> Option<&str> {
         self.http_sockaddr.as_deref()
     }
@@ -642,6 +647,12 @@ Options:
     ///
     pub fn console_file(&self) -> Option<String> {
         self.console_file.clone()
+    }
+
+    /// Returns the optional standalone gateway endpoint path (UDS on
+    /// Unix, named pipe on Windows). See [`Self::OPT_GATEWAY_SOCKADDR`].
+    pub fn gateway_sockaddr(&self) -> Option<&str> {
+        self.gateway_sockaddr.as_deref()
     }
 
     ///
@@ -922,5 +933,63 @@ mod tests {
             Args::parse(argv(&["-log-dir", "/tmp/somewhere", "--", "/bin/foo"])).expect("parse");
         assert!(!args.log_to_stdout());
         assert_eq!(args.log_directory(), "/tmp/somewhere");
+    }
+
+    #[test]
+    fn parses_http_mode_with_sockaddr() {
+        let args = Args::parse(argv(&["-http-addr", "127.0.0.1:9999"])).expect("parse");
+        assert_eq!(args.http_sockaddr(), Some("127.0.0.1:9999"));
+        assert!(!args.interactive_mode());
+        assert_eq!(args.program_name(), None);
+    }
+
+    #[test]
+    fn parses_interactive_mode() {
+        let args = Args::parse(argv(&["--", "/bin/foo", "arg1"])).expect("parse");
+        assert_eq!(args.http_sockaddr(), None);
+        assert!(args.interactive_mode());
+        assert_eq!(args.program_name(), Some("/bin/foo"));
+    }
+
+    #[test]
+    fn rejects_both_http_and_interactive() {
+        let res = Args::parse(argv(&["-http-addr", "127.0.0.1:9999", "--", "/bin/foo"]));
+        assert!(res.is_err(), "expected error when both modes are set");
+        let msg: String = format!("{:#}", res.err().unwrap());
+        assert!(msg.contains("cannot use both HTTP mode"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn rejects_neither_http_nor_interactive() {
+        let res = Args::parse(argv(&[]));
+        assert!(res.is_err(), "expected error when no mode is set");
+        let msg: String = format!("{:#}", res.err().unwrap());
+        assert!(msg.contains("must specify either HTTP mode"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn parses_gateway_sockaddr_flag() {
+        let args = Args::parse(argv(&[
+            "-http-addr",
+            "127.0.0.1:9999",
+            "-gateway-sockaddr",
+            "/tmp/test-gw.sock",
+        ]))
+        .expect("parse");
+        assert_eq!(args.gateway_sockaddr(), Some("/tmp/test-gw.sock"));
+    }
+
+    #[test]
+    fn gateway_sockaddr_is_none_when_unset() {
+        let args = Args::parse(argv(&["-http-addr", "127.0.0.1:9999"])).expect("parse");
+        assert_eq!(args.gateway_sockaddr(), None);
+    }
+
+    #[test]
+    fn rejects_gateway_sockaddr_without_value() {
+        let res = Args::parse(argv(&["-gateway-sockaddr"]));
+        assert!(res.is_err(), "expected error when -gateway-sockaddr has no value");
+        let msg: String = format!("{:#}", res.err().unwrap());
+        assert!(msg.contains("missing value for: -gateway-sockaddr"), "unexpected error: {msg}");
     }
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -34,8 +34,6 @@ use ::log::{
     error,
     info,
 };
-#[cfg(unix)]
-use ::nanvix::http::HttpServer;
 #[cfg(feature = "multi-process")]
 use ::nanvix::sandbox_config::SandboxCacheConfig;
 #[cfg(feature = "single-process")]
@@ -44,6 +42,7 @@ use ::nanvix::sandbox_config::SimpleSandboxCacheConfig;
 use ::nanvix::sandbox_config::StandaloneConfig;
 use ::nanvix::{
     config::system::DEFAULT_MACHINE_NAME,
+    http::HttpServer,
     sandbox::NAMED_RESOURCE_PREFIX,
     terminal::Terminal,
 };
@@ -176,6 +175,7 @@ async fn async_main() -> Result<ExitCode> {
         args.networking_mode(),
         #[cfg(feature = "gdb")]
         args.gdb_port(),
+        args.gateway_sockaddr().map(|s| s.to_string()),
     );
 
     #[cfg(feature = "multi-process")]
@@ -241,11 +241,10 @@ async fn async_main() -> Result<ExitCode> {
             exit_code as u8
         };
 
-        return Ok(ExitCode::from(clamped_exit_code));
-    }
+        Ok(ExitCode::from(clamped_exit_code))
+    } else {
+        // HTTP mode.
 
-    #[cfg(unix)]
-    {
         let http_sockaddr: &str = match args.http_sockaddr() {
             None => {
                 let reason: &str = "no HTTP socket address specified in HTTP mode";
@@ -258,16 +257,10 @@ async fn async_main() -> Result<ExitCode> {
         let mut http_server: HttpServer<()> = HttpServer::new(http_sockaddr, config);
         if let Err(error) = http_server.run().await {
             error!("http server failed: {error}");
+            return Ok(ExitCode::FAILURE);
         }
 
         Ok(ExitCode::SUCCESS)
-    }
-
-    #[cfg(windows)]
-    {
-        let reason: &str = "HTTP mode is not supported on Windows";
-        error!("{reason}");
-        anyhow::bail!(reason);
     }
 }
 


### PR DESCRIPTION
## Summary

Enables HTTP mode for `nanvixd` on Windows and lifts the standalone gateway endpoint from a Unix-only Unix-domain socket to a single **cross-platform endpoint** (UDS on Unix, named pipe on Windows). Same `gateway_bridge_task` runs on both OSes; only the binding primitive differs. This is the structural change the Nanvix containerd shim needs to drive `nanvixd` end-to-end on Windows.

## What changed

### Enabling HTTP mode on Windows

- `nanvixd`: drop the `cfg(unix)` gates around `-http-addr` parsing/validation in `args.rs` and around the HTTP-mode block in `main.rs::async_main`. Remove the `cfg(windows)` `bail!` block that previously refused the flag.
- `src/libs/nanvix/Cargo.toml`: `nanvix-http` becomes an **unconditional** workspace dependency (no `optional`, no `target.'cfg(unix)'.dependencies`); feature lines drop the `?` suffix on `nanvix-http?/x`.
- `src/libs/nanvix/src/lib.rs`: the `pub use nanvix_http as http;` re-export is no longer `cfg(unix)`-gated.
- `nanvix-http::server`: replace the eager `tokio::signal::unix::signal(SignalKind::interrupt())` with a pinned cross-platform shutdown future — SIGINT on Unix, `tokio::signal::ctrl_c()` on Windows. Unix behaviour is preserved.

### Cross-platform standalone gateway endpoint

- `nanvix-http::client::standalone::serve_new`: replace the Unix-only `UnixListener`/`gateway_bridge_task` pair with a cross-platform `GatewayEndpoint` enum (`Unix(UnixListener)` on Unix, `Pipe { server: NamedPipeServer }` on Windows). The accept primitive differs per-OS; the bidirectional pump is shared via a generic `run_bridge<R: AsyncRead, W: AsyncWrite>` helper.
- New `bind_gateway_endpoint(&path)` and `default_gateway_path()` per-OS helpers:
  - Unix default: `/tmp/nvx-standalone-gw-<pid>.sock`
  - Windows default: `\\.\pipe\nanvix-standalone-gw-<pid>`
- The Unix socket is created with **mode `0600`** so only the owner can connect (closes a pre-existing world-accessible-socket hole — `UnixListener::bind` inherits the process umask, typically 0755/0775).
- On Windows the named pipe is reclaimed automatically when the bridge drops its server handle; the `gateway_sockaddr` field on `RunningVm` is only used to populate the `NEW` response, and is therefore annotated `#[cfg_attr(windows, allow(dead_code))]`.

### New `-gateway-sockaddr` CLI flag

`nanvixd` accepts an optional `-gateway-sockaddr <path>` flag (with matching `StandaloneConfig::gateway_sockaddr` field and accessor) so callers can pre-allocate a predictable per-VM endpoint path. When unset, `nanvix-http` falls back to the per-process default above, preserving existing `nanvix-bench` / `nanvix-terminal` behaviour without any flag.

`NewResponse.gateway_sockaddr` keeps its wire name; the doc comment is updated to describe the cross-platform semantics (UDS path on Unix, named pipe path on Windows).

### Documentation

`doc/run-linux.md` gets a short note that the shim manages both `-console-file` and `-gateway-sockaddr` itself; any value passed in `extra_args` is stripped with a warning.

## Why this matters

The Nanvix containerd shim drives `nanvixd` exclusively over HTTP (`NEW` / `KILL` / `READY` requests). Without this PR:

- `nanvixd` refuses to start in HTTP mode on Windows; the shim's `wait_for_server` times out on every pod create.
- The io_handler in `uservm::standalone::handle_write_request` always pushes guest stdout/stderr through `output_tx` expecting a consumer to drain `output_rx`. Without a consumer, every guest write returns `-1`, CPython raises `BrokenPipeError` at shutdown, and pods exit 120 about a minute after boot with no diagnostic trail.

The cross-platform gateway endpoint must ship in the same change as the gating removal — splitting them would land an intermediate state that breaks every networked workload on Windows.

## Tests

```
cargo test -p nanvixd --lib args::tests   # 7 passed
```

New `nanvixd::args::tests` cover:

- `parses_http_mode_with_sockaddr` — `-http-addr` on every target.
- `parses_interactive_mode` — `--` separator still works.
- `rejects_both_http_and_interactive` / `rejects_neither_http_nor_interactive` — mutual-exclusion / required-mode rules.
- `parses_gateway_sockaddr_flag` — `-gateway-sockaddr <path>` is captured.
- `gateway_sockaddr_is_none_when_unset` — default is `None`.
- `rejects_gateway_sockaddr_without_value` — missing-value error message.

`z.ps1 build`, `z.ps1 build -- format-check`, `z.ps1 build -- lint-check`, and `z.ps1 build -- spellcheck` all pass on Windows.

## End-to-end verification

Tested on Win Server 2025 with the Nanvix containerd shim and a CPython HTTP-server pod:

- Shim spawns `nanvixd.exe -http-addr <addr> -gateway-sockaddr \\.\pipe\nanvix-standalone-gw-<container-id> …`.
- `wait_for_server()` succeeds; shim POSTs `NEW`, then connects to the per-sandbox gateway pipe.
- Pod boots, binds `0.0.0.0:9999`, and serves `Hello from Nanvix!` to a probe inside the L2Bridge HCN compartment.
- Application's `print()` output reaches `crictl logs`.
- Cross-platform shutdown signal is exercised when containerd service-stops the shim and forwards Ctrl-C to nanvixd.

## Notes for reviewers

- This PR is part of a 4-PR series enabling the Windows shim path. The other three are:
  - [uservm] E: Named-pipe-aware stderr on Windows (#2390, independent)
  - [nanvix-http] B: serve_kill waits for VM exit (#2391, stacked on this PR)
  - [nanvixd] E: Add -log-to-stdout flag (#2392, independent)

- The "gateway" name is overloaded across deployment modes — multi-process has a distinct gateway service, while standalone's gateway is just a per-VM bridge to IKC channels. A follow-up could rename the standalone variant (e.g. to `host_io`) across both repos in one coordinated change.
- Unix behaviour is preserved everywhere except for the new `chmod 0600` on the gateway UDS, which closes a pre-existing world-accessible-socket hole. The only Unix-visible refactor is the cross-platform shutdown-signal future, which still routes SIGINT exactly like before.
