### PR TITLE
[hostfs-api] lstat, readlink, and symlink wire formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ name = "hostfs-api"
 version = "0.15.30"
 dependencies = [
  "sys",
+ "sysapi",
 ]
 
 [[package]]

--- a/src/libs/hostfs-api/Cargo.toml
+++ b/src/libs/hostfs-api/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib"]
 
 [dependencies]
 sys = { workspace = true }
+sysapi = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/hostfs-api/src/error.rs
+++ b/src/libs/hostfs-api/src/error.rs
@@ -17,5 +17,13 @@ pub const HOSTFS_ERR_NOT_DIR: i32 = -20;
 pub const HOSTFS_ERR_IS_DIR: i32 = -21;
 /// Error code: invalid argument.
 pub const HOSTFS_ERR_INVALID: i32 = -22;
+/// Error code: too many levels of symbolic links (ELOOP).
+pub const HOSTFS_ERR_LOOP: i32 = -40;
 /// Error code: directory not empty.
 pub const HOSTFS_ERR_NOT_EMPTY: i32 = -90;
+/// Error code: operation not supported on this host platform (EOPNOTSUPP).
+///
+/// Currently used by the symlink operation on Windows when the process lacks the
+/// privilege to create symbolic links (no Developer Mode and no
+/// `SeCreateSymbolicLinkPrivilege`).
+pub const HOSTFS_ERR_NOT_SUPPORTED: i32 = -95;

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -37,10 +37,12 @@ mod error;
 mod flush;
 pub mod long_msg;
 mod lseek;
+mod lstat;
 mod mkdir;
 mod open;
 mod read;
 mod readdir;
+mod readlink;
 mod rename;
 mod rmdir;
 mod stat;
@@ -55,6 +57,11 @@ pub use self::{
         LseekRequest,
         LseekResponse,
     },
+    lstat::{
+        file_kind,
+        LstatRequest,
+        LstatResponse,
+    },
     mkdir::MkdirRequest,
     open::{
         OpenRequest,
@@ -67,6 +74,11 @@ pub use self::{
     readdir::{
         ReadDirEntry,
         ReadDirRequest,
+    },
+    readlink::{
+        ReadlinkRequest,
+        ReadlinkResponse,
+        MAX_INLINE_READLINK_TARGET,
     },
     rename::RenameRequest,
     rmdir::RmdirRequest,
@@ -238,9 +250,11 @@ pub use self::error::{
     HOSTFS_ERR_INVALID,
     HOSTFS_ERR_IO,
     HOSTFS_ERR_IS_DIR,
+    HOSTFS_ERR_LOOP,
     HOSTFS_ERR_NOT_DIR,
     HOSTFS_ERR_NOT_EMPTY,
     HOSTFS_ERR_NOT_FOUND,
+    HOSTFS_ERR_NOT_SUPPORTED,
     HOSTFS_ERR_PERMISSION,
 };
 

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -22,6 +22,17 @@
 //! - **Rmdir**: `[op_id:4][path_len:2][path:N]`
 //! - **Mkdir**: `[op_id:4][mode:4][path_len:2][path:N]`
 //! - **Rename**: `[op_id:4][old_path_len:2][new_path_len:2][old_path:N][new_path:M]`
+//! - **Symlink**: `[op_id:4][target_len:2][linkpath_len:2][target:N][linkpath:M]`
+//! - **Readlink**: `[op_id:4][path_len:2][path:N]`
+//! - **Lstat**: `[op_id:4][path_len:2][path:N]`
+//!
+//! # Long Response Format
+//!
+//! - **Readlink response**: `[op_id:4][status:4][target_len:2][target:N]`. Used by
+//!   `HostFsReadlinkResponsePart` messages when the target string exceeds the inline
+//!   response capacity. Errors are always reported via the single-message
+//!   `HostFsReadlinkResponse` form; the multi-part response is only emitted for a
+//!   successful `readlink` whose target does not fit inline.
 
 #[cfg(feature = "std")]
 use crate::OperationId;
@@ -47,6 +58,19 @@ pub const MKDIR_HEADER_SIZE: usize = 10;
 
 /// Header size for long rename: op_id(4) + old_path_len(2) + new_path_len(2) = 8
 pub const RENAME_HEADER_SIZE: usize = 8;
+
+/// Header size for long symlink: op_id(4) + target_len(2) + linkpath_len(2) = 8
+pub const SYMLINK_HEADER_SIZE: usize = 8;
+
+/// Header size for long readlink: op_id(4) + path_len(2) = 6
+pub const READLINK_HEADER_SIZE: usize = 6;
+
+/// Header size for long lstat: op_id(4) + path_len(2) = 6
+pub const LSTAT_HEADER_SIZE: usize = 6;
+
+/// Header size for the long Readlink *response* body:
+/// `op_id(4) + status(4) + target_len(2) = 10`.
+pub const READLINK_RESPONSE_HEADER_SIZE: usize = 10;
 
 //==================================================================================================
 // Deserialization (hostfsd, std)
@@ -187,4 +211,94 @@ pub fn deserialize_long_rename(bytes: &[u8]) -> Option<LongRenameRequest> {
         old_path,
         new_path,
     })
+}
+
+/// Result of deserializing a long SYMLINK request.
+///
+/// `target` is the textual target stored in the symbolic link (interpreted verbatim;
+/// it is not validated to be a sandbox-relative path). `linkpath` is the path of the
+/// link to be created.
+#[cfg(feature = "std")]
+pub struct LongSymlinkRequest {
+    pub op_id: OperationId,
+    pub target: std::string::String,
+    pub linkpath: std::string::String,
+}
+
+/// Deserializes a long SYMLINK request from assembled bytes.
+#[cfg(feature = "std")]
+pub fn deserialize_long_symlink(bytes: &[u8]) -> Option<LongSymlinkRequest> {
+    if bytes.len() < SYMLINK_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    let target_len = u16::from_le_bytes([bytes[4], bytes[5]]) as usize;
+    let linkpath_len = u16::from_le_bytes([bytes[6], bytes[7]]) as usize;
+    if bytes.len() < SYMLINK_HEADER_SIZE + target_len + linkpath_len {
+        return None;
+    }
+    let target_start = SYMLINK_HEADER_SIZE;
+    let linkpath_start = target_start + target_len;
+    let target =
+        std::string::String::from_utf8(bytes[target_start..target_start + target_len].to_vec())
+            .ok()?;
+    let linkpath = std::string::String::from_utf8(
+        bytes[linkpath_start..linkpath_start + linkpath_len].to_vec(),
+    )
+    .ok()?;
+    Some(LongSymlinkRequest {
+        op_id,
+        target,
+        linkpath,
+    })
+}
+
+/// Result of deserializing a long READLINK request.
+#[cfg(feature = "std")]
+pub struct LongReadlinkRequest {
+    pub op_id: OperationId,
+    pub path: std::string::String,
+}
+
+/// Deserializes a long READLINK request from assembled bytes.
+#[cfg(feature = "std")]
+pub fn deserialize_long_readlink(bytes: &[u8]) -> Option<LongReadlinkRequest> {
+    if bytes.len() < READLINK_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    let path_len = u16::from_le_bytes([bytes[4], bytes[5]]) as usize;
+    if bytes.len() < READLINK_HEADER_SIZE + path_len {
+        return None;
+    }
+    let path = std::string::String::from_utf8(
+        bytes[READLINK_HEADER_SIZE..READLINK_HEADER_SIZE + path_len].to_vec(),
+    )
+    .ok()?;
+    Some(LongReadlinkRequest { op_id, path })
+}
+
+/// Result of deserializing a long LSTAT request.
+#[cfg(feature = "std")]
+pub struct LongLstatRequest {
+    pub op_id: OperationId,
+    pub path: std::string::String,
+}
+
+/// Deserializes a long LSTAT request from assembled bytes.
+#[cfg(feature = "std")]
+pub fn deserialize_long_lstat(bytes: &[u8]) -> Option<LongLstatRequest> {
+    if bytes.len() < LSTAT_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    let path_len = u16::from_le_bytes([bytes[4], bytes[5]]) as usize;
+    if bytes.len() < LSTAT_HEADER_SIZE + path_len {
+        return None;
+    }
+    let path = std::string::String::from_utf8(
+        bytes[LSTAT_HEADER_SIZE..LSTAT_HEADER_SIZE + path_len].to_vec(),
+    )
+    .ok()?;
+    Some(LongLstatRequest { op_id, path })
 }

--- a/src/libs/hostfs-api/src/lstat.rs
+++ b/src/libs/hostfs-api/src/lstat.rs
@@ -1,0 +1,195 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Lstat request and response wire format.
+//!
+//! `lstat` is the POSIX variant of `stat` that does *not* follow the final symbolic
+//! link component of the path. The request takes a path (rather than an FD) because
+//! a symbolic link cannot be opened without following it (POSIX `open` follows links
+//! by default and `O_NOFOLLOW` fails with `ELOOP` on a link). The response mirrors
+//! [`StatResponse`](crate::StatResponse) with an extra `kind` field that distinguishes
+//! regular files, directories, and symbolic links.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    HOSTFS_DATA_START,
+    MAX_INLINE_PATH_LEN,
+};
+use ::core::mem;
+use ::sys::ipc::Message;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// File kind reported by an [`LstatResponse`].
+///
+/// These values are deliberately small integers (not POSIX `S_IF*` mode bits) so the
+/// wire format does not depend on host or guest libc mode-bit definitions. The guest
+/// is responsible for translating this value into whatever its VFS layer expects.
+pub mod file_kind {
+    /// Regular file.
+    pub const REGULAR: u8 = 0;
+    /// Directory.
+    pub const DIRECTORY: u8 = 1;
+    /// Symbolic link.
+    pub const SYMLINK: u8 = 2;
+    /// Anything else (block/char device, FIFO, socket, unknown).
+    pub const OTHER: u8 = 3;
+}
+
+/// Lstat request: stat a path without following the final symbolic link.
+///
+/// Inline single-message form. For paths that exceed [`MAX_INLINE_PATH_LEN`], the
+/// caller must use the multi-part variant
+/// (`LongLstatRequest` in [`long_msg`](crate::long_msg)).
+#[derive(Debug, Clone)]
+pub struct LstatRequest {
+    /// Length of the inline path in bytes.
+    pub path_len: u16,
+    /// Inline path bytes.
+    pub path: [u8; MAX_INLINE_PATH_LEN],
+}
+
+/// Lstat response.
+///
+/// The `status` field is `0` on success or a negative `HOSTFS_ERR_*` code on failure.
+/// On error, the remaining fields are undefined.
+#[derive(Debug, Clone, Copy)]
+pub struct LstatResponse {
+    /// Status: `0` on success, negative `HOSTFS_ERR_*` on failure.
+    pub status: i32,
+    /// File size in bytes (link length in bytes for symbolic links).
+    pub size: u64,
+    /// Host file mode bits.
+    ///
+    /// On Unix hosts this is the raw `st_mode` (permission bits plus type bits). On
+    /// Windows hosts this is a synthetic value: the type bits are best-effort and
+    /// the permission bits are derived from the read-only attribute, so only the
+    /// permission bits should be considered meaningful by the guest. In all cases
+    /// the authoritative file-type discriminant is [`Self::kind`], not the type
+    /// bits embedded in `mode`.
+    pub mode: u32,
+    /// File kind discriminant; see [`file_kind`].
+    pub kind: u8,
+}
+
+impl LstatRequest {
+    /// Size of `path_len` field.
+    const SIZE_OF_PATH_LEN: usize = mem::size_of::<u16>();
+    /// Offset of `path_len` field (relative to data section start).
+    const OFFSET_OF_PATH_LEN: usize = 0;
+    /// Offset of `path` field (relative to data section start).
+    const OFFSET_OF_PATH: usize = Self::OFFSET_OF_PATH_LEN + Self::SIZE_OF_PATH_LEN;
+
+    /// Encodes this request into the message payload.
+    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+        let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
+        let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
+        payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
+            .copy_from_slice(&self.path_len.to_le_bytes());
+        let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        payload[path_off..path_off + copy_len].copy_from_slice(&self.path[..copy_len]);
+    }
+
+    ///
+    /// Decodes a `LstatRequest` from the message payload.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` if the encoded `path_len` is larger than the inline path buffer.
+    ///
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
+        let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
+        let path_len: u16 = u16::from_le_bytes(
+            payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
+                .try_into()
+                .ok()?,
+        );
+        if (path_len as usize) > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut path: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        let copy_len: usize = path_len as usize;
+        path[..copy_len].copy_from_slice(&payload[path_off..path_off + copy_len]);
+        Some(Self { path_len, path })
+    }
+}
+
+impl LstatResponse {
+    /// Size of `status` field.
+    const SIZE_OF_STATUS: usize = mem::size_of::<i32>();
+    /// Size of `size` field.
+    const SIZE_OF_SIZE: usize = mem::size_of::<u64>();
+    /// Size of `mode` field.
+    const SIZE_OF_MODE: usize = mem::size_of::<u32>();
+    /// Size of `kind` field.
+    const SIZE_OF_KIND: usize = mem::size_of::<u8>();
+    /// Offset of `status` field (relative to data section start).
+    const OFFSET_OF_STATUS: usize = 0;
+    /// Offset of `size` field (relative to data section start).
+    const OFFSET_OF_SIZE: usize = Self::OFFSET_OF_STATUS + Self::SIZE_OF_STATUS;
+    /// Offset of `mode` field (relative to data section start).
+    const OFFSET_OF_MODE: usize = Self::OFFSET_OF_SIZE + Self::SIZE_OF_SIZE;
+    /// Offset of `kind` field (relative to data section start).
+    const OFFSET_OF_KIND: usize = Self::OFFSET_OF_MODE + Self::SIZE_OF_MODE;
+
+    /// Encodes this response into the message payload.
+    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+        let status_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_STATUS;
+        let size_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_SIZE;
+        let mode_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_MODE;
+        let kind_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_KIND;
+        payload[status_off..status_off + Self::SIZE_OF_STATUS]
+            .copy_from_slice(&self.status.to_le_bytes());
+        payload[size_off..size_off + Self::SIZE_OF_SIZE].copy_from_slice(&self.size.to_le_bytes());
+        payload[mode_off..mode_off + Self::SIZE_OF_MODE].copy_from_slice(&self.mode.to_le_bytes());
+        payload[kind_off] = self.kind;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Decodes an `LstatResponse` from the message payload.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` if the encoded `target_len` exceeds the inline target buffer.
+    ///
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let status_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_STATUS;
+        let size_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_SIZE;
+        let mode_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_MODE;
+        let kind_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_KIND;
+        let status: i32 = i32::from_le_bytes(
+            payload[status_off..status_off + Self::SIZE_OF_STATUS]
+                .try_into()
+                .ok()?,
+        );
+        let size: u64 = u64::from_le_bytes(
+            payload[size_off..size_off + Self::SIZE_OF_SIZE]
+                .try_into()
+                .ok()?,
+        );
+        let mode: u32 = u32::from_le_bytes(
+            payload[mode_off..mode_off + Self::SIZE_OF_MODE]
+                .try_into()
+                .ok()?,
+        );
+        let kind: u8 = u8::from_le_bytes(
+            payload[kind_off..kind_off + Self::SIZE_OF_KIND]
+                .try_into()
+                .ok()?,
+        );
+        Some(Self {
+            status,
+            size,
+            mode,
+            kind,
+        })
+    }
+}

--- a/src/libs/hostfs-api/src/readlink.rs
+++ b/src/libs/hostfs-api/src/readlink.rs
@@ -1,0 +1,179 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Readlink request and response wire format.
+//!
+//! `readlink` reads the textual target of a symbolic link without following it.
+//! The target string is returned verbatim and is not necessarily a path that the
+//! daemon (or the guest) can resolve in isolation — the guest is responsible for
+//! any further interpretation.
+//!
+//! # Inline Limit
+//!
+//! The inline single-message response carries up to [`MAX_INLINE_READLINK_TARGET`]
+//! bytes of the link target. Symbolic links whose target exceeds that limit are
+//! returned via the multi-part `HostFsReadlinkResponsePart` wire form (see
+//! [`long_msg`](crate::long_msg)). The total target length is capped at
+//! [`PATH_MAX`](::sysapi::limits::PATH_MAX) bytes; anything longer is reported as
+//! [`HOSTFS_ERR_INVALID`](crate::HOSTFS_ERR_INVALID).
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    HOSTFS_DATA_START,
+    MAX_INLINE_PATH_LEN,
+};
+use ::core::mem;
+use ::sys::ipc::Message;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum length, in bytes, of a symbolic link target carried inline in a
+/// single-message [`ReadlinkResponse`].
+pub const MAX_INLINE_READLINK_TARGET: usize = Message::PAYLOAD_SIZE
+    - HOSTFS_DATA_START
+    - ReadlinkResponse::SIZE_OF_STATUS
+    - ReadlinkResponse::SIZE_OF_TARGET_LEN;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Readlink request: read the target of a symbolic link.
+///
+/// Inline single-message form. For paths exceeding [`MAX_INLINE_PATH_LEN`] the caller
+/// must use the multi-part variant
+/// (`LongReadlinkRequest` in [`long_msg`](crate::long_msg)).
+#[derive(Debug, Clone)]
+pub struct ReadlinkRequest {
+    /// Length of the inline path in bytes.
+    pub path_len: u16,
+    /// Inline path bytes.
+    pub path: [u8; MAX_INLINE_PATH_LEN],
+}
+
+/// Readlink response.
+///
+/// On success, `status` is `0`, `target_len` gives the number of valid bytes in
+/// `target`, and bytes beyond `target_len` are undefined. On failure, `status` is a
+/// negative `HOSTFS_ERR_*` code and the remaining fields are undefined.
+#[derive(Debug, Clone)]
+pub struct ReadlinkResponse {
+    /// Status: `0` on success, negative `HOSTFS_ERR_*` on failure.
+    pub status: i32,
+    /// Number of valid bytes in `target`.
+    pub target_len: u16,
+    /// Inline target bytes.
+    pub target: [u8; MAX_INLINE_READLINK_TARGET],
+}
+
+impl ReadlinkRequest {
+    /// Size of `path_len` field.
+    const SIZE_OF_PATH_LEN: usize = mem::size_of::<u16>();
+    /// Offset of `path_len` field (relative to data section start).
+    const OFFSET_OF_PATH_LEN: usize = 0;
+    /// Offset of `path` field (relative to data section start).
+    const OFFSET_OF_PATH: usize = Self::OFFSET_OF_PATH_LEN + Self::SIZE_OF_PATH_LEN;
+
+    /// Encodes this request into the message payload.
+    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+        let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
+        let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
+        payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
+            .copy_from_slice(&self.path_len.to_le_bytes());
+        let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        payload[path_off..path_off + copy_len].copy_from_slice(&self.path[..copy_len]);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Decodes a `ReadlinkRequest` from the message payload.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` if the encoded `path_len` is larger than the inline path buffer.
+    ///
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
+        let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
+        let path_len: u16 = u16::from_le_bytes(
+            payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
+                .try_into()
+                .ok()?,
+        );
+        if (path_len as usize) > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut path: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        let copy_len: usize = path_len as usize;
+        path[..copy_len].copy_from_slice(&payload[path_off..path_off + copy_len]);
+        Some(Self { path_len, path })
+    }
+}
+
+impl ReadlinkResponse {
+    /// Size of `status` field.
+    const SIZE_OF_STATUS: usize = mem::size_of::<i32>();
+    /// Size of `target_len` field.
+    const SIZE_OF_TARGET_LEN: usize = mem::size_of::<u16>();
+    /// Offset of `status` field (relative to data section start).
+    const OFFSET_OF_STATUS: usize = 0;
+    /// Offset of `target_len` field (relative to data section start).
+    const OFFSET_OF_TARGET_LEN: usize = Self::OFFSET_OF_STATUS + Self::SIZE_OF_STATUS;
+    /// Offset of `target` field (relative to data section start).
+    const OFFSET_OF_TARGET: usize = Self::OFFSET_OF_TARGET_LEN + Self::SIZE_OF_TARGET_LEN;
+
+    /// Encodes this response into the message payload.
+    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+        let status_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_STATUS;
+        let target_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_TARGET_LEN;
+        let target_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_TARGET;
+        payload[status_off..status_off + Self::SIZE_OF_STATUS]
+            .copy_from_slice(&self.status.to_le_bytes());
+        payload[target_len_off..target_len_off + Self::SIZE_OF_TARGET_LEN]
+            .copy_from_slice(&self.target_len.to_le_bytes());
+        let copy_len: usize = (self.target_len as usize).min(MAX_INLINE_READLINK_TARGET);
+        payload[target_off..target_off + copy_len].copy_from_slice(&self.target[..copy_len]);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Decodes a `ReadlinkResponse` from the message payload.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` if the encoded `target_len` exceeds the inline target buffer.
+    ///
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let status_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_STATUS;
+        let target_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_TARGET_LEN;
+        let target_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_TARGET;
+        let status: i32 = i32::from_le_bytes(
+            payload[status_off..status_off + Self::SIZE_OF_STATUS]
+                .try_into()
+                .ok()?,
+        );
+        let target_len: u16 = u16::from_le_bytes(
+            payload[target_len_off..target_len_off + Self::SIZE_OF_TARGET_LEN]
+                .try_into()
+                .ok()?,
+        );
+        if (target_len as usize) > MAX_INLINE_READLINK_TARGET {
+            return None;
+        }
+        let mut target: [u8; MAX_INLINE_READLINK_TARGET] = [0u8; MAX_INLINE_READLINK_TARGET];
+        let copy_len: usize = target_len as usize;
+        target[..copy_len].copy_from_slice(&payload[target_off..target_off + copy_len]);
+        Some(Self {
+            status,
+            target_len,
+            target,
+        })
+    }
+}


### PR DESCRIPTION
Extend the hostfs IPC API with the request/response types required to support symbolic links and lstat semantics from the guest. No daemon or guest VFS wiring is included in this change; this commit only defines the wire format and the long-message (multi-part) helpers.

New modules -----------
* `lstat`  — `LstatRequest` / `LstatResponse` plus a `file_kind` module exposing a small, libc-independent file-type discriminant (`REGULAR`, `DIRECTORY`, `SYMLINK`, `OTHER`). `lstat` takes a path (not an FD) because a symlink cannot be opened without following it. The response carries `status`, `size`, `mode`, and `kind`; `mode` is the raw `st_mode` on Unix hosts and a synthetic value on Windows, with `kind` as the authoritative type discriminant.
* `readlink` — `ReadlinkRequest` / `ReadlinkResponse` and the new `MAX_INLINE_READLINK_TARGET` constant computed from the message payload size. Targets longer than the inline limit are delivered via the multi-part response form; targets longer than `PATH_MAX` are rejected with `HOSTFS_ERR_INVALID`.

Long-message support (`long_msg`) ---------------------------------
* Document the new request layouts (Symlink, Readlink, Lstat) and the new long Readlink response layout (`[op_id:4][status:4][target_len:2][target:N]`). Errors for readlink are always reported via the single-message response; the multi-part response is only used for successful, oversized targets.
* Add header-size constants: `SYMLINK_HEADER_SIZE`, `READLINK_HEADER_SIZE`, `LSTAT_HEADER_SIZE`, and `READLINK_RESPONSE_HEADER_SIZE`.
* Add `deserialize_long_symlink`, `deserialize_long_readlink`, and `deserialize_long_lstat`, returning `LongSymlinkRequest`, `LongReadlinkRequest`, and `LongLstatRequest` respectively (all gated on `feature = "std"` for the hostfsd side).

Error codes (`error`) ---------------------
* `HOSTFS_ERR_LOOP` (-40) — too many levels of symbolic links (`ELOOP`).
* `HOSTFS_ERR_NOT_SUPPORTED` (-95) — operation not supported on the host. Used by `symlink` on Windows when the process lacks the privilege to create symbolic links (no Developer Mode and no `SeCreateSymbolicLinkPrivilege`).

Crate plumbing --------------
* Re-export the new types and constants from `lib.rs`.
* Add a `sysapi` workspace dependency for `PATH_MAX`, referenced from the `readlink` module docs.