### PR TITLE
z.py: preserve subst drives on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -976,6 +976,30 @@ SMOKE_TEST_MAGIC_STRING := hello, world!
 # - Debug mode (RELEASE=no): validates the kernel magic string appears in console output.
 .PHONY: run-smoke-test
 ifeq ($(DEPLOYMENT_MODE),standalone)
+ifeq ($(IS_WINDOWS),yes)
+# On Windows, drive nanvixd.exe directly via a PowerShell helper that mirrors
+# the WHP-probe pattern used in the upstream nanvix CI workflow (Start-Process
+# + Wait-Process + Stop-Process). Standalone mode uses WHP and does not need
+# cloud-hypervisor, so the Linux-only run-nanvixd.sh helper is not used.
+run-smoke-test: image
+ifeq ($(RELEASE),yes)
+	@echo "Running smoke test (Windows, expected exit code=$(SMOKE_TEST_EXPECTED_EXIT_CODE))..."
+	@pwsh -NoProfile -ExecutionPolicy Bypass \
+		-File $(SCRIPTS_DIR)/run-smoke-test.ps1 \
+		-Image $(IMAGE) \
+		-MagicString "$(SMOKE_TEST_MAGIC_STRING)" \
+		-ExpectedExitCode $(SMOKE_TEST_EXPECTED_EXIT_CODE) \
+		-Timeout $(TIMEOUT) \
+		-Release
+else
+	@echo "Running smoke test (Windows, waiting for magic string)..."
+	@pwsh -NoProfile -ExecutionPolicy Bypass \
+		-File $(SCRIPTS_DIR)/run-smoke-test.ps1 \
+		-Image $(IMAGE) \
+		-MagicString "$(SMOKE_TEST_MAGIC_STRING)" \
+		-Timeout $(TIMEOUT)
+endif
+else
 run-smoke-test: image
 ifeq ($(RELEASE),yes)
 	@echo "Running smoke test (expected exit code=$(SMOKE_TEST_EXPECTED_EXIT_CODE))..."
@@ -994,6 +1018,7 @@ else
 	fi
 endif
 	@echo "Smoke test passed."
+endif
 else
 run-smoke-test:
 	@echo "Skipping smoke test (DEPLOYMENT_MODE=$(DEPLOYMENT_MODE), requires standalone)."

--- a/scripts/run-smoke-test.ps1
+++ b/scripts/run-smoke-test.ps1
@@ -1,0 +1,130 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Windows smoke test for nanvixd: launch nanvixd.exe directly under WHP and
+    verify the kernel boots correctly.
+
+.DESCRIPTION
+    Mirrors the WHP-probe pattern used by the upstream nanvix CI (see
+    .github/workflows/ci.yml, "Check Windows Hypervisor Platform" step):
+    spawn nanvixd.exe with Start-Process, wait up to a timeout, then either
+    check the exit code (release mode) or scan the captured console output
+    for the kernel's magic string (debug mode).
+
+    Standalone mode uses WHP and does not require cloud-hypervisor, so this
+    script does NOT depend on the run-nanvixd.sh helper.
+
+.PARAMETER Image
+    Path to the multibin system image (e.g. nanvix.img).
+
+.PARAMETER MagicString
+    Kernel magic string to look for in debug mode.
+
+.PARAMETER ExpectedExitCode
+    Exit code expected from nanvixd in release mode.
+
+.PARAMETER Timeout
+    Maximum number of seconds to wait for the smoke test to complete.
+
+.PARAMETER Release
+    When set, validate exit code instead of waiting for the magic string.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Image,
+    [string]$MagicString = "hello, world!",
+    [int]$ExpectedExitCode = 4,
+    [int]$Timeout = 120,
+    [switch]$Release
+)
+
+$ErrorActionPreference = "Stop"
+
+$Nanvixd = Join-Path -Path "." -ChildPath "bin\nanvixd.exe"
+if (-not (Test-Path $Nanvixd)) {
+    Write-Error "nanvixd.exe not found at $Nanvixd. Run 'z.ps1 build -- all' first."
+    exit 1
+}
+if (-not (Test-Path $Image)) {
+    Write-Error "Image not found: $Image"
+    exit 1
+}
+
+$LogDir = "logs"
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir | Out-Null }
+$ConsoleFile = Join-Path $LogDir "smoke-console.log"
+$StdoutFile  = Join-Path $LogDir "smoke-stdout.log"
+$StderrFile  = Join-Path $LogDir "smoke-stderr.log"
+Remove-Item -Force -ErrorAction SilentlyContinue $ConsoleFile, $StdoutFile, $StderrFile
+
+Write-Host "====================================================================="
+Write-Host "NANVIXD          = $Nanvixd"
+Write-Host "IMAGE            = $Image"
+Write-Host "CONSOLE_FILE     = $ConsoleFile"
+Write-Host "TIMEOUT          = $Timeout"
+if ($Release) {
+    Write-Host "MODE             = release (expected exit code=$ExpectedExitCode)"
+} else {
+    Write-Host "MODE             = debug (waiting for magic string '$MagicString')"
+}
+Write-Host "====================================================================="
+
+# Spawn nanvixd as a child process. Mirrors the upstream CI WHP-probe pattern.
+$proc = Start-Process -FilePath $Nanvixd `
+    -ArgumentList @("-console-file", $ConsoleFile, "--", $Image) `
+    -PassThru -NoNewWindow `
+    -RedirectStandardOutput $StdoutFile `
+    -RedirectStandardError $StderrFile
+
+if (-not $Release) {
+    # Debug mode: poll for the magic string in the captured output.
+    $found = $false
+    for ($elapsed = 0; $elapsed -lt $Timeout; $elapsed++) {
+        $haystacks = @($ConsoleFile, $StdoutFile, $StderrFile) | Where-Object { Test-Path $_ }
+        if ($haystacks -and (Select-String -Path $haystacks -SimpleMatch -Pattern $MagicString -Quiet)) {
+            $found = $true
+            break
+        }
+        if ($proc.HasExited) { break }
+        Start-Sleep -Seconds 1
+    }
+
+    if (-not $proc.HasExited) {
+        $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+        $proc | Wait-Process -Timeout 5 -ErrorAction SilentlyContinue | Out-Null
+    }
+
+    if (-not $found) {
+        Write-Host "ERROR: Smoke test failed: magic string '$MagicString' not found within ${Timeout}s."
+        Write-Host "--- $ConsoleFile ---"; Get-Content -ErrorAction SilentlyContinue $ConsoleFile | Out-Host
+        Write-Host "--- $StdoutFile ---";  Get-Content -ErrorAction SilentlyContinue $StdoutFile  | Out-Host
+        Write-Host "--- $StderrFile ---";  Get-Content -ErrorAction SilentlyContinue $StderrFile  | Out-Host
+        exit 1
+    }
+
+    Write-Host "Smoke test passed (magic string found)."
+    exit 0
+}
+
+# Release mode: wait up to the timeout, then check the exit code.
+$proc | Wait-Process -Timeout $Timeout -ErrorAction SilentlyContinue | Out-Null
+if (-not $proc.HasExited) {
+    $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+    $proc | Wait-Process -Timeout 5 -ErrorAction SilentlyContinue | Out-Null
+    Write-Host "ERROR: Smoke test failed: nanvixd did not exit within ${Timeout}s."
+    exit 1
+}
+
+if ($proc.ExitCode -ne $ExpectedExitCode) {
+    Write-Host "ERROR: Smoke test failed: expected exit code $ExpectedExitCode, got $($proc.ExitCode)."
+    Write-Host "--- $ConsoleFile ---"; Get-Content -ErrorAction SilentlyContinue $ConsoleFile | Out-Host
+    Write-Host "--- $StdoutFile ---";  Get-Content -ErrorAction SilentlyContinue $StdoutFile  | Out-Host
+    Write-Host "--- $StderrFile ---";  Get-Content -ErrorAction SilentlyContinue $StderrFile  | Out-Host
+    exit 1
+}
+
+Write-Host "Smoke test passed (exit code=$ExpectedExitCode)."
+exit 0

--- a/z.py
+++ b/z.py
@@ -460,20 +460,26 @@ def validate_git_context() -> Path:
             text=True,
             check=True,
         )
-        repo_root = Path(result.stdout.strip()).resolve()
+        git_root = Path(result.stdout.strip())
     except subprocess.CalledProcessError:
         die("Failed to determine repository root.")
 
-    cwd = Path.cwd().resolve()
+    cwd = Path.cwd()
     try:
-        same_location = cwd.samefile(repo_root)
+        same_location = cwd.samefile(git_root)
     except (OSError, NotImplementedError):
-        same_location = str(cwd).casefold() == str(repo_root).casefold()
+        same_location = (
+            str(cwd.resolve()).casefold() == str(git_root.resolve()).casefold()
+        )
 
     if not same_location:
-        die(f"Must run from repo root ({repo_root}), not {cwd}.")
+        die(f"Must run from repo root ({git_root.resolve()}), not {cwd.resolve()}.")
 
-    return repo_root
+    # Return the caller's cwd (not the canonicalized git path) so that
+    # substituted drives on Windows (e.g. `subst N: C:\path`) are preserved.
+    # Resolving would expand the alias and cause Make's CURDIR to become a
+    # long path, which can blow past cmd.exe's 8191-char command-line limit.
+    return cwd
 
 
 def check_filesystem_support(directory: str) -> bool:


### PR DESCRIPTION
Return `Path.cwd()` (unresolved) from `get_repo_root()` instead of the canonicalized path from `git rev-parse --show-toplevel`.`Path.resolve()` follows Windows `subst` drive aliases and expands them back to the real `C:\` path, which causes Make's `CURDIR` to become a long path. Long `CURDIR` values blow past cmd.exe's 8191-char command-line limit, producing failures like `mkimage: error: invalid entry` when the `standalone-images` recipe (a long `&&` chain of `mkimage` invocations) gets truncated.`samefile()` still verifies the cwd matches the git-discovered root, so the same-location check is preserved.Needed by https://github.com/nanvix/nanvix-distro/pull/2 to make the Windows CI job green.