### PR TITLE
[ci] B: Allow skipped benchmark finalize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,9 +1415,11 @@ jobs:
       - benchmark-finalize
       - windows-benchmark-finalize
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
-    # Benchmark finalize may be skipped when self-hosted runners are offline;
-    # release proceeds if the corresponding gate reported the benchmark
-    # pipeline should not run.
+    # Benchmark finalize may be skipped when self-hosted runners are offline,
+    # when the gate reports the benchmark pipeline should not run, or when the
+    # matrix expansion silently elides the benchmark jobs (see #2415). Treat
+    # a skipped finalize as non-blocking for the release pipeline; only a
+    # genuine benchmark failure should block publishing.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
@@ -1425,9 +1427,9 @@ jobs:
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
-        needs.benchmark-gate-linux.outputs.should-run != 'true') &&
+        needs.benchmark-finalize.result == 'skipped') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
-        needs.benchmark-gate-windows.outputs.should-run != 'true')
+        needs.windows-benchmark-finalize.result == 'skipped')
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1480,9 +1482,11 @@ jobs:
       - benchmark-finalize
       - windows-benchmark-finalize
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
-    # Benchmark finalize may be skipped when self-hosted runners are offline;
-    # release proceeds if the corresponding gate reported the benchmark
-    # pipeline should not run.
+    # Benchmark finalize may be skipped when self-hosted runners are offline,
+    # when the gate reports the benchmark pipeline should not run, or when the
+    # matrix expansion silently elides the benchmark jobs (see #2415). Treat
+    # a skipped finalize as non-blocking for the release pipeline; only a
+    # genuine benchmark failure should block publishing.
     if: |
       !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
@@ -1490,9 +1494,9 @@ jobs:
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
-        needs.benchmark-gate-linux.outputs.should-run != 'true') &&
+        needs.benchmark-finalize.result == 'skipped') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
-        needs.benchmark-gate-windows.outputs.should-run != 'true') &&
+        needs.windows-benchmark-finalize.result == 'skipped') &&
       needs.windows-integration-test.result == 'success'
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
## Summary

The `release-archive` and `windows-release-archive` jobs previously required either `benchmark-finalize == 'success'` *or* the gate reporting `should-run != 'true'`. This conflated two distinct conditions:

1. *The benchmarks were intentionally not scheduled to run* (gate said no — runners offline, draft PR, etc.).
2. *The benchmarks completed successfully*.

When the benchmark matrix expands but the jobs end up `skipped` for any *other* reason (e.g. the GitHub Actions matrix-collapse issue seen in scheduled Run #4424 / issue #2415), the gate still reports `should-run=true` while `benchmark-finalize` is `skipped`. Neither branch of the original disjunction is satisfied, so the release pipeline is skipped and `notify-release-failure` files a spurious issue even though nothing actually failed.

## Change

Relax both release-archive `if:` conditions to treat `benchmark-finalize.result == 'skipped'` as equivalent to `'success'`. The gate-outputs branch is removed because `skipped` already covers `gate said no` (finalize is skipped in that case too).

A genuine benchmark regression still produces `benchmark-finalize.result == 'failure'`, which neither branch tolerates, so publishing remains correctly blocked on real regressions.

## Related

- Issue #2415
- Complementary to #2416 (which addresses the root-cause matrix expansion)
