### PR TITLE
[ci] Add explicit matrix axis to benchmark jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,6 +917,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # An explicit top-level axis is required so the matrix expands into a
+        # concrete job. With `include:` alone GitHub Actions occasionally
+        # collapses the matrix to zero combinations and reports the job as
+        # skipped even when its `if:` guard would have passed.
+        machine-type: [ microvm ]
         include:
           - machine-type: microvm
             standard-benchmarks: "boot-time cold-start cold-start-uvm concurrent
@@ -1066,6 +1071,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # An explicit top-level axis is required so the matrix expands into a
+        # concrete job. With `include:` alone GitHub Actions occasionally
+        # collapses the matrix to zero combinations and reports the job as
+        # skipped even when its `if:` guard would have passed.
+        machine-type: [ microvm ]
         include:
           - machine-type: microvm
             standard-benchmarks: "boot-time cold-start snapshot-restore vfs-bench warm-start-vmm"


### PR DESCRIPTION
## Summary

The `benchmark` and `windows-benchmark` matrix jobs use `strategy.matrix.include` with no top-level matrix axis. In that configuration GitHub Actions can fail to expand the matrix into a concrete job under specific runtime conditions, marking the job `skipped` pre-execution even when its `if:` guard would have passed.

## Root cause

The matrix-expansion regression was introduced by commit `14f17e3` (`[ci] E: Remove hyperlight machine type from CI`, May 8), which reduced the benchmark matrices from two `include:` entries (`microvm` + `hyperlight`) to one. With multiple entries, GitHub Actions can derive `machine-type` as an implicit axis from the shared key; with a single entry there is no implicit axis to expand on.

This was latent until now because the self-hosted benchmark runners were typically offline, so the benchmark gate returned `should-run=false` and the benchmark `if:` guard skipped the job *legitimately*. When the runners came back online on May 26, the underlying matrix-expansion bug surfaced for the first time on the May 27 scheduled run, breaking the release-archive condition and triggering issue #2415.

## Evidence

| Run | Date | Event | Benchmark matrix | Benchmark result |
|---|---|---|---|---|
| `25535159111` | May 8 (pre-hyperlight-removal) | schedule | `include:` with **2 entries** | ran as `Benchmark (microvm)` / `Benchmark (hyperlight)` |
| `26475897001` | May 26 21:21 | push | `include:` with 1 entry | ran as `Benchmark (microvm)` |
| `26490450088` attempts 1 & 2 | May 27 04:17 | schedule | `include:` with 1 entry | skipped, matrix unexpanded as `Benchmark (${{ matrix.machine-type }})` |

Every other matrix in `ci.yml` already has an explicit top-level axis; these two benchmark jobs were the only ones with the fragile shape, and they are exactly the two that broke.

## Change

Add an explicit `machine-type: [ microvm ]` axis to both matrices so the matrix always expands into a concrete job, regardless of `include:` quirks. `include:` continues to carry the per-machine-type parameters.

## Related

- Issue #2415
- Complementary defense-in-depth fix: #2417
