### PR TITLE
[config] Introduce MAX_PROCESSES constant

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -97,6 +97,15 @@ ikc_poll_batch_size = 8
 #   of 64 KiB, 32 threads imply up to ~2 MiB of kernel-stack reservation.
 max_threads = 32
 
+# Maximum number of processes that may exist system-wide at the same time.
+# A process slot is considered occupied from creation until the zombie is buried (i.e. waited on).
+# Constraints:
+# - Must be at least 1 (the kernel process always exists).
+# - Must not exceed 255. This upper bound lets the kernel encode per-frame reference counts in a
+#   single byte (a frame can be shared by at most max_processes owners), which keeps the
+#   BSS-backed refcount table small.
+max_processes = 255
+
 #==================================================================================================
 # Synchronization Limits
 #==================================================================================================

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -147,6 +147,10 @@ pub struct ProcessManager {
     zombies: LinkedList<ZombieProcess>,
     /// Thread manager.
     tm: ThreadManager,
+    /// Number of live processes (including the kernel process). A process slot is considered
+    /// occupied from creation until the corresponding zombie is buried (popped off the zombie
+    /// list). Used to enforce [`config::kernel::MAX_PROCESSES`].
+    live_count: usize,
     /// Number of messages buffered (not yet consumed).
     number_buffered_messages: usize,
     /// Detached-thread zombies whose reaping was deferred because their
@@ -182,6 +186,7 @@ impl ProcessManager {
             zombies: LinkedList::new(),
             running: Some(kernel),
             tm,
+            live_count: 1,
             number_buffered_messages: 0,
             deferred_reap: Vec::new(),
         }
@@ -483,6 +488,17 @@ impl ProcessManager {
 
         trace!("args={:?}, env={:?}", args, env);
 
+        // Refuse to create a new process when the system-wide live-process cap has been reached.
+        if self.live_count >= ::config::kernel::MAX_PROCESSES {
+            let reason: &str = "maximum number of processes reached";
+            error!(
+                "{reason} (live_count={}, max_processes={})",
+                self.live_count,
+                ::config::kernel::MAX_PROCESSES
+            );
+            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        }
+
         // Reserve the next process and thread identifiers early, before any resource allocation.
         let (pid, next_pid): (ProcessIdentifier, ProcessIdentifier) = self.try_next_pid()?;
         let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
@@ -620,6 +636,7 @@ impl ProcessManager {
             // Commit the next process and thread identifiers now that all fallible operations have succeeded.
             self.next_pid = next_pid;
             self.tm.commit_next_tid(next_tid);
+            self.live_count += 1;
             let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
 
             // Add process to the queue of ready processes.
@@ -1242,6 +1259,12 @@ impl ProcessManager {
             let (mut more_zombie_threads, zombie_thread): (VecDeque<ZombieThread>, ZombieThread) =
                 zombie_threads.pop_front();
             more_zombie_threads.push_front(zombie_thread);
+
+            // The kernel process is never reaped, so live_count must stay at least 1.
+            if self.live_count <= 1 {
+                unreachable!("live_count underflow: kernel process must always remain counted");
+            }
+            self.live_count -= 1;
 
             Some((more_zombie_threads, state, status))
         } else {

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -181,6 +181,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "max_threads"), "max_threads");
     constants.push_str(&format!("pub const MAX_THREADS: usize = {val};\n"));
 
+    let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "max_processes"),
+        "max_processes",
+    );
+    constants.push_str(&format!("pub const MAX_PROCESSES: usize = {val};\n"));
+
     constants.push_str("}\n");
 
     //==============================================================================================
@@ -244,6 +250,19 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     let max_threads: usize =
         parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "max_threads"), "max_threads");
     assert!(max_threads >= 1, "max_threads must be at least 1");
+
+    // max_processes must fit in a u8 so per-frame reference counts can be stored in a single byte.
+    let max_processes: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "max_processes"),
+        "max_processes",
+    );
+    assert!(max_processes >= 1, "max_processes must be at least 1");
+    assert!(
+        max_processes <= u8::MAX as usize,
+        "max_processes ({}) must not exceed u8::MAX ({})",
+        max_processes,
+        u8::MAX,
+    );
 
     // Write the generated file.
     fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -23,6 +23,12 @@ include!(concat!(env!("OUT_DIR"), "/kernel_config.rs"));
 // Linuxd build-time constants are generated in a similar fashion to kernel variables.
 include!(concat!(env!("OUT_DIR"), "/linuxd_config.rs"));
 
+// Compile-time assertions on kernel build-time constants.
+//
+// Mirrored from `build.rs` so misuse of the generated constants is caught at the use site too.
+static_assert::assert_eq!(kernel::MAX_PROCESSES >= 1);
+static_assert::assert_eq!(kernel::MAX_PROCESSES <= u8::MAX as usize);
+
 //==================================================================================================
 // System
 //==================================================================================================


### PR DESCRIPTION
Add a new `max_processes` knob to `build/kernel_config.toml` and wire it through the `config` crate so the kernel has a single, build-time source of truth for the maximum number of live processes that may coexist.

Rationale
---------
The kernel needs an explicit cap on the number of live processes to bound BSS-resident data structures whose size is parameterized by the process count. In particular, per-frame reference counts must fit in a single byte so the refcount table stays small, which requires `max_processes <= u8::MAX`.

Changes
-------
* build/kernel_config.toml
  - Add `max_processes = 255` with documentation describing the slot lifetime (occupied from creation until the zombie is buried) and the u8 upper-bound rationale.

* src/libs/config/build.rs
  - Generate `kernel::MAX_PROCESSES` from the TOML value.
  - Enforce at build time:
      * `max_processes >= 1` (the kernel process always exists).
      * `max_processes <= u8::MAX`.

* src/libs/config/src/lib.rs
  - Mirror the invariants as `static_assert!` checks at the use site, so misuse of the generated constants is also caught downstream.

* src/kernel/src/pm/process/manager/mod.rs
  - Track a `live_count: usize` field on `ProcessManager`, initialized to 1 to account for the always-present kernel process.
  - In the process-creation path, refuse new processes with `ErrorCode::OutOfMemory` ("maximum number of processes reached") once `live_count >= MAX_PROCESSES`. The check runs before any PID or thread reservations to avoid partial state on rejection.
  - Increment `live_count` only after all fallible allocations succeed and the new PID/TID are committed.
  - Decrement `live_count` when a zombie is reaped (buried). An `unreachable!` guard catches accounting bugs at runtime in both debug and release builds, since the kernel process is never reaped and the count must always remain at least 1.

Impact
------
No behavioral change for workloads under the cap. Process creation now fails cleanly with `OutOfMemory` once `MAX_PROCESSES` live processes exist, instead of being implicitly bounded by other resources.
