### PR TITLE
[hostfsd] Add symlink, readlink, and lstat support to host filesystem daemon

### DIFF
--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -73,6 +73,14 @@ pub struct HostFsHandler {
     fd_table: FdTable,
     /// Assembler for multi-part request messages.
     assembler: HostFsAssembler,
+    /// Queue of additional response payloads that a single request may produce.
+    ///
+    /// Most hostfs operations reply with a single message, but a few (currently the
+    /// long-target variant of `readlink`) emit a multi-part response. The first part
+    /// is returned directly from [`Self::handle_request`]; the remaining parts are
+    /// queued here and must be drained by the caller via
+    /// [`Self::take_next_response_part`] before submitting the next request.
+    extra_responses: std::collections::VecDeque<[u8; Message::PAYLOAD_SIZE]>,
 }
 
 impl HostFsHandler {
@@ -84,7 +92,20 @@ impl HostFsHandler {
             sandbox: Sandbox::new(root)?,
             fd_table: FdTable::new(),
             assembler: HostFsAssembler::new(),
+            extra_responses: std::collections::VecDeque::new(),
         })
+    }
+
+    /// Pops and returns the next queued response part, if any.
+    ///
+    /// After a call to [`Self::handle_request`] returns `Some(payload)`, callers must
+    /// repeatedly invoke this method (sending each returned payload as its own IKC
+    /// message) until it returns `None`. Only then is the next request safe to feed
+    /// in. This contract preserves the strict in-order arrival of response parts on
+    /// the vfsd side, which is required for the multi-part response assembler to
+    /// keep a single in-flight stream.
+    pub fn take_next_response_part(&mut self) -> Option<[u8; Message::PAYLOAD_SIZE]> {
+        self.extra_responses.pop_front()
     }
 
     /// Dispatches a hostfs request message and returns the response payload.
@@ -119,13 +140,24 @@ impl HostFsHandler {
         };
 
         // Helper: run a single-message handler, echo op_id, and wrap the result.
+        //
+        // The op_id stamp at bytes [2..6] is skipped when the handler produced a
+        // multi-part response, because those bytes belong to the
+        // `SystemCallMessagePart` framing (`total_parts` + `part_number`) and the
+        // op_id is embedded in the assembled response body instead.
         let run =
             |this: &mut Self,
              f: fn(&mut Self, &[u8; Message::PAYLOAD_SIZE], &mut [u8; Message::PAYLOAD_SIZE])|
              -> Option<[u8; Message::PAYLOAD_SIZE]> {
                 let mut response = [0u8; Message::PAYLOAD_SIZE];
                 f(this, payload, &mut response);
-                set_op_id(&mut response, get_op_id(payload));
+                let resp_header_raw: u16 = u16::from_ne_bytes([response[0], response[1]]);
+                let is_multipart: bool = SystemCallMessageHeader::try_from(resp_header_raw)
+                    .map(|h| h.is_hostfs_multipart_response())
+                    .unwrap_or(false);
+                if !is_multipart {
+                    set_op_id(&mut response, get_op_id(payload));
+                }
                 Some(response)
             };
 
@@ -135,7 +167,10 @@ impl HostFsHandler {
             | SystemCallMessageHeader::HostFsRenameRequestPart
             | SystemCallMessageHeader::HostFsUnlinkRequestPart
             | SystemCallMessageHeader::HostFsMkdirRequestPart
-            | SystemCallMessageHeader::HostFsRmdirRequestPart => {
+            | SystemCallMessageHeader::HostFsRmdirRequestPart
+            | SystemCallMessageHeader::HostFsSymlinkRequestPart
+            | SystemCallMessageHeader::HostFsReadlinkRequestPart
+            | SystemCallMessageHeader::HostFsLstatRequestPart => {
                 self.handle_long_part(syscall_msg.header, &syscall_msg.payload)
             },
             // Single-message requests: dispatch inline.
@@ -159,6 +194,8 @@ impl HostFsHandler {
             SystemCallMessageHeader::HostFsLseekRequest => run(self, Self::handle_lseek),
             SystemCallMessageHeader::HostFsTruncateRequest => run(self, Self::handle_truncate),
             SystemCallMessageHeader::HostFsFlushRequest => run(self, Self::handle_flush),
+            SystemCallMessageHeader::HostFsReadlinkRequest => run(self, Self::handle_readlink),
+            SystemCallMessageHeader::HostFsLstatRequest => run(self, Self::handle_lstat),
             other => {
                 log::error!("hostfsd: unexpected message header: {:?}", other);
                 let mut response = [0u8; Message::PAYLOAD_SIZE];
@@ -277,6 +314,39 @@ impl HostFsHandler {
                 } else {
                     log::error!("hostfsd: failed to deserialize long rmdir request");
                     set_header(&mut response, SystemCallMessageHeader::HostFsRmdirResponse as u16);
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageHeader::HostFsSymlinkRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_symlink(&assembled) {
+                    self.handle_long_symlink(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long symlink request");
+                    set_header(
+                        &mut response,
+                        SystemCallMessageHeader::HostFsSymlinkResponse as u16,
+                    );
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageHeader::HostFsReadlinkRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_readlink(&assembled) {
+                    self.handle_long_readlink(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long readlink request");
+                    set_header(
+                        &mut response,
+                        SystemCallMessageHeader::HostFsReadlinkResponse as u16,
+                    );
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageHeader::HostFsLstatRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_lstat(&assembled) {
+                    self.handle_long_lstat(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long lstat request");
+                    set_header(&mut response, SystemCallMessageHeader::HostFsLstatResponse as u16);
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
@@ -519,6 +589,364 @@ impl HostFsHandler {
             Err(e) => {
                 set_header(response, SystemCallMessageHeader::HostFsRmdirResponse as u16);
                 set_payload_data(response, &io_error_to_code(&e).to_le_bytes());
+            },
+        }
+    }
+
+    /// Handles a fully assembled long SYMLINK request.
+    ///
+    /// Creates a symbolic link at `linkpath` pointing to the verbatim `target` string.
+    /// The `target` is not sandbox-validated at creation time (POSIX semantics: a link's
+    /// target is stored as-is and only resolved on dereference). However, when the link
+    /// is later opened/stat'd through hostfsd, [`Sandbox::resolve`] will reject any
+    /// access that escapes the mount root, so an out-of-sandbox target simply produces
+    /// an unusable link rather than a security hole.
+    ///
+    /// The `linkpath` is resolved with [`Sandbox::resolve_nofollow`] so an existing
+    /// link at that name is not followed.
+    fn handle_long_symlink(
+        &mut self,
+        req: long_msg::LongSymlinkRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_header(response, SystemCallMessageHeader::HostFsSymlinkResponse as u16);
+
+        // Reject empty target and embedded NUL bytes — these are invalid as POSIX
+        // pathnames and would silently corrupt the link.
+        if req.target.is_empty() || req.target.as_bytes().contains(&0) {
+            set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+            return;
+        }
+
+        let link_path: PathBuf = match self.sandbox.resolve_nofollow(&req.linkpath) {
+            Some(p) => p,
+            None => {
+                log::warn!("hostfsd: symlink linkpath escapes sandbox: {:?}", req.linkpath);
+                set_payload_data(response, &HOSTFS_ERR_PERMISSION.to_le_bytes());
+                return;
+            },
+        };
+
+        match create_symlink(&req.target, &link_path) {
+            Ok(()) => {
+                self.fd_table.invalidate_dir_caches();
+                set_payload_data(response, &0i32.to_le_bytes());
+            },
+            Err(e) => {
+                set_payload_data(response, &symlink_error_to_code(&e).to_le_bytes());
+            },
+        }
+    }
+
+    /// Handles a fully assembled long READLINK request.
+    fn handle_long_readlink(
+        &mut self,
+        req: long_msg::LongReadlinkRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        self.do_readlink(req.op_id, &req.path, response);
+    }
+
+    /// Handles a fully assembled long LSTAT request.
+    fn handle_long_lstat(
+        &mut self,
+        req: long_msg::LongLstatRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        self.do_lstat(&req.path, response);
+    }
+
+    /// Handles an inline single-message READLINK request.
+    fn handle_readlink(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        let req: ReadlinkRequest = match ReadlinkRequest::decode(payload) {
+            Some(r) => r,
+            None => {
+                set_header(response, SystemCallMessageHeader::HostFsReadlinkResponse as u16);
+                let err = ReadlinkResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    target_len: 0,
+                    target: [0u8; MAX_INLINE_READLINK_TARGET],
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        let path_len: usize = (req.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        let path_str: &str = match core::str::from_utf8(&req.path[..path_len]) {
+            Ok(s) => s,
+            Err(_) => {
+                set_header(response, SystemCallMessageHeader::HostFsReadlinkResponse as u16);
+                let err = ReadlinkResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    target_len: 0,
+                    target: [0u8; MAX_INLINE_READLINK_TARGET],
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        self.do_readlink(get_op_id(payload), path_str, response);
+    }
+
+    /// Handles an inline single-message LSTAT request.
+    fn handle_lstat(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        let req: LstatRequest = match LstatRequest::decode(payload) {
+            Some(r) => r,
+            None => {
+                set_header(response, SystemCallMessageHeader::HostFsLstatResponse as u16);
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        let path_len: usize = (req.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        let path_str: &str = match core::str::from_utf8(&req.path[..path_len]) {
+            Ok(s) => s,
+            Err(_) => {
+                set_header(response, SystemCallMessageHeader::HostFsLstatResponse as u16);
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        self.do_lstat(path_str, response);
+    }
+
+    /// Shared `readlink` implementation used by both the inline and multi-part
+    /// request handlers.
+    ///
+    /// `op_id` is the request's operation identifier. It is required because a
+    /// successful read of a long target produces a multi-part response whose body
+    /// embeds the op_id at a fixed offset for vfsd-side routing — callers (inline or
+    /// long path) cannot rely on `set_op_id` having been applied to `response` yet.
+    fn do_readlink(
+        &mut self,
+        op_id: OperationId,
+        path_str: &str,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_header(response, SystemCallMessageHeader::HostFsReadlinkResponse as u16);
+
+        let host_path: PathBuf = match self.sandbox.resolve_nofollow(path_str) {
+            Some(p) => p,
+            None => {
+                let err = ReadlinkResponse {
+                    status: HOSTFS_ERR_PERMISSION,
+                    target_len: 0,
+                    target: [0u8; MAX_INLINE_READLINK_TARGET],
+                };
+                err.encode(response);
+                return;
+            },
+        };
+
+        // Refuse to follow any symlink before reading: `read_link` itself never follows
+        // the final component, but `symlink_metadata` lets us produce ENOENT for missing
+        // paths and EINVAL for non-symlinks (matching POSIX readlink semantics).
+        let meta = match fs::symlink_metadata(&host_path) {
+            Ok(m) => m,
+            Err(e) => {
+                let err = ReadlinkResponse {
+                    status: io_error_to_code(&e),
+                    target_len: 0,
+                    target: [0u8; MAX_INLINE_READLINK_TARGET],
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        if !meta.file_type().is_symlink() {
+            let err = ReadlinkResponse {
+                status: HOSTFS_ERR_INVALID,
+                target_len: 0,
+                target: [0u8; MAX_INLINE_READLINK_TARGET],
+            };
+            err.encode(response);
+            return;
+        }
+
+        match fs::read_link(&host_path) {
+            Ok(target_path) => {
+                // Preserve the verbatim target bytes on Unix: `to_string_lossy` would
+                // replace invalid UTF-8 sequences with U+FFFD, silently corrupting
+                // non-UTF-8 link targets. On Windows, paths are natively UTF-16 and the
+                // hostfs wire format is byte-oriented, so a lossy UTF-8 conversion is
+                // the closest faithful representation available.
+                #[cfg(unix)]
+                let target_owned: Vec<u8> = {
+                    use std::os::unix::ffi::OsStrExt;
+                    target_path.as_os_str().as_bytes().to_vec()
+                };
+                #[cfg(not(unix))]
+                let target_owned: Vec<u8> = target_path.to_string_lossy().into_owned().into_bytes();
+                let target_bytes: &[u8] = &target_owned;
+                // Targets exceeding the per-response cap are rejected outright rather
+                // than truncated so callers get a deterministic, clear error.
+                if target_bytes.len() > ::sysapi::limits::PATH_MAX {
+                    log::warn!(
+                        "hostfsd: readlink target exceeds PATH_MAX ({} > {})",
+                        target_bytes.len(),
+                        ::sysapi::limits::PATH_MAX
+                    );
+                    let err = ReadlinkResponse {
+                        status: HOSTFS_ERR_INVALID,
+                        target_len: 0,
+                        target: [0u8; MAX_INLINE_READLINK_TARGET],
+                    };
+                    err.encode(response);
+                    return;
+                }
+                if target_bytes.len() <= MAX_INLINE_READLINK_TARGET {
+                    // Inline fast path: target fits in a single response message.
+                    let mut target_buf: [u8; MAX_INLINE_READLINK_TARGET] =
+                        [0u8; MAX_INLINE_READLINK_TARGET];
+                    target_buf[..target_bytes.len()].copy_from_slice(target_bytes);
+                    let resp = ReadlinkResponse {
+                        status: 0,
+                        target_len: target_bytes.len() as u16,
+                        target: target_buf,
+                    };
+                    resp.encode(response);
+                    return;
+                }
+                // Multi-part response: emit a stream of `HostFsReadlinkResponsePart`
+                // messages. The first part is written into `response` (and returned
+                // by `handle_request`); the rest are queued in `extra_responses` for
+                // the caller to drain.
+                self.emit_long_readlink_response(response, op_id, 0, target_bytes);
+            },
+            Err(e) => {
+                let err = ReadlinkResponse {
+                    status: io_error_to_code(&e),
+                    target_len: 0,
+                    target: [0u8; MAX_INLINE_READLINK_TARGET],
+                };
+                err.encode(response);
+            },
+        }
+    }
+
+    /// Builds a multi-part `HostFsReadlinkResponsePart` stream for a successful
+    /// `readlink` whose target exceeds the inline capacity.
+    ///
+    /// Wire-format details (body layout, per-part framing, chunk size) live in
+    /// [`long_msg::serialize_long_readlink_response`] and
+    /// [`long_msg::chunk_long_response`]. This method only encodes the policy that
+    /// is local to the daemon: the first chunk is written into `first_response`,
+    /// and the remaining chunks are queued in `extra_responses` for the caller to
+    /// drain via [`Self::take_next_response_part`].
+    ///
+    /// Note: `op_id` is recorded *only* in the first 4 bytes of the assembled body.
+    /// The outer-frame bytes `[2..6]` belong to the `SystemCallMessagePart` framing
+    /// (`total_parts` + `part_number`), so `set_op_id` is intentionally not applied
+    /// to multi-part responses (see `is_hostfs_multipart_response` in `handle_request`).
+    fn emit_long_readlink_response(
+        &mut self,
+        first_response: &mut [u8; Message::PAYLOAD_SIZE],
+        op_id: OperationId,
+        status: i32,
+        target_bytes: &[u8],
+    ) {
+        // `target_bytes.len()` is bounded above by `PATH_MAX` at the call site, which
+        // is well below `MAX_PATH_LEN` (u16::MAX), so the serializer cannot return
+        // `None` here. Use a debug-only assert and fall through with an empty body
+        // in release builds rather than panic on a malformed input.
+        let body: Vec<u8> = long_msg::serialize_long_readlink_response(op_id, status, target_bytes)
+            .unwrap_or_default();
+        debug_assert!(
+            !body.is_empty(),
+            "serialize_long_readlink_response failed: target len {} exceeds wire limit",
+            target_bytes.len()
+        );
+
+        // `target_bytes.len()` is bounded above by `PATH_MAX` at the call site,
+        // which keeps the chunked stream well below `MAX_LONG_RESPONSE_PARTS`. The
+        // chunker can therefore not return `None` in practice, but guard with a
+        // debug assert and drop the response in release builds rather than emit a
+        // wrapped/malformed stream.
+        let parts_vec: Vec<[u8; Message::PAYLOAD_SIZE]> = match long_msg::chunk_long_response(
+            SystemCallMessageHeader::HostFsReadlinkResponsePart as u16,
+            &body,
+        ) {
+            Some(v) => v,
+            None => {
+                debug_assert!(
+                    false,
+                    "chunk_long_response rejected body of {} bytes (exceeds wire-format limit)",
+                    body.len()
+                );
+                log::error!(
+                    "hostfsd: dropping readlink response body ({} bytes) that exceeds the \
+                     long-response part limit",
+                    body.len()
+                );
+                return;
+            },
+        };
+        let mut parts: std::vec::IntoIter<[u8; Message::PAYLOAD_SIZE]> = parts_vec.into_iter();
+        if let Some(first) = parts.next() {
+            *first_response = first;
+        }
+        self.extra_responses.extend(parts);
+    }
+
+    /// Shared `lstat` implementation used by both the inline and multi-part
+    /// request handlers.
+    fn do_lstat(&mut self, path_str: &str, response: &mut [u8; Message::PAYLOAD_SIZE]) {
+        set_header(response, SystemCallMessageHeader::HostFsLstatResponse as u16);
+
+        let host_path: PathBuf = match self.sandbox.resolve_nofollow(path_str) {
+            Some(p) => p,
+            None => {
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_PERMISSION,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+
+        match fs::symlink_metadata(&host_path) {
+            Ok(meta) => {
+                let kind: u8 = metadata_kind(&meta);
+                let mode: u32 = metadata_mode(&meta, kind);
+                let resp = LstatResponse {
+                    status: 0,
+                    size: meta.len(),
+                    mode,
+                    kind,
+                };
+                resp.encode(response);
+            },
+            Err(e) => {
+                let err = LstatResponse {
+                    status: io_error_to_code(&e),
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
             },
         }
     }
@@ -1219,7 +1647,30 @@ impl HostFsHandler {
 /// Converts an `io::Error` to a simple integer error code.
 ///
 /// These codes are defined in the `hostfs-api` crate as `HOSTFS_ERR_*` constants.
+///
+/// `ELOOP` (too many levels of symbolic links) is detected via the raw OS error code
+/// because `std::io::ErrorKind::FilesystemLoop` is unstable. The Linux/macOS code is
+/// `40`/`62`; on Windows the closest equivalent reported by `CreateFileW` when a
+/// reparse-point chain cannot be resolved is `ERROR_CANT_RESOLVE_FILENAME` (1921).
 fn io_error_to_code(e: &io::Error) -> i32 {
+    // ELOOP-style errors do not have a stable `ErrorKind`, so probe the raw OS code.
+    if let Some(raw) = e.raw_os_error() {
+        #[cfg(target_os = "linux")]
+        const ELOOP_RAW: i32 = 40;
+        #[cfg(target_os = "macos")]
+        const ELOOP_RAW: i32 = 62;
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        const ELOOP_RAW: i32 = i32::MIN; // sentinel: no match on this platform
+        #[cfg(windows)]
+        const ERROR_CANT_RESOLVE_FILENAME: i32 = 1921;
+        if raw == ELOOP_RAW {
+            return HOSTFS_ERR_LOOP;
+        }
+        #[cfg(windows)]
+        if raw == ERROR_CANT_RESOLVE_FILENAME {
+            return HOSTFS_ERR_LOOP;
+        }
+    }
     match e.kind() {
         io::ErrorKind::NotFound => HOSTFS_ERR_NOT_FOUND,
         io::ErrorKind::PermissionDenied => HOSTFS_ERR_PERMISSION,
@@ -1254,6 +1705,138 @@ fn open_dir_handle(path: &std::path::Path) -> io::Result<File> {
     #[cfg(not(windows))]
     {
         File::open(path)
+    }
+}
+
+/// Creates a symbolic link at `linkpath` pointing to the verbatim `target` string.
+///
+/// On Unix, [`std::os::unix::fs::symlink`] is used directly: the resulting link is
+/// type-agnostic, matching POSIX `symlink(2)` semantics.
+///
+/// On Windows, symbolic links are typed at creation time (file vs. directory). The
+/// best-effort policy is:
+/// 1. If the target resolves (relative to the link's parent) to an existing directory,
+///    use [`std::os::windows::fs::symlink_dir`].
+/// 2. Otherwise — including the common case of a target that does not yet exist or is a
+///    file — use [`std::os::windows::fs::symlink_file`].
+///
+/// On Windows, creating a symbolic link requires either administrative privileges or
+/// Developer Mode (which grants `SeCreateSymbolicLinkPrivilege` to standard users).
+/// Without those, the call fails with `ERROR_PRIVILEGE_NOT_HELD`, which is mapped to
+/// [`HOSTFS_ERR_NOT_SUPPORTED`] by [`symlink_error_to_code`].
+///
+/// Note: the Windows file-vs-directory probe uses `fs::metadata`, which *follows*
+/// symbolic links. If `target` itself resolves through another link to a directory,
+/// the directory variant is selected; if it resolves to a file or does not exist,
+/// the file variant is used. This is best-effort classification at creation time and
+/// does not affect the verbatim storage of the link target.
+fn create_symlink(target: &str, linkpath: &std::path::Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, linkpath)
+    }
+    #[cfg(windows)]
+    {
+        // Resolve `target` relative to the link's parent to decide which variant of the
+        // Windows symlink API to use. If the target's type cannot be determined (e.g.,
+        // it does not exist yet), default to the file variant — this matches the most
+        // common case and lets the link become valid once the target is created.
+        let parent: &std::path::Path = linkpath
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let absolute_target: std::path::PathBuf = parent.join(target);
+        let is_dir: bool = fs::metadata(&absolute_target)
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        if is_dir {
+            std::os::windows::fs::symlink_dir(target, linkpath)
+        } else {
+            std::os::windows::fs::symlink_file(target, linkpath)
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (target, linkpath);
+        Err(io::Error::new(io::ErrorKind::Unsupported, "symlink not supported on this platform"))
+    }
+}
+
+/// Translates an `io::Error` from a symlink creation attempt into a hostfs error code.
+///
+/// Has the same behaviour as [`io_error_to_code`] for the cases it can handle, plus a
+/// Windows-specific mapping of `ERROR_PRIVILEGE_NOT_HELD` (raw OS code 1314) to
+/// [`HOSTFS_ERR_NOT_SUPPORTED`]. That error appears when the daemon is run without
+/// Developer Mode and without the symlink privilege, and surfacing it as a distinct
+/// code lets the guest report a clearer diagnostic.
+fn symlink_error_to_code(e: &io::Error) -> i32 {
+    #[cfg(windows)]
+    {
+        // ERROR_PRIVILEGE_NOT_HELD: returned by CreateSymbolicLinkW when the caller
+        // lacks SeCreateSymbolicLinkPrivilege (e.g., no Developer Mode).
+        const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
+        if e.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD) {
+            return HOSTFS_ERR_NOT_SUPPORTED;
+        }
+    }
+    io_error_to_code(e)
+}
+
+/// Derives a hostfs [`file_kind`] discriminant from host [`fs::Metadata`].
+///
+/// Symbolic links take precedence over the regular/dir classification because the
+/// metadata is expected to come from [`fs::symlink_metadata`] (an `lstat`), and the
+/// caller wants to know that the path resolves to a link rather than what the link
+/// points to.
+fn metadata_kind(meta: &fs::Metadata) -> u8 {
+    let ft = meta.file_type();
+    if ft.is_symlink() {
+        file_kind::SYMLINK
+    } else if ft.is_dir() {
+        file_kind::DIRECTORY
+    } else if ft.is_file() {
+        file_kind::REGULAR
+    } else {
+        file_kind::OTHER
+    }
+}
+
+/// Reports a `st_mode`-style value for an `lstat` response.
+///
+/// On Unix, the host kernel already supplies a `st_mode` that includes both the
+/// permission bits and the type bits. On Windows, the Rust standard library exposes a
+/// permission *boolean* (read-only) and no file-type bits, so a synthetic value is
+/// built from POSIX-style constants. The guest must treat the value as informational
+/// — the authoritative file kind is the separate [`LstatResponse::kind`] field.
+fn metadata_mode(meta: &fs::Metadata, kind: u8) -> u32 {
+    #[cfg(unix)]
+    {
+        let _ = kind;
+        meta.permissions().mode()
+    }
+    #[cfg(not(unix))]
+    {
+        // POSIX file-type constants. Defined locally to avoid pulling sysapi into this
+        // host-side crate just for two integer literals.
+        const S_IFREG: u32 = 0o100_000;
+        const S_IFDIR: u32 = 0o040_000;
+        const S_IFLNK: u32 = 0o120_000;
+        const PERM_RW: u32 = 0o666;
+        const PERM_RO: u32 = 0o444;
+        const PERM_DIR: u32 = 0o755;
+        let type_bits: u32 = match kind {
+            file_kind::SYMLINK => S_IFLNK,
+            file_kind::DIRECTORY => S_IFDIR,
+            file_kind::REGULAR => S_IFREG,
+            _ => 0,
+        };
+        let perm_bits: u32 = if kind == file_kind::DIRECTORY {
+            PERM_DIR
+        } else if meta.permissions().readonly() {
+            PERM_RO
+        } else {
+            PERM_RW
+        };
+        type_bits | perm_bits
     }
 }
 

--- a/src/daemons/hostfsd/src/sandbox.rs
+++ b/src/daemons/hostfsd/src/sandbox.rs
@@ -106,7 +106,9 @@ impl Sandbox {
     ///
     /// # Parameters
     ///
-    /// - `relative_path`: The guest-relative path to resolve, which must not be absolute.
+    /// - `relative_path`: The guest path to resolve, relative to the sandbox root. A
+    ///   leading `/` is also accepted and treated as guest-absolute; it is normalized
+    ///   to a sandbox-relative path before resolution.
     ///
     /// # Symlink TOCTOU
     ///

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -1247,3 +1247,318 @@ fn test_long_rename_multi_part() {
     assert!(!tmp.path().join(&old_path).exists());
     assert_eq!(fs::read(tmp.path().join(&new_path)).unwrap(), b"payload");
 }
+
+//==================================================================================================
+// Symlink Tests (lstat / readlink / symlink)
+//==================================================================================================
+
+/// Builds an inline Lstat request payload.
+fn make_lstat_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
+    let req: LstatRequest =
+        LstatRequest::from_path(path.as_bytes()).expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsLstatRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
+}
+
+/// Builds an inline Readlink request payload.
+fn make_readlink_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
+    let req: ReadlinkRequest =
+        ReadlinkRequest::from_path(path.as_bytes()).expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsReadlinkRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
+}
+
+/// Serializes a long Symlink request:
+/// `[op_id:4][target_len:2][linkpath_len:2][target:N][linkpath:M]`.
+fn make_long_symlink_parts(
+    target: &str,
+    linkpath: &str,
+    op_id: OperationId,
+) -> Vec<[u8; Message::PAYLOAD_SIZE]> {
+    let t: &[u8] = target.as_bytes();
+    let l: &[u8] = linkpath.as_bytes();
+    let mut data: Vec<u8> = Vec::new();
+    data.extend_from_slice(&op_id.to_le_bytes());
+    data.extend_from_slice(&(t.len() as u16).to_le_bytes());
+    data.extend_from_slice(&(l.len() as u16).to_le_bytes());
+    data.extend_from_slice(t);
+    data.extend_from_slice(l);
+    split_into_parts(SystemCallMessageHeader::HostFsSymlinkRequestPart, &data)
+}
+
+/// Creates a symbolic link on the host. Returns `Ok(())` on success or an error.
+///
+/// On Windows this requires Developer Mode (or admin); if not enabled, returns
+/// `Err(_)` with `ErrorKind::PermissionDenied`. Tests that depend on host symlink
+/// creation should skip gracefully in that case.
+fn host_symlink(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, link)
+    }
+    #[cfg(windows)]
+    {
+        // Use symlink_file by default; tests that need dir links create them explicitly.
+        std::os::windows::fs::symlink_file(target, link)
+    }
+}
+
+/// Returns true if the OS refused to create the symlink due to insufficient privileges.
+/// On Windows non-Developer-Mode setups, symlink creation fails with
+/// `ERROR_PRIVILEGE_NOT_HELD` (1314); tests should skip in that case. On Unix, host
+/// `symlink(2)` does not require special privileges, so this always returns `false`.
+fn is_privilege_error(err: &std::io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        // ERROR_PRIVILEGE_NOT_HELD = 1314
+        err.raw_os_error() == Some(1314)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = err;
+        false
+    }
+}
+
+#[test]
+fn test_lstat_regular_file() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("file.txt"), b"hello").unwrap();
+    let req = make_lstat_request("file.txt");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "lstat should succeed");
+    assert_eq!(r.kind, file_kind::REGULAR);
+    assert_eq!(r.size, 5);
+}
+
+#[test]
+fn test_lstat_directory() {
+    let (mut handler, tmp) = setup();
+    fs::create_dir(tmp.path().join("dir")).unwrap();
+    let req = make_lstat_request("dir");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "lstat should succeed");
+    assert_eq!(r.kind, file_kind::DIRECTORY);
+}
+
+#[test]
+fn test_lstat_nonexistent_fails() {
+    let (mut handler, _tmp) = setup();
+    let req = make_lstat_request("missing");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, HOSTFS_ERR_NOT_FOUND);
+}
+
+#[test]
+fn test_lstat_symlink_does_not_follow() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("target.txt"), b"contents").unwrap();
+    if let Err(e) = host_symlink(std::path::Path::new("target.txt"), &tmp.path().join("link")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_lstat_request("link");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "lstat should succeed");
+    assert_eq!(r.kind, file_kind::SYMLINK, "lstat must NOT follow the symlink");
+}
+
+#[test]
+fn test_readlink_returns_target() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("target.txt"), b"x").unwrap();
+    let target_str = "target.txt";
+    if let Err(e) = host_symlink(std::path::Path::new(target_str), &tmp.path().join("link")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_readlink_request("link");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = ReadlinkResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "readlink should succeed");
+    let got = &r.target[..r.target_len as usize];
+    assert_eq!(got, target_str.as_bytes());
+}
+
+#[test]
+fn test_readlink_regular_file_fails() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("file.txt"), b"x").unwrap();
+    let req = make_readlink_request("file.txt");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = ReadlinkResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, HOSTFS_ERR_INVALID, "readlink on non-symlink must fail with EINVAL");
+}
+
+#[test]
+fn test_readlink_nonexistent_fails() {
+    let (mut handler, _tmp) = setup();
+    let req = make_readlink_request("missing");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = ReadlinkResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, HOSTFS_ERR_NOT_FOUND);
+}
+
+#[test]
+fn test_unlink_removes_symlink_not_target() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("target.txt"), b"preserve me").unwrap();
+    if let Err(e) = host_symlink(std::path::Path::new("target.txt"), &tmp.path().join("link")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_unlink_request("link");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(resp[ds..ds + 4].try_into().unwrap());
+    assert_eq!(status, 0, "unlink of symlink should succeed");
+    // Target file must survive.
+    assert_eq!(fs::read(tmp.path().join("target.txt")).unwrap(), b"preserve me");
+    // Symlink itself must be gone.
+    assert!(
+        !tmp.path().join("link").exists() && fs::symlink_metadata(tmp.path().join("link")).is_err()
+    );
+}
+
+#[test]
+fn test_symlink_creates_link() {
+    let (mut handler, tmp) = setup();
+    // Build multi-part symlink request.
+    let parts = make_long_symlink_parts("target.txt", "link", OperationId::from_raw(101));
+    let response = feed_parts(&mut handler, &parts);
+    assert_eq!(get_op_id(&response), OperationId::from_raw(101));
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
+    if status == HOSTFS_ERR_NOT_SUPPORTED {
+        println!("skipping: host cannot create symlinks (ENOTSUP)");
+        return;
+    }
+    assert_eq!(status, 0, "symlink should succeed, got {}", status);
+    // Verify the link exists and points to the intended target.
+    let meta = fs::symlink_metadata(tmp.path().join("link")).expect("link should exist");
+    assert!(meta.file_type().is_symlink(), "created entry must be a symlink");
+    let target = fs::read_link(tmp.path().join("link")).expect("readlink");
+    assert_eq!(target, std::path::PathBuf::from("target.txt"));
+}
+
+#[test]
+fn test_symlink_rejects_empty_target() {
+    let (mut handler, _tmp) = setup();
+    let parts = make_long_symlink_parts("", "link", OperationId::from_raw(102));
+    let response = feed_parts(&mut handler, &parts);
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
+    assert_eq!(status, HOSTFS_ERR_INVALID);
+}
+
+#[test]
+fn test_symlink_rejects_nul_in_target() {
+    let (mut handler, _tmp) = setup();
+    let parts = make_long_symlink_parts("a\0b", "link", OperationId::from_raw(103));
+    let response = feed_parts(&mut handler, &parts);
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
+    assert_eq!(status, HOSTFS_ERR_INVALID);
+}
+
+#[test]
+fn test_symlink_linkpath_escapes_sandbox() {
+    let (mut handler, _tmp) = setup();
+    let parts = make_long_symlink_parts("target.txt", "../escape", OperationId::from_raw(104));
+    let response = feed_parts(&mut handler, &parts);
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
+    assert_eq!(status, HOSTFS_ERR_PERMISSION);
+}
+
+/// Reassembles a sequence of multi-part response messages into the raw body.
+///
+/// Each part has the wire layout:
+/// `[header:2][total_parts:2 LE][part_number:2 LE][payload_size:1][payload:N]`
+/// (see `build_long_readlink_response_part` in handler.rs).
+fn drain_multipart_response(
+    handler: &mut HostFsHandler,
+    first: [u8; Message::PAYLOAD_SIZE],
+    expected_header: SystemCallMessageHeader,
+) -> Vec<u8> {
+    fn read_part(
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        expected_header: SystemCallMessageHeader,
+    ) -> (u16, u16, Vec<u8>) {
+        let header_raw: u16 = u16::from_ne_bytes([payload[0], payload[1]]);
+        assert_eq!(header_raw, expected_header as u16, "unexpected response header");
+        let total_parts: u16 = u16::from_le_bytes([payload[2], payload[3]]);
+        let part_number: u16 = u16::from_le_bytes([payload[4], payload[5]]);
+        let payload_size: usize = payload[6] as usize;
+        let chunk: Vec<u8> = payload[7..7 + payload_size].to_vec();
+        (total_parts, part_number, chunk)
+    }
+
+    let (total_parts, part_number, chunk0) = read_part(&first, expected_header);
+    assert_eq!(part_number, 0, "first response part must have part_number == 0");
+
+    let mut body: Vec<u8> = chunk0;
+    for expected_pn in 1..total_parts {
+        let next: [u8; Message::PAYLOAD_SIZE] = handler
+            .take_next_response_part()
+            .expect("expected another response part");
+        let (tp, pn, chunk) = read_part(&next, expected_header);
+        assert_eq!(tp, total_parts, "total_parts mismatch across parts");
+        assert_eq!(pn, expected_pn, "out-of-order response part");
+        body.extend_from_slice(&chunk);
+    }
+    assert!(handler.take_next_response_part().is_none(), "unexpected extra response parts queued");
+    body
+}
+
+#[test]
+fn test_readlink_long_target_multipart_response() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("target.txt"), b"x").unwrap();
+
+    // Construct a target longer than the inline cap so the handler is forced into
+    // the multi-part response path.
+    let target_str: String = "a/".repeat(120) + "tail.txt";
+    assert!(target_str.len() > MAX_INLINE_READLINK_TARGET, "test target must exceed inline cap");
+    assert!(target_str.len() <= ::sysapi::limits::PATH_MAX, "test target must fit long cap");
+
+    if let Err(e) = host_symlink(std::path::Path::new(&target_str), &tmp.path().join("link")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+
+    let req = make_readlink_request("link");
+    let first = handler.handle_request(&req).expect("response expected");
+
+    let body = drain_multipart_response(
+        &mut handler,
+        first,
+        SystemCallMessageHeader::HostFsReadlinkResponsePart,
+    );
+    assert!(body.len() >= hostfs_api::long_msg::READLINK_RESPONSE_HEADER_SIZE, "body too short");
+    let resp = hostfs_api::long_msg::deserialize_long_readlink_response(&body)
+        .expect("readlink long response must deserialize");
+    assert_eq!(resp.status, 0, "readlink should succeed");
+    assert_eq!(resp.target.len(), target_str.len());
+    assert_eq!(resp.target, target_str.as_bytes());
+}

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -1154,6 +1154,41 @@ fn test_long_unlink_multi_part() {
     assert!(!tmp.path().join(&path).exists());
 }
 
+/// Ensures that unlinking a symbolic link via the multi-part long-request path
+/// removes the link itself and leaves the target intact. Exercises the long-unlink
+/// decoding code path, which is distinct from the inline one covered by
+/// `test_unlink_removes_symlink_not_target`.
+#[test]
+fn test_long_unlink_symlink_removes_link_not_target() {
+    let (mut handler, tmp) = setup();
+    // Use a long parent dir so the encoded path exceeds the inline limit and the
+    // request must be split across multiple parts.
+    let long_dir: String = "u".repeat(60);
+    fs::create_dir(tmp.path().join(&long_dir)).unwrap();
+    let target_rel: String = format!("{}/target.txt", long_dir);
+    let link_rel: String = format!("{}/link", long_dir);
+    fs::write(tmp.path().join(&target_rel), b"keep me").unwrap();
+    // Use a relative target so the link is portable within the sandbox.
+    if let Err(e) = host_symlink(std::path::Path::new("target.txt"), &tmp.path().join(&link_rel)) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+
+    let parts = make_long_unlink_parts(&link_rel, OperationId::from_raw(13));
+    assert!(parts.len() >= 2, "long unlink should require multiple parts, got {}", parts.len());
+
+    let response = feed_parts(&mut handler, &parts);
+    assert_eq!(get_op_id(&response), OperationId::from_raw(13));
+    let ds: usize = HOSTFS_DATA_START;
+    let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
+    assert_eq!(status, 0, "long unlink of symlink should succeed");
+    assert!(tmp.path().join(&link_rel).symlink_metadata().is_err(), "symlink should be removed");
+    assert!(tmp.path().join(&target_rel).exists(), "symlink target must not be removed");
+}
+
 #[test]
 fn test_long_rmdir_multi_part() {
     let (mut handler, tmp) = setup();

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -38,6 +38,8 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
+use ::sys::ipc::Message;
+
 use crate::OperationId;
 
 //==================================================================================================
@@ -74,6 +76,16 @@ pub const LSTAT_HEADER_SIZE: usize = 6;
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
 pub const READLINK_RESPONSE_HEADER_SIZE: usize = 10;
+
+/// Maximum number of body bytes that can be carried by a single multi-part
+/// long-response message.
+///
+/// Derived from the wire layout enforced by [`build_long_response_part`]: the
+/// outer `SystemCallMessage` header (2 bytes), the inner `SystemCallMessagePart`
+/// framing (`total_parts:2 + part_number:2 + payload_size:1` = 5 bytes), and then
+/// the body chunk. Total framing overhead is 7 bytes, so the per-part chunk cap is
+/// `Message::PAYLOAD_SIZE - 7`.
+pub const LONG_RESPONSE_CHUNK_SIZE: usize = Message::PAYLOAD_SIZE - 7;
 
 //==================================================================================================
 // Long-response Deserialization (no_std-friendly)
@@ -116,6 +128,120 @@ pub fn deserialize_long_readlink_response(bytes: &[u8]) -> Option<LongReadlinkRe
         status,
         target: &bytes[target_start..target_end],
     })
+}
+
+/// Builds a single multi-part long-response message payload.
+///
+/// Wire layout (within `Message::PAYLOAD_SIZE`):
+///
+/// ```text
+/// bytes  0..2   : outer SystemCallMessageHeader discriminant (u16, native-endian)
+/// bytes  2..4   : total_parts (u16 LE)
+/// bytes  4..6   : part_number (u16 LE)
+/// byte    6     : payload_size (u8)
+/// bytes  7..    : payload chunk (`chunk.len()` bytes)
+/// ```
+///
+/// This mirrors the existing multi-part *request* wire format: the inner
+/// `SystemCallMessagePart` fields (`total_parts`, `part_number`, `payload_size`,
+/// payload) are encoded into the outer `SystemCallMessage` payload so the receiver
+/// can decode it with the standard
+/// `SystemCallMessage::try_from_bytes` → `SystemCallMessagePart::from_bytes` path.
+///
+/// `header_value` is the outer `SystemCallMessageHeader` discriminant (as a raw
+/// `u16`) of the *Part* response variant being emitted (e.g.
+/// `SystemCallMessageHeader::HostFsReadlinkResponsePart as u16`). It is taken as a
+/// raw value so this crate does not need to depend on the `syscall` crate.
+///
+/// Note: the request op_id is *not* written into bytes `2..6` here. Those bytes
+/// belong to the `SystemCallMessagePart` framing (`total_parts` + `part_number`);
+/// the op_id lives in the first four bytes of the assembled body instead, where the
+/// response assembler reads it.
+///
+/// `chunk` must fit in the inner `SystemCallMessagePart` payload (≤ 41 bytes on
+/// current builds; the byte at offset 6 encodes the chunk length, so it must also
+/// fit in a `u8`).
+pub fn build_long_response_part(
+    header_value: u16,
+    total_parts: u16,
+    part_number: u16,
+    chunk: &[u8],
+) -> [u8; Message::PAYLOAD_SIZE] {
+    // The chunk length is written into a single byte at offset 6 and must also fit
+    // within the outer Message payload after the 7-byte framing header.
+    debug_assert!(chunk.len() <= u8::MAX as usize);
+    debug_assert!(7 + chunk.len() <= Message::PAYLOAD_SIZE);
+
+    let mut out: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    // Outer SystemCallMessage header.
+    out[0..2].copy_from_slice(&header_value.to_ne_bytes());
+    // Inner SystemCallMessagePart fields, encoded little-endian to match
+    // `SystemCallMessagePart::from_bytes` on the receiving side. Offsets are
+    // relative to the outer Message::PAYLOAD because SystemCallMessage::PAYLOAD
+    // starts at byte 2.
+    out[2..4].copy_from_slice(&total_parts.to_le_bytes());
+    out[4..6].copy_from_slice(&part_number.to_le_bytes());
+    out[6] = chunk.len() as u8;
+    out[7..7 + chunk.len()].copy_from_slice(chunk);
+    out
+}
+
+/// Maximum number of chunks a single long response stream may contain.
+///
+/// `total_parts` and `part_number` are encoded as `u16` in the
+/// `SystemCallMessagePart` framing, so the assembled body cannot be split into
+/// more than `u16::MAX` parts without producing a malformed (wrapped) stream.
+pub const MAX_LONG_RESPONSE_PARTS: usize = u16::MAX as usize;
+
+/// Splits an assembled long-response `body` into a sequence of framed multi-part
+/// payloads, each stamped with `header_value` as the outer
+/// `SystemCallMessageHeader` discriminant.
+///
+/// `body` is chunked into [`LONG_RESPONSE_CHUNK_SIZE`]-byte slices; each slice is
+/// wrapped with [`build_long_response_part`] using `total_parts =
+/// ceil(body.len() / LONG_RESPONSE_CHUNK_SIZE)` and a sequential `part_number`.
+///
+/// Returns `None` if `body` would require more than [`MAX_LONG_RESPONSE_PARTS`]
+/// chunks (i.e. its chunk count does not fit in the `u16` wire-format field),
+/// to avoid producing a malformed stream with wrapped `total_parts`/`part_number`
+/// values. Otherwise returns a `Vec` that is non-empty for a non-empty `body`;
+/// callers are responsible for queueing/distributing the resulting parts (e.g.
+/// writing the first into a response slot and pushing the rest onto a tail queue).
+pub fn chunk_long_response(
+    header_value: u16,
+    body: &[u8],
+) -> Option<Vec<[u8; Message::PAYLOAD_SIZE]>> {
+    let chunk_size: usize = LONG_RESPONSE_CHUNK_SIZE;
+    let total_parts_usize: usize = body.len().div_ceil(chunk_size);
+    if total_parts_usize > MAX_LONG_RESPONSE_PARTS {
+        return None;
+    }
+    let total_parts: u16 = total_parts_usize as u16;
+    let mut parts: Vec<[u8; Message::PAYLOAD_SIZE]> = Vec::with_capacity(total_parts_usize);
+    for (part_number, chunk) in body.chunks(chunk_size).enumerate() {
+        parts.push(build_long_response_part(header_value, total_parts, part_number as u16, chunk));
+    }
+    Some(parts)
+}
+
+/// Serializes the body of a long READLINK *response*.
+///
+/// Wire format: `[op_id:4][status:4][target_len:2][target:N]` (see
+/// [`READLINK_RESPONSE_HEADER_SIZE`]). This is the inverse of
+/// [`deserialize_long_readlink_response`]. Returns `None` if `target` is longer
+/// than [`MAX_PATH_LEN`].
+pub fn serialize_long_readlink_response(
+    op_id: OperationId,
+    status: i32,
+    target: &[u8],
+) -> Option<Vec<u8>> {
+    let target_len: u16 = u16::try_from(target.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(READLINK_RESPONSE_HEADER_SIZE + target.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&status.to_le_bytes());
+    buf.extend_from_slice(&target_len.to_le_bytes());
+    buf.extend_from_slice(target);
+    Some(buf)
 }
 
 //==================================================================================================
@@ -357,11 +483,7 @@ pub fn deserialize_long_lstat(bytes: &[u8]) -> Option<LongLstatRequest> {
 ///
 /// Wire format: `[op_id:4][flags:4][path_len:2][path:N]`. Returns `None` if `path`
 /// is longer than [`MAX_PATH_LEN`].
-pub fn serialize_long_open_request(
-    op_id: OperationId,
-    flags: i32,
-    path: &[u8],
-) -> Option<Vec<u8>> {
+pub fn serialize_long_open_request(op_id: OperationId, flags: i32, path: &[u8]) -> Option<Vec<u8>> {
     let path_len: u16 = u16::try_from(path.len()).ok()?;
     let mut buf: Vec<u8> = Vec::with_capacity(OPEN_HEADER_SIZE + path.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
@@ -401,11 +523,7 @@ pub fn serialize_long_rmdir_request(op_id: OperationId, path: &[u8]) -> Option<V
 ///
 /// Wire format: `[op_id:4][mode:4][path_len:2][path:N]`. Returns `None` if `path`
 /// is longer than [`MAX_PATH_LEN`].
-pub fn serialize_long_mkdir_request(
-    op_id: OperationId,
-    mode: u32,
-    path: &[u8],
-) -> Option<Vec<u8>> {
+pub fn serialize_long_mkdir_request(op_id: OperationId, mode: u32, path: &[u8]) -> Option<Vec<u8>> {
     let path_len: u16 = u16::try_from(path.len()).ok()?;
     let mut buf: Vec<u8> = Vec::with_capacity(MKDIR_HEADER_SIZE + path.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
@@ -426,8 +544,7 @@ pub fn serialize_long_rename_request(
 ) -> Option<Vec<u8>> {
     let old_path_len: u16 = u16::try_from(old_path.len()).ok()?;
     let new_path_len: u16 = u16::try_from(new_path.len()).ok()?;
-    let mut buf: Vec<u8> =
-        Vec::with_capacity(RENAME_HEADER_SIZE + old_path.len() + new_path.len());
+    let mut buf: Vec<u8> = Vec::with_capacity(RENAME_HEADER_SIZE + old_path.len() + new_path.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
     buf.extend_from_slice(&old_path_len.to_le_bytes());
     buf.extend_from_slice(&new_path_len.to_le_bytes());
@@ -447,8 +564,7 @@ pub fn serialize_long_symlink_request(
 ) -> Option<Vec<u8>> {
     let target_len: u16 = u16::try_from(target.len()).ok()?;
     let link_len: u16 = u16::try_from(linkpath.len()).ok()?;
-    let mut buf: Vec<u8> =
-        Vec::with_capacity(SYMLINK_HEADER_SIZE + target.len() + linkpath.len());
+    let mut buf: Vec<u8> = Vec::with_capacity(SYMLINK_HEADER_SIZE + target.len() + linkpath.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
     buf.extend_from_slice(&target_len.to_le_bytes());
     buf.extend_from_slice(&link_len.to_le_bytes());

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -516,6 +516,12 @@ impl SystemCallMessageHeader {
     }
 
     /// Returns `true` if this header is a hostfs response variant.
+    ///
+    /// Note: `HostFsReadlinkResponsePart` is intentionally excluded. The multi-part
+    /// response framing places `total_parts`/`part_number` in bytes `[2..6]`, where
+    /// `get_op_id` expects the logical op_id, so treating it as a regular hostfs
+    /// response on the vfsd side would remove the wrong entry from the pending
+    /// queue. Re-add it only once vfsd implements a multi-part response assembler.
     pub fn is_hostfs_response(&self) -> bool {
         matches!(
             self,
@@ -534,7 +540,6 @@ impl SystemCallMessageHeader {
                 | Self::HostFsFlushResponse
                 | Self::HostFsSymlinkResponse
                 | Self::HostFsReadlinkResponse
-                | Self::HostFsReadlinkResponsePart
                 | Self::HostFsLstatResponse
         )
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -253,6 +253,15 @@ pub enum SystemCallMessageHeader {
     HostFsUnlinkRequestPart,
     HostFsMkdirRequestPart,
     HostFsRmdirRequestPart,
+    HostFsSymlinkRequestPart,
+    HostFsSymlinkResponse,
+    HostFsReadlinkRequest,
+    HostFsReadlinkRequestPart,
+    HostFsReadlinkResponse,
+    HostFsReadlinkResponsePart,
+    HostFsLstatRequest,
+    HostFsLstatRequestPart,
+    HostFsLstatResponse,
     HostMountRequestPart,
     HostMountResponse,
     HostUmountRequestPart,
@@ -406,6 +415,15 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == HostFsUnlinkRequestPart as u16 => Ok(HostFsUnlinkRequestPart),
             x if x == HostFsMkdirRequestPart as u16 => Ok(HostFsMkdirRequestPart),
             x if x == HostFsRmdirRequestPart as u16 => Ok(HostFsRmdirRequestPart),
+            x if x == HostFsSymlinkRequestPart as u16 => Ok(HostFsSymlinkRequestPart),
+            x if x == HostFsSymlinkResponse as u16 => Ok(HostFsSymlinkResponse),
+            x if x == HostFsReadlinkRequest as u16 => Ok(HostFsReadlinkRequest),
+            x if x == HostFsReadlinkRequestPart as u16 => Ok(HostFsReadlinkRequestPart),
+            x if x == HostFsReadlinkResponse as u16 => Ok(HostFsReadlinkResponse),
+            x if x == HostFsReadlinkResponsePart as u16 => Ok(HostFsReadlinkResponsePart),
+            x if x == HostFsLstatRequest as u16 => Ok(HostFsLstatRequest),
+            x if x == HostFsLstatRequestPart as u16 => Ok(HostFsLstatRequestPart),
+            x if x == HostFsLstatResponse as u16 => Ok(HostFsLstatResponse),
             _ => Err(()),
         }
     }
@@ -447,6 +465,15 @@ impl SystemCallMessageHeader {
                 | Self::HostFsUnlinkRequestPart
                 | Self::HostFsMkdirRequestPart
                 | Self::HostFsRmdirRequestPart
+                | Self::HostFsSymlinkRequestPart
+                | Self::HostFsSymlinkResponse
+                | Self::HostFsReadlinkRequest
+                | Self::HostFsReadlinkRequestPart
+                | Self::HostFsReadlinkResponse
+                | Self::HostFsReadlinkResponsePart
+                | Self::HostFsLstatRequest
+                | Self::HostFsLstatRequestPart
+                | Self::HostFsLstatResponse
         )
     }
 
@@ -477,6 +504,13 @@ impl SystemCallMessageHeader {
             Self::HostFsLseekRequest => Some(Self::HostFsLseekResponse),
             Self::HostFsTruncateRequest => Some(Self::HostFsTruncateResponse),
             Self::HostFsFlushRequest => Some(Self::HostFsFlushResponse),
+            Self::HostFsSymlinkRequestPart => Some(Self::HostFsSymlinkResponse),
+            Self::HostFsReadlinkRequest | Self::HostFsReadlinkRequestPart => {
+                Some(Self::HostFsReadlinkResponse)
+            },
+            Self::HostFsLstatRequest | Self::HostFsLstatRequestPart => {
+                Some(Self::HostFsLstatResponse)
+            },
             _ => None,
         }
     }
@@ -498,7 +532,16 @@ impl SystemCallMessageHeader {
                 | Self::HostFsLseekResponse
                 | Self::HostFsTruncateResponse
                 | Self::HostFsFlushResponse
+                | Self::HostFsSymlinkResponse
+                | Self::HostFsReadlinkResponse
+                | Self::HostFsReadlinkResponsePart
+                | Self::HostFsLstatResponse
         )
+    }
+
+    /// Returns `true` if this header represents a *part* of a multi-part hostfs *response* stream.
+    pub fn is_hostfs_multipart_response(&self) -> bool {
+        matches!(self, Self::HostFsReadlinkResponsePart)
     }
 }
 

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -436,26 +436,47 @@ async fn standalone_io_handler(
                                     continue;
                                 },
                             };
-                            let response: Message = Message::new(
-                                MessageSender::from(ProcessIdentifier::KERNEL),
-                                MessageReceiver::from(ProcessIdentifier::VFSD),
-                                MessageType::Ikc,
-                                None,
-                                response_payload,
-                            );
-                            // NOTE: `increment_io_thread_messages_received()` counts
-                            // messages flowing from the IO thread back into the VM,
-                            // not messages the IO thread receives. The name is a
-                            // project-wide convention; renaming is out of scope here.
-                            counters.increment_io_thread_messages_received();
-                            if response_tx
-                                .blocking_send(IkcFrame::Message(response))
-                                .is_err()
-                            {
-                                error!(
-                                    "hostfsd-worker: failed to send response (VM input channel \
-                                     closed)"
+                            // Build the first response message and any queued
+                            // multi-part follow-ups together so the entire response
+                            // stream is delivered before the next request is
+                            // processed. Hostfs multi-part responses (currently the
+                            // long-target `readlink` form) leave additional payloads
+                            // in the handler's queue that must be drained via
+                            // `take_next_response_part` immediately after the head.
+                            let mut response_payloads: std::vec::Vec<[u8; Message::PAYLOAD_SIZE]> =
+                                std::vec::Vec::new();
+                            response_payloads.push(response_payload);
+                            while let Some(extra) = handler.take_next_response_part() {
+                                response_payloads.push(extra);
+                            }
+                            let mut send_failed = false;
+                            for payload in response_payloads {
+                                let response: Message = Message::new(
+                                    MessageSender::from(ProcessIdentifier::KERNEL),
+                                    MessageReceiver::from(ProcessIdentifier::VFSD),
+                                    MessageType::Ikc,
+                                    None,
+                                    payload,
                                 );
+                                // NOTE: `increment_io_thread_messages_received()`
+                                // counts messages flowing from the IO thread back
+                                // into the VM, not messages the IO thread receives.
+                                // The name is a project-wide convention; renaming is
+                                // out of scope here.
+                                counters.increment_io_thread_messages_received();
+                                if response_tx
+                                    .blocking_send(IkcFrame::Message(response))
+                                    .is_err()
+                                {
+                                    error!(
+                                        "hostfsd-worker: failed to send response (VM input \
+                                         channel closed)"
+                                    );
+                                    send_failed = true;
+                                    break;
+                                }
+                            }
+                            if send_failed {
                                 break;
                             }
                         }
@@ -696,6 +717,9 @@ fn hostfs_error_target(
             | SystemCallMessageHeader::HostFsUnlinkRequestPart
             | SystemCallMessageHeader::HostFsMkdirRequestPart
             | SystemCallMessageHeader::HostFsRmdirRequestPart
+            | SystemCallMessageHeader::HostFsSymlinkRequestPart
+            | SystemCallMessageHeader::HostFsReadlinkRequestPart
+            | SystemCallMessageHeader::HostFsLstatRequestPart
     );
 
     if is_request_part {
@@ -751,6 +775,9 @@ fn hostfs_part_info(
             | SystemCallMessageHeader::HostFsUnlinkRequestPart
             | SystemCallMessageHeader::HostFsMkdirRequestPart
             | SystemCallMessageHeader::HostFsRmdirRequestPart
+            | SystemCallMessageHeader::HostFsSymlinkRequestPart
+            | SystemCallMessageHeader::HostFsReadlinkRequestPart
+            | SystemCallMessageHeader::HostFsLstatRequestPart
     );
     if !is_request_part {
         return None;


### PR DESCRIPTION
This pull request introduces comprehensive improvements and new tests for symbolic link (symlink) support in the host filesystem daemon (`hostfsd`). It adds end-to-end tests for symlink operations (creation, reading, lstat, and unlinking), implements multi-part response chunking utilities for long responses, and clarifies path handling in documentation. Additionally, it introduces new helpers and constants to facilitate multi-part message handling and response assembly.

**Symlink feature testing and multi-part response utilities:**

*Symlink operation tests:*
- Adds extensive tests for symlink operations in `handler_test.rs`, including creation (`symlink`), querying (`lstat` and `readlink`), and removal (`unlink`), with coverage for both inline and multi-part request/response paths. Tests include edge cases such as privilege errors, empty targets, invalid characters, and sandbox escape attempts. [[1]](diffhunk://#diff-6960bcff9c86d6f5ebb12e9e94ff2cf9f31a257d85407999e8c4db0d4dac4253R1250-R1564) [[2]](diffhunk://#diff-6960bcff9c86d6f5ebb12e9e94ff2cf9f31a257d85407999e8c4db0d4dac4253R1157-R1191)

*Multi-part response utilities:*
- Implements `build_long_response_part` and `chunk_long_response` in `long_msg.rs` to support chunking large responses (such as long symlink targets) into multiple protocol messages, mirroring the existing multi-part request format. Introduces the `LONG_RESPONSE_CHUNK_SIZE` constant for consistent chunk sizing. [[1]](diffhunk://#diff-145f205f73f3b1d671d90a95efc6c9cd7e400df44b307d356c8b05dcc5123f40R80-R89) [[2]](diffhunk://#diff-145f205f73f3b1d671d90a95efc6c9cd7e400df44b307d356c8b05dcc5123f40R133-R237)
- Adds a test utility `drain_multipart_response` to reassemble multi-part responses in tests, ensuring correctness of chunked response handling.

*Documentation and code clarity:*
- Updates documentation in `sandbox.rs` to clarify that guest-absolute paths (with leading `/`) are accepted and normalized for resolution, improving developer understanding.

*Minor refactoring and style:*
- Refactors several serialization functions in `long_msg.rs` for consistency and readability, consolidating function signatures and formatting. [[1]](diffhunk://#diff-145f205f73f3b1d671d90a95efc6c9cd7e400df44b307d356c8b05dcc5123f40L360-R477) [[2]](diffhunk://#diff-145f205f73f3b1d671d90a95efc6c9cd7e400df44b307d356c8b05dcc5123f40L404-R517) [[3]](diffhunk://#diff-145f205f73f3b1d671d90a95efc6c9cd7e400df44b307d356c8b05dcc5123f40L429-R538)
- Adds necessary imports for message handling in `long_msg.rs`.

These changes significantly enhance the reliability and test coverage of symlink handling in the host filesystem daemon, while also providing reusable utilities for robust multi-part message support.