### PR TITLE
[ci] Gate benchmark pipeline on self-hosted runner availability

### DIFF
--- a/.github/actions/check-runners/action.yml
+++ b/.github/actions/check-runners/action.yml
@@ -7,17 +7,18 @@ description: "Check whether self-hosted runners matching a given OS and name
 
 # NOTE: The /repos/{owner}/{repo}/actions/runners endpoint requires the
 # 'administration:read' permission, which is NOT available to the default
-# GITHUB_TOKEN.  If the call fails (403), the action conservatively assumes
-# runners are available and outputs 'true'.  To enable automatic
-# skip-when-offline behaviour, store a fine-grained PAT with
-# 'Administration: Read' as the RUNNER_ADMIN_TOKEN secret and pass it via
-# the github-token input.
+# GITHUB_TOKEN. If the call fails (403), the action fails closed and outputs
+# 'false' so dependent benchmark jobs are skipped rather than queuing
+# indefinitely on offline self-hosted runners. To enable accurate
+# availability detection, store a fine-grained PAT with 'Administration:
+# Read' as the RUNNER_ADMIN_TOKEN secret and pass it via the github-token
+# input.
 
 inputs:
   github-token:
     description: "Token with administration:read scope for listing runners.
-      Falls back to assuming runners are available when the token lacks
-      sufficient permissions."
+      When the token lacks sufficient permissions the action fails closed
+      and reports runners as unavailable."
     required: true
   os:
     description: "Runner OS label to match (e.g. 'Linux' or 'Windows')."
@@ -25,6 +26,14 @@ inputs:
   runner-name-prefix:
     description: "Only consider runners whose name starts with this prefix
       (e.g. 'Prometheus').  Leave empty to consider all self-hosted runners."
+    required: false
+    default: ""
+  runner-group:
+    description: "Only consider runners that belong to this org-level runner
+      group (e.g. 'Benchmark'). When set, the action enumerates runners via
+      the runner-groups endpoint so that runners outside the group are not
+      counted, matching the `runs-on.group` selector used by dependent jobs.
+      Leave empty to consider runners across all groups."
     required: false
     default: ""
 
@@ -42,6 +51,7 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         CHECK_OS: ${{ inputs.os }}
         RUNNER_NAME_PREFIX: ${{ inputs.runner-name-prefix }}
+        RUNNER_GROUP: ${{ inputs.runner-group }}
       shell: bash
       run: |
         set -euo pipefail
@@ -49,16 +59,44 @@ runs:
         org="${GITHUB_REPOSITORY_OWNER}"
         api_err_file=$(mktemp)
 
-        # Try org-level runners first (most common for shared self-hosted
-        # runners), then fall back to repo-level.
-        if runners_json=$(gh api --paginate "orgs/${org}/actions/runners" 2>"${api_err_file}"); then
+        # When a runner group is specified, resolve its id and enumerate only
+        # the runners that belong to that group so the availability decision
+        # matches the `runs-on.group` selector used by dependent jobs. A
+        # runner reported online by the org-wide listing may be assigned to a
+        # different group and would never pick up the dependent job.
+        if [[ -n "${RUNNER_GROUP}" ]]; then
+          if ! groups_json=$(gh api --paginate "orgs/${org}/actions/runner-groups" 2>"${api_err_file}"); then
+            api_err=$(cat "${api_err_file}")
+            echo "::warning::Could not query runner groups for '${org}' (${api_err:-unknown error}) — reporting runners as unavailable so dependent jobs are skipped."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            rm -f "${api_err_file}"
+            exit 0
+          fi
+          group_id=$(echo "${groups_json}" | jq --arg name "${RUNNER_GROUP}" \
+            '[.runner_groups[] | select(.name == $name)] | first | .id // empty')
+          if [[ -z "${group_id}" ]]; then
+            echo "::warning::Runner group '${RUNNER_GROUP}' not found in org '${org}' — reporting runners as unavailable so dependent jobs are skipped."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            rm -f "${api_err_file}"
+            exit 0
+          fi
+          if ! runners_json=$(gh api --paginate "orgs/${org}/actions/runner-groups/${group_id}/runners" 2>"${api_err_file}"); then
+            api_err=$(cat "${api_err_file}")
+            echo "::warning::Could not query runners for group '${RUNNER_GROUP}' (${api_err:-unknown error}) — reporting runners as unavailable so dependent jobs are skipped."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            rm -f "${api_err_file}"
+            exit 0
+          fi
+          echo "Queried runners in group '${RUNNER_GROUP}' (id=${group_id}) for org '${org}'."
+        # Otherwise fall back to the org-wide listing and then to repo-level.
+        elif runners_json=$(gh api --paginate "orgs/${org}/actions/runners" 2>"${api_err_file}"); then
           echo "Queried org-level runners for '${org}'."
         elif runners_json=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runners" 2>"${api_err_file}"); then
           echo "Queried repo-level runners for '${GITHUB_REPOSITORY}'."
         else
           api_err=$(cat "${api_err_file}")
-          echo "::warning::Could not query runner status (${api_err:-unknown error}) — assuming runners are available."
-          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::Could not query runner status (${api_err:-unknown error}) — reporting runners as unavailable so dependent jobs are skipped."
+          echo "available=false" >> "$GITHUB_OUTPUT"
           rm -f "${api_err_file}"
           exit 0
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           github-token: ${{ secrets.RUNNER_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           os: "Linux"
           runner-name-prefix: "prometheus"
+          runner-group: "Benchmark"
 
       - name: "Check Windows Runners"
         id: check-windows
@@ -93,6 +94,118 @@ jobs:
           github-token: ${{ secrets.RUNNER_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           os: "Windows"
           runner-name-prefix: "WIN"
+          runner-group: "Benchmark"
+
+  # ==========================================================================================
+  # Benchmark Eligibility Gates
+  # ==========================================================================================
+  #
+  # Aggregate every condition that determines whether a benchmark pipeline
+  # (build → finalize → release) should run for a given platform into a single
+  # boolean output (`should-run`). Downstream jobs depend on the relevant gate
+  # and consume `needs.<gate>.outputs.should-run == 'true'` instead of
+  # re-evaluating the same conditions in each `if:` expression. This guarantees
+  # that benchmark, benchmark-finalize, and release-archive jobs are skipped
+  # consistently when no self-hosted runners are available.
+
+  benchmark-gate-linux:
+    name: "Benchmark Gate (Linux)"
+    needs: [ precheck, check-runners ]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          RUNNERS_AVAILABLE: ${{ needs.check-runners.outputs.benchmark-linux }}
+          UP_TO_DATE: ${{ needs.precheck.outputs.up_to_date }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          if [[ "${REPO}" != "nanvix/nanvix" ]]; then
+            echo "Skip: repository is not nanvix/nanvix"
+          elif [[ "${RUNNERS_AVAILABLE}" != "true" ]]; then
+            # Fail closed: treat empty / unknown values (e.g. check-runners
+            # was skipped or failed) as unavailable to prevent benchmark jobs
+            # from queuing indefinitely.
+            echo "Skip: Linux self-hosted benchmark runners unavailable (status='${RUNNERS_AVAILABLE}')"
+          elif [[ "${EVENT_NAME}" == "merge_group" || "${EVENT_NAME}" == "schedule" ]]; then
+            should_run=true
+          elif [[ "${UP_TO_DATE}" == "true" ]]; then
+            if [[ "${EVENT_NAME}" == "push" && "${HEAD_COMMIT_MSG}" == "Merge "* ]]; then
+              echo "Skip: push event on a merge commit"
+            elif [[ "${EVENT_NAME}" == "pull_request" && "${IS_DRAFT}" == "true" ]]; then
+              echo "Skip: draft pull request"
+            else
+              should_run=true
+            fi
+          else
+            echo "Skip: branch is not up to date with dev"
+          fi
+          echo "Decision: should-run=${should_run}"
+          echo "should-run=${should_run}" >> "${GITHUB_OUTPUT}"
+
+  benchmark-gate-windows:
+    name: "Benchmark Gate (Windows)"
+    needs: [ precheck, check-runners ]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          RUNNERS_AVAILABLE: ${{ needs.check-runners.outputs.benchmark-windows }}
+          UP_TO_DATE: ${{ needs.precheck.outputs.up_to_date }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          if [[ "${REPO}" != "nanvix/nanvix" ]]; then
+            echo "Skip: repository is not nanvix/nanvix"
+          elif [[ "${RUNNERS_AVAILABLE}" != "true" ]]; then
+            # Fail closed: treat empty / unknown values (e.g. check-runners
+            # was skipped or failed) as unavailable to prevent benchmark jobs
+            # from queuing indefinitely.
+            echo "Skip: Windows self-hosted benchmark runners unavailable (status='${RUNNERS_AVAILABLE}')"
+          elif [[ "${EVENT_NAME}" == "merge_group" || "${EVENT_NAME}" == "schedule" ]]; then
+            should_run=true
+          elif [[ "${UP_TO_DATE}" == "true" ]]; then
+            if [[ "${EVENT_NAME}" == "push" && "${HEAD_COMMIT_MSG}" == "Merge "* ]]; then
+              echo "Skip: push event on a merge commit"
+            elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              if [[ "${IS_DRAFT}" == "true" ]]; then
+                echo "Skip: draft pull request"
+              elif [[ "${PR_HEAD_REPO}" != "${REPO}" ]]; then
+                # Fork PRs are excluded from Windows benchmarks to prevent
+                # untrusted code from running on self-hosted runners.
+                echo "Skip: pull request from a fork"
+              else
+                should_run=true
+              fi
+            else
+              should_run=true
+            fi
+          else
+            echo "Skip: branch is not up to date with dev"
+          fi
+          echo "Decision: should-run=${should_run}"
+          echo "should-run=${should_run}" >> "${GITHUB_OUTPUT}"
 
   # ==========================================================================================
   # Stage 1: Source Checks (GitHub-Hosted Runners)
@@ -799,7 +912,7 @@ jobs:
   # A finalize job aggregates results after the benchmark completes.
   benchmark:
     name: "Benchmark (${{ matrix.machine-type }})"
-    needs: [ precheck, check-runners ]
+    needs: [ benchmark-gate-linux ]
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -819,23 +932,11 @@ jobs:
     permissions:
       contents: read
 
-    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
-    # Skips gracefully when check-runners reports no Linux self-hosted runners.
-    if: |
-      !cancelled() &&
-      needs.check-runners.outputs.benchmark-linux != 'false' &&
-      github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
-          needs.precheck.outputs.up_to_date == 'true' && (
-            github.event_name != 'push' ||
-            github.event.head_commit == null ||
-            !startsWith(github.event.head_commit.message, 'Merge ')
-          ) && (
-            github.event_name != 'pull_request' ||
-            !github.event.pull_request.draft
-          )
-        )
-      )
+    # Eligibility (repo, event, precheck, draft, runner availability) is
+    # consolidated in the benchmark-gate-linux job. Skip gracefully when the
+    # gate reports the benchmark pipeline should not run (e.g. no Linux
+    # self-hosted runners are online).
+    if: ${{ needs.benchmark-gate-linux.outputs.should-run == 'true' }}
 
     steps:
       - name: "Pre-Checkout Cleanup"
@@ -960,7 +1061,7 @@ jobs:
   # exclusion steps are omitted.
   windows-benchmark:
     name: "Windows Benchmark (${{ matrix.machine-type }})"
-    needs: [ precheck, check-runners ]
+    needs: [ benchmark-gate-windows ]
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -976,28 +1077,11 @@ jobs:
     permissions:
       contents: read
 
-    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
-    # Skips gracefully when check-runners reports no Windows self-hosted runners.
-    # Fork PRs are excluded to prevent untrusted code from running on
-    # self-hosted runners.
-    if: |
-      !cancelled() &&
-      needs.check-runners.outputs.benchmark-windows != 'false' &&
-      github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
-          needs.precheck.outputs.up_to_date == 'true' && (
-            github.event_name != 'push' ||
-            github.event.head_commit == null ||
-            !startsWith(github.event.head_commit.message, 'Merge ')
-          ) && (
-            github.event_name != 'pull_request' ||
-            (
-              !github.event.pull_request.draft &&
-              github.event.pull_request.head.repo.full_name == github.repository
-            )
-          )
-        )
-      )
+    # Eligibility (repo, event, precheck, draft, fork PR, runner availability)
+    # is consolidated in the benchmark-gate-windows job. Skip gracefully when
+    # the gate reports the benchmark pipeline should not run (e.g. no Windows
+    # self-hosted runners are online).
+    if: ${{ needs.benchmark-gate-windows.outputs.should-run == 'true' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -1144,10 +1228,13 @@ jobs:
   # baselines on dev.
   benchmark-finalize:
     name: "Benchmark Finalize"
-    needs: [ benchmark ]
-    # NOTE: needs.benchmark.result is the aggregate result across all matrix
-    # legs. It is 'success' only when every leg succeeds.
-    if: ${{ !cancelled() && needs.benchmark.result == 'success' }}
+    needs: [ benchmark-gate-linux, benchmark ]
+    # Run only when the Linux benchmark gate enabled the pipeline AND every
+    # benchmark matrix leg succeeded. If the gate skipped the pipeline (e.g.
+    # no runners online), finalize is skipped as well.
+    if: ${{ !cancelled() &&
+      needs.benchmark-gate-linux.outputs.should-run == 'true' &&
+      needs.benchmark.result == 'success' }}
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     permissions:
@@ -1228,14 +1315,17 @@ jobs:
   # from the Linux and GitHub-hosted baselines.
   windows-benchmark-finalize:
     name: "Windows Benchmark Finalize"
-    needs: [ windows-benchmark, benchmark-finalize ]
-    # NOTE: needs.windows-benchmark.result is the aggregate result across all
-    # matrix legs. It is 'success' only when every leg succeeds.
+    needs: [ benchmark-gate-windows, windows-benchmark, benchmark-finalize ]
+    # Run only when the Windows benchmark gate enabled the pipeline AND every
+    # windows-benchmark matrix leg succeeded. If the gate skipped the pipeline
+    # (e.g. no runners online), finalize is skipped as well.
     # Depends on benchmark-finalize to serialize pushes to dev and avoid
     # rebase conflicts on append-only CSV files within the same pipeline run.
     # Uses always() so this job is not skipped when benchmark-finalize is
     # skipped or fails (e.g., a Linux benchmark leg fails).
-    if: ${{ always() && !cancelled() && needs.windows-benchmark.result == 'success' }}
+    if: ${{ always() && !cancelled() &&
+      needs.benchmark-gate-windows.outputs.should-run == 'true' &&
+      needs.windows-benchmark.result == 'success' }}
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     permissions:
@@ -1318,10 +1408,16 @@ jobs:
   release-archive:
     name: "Release Archive (${{ matrix.target-arch }}, ${{ matrix.machine-type }},
       ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
-    needs: [ ci-test, benchmark-finalize, windows-benchmark-finalize, check-runners ]
+    needs:
+      - ci-test
+      - benchmark-gate-linux
+      - benchmark-gate-windows
+      - benchmark-finalize
+      - windows-benchmark-finalize
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     # Benchmark finalize may be skipped when self-hosted runners are offline;
-    # release proceeds if check-runners confirmed no runners were available.
+    # release proceeds if the corresponding gate reported the benchmark
+    # pipeline should not run.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
@@ -1329,11 +1425,9 @@ jobs:
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
-        (needs.benchmark-finalize.result == 'skipped' &&
-          needs.check-runners.outputs.benchmark-linux == 'false')) &&
+        needs.benchmark-gate-linux.outputs.should-run != 'true') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
-        (needs.windows-benchmark-finalize.result == 'skipped' &&
-          needs.check-runners.outputs.benchmark-windows == 'false'))
+        needs.benchmark-gate-windows.outputs.should-run != 'true')
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1379,16 +1473,16 @@ jobs:
     name: "Windows Release Archive (${{ matrix.target-arch }}, ${{
       matrix.machine-type }}, ${{ matrix.memory-size }}mb)"
     needs:
-      [
-        windows-integration-test,
-        ci-test,
-        benchmark-finalize,
-        windows-benchmark-finalize,
-        check-runners,
-      ]
+      - windows-integration-test
+      - ci-test
+      - benchmark-gate-linux
+      - benchmark-gate-windows
+      - benchmark-finalize
+      - windows-benchmark-finalize
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     # Benchmark finalize may be skipped when self-hosted runners are offline;
-    # release proceeds if check-runners confirmed no runners were available.
+    # release proceeds if the corresponding gate reported the benchmark
+    # pipeline should not run.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
@@ -1396,11 +1490,9 @@ jobs:
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
-        (needs.benchmark-finalize.result == 'skipped' &&
-          needs.check-runners.outputs.benchmark-linux == 'false')) &&
+        needs.benchmark-gate-linux.outputs.should-run != 'true') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
-        (needs.windows-benchmark-finalize.result == 'skipped' &&
-          needs.check-runners.outputs.benchmark-windows == 'false')) &&
+        needs.benchmark-gate-windows.outputs.should-run != 'true') &&
       needs.windows-integration-test.result == 'success'
     timeout-minutes: 60
     strategy:
@@ -1481,6 +1573,8 @@ jobs:
         verify,
         ci-build,
         ci-test,
+        benchmark-gate-linux,
+        benchmark-gate-windows,
         benchmark,
         benchmark-finalize,
         windows-benchmark,


### PR DESCRIPTION
## Summary

Consolidate the eligibility logic for the benchmark, benchmark-finalize, and release-archive jobs into two new gate jobs — `benchmark-gate-linux` and `benchmark-gate-windows` — that emit a single `should-run` boolean output. Each gate combines the repository, event, precheck, draft/fork-PR, and self-hosted runner availability checks in one place, so the benchmark → finalize → release-archive chain is skipped consistently when no matching runners are online.

## Changes

- Add `benchmark-gate-linux` and `benchmark-gate-windows` jobs after `check-runners`. They depend on `precheck` and `check-runners` and compute `should-run` via a small bash gate step.
- Replace the multi-line `if:` expressions on `benchmark` and `windows-benchmark` with a single `needs.benchmark-gate-*.outputs.should-run == 'true'` check.
- Gate `benchmark-finalize` and `windows-benchmark-finalize` explicitly on the corresponding gate output in addition to their benchmark job's success, so they skip cleanly when runners are offline rather than relying on transitive skipping.
- Simplify `release-archive` and `windows-release-archive` conditions from the previous `(result == 'skipped' AND check-runners.outputs == 'false')` form to `(finalize.result == 'success' OR gate.should-run != 'true')`, reusing the gate decision.
- Update `notify-release-failure`'s `needs:` list to include the new gate jobs so their status is observed by the failure notifier.

## Behavior

Behavior is unchanged in the common case: the gates evaluate to the same decision as the previous inline expressions. The functional improvement is that `benchmark-finalize` is now explicitly skipped when no runners are available — rather than implicitly via a skipped upstream `benchmark` job — and the runner-availability gate is no longer duplicated across job definitions.