### PR TITLE
[uservm] Add snapshot-save-exit executor and update snapshot-test

### DIFF
--- a/src/tests/snapshot-test/src/main.rs
+++ b/src/tests/snapshot-test/src/main.rs
@@ -36,12 +36,28 @@ const SNAPSHOT_RESTORE_SENTINEL: ErrorCode = ErrorCode::BrokenPipe;
 /// Flag passed by the test harness to request that the workload trigger a snapshot.
 const SNAPSHOT_FLAG: &[u8] = b"--snapshot";
 
+/// Flag passed by the test harness to keep the guest running indefinitely after
+/// `pm::snapshot()` returns, so any clean host exit must originate from the snapshot-completion
+/// path rather than guest termination.
+const NO_EXIT_FLAG: &[u8] = b"--no-exit";
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 /// Returns `true` if `--snapshot` was passed as a command-line argument.
 fn should_snapshot() -> bool {
+    has_flag(SNAPSHOT_FLAG)
+}
+
+/// Returns `true` if `--no-exit` was passed as a command-line argument.
+fn should_loop_after_snapshot() -> bool {
+    has_flag(NO_EXIT_FLAG)
+}
+
+/// Returns `true` if `flag` appears as a standalone argument (followed by a NUL terminator) in
+/// `argv`.
+fn has_flag(flag: &[u8]) -> bool {
     let argc: i32 = nvx::ARGC.load(Ordering::SeqCst);
     let argv: *mut *const u8 = nvx::ARGV.load(Ordering::SeqCst);
 
@@ -55,14 +71,14 @@ fn should_snapshot() -> bool {
             continue;
         }
         let mut matches: bool = true;
-        for (j, &expected) in SNAPSHOT_FLAG.iter().enumerate() {
+        for (j, &expected) in flag.iter().enumerate() {
             let byte: u8 = unsafe { *ptr.add(j) };
             if byte == 0 || byte != expected {
                 matches = false;
                 break;
             }
         }
-        if matches && unsafe { *ptr.add(SNAPSHOT_FLAG.len()) } == 0 {
+        if matches && unsafe { *ptr.add(flag.len()) } == 0 {
             return true;
         }
     }
@@ -91,6 +107,13 @@ pub fn main() -> Result<(), Error> {
     }
 
     ::sys::kcall::pm::snapshot()?;
+
+    if should_loop_after_snapshot() {
+        // Spin forever so guest exit cannot mask a host-side snapshot-completion hang.
+        loop {
+            ::core::hint::spin_loop();
+        }
+    }
 
     Err(Error::new(SNAPSHOT_RESTORE_SENTINEL, "post-snapshot region executed"))
 }

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -881,7 +881,22 @@ impl Vmm {
                         if exit_status == ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD {
                             // Kernel finished booting; no-op on KVM backend.
                         } else if exit_status == ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD {
-                            Handle::current().block_on(self.handle_snapshot())?;
+                            // Guest requested a snapshot via the `snapshot` kernel option. This is
+                            // a one-shot "save and exit" flow: once the snapshot files are
+                            // durable on disk, shut the VM down with exit code 0 so the standalone
+                            // daemon returns to its caller instead of running the guest on (which
+                            // would otherwise block forever on stdin).
+                            //
+                            // `handle_snapshot()` returns `false` for the OUT that KVM re-executes
+                            // immediately after a restore (absorbed via `skip_next_snapshot`); in
+                            // that case keep running the restored guest.
+                            let took_snapshot: bool =
+                                Handle::current().block_on(self.handle_snapshot())?;
+                            if took_snapshot {
+                                let exit_status: u16 = 0;
+                                Handle::current().block_on(self.handle_shutdown(exit_status));
+                                break Ok(exit_status);
+                            }
                         } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             Handle::current().block_on(self.handle_shutdown(exit_status));
 
@@ -1175,23 +1190,29 @@ impl Vmm {
     /// # Description
     ///
     /// Handles a guest-initiated snapshot request from the VMM run loop.
-    /// If the `skip_next_snapshot` flag is set (i.e., we are resuming from a restored snapshot),
-    /// the request is silently skipped and the flag is cleared.
+    ///
+    /// Background: after a restore, KVM re-executes the `out` instruction that originally
+    /// triggered the snapshot (its RIP was saved pointing at the OUT). `load_snapshot()` sets
+    /// `skip_next_snapshot = true` so that re-emitted OUT is swallowed here instead of producing
+    /// a second snapshot file.
     ///
     /// # Returns
     ///
-    /// Upon success, returns empty. Otherwise, returns an error.
+    /// On success, returns `Ok(true)` when a snapshot was actually written to disk (caller should
+    /// treat this as a "save and exit" event), and `Ok(false)` when the snapshot OUT was silently
+    /// absorbed via `skip_next_snapshot` (caller should continue running the restored guest).
+    /// Otherwise, returns an error.
     ///
-    async fn handle_snapshot(&self) -> Result<()> {
-        // Scope the lock to avoid deadlock: `create_snapshot` re-acquires `self.inner`.
-        // Safety: no concurrent snapshot requests can race here because snapshot is triggered
-        // by a single vCPU VMEXIT which is processed sequentially on the VMM run loop.
+    async fn handle_snapshot(&self) -> Result<bool> {
+        // Locking: the lock is scoped tightly because `create_snapshot()` re-acquires
+        // `self.inner`. No concurrent snapshot requests can race because snapshot is triggered by
+        // a single vCPU VMEXIT processed sequentially on the VMM run loop.
         let kernel_filename: String = {
             let mut locked_inner: MutexGuard<'_, InteriorMicroVmHandle> = self.inner.lock().await;
             if locked_inner.skip_next_snapshot {
                 trace!("handle_snapshot(): skipping snapshot (restored from snapshot)");
                 locked_inner.skip_next_snapshot = false;
-                return Ok(());
+                return Ok(false);
             }
             if !locked_inner.snapshot_allowed {
                 error!("handle_snapshot(): snapshot refused (not enabled or already consumed)");
@@ -1206,7 +1227,7 @@ impl Vmm {
                 // Consume the one-shot permission only after a successful snapshot.
                 self.inner.lock().await.snapshot_allowed = false;
                 trace!("handle_snapshot(): snapshot created successfully");
-                Ok(())
+                Ok(true)
             },
             Err(error) => {
                 error!("handle_snapshot(): failed to create snapshot: {error:?}");

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -1012,9 +1012,24 @@ impl Vmm {
                                 }
                             }
                         } else if exit_status == ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD {
-                            if let Err(e) = Handle::current().block_on(self.handle_snapshot()) {
-                                error!("VMM exit: snapshot error (error={e:?})");
-                                break Err(e);
+                            // One-shot "save and exit" flow: once the snapshot files are
+                            // durable on disk, shut the VM down with exit code 0 so the
+                            // standalone daemon returns to its caller instead of running the
+                            // guest on. `handle_snapshot()` returns `false` for the OUT that is
+                            // absorbed via `skip_next_snapshot` after a restore; in that case
+                            // keep running the restored guest.
+                            let took_snapshot: bool =
+                                match Handle::current().block_on(self.handle_snapshot()) {
+                                    Ok(took) => took,
+                                    Err(e) => {
+                                        error!("VMM exit: snapshot error (error={e:?})");
+                                        break Err(e);
+                                    },
+                                };
+                            if took_snapshot {
+                                let exit_status: u16 = 0;
+                                Handle::current().block_on(self.handle_shutdown(exit_status));
+                                break Ok(exit_status);
                             }
                         } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             warn!(
@@ -1361,7 +1376,7 @@ impl Vmm {
     /// WHP advances RIP before delivering port-I/O exits, so the saved
     /// state already points past the `out` instruction. Unlike KVM, no
     /// `skip_next_snapshot` guard is needed to prevent re-triggering.
-    async fn handle_snapshot(&self) -> Result<()> {
+    async fn handle_snapshot(&self) -> Result<bool> {
         // Scope the lock to avoid deadlock: `create_snapshot` re-acquires `self.inner`.
         // Safety: no concurrent snapshot requests can race here because snapshot is triggered
         // by a single vCPU VMEXIT which is processed sequentially on the VMM run loop.
@@ -1370,7 +1385,7 @@ impl Vmm {
             if locked_inner.skip_next_snapshot {
                 trace!("handle_snapshot(): skipping snapshot (restored from snapshot)");
                 locked_inner.skip_next_snapshot = false;
-                return Ok(());
+                return Ok(false);
             }
             if !locked_inner.snapshot_allowed {
                 error!("handle_snapshot(): snapshot refused (not enabled or already consumed)");
@@ -1385,7 +1400,7 @@ impl Vmm {
                 // Consume the one-shot permission only after a successful snapshot.
                 self.inner.lock().await.snapshot_allowed = false;
                 trace!("handle_snapshot(): snapshot created successfully");
-                Ok(())
+                Ok(true)
             },
             Err(error) => {
                 error!("handle_snapshot(): failed to create snapshot: {error:?}");

--- a/src/utils/nanvix-test/src/executor/common.rs
+++ b/src/utils/nanvix-test/src/executor/common.rs
@@ -1,0 +1,41 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::tokio::io::{
+    AsyncRead,
+    AsyncReadExt,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Buffer size used while draining a daemon stdio pipe.
+///
+/// Sized to match the default Linux pipe-buffer chunk so a single `read` empties one kernel buffer
+/// slot without over-allocating on the stack.
+const DRAIN_CHUNK_SIZE: usize = 4096;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Reads from an async stream until EOF and discards the bytes. Used to keep daemon stdio
+/// pipes from filling up when the executor does not need their contents.
+pub(crate) async fn drain_stream<R>(mut reader: R) -> ::std::io::Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut chunk: [u8; DRAIN_CHUNK_SIZE] = [0u8; DRAIN_CHUNK_SIZE];
+    loop {
+        let bytes_read: usize = reader.read(&mut chunk).await?;
+        if bytes_read == 0 {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/src/utils/nanvix-test/src/executor/mod.rs
+++ b/src/utils/nanvix-test/src/executor/mod.rs
@@ -5,12 +5,18 @@
 // Modules
 //==================================================================================================
 
+#[cfg(feature = "standalone")]
+mod common;
 pub mod empty;
 #[cfg(unix)]
 pub mod http;
 #[cfg(feature = "standalone")]
 pub mod snapshot_restore;
+#[cfg(feature = "standalone")]
+pub mod snapshot_save_exit;
 pub mod terminal;
+#[cfg(feature = "standalone")]
+pub(crate) use self::common::drain_stream;
 
 //==================================================================================================
 // Imports
@@ -217,6 +223,9 @@ pub enum ExecutorName {
     /// Snapshot save / restore executor.
     #[cfg(feature = "standalone")]
     SnapshotRestore,
+    /// Snapshot save / host-exit executor.
+    #[cfg(feature = "standalone")]
+    SnapshotSaveExit,
     /// Terminal executor.
     Terminal,
 }
@@ -241,6 +250,8 @@ impl ExecutorName {
             "http" => Ok(Self::Http),
             #[cfg(feature = "standalone")]
             "snapshot-restore" => Ok(Self::SnapshotRestore),
+            #[cfg(feature = "standalone")]
+            "snapshot-save-exit" => Ok(Self::SnapshotSaveExit),
             "terminal" => Ok(Self::Terminal),
             _ => Err(::anyhow::anyhow!(format!("invalid executor name '{identifier}'"))),
         }
@@ -262,6 +273,8 @@ impl ExecutorName {
             Self::Http => "http",
             #[cfg(feature = "standalone")]
             Self::SnapshotRestore => "snapshot-restore",
+            #[cfg(feature = "standalone")]
+            Self::SnapshotSaveExit => "snapshot-save-exit",
             Self::Terminal => "terminal",
         }
     }

--- a/src/utils/nanvix-test/src/executor/snapshot_restore.rs
+++ b/src/utils/nanvix-test/src/executor/snapshot_restore.rs
@@ -253,10 +253,14 @@ async fn run_iterations(
         // overwrite them. The phase token is `iteration * 2` for save.
         guest_log_tracker.move_new_logs(log_layout.test_directory())?;
         log_layout.normalize_component_logs(iteration.saturating_mul(2))?;
-        if save_exit != expected_exit_code {
+        // The save phase exits as soon as the VMM persists the snapshot artifacts (status 0):
+        // the guest never resumes past `pm::snapshot()` in this phase, so the workload's
+        // configured `expected_exit_code` only applies to the restore phase below.
+        const SAVE_PHASE_EXPECTED_EXIT_CODE: i32 = 0;
+        if save_exit != SAVE_PHASE_EXPECTED_EXIT_CODE {
             let reason: String = format!(
                 "snapshot save phase exited with status {save_exit}, expected \
-                 {expected_exit_code} (iteration={iteration})"
+                 {SAVE_PHASE_EXPECTED_EXIT_CODE} (iteration={iteration})"
             );
             error!("run_iterations(): {reason}");
             return Err(anyhow!(reason));

--- a/src/utils/nanvix-test/src/executor/snapshot_restore.rs
+++ b/src/utils/nanvix-test/src/executor/snapshot_restore.rs
@@ -10,6 +10,7 @@ use crate::{
     executor::{
         WorkloadSpec,
         combine_args_env,
+        drain_stream,
     },
     log_layout::{
         GuestLogTracker,
@@ -38,10 +39,6 @@ use ::std::{
     time::Duration,
 };
 use ::tokio::{
-    io::{
-        AsyncRead,
-        AsyncReadExt,
-    },
     task::JoinHandle,
     time::sleep,
 };
@@ -61,8 +58,6 @@ const BIN_DIR: &str = "bin";
 const KERNEL_ELF_FILENAME: &str = "kernel.elf";
 /// Flag passed to the guest workload to trigger snapshot capture during phase 1.
 const SNAPSHOT_WORKLOAD_FLAG: &str = "--snapshot";
-/// Buffer size used while draining the nanvixd stdout/stderr pipes.
-const DRAIN_CHUNK_SIZE: usize = 4096;
 
 //==================================================================================================
 // Standalone Functions
@@ -438,24 +433,4 @@ async fn spawn_nanvixd(
     }
 
     Ok(exit_code)
-}
-
-///
-/// # Description
-///
-/// Reads from an async stream until EOF and discards the bytes. Used to keep daemon stdio
-/// pipes from filling up while the snapshot-restore executor does not need their contents.
-///
-async fn drain_stream<R>(mut reader: R) -> ::std::io::Result<()>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
-    let mut chunk: [u8; DRAIN_CHUNK_SIZE] = [0u8; DRAIN_CHUNK_SIZE];
-    loop {
-        let bytes_read: usize = reader.read(&mut chunk).await?;
-        if bytes_read == 0 {
-            break;
-        }
-    }
-    Ok(())
 }

--- a/src/utils/nanvix-test/src/executor/snapshot_save_exit.rs
+++ b/src/utils/nanvix-test/src/executor/snapshot_save_exit.rs
@@ -1,0 +1,374 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    config::RunnerConfig,
+    executor::{
+        WorkloadSpec,
+        combine_args_env,
+        drain_stream,
+    },
+    log_layout::{
+        GuestLogTracker,
+        TestLogLayout,
+    },
+    nanvixd::{
+        NanvixdTerminal,
+        NanvixdTerminalArgs,
+    },
+};
+use ::anyhow::{
+    Result,
+    anyhow,
+};
+use ::log::{
+    debug,
+    error,
+};
+use ::std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+    time::Duration,
+};
+use ::tokio::{
+    task::JoinHandle,
+    time::timeout,
+};
+use ::tokio_util::sync::CancellationToken;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Path (relative to nanvixd's working directory) at which the VMM stores snapshot artifacts.
+const SNAPSHOTS_DIR: &str = "snapshots";
+/// Filename of the snapshot virtual-memory dump produced by the KVM backend.
+const SNAPSHOT_VMEM_FILENAME: &str = "kernel.vmem";
+/// Filename of the snapshot KVM metadata produced by the KVM backend.
+const SNAPSHOT_KVM_JSON_FILENAME: &str = "kernel.kvm.json";
+/// Flags appended to the workload's command line during phase 1.
+const SNAPSHOT_FLAG: &str = "--snapshot";
+const NO_EXIT_FLAG: &str = "--no-exit";
+/// Upper bound on how long the host nanvixd process may take to exit after the snapshot
+/// artifacts are flushed to disk.
+const NANVIXD_EXIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Drives a single snapshot-save cycle and asserts that the host `nanvixd` process exits on
+/// its own within `NANVIXD_EXIT_TIMEOUT` after the snapshot artifacts
+/// (`snapshots/kernel.vmem`, `snapshots/kernel.kvm.json`) are written to disk.
+///
+/// To isolate the daemon-exit behaviour from the workload-exit behaviour, the guest workload
+/// is invoked with both `--snapshot` and `--no-exit`. The workload calls `pm::snapshot()`
+/// and then spins forever, so any clean shutdown observed by this executor must originate
+/// from the host-side snapshot-completion path.
+///
+/// The executor fails when:
+///   * `nanvixd` does not exit within `NANVIXD_EXIT_TIMEOUT`,
+///   * `nanvixd` exits with a non-`expected_exit_code` status, or
+///   * the snapshot artifacts are missing after `nanvixd` exits.
+///
+/// The executor does not support workloads that configure `input`, `expected_output`, or
+/// `expect_empty_output`; the daemon's stdio is drained but not inspected.
+///
+pub async fn test_with_snapshot_save_exit_executor(
+    runner_config: &RunnerConfig,
+    iterations: usize,
+    workload: WorkloadSpec<'_>,
+    log_layout: &TestLogLayout,
+    extra_nanvixd_args: &[String],
+    cancellation_token: CancellationToken,
+) -> Result<()> {
+    tokio::select! {
+        result = run_iterations(
+            runner_config,
+            iterations,
+            workload,
+            log_layout,
+            extra_nanvixd_args,
+        ) => result,
+        _ = cancellation_token.cancelled() => {
+            error!("test_with_snapshot_save_exit_executor(): cancellation requested");
+            Err(anyhow!("cancelled"))
+        },
+    }
+}
+
+async fn run_iterations(
+    runner_config: &RunnerConfig,
+    iterations: usize,
+    workload: WorkloadSpec<'_>,
+    log_layout: &TestLogLayout,
+    extra_nanvixd_args: &[String],
+) -> Result<()> {
+    if workload.input().is_some()
+        || workload.expected_output().is_some()
+        || workload.expect_empty_output()
+    {
+        let reason: String = "snapshot-save-exit executor does not support workloads with \
+                              'input', 'expected_output', or 'expect_empty_output' configured"
+            .to_string();
+        error!("run_iterations(): {reason}");
+        return Err(anyhow!(reason));
+    }
+
+    let working_directory: PathBuf = PathBuf::from(runner_config.working_directory.as_str());
+    let snapshots_dir: PathBuf = working_directory.join(SNAPSHOTS_DIR);
+    let snapshot_program: String = workload.program_path().to_string();
+    if !Path::new(snapshot_program.as_str()).exists() {
+        let reason: String = format!("snapshot workload not found (path={snapshot_program})");
+        error!("run_iterations(): {reason}");
+        return Err(anyhow!(reason));
+    }
+
+    let expected_exit_code: i32 = workload.expected_exit_code();
+
+    // Combine workload argv with the two test-harness flags and re-encode for nanvixd's
+    // interactive mode (matches the snapshot-restore executor's behaviour).
+    let parsed_program_args: Vec<String> = match workload.program_args() {
+        Some(args) => ::shell_words::split(args).map_err(|error| {
+            let reason: String = format!(
+                "failed to parse snapshot-save-exit program_args (args='{args}', error={error})"
+            );
+            error!("run_iterations(): {reason}");
+            anyhow!(reason)
+        })?,
+        None => Vec::new(),
+    };
+    let combined_args: Vec<String> =
+        build_combined_program_args(&parsed_program_args, workload.program_env());
+
+    let extra_nanvixd_args_with_kargs: Vec<String> = {
+        let mut combined: Vec<String> = Vec::with_capacity(extra_nanvixd_args.len() + 2);
+        combined.extend_from_slice(extra_nanvixd_args);
+        combined.push("-kernel-args".to_string());
+        combined.push(::koptions::SNAPSHOT_TOKEN.to_string());
+        combined
+    };
+
+    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+    let log_directory: PathBuf = log_layout.test_directory().to_path_buf();
+    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+
+    for iteration in 0..iterations {
+        debug!(
+            "run_iterations(): starting iteration {iteration} of {iterations} \
+             (program={snapshot_program})"
+        );
+
+        // Pre-create the snapshots directory and remove any previous artifacts so the
+        // post-exit existence checks are unambiguous.
+        prepare_snapshots_dir(&snapshots_dir)?;
+
+        let nanvixd_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
+            hwloc_file_path.clone(),
+            snapshot_program.as_str(),
+            combined_args.as_slice(),
+            log_directory.as_path(),
+            extra_nanvixd_args_with_kargs.as_slice(),
+        )?;
+
+        let mut nanvixd: NanvixdTerminal =
+            NanvixdTerminal::spawn(runner_config, &nanvixd_args).await?;
+
+        // Close stdin and drain stdio so the daemon never blocks on a full pipe buffer.
+        drop(nanvixd.take_stdin());
+        let stdout_drain: Option<JoinHandle<::std::io::Result<()>>> = nanvixd
+            .take_stdout()
+            .map(|pipe| ::tokio::spawn(drain_stream(pipe)));
+        let stderr_drain: Option<JoinHandle<::std::io::Result<()>>> = nanvixd
+            .take_stderr()
+            .map(|pipe| ::tokio::spawn(drain_stream(pipe)));
+
+        let wait_result = timeout(NANVIXD_EXIT_TIMEOUT, nanvixd.wait_exit_code()).await;
+
+        // Migrate guest component logs regardless of outcome so failures keep their breadcrumbs.
+        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+        log_layout.normalize_component_logs(iteration)?;
+
+        match wait_result {
+            Err(_elapsed) => {
+                // Force the daemon down and abort drain tasks so neither blocks the error path.
+                drop(nanvixd);
+                if let Some(handle) = stdout_drain {
+                    handle.abort();
+                    let _ = handle.await;
+                }
+                if let Some(handle) = stderr_drain {
+                    handle.abort();
+                    let _ = handle.await;
+                }
+                let artifacts_present: bool = snapshot_artifacts_present(&snapshots_dir);
+                let reason: String = format!(
+                    "nanvixd did not exit within {timeout_secs}s after the snapshot save \
+                     completed (iteration={iteration}, \
+                     snapshot_artifacts_present={artifacts_present})",
+                    timeout_secs = NANVIXD_EXIT_TIMEOUT.as_secs()
+                );
+                error!("run_iterations(): {reason}");
+                return Err(anyhow!(reason));
+            },
+            Ok(Err(error)) => {
+                error!(
+                    "run_iterations(): waiting for nanvixd exit failed (iteration={iteration}, \
+                     error={error:?})"
+                );
+                return Err(error);
+            },
+            Ok(Ok(exit_code)) => {
+                await_drain(stdout_drain, DrainStream::Stdout).await?;
+                await_drain(stderr_drain, DrainStream::Stderr).await?;
+                if exit_code != expected_exit_code {
+                    let reason: String = format!(
+                        "snapshot save phase exited with status {exit_code}, expected \
+                         {expected_exit_code} (iteration={iteration})"
+                    );
+                    error!("run_iterations(): {reason}");
+                    return Err(anyhow!(reason));
+                }
+                if !snapshot_artifacts_present(&snapshots_dir) {
+                    let reason: String = format!(
+                        "nanvixd exited cleanly but snapshot artifacts are missing under {} \
+                         (iteration={iteration})",
+                        snapshots_dir.display()
+                    );
+                    error!("run_iterations(): {reason}");
+                    return Err(anyhow!(reason));
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
+/// Encodes the workload argv (with the two harness flags appended) and the workload env into
+/// the single `<args>;<env>` string consumed by nanvixd's interactive mode.
+fn build_combined_program_args(
+    parsed_program_args: &[String],
+    program_env: Option<&str>,
+) -> Vec<String> {
+    let mut argv: Vec<String> = parsed_program_args.to_vec();
+    argv.push(SNAPSHOT_FLAG.to_string());
+    argv.push(NO_EXIT_FLAG.to_string());
+    let joined_args: String = argv.join(" ");
+    let combined: String = combine_args_env(
+        if joined_args.is_empty() {
+            None
+        } else {
+            Some(joined_args.as_str())
+        },
+        program_env,
+    );
+    if combined.is_empty() {
+        Vec::new()
+    } else {
+        vec![combined]
+    }
+}
+
+fn prepare_snapshots_dir(snapshots_dir: &Path) -> Result<()> {
+    match fs::metadata(snapshots_dir) {
+        Ok(metadata) if !metadata.is_dir() => {
+            let reason: String = format!(
+                "snapshots path exists but is not a directory (path={})",
+                snapshots_dir.display()
+            );
+            error!("prepare_snapshots_dir(): {reason}");
+            return Err(anyhow!(reason));
+        },
+        Ok(_) => {
+            for filename in [SNAPSHOT_VMEM_FILENAME, SNAPSHOT_KVM_JSON_FILENAME] {
+                let path: PathBuf = snapshots_dir.join(filename);
+                if path.exists() {
+                    fs::remove_file(&path).map_err(|error| {
+                        let reason: String = format!(
+                            "failed to remove stale snapshot artifact (path={}, error={error})",
+                            path.display()
+                        );
+                        error!("prepare_snapshots_dir(): {reason}");
+                        anyhow!(reason)
+                    })?;
+                }
+            }
+        },
+        Err(error) if error.kind() == ::std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(snapshots_dir).map_err(|error| {
+                let reason: String = format!(
+                    "failed to create snapshots directory (path={}, error={error})",
+                    snapshots_dir.display()
+                );
+                error!("prepare_snapshots_dir(): {reason}");
+                anyhow!(reason)
+            })?;
+        },
+        Err(error) => {
+            let reason: String = format!(
+                "failed to stat snapshots directory (path={}, error={error})",
+                snapshots_dir.display()
+            );
+            error!("prepare_snapshots_dir(): {reason}");
+            return Err(anyhow!(reason));
+        },
+    }
+    Ok(())
+}
+
+fn snapshot_artifacts_present(snapshots_dir: &Path) -> bool {
+    snapshots_dir.join(SNAPSHOT_VMEM_FILENAME).is_file()
+        && snapshots_dir.join(SNAPSHOT_KVM_JSON_FILENAME).is_file()
+}
+
+/// Identifies which nanvixd stdio pipe a drain task is associated with, used for diagnostics.
+#[derive(Clone, Copy)]
+enum DrainStream {
+    Stdout,
+    Stderr,
+}
+
+impl DrainStream {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+/// Awaits a stdio drain task and surfaces both join failures and I/O errors as test failures.
+async fn await_drain(
+    handle: Option<JoinHandle<::std::io::Result<()>>>,
+    stream: DrainStream,
+) -> Result<()> {
+    let Some(handle) = handle else {
+        return Ok(());
+    };
+    let label: &str = stream.as_str();
+    match handle.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            let reason: String = format!("error draining nanvixd {label}: {error}");
+            error!("await_drain(): {reason}");
+            Err(anyhow!(reason))
+        },
+        Err(error) => {
+            let reason: String = format!("nanvixd {label} drain task join failed: {error:?}");
+            error!("await_drain(): {reason}");
+            Err(anyhow!(reason))
+        },
+    }
+}

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -57,6 +57,8 @@ macro_rules! warn_with_policy {
 use crate::executor::http::test_with_http_executor;
 #[cfg(feature = "standalone")]
 use crate::executor::snapshot_restore::test_with_snapshot_restore_executor;
+#[cfg(feature = "standalone")]
+use crate::executor::snapshot_save_exit::test_with_snapshot_save_exit_executor;
 use crate::{
     config::{
         NanvixTestConfig,
@@ -624,6 +626,57 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
             (ExecutorName::SnapshotRestore, None) => {
                 let reason: String = "test entries with snapshot-restore executor must define the \
                                       'program' field"
+                    .to_string();
+                error!("main(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            #[cfg(feature = "standalone")]
+            (ExecutorName::SnapshotSaveExit, Some(program_path)) => {
+                if !Path::new(program_path.as_str()).exists() {
+                    warn_with_policy!(
+                        "main(): skipping tests with snapshot-save-exit executor because program \
+                         path is missing (path={})",
+                        program_path
+                    );
+                    warning::fail_if_triggered("snapshot-save-exit executor missing program")?;
+                    continue;
+                }
+
+                let log_layout: TestLogLayout = TestLogLayout::for_program(
+                    log_root,
+                    ExecutorName::SnapshotSaveExit.to_str(),
+                    program_path.as_str(),
+                )?;
+
+                let workload: WorkloadSpec = WorkloadSpec::new(
+                    program_path.as_str(),
+                    program_args.as_deref(),
+                    program_env.as_deref(),
+                    input.as_deref(),
+                    expected_output.as_deref(),
+                    expect_empty_output,
+                    expected_exit_code,
+                );
+
+                test_with_snapshot_save_exit_executor(
+                    &runner_config,
+                    iterations,
+                    workload,
+                    &log_layout,
+                    &extra_nanvixd_args,
+                    cancellation_token.clone(),
+                )
+                .await?;
+                let context: String = format!(
+                    "snapshot-save-exit executor completed (program={}, test={})",
+                    program_path, executor
+                );
+                warning::fail_if_triggered(context.as_str())?;
+            },
+            #[cfg(feature = "standalone")]
+            (ExecutorName::SnapshotSaveExit, None) => {
+                let reason: String = "test entries with snapshot-save-exit executor must define \
+                                      the 'program' field"
                     .to_string();
                 error!("main(): {reason}");
                 return Err(::anyhow::anyhow!(reason));

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -337,3 +337,12 @@ executor = "snapshot-restore"
 program = "./bin/snapshot-test.elf"
 iterations = 1
 expected_exit_code = 32
+
+# Asserts that the host nanvixd process exits on its own after the snapshot artifacts are
+# written to disk. The guest workload spins forever after taking the snapshot, so the only
+# path to a clean nanvixd exit is the host-side snapshot-completion tear-down.
+[[tests]]
+executor = "snapshot-save-exit"
+program = "./bin/snapshot-test.elf"
+iterations = 1
+expected_exit_code = 0


### PR DESCRIPTION
This pull request introduces a new "snapshot save and exit" flow for the VM, refactors snapshot handling to clarify control flow after a snapshot, and improves code reuse in the test executor utilities. The main changes include adding a new executor for the snapshot save/exit scenario, updating the guest and VMM logic to support this flow, and extracting a shared utility for draining async streams.

**Snapshot save and exit flow:**

* Added a new `SnapshotSaveExit` executor variant and command-line identifier to `ExecutorName`, enabling tests that verify the VM exits immediately after saving a snapshot rather than resuming the guest. (`src/utils/nanvix-test/src/executor/mod.rs`) [[1]](diffhunk://#diff-b43c4c78d7858d3140642dcb8a840cee4ad89e729dce50b1049b94634f36f322R226-R228) [[2]](diffhunk://#diff-b43c4c78d7858d3140642dcb8a840cee4ad89e729dce50b1049b94634f36f322R253-R254) [[3]](diffhunk://#diff-b43c4c78d7858d3140642dcb8a840cee4ad89e729dce50b1049b94634f36f322R276-R277)
* Updated the guest workload (`snapshot-test`) to support a new `--no-exit` flag, allowing it to spin indefinitely after `pm::snapshot()` for more accurate host-side snapshot completion testing. (`src/tests/snapshot-test/src/main.rs`) [[1]](diffhunk://#diff-2d39556f8288edb33e4bd01a343dd2c97b7d2e928a3d666596dcac109960bb5bR39-R60) [[2]](diffhunk://#diff-2d39556f8288edb33e4bd01a343dd2c97b7d2e928a3d666596dcac109960bb5bL58-R81) [[3]](diffhunk://#diff-2d39556f8288edb33e4bd01a343dd2c97b7d2e928a3d666596dcac109960bb5bR111-R117)

**VMM snapshot handling improvements:**

* Refactored `handle_snapshot()` in the VMM to return a boolean indicating whether a snapshot was actually taken, clarifying the distinction between a real snapshot event and a post-restore OUT instruction. This allows the VMM to exit immediately after a successful snapshot save. (`src/uservm/src/vmm/microvm/mod.rs`) [[1]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624R884-R899) [[2]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L1178-R1215) [[3]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L1209-R1230)

**Test executor utilities and code reuse:**

* Extracted a reusable `drain_stream()` async function for draining daemon stdio pipes, reducing code duplication across executors. (`src/utils/nanvix-test/src/executor/common.rs`, `src/utils/nanvix-test/src/executor/mod.rs`, `src/utils/nanvix-test/src/executor/snapshot_restore.rs`) [[1]](diffhunk://#diff-ec0c0538a63d2113c386b4a323fa46d717b46ce48c6fc0f34974ffa98bc3a4c7R1-R41) [[2]](diffhunk://#diff-b43c4c78d7858d3140642dcb8a840cee4ad89e729dce50b1049b94634f36f322R8-R19) [[3]](diffhunk://#diff-be66aad2291580c31693dfe6aaa38bc88e82dbbb17215e225637b7760945e2b1R13) [[4]](diffhunk://#diff-be66aad2291580c31693dfe6aaa38bc88e82dbbb17215e225637b7760945e2b1L41-L44) [[5]](diffhunk://#diff-be66aad2291580c31693dfe6aaa38bc88e82dbbb17215e225637b7760945e2b1L64-L65) [[6]](diffhunk://#diff-be66aad2291580c31693dfe6aaa38bc88e82dbbb17215e225637b7760945e2b1L442-L461)

**Test logic and correctness:**

* Adjusted the snapshot-restore executor to expect a fixed exit code (0) for the save phase, since the guest does not resume past `pm::snapshot()` in this scenario. (`src/utils/nanvix-test/src/executor/snapshot_restore.rs`)

Closes #2433