### PR TITLE
[kernel] Frame allocator with reference counting

### DIFF
--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -91,6 +91,9 @@ pub const NUM_PAGE_TABLES: usize = config::kernel::MEMORY_SIZE / mem::PGTAB_SIZE
 #[cfg(not(feature = "whp"))]
 pub const NUM_PAGE_TABLES: usize = config::kernel::MEMORY_SIZE / mem::PGTAB_SIZE;
 
+/// Total number of physical frames covered by the configured machine memory size.
+pub const NFRAMES: usize = config::kernel::MEMORY_SIZE / mem::FRAME_SIZE;
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -109,9 +112,8 @@ pub struct Platform {
 //==================================================================================================
 
 /// Frame allocator storage.
-static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
-    / (mem::FRAME_SIZE * u8::BITS as usize)] =
-    [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+static mut FRAME_ALLOCATOR_STORAGE: [u8; NFRAMES / u8::BITS as usize] =
+    [0; NFRAMES / u8::BITS as usize];
 
 /// GDT backing storage, allocated in BSS.
 static mut GDT_STORAGE: [Gdte; gdt::GDT_NUM_ENTRIES] = gdt::DEFAULT_ENTRIES;

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -14,11 +14,14 @@
 // Imports
 //==================================================================================================
 
-use crate::hal::mem::{
-    FrameAddress,
-    PageAligned,
-    PhysicalAddress,
-    TruncatedMemoryRegion,
+use crate::hal::{
+    mem::{
+        FrameAddress,
+        PageAligned,
+        PhysicalAddress,
+        TruncatedMemoryRegion,
+    },
+    platform::NFRAMES,
 };
 use ::arch::mem::{
     self,
@@ -46,10 +49,47 @@ use ::sys::{
 // Inner
 //==================================================================================================
 
+/// BSS-backed per-frame reference count storage. Indexed by frame number.
+///
+/// Sits in BSS rather than on the kernel heap because the slab allocator caps single
+/// allocations at a few hundred bytes, but a full refcount table for the configured
+/// memory size is much larger.
+///
+/// # Size impact
+///
+/// This array is unconditionally reserved in BSS and scales linearly with the
+/// configured machine memory size: `MEMORY_SIZE / FRAME_SIZE * size_of::<u8>()`
+/// bytes (e.g. 256 KiB for a 1 GiB configuration). A `u8` is sufficient because at
+/// most [`config::kernel::MAX_PROCESSES`] (≤ 255) processes can simultaneously share a
+/// frame, so the refcount of any frame is bounded by 255.
+///
+/// # Safety
+///
+/// Accessed only through `Inner::refcount`, which is set up at boot from this storage
+/// and never aliased. The kernel is single-threaded and runs with interrupts disabled,
+/// so non-atomic access is sound.
+static mut REFCOUNT_STORAGE: [u8; NFRAMES] = [0; NFRAMES];
+
 /// Private state of the frame allocator singleton.
 struct Inner {
     /// A bitmap that keeps track of free/used frames.
     bitmap: Bitmap,
+    /// Per-frame reference count. Indexed by frame number.
+    ///
+    /// Invariants:
+    ///
+    /// - `refcount.len() >= bitmap.number_of_bits()`.
+    /// - `refcount[i] >= 1` iff bit `i` is set in `bitmap` (for `i < bitmap.number_of_bits()`).
+    /// - `refcount[i] == 0` iff bit `i` is clear in `bitmap` (for `i < bitmap.number_of_bits()`).
+    ///
+    /// A refcount greater than one means that the frame is shared between multiple
+    /// owners (e.g. parent and child after [`share`]). The frame is reclaimed (bitmap
+    /// bit cleared) only when the refcount reaches zero.
+    ///
+    /// The element type is `u8`: the kernel caps the number of live processes at
+    /// [`config::kernel::MAX_PROCESSES`] (≤ 255), so a frame can be shared by at most 255
+    /// owners and the count always fits in a byte.
+    refcount: &'static mut [u8],
 }
 
 impl Inner {
@@ -71,6 +111,9 @@ impl Inner {
                 return Err(error);
             },
         };
+        // Newly allocated frames have a single owner.
+        debug_assert_eq!(self.refcount[frame_number], 0);
+        self.refcount[frame_number] = 1;
         let frame_number: FrameNumber = match FrameNumber::from_raw_value(frame_number) {
             Some(frame_number) => frame_number,
             None => {
@@ -112,6 +155,11 @@ impl Inner {
                 return Err(error);
             },
         };
+        // Newly allocated frames have a single owner.
+        for i in frame_number..frame_number + count {
+            debug_assert_eq!(self.refcount[i], 0);
+            self.refcount[i] = 1;
+        }
         let frame_number: FrameNumber = match FrameNumber::from_raw_value(frame_number) {
             Some(frame_number) => frame_number,
             None => {
@@ -145,12 +193,33 @@ impl Inner {
     ///
     fn free(&mut self, frame: FrameAddress) -> Result<(), Error> {
         let frame_number: usize = frame.into_frame_number().into_raw_value();
-        match self.bitmap.clear(frame_number) {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                error!("{error:?} (frame={frame:?})");
-                Err(error)
-            },
+
+        if frame_number >= self.refcount.len() {
+            let reason: &str = "frame number out of bounds";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // Reject double-frees: the frame must currently have at least one owner.
+        if self.refcount[frame_number] == 0 {
+            let reason: &str = "frame is already free";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        self.refcount[frame_number] -= 1;
+
+        // Only release the bit in the bitmap when the last owner releases the frame.
+        if self.refcount[frame_number] == 0 {
+            match self.bitmap.clear(frame_number) {
+                Ok(()) => Ok(()),
+                Err(error) => {
+                    error!("{error:?} (frame={frame:?})");
+                    Err(error)
+                },
+            }
+        } else {
+            Ok(())
         }
     }
 
@@ -170,7 +239,11 @@ impl Inner {
     fn book(&mut self, phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Error> {
         let frame_number: usize = phys_addr.into_frame_number().into_raw_value();
         match self.bitmap.set(frame_number) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                debug_assert_eq!(self.refcount[frame_number], 0);
+                self.refcount[frame_number] = 1;
+                Ok(())
+            },
             Err(error) => {
                 error!("{error:?} (phys_addr={phys_addr:?})");
                 Err(error)
@@ -248,6 +321,8 @@ impl Inner {
                 error!("{error:?} (region={region:?})");
                 return Err(error);
             }
+            debug_assert_eq!(self.refcount[index], 0);
+            self.refcount[index] = 1;
         }
 
         Ok(())
@@ -305,8 +380,32 @@ pub(super) unsafe fn init(bitmap: Bitmap) -> Result<(), Error> {
         (bitmap.number_of_bits() * mem::FRAME_SIZE) / constants::MEGABYTE,
     );
 
+    let nframes: usize = bitmap.number_of_bits();
+    if nframes > NFRAMES {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "frame bitmap is larger than the configured refcount storage",
+        ));
+    }
+
+    // SAFETY: single-threaded boot; no other reference to `REFCOUNT_STORAGE` exists.
+    let refcount: &'static mut [u8] = unsafe { &mut REFCOUNT_STORAGE[..] };
+
+    // Defensively sync refcounts with any bits already set in the incoming bitmap. The
+    // current microvm boot path supplies an empty bitmap and performs all reservations
+    // via `book()` / `alloc_range()` after `init()`, so this loop normally does nothing.
+    // It is kept as a safety net so a future boot path that hands us a pre-populated
+    // bitmap (for example to express firmware-reserved regions) does not silently end
+    // up with `bitmap bit = 1, refcount = 0`, which would cause the first `free()` of
+    // such a frame to be rejected as a spurious double-free.
+    for (i, slot) in refcount.iter_mut().enumerate().take(nframes) {
+        if matches!(bitmap.test(i), Ok(true)) {
+            *slot = 1;
+        }
+    }
+
     // SAFETY: single-threaded boot; no other reference to `INSTANCE` exists.
-    unsafe { INSTANCE.write(Inner { bitmap }) };
+    unsafe { INSTANCE.write(Inner { bitmap, refcount }) };
     INSTANCE_INIT.store(true, ORDER);
     Ok(())
 }


### PR DESCRIPTION
Introduce a `NFRAMES` constant to define the total number of physical frames and extend the frame allocator with per-frame reference counts. This allows frames to be shared among multiple owners, ensuring proper reclamation only when the last owner releases them. The changes eliminate duplication in bitmap size calculations and improve memory management for shared frames.