### PR TITLE
[vfsd] Implement symlink, readlink, and lstat operations in vfsd

### DIFF
--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -239,7 +239,12 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageHeader::SymbolicLinkAtRequestPart => {
             match SymbolicLinkAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_symlinkat(source, req),
+                // `None` means the request was forwarded to hostfsd and the response
+                // will be sent asynchronously when the IKC reply arrives; emit no
+                // immediate messages in that case.
+                Ok(req) => {
+                    handler::handle_symlinkat_with_hostfs(source, req, pending).unwrap_or_default()
+                },
                 Err(e) => {
                     ::syslog::error!("dispatch: symlinkat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]
@@ -255,7 +260,9 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageHeader::ReadLinkAtRequestPart => {
             match ReadLinkAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_readlinkat(source, req),
+                Ok(req) => {
+                    handler::handle_readlinkat_with_hostfs(source, req, pending).unwrap_or_default()
+                },
                 Err(e) => {
                     ::syslog::error!("dispatch: readlinkat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -250,7 +250,7 @@ pub(crate) fn handle_fstat_with_hostfs(
 pub(crate) fn handle_fstatat_with_hostfs(
     source: ThreadIdentifier,
     request: FileStatAtRequest,
-    _pending: &mut PendingQueue,
+    pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
     let resolved: Option<alloc::string::String> =
         ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
@@ -260,38 +260,39 @@ pub(crate) fn handle_fstatat_with_hostfs(
     };
 
     if hostfs::is_hostfs_path(final_path) {
-        // For path-based stat on hostfs, we need an FD. Open + stat + close sequence
-        // would be complex. Instead, use a temporary open to get a remote FD, then stat.
-        // However, the simpler approach is to open the path first and call fstat.
-        // Since we don't have a "stat-by-path" IKC that returns without an FD open,
-        // we use the existing open + stat. But that's two async ops.
+        // Only forward when the caller explicitly requested no-follow semantics. For
+        // following stat (the default for `stat(2)`), there is no path-based stat IKC
+        // yet, so we report `OperationNotSupported` and the caller is expected to use
+        // `fstat` on an already-opened FD.
         //
-        // Alternative: the hostfsd stat handler uses the FD's stored path, so we need
-        // a valid remote FD. We can open with O_RDONLY, stat, then close.
-        // But that requires chaining three async operations, which is complex.
-        //
-        // For now, open the file to get a remote_fd, then send stat. We'll handle the
-        // response by returning stat and cleaning up the temp FD.
-        //
-        // Actually, re-reading the hostfsd code: `handle_stat` takes an FD and looks up
-        // the path from its FD table. So we DO need to open first to stat.
-        //
-        // Simpler: just open O_RDONLY, and in the open completion we'd need to stat...
-        // That's overly complex for this handler.
-        //
-        // The practical solution: for fstatat on hostfs paths, we first try to open
-        // the path. If the user already has an FD open for this path, that's ideal.
-        // But since we need a remote FD to call stat, and we don't want to chain ops,
-        // fall back to returning a synthetic stat for now.
-        //
-        // TODO(#hostfs-statat): implement path-based stat as a new hostfs operation that
-        // does not require a pre-opened FD.
-        //
-        // For now, return a minimal stat that at least allows path existence checks.
-        // We attempt to open and immediately use the resulting info.
-        // Actually, the simplest approach that works: return OperationNotSupported so
-        // the caller knows to use fstat on an already-opened FD instead.
-        return Some(vec![build_error(source, ErrorCode::OperationNotSupported)]);
+        // TODO(#hostfs-statat-follow): add a path-based following stat operation so
+        // both modes of `fstatat` are supported uniformly over hostfs.
+        if request.flag & ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW == 0 {
+            return Some(vec![build_error(source, ErrorCode::OperationNotSupported)]);
+        }
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        match hostfs::send_lstat_request(final_path, op_id) {
+            Ok(()) => {
+                if pending
+                    .insert(
+                        op_id,
+                        PendingOp {
+                            source_tid: source,
+                            source_pid: None,
+                            kind: PendingOpKind::Lstat,
+                        },
+                    )
+                    .is_err()
+                {
+                    return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+                }
+                return None;
+            },
+            Err(e) => return Some(vec![build_error(source, e)]),
+        }
     }
 
     Some(super::long::handle_fstatat(source, request))
@@ -404,6 +405,10 @@ use ::syscall::{
         FileStatAtRequest,
         FileStatRequest,
         MakeDirectoryAtRequest,
+    },
+    unistd::message::{
+        ReadLinkAtRequest,
+        SymbolicLinkAtRequest,
     },
 };
 use alloc::{
@@ -628,4 +633,89 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     }
 
     Some(super::long::handle_mkdirat(source, request))
+}
+
+pub(crate) fn handle_symlinkat_with_hostfs(
+    source: ThreadIdentifier,
+    request: SymbolicLinkAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    // Routing key is `linkpath` (where the symlink will live). `target` is an opaque
+    // string stored verbatim by the host and intentionally not consulted here.
+    let resolved: Option<alloc::string::String> =
+        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.linkpath);
+    let final_link: &str = match &resolved {
+        Some(p) => p.as_str(),
+        None => &request.linkpath,
+    };
+
+    if hostfs::is_hostfs_path(final_link) {
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        match hostfs::send_symlink_request(&request.target, final_link, op_id) {
+            Ok(()) => {
+                if pending
+                    .insert(
+                        op_id,
+                        PendingOp {
+                            source_tid: source,
+                            source_pid: None,
+                            kind: PendingOpKind::Symlink,
+                        },
+                    )
+                    .is_err()
+                {
+                    return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+                }
+                return None;
+            },
+            Err(e) => return Some(vec![build_error(source, e)]),
+        }
+    }
+
+    Some(super::long::handle_symlinkat(source, request))
+}
+
+pub(crate) fn handle_readlinkat_with_hostfs(
+    source: ThreadIdentifier,
+    request: ReadLinkAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let resolved: Option<alloc::string::String> =
+        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
+    let final_path: &str = match &resolved {
+        Some(p) => p.as_str(),
+        None => &request.path,
+    };
+
+    if hostfs::is_hostfs_path(final_path) {
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        let bufsiz: usize = request.bufsiz;
+        match hostfs::send_readlink_request(final_path, op_id) {
+            Ok(()) => {
+                if pending
+                    .insert(
+                        op_id,
+                        PendingOp {
+                            source_tid: source,
+                            source_pid: None,
+                            kind: PendingOpKind::Readlink { bufsiz },
+                        },
+                    )
+                    .is_err()
+                {
+                    return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+                }
+                return None;
+            },
+            Err(e) => return Some(vec![build_error(source, e)]),
+        }
+    }
+
+    Some(super::long::handle_readlinkat(source, request))
 }

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -368,3 +368,87 @@ pub fn send_rename_request(
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsRenameRequestPart)
 }
+
+/// Sends a SYMLINK request to hostfsd as a multi-part IKC message.
+///
+/// `target` is the symlink target string (stored verbatim by the host) and `linkpath`
+/// is the absolute guest path (under `/mnt`) where the symlink is to be created.
+///
+/// Unlike [`send_readlink_request`] and [`send_lstat_request`], this always uses the
+/// multi-part wire format even for short payloads. Symlink has no inline single-message
+/// request variant: the wire format carries two variable-length strings, which does
+/// not fit cleanly in the inline payload budget. The cost of an extra IKC roundtrip is
+/// acceptable since symlink creation is rare relative to readlink/lstat.
+pub fn send_symlink_request(
+    target: &str,
+    linkpath: &str,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    // The target is opaque to vfsd and stored verbatim by the host; do not strip /mnt.
+    let link_relative: &str = strip_mount_prefix(linkpath);
+    let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_symlink_request(
+        op_id,
+        target.as_bytes(),
+        link_relative.as_bytes(),
+    )
+    .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageHeader::HostFsSymlinkRequestPart)
+}
+
+/// Sends a READLINK request to hostfsd.
+///
+/// Uses the single-message inline form when the path fits within
+/// [`MAX_INLINE_PATH_LEN`], and falls back to a multi-part request otherwise.
+pub fn send_readlink_request(
+    path: &str,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path);
+    let path_bytes: &[u8] = relative.as_bytes();
+
+    // Inline fast path: avoids the multi-part assembler when the path fits.
+    if let Some(req) = ReadlinkRequest::from_path(path_bytes) {
+        let payload: [u8; Message::PAYLOAD_SIZE] =
+            req.serialize(SystemCallMessageHeader::HostFsReadlinkRequest as u16, op_id);
+        return if send_request(&payload) {
+            Ok(())
+        } else {
+            Err(::sys::error::ErrorCode::IoErr)
+        };
+    }
+
+    // Serialize the multi-part body via hostfs-api.
+    let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_readlink_request(op_id, path_bytes)
+        .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageHeader::HostFsReadlinkRequestPart)
+}
+
+/// Sends an LSTAT request to hostfsd.
+///
+/// Unlike [`send_stat_request`] (which takes a remote FD), this is a path-based
+/// stat that does not follow the final symbolic link component. Uses the
+/// single-message inline form when the path fits within [`MAX_INLINE_PATH_LEN`],
+/// and falls back to a multi-part request otherwise.
+pub fn send_lstat_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path);
+    let path_bytes: &[u8] = relative.as_bytes();
+
+    // Inline fast path: avoids the multi-part assembler when the path fits.
+    if let Some(req) = LstatRequest::from_path(path_bytes) {
+        let payload: [u8; Message::PAYLOAD_SIZE] =
+            req.serialize(SystemCallMessageHeader::HostFsLstatRequest as u16, op_id);
+        return if send_request(&payload) {
+            Ok(())
+        } else {
+            Err(::sys::error::ErrorCode::IoErr)
+        };
+    }
+
+    // Serialize the multi-part body via hostfs-api.
+    let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_lstat_request(op_id, path_bytes)
+        .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageHeader::HostFsLstatRequestPart)
+}

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -34,6 +34,7 @@ use ::proc::{
     SignupResponseMessage,
 };
 use ::sys::{
+    error::ErrorCode,
     ipc::{
         Message,
         MessageType,
@@ -119,6 +120,25 @@ pub fn main() {
     // Pending hostfs operations awaiting IKC responses.
     let mut pending: pending::PendingQueue = pending::PendingQueue::new();
 
+    // In-flight multi-part hostfs *response* assembler, paired with the op_id
+    // extracted eagerly from part 0 so a discarded stream can be cancelled (the
+    // pending op would otherwise sit until the eviction timer fires).
+    //
+    // Long-target `readlink` returns its response as a stream of
+    // `HostFsReadlinkResponsePart` messages. Because hostfsd's worker is single-
+    // threaded and replies to one request at a time, at most one such stream is in
+    // flight at any moment, so a single slot suffices. If a fresh `part_number == 0`
+    // arrives while another stream is still being assembled, the old stream is
+    // discarded and its caller is failed with `IoErr`.
+    //
+    // TODO: if hostfsd ever becomes multi-stream (e.g., a worker pool that interleaves
+    // long responses), replace this single-slot assembler with an op_id-keyed map so
+    // concurrent response streams can be assembled independently.
+    let mut readlink_response_asm: Option<(
+        ::syscall::message::SystemCallLongMessage,
+        ::hostfs_api::OperationId,
+    )> = None;
+
     // Process any messages that were buffered during the signup phase.
     while let Some(message) = buffered_messages.pop_front() {
         match ipc::handle_ipc_message(message, &mut assemblers, &mut pending) {
@@ -154,6 +174,109 @@ pub fn main() {
                         ::syscall::SystemCallMessage::try_from_bytes(message.payload)
                     {
                         let header: SystemCallMessageHeader = syscall_msg.header;
+                        // Multi-part response stream: assemble parts before dispatch.
+                        // The op_id is *not* at the standard payload[2..6] offset for
+                        // these messages (those bytes carry SystemCallMessagePart
+                        // framing) — it lives in the first 4 bytes of the assembled
+                        // body instead.
+                        if header == SystemCallMessageHeader::HostFsReadlinkResponsePart {
+                            let part: ::syscall::message::SystemCallMessagePart =
+                                ::syscall::message::SystemCallMessagePart::from_bytes(
+                                    syscall_msg.payload,
+                                );
+                            // A fresh stream starts at part 0.
+                            if part.part_number == 0 {
+                                if part.payload_size < 4 {
+                                    ::syslog::error!(
+                                        "readlink response part 0 too short to carry op_id \
+                                         (payload_size={})",
+                                        part.payload_size
+                                    );
+                                    continue;
+                                }
+                                let op_id: ::hostfs_api::OperationId =
+                                    ::hostfs_api::OperationId::from_le_bytes([
+                                        part.payload[0],
+                                        part.payload[1],
+                                        part.payload[2],
+                                        part.payload[3],
+                                    ]);
+                                if let Some((_, stale_op_id)) = readlink_response_asm.take() {
+                                    ::syslog::warn!(
+                                        "discarding incomplete readlink response stream on new \
+                                         part-0 arrival (cancelling stale op_id={})",
+                                        stale_op_id
+                                    );
+                                    if let Some(op) = pending.remove(stale_op_id) {
+                                        pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                    }
+                                }
+                                let capacity: usize = part.total_parts.max(1) as usize;
+                                match ::syscall::message::SystemCallLongMessage::new(capacity) {
+                                    Ok(asm) => {
+                                        readlink_response_asm = Some((asm, op_id));
+                                    },
+                                    Err(e) => {
+                                        // Allocation failure: cancel the caller now rather
+                                        // than letting the pending op linger until eviction.
+                                        ::syslog::error!(
+                                            "failed to allocate readlink response assembler \
+                                             (op_id={}, capacity={}, error={:?})",
+                                            op_id,
+                                            capacity,
+                                            e
+                                        );
+                                        readlink_response_asm = None;
+                                        if let Some(op) = pending.remove(op_id) {
+                                            pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                        }
+                                        continue;
+                                    },
+                                }
+                            }
+                            if let Some((asm, op_id)) = readlink_response_asm.as_mut() {
+                                let op_id_copy: ::hostfs_api::OperationId = *op_id;
+                                if let Err(e) = asm.add_part(part) {
+                                    ::syslog::error!(
+                                        "failed to add readlink response part (op_id={}, \
+                                         error={:?})",
+                                        op_id_copy,
+                                        e
+                                    );
+                                    readlink_response_asm = None;
+                                    if let Some(op) = pending.remove(op_id_copy) {
+                                        pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                    }
+                                    continue;
+                                }
+                                if asm.is_complete() {
+                                    let (asm_done, _) = readlink_response_asm.take().unwrap();
+                                    let mut body: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+                                    for p in asm_done.take_parts() {
+                                        let n: usize = p.payload_size as usize;
+                                        body.extend_from_slice(&p.payload[..n]);
+                                    }
+                                    // op_id is already known from part 0; the body still
+                                    // carries it in bytes [0..4] for `complete_readlink_long`.
+                                    if let Some(op) = pending.remove(op_id_copy) {
+                                        pending::complete_readlink_long(op, &body);
+                                    } else {
+                                        ::syslog::warn!(
+                                            "long readlink response with no pending op (op_id={})",
+                                            op_id_copy,
+                                        );
+                                    }
+                                }
+                            } else {
+                                let pn: u16 = part.part_number;
+                                ::syslog::warn!(
+                                    "readlink response part received without active assembler \
+                                     (part_number={})",
+                                    pn,
+                                );
+                            }
+                            continue;
+                        }
                         if header.is_hostfs_response() {
                             let op_id: ::hostfs_api::OperationId =
                                 ::hostfs_api::get_op_id(&message.payload);

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -88,6 +88,15 @@ pub(crate) enum PendingOpKind {
     Rename,
     /// stat/fstat — response contains size, mode, is_dir.
     Stat,
+    /// symlink — response is a status code.
+    Symlink,
+    /// readlink — response contains the link target bytes.
+    Readlink {
+        /// Caller-supplied buffer size; response will be truncated to this length.
+        bufsiz: usize,
+    },
+    /// lstat — path-based stat that does not follow the final symbolic link.
+    Lstat,
 }
 
 //==================================================================================================
@@ -98,6 +107,48 @@ pub(crate) enum PendingOpKind {
 ///
 /// This prevents unbounded growth if hostfsd is unavailable or unresponsive.
 const MAX_PENDING_OPS: usize = 64;
+
+//==================================================================================================
+// Synthetic stat(2) Constants
+//==================================================================================================
+//
+// Hostfsd does not forward several `stat`/`lstat` fields from the host (timestamps,
+// device id, inode, link count). The constants below are the synthetic values used
+// to populate those fields so both completion paths report identical, deterministic
+// metadata.
+
+/// Fixed timestamp (2024-01-01T00:00:00Z) used for `st_atim`/`st_mtim`/`st_ctim`.
+///
+/// Keeps stat output stable across runs and hosts; tooling that only cares about
+/// ordering or equality continues to work.
+const STAT_FIXED_EPOCH: i64 = 1_704_067_200;
+
+/// Conventional Unix block size reported as `st_blksize`.
+///
+/// Matches what guest userland and libc helpers (e.g., `st_blksize`-based I/O sizing)
+/// expect from a regular filesystem.
+const STAT_BLOCK_SIZE: i64 = 4096;
+
+/// POSIX-defined unit (in bytes) used to convert `st_size` into `st_blocks`.
+const STAT_SECTOR_SIZE: u64 = 512;
+
+/// Synthetic device id reported as `st_dev` for hostfs entries.
+///
+/// Distinct from ramfs (`1`) so guest tooling can tell the two filesystems apart;
+/// hostfsd does not expose the host's real `st_dev`.
+const STAT_HOSTFS_DEV: u64 = 2;
+
+/// Synthetic inode number reported as `st_ino`.
+///
+/// Inode numbers are not tracked by hostfsd; a constant keeps the field valid
+/// without implying any cross-call identity (callers must not key caches on it).
+const STAT_SYNTHETIC_INO: u64 = 1;
+
+/// `st_nlink` value for directories (self + `.`).
+const STAT_NLINK_DIR: u64 = 2;
+
+/// `st_nlink` value for non-directory entries (hostfsd does not track hardlinks).
+const STAT_NLINK_FILE: u64 = 1;
 
 /// Map of pending hostfs operations keyed by operation identifier.
 ///
@@ -181,6 +232,13 @@ impl PendingQueue {
     }
 }
 
+/// Sends an error response to a pending op's caller without consulting any IKC
+/// payload. Intended for recovery paths (e.g., a long-response stream is discarded
+/// due to assembler desync) where the op must be cancelled rather than completed.
+pub(crate) fn cancel_pending_op(op: PendingOp, code: ErrorCode) {
+    send_response(&build_error(op.source_tid, code));
+}
+
 //==================================================================================================
 // Response Completion
 //==================================================================================================
@@ -242,6 +300,13 @@ pub(crate) fn complete_pending_op(
             complete_status(pending.source_tid, response_payload, OpGroup::Rename)
         },
         PendingOpKind::Stat => complete_stat(pending.source_tid, response_payload),
+        PendingOpKind::Symlink => {
+            complete_status(pending.source_tid, response_payload, OpGroup::Symlink)
+        },
+        PendingOpKind::Readlink { bufsiz } => {
+            complete_readlink(pending.source_tid, response_payload, bufsiz)
+        },
+        PendingOpKind::Lstat => complete_lstat(pending.source_tid, response_payload),
     }
 }
 
@@ -271,6 +336,9 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Unlink, SystemCallMessageHeader::HostFsUnlinkResponse)
             | (PendingOpKind::Rename, SystemCallMessageHeader::HostFsRenameResponse)
             | (PendingOpKind::Stat, SystemCallMessageHeader::HostFsStatResponse)
+            | (PendingOpKind::Symlink, SystemCallMessageHeader::HostFsSymlinkResponse)
+            | (PendingOpKind::Readlink { .. }, SystemCallMessageHeader::HostFsReadlinkResponse)
+            | (PendingOpKind::Lstat, SystemCallMessageHeader::HostFsLstatResponse)
     )
 }
 
@@ -398,6 +466,7 @@ enum OpGroup {
     Rmdir,
     Unlink,
     Rename,
+    Symlink,
 }
 
 fn complete_status(
@@ -432,6 +501,10 @@ fn complete_status(
             use ::syscall::fcntl::message::RenameAtResponse;
             RenameAtResponse::build(source_tid, 0, ProcessIdentifier::VFSD, MessageType::Ipc)
         },
+        OpGroup::Symlink => {
+            use ::syscall::unistd::message::SymbolicLinkAtResponse;
+            SymbolicLinkAtResponse::build(source_tid, 0, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
     };
     send_response(&msg);
 }
@@ -448,6 +521,8 @@ fn hostfs_error_to_code(code: i32) -> ErrorCode {
         ::hostfs_api::HOSTFS_ERR_IS_DIR => ErrorCode::IsDirectory,
         ::hostfs_api::HOSTFS_ERR_INVALID => ErrorCode::InvalidArgument,
         ::hostfs_api::HOSTFS_ERR_NOT_EMPTY => ErrorCode::DirectoryNotEmpty,
+        ::hostfs_api::HOSTFS_ERR_LOOP => ErrorCode::SymbolicLinkLoop,
+        ::hostfs_api::HOSTFS_ERR_NOT_SUPPORTED => ErrorCode::OperationNotSupported,
         _ => ErrorCode::IoErr,
     }
 }
@@ -476,11 +551,6 @@ fn complete_stat(source_tid: ThreadIdentifier, response_payload: &[u8; Message::
         return;
     }
 
-    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
-    const FIXED_EPOCH: i64 = 1_704_067_200;
-    const STAT_BLOCK_SIZE: i64 = 4096;
-    const STAT_SECTOR_SIZE: u64 = 512;
-
     let is_dir: bool = resp.is_dir != 0;
     let mode: u32 = if resp.mode != 0 {
         // Use host-provided mode, adding file type bits.
@@ -500,24 +570,28 @@ fn complete_stat(source_tid: ThreadIdentifier, response_payload: &[u8; Message::
     };
 
     let st = stat {
-        st_dev: 2, // Synthetic device ID for hostfs (distinct from ramfs=1).
-        st_ino: 1,
+        st_dev: STAT_HOSTFS_DEV,
+        st_ino: STAT_SYNTHETIC_INO,
         st_mode: mode,
-        st_nlink: if is_dir { 2 } else { 1 },
+        st_nlink: if is_dir {
+            STAT_NLINK_DIR
+        } else {
+            STAT_NLINK_FILE
+        },
         st_uid: 0,
         st_gid: 0,
         st_rdev: 0,
         st_size: resp.size as off_t,
         st_atim: timespec {
-            tv_sec: FIXED_EPOCH,
+            tv_sec: STAT_FIXED_EPOCH,
             tv_nsec: 0,
         },
         st_mtim: timespec {
-            tv_sec: FIXED_EPOCH,
+            tv_sec: STAT_FIXED_EPOCH,
             tv_nsec: 0,
         },
         st_ctim: timespec {
-            tv_sec: FIXED_EPOCH,
+            tv_sec: STAT_FIXED_EPOCH,
             tv_nsec: 0,
         },
         st_blksize: STAT_BLOCK_SIZE,
@@ -533,6 +607,216 @@ fn complete_stat(source_tid: ThreadIdentifier, response_payload: &[u8; Message::
         },
         Err(e) => {
             ::syslog::error!("complete_stat: into_parts failed (error={:?})", e);
+            send_response(&build_error(source_tid, ErrorCode::IoErr));
+        },
+    }
+}
+
+/// Completes a long-form (multi-part) readlink response.
+///
+/// `body` is the assembled response body in the wire format
+/// `[op_id:4][status:4][target_len:2][target:N]`. The op_id has already been
+/// consumed by the caller to look up the pending op, but it remains in `body` and
+/// is skipped here.
+pub(crate) fn complete_readlink_long(pending: PendingOp, body: &[u8]) {
+    use ::syscall::{
+        message::MessagePartitioner,
+        unistd::message::ReadLinkAtResponse,
+    };
+
+    // Caller is responsible for routing only `Readlink` ops here; main.rs dispatches
+    // long readlink responses via the dedicated assembler, and no other pending kind
+    // produces a multi-part response in the current protocol.
+    let PendingOpKind::Readlink { bufsiz } = pending.kind else {
+        unreachable!("complete_readlink_long invoked with non-Readlink pending op");
+    };
+
+    let resp: ::hostfs_api::long_msg::LongReadlinkResponse<'_> =
+        match ::hostfs_api::long_msg::deserialize_long_readlink_response(body) {
+            Some(r) => r,
+            None => {
+                ::syslog::error!(
+                    "complete_readlink_long: failed to deserialize response body (len={})",
+                    body.len()
+                );
+                send_response(&build_error(pending.source_tid, ErrorCode::IoErr));
+                return;
+            },
+        };
+
+    if resp.status < 0 {
+        send_response(&build_error(pending.source_tid, hostfs_error_to_code(resp.status)));
+        return;
+    }
+
+    // Truncate to the caller's buffer size, matching POSIX readlink semantics.
+    let copy_len: usize = resp.target.len().min(bufsiz);
+    let buffer: alloc::vec::Vec<u8> = resp.target[..copy_len].to_vec();
+
+    let response: ReadLinkAtResponse = match ReadLinkAtResponse::new(buffer) {
+        Ok(r) => r,
+        Err(e) => {
+            ::syslog::error!("complete_readlink_long: build response failed (error={:?})", e);
+            send_response(&build_error(pending.source_tid, ErrorCode::IoErr));
+            return;
+        },
+    };
+    match response.into_parts(pending.source_tid, ProcessIdentifier::VFSD, MessageType::Ipc) {
+        Ok(parts) => {
+            for part in parts {
+                send_response(&part);
+            }
+        },
+        Err(e) => {
+            ::syslog::error!("complete_readlink_long: into_parts failed (error={:?})", e);
+            send_response(&build_error(pending.source_tid, ErrorCode::IoErr));
+        },
+    }
+}
+
+fn complete_readlink(
+    source_tid: ThreadIdentifier,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+    bufsiz: usize,
+) {
+    use ::syscall::{
+        message::MessagePartitioner,
+        unistd::message::ReadLinkAtResponse,
+    };
+
+    let resp: ::hostfs_api::ReadlinkResponse =
+        match ::hostfs_api::ReadlinkResponse::decode(response_payload) {
+            Some(r) => r,
+            None => {
+                ::syslog::error!("complete_readlink: failed to decode response");
+                send_response(&build_error(source_tid, ErrorCode::IoErr));
+                return;
+            },
+        };
+
+    if resp.status < 0 {
+        send_response(&build_error(source_tid, hostfs_error_to_code(resp.status)));
+        return;
+    }
+
+    let target_len: usize = resp.target_len as usize;
+    let max: usize = target_len.min(resp.target.len()).min(bufsiz);
+    let buffer: alloc::vec::Vec<u8> = resp.target[..max].to_vec();
+
+    let response: ReadLinkAtResponse = match ReadLinkAtResponse::new(buffer) {
+        Ok(r) => r,
+        Err(e) => {
+            ::syslog::error!("complete_readlink: build response failed (error={:?})", e);
+            send_response(&build_error(source_tid, ErrorCode::IoErr));
+            return;
+        },
+    };
+    match response.into_parts(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc) {
+        Ok(parts) => {
+            for part in parts {
+                send_response(&part);
+            }
+        },
+        Err(e) => {
+            ::syslog::error!("complete_readlink: into_parts failed (error={:?})", e);
+            send_response(&build_error(source_tid, ErrorCode::IoErr));
+        },
+    }
+}
+
+fn complete_lstat(source_tid: ThreadIdentifier, response_payload: &[u8; Message::PAYLOAD_SIZE]) {
+    use ::sysapi::{
+        sys_stat::{
+            file_mode,
+            file_type,
+            stat,
+        },
+        sys_types::off_t,
+        time::timespec,
+    };
+    use ::syscall::{
+        message::MessagePartitioner,
+        sys::stat::message::FileStatAtResponse,
+    };
+
+    let resp: ::hostfs_api::LstatResponse =
+        match ::hostfs_api::LstatResponse::decode(response_payload) {
+            Some(r) => r,
+            None => {
+                ::syslog::error!("complete_lstat: failed to decode response");
+                send_response(&build_error(source_tid, ErrorCode::IoErr));
+                return;
+            },
+        };
+
+    if resp.status < 0 {
+        send_response(&build_error(source_tid, hostfs_error_to_code(resp.status)));
+        return;
+    }
+
+    let type_bits: u32 = match resp.kind {
+        ::hostfs_api::file_kind::DIRECTORY => file_type::S_IFDIR,
+        ::hostfs_api::file_kind::SYMLINK => file_type::S_IFLNK,
+        ::hostfs_api::file_kind::REGULAR => file_type::S_IFREG,
+        _ => file_type::S_IFREG,
+    };
+    // Mask `resp.mode` down to permission bits before OR-ing with our canonical
+    // `type_bits`. On Unix hosts `resp.mode` is the raw `st_mode` (already includes
+    // type bits); on Windows it is a synthetic value built by hostfsd that also
+    // includes synthetic type bits. The mask strips those in both cases so the
+    // file-type bits are unambiguously driven by `resp.kind` (the authoritative
+    // discriminant on the wire).
+    let mode: u32 = if resp.mode != 0 {
+        type_bits | (resp.mode & 0o7777)
+    } else {
+        match resp.kind {
+            ::hostfs_api::file_kind::DIRECTORY => file_type::S_IFDIR | file_mode::S_IRWXU,
+            ::hostfs_api::file_kind::SYMLINK => {
+                file_type::S_IFLNK | file_mode::S_IRUSR | file_mode::S_IWUSR
+            },
+            _ => file_type::S_IFREG | file_mode::S_IRUSR | file_mode::S_IWUSR,
+        }
+    };
+    let is_dir: bool = resp.kind == ::hostfs_api::file_kind::DIRECTORY;
+
+    let st = stat {
+        st_dev: STAT_HOSTFS_DEV,
+        st_ino: STAT_SYNTHETIC_INO,
+        st_mode: mode,
+        st_nlink: if is_dir {
+            STAT_NLINK_DIR
+        } else {
+            STAT_NLINK_FILE
+        },
+        st_uid: 0,
+        st_gid: 0,
+        st_rdev: 0,
+        st_size: resp.size as off_t,
+        st_atim: timespec {
+            tv_sec: STAT_FIXED_EPOCH,
+            tv_nsec: 0,
+        },
+        st_mtim: timespec {
+            tv_sec: STAT_FIXED_EPOCH,
+            tv_nsec: 0,
+        },
+        st_ctim: timespec {
+            tv_sec: STAT_FIXED_EPOCH,
+            tv_nsec: 0,
+        },
+        st_blksize: STAT_BLOCK_SIZE,
+        st_blocks: resp.size.div_ceil(STAT_SECTOR_SIZE) as off_t,
+    };
+
+    let response: FileStatAtResponse = FileStatAtResponse::new(st);
+    match response.into_parts(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc) {
+        Ok(parts) => {
+            for part in parts {
+                send_response(&part);
+            }
+        },
+        Err(e) => {
+            ::syslog::error!("complete_lstat: into_parts failed (error={:?})", e);
             send_response(&build_error(source_tid, ErrorCode::IoErr));
         },
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -517,11 +517,13 @@ impl SystemCallMessageHeader {
 
     /// Returns `true` if this header is a hostfs response variant.
     ///
-    /// Note: `HostFsReadlinkResponsePart` is intentionally excluded. The multi-part
-    /// response framing places `total_parts`/`part_number` in bytes `[2..6]`, where
-    /// `get_op_id` expects the logical op_id, so treating it as a regular hostfs
-    /// response on the vfsd side would remove the wrong entry from the pending
-    /// queue. Re-add it only once vfsd implements a multi-part response assembler.
+    /// Note: `HostFsReadlinkResponsePart` is intentionally excluded because of its
+    /// framing, not because vfsd lacks a multi-part assembler (it now has one). For
+    /// these parts, bytes `[2..6]` carry `total_parts`/`part_number`, while the
+    /// logical op_id lives in the first 4 bytes of the assembled body. Treating
+    /// them as regular hostfs responses would make `get_op_id` read the framing
+    /// bytes and remove the wrong entry from the pending queue. They are dispatched
+    /// through `is_hostfs_multipart_response` and the dedicated assembler in vfsd.
     pub fn is_hostfs_response(&self) -> bool {
         matches!(
             self,

--- a/src/tests/mount-test/src/main.rs
+++ b/src/tests/mount-test/src/main.rs
@@ -32,6 +32,7 @@ mod cross_fs;
 mod file_ops;
 mod fs_ops;
 mod mount_lifecycle;
+mod symlink_ops;
 
 //==================================================================================================
 // Imports
@@ -57,6 +58,9 @@ pub fn main() -> Result<(), Error> {
 
     // Phase 3: File operations (write/read, seek, fstat, truncate, fsync).
     file_ops::test()?;
+
+    // Phase 3.5: Symbolic link operations (symlink, readlink, lstat).
+    symlink_ops::test()?;
 
     // Phase 4: Cross-filesystem consistency tests (RAMFS vs HostFS).
     cross_fs::test()?;

--- a/src/tests/mount-test/src/symlink_ops.rs
+++ b/src/tests/mount-test/src/symlink_ops.rs
@@ -1,0 +1,202 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Symbolic link tests over hostfs: symlink, readlink, lstat.
+//!
+//! These tests exercise the `/mnt` mount point routing of symbolic-link operations
+//! through vfsd → hostfsd. On hosts where symbolic links cannot be created (notably
+//! Windows without Developer Mode), the host returns `ENOTSUP`; the tests detect
+//! this and skip gracefully so the rest of the mount-test suite remains usable.
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::syscall::safe::{
+    FileSystem,
+    FileSystemPath,
+    FileSystemPermissions,
+    FileType,
+    RegularFile,
+};
+
+pub fn test() -> Result<(), Error> {
+    // Create a regular file as the symlink target so readlink/lstat have something
+    // to refer to (the target is stored verbatim and not validated at create time).
+    let target_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-target.txt")?;
+    let perms: FileSystemPermissions = FileSystemPermissions::empty()
+        .user_read(true)
+        .user_write(true);
+    {
+        let mut f: RegularFile = FileSystem::create_regular_file(&target_path, Some(perms))?;
+        f.write(b"hello-symlink")?;
+    }
+
+    // Probe whether the host supports symlink creation by attempting a small one
+    // and skipping the remaining tests on `OperationNotSupported`.
+    let probe_link: FileSystemPath = FileSystemPath::new("/mnt/symlink-probe")?;
+    let _ = ::syscall::safe::fs::unlink(&probe_link);
+    let probe_target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    match ::syscall::safe::fs::symlink(&probe_target, &probe_link) {
+        Ok(()) => {
+            let _ = ::syscall::safe::fs::unlink(&probe_link);
+        },
+        Err(e) if e.code == ErrorCode::OperationNotSupported => {
+            ::syslog::warn!(
+                "mount-test: [SKIP] host does not support symlinks (e.g., Windows without \
+                 Developer Mode); skipping symlink_ops tests"
+            );
+            // Clean up the target file before returning.
+            let _ = ::syscall::safe::fs::unlink(&target_path);
+            return Ok(());
+        },
+        Err(e) => return Err(e),
+    }
+
+    // Inline-path tests: all use short link names whose wire path (after stripping
+    // the `/mnt/` mount prefix) fits within `MAX_INLINE_PATH_LEN` (36 bytes), so
+    // readlink/lstat take the single-message fast path.
+    test_symlink_create_readlink()?;
+    test_lstat_does_not_follow()?;
+    test_unlink_removes_symlink_not_target(&target_path)?;
+    test_symlink_to_nonexistent_target()?;
+
+    // Multi-part-path test: uses a link name whose wire path exceeds
+    // `MAX_INLINE_PATH_LEN`, forcing readlink/lstat through the multi-part
+    // assembler instead of the inline single-message form.
+    test_long_path_multipart()?;
+
+    // Final cleanup of the target file.
+    ::syscall::safe::fs::unlink(&target_path)?;
+    Ok(())
+}
+
+/// Tests creating a symlink and reading its target back verbatim.
+fn test_symlink_create_readlink() -> Result<(), Error> {
+    let link_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-readlink.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+    ::syslog::info!("mount-test: [PASS] symlink /mnt/symlink-readlink.lnk -> symlink-target.txt");
+
+    match ::syscall::safe::fs::readlink(&link_path) {
+        Ok(read) => {
+            if read.as_str() != target.as_str() {
+                panic!("readlink: expected '{}', got '{}'", target.as_str(), read.as_str());
+            }
+        },
+        Err(e) => panic!("readlink failed: {e:?}"),
+    }
+    ::syslog::info!("mount-test: [PASS] readlink returns stored target");
+
+    ::syscall::safe::fs::unlink(&link_path)?;
+    Ok(())
+}
+
+/// Tests that lstat reports SymbolicLink for the link itself.
+fn test_lstat_does_not_follow() -> Result<(), Error> {
+    let link_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-lstat.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+
+    let attr = ::syscall::safe::fs::lstat(&link_path)?;
+    if attr.file_type() != FileType::SymbolicLink {
+        panic!("lstat: expected SymbolicLink, got {:?}", attr.file_type());
+    }
+    ::syslog::info!("mount-test: [PASS] lstat reports SymbolicLink without following");
+
+    ::syscall::safe::fs::unlink(&link_path)?;
+    Ok(())
+}
+
+/// Tests that unlink on a symlink removes the link itself, not its target.
+fn test_unlink_removes_symlink_not_target(target_path: &FileSystemPath) -> Result<(), Error> {
+    let link_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-unlink.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+    ::syscall::safe::fs::unlink(&link_path)?;
+
+    // The target must still exist.
+    let attr = ::syscall::safe::fs::lstat(target_path)?;
+    if attr.file_type() == FileType::SymbolicLink {
+        panic!("unlink removed the target instead of the symlink");
+    }
+    ::syslog::info!("mount-test: [PASS] unlink removes symlink, not its target");
+
+    Ok(())
+}
+
+/// Tests creating a symlink whose target does not exist (POSIX allows this).
+fn test_symlink_to_nonexistent_target() -> Result<(), Error> {
+    let link_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-dangling.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("does-not-exist.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    // Symlink creation must succeed even if the target does not exist.
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+
+    // lstat on the dangling link must succeed and report SymbolicLink.
+    let attr = ::syscall::safe::fs::lstat(&link_path)?;
+    if attr.file_type() != FileType::SymbolicLink {
+        panic!("dangling symlink: expected SymbolicLink, got {:?}", attr.file_type());
+    }
+
+    // readlink on the dangling link must return the stored target.
+    match ::syscall::safe::fs::readlink(&link_path) {
+        Ok(read) => {
+            if read.as_str() != target.as_str() {
+                panic!(
+                    "readlink dangling: expected '{}', got '{}'",
+                    target.as_str(),
+                    read.as_str()
+                );
+            }
+        },
+        Err(e) => panic!("readlink dangling failed: {e:?}"),
+    }
+    ::syslog::info!("mount-test: [PASS] dangling symlink: create, lstat, readlink all OK");
+
+    ::syscall::safe::fs::unlink(&link_path)?;
+    Ok(())
+}
+
+/// Tests that readlink/lstat work over the multi-part wire format.
+///
+/// Uses a link path whose wire form (after the `/mnt/` prefix is stripped) exceeds
+/// `hostfs_api::MAX_INLINE_PATH_LEN` (36 bytes), so vfsd sends the request through
+/// the multi-part assembler rather than the inline single-message fast path.
+fn test_long_path_multipart() -> Result<(), Error> {
+    // Stripped wire path: "long-symlink-name-padding-AAAAAAAAAAAA.lnk" (42 bytes > 36).
+    let link_path: FileSystemPath =
+        FileSystemPath::new("/mnt/long-symlink-name-padding-AAAAAAAAAAAA.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    // Symlink creation always uses the multi-part wire format; here we exercise
+    // it together with the multi-part readlink and lstat request paths.
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+
+    let read = ::syscall::safe::fs::readlink(&link_path)?;
+    if read.as_str() != target.as_str() {
+        panic!(
+            "readlink (multi-part request): expected '{}', got '{}'",
+            target.as_str(),
+            read.as_str()
+        );
+    }
+    ::syslog::info!("mount-test: [PASS] readlink works over multi-part request path");
+
+    let attr = ::syscall::safe::fs::lstat(&link_path)?;
+    if attr.file_type() != FileType::SymbolicLink {
+        panic!("lstat (multi-part request): expected SymbolicLink, got {:?}", attr.file_type());
+    }
+    ::syslog::info!("mount-test: [PASS] lstat works over multi-part request path");
+
+    ::syscall::safe::fs::unlink(&link_path)?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request adds support for forwarding `symlinkat`, `readlinkat`, and `fstatat` (with `AT_SYMLINK_NOFOLLOW`) syscalls to hostfsd, enabling proper handling of symbolic links and path-based stat operations on host-mounted filesystems. It introduces new handlers and message dispatch logic for these syscalls, implements multi-part response assembly for long `readlink` responses, and defines synthetic stat constants to ensure consistent metadata reporting. The changes also improve error handling and resource management for pending asynchronous hostfs operations.

**Hostfs syscall forwarding and handlers:**

- Added forwarding and handler logic for `symlinkat` and `readlinkat` syscalls to hostfsd, including new functions `handle_symlinkat_with_hostfs` and `handle_readlinkat_with_hostfs` in `hostfs_handlers.rs`, and updated dispatch logic in `assembler.rs`. These handlers manage asynchronous operation tracking and error handling for hostfs paths. [[1]](diffhunk://#diff-e0137ece3d1ddfdee57536b2e5b8fe7e11cf9ab30901553ae5ebf3ecdccc5cbbL242-R247) [[2]](diffhunk://#diff-e0137ece3d1ddfdee57536b2e5b8fe7e11cf9ab30901553ae5ebf3ecdccc5cbbL258-R265) [[3]](diffhunk://#diff-e76b2806c0bd663ac1c38bce8f5fc2b60a3fe23c3f51f13a946c27f39ddbe941R637-R721)
- Implemented forwarding for `fstatat` with `AT_SYMLINK_NOFOLLOW` to hostfsd using a new path-based lstat operation, with fallback and error handling for unsupported modes. [[1]](diffhunk://#diff-e76b2806c0bd663ac1c38bce8f5fc2b60a3fe23c3f51f13a946c27f39ddbe941L253-R253) [[2]](diffhunk://#diff-e76b2806c0bd663ac1c38bce8f5fc2b60a3fe23c3f51f13a946c27f39ddbe941L263-R296)

**Hostfsd request/response message handling:**

- Introduced new functions in `hostfs.rs` to send `symlink`, `readlink`, and `lstat` requests to hostfsd, supporting both inline and multi-part message formats for large payloads.
- Added logic in `main.rs` to assemble multi-part `readlink` responses from hostfsd, handle incomplete/discarded streams, and pair responses with pending operations. [[1]](diffhunk://#diff-af2c771fb504fcfc0a91c9c228d79f5f4ecb74dda4c14286ee57ffcbdb1c0809R123-R141) [[2]](diffhunk://#diff-af2c771fb504fcfc0a91c9c228d79f5f4ecb74dda4c14286ee57ffcbdb1c0809R177-R262)

**Pending operation management and stat constants:**

- Extended the `PendingOpKind` enum to track new hostfs operation types (`Symlink`, `Readlink`, `Lstat`) and their associated data (e.g., buffer size for `Readlink`).
- Defined synthetic stat constants for consistent metadata reporting on hostfs files, ensuring deterministic stat results and compatibility with guest tooling.

**Other improvements:**

- Updated imports and minor code organization to support new syscall handlers and error codes. [[1]](diffhunk://#diff-e76b2806c0bd663ac1c38bce8f5fc2b60a3fe23c3f51f13a946c27f39ddbe941R409-R412) [[2]](diffhunk://#diff-af2c771fb504fcfc0a91c9c228d79f5f4ecb74dda4c14286ee57ffcbdb1c0809R37)