### PR TITLE
[hostfs-api] Add request serialization helpers

### DIFF
--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -53,43 +53,34 @@ fn setup() -> (HostFsHandler, TempDir) {
 
 /// Builds an Open request payload for the given path and flags.
 fn make_open_request(path: &str, flags: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    let path_bytes: &[u8] = path.as_bytes();
-    let path_len: u16 = path_bytes.len().min(MAX_INLINE_PATH_LEN) as u16;
-    let mut path_arr: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-    path_arr[..path_len as usize].copy_from_slice(&path_bytes[..path_len as usize]);
-
-    let req: OpenRequest = OpenRequest {
-        flags,
-        path_len,
-        path: path_arr,
-    };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsOpenRequest as u16);
-    req.encode(&mut payload);
-    payload
+    let req: OpenRequest = OpenRequest::from_path(flags, path.as_bytes())
+        .expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsOpenRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Close request payload.
 fn make_close_request(fd: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: CloseRequest = CloseRequest { fd };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsCloseRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsCloseRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Read request payload.
 fn make_read_request(fd: i32, count: u32, offset: i64) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: ReadRequest = ReadRequest { fd, count, offset };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsReadRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsReadRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Write request payload.
 fn make_write_request(fd: i32, data: &[u8], offset: i64) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let data_len: u16 = data.len().min(MAX_INLINE_WRITE_DATA) as u16;
     let mut data_arr: [u8; MAX_INLINE_WRITE_DATA] = [0u8; MAX_INLINE_WRITE_DATA];
     data_arr[..data_len as usize].copy_from_slice(&data[..data_len as usize]);
@@ -101,120 +92,86 @@ fn make_write_request(fd: i32, data: &[u8], offset: i64) -> [u8; Message::PAYLOA
         data_len,
         data: data_arr,
     };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsWriteRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsWriteRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Stat request payload.
 fn make_stat_request(fd: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: StatRequest = StatRequest { fd };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsStatRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsStatRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Mkdir request payload.
 fn make_mkdir_request(path: &str, mode: u32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    let path_bytes: &[u8] = path.as_bytes();
-    let path_len: u16 = path_bytes.len().min(MAX_INLINE_PATH_LEN) as u16;
-    let mut path_arr: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-    path_arr[..path_len as usize].copy_from_slice(&path_bytes[..path_len as usize]);
-
-    let req: MkdirRequest = MkdirRequest {
-        mode,
-        path_len,
-        path: path_arr,
-    };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsMkdirRequest as u16);
-    req.encode(&mut payload);
-    payload
+    let req: MkdirRequest = MkdirRequest::from_path(mode, path.as_bytes())
+        .expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsMkdirRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds an Unlink request payload.
 fn make_unlink_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    let path_bytes: &[u8] = path.as_bytes();
-    let path_len: u16 = path_bytes.len().min(MAX_INLINE_PATH_LEN) as u16;
-    let mut path_arr: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-    path_arr[..path_len as usize].copy_from_slice(&path_bytes[..path_len as usize]);
-
-    let req: UnlinkRequest = UnlinkRequest {
-        path_len,
-        path: path_arr,
-    };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsUnlinkRequest as u16);
-    req.encode(&mut payload);
-    payload
+    let req: UnlinkRequest =
+        UnlinkRequest::from_path(path.as_bytes()).expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsUnlinkRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Rmdir request payload.
 fn make_rmdir_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    let path_bytes: &[u8] = path.as_bytes();
-    let path_len: u16 = path_bytes.len().min(MAX_INLINE_PATH_LEN) as u16;
-    let mut path_arr: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-    path_arr[..path_len as usize].copy_from_slice(&path_bytes[..path_len as usize]);
-
-    let req: RmdirRequest = RmdirRequest {
-        path_len,
-        path: path_arr,
-    };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsRmdirRequest as u16);
-    req.encode(&mut payload);
-    payload
+    let req: RmdirRequest =
+        RmdirRequest::from_path(path.as_bytes()).expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsRmdirRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Rename request payload.
 fn make_rename_request(old_path: &str, new_path: &str) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    let old_bytes: &[u8] = old_path.as_bytes();
-    let new_bytes: &[u8] = new_path.as_bytes();
-    let old_len: u16 = old_bytes.len().min(MAX_INLINE_PATH_LEN) as u16;
-    let new_len: u16 = new_bytes.len().min(MAX_INLINE_PATH_LEN - old_len as usize) as u16;
-
-    let mut paths: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-    paths[..old_len as usize].copy_from_slice(&old_bytes[..old_len as usize]);
-    paths[old_len as usize..old_len as usize + new_len as usize]
-        .copy_from_slice(&new_bytes[..new_len as usize]);
-
-    let req: RenameRequest = RenameRequest {
-        old_path_len: old_len,
-        new_path_len: new_len,
-        paths,
-    };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsRenameRequest as u16);
-    req.encode(&mut payload);
-    payload
+    let req: RenameRequest = RenameRequest::from_paths(old_path.as_bytes(), new_path.as_bytes())
+        .expect("test paths fit in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsRenameRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds an Lseek request payload.
 fn make_lseek_request(fd: i32, offset: i64, whence: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: LseekRequest = LseekRequest { fd, offset, whence };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsLseekRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsLseekRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Truncate request payload.
 fn make_truncate_request(fd: i32, length: i64) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: TruncateRequest = TruncateRequest { fd, length };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsTruncateRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsTruncateRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a Flush request payload.
 fn make_flush_request(fd: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: FlushRequest = FlushRequest { fd };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsFlushRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsFlushRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Builds a ReadDir request payload.
@@ -224,15 +181,15 @@ fn make_readdir_request(fd: i32) -> [u8; Message::PAYLOAD_SIZE] {
 
 /// Builds a ReadDir request payload with a specified offset.
 fn make_readdir_request_at(fd: i32, offset: u32) -> [u8; Message::PAYLOAD_SIZE] {
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     let req: ReadDirRequest = ReadDirRequest {
         fd,
         _reserved: 0,
         offset,
     };
-    set_header(&mut payload, SystemCallMessageHeader::HostFsReadDirRequest as u16);
-    req.encode(&mut payload);
-    payload
+    req.serialize(
+        SystemCallMessageHeader::HostFsReadDirRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
 }
 
 /// Opens a file via the handler and returns the remote FD.

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -187,17 +187,9 @@ pub fn send_open_request(
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
     let relative: &str = strip_mount_prefix(path);
-    let path_bytes: &[u8] = relative.as_bytes();
-
-    // Serialize: [op_id:4][flags:4][path_len:2][path:N]
-    let path_len: u16 =
-        u16::try_from(path_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let total_len: usize = long_msg::OPEN_HEADER_SIZE + path_bytes.len();
-    let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(total_len);
-    buf.extend_from_slice(&op_id.to_le_bytes());
-    buf.extend_from_slice(&flags.to_le_bytes());
-    buf.extend_from_slice(&path_len.to_le_bytes());
-    buf.extend_from_slice(path_bytes);
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_open_request(op_id, flags, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsOpenRequestPart)
 }
@@ -207,11 +199,8 @@ pub fn send_close_request(
     remote_fd: i32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let req: CloseRequest = CloseRequest { fd: remote_fd };
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsCloseRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    let payload: [u8; Message::PAYLOAD_SIZE] = CloseRequest { fd: remote_fd }
+        .serialize(SystemCallMessageHeader::HostFsCloseRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -227,16 +216,12 @@ pub fn send_read_request(
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
     let count: u32 = count.min(MAX_INLINE_READ_DATA) as u32;
-    let req: ReadRequest = ReadRequest {
+    let payload: [u8; Message::PAYLOAD_SIZE] = ReadRequest {
         fd: remote_fd,
         count,
         offset: -1, // Use current position.
-    };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsReadRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    }
+    .serialize(SystemCallMessageHeader::HostFsReadRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -251,22 +236,9 @@ pub fn send_write_request(
     buf: &[u8],
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let write_len: usize = buf.len().min(MAX_INLINE_WRITE_DATA);
-    let mut data: [u8; MAX_INLINE_WRITE_DATA] = [0u8; MAX_INLINE_WRITE_DATA];
-    data[..write_len].copy_from_slice(&buf[..write_len]);
-
-    let req: WriteRequest = WriteRequest {
-        fd: remote_fd,
-        count: write_len as u32,
-        offset: -1, // Use current position.
-        data_len: write_len as u16,
-        data,
-    };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsWriteRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    // Offset -1 means use current file position.
+    let payload: [u8; Message::PAYLOAD_SIZE] = WriteRequest::from_slice(remote_fd, -1, buf)
+        .serialize(SystemCallMessageHeader::HostFsWriteRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -282,16 +254,12 @@ pub fn send_lseek_request(
     whence: i32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let req: LseekRequest = LseekRequest {
+    let payload: [u8; Message::PAYLOAD_SIZE] = LseekRequest {
         fd: remote_fd,
         offset,
         whence,
-    };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsLseekRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    }
+    .serialize(SystemCallMessageHeader::HostFsLseekRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -306,15 +274,11 @@ pub fn send_truncate_request(
     length: i64,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let req: TruncateRequest = TruncateRequest {
+    let payload: [u8; Message::PAYLOAD_SIZE] = TruncateRequest {
         fd: remote_fd,
         length,
-    };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsTruncateRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    }
+    .serialize(SystemCallMessageHeader::HostFsTruncateRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -328,12 +292,8 @@ pub fn send_flush_request(
     remote_fd: i32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let req: FlushRequest = FlushRequest { fd: remote_fd };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsFlushRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    let payload: [u8; Message::PAYLOAD_SIZE] = FlushRequest { fd: remote_fd }
+        .serialize(SystemCallMessageHeader::HostFsFlushRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -349,17 +309,9 @@ pub fn send_mkdir_request(
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
     let relative: &str = strip_mount_prefix(path);
-    let path_bytes: &[u8] = relative.as_bytes();
-
-    // Serialize: [op_id:4][mode:4][path_len:2][path:N]
-    let path_len: u16 =
-        u16::try_from(path_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let total_len: usize = long_msg::MKDIR_HEADER_SIZE + path_bytes.len();
-    let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(total_len);
-    buf.extend_from_slice(&op_id.to_le_bytes());
-    buf.extend_from_slice(&mode.to_le_bytes());
-    buf.extend_from_slice(&path_len.to_le_bytes());
-    buf.extend_from_slice(path_bytes);
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_mkdir_request(op_id, mode, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsMkdirRequestPart)
 }
@@ -367,16 +319,9 @@ pub fn send_mkdir_request(
 /// Sends an RMDIR request to hostfsd as a multi-part IKC message.
 pub fn send_rmdir_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
     let relative: &str = strip_mount_prefix(path);
-    let path_bytes: &[u8] = relative.as_bytes();
-
-    // Serialize: [op_id:4][path_len:2][path:N]
-    let path_len: u16 =
-        u16::try_from(path_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let total_len: usize = long_msg::RMDIR_HEADER_SIZE + path_bytes.len();
-    let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(total_len);
-    buf.extend_from_slice(&op_id.to_le_bytes());
-    buf.extend_from_slice(&path_len.to_le_bytes());
-    buf.extend_from_slice(path_bytes);
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_rmdir_request(op_id, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsRmdirRequestPart)
 }
@@ -384,16 +329,9 @@ pub fn send_rmdir_request(path: &str, op_id: OperationId) -> Result<(), ::sys::e
 /// Sends an UNLINK request to hostfsd as a multi-part IKC message.
 pub fn send_unlink_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
     let relative: &str = strip_mount_prefix(path);
-    let path_bytes: &[u8] = relative.as_bytes();
-
-    // Serialize: [op_id:4][path_len:2][path:N]
-    let path_len: u16 =
-        u16::try_from(path_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let total_len: usize = long_msg::UNLINK_HEADER_SIZE + path_bytes.len();
-    let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(total_len);
-    buf.extend_from_slice(&op_id.to_le_bytes());
-    buf.extend_from_slice(&path_len.to_le_bytes());
-    buf.extend_from_slice(path_bytes);
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_unlink_request(op_id, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsUnlinkRequestPart)
 }
@@ -403,12 +341,8 @@ pub fn send_stat_request(
     remote_fd: i32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let req: StatRequest = StatRequest { fd: remote_fd };
-
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-    set_header(&mut payload, SystemCallMessageHeader::HostFsStatRequest as u16);
-    set_op_id(&mut payload, op_id);
-    req.encode(&mut payload);
+    let payload: [u8; Message::PAYLOAD_SIZE] = StatRequest { fd: remote_fd }
+        .serialize(SystemCallMessageHeader::HostFsStatRequest as u16, op_id);
 
     if send_request(&payload) {
         Ok(())
@@ -425,21 +359,12 @@ pub fn send_rename_request(
 ) -> Result<(), ::sys::error::ErrorCode> {
     let old_relative: &str = strip_mount_prefix(old_path);
     let new_relative: &str = strip_mount_prefix(new_path);
-    let old_bytes: &[u8] = old_relative.as_bytes();
-    let new_bytes: &[u8] = new_relative.as_bytes();
-
-    // Serialize: [op_id:4][old_path_len:2][new_path_len:2][old_path:N][new_path:M]
-    let old_path_len: u16 =
-        u16::try_from(old_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let new_path_len: u16 =
-        u16::try_from(new_bytes.len()).map_err(|_| ::sys::error::ErrorCode::InvalidArgument)?;
-    let total_len: usize = long_msg::RENAME_HEADER_SIZE + old_bytes.len() + new_bytes.len();
-    let mut buf: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(total_len);
-    buf.extend_from_slice(&op_id.to_le_bytes());
-    buf.extend_from_slice(&old_path_len.to_le_bytes());
-    buf.extend_from_slice(&new_path_len.to_le_bytes());
-    buf.extend_from_slice(old_bytes);
-    buf.extend_from_slice(new_bytes);
+    let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_rename_request(
+        op_id,
+        old_relative.as_bytes(),
+        new_relative.as_bytes(),
+    )
+    .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsRenameRequestPart)
 }

--- a/src/libs/hostfs-api/src/close.rs
+++ b/src/libs/hostfs-api/src/close.rs
@@ -3,7 +3,12 @@
 
 //! Close request wire format.
 
-use crate::HOSTFS_DATA_START;
+use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
 use ::sys::ipc::Message;
 
 /// Close request: close a remote file descriptor.
@@ -14,10 +19,14 @@ pub struct CloseRequest {
 }
 
 impl CloseRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(&self, header_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
+        payload
     }
 
     /// Decodes a CloseRequest from the message payload.

--- a/src/libs/hostfs-api/src/flush.rs
+++ b/src/libs/hostfs-api/src/flush.rs
@@ -3,7 +3,12 @@
 
 //! Flush request wire format.
 
-use crate::HOSTFS_DATA_START;
+use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
 use ::sys::ipc::Message;
 
 /// Flush request: flush pending writes.
@@ -14,10 +19,14 @@ pub struct FlushRequest {
 }
 
 impl FlushRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(&self, header_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
+        payload
     }
 
     /// Decodes a FlushRequest from the message payload.

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -34,7 +34,10 @@
 //!   `HostFsReadlinkResponse` form; the multi-part response is only emitted for a
 //!   successful `readlink` whose target does not fit inline.
 
-#[cfg(feature = "std")]
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use crate::OperationId;
 
 //==================================================================================================
@@ -71,6 +74,49 @@ pub const LSTAT_HEADER_SIZE: usize = 6;
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
 pub const READLINK_RESPONSE_HEADER_SIZE: usize = 10;
+
+//==================================================================================================
+// Long-response Deserialization (no_std-friendly)
+//==================================================================================================
+
+/// Result of deserializing the body of a long READLINK *response*.
+///
+/// The `target` field borrows directly from the input buffer; no allocation is
+/// performed. This makes the helper usable from `no_std` callers (e.g., vfsd).
+pub struct LongReadlinkResponse<'a> {
+    /// Operation identifier echoed by hostfsd. Matches the request's `op_id`.
+    pub op_id: crate::OperationId,
+    /// Status code (`0` on success, negative `HOSTFS_ERR_*` value on failure).
+    pub status: i32,
+    /// Symbolic-link target bytes, exactly `target_len` long.
+    pub target: &'a [u8],
+}
+
+/// Deserializes the body of a long READLINK response.
+///
+/// `bytes` is the assembled body in wire format
+/// `[op_id:4][status:4][target_len:2][target:N]`. Returns `None` if the buffer is
+/// shorter than the declared header, or if the declared `target_len` exceeds the
+/// remainder of the buffer.
+pub fn deserialize_long_readlink_response(bytes: &[u8]) -> Option<LongReadlinkResponse<'_>> {
+    if bytes.len() < READLINK_RESPONSE_HEADER_SIZE {
+        return None;
+    }
+    let op_id: crate::OperationId =
+        crate::OperationId::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let status: i32 = i32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    let target_len: usize = u16::from_le_bytes([bytes[8], bytes[9]]) as usize;
+    let target_start: usize = READLINK_RESPONSE_HEADER_SIZE;
+    let target_end: usize = target_start.checked_add(target_len)?;
+    if bytes.len() < target_end {
+        return None;
+    }
+    Some(LongReadlinkResponse {
+        op_id,
+        status,
+        target: &bytes[target_start..target_end],
+    })
+}
 
 //==================================================================================================
 // Deserialization (hostfsd, std)
@@ -301,4 +347,138 @@ pub fn deserialize_long_lstat(bytes: &[u8]) -> Option<LongLstatRequest> {
     )
     .ok()?;
     Some(LongLstatRequest { op_id, path })
+}
+
+//==================================================================================================
+// Serialization (vfsd, no_std + alloc)
+//==================================================================================================
+
+/// Serializes the body of a long OPEN request.
+///
+/// Wire format: `[op_id:4][flags:4][path_len:2][path:N]`. Returns `None` if `path`
+/// is longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_open_request(
+    op_id: OperationId,
+    flags: i32,
+    path: &[u8],
+) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(OPEN_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&flags.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long UNLINK request.
+///
+/// Wire format: `[op_id:4][path_len:2][path:N]`. Returns `None` if `path` is
+/// longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_unlink_request(op_id: OperationId, path: &[u8]) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(UNLINK_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long RMDIR request.
+///
+/// Wire format: `[op_id:4][path_len:2][path:N]`. Returns `None` if `path` is
+/// longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_rmdir_request(op_id: OperationId, path: &[u8]) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(RMDIR_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long MKDIR request.
+///
+/// Wire format: `[op_id:4][mode:4][path_len:2][path:N]`. Returns `None` if `path`
+/// is longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_mkdir_request(
+    op_id: OperationId,
+    mode: u32,
+    path: &[u8],
+) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(MKDIR_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&mode.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long RENAME request.
+///
+/// Wire format: `[op_id:4][old_path_len:2][new_path_len:2][old_path:N][new_path:M]`.
+/// Returns `None` if either path is longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_rename_request(
+    op_id: OperationId,
+    old_path: &[u8],
+    new_path: &[u8],
+) -> Option<Vec<u8>> {
+    let old_path_len: u16 = u16::try_from(old_path.len()).ok()?;
+    let new_path_len: u16 = u16::try_from(new_path.len()).ok()?;
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(RENAME_HEADER_SIZE + old_path.len() + new_path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&old_path_len.to_le_bytes());
+    buf.extend_from_slice(&new_path_len.to_le_bytes());
+    buf.extend_from_slice(old_path);
+    buf.extend_from_slice(new_path);
+    Some(buf)
+}
+
+/// Serializes the body of a long SYMLINK request.
+///
+/// Wire format: `[op_id:4][target_len:2][linkpath_len:2][target:N][linkpath:M]`.
+/// Returns `None` if either string is longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_symlink_request(
+    op_id: OperationId,
+    target: &[u8],
+    linkpath: &[u8],
+) -> Option<Vec<u8>> {
+    let target_len: u16 = u16::try_from(target.len()).ok()?;
+    let link_len: u16 = u16::try_from(linkpath.len()).ok()?;
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(SYMLINK_HEADER_SIZE + target.len() + linkpath.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&target_len.to_le_bytes());
+    buf.extend_from_slice(&link_len.to_le_bytes());
+    buf.extend_from_slice(target);
+    buf.extend_from_slice(linkpath);
+    Some(buf)
+}
+
+/// Serializes the body of a long READLINK request.
+///
+/// Wire format: `[op_id:4][path_len:2][path:N]`. Returns `None` if `path` is
+/// longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_readlink_request(op_id: OperationId, path: &[u8]) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(READLINK_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long LSTAT request.
+///
+/// Wire format: `[op_id:4][path_len:2][path:N]`. Returns `None` if `path` is
+/// longer than [`MAX_PATH_LEN`].
+pub fn serialize_long_lstat_request(op_id: OperationId, path: &[u8]) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(LSTAT_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
 }

--- a/src/libs/hostfs-api/src/lseek.rs
+++ b/src/libs/hostfs-api/src/lseek.rs
@@ -3,7 +3,12 @@
 
 //! Lseek request and response wire format.
 
-use crate::HOSTFS_DATA_START;
+use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
 use ::sys::ipc::Message;
 
 /// Lseek request: seek within a file.
@@ -25,12 +30,20 @@ pub struct LseekResponse {
 }
 
 impl LseekRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
         payload[data_start + 4..data_start + 12].copy_from_slice(&self.offset.to_le_bytes());
         payload[data_start + 12..data_start + 16].copy_from_slice(&self.whence.to_le_bytes());
+        payload
     }
 
     /// Decodes a LseekRequest from the message payload.

--- a/src/libs/hostfs-api/src/lstat.rs
+++ b/src/libs/hostfs-api/src/lstat.rs
@@ -15,6 +15,9 @@
 //==================================================================================================
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -85,14 +88,39 @@ impl LstatRequest {
     /// Offset of `path` field (relative to data section start).
     const OFFSET_OF_PATH: usize = Self::OFFSET_OF_PATH_LEN + Self::SIZE_OF_PATH_LEN;
 
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`LstatRequest`] from a path slice.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
         let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
         payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
             .copy_from_slice(&self.path_len.to_le_bytes());
         let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[path_off..path_off + copy_len].copy_from_slice(&self.path[..copy_len]);
+        payload
     }
 
     ///

--- a/src/libs/hostfs-api/src/mkdir.rs
+++ b/src/libs/hostfs-api/src/mkdir.rs
@@ -4,6 +4,9 @@
 //! Mkdir request wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -21,13 +24,39 @@ pub struct MkdirRequest {
 }
 
 impl MkdirRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`MkdirRequest`] from a path slice and mode.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(mode: u32, path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            mode,
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.mode.to_le_bytes());
         payload[data_start + 4..data_start + 6].copy_from_slice(&self.path_len.to_le_bytes());
         let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[data_start + 6..data_start + 6 + copy_len].copy_from_slice(&self.path[..copy_len]);
+        payload
     }
 
     /// Decodes a MkdirRequest from the message payload.

--- a/src/libs/hostfs-api/src/open.rs
+++ b/src/libs/hostfs-api/src/open.rs
@@ -4,6 +4,9 @@
 //! Open request and response wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -30,8 +33,29 @@ pub struct OpenResponse {
 }
 
 impl OpenRequest {
-    /// Encodes this request into the operation data portion of a message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`OpenRequest`] from a path slice and POSIX `flags`.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(flags: i32, path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            flags,
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(&self, header_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         let flags_bytes: [u8; 4] = self.flags.to_le_bytes();
         let path_len_bytes: [u8; 2] = self.path_len.to_le_bytes();
@@ -40,6 +64,7 @@ impl OpenRequest {
         let path_copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[data_start + 6..data_start + 6 + path_copy_len]
             .copy_from_slice(&self.path[..path_copy_len]);
+        payload
     }
 
     /// Decodes an OpenRequest from the operation data portion of a message payload.

--- a/src/libs/hostfs-api/src/read.rs
+++ b/src/libs/hostfs-api/src/read.rs
@@ -4,6 +4,9 @@
 //! Read request and response wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_READ_DATA,
 };
@@ -30,12 +33,20 @@ pub struct ReadResponse {
 }
 
 impl ReadRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
         payload[data_start + 4..data_start + 8].copy_from_slice(&self.count.to_le_bytes());
         payload[data_start + 8..data_start + 16].copy_from_slice(&self.offset.to_le_bytes());
+        payload
     }
 
     /// Decodes a ReadRequest from the message payload.

--- a/src/libs/hostfs-api/src/readdir.rs
+++ b/src/libs/hostfs-api/src/readdir.rs
@@ -4,6 +4,9 @@
 //! ReadDir request and response wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_DIR_ENTRY_NAME_LEN,
 };
@@ -37,12 +40,20 @@ pub struct ReadDirEntry {
 }
 
 impl ReadDirRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
         payload[data_start + 4..data_start + 8].copy_from_slice(&self._reserved.to_le_bytes());
         payload[data_start + 8..data_start + 12].copy_from_slice(&self.offset.to_le_bytes());
+        payload
     }
 
     /// Decodes a ReadDirRequest from the message payload.

--- a/src/libs/hostfs-api/src/readlink.rs
+++ b/src/libs/hostfs-api/src/readlink.rs
@@ -22,6 +22,9 @@
 //==================================================================================================
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -79,14 +82,39 @@ impl ReadlinkRequest {
     /// Offset of `path` field (relative to data section start).
     const OFFSET_OF_PATH: usize = Self::OFFSET_OF_PATH_LEN + Self::SIZE_OF_PATH_LEN;
 
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`ReadlinkRequest`] from a path slice.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let path_len_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH_LEN;
         let path_off: usize = HOSTFS_DATA_START + Self::OFFSET_OF_PATH;
         payload[path_len_off..path_len_off + Self::SIZE_OF_PATH_LEN]
             .copy_from_slice(&self.path_len.to_le_bytes());
         let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[path_off..path_off + copy_len].copy_from_slice(&self.path[..copy_len]);
+        payload
     }
 
     ///

--- a/src/libs/hostfs-api/src/rename.rs
+++ b/src/libs/hostfs-api/src/rename.rs
@@ -4,6 +4,9 @@
 //! Rename request wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -21,12 +24,39 @@ pub struct RenameRequest {
 }
 
 impl RenameRequest {
-    /// Encodes this request into the message payload.
+    /// Builds an inline [`RenameRequest`] from two path slices.
+    ///
+    /// Returns `None` if the combined length of `old_path` and `new_path` exceeds
+    /// [`MAX_INLINE_PATH_LEN`]. Callers must fall back to the multi-part request form
+    /// in [`long_msg`](crate::long_msg) when this returns `None`.
+    pub fn from_paths(old_path: &[u8], new_path: &[u8]) -> Option<Self> {
+        let total: usize = old_path.len().checked_add(new_path.len())?;
+        if total > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut paths: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        paths[..old_path.len()].copy_from_slice(old_path);
+        paths[old_path.len()..old_path.len() + new_path.len()].copy_from_slice(new_path);
+        Some(Self {
+            old_path_len: old_path.len() as u16,
+            new_path_len: new_path.len() as u16,
+            paths,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
     ///
     /// If the combined path lengths exceed [`MAX_INLINE_PATH_LEN`], the recorded
     /// `old_path_len` and `new_path_len` are saturated to match the number of bytes
     /// actually written, preventing inconsistency between header fields and data.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         // Widen to usize before adding to avoid u16 overflow.
         let total_len: usize =
@@ -38,6 +68,7 @@ impl RenameRequest {
         payload[data_start + 2..data_start + 4].copy_from_slice(&(new_len as u16).to_le_bytes());
         payload[data_start + 4..data_start + 4 + total_len]
             .copy_from_slice(&self.paths[..total_len]);
+        payload
     }
 
     /// Decodes a RenameRequest from the message payload.

--- a/src/libs/hostfs-api/src/rmdir.rs
+++ b/src/libs/hostfs-api/src/rmdir.rs
@@ -4,6 +4,9 @@
 //! Rmdir request wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -19,12 +22,37 @@ pub struct RmdirRequest {
 }
 
 impl RmdirRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`RmdirRequest`] from a path slice.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 2].copy_from_slice(&self.path_len.to_le_bytes());
         let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[data_start + 2..data_start + 2 + copy_len].copy_from_slice(&self.path[..copy_len]);
+        payload
     }
 
     /// Decodes a RmdirRequest from the message payload.

--- a/src/libs/hostfs-api/src/stat.rs
+++ b/src/libs/hostfs-api/src/stat.rs
@@ -3,7 +3,12 @@
 
 //! Stat request and response wire format.
 
-use crate::HOSTFS_DATA_START;
+use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
 use ::sys::ipc::Message;
 
 /// Stat request: get file metadata.
@@ -30,10 +35,18 @@ pub struct StatResponse {
 }
 
 impl StatRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
+        payload
     }
 
     /// Decodes a StatRequest from the message payload.

--- a/src/libs/hostfs-api/src/truncate.rs
+++ b/src/libs/hostfs-api/src/truncate.rs
@@ -3,7 +3,12 @@
 
 //! Truncate request wire format.
 
-use crate::HOSTFS_DATA_START;
+use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
 use ::sys::ipc::Message;
 
 /// Truncate request: truncate a file to a given length.
@@ -16,11 +21,19 @@ pub struct TruncateRequest {
 }
 
 impl TruncateRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
         payload[data_start + 4..data_start + 12].copy_from_slice(&self.length.to_le_bytes());
+        payload
     }
 
     /// Decodes a TruncateRequest from the message payload.

--- a/src/libs/hostfs-api/src/unlink.rs
+++ b/src/libs/hostfs-api/src/unlink.rs
@@ -4,6 +4,9 @@
 //! Unlink request wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_PATH_LEN,
 };
@@ -19,12 +22,37 @@ pub struct UnlinkRequest {
 }
 
 impl UnlinkRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds an inline [`UnlinkRequest`] from a path slice.
+    ///
+    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
+    /// this returns `None`.
+    pub fn from_path(path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_PATH_LEN {
+            return None;
+        }
+        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        buf[..path.len()].copy_from_slice(path);
+        Some(Self {
+            path_len: path.len() as u16,
+            path: buf,
+        })
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 2].copy_from_slice(&self.path_len.to_le_bytes());
         let copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
         payload[data_start + 2..data_start + 2 + copy_len].copy_from_slice(&self.path[..copy_len]);
+        payload
     }
 
     /// Decodes an UnlinkRequest from the message payload.

--- a/src/libs/hostfs-api/src/write.rs
+++ b/src/libs/hostfs-api/src/write.rs
@@ -4,6 +4,9 @@
 //! Write request and response wire format.
 
 use crate::{
+    set_header,
+    set_op_id,
+    OperationId,
     HOSTFS_DATA_START,
     MAX_INLINE_WRITE_DATA,
 };
@@ -32,8 +35,30 @@ pub struct WriteResponse {
 }
 
 impl WriteRequest {
-    /// Encodes this request into the message payload.
-    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+    /// Builds a [`WriteRequest`] from a byte slice, clamping `count` and `data_len`
+    /// to [`MAX_INLINE_WRITE_DATA`] and using the given `offset`.
+    pub fn from_slice(fd: i32, offset: i64, buf: &[u8]) -> Self {
+        let write_len: usize = buf.len().min(MAX_INLINE_WRITE_DATA);
+        let mut data: [u8; MAX_INLINE_WRITE_DATA] = [0u8; MAX_INLINE_WRITE_DATA];
+        data[..write_len].copy_from_slice(&buf[..write_len]);
+        Self {
+            fd,
+            count: write_len as u32,
+            offset,
+            data_len: write_len as u16,
+            data,
+        }
+    }
+
+    /// Serializes this request into a complete message payload (header + op_id + data).
+    pub fn serialize(
+        &self,
+        header_value: u16,
+        op_id: OperationId,
+    ) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_header(&mut payload, header_value);
+        set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
         payload[data_start + 4..data_start + 8].copy_from_slice(&self.count.to_le_bytes());
@@ -43,6 +68,7 @@ impl WriteRequest {
         let copy_len: usize = (self.data_len as usize).min(MAX_INLINE_WRITE_DATA);
         payload[data_start + 18..data_start + 18 + copy_len]
             .copy_from_slice(&self.data[..copy_len]);
+        payload
     }
 
     /// Decodes a WriteRequest from the message payload.


### PR DESCRIPTION
Move hostfs IKC wire-format assembly out of vfsd into the hostfs-api crate so that request producers no longer have to manually compose [header | op_id | encoded data] payloads.

Single-message requests
-----------------------

Add `serialize(header_value: u16, op_id: OperationId) -> [u8; PAYLOAD_SIZE]` to each inline request type, writing the header, op id, and encoded fields into a fresh payload buffer:

  - CloseRequest, FlushRequest, StatRequest
  - LseekRequest, TruncateRequest
  - ReadRequest, WriteRequest
  - ReadlinkRequest, LstatRequest

The previous `encode(&mut payload)` helpers on these request types are folded into `serialize` since vfsd no longer needs the partial form. Response `encode` methods on the host side are left untouched.

Convenience builders
--------------------

Add slice-based constructors that encapsulate the inline-form length clamping and zero-padding previously open-coded in vfsd:

  - `WriteRequest::from_slice(fd, offset, buf)` clamps to MAX_INLINE_WRITE_DATA.
  - `ReadlinkRequest::from_path(path)` / `LstatRequest::from_path(path)` return `Option<Self>`, yielding `None` when the path exceeds MAX_INLINE_PATH_LEN so callers can fall back to the multi-part form.

Multi-part (long) requests
--------------------------

Add no_std serializers in `long_msg` that build the full multi-part byte stream (per-part `[header | op_id | chunk]` frames) for each long-form hostfs operation. Each helper returns `Option<Vec<u8>>` and yields `None` when a path component exceeds `u16::MAX`:

  - serialize_long_open_request
  - serialize_long_unlink_request
  - serialize_long_rmdir_request
  - serialize_long_mkdir_request
  - serialize_long_rename_request
  - serialize_long_symlink_request
  - serialize_long_readlink_request
  - serialize_long_lstat_request

To support no_std callers, `long_msg` now pulls in `alloc::vec::Vec` unconditionally and the `OperationId` import is no longer gated behind the `std` feature.

Helper signatures take `header_value: u16` rather than `SystemCallMessageHeader` to avoid introducing a dependency from hostfs-api on the `syscall` crate; callers pass `SystemCallMessageHeader::HostFs* as u16`.

Validation
----------

Verified with `z.ps1 build all`, `z.ps1 build -- run-unit-tests`, and `z.ps1 build -- run-nanvix-tests` on Windows; all 14 integration tests pass on `test-standalone-windows.toml`.