### PR TITLE
[vfsd] Implement resolve_nofollow for unlink operations and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
-ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin multiimage net-backend profiler nanvix nanvix-http nanvix-sandbox nanvix-sandbox-cache nanvix-sandbox-config nanvix-terminal syscomm user-vm-api
+ALL_HOST_RUST_LIBS := control-plane-api hostfsd hwloc multibin multiimage net-backend profiler nanvix nanvix-http nanvix-sandbox nanvix-sandbox-cache nanvix-sandbox-config nanvix-terminal syscomm user-vm-api
 # Host rlibs excluded on Windows:
 #  - nanvix-http, nanvix-sandbox-cache: depend on Unix-only APIs.
 #  - syscomm: test code references cfg(unix)-gated SocketAddr::Unix variant.

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -440,7 +440,7 @@ impl HostFsHandler {
         req: long_msg::LongUnlinkRequest,
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
-        let host_path: PathBuf = match self.sandbox.resolve(&req.path) {
+        let host_path: PathBuf = match self.sandbox.resolve_nofollow(&req.path) {
             Some(p) => p,
             None => {
                 set_header(response, SystemCallMessageHeader::HostFsUnlinkResponse as u16);
@@ -1004,7 +1004,7 @@ impl HostFsHandler {
             },
         };
 
-        let host_path: PathBuf = match self.sandbox.resolve(path_str) {
+        let host_path: PathBuf = match self.sandbox.resolve_nofollow(path_str) {
             Some(p) => p,
             None => {
                 set_header(response, SystemCallMessageHeader::HostFsUnlinkResponse as u16);

--- a/src/daemons/hostfsd/src/sandbox.rs
+++ b/src/daemons/hostfsd/src/sandbox.rs
@@ -139,3 +139,353 @@ impl Sandbox {
         Some(parent_resolved.join(file_name))
     }
 }
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::std::fs;
+    use ::tempfile::TempDir;
+
+    /// Creates a sandbox rooted at a fresh temporary directory.
+    #[allow(clippy::expect_used)]
+    fn make_sandbox() -> (TempDir, Sandbox) {
+        let tmp: TempDir = TempDir::new().expect("create tempdir");
+        let sandbox: Sandbox = Sandbox::new(tmp.path().to_path_buf()).expect("create sandbox");
+        (tmp, sandbox)
+    }
+
+    /// Creates a file symlink in a cross-platform way.
+    ///
+    /// On Unix uses `std::os::unix::fs::symlink`. On Windows uses
+    /// `std::os::windows::fs::symlink_file`, which requires either Administrator
+    /// privileges or Developer Mode (`SeCreateSymbolicLinkPrivilege`).
+    fn symlink_file(target: &Path, link: &Path) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            ::std::os::unix::fs::symlink(target, link)
+        }
+        #[cfg(windows)]
+        {
+            ::std::os::windows::fs::symlink_file(target, link)
+        }
+    }
+
+    /// Creates a directory symlink in a cross-platform way.
+    fn symlink_dir(target: &Path, link: &Path) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            ::std::os::unix::fs::symlink(target, link)
+        }
+        #[cfg(windows)]
+        {
+            ::std::os::windows::fs::symlink_dir(target, link)
+        }
+    }
+
+    /// Probes whether the host allows unprivileged symlink creation.
+    ///
+    /// On Windows this returns `false` unless the process holds
+    /// `SeCreateSymbolicLinkPrivilege` (granted by Developer Mode or running as
+    /// Administrator). Symlink-dependent tests early-return when this returns
+    /// `false` so they are silently skipped rather than failing on unsupported
+    /// hosts.
+    fn symlinks_supported() -> bool {
+        let Ok(tmp) = TempDir::new() else {
+            return false;
+        };
+        let target: PathBuf = tmp.path().join("t");
+        if fs::write(&target, b"x").is_err() {
+            return false;
+        }
+        symlink_file(&target, &tmp.path().join("l")).is_ok()
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Sandbox::new
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn new_rejects_nonexistent_root() {
+        let tmp: TempDir = TempDir::new().unwrap();
+        let missing: PathBuf = tmp.path().join("does-not-exist");
+        let err: io::Error = match Sandbox::new(missing) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn new_rejects_file_as_root() {
+        let tmp: TempDir = TempDir::new().unwrap();
+        let file: PathBuf = tmp.path().join("a-file");
+        fs::write(&file, b"x").unwrap();
+        let err: io::Error = match Sandbox::new(file) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn new_canonicalizes_root() {
+        let (tmp, sandbox) = make_sandbox();
+        assert_eq!(sandbox.root(), tmp.path().canonicalize().unwrap().as_path());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Sandbox::resolve
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_existing_file() {
+        let (_tmp, sandbox) = make_sandbox();
+        let target: PathBuf = sandbox.root().join("file.txt");
+        fs::write(&target, b"hello").unwrap();
+
+        let resolved: PathBuf = sandbox.resolve("file.txt").expect("resolve");
+        assert_eq!(resolved, target.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_strips_leading_slash() {
+        let (_tmp, sandbox) = make_sandbox();
+        fs::write(sandbox.root().join("file.txt"), b"hello").unwrap();
+
+        let a: PathBuf = sandbox.resolve("/file.txt").expect("resolve");
+        let b: PathBuf = sandbox.resolve("file.txt").expect("resolve");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn resolve_nonexistent_file_via_parent_canonicalization() {
+        let (_tmp, sandbox) = make_sandbox();
+        let resolved: PathBuf = sandbox.resolve("not-yet-created.txt").expect("resolve");
+        assert_eq!(resolved, sandbox.root().join("not-yet-created.txt"));
+    }
+
+    #[test]
+    fn resolve_nonexistent_parent_returns_none() {
+        let (_tmp, sandbox) = make_sandbox();
+        assert!(sandbox.resolve("missing-dir/file.txt").is_none());
+    }
+
+    #[test]
+    fn resolve_rejects_dotdot_escape() {
+        let (_tmp, sandbox) = make_sandbox();
+        // Create a sibling outside the sandbox and try to traverse to it.
+        let escape: &str = "../escape.txt";
+        assert!(sandbox.resolve(escape).is_none());
+    }
+
+    #[test]
+    fn resolve_normalizes_interior_dotdot() {
+        let (_tmp, sandbox) = make_sandbox();
+        fs::create_dir(sandbox.root().join("sub")).unwrap();
+        fs::write(sandbox.root().join("file.txt"), b"x").unwrap();
+
+        let resolved: PathBuf = sandbox.resolve("sub/../file.txt").expect("resolve");
+        assert_eq!(resolved, sandbox.root().join("file.txt").canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_nested_existing_path() {
+        let (_tmp, sandbox) = make_sandbox();
+        fs::create_dir_all(sandbox.root().join("a/b")).unwrap();
+        fs::write(sandbox.root().join("a/b/c.txt"), b"x").unwrap();
+
+        let resolved: PathBuf = sandbox.resolve("a/b/c.txt").expect("resolve");
+        assert_eq!(resolved, sandbox.root().join("a/b/c.txt").canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_root_itself() {
+        let (_tmp, sandbox) = make_sandbox();
+        let resolved: PathBuf = sandbox.resolve("").expect("resolve");
+        assert_eq!(resolved, sandbox.root());
+    }
+
+    #[test]
+    fn resolve_follows_symlink_within_sandbox() {
+        if !symlinks_supported() {
+            return;
+        }
+        let (_tmp, sandbox) = make_sandbox();
+        let target: PathBuf = sandbox.root().join("target.txt");
+        fs::write(&target, b"x").unwrap();
+        let link: PathBuf = sandbox.root().join("link.txt");
+        symlink_file(&target, &link).unwrap();
+
+        let resolved: PathBuf = sandbox.resolve("link.txt").expect("resolve");
+        assert_eq!(resolved, target.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_rejects_symlink_escaping_sandbox() {
+        if !symlinks_supported() {
+            return;
+        }
+        let outside: TempDir = TempDir::new().unwrap();
+        let outside_file: PathBuf = outside.path().join("secret.txt");
+        fs::write(&outside_file, b"secret").unwrap();
+
+        let (_tmp, sandbox) = make_sandbox();
+        let link: PathBuf = sandbox.root().join("escape");
+        symlink_file(&outside_file, &link).unwrap();
+
+        assert!(sandbox.resolve("escape").is_none());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Sandbox::resolve_nofollow
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_nofollow_bare_name_against_root() {
+        let (_tmp, sandbox) = make_sandbox();
+        let resolved: PathBuf = sandbox.resolve_nofollow("file.txt").expect("resolve");
+        assert_eq!(resolved, sandbox.root().join("file.txt"));
+    }
+
+    #[test]
+    fn resolve_nofollow_strips_leading_slash() {
+        let (_tmp, sandbox) = make_sandbox();
+        let a: PathBuf = sandbox.resolve_nofollow("/file.txt").expect("resolve");
+        let b: PathBuf = sandbox.resolve_nofollow("file.txt").expect("resolve");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn resolve_nofollow_empty_returns_root() {
+        let (_tmp, sandbox) = make_sandbox();
+        let resolved: PathBuf = sandbox.resolve_nofollow("").expect("resolve");
+        assert_eq!(resolved, sandbox.root());
+    }
+
+    #[test]
+    fn resolve_nofollow_root_slash_returns_root() {
+        let (_tmp, sandbox) = make_sandbox();
+        let resolved: PathBuf = sandbox.resolve_nofollow("/").expect("resolve");
+        assert_eq!(resolved, sandbox.root());
+    }
+
+    #[test]
+    fn resolve_nofollow_missing_parent_returns_none() {
+        let (_tmp, sandbox) = make_sandbox();
+        assert!(sandbox.resolve_nofollow("missing/file.txt").is_none());
+    }
+
+    #[test]
+    fn resolve_nofollow_rejects_dotdot_escape() {
+        let (_tmp, sandbox) = make_sandbox();
+        assert!(sandbox.resolve_nofollow("../escape.txt").is_none());
+    }
+
+    #[test]
+    fn resolve_nofollow_rejects_bare_dotdot() {
+        // `resolve_nofollow("..")` must not produce `<root>/..`, which would
+        // escape the sandbox once handed to a filesystem syscall.
+        let (_tmp, sandbox) = make_sandbox();
+        assert!(sandbox.resolve_nofollow("..").is_none());
+        assert!(sandbox.resolve_nofollow("/..").is_none());
+    }
+
+    #[test]
+    fn resolve_nofollow_rejects_bare_dot() {
+        // `.` as the final component is also rejected: it is not a meaningful
+        // target for operations that act on a named entry (lstat, readlink,
+        // unlink, symlink). Callers wanting the root should pass "" or "/".
+        let (_tmp, sandbox) = make_sandbox();
+        assert!(sandbox.resolve_nofollow(".").is_none());
+        assert!(sandbox.resolve_nofollow("/.").is_none());
+    }
+
+    #[test]
+    fn resolve_nofollow_rejects_trailing_dotdot_after_subdir() {
+        // Even with an existing parent, a trailing `..` must be rejected so
+        // the returned path cannot reference the parent directory itself.
+        // Note: a trailing `.` is normalized away by `Path::components()`
+        // (`sub/.` ≡ `sub`), so it is not a separate escape vector here.
+        let (_tmp, sandbox) = make_sandbox();
+        fs::create_dir(sandbox.root().join("sub")).unwrap();
+        assert!(sandbox.resolve_nofollow("sub/..").is_none());
+    }
+
+    #[test]
+    fn resolve_nofollow_nested_existing_parent() {
+        let (_tmp, sandbox) = make_sandbox();
+        fs::create_dir_all(sandbox.root().join("a/b")).unwrap();
+
+        let resolved: PathBuf = sandbox.resolve_nofollow("a/b/c.txt").expect("resolve");
+        assert_eq!(
+            resolved,
+            sandbox
+                .root()
+                .join("a/b")
+                .canonicalize()
+                .unwrap()
+                .join("c.txt")
+        );
+    }
+
+    #[test]
+    fn resolve_nofollow_does_not_follow_final_symlink() {
+        if !symlinks_supported() {
+            return;
+        }
+        let (_tmp, sandbox) = make_sandbox();
+        let target: PathBuf = sandbox.root().join("target.txt");
+        fs::write(&target, b"x").unwrap();
+        let link: PathBuf = sandbox.root().join("link.txt");
+        symlink_file(&target, &link).unwrap();
+
+        let resolved: PathBuf = sandbox.resolve_nofollow("link.txt").expect("resolve");
+        // The returned path must still point at the link itself, not the target.
+        assert_eq!(resolved, sandbox.root().join("link.txt"));
+        assert!(resolved
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    fn resolve_nofollow_follows_parent_symlink() {
+        // A symlink *in the parent chain* (not the final component) is still followed,
+        // matching the documented semantics.
+        if !symlinks_supported() {
+            return;
+        }
+        let (_tmp, sandbox) = make_sandbox();
+        fs::create_dir(sandbox.root().join("real")).unwrap();
+        symlink_dir(&sandbox.root().join("real"), &sandbox.root().join("alias")).unwrap();
+
+        let resolved: PathBuf = sandbox.resolve_nofollow("alias/file.txt").expect("resolve");
+        assert_eq!(
+            resolved,
+            sandbox
+                .root()
+                .join("real")
+                .canonicalize()
+                .unwrap()
+                .join("file.txt")
+        );
+    }
+
+    #[test]
+    fn resolve_nofollow_rejects_parent_symlink_escape() {
+        if !symlinks_supported() {
+            return;
+        }
+        let outside: TempDir = TempDir::new().unwrap();
+
+        let (_tmp, sandbox) = make_sandbox();
+        symlink_dir(outside.path(), &sandbox.root().join("escape")).unwrap();
+
+        assert!(sandbox.resolve_nofollow("escape/file.txt").is_none());
+    }
+}

--- a/src/daemons/hostfsd/src/sandbox.rs
+++ b/src/daemons/hostfsd/src/sandbox.rs
@@ -88,4 +88,54 @@ impl Sandbox {
     pub fn root(&self) -> &Path {
         &self.root
     }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves a guest-relative path to an absolute host path *without* following the
+    /// final path component.
+    ///
+    /// Behaves like [`Self::resolve`] for every component except the last: the parent
+    /// directory is canonicalized (and must exist and lie within the sandbox), and the
+    /// unmodified final component is appended. This is the correct resolution mode for
+    /// operations that must act on a symbolic link itself rather than on its target —
+    /// `lstat`, `readlink`, `unlink` on a link, and `symlink` (creating a link must not
+    /// follow any pre-existing link at the destination path).
+    ///
+    /// Bare names (no parent separator) resolve against the sandbox root.
+    ///
+    /// # Parameters
+    ///
+    /// - `relative_path`: The guest-relative path to resolve, which must not be absolute.
+    ///
+    /// # Symlink TOCTOU
+    ///
+    /// The same TOCTOU caveat as [`Self::resolve`] applies: after the parent is
+    /// canonicalized, an attacker swapping a symlink under the parent could still
+    /// influence subsequent operations on the returned path. Closing that gap requires
+    /// `openat()`-based dirfd operations.
+    ///
+    pub fn resolve_nofollow(&self, relative_path: &str) -> Option<PathBuf> {
+        let cleaned: &str = relative_path.trim_start_matches('/');
+        if cleaned.is_empty() {
+            // Refers to the sandbox root itself; resolve normally.
+            return Some(self.root.clone());
+        }
+        let candidate: PathBuf = self.root.join(cleaned);
+
+        // Reject `.` or `..` as the final component: these would let the resolved path step outside
+        // the sandbox after the parent-only containment check (e.g. `resolve_nofollow("..")` would
+        // otherwise yield `<root>/..`).
+        let last_component: ::std::path::Component<'_> = candidate.components().next_back()?;
+        if !matches!(last_component, ::std::path::Component::Normal(_)) {
+            return None;
+        }
+        let file_name: &std::ffi::OsStr = candidate.file_name()?;
+        let parent: &Path = candidate.parent()?;
+        let parent_resolved: PathBuf = parent.canonicalize().ok()?;
+        if !parent_resolved.starts_with(&self.root) {
+            return None;
+        }
+        Some(parent_resolved.join(file_name))
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `resolve_nofollow` method to the `Sandbox` struct, which enables resolving guest-relative paths to host paths without following the final path component. This is crucial for correct handling of symlink-related filesystem operations, such as `lstat`, `readlink`, `unlink` (on links), and `symlink` creation. The changes also extend the system call protocol to support new symlink and readlink operations, and update code to use the new path resolution logic where appropriate. Comprehensive unit tests are added to ensure correctness and security.

The most important changes are:

### Filesystem Path Resolution Improvements

* Added `Sandbox::resolve_nofollow`, a method that resolves paths without following the final component, preventing accidental dereferencing of symlinks and closing a class of security issues. Extensive tests are included to verify correct and secure behavior, including edge cases and symlink handling.
* Updated `HostFsHandler` to use `sandbox.resolve_nofollow` instead of `sandbox.resolve` for unlink operations, ensuring symlink-unlink semantics are correct and secure. [[1]](diffhunk://#diff-d6b24b6045848a089eed4391e17fa7393a78f7f5b154f768c130d4006e63a343L443-R443) [[2]](diffhunk://#diff-d6b24b6045848a089eed4391e17fa7393a78f7f5b154f768c130d4006e63a343L1007-R1007)

### System Call Protocol Extensions

* Added new system call message headers for symlink and readlink operations (`HostFsSymlinkRequestPart`, `HostFsSymlinkResponse`, `HostFsReadlinkRequest`, etc.), and updated header handling logic to support these operations. [[1]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R256-R264) [[2]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R418-R426) [[3]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R468-R476) [[4]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R507-R513) [[5]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R535-R545)

### Build System

* Registered the new `hostfsd` daemon in the build system by adding it to `ALL_HOST_RUST_LIBS` in the `Makefile`.
This pull request introduces a new path resolution method to the `Sandbox` abstraction in `hostfsd`, improves the security and correctness of file operations involving symlinks, and adds comprehensive tests for the new functionality. The changes ensure that certain filesystem operations (like `unlink`) act on the symlink itself rather than its target, preventing unintended symlink traversal.

Key changes:

**Path resolution and security improvements:**
* Added a new method `resolve_nofollow` to the `Sandbox` class in `src/daemons/hostfsd/src/sandbox.rs`, which resolves a guest-relative path to a host path without following the final path component. This is essential for safely handling operations that should not dereference symlinks (e.g., unlinking a symlink).
* Updated `HostFsHandler` methods in `src/daemons/hostfsd/src/handler.rs` to use `sandbox.resolve_nofollow` instead of `sandbox.resolve` for unlink operations, ensuring symlinks are not followed during these actions [[1]](diffhunk://#diff-d6b24b6045848a089eed4391e17fa7393a78f7f5b154f768c130d4006e63a343L443-R443) [[2]](diffhunk://#diff-d6b24b6045848a089eed4391e17fa7393a78f7f5b154f768c130d4006e63a343L1007-R1007).

**Testing and validation:**
* Added extensive unit tests for both `resolve` and the new `resolve_nofollow` methods in `src/daemons/hostfsd/src/sandbox.rs`, covering normal operation, symlink handling, edge cases, and security boundaries.

**Build system:**
* Included `hostfsd` in the `ALL_HOST_RUST_LIBS` variable in the `Makefile`, ensuring it is built as part of the host-side Rust libraries.