### PR TITLE
[uservm] Fix pvclock time regression across WHP snapshots

### DIFF
--- a/doc/snapshotting.md
+++ b/doc/snapshotting.md
@@ -1,0 +1,242 @@
+# Deterministic Snapshotting in Standalone Mode
+
+This document describes guidelines for taking and restoring deterministic snapshots in Nanvix
+standalone build modes, with emphasis on interactions with RAMFS and host-mounted filesystems.
+
+## 1. Overview
+
+A snapshot captures the full execution state of a Nanvix guest VM at a specific point in time,
+enabling fast warm-start restores that skip kernel boot, initrd loading, and daemon initialization.
+Snapshots are supported only in standalone builds (`DEPLOYMENT_MODE=standalone`).
+
+A snapshot consists of two files stored in `snapshots/` relative to the working directory:
+
+| Platform | Memory file | State file |
+| --- | --- | --- |
+| Linux/KVM | `snapshots/<stem>.vmem` | `snapshots/<stem>.kvm.json` |
+| Windows/WHP | `snapshots/<stem>.vmem` | `snapshots/<stem>.whp.cbor` |
+
+Where `<stem>` is derived from the kernel filename (e.g., `kernel` from `bin/kernel.elf`).
+
+## 2. What a Snapshot Captures
+
+### 2.1 Deterministic State (Included)
+
+| Component | Storage | Notes |
+| --- | --- | --- |
+| Guest physical memory | `.vmem` file | All pages, including kernel heap, stacks, and daemon data |
+| vCPU registers | State file | RIP, RSP, general-purpose, segment, control registers |
+| Interrupt controller | State file | LAPIC/IOAPIC state |
+| Timer state | State file | PIT/LAPIC timer configuration |
+| RAMFS contents | Guest memory | RAMFS is loaded into guest physical memory; any modifications are captured |
+| vfsd state | Guest memory | File descriptor table, pending queue, hostfs enabled flag |
+
+### 2.2 Non-Deterministic State (Not Included)
+
+| Component | Reason |
+| --- | --- |
+| Host TSC value | Host CPU timestamp counter continues independently |
+| Wall-clock time | `pvclock boot_time_ns` is not re-written on restore |
+| IKC channels | Host-side Tokio mpsc channels are recreated on each spawn |
+| hostfsd worker thread | Host OS thread with open file descriptors; spawned fresh |
+| Host file descriptors | Kernel fd table entries are per-process, not serialized |
+| Network sockets | Host kernel state; not captured |
+
+## 3. Guidelines for Deterministic Snapshots
+
+### 3.1 Rule: Snapshot Before Mounting HostFS
+
+To guarantee deterministic restore, **take the snapshot before any host-mounted filesystem
+operations**:
+
+```text
+boot → daemon init → [snapshot] → mount hostfs → workload
+```
+
+This ensures:
+
+- `HOSTFS_ENABLED` is `false` in the snapshot — no hostfs routing occurs on restore until
+  explicitly re-mounted.
+- The vfsd pending queue is empty — no orphaned IKC operations waiting for responses that
+  will never arrive.
+- The fd table contains no hostfs-backed descriptors — no stale `remote_fd` references to
+  non-existent host file handles.
+- RAMFS state is fully self-contained in guest memory — byte-for-byte reproducible.
+
+### 3.2 Rule: RAMFS State is Part of the Snapshot
+
+RAMFS data resides entirely in guest physical memory. Any files created, modified, or deleted
+on RAMFS before the snapshot are captured and restored exactly. This makes RAMFS the safe
+filesystem for pre-populating guest state before snapshotting:
+
+```text
+boot → create files on RAMFS → [snapshot] → restore (files are present)
+```
+
+### 3.3 Rule: HostFS Reinitializes on Restore
+
+On snapshot restore, the host-side `standalone_io_handler` spawns a fresh `hostfsd-worker`
+thread. This worker has:
+
+- No open file descriptors from the previous session.
+- No knowledge of the guest's pre-snapshot hostfs state.
+- A clean mapping to the `-mount` directory (if provided).
+
+The guest must call `mount("", "/mnt", "hostfs", 0)` after restore to establish a new
+hostfs session.
+
+### 3.4 Rule: One Snapshot Per VM Lifetime
+
+The kernel grants exactly one snapshot opportunity per boot, gated by the `snapshot` kernel
+argument. After the snapshot is taken, subsequent `snapshot()` calls return an error.
+
+## 4. Snapshot Workflow
+
+### 4.1 Taking a Snapshot (Cold Boot Phase)
+
+```text
+nanvixd -snapshot bin/kernel.elf -- bin/snapshot-program.initrd
+```
+
+The guest program triggers the snapshot via:
+
+```rust
+::sys::kcall::pm::snapshot()?;
+```
+
+For C callers, the equivalent is:
+
+```c
+int ret = __kcall_snapshot();
+assert(ret == 0);
+```
+
+This issues a kernel call that writes to I/O port `0x604` with the snapshot command. The VMM
+intercepts the port-I/O exit, serializes guest memory and CPU state to disk, then allows the
+guest to continue (or exit).
+
+**Prerequisites:**
+
+- The kernel must be booted with the `"snapshot"` kernel argument.
+- The `snapshots/` directory must exist.
+- Standalone build mode is required.
+
+### 4.2 Restoring from a Snapshot (Warm Start)
+
+```text
+nanvixd -snapshot bin/kernel.elf -mount ./data -- bin/workload.initrd
+```
+
+When `-snapshot` points to an existing snapshot, the restore path:
+
+1. Creates VM infrastructure (partition, virtual memory, vCPU).
+2. **Skips** kernel, initrd, and RAMFS loading entirely.
+3. Maps the `.vmem` file as guest physical memory (COW on WHP, `MAP_FIXED` on KVM).
+4. Restores vCPU registers, interrupt controller, and timer state from the state file.
+5. Sets `skip_next_snapshot = true` to prevent re-triggering.
+6. Resumes execution from the instruction following the snapshot call.
+
+The guest resumes as if `snapshot()` just returned `Ok(())`.
+
+### 4.3 The `skip_next_snapshot` Mechanism
+
+On KVM, the vCPU's RIP remains on the `out` instruction that triggered the snapshot (KVM
+does not advance RIP for I/O exits). On restore, KVM re-executes that instruction, generating
+another snapshot command exit. The `skip_next_snapshot` flag causes the VMM to silently skip
+this re-triggered request.
+
+On WHP, RIP is advanced past the `out` instruction before the exit is delivered, so
+re-triggering does not occur. The guard is present defensively.
+
+## 5. Interaction with Host-Mounted Filesystem
+
+### 5.1 Safe Pattern: Snapshot Before Mount
+
+```text
+[Cold boot]
+  kernel boots → procd/memd/vfsd initialize → snapshot()
+
+[Warm restore]
+  resume → mount("", "/mnt", "hostfs", 0) → open/read/write on /mnt → umount → exit
+```
+
+In this pattern:
+
+- The snapshot contains only kernel + daemon initialization state.
+- HostFS is mounted fresh after each restore with a clean hostfsd worker.
+- Each restore is deterministic regardless of host directory contents at snapshot time.
+
+### 5.2 Unsafe Pattern: Snapshot After Mount (Avoid)
+
+```text
+[Cold boot]
+  kernel boots → mount hostfs → open files → snapshot()  ← UNSAFE
+
+[Warm restore]
+  resume → use stale FDs → UNDEFINED BEHAVIOR
+```
+
+Problems with this pattern:
+
+- Guest FDs reference `remote_fd` values from the old hostfsd worker.
+- The new hostfsd worker has no mapping for those remote FDs.
+- Pending IKC operations in the queue will never receive responses.
+- Callers block indefinitely or receive unexpected errors.
+
+### 5.3 Future: Hostfs-Aware Snapshots
+
+If hostfs-aware snapshots become necessary, the restore path would need to:
+
+1. Call `PendingQueue::drain_with_error()` to fail all in-flight operations.
+2. Invalidate all FDs marked as hostfs-backed (`is_hostfs_remote`).
+3. Signal the guest to re-mount hostfs, re-establishing the session.
+
+The `drain_with_error()` method exists in the codebase as recovery infrastructure but is
+not yet wired into the restore path.
+
+## 6. Warm-Start Benchmark Pattern
+
+The canonical warm-start benchmark demonstrates the correct snapshot usage:
+
+**Phase 1 — Create snapshot (once):**
+
+```rust
+UserVm::spawn(UserVmArgs {
+    kernel_filename: "bin/kernel.elf",
+    initrd_filename: Some("snapshot-rust-nostd.elf"),
+    kernel_args: Some("snapshot"),  // grants one-shot permission
+    snapshot_path: None,            // cold boot
+    ramfs_filename: None,
+    ..
+});
+// Guest calls snapshot(), VMM saves state, guest exits.
+```
+
+**Phase 2 — Measure restore latency (N iterations):**
+
+```rust
+let start = Instant::now();
+UserVm::spawn(UserVmArgs {
+    kernel_filename: "bin/kernel.elf",
+    initrd_filename: None,                          // not needed
+    kernel_args: None,                              // not needed
+    snapshot_path: Some("bin/kernel.elf"),           // triggers restore
+    mount_directory: Some("./data".to_string()),    // hostfs available post-restore
+    ..
+});
+// Guest resumes, mounts hostfs, runs workload, exits.
+latencies.push(start.elapsed());
+```
+
+## 7. Checklist for Deterministic Snapshots
+
+- [ ] Build with `DEPLOYMENT_MODE=standalone`.
+- [ ] Pass `"snapshot"` as a kernel argument during the cold-boot phase.
+- [ ] Ensure `snapshots/` directory exists before taking the snapshot.
+- [ ] Take the snapshot **before** calling `mount("", "/mnt", "hostfs", 0)`.
+- [ ] Do not hold open hostfs file descriptors at snapshot time.
+- [ ] Ensure the vfsd pending queue is empty (no in-flight IKC operations).
+- [ ] On restore, provide `-mount <dir>` if hostfs access is needed post-restore.
+- [ ] On restore, the guest must explicitly mount hostfs again.
+- [ ] RAMFS state from before the snapshot is available immediately on restore.
+- [ ] Do not rely on wall-clock time being consistent across restores.

--- a/src/benchmarks/snapshot-rust-nostd/src/main.rs
+++ b/src/benchmarks/snapshot-rust-nostd/src/main.rs
@@ -27,6 +27,6 @@ use ::sys::error::Error;
 ///
 #[unsafe(no_mangle)]
 pub fn main() -> Result<(), Error> {
-    ::sys::kcall::pm::__kcall_snapshot()?;
+    ::sys::kcall::pm::snapshot()?;
     Ok(())
 }

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -705,13 +705,31 @@ pub fn __kcall_set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
-pub fn __kcall_snapshot() -> Result<(), Error> {
+pub fn snapshot() -> Result<(), Error> {
     let result: i64 = kcall0!(KcallNumber::Snapshot.into());
 
+    // NOTE: errors are unlikely because snapshot typically succeeds.
     if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to snapshot()"))
     } else {
         Ok(())
+    }
+}
+
+///
+/// # Description
+///
+/// Creates a snapshot of the virtual machine. The snapshot captures all guest memory and
+/// processor state into files managed by the VMM.
+///
+/// # Returns
+///
+/// Returns 0 on success, or a negative error code on failure.
+///
+#[unsafe(no_mangle)]
+pub extern "C" fn __kcall_snapshot() -> i32 {
+    match snapshot() {
+        Ok(()) => 0,
+        Err(e) => -(e.code as i32),
     }
 }

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -306,6 +306,10 @@ struct WhpSnapshot {
     guest_state: GuestState,
     /// Full vCPU register and LAPIC state.
     vcpu_state: vcpu::VcpuState,
+    /// Pvclock `system_time` value (nanoseconds) at the moment the snapshot was taken.
+    /// On restore, this becomes the time base so the guest sees monotonically advancing time.
+    #[serde(default)]
+    pvclock_time_ns: u64,
 }
 
 //==================================================================================================
@@ -340,6 +344,13 @@ pub struct Vmm {
     shutdown_flag: Arc<AtomicBool>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorWhpHandle>>,
+    /// Pvclock time base in nanoseconds. When restoring from a snapshot, this is set to
+    /// the `system_time` value at snapshot time so that the guest sees monotonically
+    /// increasing time (base + run-loop elapsed).
+    pvclock_time_base_ns: Arc<std::sync::atomic::AtomicU64>,
+    /// Last pvclock `system_time` value (nanoseconds) written to the guest. Used by
+    /// `create_snapshot` to persist the current time without needing access to `loop_start`.
+    pvclock_last_written_ns: Arc<std::sync::atomic::AtomicU64>,
     /// Performance timings collector for fine-grained startup breakdown.
     #[cfg(feature = "profile-time")]
     perf_timings: PerfTimings,
@@ -639,6 +650,8 @@ impl Vmm {
                 skip_next_snapshot: false,
                 snapshot_allowed,
             })),
+            pvclock_time_base_ns: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            pvclock_last_written_ns: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             #[cfg(feature = "profile-time")]
             perf_timings,
             guest_profiler: None,
@@ -763,11 +776,17 @@ impl Vmm {
             // exits. The guest kernel tolerates stale system_time values
             // within a few milliseconds.
             if last_pvclock_update.elapsed() >= PVCLOCK_UPDATE_INTERVAL {
+                let pvclock_base: u64 = self
+                    .pvclock_time_base_ns
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                let system_time_ns: u64 = pvclock_base + loop_start.elapsed().as_nanos() as u64;
                 Self::update_pvclock(
                     &mut self.vmem.blocking_lock(),
                     &mut pvclock_version,
-                    loop_start.elapsed().as_nanos() as u64,
+                    system_time_ns,
                 );
+                self.pvclock_last_written_ns
+                    .store(system_time_ns, std::sync::atomic::Ordering::Relaxed);
                 last_pvclock_update = Instant::now();
             }
 
@@ -1191,17 +1210,28 @@ impl Vmm {
             anyhow::bail!(reason)
         }
 
-        // Save vCPU and guest state.
+        // Capture the last pvclock system_time written to the guest so restore can
+        // use it as the time base, ensuring monotonically advancing guest time.
+        let pvclock_time_ns: u64 = self
+            .pvclock_last_written_ns
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        // Save vCPU, guest state, and pvclock time.
         let whp_snapshot = WhpSnapshot {
             guest_state: self.guest.lock().await.save_state()?,
             vcpu_state: self.vcpu.lock().await.save_state()?,
+            pvclock_time_ns,
         };
 
         let mut file: File = File::create(&whp_filepath)?;
         match ::serde_cbor::to_vec(&whp_snapshot) {
             Ok(buffer) => {
                 file.write_all(&buffer)?;
-                trace!("create_snapshot(): wrote {} bytes to WHP snapshot file", buffer.len());
+                trace!(
+                    "create_snapshot(): wrote {} bytes to WHP snapshot file \
+                     (pvclock_ns={pvclock_time_ns})",
+                    buffer.len()
+                );
                 Ok(())
             },
             Err(e) => {
@@ -1266,6 +1296,15 @@ impl Vmm {
             .lock()
             .await
             .load_state(&whp_snapshot.vcpu_state)?;
+
+        // Restore pvclock time base so the run loop resumes with monotonically advancing
+        // time: system_time = snapshot_time + new_loop_elapsed.
+        let restored_time_ns: u64 = whp_snapshot.pvclock_time_ns;
+        self.pvclock_time_base_ns
+            .store(restored_time_ns, std::sync::atomic::Ordering::Relaxed);
+        self.pvclock_last_written_ns
+            .store(restored_time_ns, std::sync::atomic::Ordering::Relaxed);
+        trace!("load_snapshot(): restored pvclock_time_base_ns={restored_time_ns}");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fix guest clock regression after restoring from a WHP snapshot and add documentation for the snapshotting subsystem.

## Changes

- **`[sys]` Refactor snapshot kcall** — Split `__kcall_snapshot()` into an idiomatic Rust `snapshot()` wrapper (returns `Result<(), Error>`) and a C-compatible `extern "C"` shim that translates the result to an `i32` return code.
- **`[uservm]` Persist pvclock time across snapshots** — Track the last pvclock `system_time` written to the guest via two `AtomicU64` fields (`pvclock_time_base_ns`, `pvclock_last_written_ns`). On snapshot, persist the current time; on restore, reload it as the base so the run loop computes `system_time = base + loop_elapsed`, ensuring monotonically advancing guest time.
- **`[doc]` Add snapshotting usage guidelines** — New `doc/snapshotting.md` covering deterministic snapshot design, safe/unsafe patterns with hostfs, the warm-start benchmark workflow, and a correctness checklist.

## Problem

Previously, `system_time` was computed purely from run-loop elapsed time, resetting to zero on every restore. This caused the guest clock to jump backwards, breaking any guest-side time monotonicity assumptions.