### PR TITLE
[arch] Add copy-on-write flag to PTEs

### DIFF
--- a/src/libs/arch/src/x86/mem/paging/flags.rs
+++ b/src/libs/arch/src/x86/mem/paging/flags.rs
@@ -116,6 +116,22 @@ pub enum PageSizeFlag {
     Large = (1 << Self::SHIFT),
 }
 
+///
+/// # Description
+///
+/// A type that represents the copy-on-write flag of a page table entry. This is an
+/// OS-defined flag that lives in one of the architecturally-available bits (AVL,
+/// bit 9 of the x86 PTE). When set, the page is shared with another address space
+/// and writes to it must trigger a copy on the page-fault path.
+///
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CopyOnWriteFlag {
+    /// The page is not shared via copy-on-write.
+    NotCopyOnWrite = 0,
+    /// The page is shared via copy-on-write.
+    CopyOnWrite = (1 << Self::SHIFT),
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -262,6 +278,25 @@ impl PageSizeFlag {
         match value & Self::MASK {
             0 => PageSizeFlag::Standard,
             _ => PageSizeFlag::Large,
+        }
+    }
+
+    pub fn into_raw_value(self) -> PteWord {
+        self as PteWord
+    }
+}
+
+impl CopyOnWriteFlag {
+    /// Bit shift of the copy-on-write flag in the page table entry. This lives in one of
+    /// the OS-available (AVL) bits (9..=11) of the x86 PTE.
+    const SHIFT: PteWord = 9;
+    /// Bit mask of the copy-on-write flag in the page table entry.
+    const MASK: PteWord = (1 << Self::SHIFT);
+
+    pub fn from_raw_value(value: PteWord) -> Self {
+        match value & Self::MASK {
+            0 => CopyOnWriteFlag::NotCopyOnWrite,
+            _ => CopyOnWriteFlag::CopyOnWrite,
         }
     }
 

--- a/src/libs/arch/src/x86/mem/paging/pte.rs
+++ b/src/libs/arch/src/x86/mem/paging/pte.rs
@@ -13,6 +13,7 @@ use crate::{
     x86::mem::paging::{
         flags::{
             AccessedFlag,
+            CopyOnWriteFlag,
             DirtyFlag,
             PageCacheDisableFlag,
             PageWriteThroughFlag,
@@ -50,6 +51,8 @@ pub struct PageTableEntryFlags {
     accessed: AccessedFlag,
     /// Dirty flag.
     dirty: DirtyFlag,
+    /// Copy-on-write flag (OS-defined, stored in an AVL bit).
+    cow: CopyOnWriteFlag,
 }
 
 impl PageTableEntryFlags {
@@ -89,6 +92,7 @@ impl PageTableEntryFlags {
             page_cache_disable,
             accessed,
             dirty,
+            cow: CopyOnWriteFlag::NotCopyOnWrite,
         }
     }
 
@@ -114,6 +118,7 @@ impl PageTableEntryFlags {
             page_cache_disable: PageCacheDisableFlag::from_raw_value(value),
             accessed: AccessedFlag::from_raw_value(value),
             dirty: DirtyFlag::from_raw_value(value),
+            cow: CopyOnWriteFlag::from_raw_value(value),
         }
     }
 
@@ -136,6 +141,7 @@ impl PageTableEntryFlags {
         value |= self.page_cache_disable.into_raw_value();
         value |= self.accessed.into_raw_value();
         value |= self.dirty.into_raw_value();
+        value |= self.cow.into_raw_value();
 
         value
     }
@@ -208,6 +214,34 @@ impl PageTableEntryFlags {
     #[inline(always)]
     pub fn set_user_supervisor(&mut self, user_supervisor: UserSupervisorFlag) {
         self.user_supervisor = user_supervisor;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if the copy-on-write flag is set.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the copy-on-write flag is set, `false` otherwise.
+    ///
+    #[inline(always)]
+    pub fn is_cow(&self) -> bool {
+        matches!(self.cow, CopyOnWriteFlag::CopyOnWrite)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the copy-on-write flag.
+    ///
+    /// # Parameters
+    ///
+    /// - `cow`: The copy-on-write flag.
+    ///
+    #[inline(always)]
+    pub fn set_cow(&mut self, cow: CopyOnWriteFlag) {
+        self.cow = cow;
     }
 }
 
@@ -366,6 +400,32 @@ impl PageTableEntry {
     ///
     pub fn set_user_supervisor(&mut self, user_supervisor: UserSupervisorFlag) {
         self.flags.set_user_supervisor(user_supervisor);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the target page table entry is marked copy-on-write.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the entry is marked copy-on-write, `false` otherwise.
+    ///
+    pub fn is_cow(&self) -> bool {
+        self.flags.is_cow()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the copy-on-write flag in the target page table entry.
+    ///
+    /// # Parameters
+    ///
+    /// - `cow`: The copy-on-write flag.
+    ///
+    pub fn set_cow(&mut self, cow: CopyOnWriteFlag) {
+        self.flags.set_cow(cow);
     }
 }
 


### PR DESCRIPTION
Introduce a new `CopyOnWriteFlag` enum in the x86 paging flags module to represent an OS-defined copy-on-write (COW) marker stored in one of the architecturally-available (AVL) bits of a page table entry. Bit 9 is used, which is ignored by the hardware and free for OS use.

Changes:
- `src/libs/arch/src/x86/mem/paging/flags.rs`:
  - Add the `CopyOnWriteFlag` enum with `NotCopyOnWrite` and `CopyOnWrite` variants.
  - Implement `from_raw_value` and `into_raw_value` for encoding/decoding the flag from/to the raw PTE word, using `SHIFT = 9` and the corresponding `MASK`.

- `src/libs/arch/src/x86/mem/paging/pte.rs`:
  - Extend `PageTableEntryFlags` with a `cow: CopyOnWriteFlag` field.
  - Initialize `cow` to `NotCopyOnWrite` in `PageTableEntryFlags::new` and propagate it through `from_raw_value` / `into_raw_value`.
  - Add `is_cow` / `set_cow` accessors on both `PageTableEntryFlags` and `PageTableEntry` so higher-level code can query and toggle the COW state of a mapping.

This is a low-level enabler for upcoming copy-on-write support in the virtual memory subsystem (e.g. fork-style address-space duplication). It does not yet change any mapping policy: all existing entries continue to be created as `NotCopyOnWrite`, and no fault handler behavior is altered in this commit.