### PR TITLE
[nanvixd] Add -log-to-stdout flag

### DIFF
--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -347,6 +347,18 @@ RUST_LOG=debug ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/hello-rust-n
 RUST_LOG=trace ./bin/nanvixd.elf -http-addr 127.0.0.1:8080
 ```
 
+By default, `nanvixd`'s own structured (`logrus`) records are written to an auto-named file
+(`nanvixd_<timestamp>.log`) inside the log directory (overridable via `-log-dir <dir>`). Pass
+`-log-to-stdout` to route those records to stdout instead:
+
+```bash
+./bin/nanvixd.elf -log-to-stdout -- ./bin/hello-rust-nostd.elf
+```
+
+This is useful when a parent process (for example, the Nanvix containerd shim) captures
+`nanvixd`'s stdout and forwards it to its own log sink. `-log-to-stdout` and `-log-dir` are
+mutually exclusive.
+
 ## Expert Mode: Standalone User VM
 
 > **Warning:** This is an expert-level feature intended for low-level debugging and kernel

--- a/doc/run-windows.md
+++ b/doc/run-windows.md
@@ -165,6 +165,17 @@ $env:RUST_LOG = "debug"
 .\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
 ```
 
+By default, `nanvixd`'s own structured (`logrus`) records are written to an auto-named file
+(`nanvixd_<timestamp>.log`) inside the log directory (overridable via `-log-dir <dir>`). Pass
+`-log-to-stdout` to route those records to stdout instead:
+
+```powershell
+.\bin\nanvixd.exe -log-to-stdout -- .\bin\hello-rust-nostd.elf
+```
+
+This is useful when a parent process captures `nanvixd`'s stdout and forwards it to its own
+log sink. `-log-to-stdout` and `-log-dir` are mutually exclusive.
+
 ## Expert Mode: Standalone UserVM
 
 > **Warning:** This is an expert-level feature intended for low-level debugging and kernel

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -90,6 +90,8 @@ pub struct Args {
     gdb_port: Option<u16>,
     /// Networking mode (applies to all deployment modes).
     networking_mode: NetworkingMode,
+    /// When `true`, route nanvixd's logs to stdout instead of a auto-named file.
+    log_to_stdout: bool,
 }
 
 //==================================================================================================
@@ -143,6 +145,8 @@ impl Args {
     pub const OPT_GDB_PORT: &'static str = "-gdb-port";
     /// Command-line flag that enables host networking for the guest.
     pub const OPT_ALLOW_HOST_NETWORKING: &'static str = "-allow-host-networking";
+    /// Command-line flag that routes nanvixd's logs to stdout instead of the auto-named file.
+    pub const OPT_LOG_TO_STDOUT: &'static str = "-log-to-stdout";
 
     ///
     /// # Description
@@ -180,6 +184,7 @@ impl Args {
         let mut hwloc: Option<HwLoc> = None;
         let mut netns_pool_size: usize = Self::DEFAULT_NETNS_POOL_SIZE;
         let mut log_directory: String = DEFAULT_LOG_DIRECTORY.to_string();
+        let mut log_directory_set: bool = false;
         let mut l2: bool = false;
         let mut l2_snapshot_path: String = String::new();
         let mut control_plane_socket_type: Option<SocketType> = None;
@@ -194,6 +199,7 @@ impl Args {
         #[cfg(feature = "gdb")]
         let mut gdb_port: Option<u16> = None;
         let mut networking_mode: NetworkingMode = NetworkingMode::Disabled;
+        let mut log_to_stdout: bool = false;
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -268,6 +274,7 @@ impl Args {
                 Self::OPT_LOG_DIRECTORY => {
                     i += 1;
                     log_directory = args[i].clone();
+                    log_directory_set = true;
                 },
                 Self::OPT_NETNS_POOL_SIZE => {
                     i += 1;
@@ -345,12 +352,25 @@ impl Args {
                 Self::OPT_ALLOW_HOST_NETWORKING => {
                     networking_mode = NetworkingMode::Enabled;
                 },
+                Self::OPT_LOG_TO_STDOUT => {
+                    log_to_stdout = true;
+                },
                 arg => {
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
             }
 
             i += 1;
+        }
+
+        // -log-to-stdout and -log-dir are mutually exclusive: -log-to-stdout routes nanvixd's
+        // logs to stdout, making an explicit log directory meaningless.
+        if log_to_stdout && log_directory_set {
+            anyhow::bail!(
+                "{} and {} are mutually exclusive",
+                Self::OPT_LOG_TO_STDOUT,
+                Self::OPT_LOG_DIRECTORY,
+            );
         }
 
         // If we set the l2 snapshot path, but do not enable l2, we have an invalid configuration.
@@ -466,6 +486,7 @@ impl Args {
             #[cfg(feature = "gdb")]
             gdb_port,
             networking_mode,
+            log_to_stdout,
         })
     }
 
@@ -522,7 +543,9 @@ Options:
   {kernel_args} <args>                      Pass kernel arguments to guest control registers \
              (standalone mode only).
   {allow_host_networking}                   Enable host networking for the guest (disabled when \
-             omitted).{gdb_port_line}
+             omitted).
+  {log_to_stdout}                          Route nanvixd's own logrus output to stdout instead of \
+             a file in {log_dir} (file logger is otherwise the default).{gdb_port_line}
 ",
             http_usage = http_usage,
             program_name = program_name,
@@ -545,6 +568,7 @@ Options:
             mount = Self::OPT_MOUNT_DIRECTORY,
             kernel_args = Self::OPT_KERNEL_ARGS,
             allow_host_networking = Self::OPT_ALLOW_HOST_NETWORKING,
+            log_to_stdout = Self::OPT_LOG_TO_STDOUT,
             gdb_port_line = if cfg!(feature = "gdb") {
                 "\n  -gdb-port <port>                         GDB server port (standalone mode \
                  only)."
@@ -832,5 +856,71 @@ Options:
     /// Returns the networking mode.
     pub fn networking_mode(&self) -> NetworkingMode {
         self.networking_mode
+    }
+
+    /// When `true`, nanvixd should route its logrus output to stdout
+    /// instead of the file logger. See [`Self::OPT_LOG_TO_STDOUT`].
+    pub fn log_to_stdout(&self) -> bool {
+        self.log_to_stdout
+    }
+}
+
+//==================================================================================================
+// Unit tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(extras: &[&str]) -> Vec<String> {
+        let mut v: Vec<String> = vec!["nanvixd".to_string()];
+        for s in extras {
+            v.push((*s).to_string());
+        }
+        v
+    }
+
+    #[test]
+    fn log_to_stdout_defaults_to_false() {
+        let args = Args::parse(argv(&["--", "/bin/foo"])).expect("parse");
+        assert!(!args.log_to_stdout());
+    }
+
+    #[test]
+    fn log_to_stdout_flag_sets_true() {
+        let args = Args::parse(argv(&["-log-to-stdout", "--", "/bin/foo"])).expect("parse");
+        assert!(args.log_to_stdout());
+    }
+
+    #[test]
+    fn log_to_stdout_composes_with_interactive_mode() {
+        let args = Args::parse(argv(&["-log-to-stdout", "--", "/bin/foo", "arg1"])).expect("parse");
+        assert!(args.log_to_stdout());
+        assert!(args.interactive_mode());
+        assert_eq!(args.program_name(), Some("/bin/foo"));
+    }
+
+    #[test]
+    fn log_to_stdout_and_log_dir_are_mutually_exclusive() {
+        let err = Args::parse(argv(&[
+            "-log-to-stdout",
+            "-log-dir",
+            "/tmp/somewhere",
+            "--",
+            "/bin/foo",
+        ]))
+        .expect_err("parse should fail when both -log-to-stdout and -log-dir are provided");
+        let msg = format!("{err}");
+        assert!(msg.contains(Args::OPT_LOG_TO_STDOUT), "unexpected error: {msg}");
+        assert!(msg.contains(Args::OPT_LOG_DIRECTORY), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn log_dir_alone_is_accepted() {
+        let args =
+            Args::parse(argv(&["-log-dir", "/tmp/somewhere", "--", "/bin/foo"])).expect("parse");
+        assert!(!args.log_to_stdout());
+        assert_eq!(args.log_directory(), "/tmp/somewhere");
     }
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -122,7 +122,12 @@ async fn async_main() -> Result<ExitCode> {
     let args: Arc<Args> =
         Arc::new(Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?);
 
-    ::nanvix::log::init(true, DEFAULT_LOG_LEVEL, args.log_directory().to_string(), None);
+    ::nanvix::log::init(
+        !args.log_to_stdout(),
+        DEFAULT_LOG_LEVEL,
+        args.log_directory().to_string(),
+        None,
+    );
 
     print_startup_info(&args);
 


### PR DESCRIPTION
## Summary

Adds a new `-log-to-stdout` boolean flag to `nanvixd`. When set, `nanvixd` passes `log_to_file=false` to `nanvix::log::init` so logrus writes records to stdout instead of the auto-named file inside `log_directory`. Default is **off**; standalone, interactive, and multi-process callers see no behaviour change.

## Why this matters

The Nanvix containerd shim spawns `nanvixd` with `Stdio::piped()` and tees the child's stdout into a per-sandbox log file (`<bundle>/nanvixd-<UTC-ts>-<shim-pid>.log`). That file is the "one place an operator looks" for nanvixd-level diagnostics: it sits next to the OCI bundle's other artifacts and is automatically cleaned by containerd on container Delete.

Without this flag, `nanvix::log::init` is always called with `log_to_file=true`, so logrus writes only to `<log_directory>/nanvixd_<ts>.log` — a path the shim does not pass in and the operator does not know about. The shim's child-pipe tee captures nothing useful (only panics or pre-init eprintln output).

## Why a flag instead of always-duplicating

A simpler approach would have been to modify `syslog::init` so that the `log_to_file=true` branch also calls `flexi_logger::Logger::duplicate_to_stdout(Duplicate::All)`, producing both a file and a stdout copy of every record. We considered and rejected that:

- It silently changes the semantics of `log_to_file=true` from "file XOR stdout" to "file AND stdout". Callers reading the API would still expect file-only behaviour; the duplication would be invisible at the call site.
- Once the shim's child-pipe tee captures the logrus stream, the separately-named `nanvixd_<ts>.log` file in `log_directory` is redundant — two files with identical content, only one of which the operator can find.

With a per-caller flag the existing semantic stays clean ("file XOR stdout"), and each caller picks the appropriate destination at startup. `syslog::init`'s API is unchanged.

## Tests

```
cargo test -p nanvixd --lib args::tests::log_to_stdout   # 3 passed
```

- `log_to_stdout_defaults_to_false` — verifies the default is `false` when the flag is absent.
- `log_to_stdout_flag_sets_true` — verifies the flag sets the field.
- `log_to_stdout_composes_with_interactive_mode` — flag is compatible with interactive mode (the only mode currently usable on every supported target).

`z.ps1 build`, `z.ps1 build -- format-check`, `z.ps1 build -- lint-check`, and `z.ps1 build -- spellcheck` all pass on Windows.

## End-to-end verification

On the test pool, with this patch + the matching shim change (`shim: pass -log-to-stdout to nanvixd`):

- After a python-http pod run, `<bundle>/nanvixd-<UTC-ts>-<shim-pid>.log` contains 32 KB of logrus records prefixed by the shim's `[stdout]` tee marker.
- No `nanvixd_<ts>.log` exists in either the bundle dir or `log_directory` — confirms the file logger did not run.

## Notes for reviewers

- Self-contained patch. Two files, ~70 lines net (with tests).
- Independent of the other Windows-shim PRs (#2389, #2390, #2391). Apply at any point.
- Useful only when nanvixd is run by a parent that captures its stdout; the file logger remains the right default for ad-hoc and CI runs.
