### PR TITLE
[ci] Fix benchmark matrix skip on schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,7 +941,13 @@ jobs:
     # consolidated in the benchmark-gate-linux job. Skip gracefully when the
     # gate reports the benchmark pipeline should not run (e.g. no Linux
     # self-hosted runners are online).
-    if: ${{ needs.benchmark-gate-linux.outputs.should-run == 'true' }}
+    #
+    # NOTE: !cancelled() is required so the matrix expands when an ancestor
+    # in the needs graph is skipped (e.g. precheck on schedule events).
+    # Without it, GitHub Actions applies the implicit success() guard and
+    # collapses the matrix pre-expansion, marking this job as skipped even
+    # when the gate reports should-run=true.
+    if: ${{ !cancelled() && needs.benchmark-gate-linux.outputs.should-run == 'true' }}
 
     steps:
       - name: "Pre-Checkout Cleanup"
@@ -1091,7 +1097,13 @@ jobs:
     # is consolidated in the benchmark-gate-windows job. Skip gracefully when
     # the gate reports the benchmark pipeline should not run (e.g. no Windows
     # self-hosted runners are online).
-    if: ${{ needs.benchmark-gate-windows.outputs.should-run == 'true' }}
+    #
+    # NOTE: !cancelled() is required so the matrix expands when an ancestor
+    # in the needs graph is skipped (e.g. precheck on schedule events).
+    # Without it, GitHub Actions applies the implicit success() guard and
+    # collapses the matrix pre-expansion, marking this job as skipped even
+    # when the gate reports should-run=true.
+    if: ${{ !cancelled() && needs.benchmark-gate-windows.outputs.should-run == 'true' }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #2432.

## Summary

The `benchmark` and `windows-benchmark` jobs in the nightly schedule run are being marked as skipped with the literal placeholder `${{ matrix.machine-type }}` in the job name. This cascades through `benchmark-finalize` and `release-archive` (skipped) into `notify-release-failure`, which opens a spurious failure issue every night (#2432, #2415).

## Root cause

The benchmark guards were changed from

```yaml
if: ${{ !cancelled() && needs.benchmark-gate-linux.outputs.should-run == 'true' }}
```

to

```yaml
if: ${{ needs.benchmark-gate-linux.outputs.should-run == 'true' }}
```

in commit `4b2f822a9`.

On `schedule` events the `precheck` job is intentionally skipped. `precheck` is an ancestor of the benchmark jobs through `benchmark-gate-*`. When any ancestor in the `needs` graph is in the `skipped` state and the `if:` expression does not call `always()` / `!cancelled()` / `cancelled()` / `failure()`, GitHub Actions applies an implicit `success()` check that evaluates to false and **collapses the matrix pre-expansion**. The job is marked skipped before `matrix.machine-type` is substituted, which is why the job name still contains `${{ matrix.machine-type }}`.

## Fix

Re-add `!cancelled() &&` to both `benchmark` and `windows-benchmark` `if:` guards, matching the pattern already used by `benchmark-finalize` and `windows-benchmark-finalize`. The gate job output (`should-run`) continues to govern whether the benchmark actually runs; `!cancelled()` only neutralizes the implicit `success()` check so the matrix expands.

## Validation

Reproduced and validated on `fix-benchmark-matrix-collapse-cancelled` using two temporary commits that forced `workflow_dispatch` to mimic `schedule` (precheck skipped, gate short-circuited to true). Both temp commits were stripped from this PR.

- Run [26558022598](https://github.com/nanvix/nanvix/actions/runs/26558022598) (without the gate path being taken on dispatch): job names were `Benchmark (${{ matrix.machine-type }})` and `Windows Benchmark (${{ matrix.machine-type }})` — collapsed.
- Run [26558191300](https://github.com/nanvix/nanvix/actions/runs/26558191300) (with `!cancelled()` and gate forced true on dispatch): job names were `Benchmark (microvm)` and `Windows Benchmark (microvm)` — matrix expanded as expected. The run was canceled once expansion was confirmed.

## Notes

- The earlier mitigation `7150334ee` (matrix axis change) did not address the regression and may be revisited as superfluous in a follow-up.
- No behavior change for non-schedule events: when `should-run == 'false'`, the job still skips.
