### PR TITLE
[kernel] Implement duplicate() kernel call and resource ownership checks

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -27,6 +27,7 @@ use ::alloc::collections::{
     LinkedList,
     VecDeque,
 };
+use ::arch::cpu::excp;
 use ::core::{
     cell::{
         RefCell,
@@ -1073,12 +1074,28 @@ fn do_exception_handler(
         let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
         let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
 
-        if pm
-            .handle_stack_page_fault(
-                mm,
-                info.addr() as usize,
-                ::arch::cpu::excp::ErrorCode::new(info.code()),
-            )
+        let error_code: excp::ErrorCode = excp::ErrorCode::new(info.code());
+
+        // Dispatch by the hardware-reported P (present) bit, which strictly partitions the
+        // two handlers below:
+        //
+        //   - Copy-on-write fault: user-mode write to a *present* page with the AVL CoW bit
+        //     set (P=1, W=1, U=1). The CoW handler accepts only when `error_code.is_present()`
+        //     is true.
+        //   - Stack demand-paging:  access to an *absent* page (P=0). The stack handler only
+        //     fires when the page is not present.
+        //
+        // Routing on `is_present()` makes the disjointedness explicit and avoids relying on the
+        // order of the two handlers.
+        if error_code.is_present() {
+            if pm
+                .handle_cow_page_fault(mm, info.addr() as usize, error_code)
+                .map_err(SleepError::Generic)?
+            {
+                return Ok(());
+            }
+        } else if pm
+            .handle_stack_page_fault(mm, info.addr() as usize, error_code)
             .map_err(SleepError::Generic)?
         {
             return Ok(());

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
@@ -15,6 +15,7 @@ use crate::hal::mem::{
 };
 use ::arch::mem::paging::{
     AccessedFlag,
+    CopyOnWriteFlag,
     DirtyFlag,
     FrameNumber,
     PageCacheDisableFlag,
@@ -333,6 +334,175 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
     ///
     /// # Description
     ///
+    /// Marks a present user page as copy-on-write: clears the writable bit and sets the AVL
+    /// copy-on-write bit.
+    ///
+    /// After this call, any user-mode write to the page faults with `P=1, W=1, U=1`,
+    /// which the in-kernel page-fault handler recognizes (via the AVL bit) as a
+    /// copy-on-write fault.
+    ///
+    /// The page must be currently writable. Pages that are already read-only must not
+    /// be marked copy-on-write: stamping the AVL copy-on-write bit on a genuinely
+    /// read-only mapping would cause a subsequent user-mode write to be silently
+    /// resolved as a copy-on-write fault instead of raising a protection fault.
+    ///
+    /// # Parameters
+    ///
+    /// - `page_address`: Page address of the entry to mark.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn mark_cow(&mut self, page_address: PageAddress) -> Result<(), Error> {
+        let mut pte: PageTableEntry = match self.read_pte(page_address) {
+            Some(pte) => pte,
+            None => {
+                let reason: &str = "failed to read page table entry";
+                error!("mark_cow(): {reason} (page_address={page_address:?})");
+                return Err(Error::new(ErrorCode::TryAgain, reason));
+            },
+        };
+
+        if !pte.is_present() {
+            let reason: &str = "page is not present";
+            error!("mark_cow(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+        }
+
+        if !pte.flags().is_writable() {
+            let reason: &str = "page is already read-only";
+            error!("mark_cow(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        pte.set_read_write(ReadWriteFlag::ReadOnly);
+        pte.set_cow(CopyOnWriteFlag::CopyOnWrite);
+        self.write_pte(page_address, pte);
+
+        // Invalidate the TLB entry so the new copy-on-write permissions take effect immediately.
+        // SAFETY: called from kernel mode after modifying a PTE.
+        unsafe { ::arch::mem::paging::invlpg(page_address.into_raw_value()) };
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Clears the copy-on-write mark on a present user page: clears the AVL copy-on-write
+    /// bit and restores the writable bit. Inverse of [`Self::mark_cow`].
+    ///
+    /// The PTE must currently be present and marked copy-on-write.
+    ///
+    /// # Parameters
+    ///
+    /// - `page_address`: Page address of the entry to unmark.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn unmark_cow(&mut self, page_address: PageAddress) -> Result<(), Error> {
+        let mut pte: PageTableEntry = match self.read_pte(page_address) {
+            Some(pte) => pte,
+            None => {
+                let reason: &str = "failed to read page table entry";
+                error!("unmark_cow(): {reason} (page_address={page_address:?})");
+                return Err(Error::new(ErrorCode::TryAgain, reason));
+            },
+        };
+
+        if !pte.is_present() {
+            let reason: &str = "page is not present";
+            error!("unmark_cow(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+        }
+
+        if !pte.is_cow() {
+            let reason: &str = "page is not copy-on-write";
+            error!("unmark_cow(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        pte.set_cow(CopyOnWriteFlag::NotCopyOnWrite);
+        pte.set_read_write(ReadWriteFlag::ReadWrite);
+        self.write_pte(page_address, pte);
+
+        // SAFETY: called from kernel mode after modifying a PTE.
+        unsafe { ::arch::mem::paging::invlpg(page_address.into_raw_value()) };
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves a copy-on-write mapping by repointing the PTE at `new_frame`,
+    /// clearing the AVL copy-on-write bit, and restoring the writable bit.
+    ///
+    /// The PTE must currently be present and marked copy-on-write.
+    ///
+    /// # Parameters
+    ///
+    /// - `page_address`: Page address of the entry to resolve.
+    /// - `new_frame`: New physical frame to install in the PTE.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the previous frame address (the one the PTE pointed at before
+    /// the swap) is returned, so the caller can release its reference. Upon failure,
+    /// an error is returned instead.
+    ///
+    pub fn replace_cow_frame(
+        &mut self,
+        page_address: PageAddress,
+        new_frame: FrameAddress,
+    ) -> Result<FrameAddress, Error> {
+        let pte: PageTableEntry = match self.read_pte(page_address) {
+            Some(pte) => pte,
+            None => {
+                let reason: &str = "failed to read page table entry";
+                error!("replace_cow_frame(): {reason} (page_address={page_address:?})");
+                return Err(Error::new(ErrorCode::TryAgain, reason));
+            },
+        };
+
+        if !pte.is_present() {
+            let reason: &str = "page is not present";
+            error!("replace_cow_frame(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+        }
+
+        if !pte.is_cow() {
+            let reason: &str = "page is not copy-on-write";
+            error!("replace_cow_frame(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        if pte.flags().is_writable() {
+            let reason: &str = "copy-on-write page is unexpectedly writable";
+            error!("replace_cow_frame(): {reason} (page_address={page_address:?})");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        let old_frame: FrameAddress = FrameAddress::from_frame_number(pte.frame_number())?;
+
+        let mut new_flags: PageTableEntryFlags = pte.flags();
+        new_flags.set_read_write(ReadWriteFlag::ReadWrite);
+        new_flags.set_cow(CopyOnWriteFlag::NotCopyOnWrite);
+        let new_pte: PageTableEntry = PageTableEntry::new(new_flags, new_frame.into_frame_number());
+        self.write_pte(page_address, new_pte);
+
+        // SAFETY: called from kernel mode after modifying a PTE.
+        unsafe { ::arch::mem::paging::invlpg(page_address.into_raw_value()) };
+
+        Ok(old_frame)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Bulk-fills page table entries for contiguous identity-mapped physical memory.
     ///
     /// Each entry maps physical frame `base_frame + i` with the given PTE flags.
@@ -446,9 +616,50 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
         self.entries[pte_idx] = pte.into_raw_value();
     }
 
+    ///
+    /// # Description
+    ///
+    /// Reads the page table entry at the given page address, if it is present.
+    ///
+    /// # Parameters
+    ///
+    /// - `page_address`: Page address of the entry to read.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(pte)` if the entry is present.
+    /// - `None` if the entry is not present (or could not be decoded).
+    ///
+    pub fn read_pte_at(&self, page_address: PageAddress) -> Option<PageTableEntry> {
+        match self.read_pte(page_address) {
+            Some(pte) if pte.is_present() => Some(pte),
+            _ => None,
+        }
+    }
+
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
         let vaddr: usize = self.entries.as_ptr() as usize;
         let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
         Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Iterates over the present entries in the target page table.
+    ///
+    /// # Returns
+    ///
+    /// An iterator that yields, for each present entry, a tuple `(pte_index, pte)` where
+    /// `pte_index` is the index of the entry within the page table (0–1023 on x86) and
+    /// `pte` is the decoded [`PageTableEntry`].
+    ///
+    pub fn iter_present_ptes(&self) -> impl Iterator<Item = (usize, PageTableEntry)> + '_ {
+        self.entries.iter().enumerate().filter_map(
+            |(idx, raw)| match PageTableEntry::from_raw_value(*raw) {
+                Some(pte) if pte.is_present() => Some((idx, pte)),
+                _ => None,
+            },
+        )
     }
 }

--- a/src/kernel/src/ipc/mbx/mailbox.rs
+++ b/src/kernel/src/ipc/mbx/mailbox.rs
@@ -47,6 +47,19 @@ impl Mailbox {
     ///
     /// # Description
     ///
+    /// Checks whether the mailbox has no buffered messages.
+    ///
+    /// # Returns
+    ///
+    /// `true` if no messages are buffered in the mailbox, otherwise `false`.
+    ///
+    pub(crate) fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Attempts to consume a message addressed to the given thread or its process.
     ///
     /// # Parameters

--- a/src/kernel/src/ipc/rendezvous.rs
+++ b/src/kernel/src/ipc/rendezvous.rs
@@ -171,7 +171,7 @@ static PENDING: PendingLists = PendingLists::new();
 /// Upon successful completion, empty is returned. On failure, an error is returned instead.
 ///
 fn cross_process_copy(
-    pm: &ProcessManager,
+    pm: &mut ProcessManager,
     src_pid: ProcessIdentifier,
     src_buffer: usize,
     dst_pid: ProcessIdentifier,
@@ -252,7 +252,7 @@ pub fn do_push(
         if actual_len > 0 {
             // Perform cross-process copy: caller's buffer -> puller's buffer.
             // SAFETY: the process manager is initialized and access is synchronized.
-            let pm: &ProcessManager = unsafe { ProcessManager::get() };
+            let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
             if let Err(copy_error) = cross_process_copy(
                 pm,
                 caller_pid,
@@ -394,7 +394,7 @@ pub fn do_pull(
         if actual_len > 0 {
             // Perform cross-process copy: pusher's buffer -> caller's buffer.
             // SAFETY: the process manager is initialized and access is synchronized.
-            let pm: &ProcessManager = unsafe { ProcessManager::get() };
+            let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
             if let Err(copy_error) = cross_process_copy(
                 pm,
                 push_req.pid,

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -120,6 +120,8 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::CreateThread => pm::create_thread(pid, arg0),
         // Handle `detach_thread()` locally.
         KcallNumber::DetachThread => pm::detach_thread(pid, arg0),
+        // Handle `duplicate()` locally.
+        KcallNumber::Duplicate => pm::duplicate(pid, arg0),
         // Handle `send()` locally.
         KcallNumber::Send => ipc::send(pid, tid, arg0),
         // SAFETY: The calling thread is not the kernel and no resources are held.

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -226,6 +226,84 @@ impl Inner {
     ///
     /// # Description
     ///
+    /// Adds a new reference to a frame that has already been allocated.
+    ///
+    /// This is used to implement page sharing (e.g. for copy-on-write). The matching
+    /// number of [`free`] calls must be issued to actually release the frame back to
+    /// the bitmap.
+    ///
+    /// # Parameters
+    ///
+    /// - `frame`: Address of the frame to share.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    fn share(&mut self, frame: FrameAddress) -> Result<(), Error> {
+        let frame_number: usize = frame.into_frame_number().into_raw_value();
+
+        if frame_number >= self.refcount.len() {
+            let reason: &str = "frame number out of bounds";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // The frame must currently have at least one owner. Sharing an unallocated
+        // frame is a logic error.
+        if self.refcount[frame_number] == 0 {
+            let reason: &str = "cannot share an unallocated frame";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        self.refcount[frame_number] = match self.refcount[frame_number].checked_add(1) {
+            Some(n) => n,
+            None => {
+                let reason: &str = "frame reference count overflow";
+                error!("{reason} (frame={frame:?})");
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            },
+        };
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the current reference count of an already-allocated frame.
+    ///
+    /// # Parameters
+    ///
+    /// - `frame`: Address of the frame to query.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the current reference count is returned. Upon failure, an error is
+    /// returned instead (out-of-bounds address, or the frame is not currently allocated).
+    ///
+    fn refcount(&self, frame: FrameAddress) -> Result<u8, Error> {
+        let frame_number: usize = frame.into_frame_number().into_raw_value();
+
+        if frame_number >= self.refcount.len() {
+            let reason: &str = "frame number out of bounds";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        if self.refcount[frame_number] == 0 {
+            let reason: &str = "frame is not allocated";
+            error!("{reason} (frame={frame:?})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        Ok(self.refcount[frame_number])
+    }
+
+    ///
+    /// # Description
+    ///
     /// Books a frame so that it will not be handed out by [`alloc`].
     ///
     /// # Parameters
@@ -467,4 +545,14 @@ pub(super) fn book(phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Error>
 /// Book every frame in the given physical memory region.
 pub(super) fn alloc_range(region: &TruncatedMemoryRegion<PhysicalAddress>) -> Result<(), Error> {
     instance().alloc_range(region)
+}
+
+/// Add a new reference to an already-allocated frame (e.g. for copy-on-write sharing).
+pub(super) fn share(frame: FrameAddress) -> Result<(), Error> {
+    instance().share(frame)
+}
+
+/// Returns the current reference count of an already-allocated frame.
+pub(super) fn refcount(frame: FrameAddress) -> Result<u8, Error> {
+    instance().refcount(frame)
 }

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -166,7 +166,36 @@ impl PhysMemoryManager {
             return Ok(());
         }
 
-        // Watermark check: reject user allocations that would breach the kernel reserve.
+        Self::check_user_watermark(count)?;
+
+        for _ in 0..count {
+            match self.upool.alloc() {
+                Ok(frame) => frames.push(frame),
+                Err(error) => {
+                    frames.clear();
+                    return Err(error);
+                },
+            }
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Rejects user allocations of `count` frames that would breach the kernel
+    /// watermark, i.e. that would drop the number of free frames below
+    /// [`config::kernel::KERNEL_WATERMARK`].
+    ///
+    /// # Parameters
+    ///
+    /// - `count`: Number of user frames the caller intends to allocate.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    fn check_user_watermark(count: usize) -> Result<(), Error> {
         let watermark_threshold: usize = config::kernel::KERNEL_WATERMARK
             .checked_add(count)
             .ok_or_else(|| {
@@ -178,16 +207,6 @@ impl PhysMemoryManager {
             let reason: &str = "would breach kernel watermark";
             error!("{reason}");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
-        }
-
-        for _ in 0..count {
-            match self.upool.alloc() {
-                Ok(frame) => frames.push(frame),
-                Err(error) => {
-                    frames.clear();
-                    return Err(error);
-                },
-            }
         }
         Ok(())
     }

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -183,6 +183,24 @@ impl PhysMemoryManager {
     ///
     /// # Description
     ///
+    /// Allocates a single user frame, applying the same kernel watermark check as
+    /// [`Self::alloc_many_user_frames`]. This is the single-frame fast path used on
+    /// hot paths such as copy-on-write fault resolution, where allocating an
+    /// intermediate [`Vec`] would be wasteful.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, a [`UserFrame`] is returned. Upon failure, an error is returned
+    /// instead.
+    ///
+    pub fn alloc_user_frame(&mut self) -> Result<UserFrame, Error> {
+        Self::check_user_watermark(1)?;
+        self.upool.alloc()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Rejects user allocations of `count` frames that would breach the kernel
     /// watermark, i.e. that would drop the number of free frames below
     /// [`config::kernel::KERNEL_WATERMARK`].

--- a/src/kernel/src/mm/phys/test.rs
+++ b/src/kernel/src/mm/phys/test.rs
@@ -134,6 +134,61 @@ fn test_user_frame_drop_frees_frame() -> bool {
     }
 }
 
+///
+/// # Description
+///
+/// Verifies that [`UserFrame::share`] increments the reference count on the underlying
+/// physical frame, so the frame remains allocated until all aliases are dropped.
+///
+fn test_user_frame_share_keeps_frame_alive() -> bool {
+    let addr = match frame::alloc() {
+        Ok(addr) => addr,
+        Err(e) => {
+            error!("frame allocation failed (error={e:?})");
+            return false;
+        },
+    };
+
+    let first: UserFrame = UserFrame::new(addr);
+
+    // Create a second owner via `share`. The underlying frame is now shared
+    // between `first` and `second`.
+    let second: UserFrame = match first.share() {
+        Ok(handle) => handle,
+        Err(e) => {
+            error!("share failed (error={e:?})");
+            return false;
+        },
+    };
+
+    // Dropping `first` decrements the reference count to 1; the frame must
+    // still be allocated.
+    drop(first);
+
+    // Re-sharing from `second` must succeed because the frame is still alive.
+    let third: UserFrame = match second.share() {
+        Ok(handle) => handle,
+        Err(e) => {
+            error!("share after partial drop failed (error={e:?})");
+            return false;
+        },
+    };
+
+    // Drop the remaining handles. The last drop reclaims the frame.
+    drop(second);
+    drop(third);
+
+    // After the final drop, the frame must be free; an explicit `free` of the
+    // same address must therefore fail.
+    match frame::free(addr) {
+        Ok(()) => {
+            error!("frame was not reclaimed after all shared owners dropped");
+            false
+        },
+        Err(_) => true,
+    }
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -145,6 +200,7 @@ pub fn test() -> bool {
     passed &= run_test!(test_user_frame_drop_reclaims_frames);
     passed &= run_test!(test_user_frame_leak_prevents_drop);
     passed &= run_test!(test_user_frame_drop_frees_frame);
+    passed &= run_test!(test_user_frame_share_keeps_frame_alive);
 
     passed
 }

--- a/src/kernel/src/mm/phys/upool.rs
+++ b/src/kernel/src/mm/phys/upool.rs
@@ -71,6 +71,41 @@ impl UserFrame {
         let this: ManuallyDrop<Self> = ManuallyDrop::new(self);
         this.addr
     }
+
+    ///
+    /// # Description
+    ///
+    /// Adds a new reference to the underlying physical frame and returns a fresh
+    /// [`UserFrame`] handle that owns that reference. The two handles share the
+    /// same physical frame, and the frame is only reclaimed once both handles are
+    /// dropped.
+    ///
+    /// This is the building block for copy-on-write sharing: the parent retains
+    /// its handle, the child receives the returned handle.
+    ///
+    /// # Returns
+    ///
+    /// On success, a new [`UserFrame`] that aliases the same physical frame as
+    /// `self`. On failure, an error is returned.
+    ///
+    pub fn share(&self) -> Result<UserFrame, Error> {
+        frame::share(self.addr)?;
+        Ok(Self { addr: self.addr })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the current reference count of the underlying physical frame.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the current reference count of the underlying physical frame is returned.
+    /// Upon failure, an error is returned instead.
+    ///
+    pub fn refcount(&self) -> Result<u8, Error> {
+        frame::refcount(self.addr)
+    }
 }
 
 impl Drop for UserFrame {

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -11,6 +11,7 @@ use crate::{
         mem::{
             AccessPermission,
             Address,
+            FrameAddress,
             PageAligned,
             PageTableAddress,
             VirtualAddress,
@@ -37,10 +38,17 @@ use ::alloc::{
     collections::LinkedList,
     vec::Vec,
 };
-use ::arch::mem;
+use ::arch::mem::{
+    self,
+    paging::PageTableEntry,
+    PAGE_ALIGNMENT,
+};
 use ::core::{
     hint::unlikely,
-    mem::MaybeUninit,
+    mem::{
+        ManuallyDrop,
+        MaybeUninit,
+    },
     sync::atomic::{
         AtomicBool,
         Ordering,
@@ -59,6 +67,12 @@ use ::sys::error::{
 // to use this ordering semantics because Nanvix is a single-core system, and the kernel runs with
 // interrupts disabled.
 const ORDER: Ordering = Ordering::Relaxed;
+
+/// Number of user mappings processed per chunk by [`VirtMemoryManager::link_user_pages`]
+/// and [`VirtMemoryManager::rollback_linked_pages`]. Sized so the per-chunk buffer fits
+/// comfortably on the kernel stack while keeping the snapshot/rollback walks of the
+/// parent's user mappings to a small number of passes for typical user processes.
+const LINK_CHUNK: usize = 32;
 
 //==================================================================================================
 // Global Variables
@@ -213,6 +227,271 @@ impl VirtMemoryManager {
         );
 
         Ok(new_vmem)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Shares every user-space page mapped in `parent` with `child` using copy-on-write
+    /// semantics.
+    ///
+    /// For each present user mapping in `parent`, this function adds a new reference to
+    /// the underlying physical frame and installs the same mapping in `child` at the same
+    /// virtual address. If the parent mapping is writable, both the parent and child PTEs
+    /// are then marked copy-on-write (read-only in hardware + AVL bit set), so that the
+    /// first write from either side triggers a page fault. The in-kernel page-fault
+    /// handler resolves such faults by allocating a private frame and pointing the
+    /// faulting PTE at it.
+    ///
+    /// Read-only mappings (e.g. the text segment) are shared without the copy-on-write
+    /// bit set: a write to them must continue to fault as a regular protection fault.
+    ///
+    /// # Parameters
+    ///
+    /// - `parent`: Virtual memory space whose user mappings should be shared.
+    /// - `child`: Destination virtual memory space. Must not already contain any user
+    ///   mappings overlapping those of `parent`.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned and both
+    /// `parent` and `child` are restored to the state they had on entry: any pages
+    /// already linked into `child` are unmapped (releasing the shared refcount) and any
+    /// copy-on-write marks installed on `parent` are cleared.
+    ///
+    pub fn link_user_pages(&mut self, parent: &mut Vmem, child: &mut Vmem) -> Result<(), Error> {
+        let page_table_allocator = || {
+            // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
+            // concurrent or re-entrant access to the physical memory manager is possible.
+            let mut kframe: KernelFrame =
+                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+            kframe.clear()?;
+            let kpage: KernelPage = KernelPage::new(kframe);
+            let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+            let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
+            Ok(page_table)
+        };
+
+        // Process the parent's user mappings in fixed-size chunks. We cannot mutate
+        // `parent` while borrowing its page tables via `for_each_user_mapping`, so each
+        // chunk first snapshots up to LINK_CHUNK entries into a stack-resident buffer,
+        // then performs the share/map/mark steps. This avoids any heap allocation that
+        // scales with the parent's mapping count (the kernel slab allocator caps at
+        // 512-byte requests, which a single Vec proportional to the mapping set quickly
+        // exceeds).
+        //
+        // The selection filter checks `child` for an existing mapping at the candidate
+        // vaddr and skips entries already linked by a prior chunk. This makes the walk
+        // robust against the parent's iteration revisiting entries we have already
+        // processed (e.g. writable entries that are now CoW-marked but still present).
+        loop {
+            let mut buf: [MaybeUninit<(PageAligned<VirtualAddress>, FrameAddress, bool)>;
+                LINK_CHUNK] = [const { MaybeUninit::uninit() }; LINK_CHUNK];
+            let mut count: usize = 0;
+            parent.for_each_user_mapping(|vaddr, pte: PageTableEntry| {
+                if count < LINK_CHUNK && child.try_find_user_pte(vaddr)?.is_none() {
+                    let frame: FrameAddress = FrameAddress::from_frame_number(pte.frame_number())?;
+                    buf[count].write((vaddr, frame, pte.flags().is_writable()));
+                    count += 1;
+                }
+                Ok(())
+            })?;
+
+            if count == 0 {
+                break;
+            }
+
+            for slot in buf.iter().take(count) {
+                // SAFETY: `slot` was written above for indices < count.
+                let (vaddr, frame, writable) = unsafe { slot.assume_init_read() };
+                if let Err(e) = Self::link_one_user_page(
+                    parent,
+                    child,
+                    vaddr,
+                    frame,
+                    writable,
+                    &page_table_allocator,
+                ) {
+                    Self::rollback_linked_pages(parent, child);
+                    return Err(e);
+                }
+            }
+
+            if count < LINK_CHUNK {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Links a single user page from `parent` into `child` with copy-on-write semantics.
+    ///
+    /// On failure the caller is expected to invoke [`Self::rollback_linked_pages`] to
+    /// undo any prior fully-linked iterations; this helper itself leaves no partial
+    /// per-iteration state behind.
+    fn link_one_user_page<F>(
+        parent: &mut Vmem,
+        child: &mut Vmem,
+        vaddr: PageAligned<VirtualAddress>,
+        frame: FrameAddress,
+        writable: bool,
+        page_table_allocator: &F,
+    ) -> Result<(), Error>
+    where
+        F: Fn() -> Result<PageTable<PageTableStorage>, Error>,
+    {
+        // Wrap the parent's already-owned frame in a [`ManuallyDrop`] handle so that
+        // we can call [`UserFrame::share`] on it without risking a spurious decrement
+        // of the parent's refcount if `share` itself returns an error. The parent's
+        // page table still holds the original reference; only `child_handle` carries
+        // the freshly-acquired one.
+        let parent_handle: ManuallyDrop<UserFrame> = ManuallyDrop::new(UserFrame::new(frame));
+        let child_handle: UserFrame = parent_handle.share()?;
+
+        // The child installs the shared frame at the same virtual address. If the
+        // page is writable the mapping is created RDWR so the subsequent CoW marking
+        // can switch it to RO+CoW (mark_cow requires the entry to be writable);
+        // otherwise the page is plain read-only with no CoW bit on either side. If
+        // `map` fails it drops `child_handle`, releasing the refcount just acquired
+        // by `share`.
+        let access: AccessPermission = if writable {
+            AccessPermission::RDWR
+        } else {
+            AccessPermission::RDONLY
+        };
+        child.map(child_handle, vaddr, access, page_table_allocator)?;
+
+        if writable {
+            if let Err(e) = parent.mark_user_page_cow(vaddr) {
+                if let Err(re) = child.unmap(vaddr) {
+                    warn!(
+                        "link_user_pages(): partial rollback unmap failed (vaddr={vaddr:?}, \
+                         error={re:?})"
+                    );
+                }
+                return Err(e);
+            }
+            if let Err(e) = child.mark_user_page_cow(vaddr) {
+                if let Err(re) = parent.unmark_user_page_cow(vaddr) {
+                    warn!(
+                        "link_user_pages(): partial rollback unmark failed (vaddr={vaddr:?}, \
+                         error={re:?})"
+                    );
+                }
+                if let Err(re) = child.unmap(vaddr) {
+                    warn!(
+                        "link_user_pages(): partial rollback unmap failed (vaddr={vaddr:?}, \
+                         error={re:?})"
+                    );
+                }
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Rolls back pages already linked by [`Self::link_user_pages`] on the error path.
+    ///
+    /// Iterates `child`'s user mappings in fixed-size chunks (avoiding any allocation
+    /// proportional to the mapping set) and, for each one: unmaps it from `child`
+    /// (releasing the shared refcount via the returned `UserFrame`'s `Drop`) and, if the
+    /// child PTE was marked copy-on-write, clears the matching mark on `parent`. The
+    /// child's CoW bit unambiguously identifies pages this call installed because
+    /// `link_user_pages` is invoked on a freshly created `child` with no pre-existing
+    /// user mappings, and the only path that sets the child's CoW bit also marked the
+    /// parent's. Steps log and continue on failure to make a best-effort restoration.
+    fn rollback_linked_pages(parent: &mut Vmem, child: &mut Vmem) {
+        loop {
+            let mut buf: [MaybeUninit<(PageAligned<VirtualAddress>, bool)>; LINK_CHUNK] =
+                [const { MaybeUninit::uninit() }; LINK_CHUNK];
+            let mut count: usize = 0;
+            let walk: Result<(), Error> = child.for_each_user_mapping(|vaddr, pte| {
+                if count < LINK_CHUNK {
+                    buf[count].write((vaddr, pte.is_cow()));
+                    count += 1;
+                }
+                Ok(())
+            });
+            if let Err(e) = walk {
+                warn!("link_user_pages(): rollback walk failed (error={e:?})");
+                return;
+            }
+            if count == 0 {
+                return;
+            }
+            for slot in buf.iter().take(count) {
+                // SAFETY: `slot` was written above for indices < count.
+                let (vaddr, was_cow) = unsafe { slot.assume_init_read() };
+                if was_cow {
+                    if let Err(re) = parent.unmark_user_page_cow(vaddr) {
+                        warn!(
+                            "link_user_pages(): rollback unmark failed (vaddr={vaddr:?}, \
+                             error={re:?})"
+                        );
+                    }
+                }
+                if let Err(re) = child.unmap(vaddr) {
+                    warn!(
+                        "link_user_pages(): rollback unmap failed (vaddr={vaddr:?}, error={re:?})"
+                    );
+                }
+            }
+            if count < LINK_CHUNK {
+                return;
+            }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to handle a page fault as a copy-on-write fault.
+    ///
+    /// A page fault is treated as a copy-on-write fault when it is a user-mode write to
+    /// a present page whose PTE has the AVL copy-on-write bit set. In that case this
+    /// function allocates a private frame for the faulting address, copies the contents
+    /// of the shared frame into it, and points the faulting PTE at the new frame with
+    /// the writable bit restored and the copy-on-write bit cleared. The reference held
+    /// on the old shared frame is then released.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory space of the faulting process.
+    /// - `fault_addr`: Faulting virtual address (need not be page-aligned).
+    /// - `error_code`: Typed x86 page-fault error code.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the fault was resolved as a copy-on-write fault.
+    /// - `Ok(false)` if the fault is not a copy-on-write fault and should be forwarded
+    ///   to the registered handler.
+    /// - `Err(_)` if the fault was a copy-on-write fault but resolving it failed.
+    ///
+    pub fn try_resolve_cow_fault(
+        &mut self,
+        vmem: &mut Vmem,
+        fault_addr: usize,
+        error_code: ::arch::cpu::excp::ErrorCode,
+    ) -> Result<bool, Error> {
+        // Copy-on-write faults are user-mode writes to a present page.
+        if !error_code.is_present() || !error_code.is_write() || !error_code.is_user() {
+            return Ok(false);
+        }
+
+        // Reject addresses that are not in user space outright. We must do this before
+        // touching `vmem` so that bogus addresses do not error out.
+        let page_addr: usize = ::sys::mm::align_down(fault_addr, PAGE_ALIGNMENT);
+        let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(page_addr) {
+            Ok(v) => v,
+            Err(_) => return Ok(false),
+        };
+
+        // Delegate to the shared resolver. It returns `Ok(false)` if the page is not
+        // copy-on-write (in which case the fault is forwarded to the registered handler)
+        // and `Ok(true)` if a copy-on-write mapping was resolved.
+        vmem.resolve_cow_at(vaddr)
     }
 
     ///

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -28,7 +28,10 @@ use crate::{
         },
     },
     mm::{
-        phys::UserFrame,
+        phys::{
+            PhysMemoryManager,
+            UserFrame,
+        },
         virt::{
             kpage::KernelPage,
             page_table_allocator::PAGE_TABLE_ALLOCATOR,
@@ -45,13 +48,17 @@ use ::arch::mem::{
     self,
     paging::{
         PageDirectoryEntry,
+        PageTableEntry,
         PteWord,
     },
     PAGE_ALIGNMENT,
     PAGE_TABLE_LENGTH,
     PGTAB_ALIGNMENT,
 };
-use ::core::cell::RefCell;
+use ::core::{
+    cell::RefCell,
+    mem::ManuallyDrop,
+};
 use ::sys::{
     config,
     error::{
@@ -639,6 +646,319 @@ impl Vmem {
     ///
     /// # Description
     ///
+    /// Attempts to find the page-table entry that backs the user page at `vaddr`.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the target page.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(pte))` if the page is present, where `pte` is a decoded copy of the
+    ///   page-table entry that backs the mapping.
+    /// - `Ok(None)` if the page table or page is not present.
+    /// - `Err(_)` on unexpected failures.
+    ///
+    pub(crate) fn try_find_user_pte(
+        &self,
+        vaddr: PageAligned<VirtualAddress>,
+    ) -> Result<Option<PageTableEntry>, Error> {
+        let page_addr: PageAddress = PageAddress::new(vaddr);
+        let pgtab_addr: PageTableAddress = PageTableAddress::new(PageTableAligned::from_raw_value(
+            ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
+        )?);
+
+        for (lookup_pgtable_addr, page_table) in self.user_page_tables.iter() {
+            if lookup_pgtable_addr == &pgtab_addr {
+                return Ok(page_table.read_pte_at(page_addr));
+            }
+        }
+
+        Ok(None)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Invokes `f` once for each present user-space page in the target virtual memory
+    /// space, in the order they appear in the internal user page-table list.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: Callback invoked with `(vaddr, pte)` for every present user mapping. The
+    ///   virtual address is page-aligned and lies in user space; `pte` is a decoded copy
+    ///   of the page-table entry that backs the mapping. Returning an error from `f`
+    ///   short-circuits the iteration and propagates the error to the caller.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, the first error returned by `f`
+    /// is propagated.
+    ///
+    pub fn for_each_user_mapping<F>(&self, mut f: F) -> Result<(), Error>
+    where
+        F: FnMut(PageAligned<VirtualAddress>, PageTableEntry) -> Result<(), Error>,
+    {
+        for (pgtab_addr, page_table) in self.user_page_tables.iter() {
+            let base: usize = pgtab_addr.into_raw_value();
+            for (pte_idx, pte) in page_table.iter_present_ptes() {
+                let raw_vaddr: usize = base
+                    .checked_add(
+                        pte_idx.checked_mul(mem::PAGE_SIZE).ok_or_else(|| {
+                            Error::new(ErrorCode::BadAddress, "pte offset overflow")
+                        })?,
+                    )
+                    .ok_or_else(|| {
+                        Error::new(ErrorCode::BadAddress, "user mapping vaddr overflow")
+                    })?;
+                let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+                f(vaddr, pte)?;
+            }
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the user page at `vaddr` as copy-on-write: clears the writable bit
+    /// and sets the AVL copy-on-write bit on the underlying page-table entry.
+    ///
+    /// The page must be currently mapped and present. This is intended to be used
+    /// when sharing a user page between two address spaces (e.g. during fork).
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the user page to mark.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn mark_user_page_cow(&mut self, vaddr: PageAligned<VirtualAddress>) -> Result<(), Error> {
+        if !Self::is_user_addr(vaddr.into_inner()) {
+            let reason: &str = "address is not in user space";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        let pgtab_aligned: PageTableAligned<VirtualAddress> = PageTableAligned::from_raw_value(
+            ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
+        )?;
+        let pgtable_vaddr: PageTableAddress = PageTableAddress::new(pgtab_aligned);
+        let page_table: &mut PageTable<PageTableStorage> =
+            self.lookup_user_page_table(pgtable_vaddr)?;
+        page_table.mark_cow(PageAddress::new(vaddr))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Inverse of [`Self::mark_user_page_cow`]: clears the copy-on-write mark on the user
+    /// page at `vaddr`, restoring its writable bit and clearing the AVL copy-on-write bit.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the user page to be unmarked.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn unmark_user_page_cow(
+        &mut self,
+        vaddr: PageAligned<VirtualAddress>,
+    ) -> Result<(), Error> {
+        if !Self::is_user_addr(vaddr.into_inner()) {
+            let reason: &str = "address is not in user space";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        let pgtab_aligned: PageTableAligned<VirtualAddress> = PageTableAligned::from_raw_value(
+            ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
+        )?;
+        let pgtable_vaddr: PageTableAddress = PageTableAddress::new(pgtab_aligned);
+        let page_table: &mut PageTable<PageTableStorage> =
+            self.lookup_user_page_table(pgtable_vaddr)?;
+        page_table.unmark_cow(PageAddress::new(vaddr))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves a copy-on-write fault on the user page at `vaddr` by repointing
+    /// its page-table entry at `new_frame`, clearing the AVL copy-on-write bit,
+    /// and restoring the writable bit.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the user page being resolved.
+    /// - `new_frame`: Physical frame to install in the PTE.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the previous frame address (the shared frame the PTE pointed
+    /// at) is returned. The caller is responsible for releasing that reference.
+    /// Upon failure, an error is returned instead.
+    ///
+    fn replace_user_page_cow_frame(
+        &mut self,
+        vaddr: PageAligned<VirtualAddress>,
+        new_frame: FrameAddress,
+    ) -> Result<FrameAddress, Error> {
+        if !Self::is_user_addr(vaddr.into_inner()) {
+            let reason: &str = "address is not in user space";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        let pgtab_aligned: PageTableAligned<VirtualAddress> = PageTableAligned::from_raw_value(
+            ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
+        )?;
+        let pgtable_vaddr: PageTableAddress = PageTableAddress::new(pgtab_aligned);
+        let page_table: &mut PageTable<PageTableStorage> =
+            self.lookup_user_page_table(pgtable_vaddr)?;
+        page_table.replace_cow_frame(PageAddress::new(vaddr), new_frame)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves a copy-on-write mapping at `vaddr`, if any. Allocates a private user frame,
+    /// copies the shared frame's contents into it, repoints the PTE at the new frame, and
+    /// drops the reference on the previously-shared frame.
+    ///
+    /// This is the building block used by both the page-fault handler (lazy resolution on a
+    /// user-mode write) and the kernel-side write paths (eager resolution before the kernel
+    /// writes to a user page via its physical alias, which would otherwise silently mutate
+    /// the shared frame and bypass the copy-on-write contract).
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Page-aligned user virtual address to resolve.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if a copy-on-write mapping was found at `vaddr` and resolved.
+    /// - `Ok(false)` if `vaddr` is not mapped or the PTE is not marked copy-on-write.
+    /// - `Err(_)` if the resolution failed (e.g. out of frames).
+    ///
+    pub fn resolve_cow_at(&mut self, vaddr: PageAligned<VirtualAddress>) -> Result<bool, Error> {
+        if !Self::is_user_addr(vaddr.into_inner()) {
+            return Ok(false);
+        }
+
+        let pte: PageTableEntry = match self.try_find_user_pte(vaddr)? {
+            Some(pte) => pte,
+            None => return Ok(false),
+        };
+        if !pte.is_cow() {
+            return Ok(false);
+        }
+
+        // Fast path: if this address space holds the last reference to the shared frame,
+        // we can simply clear the copy-on-write mark in place — no allocation, no copy,
+        // no free. This happens when every other sharer has already resolved its own CoW
+        // mapping for this frame. Safe because the kernel is single-threaded and runs
+        // with interrupts disabled, so the refcount cannot change under us between the
+        // query and the unmark.
+        let src_frame: FrameAddress = FrameAddress::from_frame_number(pte.frame_number())?;
+        // Wrap in `ManuallyDrop` so `refcount()` (which borrows `&self`) does not free
+        // the frame when the temporary goes out of scope.
+        let probe: ManuallyDrop<UserFrame> = ManuallyDrop::new(UserFrame::new(src_frame));
+        if probe.refcount()? == 1 {
+            self.unmark_user_page_cow(vaddr)?;
+            return Ok(true);
+        }
+
+        // Allocate a fresh user frame via the single-frame helper; this keeps the kernel
+        // watermark check on this path without paying the cost of an intermediate `Vec`.
+        // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
+        // concurrent or re-entrant access to the physical memory manager is possible.
+        let new_frame: UserFrame = unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame()?;
+
+        let src_paddr: usize = pte.frame_address();
+        let dst_paddr: usize = new_frame.address().into_raw_value();
+        super::memcpy(dst_paddr as *mut u8, src_paddr as *const u8, mem::PAGE_SIZE)?;
+
+        // Repoint the PTE at the new frame; the previous frame address is returned so we
+        // can drop the shared reference.
+        let new_frame_addr: FrameAddress = new_frame.address();
+        let old_frame: FrameAddress = self.replace_user_page_cow_frame(vaddr, new_frame_addr)?;
+
+        // The new frame is now owned by the page table; suppress its Drop.
+        let _ = new_frame.leak();
+
+        // Drop the shared reference: this decrements the per-frame refcount, freeing the
+        // frame only when the last sharer releases it.
+        drop(UserFrame::new(old_frame));
+
+        Ok(true)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Eagerly resolves all copy-on-write mappings overlapping the byte range `[addr, addr + size)`
+    /// in user space. Pages outside user space or not marked copy-on-write are left untouched.
+    ///
+    /// This must be called by kernel-side write paths (e.g. `copy_to_user`) before they write
+    /// to user memory via its physical alias, so that the write does not silently mutate a
+    /// frame that is still shared with another address space.
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Start of the byte range (need not be page-aligned).
+    /// - `size`: Length of the byte range, in bytes. A zero-length range is a no-op.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn resolve_cow_for_region(
+        &mut self,
+        addr: VirtualAddress,
+        size: usize,
+    ) -> Result<(), Error> {
+        if size == 0 {
+            return Ok(());
+        }
+
+        let start: usize = ::sys::mm::align_down(addr.into_raw_value(), PAGE_ALIGNMENT);
+        let end_inclusive: usize =
+            addr.into_raw_value().checked_add(size - 1).ok_or_else(|| {
+                let reason: &str = "resolve_cow_for_region: overflow";
+                error!("{reason} (addr={addr:?}, size={size:?})");
+                Error::new(ErrorCode::BadAddress, reason)
+            })?;
+        let last_page: usize = ::sys::mm::align_down(end_inclusive, PAGE_ALIGNMENT);
+
+        let mut page: usize = start;
+        loop {
+            let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(page)?;
+            // Only resolve pages that lie in user space; the routine is safe to call on
+            // ranges that straddle user/kernel boundaries because non-user pages return
+            // `Ok(false)`. Callers that need to enforce that the whole range is in user
+            // space do so themselves (e.g. `copy_to_user_unaligned`).
+            self.resolve_cow_at(vaddr)?;
+
+            if page == last_page {
+                break;
+            }
+            page = page.checked_add(mem::PAGE_SIZE).ok_or_else(|| {
+                let reason: &str = "resolve_cow_for_region: page overflow";
+                error!("{reason} (page={page:?})");
+                Error::new(ErrorCode::BadAddress, reason)
+            })?;
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Translates a user-space virtual address to a guest physical address by walking the page
     /// tables. The returned physical address includes the intra-page offset from the original
     /// virtual address.
@@ -799,7 +1119,7 @@ impl Vmem {
     ///  errors that occur while copying data will cause this function to panic.
     ///
     pub fn copy_to_user_unaligned_unchecked(
-        &self,
+        &mut self,
         mut dst: VirtualAddress,
         mut src: VirtualAddress,
         mut size: usize,
@@ -837,6 +1157,14 @@ impl Vmem {
                  size={size:?})",
             );
             return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // Eagerly resolve any copy-on-write mappings in the destination range. Kernel writes
+        // below target the destination frames via their physical alias, which bypasses the
+        // page-table read-only/CoW bits, so resolution must happen up front rather than via
+        // the page-fault path. The dry-run pass is skipped because it does not write.
+        if !dry_run {
+            self.resolve_cow_for_region(dst, size)?;
         }
 
         while size > 0 {
@@ -948,7 +1276,7 @@ impl Vmem {
     ///
     ///
     pub fn copy_to_user_unaligned(
-        &self,
+        &mut self,
         dst: VirtualAddress,
         src: VirtualAddress,
         size: usize,

--- a/src/kernel/src/pm/kcall/duplicate.rs
+++ b/src/kernel/src/pm/kcall/duplicate.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    kcall::KcallResult,
+    mm::{
+        VirtMemoryManager,
+        Vmem,
+    },
+    pm::{
+        self,
+        ProcessManager,
+    },
+};
+use ::core::mem::size_of;
+use ::sys::{
+    error::ErrorCode,
+    mm::{
+        Address,
+        VirtualAddress,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadCreateArgs,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Kernel call handler for duplicating the calling process. The child process inherits a clone
+/// of the caller's address space and starts executing the user-supplied entry function on the
+/// user-supplied stack. The operation is refused when the calling process owns one or more
+/// special resources (memory-mapped I/O regions, port-mapped I/O ports, event ownerships, or
+/// buffered in-flight mailbox messages).
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Pointer to the [`ThreadCreateArgs`] structure describing the child main thread's
+///   entry point and stack, in user space.
+///
+/// # Returns
+///
+/// A [`KcallResult`] containing the process identifier of the newly created process on success
+/// or the error code on failure.
+///
+pub fn duplicate(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
+    // Unpack kernel call arguments.
+    let unsafe_args: VirtualAddress = VirtualAddress::from_raw_value(arg0 as usize);
+
+    // Check that the argument lies entirely in user space.
+    if !Vmem::is_user_region(unsafe_args, size_of::<ThreadCreateArgs>()) {
+        let reason: &str = "duplicate args do not lie in user space";
+        error!("{reason} (args={unsafe_args:?})");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Copy the arguments from user space.
+    let mut args: ThreadCreateArgs = ThreadCreateArgs::default();
+    if let Err(error) = pm::copy_from_user(
+        pm,
+        pid,
+        &mut args,
+        unsafe_args.into_raw_value() as *const ThreadCreateArgs,
+    ) {
+        let reason: &str = "failed to copy duplicate args from user space";
+        error!("{reason} (error={:?})", error);
+        return KcallResult::Error(error.code.into());
+    }
+
+    // Handle the request.
+    match pm.duplicate_process(mm, pid, &args) {
+        Ok(child_pid) => {
+            debug!("process {child_pid:?} duplicated from {pid:?}");
+            KcallResult::Success(<i32>::from(child_pid).into())
+        },
+        Err(e) => KcallResult::Error(e.code.into()),
+    }
+}

--- a/src/kernel/src/pm/kcall/mod.rs
+++ b/src/kernel/src/pm/kcall/mod.rs
@@ -8,6 +8,7 @@
 mod capctl;
 mod create_thread;
 mod detach_thread;
+mod duplicate;
 mod get_thread_data_area;
 mod gettime;
 mod join_thread;
@@ -30,6 +31,7 @@ mod wait_cond;
 pub use capctl::capctl;
 pub use create_thread::create_thread;
 pub use detach_thread::detach_thread;
+pub use duplicate::duplicate;
 pub use get_thread_data_area::get_thread_data_area;
 pub use gettime::gettime;
 pub use join_thread::join_thread;

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod clock;
 mod kcall;
 mod process;
 pub mod sync;
+#[cfg(feature = "test")]
+mod test;
 pub mod thread;
 
 //==================================================================================================
@@ -133,6 +135,12 @@ pub fn init(root: Vmem) -> Result<(), Error> {
     info!("initializing the thread manager...");
     let (kernel, tm): (ReadyThread, ThreadManager) = thread::init();
     ProcessManager::init(interrupt_capable, kernel, root, tm);
+
+    #[cfg(feature = "test")]
+    {
+        let passed: bool = test::test();
+        assert!(passed, "pm in-kernel tests failed");
+    }
 
     Ok(())
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -649,6 +649,134 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Duplicates the calling process. The child process is created with a clone of the
+    /// caller's address space, and its main thread starts executing the user-supplied entry
+    /// function on the user-supplied stack.
+    ///
+    /// The operation is refused when the calling process owns any "special" resources, as
+    /// reported by [`ProcessState::has_special_resources`]. This guarantees that no resource
+    /// that is uniquely owned by the parent (memory-mapped I/O regions, port-mapped I/O
+    /// ports, event ownerships, or buffered in-flight messages) is silently leaked or
+    /// duplicated into the child.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Memory manager to use.
+    /// - `pid`: Process identifier of the calling (parent) process.
+    /// - `args`: Thread creation arguments describing the child main thread's entry point
+    ///   and stack.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, the process identifier of the new (child) process is
+    /// returned. Otherwise, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function fails with the following error codes, among others:
+    ///
+    /// - [`ErrorCode::OperationNotPermitted`]: The calling process owns one or more special
+    ///   resources that prevent it from being duplicated.
+    /// - [`ErrorCode::InvalidArgument`]: The supplied entry function or stack does not lie
+    ///   within the user address space.
+    ///
+    pub fn duplicate_process(
+        &mut self,
+        mm: &mut VirtMemoryManager,
+        pid: ProcessIdentifier,
+        args: &ThreadCreateArgs,
+    ) -> Result<ProcessIdentifier, Error> {
+        trace!("pid={pid:?}, args={args:?}");
+
+        // Sanity-check the caller against the running process, mirroring create_thread().
+        debug_assert!(
+            self.get_running().state().pid() == pid,
+            "duplicate_process: pid must match the running process"
+        );
+
+        // Validate user-supplied entry point and stack range.
+        if !Vmem::is_user_addr(args.user_fn) {
+            let reason: &str = "user function does not lie within the user address space";
+            error!("{reason} (user_fn={:?})", args.user_fn);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if !Vmem::is_user_region(args.user_stack_base, args.user_stack_size) {
+            let reason: &str = "user stack does not lie within the user address space";
+            error!(
+                "{reason} (user_stack_base={:?}, user_stack_size={})",
+                args.user_stack_base, args.user_stack_size
+            );
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if let Some(user_tda) = args.user_tda {
+            if !Vmem::is_user_addr(user_tda) {
+                let reason: &str =
+                    "user-space thread data area does not lie within the user address space";
+                error!("{reason} (user_tda={:?})", user_tda);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+        }
+
+        // Refuse to duplicate when the caller owns special resources.
+        if self.get_running().state().has_special_resources() {
+            let reason: &str = "caller owns special resources (mmio/pmio/events/mailbox)";
+            error!("{reason} (pid={pid:?})");
+            return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
+        }
+
+        // Refuse to create a new process when the system-wide live-process cap has been reached.
+        if self.live_count >= ::config::kernel::MAX_PROCESSES {
+            let reason: &str = "maximum number of processes reached";
+            error!(
+                "{reason} (live_count={}, max_processes={})",
+                self.live_count,
+                ::config::kernel::MAX_PROCESSES
+            );
+            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        }
+
+        // Reserve identifiers early, before any allocation that could fail.
+        let (child_pid, next_pid): (ProcessIdentifier, ProcessIdentifier) = self.try_next_pid()?;
+        let (child_tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
+
+        // Clone caller's address space.
+        let mut vmem: Vmem = mm.new_vmem(self.get_running().state().vmem())?;
+
+        // Share parent's user-space pages with the child using copy-on-write semantics:
+        // both address spaces transparently see the same data until either side writes,
+        // at which point the in-kernel page-fault handler allocates a private copy for
+        // the faulting side.
+        mm.link_user_pages(self.get_running_mut().state_mut().vmem_mut(), &mut vmem)?;
+
+        // Forge a kernel context that, on first dispatch, enters user mode at `user_fn` on the
+        // supplied user stack.
+        let (kernel_stack, context): (KernelStack, ContextInformation) =
+            Self::forge_user_context(mm, &mut vmem, args, self.interrupt_capable)?;
+
+        //==============================================================
+        // NOTE: if we fail beyond this point we leak page mappings.
+        //==============================================================
+
+        Ok(no_fail!(ProcessIdentifier, {
+            let thread: ReadyThread =
+                self.tm
+                    .create_thread(child_tid, Some(kernel_stack), None, args.user_tda, context);
+
+            // Commit reserved identifiers now that all fallible operations succeeded.
+            self.next_pid = next_pid;
+            self.tm.commit_next_tid(next_tid);
+            self.live_count += 1;
+
+            let process: RunnableProcess = RunnableProcess::new(child_pid, thread, vmem);
+            self.ready.push_back(process);
+
+            Ok(child_pid)
+        }))
+    }
+
+    ///
+    /// # Description
+    ///
     /// Schedule a thread to run.
     ///
     /// # Returns
@@ -1882,13 +2010,25 @@ impl ProcessManager {
     /// Upon successful completion, empty is returned. On failure, an error is returned instead.
     ///
     pub fn vmcopy_user_to_user(
-        &self,
+        &mut self,
         src_pid: ProcessIdentifier,
         src: VirtualAddress,
         dst_pid: ProcessIdentifier,
         dst: VirtualAddress,
         size: usize,
     ) -> Result<(), Error> {
+        // Eagerly resolve any copy-on-write mappings in the destination region before the
+        // copy. The byte-copy path below targets the destination frames via their physical
+        // alias, which bypasses the page-table read-only/CoW bits, so the resolution must
+        // happen here rather than on the page-fault path.
+        if size > 0 {
+            let mut dst_proc = self.find_process_mut(dst_pid)?;
+            dst_proc
+                .state_mut()
+                .vmem_mut()
+                .resolve_cow_for_region(dst, size)?;
+        }
+
         let src_proc: ProcessRef<'_> = self.find_process(src_pid)?;
         let dst_proc: ProcessRef<'_> = self.find_process(dst_pid)?;
         let src_vmem: &Vmem = src_proc.state().vmem();
@@ -2329,5 +2469,33 @@ impl ProcessManager {
         self.mmap(mm, pid, vaddr, 1, AccessPermission::RDWR)?;
 
         Ok(true)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Handles a page fault that may be caused by a copy-on-write mapping in the
+    /// running process's address space.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Virtual memory manager.
+    /// - `fault_addr`: Faulting virtual address.
+    /// - `error_code`: Typed x86 page-fault error code.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the fault was resolved as a copy-on-write fault.
+    /// - `Ok(false)` if the fault is not a copy-on-write fault.
+    /// - `Err(...)` if resolving the fault failed.
+    ///
+    pub fn handle_cow_page_fault(
+        &mut self,
+        mm: &mut VirtMemoryManager,
+        fault_addr: usize,
+        error_code: excp::ErrorCode,
+    ) -> Result<bool, Error> {
+        let vmem: &mut Vmem = self.get_running_mut().state_mut().vmem_mut();
+        mm.try_resolve_cow_fault(vmem, fault_addr, error_code)
     }
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1721,6 +1721,35 @@ impl ProcessManager {
         self.running.as_ref().expect("the kernel should be running")
     }
 
+    ///
+    /// # Description
+    ///
+    /// Reports whether the currently running process owns any "special" resources, as
+    /// defined by [`crate::pm::process::state::ProcessState::has_special_resources`].
+    ///
+    /// Thin test-only accessor used by in-kernel tests; it avoids widening the visibility of
+    /// [`Self::get_running`]. The `duplicate()` kernel call reaches the same predicate
+    /// directly through its internal `get_running()` view.
+    ///
+    #[cfg(feature = "test")]
+    pub fn current_has_special_resources(&self) -> bool {
+        self.get_running().state().has_special_resources()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a shared reference to the currently running process's virtual address space.
+    ///
+    /// Thin test-only accessor used by in-kernel tests that need a reference [`Vmem`] to clone
+    /// from (e.g. via [`crate::mm::VirtMemoryManager::new_vmem`]). Production code paths reach
+    /// this through the internal [`Self::get_running`] view instead.
+    ///
+    #[cfg(feature = "test")]
+    pub fn current_vmem(&self) -> &Vmem {
+        self.get_running().state().vmem()
+    }
+
     fn get_running_mut(&mut self) -> &mut RunningProcess {
         // NOTE: it is safe to call unwrap because there is always a process running.
         self.running.as_mut().expect("the kernel should be running")

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -281,6 +281,44 @@ impl ProcessState {
         &mut self.vmem
     }
 
+    ///
+    /// # Description
+    ///
+    /// Checks whether the process owns any "special" resources that prevent it from being
+    /// safely duplicated. A process is considered to own special resources when it holds any
+    /// of the following:
+    ///
+    /// - One or more allocated memory-mapped I/O regions.
+    /// - One or more allocated port-mapped I/O ports.
+    /// - One or more event ownerships.
+    /// - One or more in-flight (buffered) inter-process messages in its mailbox.
+    ///
+    /// Mutexes and condition variables are intentionally excluded because their addresses
+    /// alias user-space objects and are recreated lazily on access from the cloned address
+    /// space. Resources covered above, by contrast, are uniquely owned by the parent and
+    /// cannot be safely transferred to a child via address-space cloning alone.
+    ///
+    /// # Scope
+    ///
+    /// This predicate only inspects per-process state. It does **not** inspect global state
+    /// such as the rendezvous lists used by `push`/`pull`; threads belonging to this process
+    /// that are currently sleeping on a rendezvous are not tracked here. Such pending
+    /// rendezvous reference user buffers in the parent's address space only, so they remain
+    /// correct after duplication: copy-on-write resolution on the kernel-side write paths
+    /// (`vmcopy_user_to_user`, `copy_to_user_unaligned`) ensures wake-up writes hit the
+    /// parent's private frames, not the child's.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the process owns any of the resources listed above, otherwise `false`.
+    ///
+    pub fn has_special_resources(&self) -> bool {
+        !self.mmio.is_empty()
+            || !self.pmio.is_empty()
+            || !self.events.is_empty()
+            || !self.mailbox.is_empty()
+    }
+
     pub fn copy_from_user_unaligned(
         &self,
         dst: VirtualAddress,

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -329,7 +329,7 @@ impl ProcessState {
     }
 
     pub fn copy_to_user_unaligned(
-        &self,
+        &mut self,
         dst: VirtualAddress,
         src: VirtualAddress,
         size: usize,

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -1,0 +1,879 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::{
+        arch::x86::mem::mmu::page_table::PageTable,
+        mem::{
+            AccessPermission,
+            PageAligned,
+            VirtualAddress,
+        },
+    },
+    ipc::Mailbox,
+    mm::{
+        phys::{
+            PhysMemoryManager,
+            UserFrame,
+        },
+        KernelPage,
+        PageTableStorage,
+        VirtMemoryManager,
+        Vmem,
+    },
+    pm::ProcessManager,
+};
+use ::arch::mem::paging::PageTableEntry;
+use ::sys::{
+    error::ErrorCode,
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    mm::Address,
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Verifies that a freshly constructed mailbox reports as empty, and that posting a single
+/// message causes it to report as non-empty.
+///
+fn test_mailbox_is_empty_tracks_buffered_messages() -> bool {
+    let mut mailbox: Mailbox = Mailbox::default();
+    if !mailbox.is_empty() {
+        error!("freshly constructed mailbox reported as non-empty");
+        return false;
+    }
+
+    let message: Message = Message::new(
+        MessageSender::from(ProcessIdentifier::KERNEL),
+        MessageReceiver::from(ProcessIdentifier::KERNEL),
+        MessageType::Ipc,
+        Option::<ErrorCode>::None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    mailbox.send(message);
+    if mailbox.is_empty() {
+        error!("mailbox reported as empty after sending a message");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies that the kernel process (the process running at kernel-test time) does not own any
+/// special resources, i.e. that [`crate::pm::process::state::ProcessState::has_special_resources`]
+/// returns `false` for the kernel process. This is the precondition that allows the
+/// `duplicate()` kernel call to succeed.
+///
+fn test_kernel_process_has_no_special_resources() -> bool {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+    if pm.current_has_special_resources() {
+        error!("kernel process unexpectedly owns special resources");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// End-to-end exercise of the copy-on-write resolution path.
+///
+/// Sets up a single user page that is shared between the page table of a freshly created
+/// virtual memory space and a standalone [`UserFrame`] handle (the latter standing in for the
+/// "other" address space that would normally co-own the frame after a fork-style duplication).
+/// The page is then marked copy-on-write, and [`Vmem::resolve_cow_at`] is invoked to verify
+/// that:
+///
+/// - the call reports the fault as resolved (`Ok(true)`),
+/// - the page-table entry is rewritten to a *different* frame number,
+/// - the rewritten entry is writable and no longer carries the copy-on-write bit, and
+/// - dropping the lingering shared handle releases the last reference to the original frame
+///   (otherwise the resolver would have failed to drop its reference).
+///
+fn test_cow_resolution_creates_private_frame() -> bool {
+    // Pick a page-aligned user-space virtual address that is guaranteed not to overlap any
+    // mapping the kernel process already owns. `USER_MMAP_BASE_RAW` is the base of the
+    // user-mmap region and is reserved for ad-hoc user mappings.
+    const TEST_VADDR_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW;
+
+    let vaddr: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(TEST_VADDR_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value failed (error={e:?})");
+                return false;
+            },
+        };
+
+    // SAFETY: pm/init() runs after the physical and virtual memory managers are initialized;
+    // access is synchronized because the kernel is single-threaded with interrupts disabled.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+    let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+
+    // Build a fresh address space cloned off the kernel process's vmem so the test does not
+    // disturb the running kernel mappings.
+    let mut parent: Vmem = match mm.new_vmem(pm.current_vmem()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("new_vmem failed (error={e:?})");
+            return false;
+        },
+    };
+
+    // Allocate a user frame and create a second handle aliasing the same physical frame.
+    // The second handle stands in for the "other" address space that co-owns the frame.
+    let uframe1: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame failed (error={e:?})");
+            return false;
+        },
+    };
+    let uframe2: UserFrame = match uframe1.share() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("UserFrame::share failed (error={e:?})");
+            return false;
+        },
+    };
+
+    // Map the first handle into `parent` at the test address. `Vmem::map` leaks the handle
+    // into the page table, so it must not be referenced again from this function.
+    let page_table_allocator = || {
+        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        kframe.clear()?;
+        let kpage: KernelPage = KernelPage::new(kframe);
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        Ok(PageTable::new(pgtable_storage))
+    };
+    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR, page_table_allocator) {
+        error!("Vmem::map failed (error={e:?})");
+        drop(uframe2);
+        return false;
+    }
+
+    // Mark the page copy-on-write.
+    if let Err(e) = parent.mark_user_page_cow(vaddr) {
+        error!("mark_user_page_cow failed (error={e:?})");
+        drop(uframe2);
+        return false;
+    }
+
+    // After marking, the PTE must be present, read-only, carry the CoW bit, and still point at
+    // the original (shared) frame.
+    let before: PageTableEntry = match parent.try_find_user_pte(vaddr) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("PTE missing after map + mark_user_page_cow");
+            drop(uframe2);
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte failed (error={e:?})");
+            drop(uframe2);
+            return false;
+        },
+    };
+    if before.flags().is_writable() {
+        error!("PTE is unexpectedly writable after mark_user_page_cow");
+        drop(uframe2);
+        return false;
+    }
+    if !before.is_cow() {
+        error!("PTE is missing CoW bit after mark_user_page_cow");
+        drop(uframe2);
+        return false;
+    }
+    let original_frame_number = before.frame_number().into_raw_value();
+
+    // Resolve the CoW mapping. This must allocate a new frame, copy the page contents, repoint
+    // the PTE, and drop the resolver's reference on the previously shared frame.
+    match parent.resolve_cow_at(vaddr) {
+        Ok(true) => {},
+        Ok(false) => {
+            error!("resolve_cow_at returned false on a CoW mapping");
+            drop(uframe2);
+            return false;
+        },
+        Err(e) => {
+            error!("resolve_cow_at failed (error={e:?})");
+            drop(uframe2);
+            return false;
+        },
+    };
+
+    // The PTE must now be writable, no longer CoW, and point at a different frame.
+    let after: PageTableEntry = match parent.try_find_user_pte(vaddr) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("PTE missing after resolve_cow_at");
+            drop(uframe2);
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte failed after resolve_cow_at (error={e:?})");
+            drop(uframe2);
+            return false;
+        },
+    };
+    if !after.flags().is_writable() {
+        error!("PTE is not writable after resolve_cow_at");
+        drop(uframe2);
+        return false;
+    }
+    if after.is_cow() {
+        error!("PTE still has CoW bit after resolve_cow_at");
+        drop(uframe2);
+        return false;
+    }
+    if after.frame_number().into_raw_value() == original_frame_number {
+        error!("PTE was not repointed at a new frame");
+        drop(uframe2);
+        return false;
+    }
+
+    // Drop the lingering shared handle: this must release the last reference to the original
+    // frame. If `resolve_cow_at` had failed to drop its own reference, refcount would still be
+    // 1 here and the underlying frame would leak — that would not crash the test but would
+    // show up as a frame-allocator inconsistency on subsequent runs.
+    drop(uframe2);
+
+    // NOTE: dropping `parent` here does not free the private frame installed by
+    // `resolve_cow_at` — `PageTable` has no `Drop` impl that walks its PTEs. This is a
+    // pre-existing behavior independent of CoW; production processes release their frames
+    // through the explicit harvest/unmap path on exit.
+    drop(parent);
+
+    true
+}
+
+///
+/// # Description
+///
+/// Exercises the fast path in [`Vmem::resolve_cow_at`]: when the resolving address space
+/// is the sole remaining owner of the shared frame (refcount == 1), the resolver must
+/// simply clear the copy-on-write mark in place — without allocating a new frame, copying
+/// any contents, or freeing the old frame.
+///
+/// Setup mirrors `test_cow_resolution_creates_private_frame` but drops the lingering
+/// shared handle *before* invoking `resolve_cow_at`, leaving refcount = 1.
+///
+/// Asserts that after the call the PTE is writable, no longer CoW, and still points at
+/// the *original* frame (proving no copy occurred).
+///
+fn test_cow_resolution_fast_path_when_sole_owner() -> bool {
+    const TEST_VADDR_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW;
+
+    let vaddr: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(TEST_VADDR_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value failed (error={e:?})");
+                return false;
+            },
+        };
+
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+    let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+
+    let mut parent: Vmem = match mm.new_vmem(pm.current_vmem()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("new_vmem failed (error={e:?})");
+            return false;
+        },
+    };
+
+    let uframe1: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame failed (error={e:?})");
+            return false;
+        },
+    };
+    let uframe2: UserFrame = match uframe1.share() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("UserFrame::share failed (error={e:?})");
+            return false;
+        },
+    };
+
+    let page_table_allocator = || {
+        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        kframe.clear()?;
+        let kpage: KernelPage = KernelPage::new(kframe);
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        Ok(PageTable::new(pgtable_storage))
+    };
+    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR, page_table_allocator) {
+        error!("Vmem::map failed (error={e:?})");
+        drop(uframe2);
+        return false;
+    }
+
+    if let Err(e) = parent.mark_user_page_cow(vaddr) {
+        error!("mark_user_page_cow failed (error={e:?})");
+        drop(uframe2);
+        return false;
+    }
+
+    // Capture the original frame number, then drop the second handle so that the page
+    // table holds the only remaining reference (refcount == 1). This is the precondition
+    // for the fast path in `resolve_cow_at`.
+    let before: PageTableEntry = match parent.try_find_user_pte(vaddr) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("PTE missing after map + mark_user_page_cow");
+            drop(uframe2);
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte failed (error={e:?})");
+            drop(uframe2);
+            return false;
+        },
+    };
+    let original_frame_number = before.frame_number().into_raw_value();
+    drop(uframe2);
+
+    // Resolve the CoW mapping. The fast path must clear the CoW mark in place.
+    match parent.resolve_cow_at(vaddr) {
+        Ok(true) => {},
+        Ok(false) => {
+            error!("resolve_cow_at returned false on a CoW mapping");
+            return false;
+        },
+        Err(e) => {
+            error!("resolve_cow_at failed (error={e:?})");
+            return false;
+        },
+    };
+
+    // The PTE must now be writable, no longer CoW, and still point at the original frame
+    // (no copy was performed because refcount was already 1).
+    let after: PageTableEntry = match parent.try_find_user_pte(vaddr) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("PTE missing after resolve_cow_at");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte failed after resolve_cow_at (error={e:?})");
+            return false;
+        },
+    };
+    if !after.flags().is_writable() {
+        error!("PTE is not writable after fast-path resolve_cow_at");
+        return false;
+    }
+    if after.is_cow() {
+        error!("PTE still has CoW bit after fast-path resolve_cow_at");
+        return false;
+    }
+    if after.frame_number().into_raw_value() != original_frame_number {
+        error!(
+            "fast path unexpectedly repointed PTE at a new frame (old={original_frame_number:#x}, \
+             new={:#x})",
+            after.frame_number().into_raw_value()
+        );
+        return false;
+    }
+
+    drop(parent);
+    true
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Verifies that [`VirtMemoryManager::link_user_pages`] skips parent mappings whose
+/// virtual address already exists in `child`, leaving both sides of the collision
+/// untouched while still linking the remaining pages.
+///
+/// Setup:
+///
+/// - `parent` is given two consecutive writable user pages at `vaddr_a` and `vaddr_b`.
+/// - `child` is pre-populated with an independent user page at `vaddr_b`, so that
+///   address is filtered out of the snapshot used by `link_user_pages`.
+///
+/// Expected post-conditions after the call returns `Ok`:
+///
+/// - parent's `vaddr_a` PTE is read-only with the copy-on-write bit set and still
+///   points at the original frame (the page was linked into `child`).
+/// - parent's `vaddr_b` PTE is untouched (writable, not CoW, original frame) because
+///   the collision caused the entry to be skipped.
+/// - `child` has a read-only CoW PTE at `vaddr_a` pointing at the parent's frame.
+/// - `child`'s mapping at `vaddr_b` is unchanged (the pre-existing page is intact).
+///
+fn test_link_user_pages_skips_preexisting_child_mappings() -> bool {
+    const VADDR_A_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW;
+    const VADDR_B_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW + ::arch::mem::PAGE_SIZE;
+
+    let vaddr_a: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(VADDR_A_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value(vaddr_a) failed (error={e:?})");
+                return false;
+            },
+        };
+    let vaddr_b: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(VADDR_B_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value(vaddr_b) failed (error={e:?})");
+                return false;
+            },
+        };
+
+    // SAFETY: pm/init() runs after the physical and virtual memory managers are
+    // initialized; access is synchronized because the kernel is single-threaded with
+    // interrupts disabled.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+
+    let mut parent: Vmem = {
+        let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+        match mm.new_vmem(pm.current_vmem()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("new_vmem(parent) failed (error={e:?})");
+                return false;
+            },
+        }
+    };
+    let mut child: Vmem = {
+        let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+        match mm.new_vmem(pm.current_vmem()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("new_vmem(child) failed (error={e:?})");
+                return false;
+            },
+        }
+    };
+
+    // Allocate three independent user frames.
+    let frame_a: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame(a) failed (error={e:?})");
+            return false;
+        },
+    };
+    let frame_b: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame(b) failed (error={e:?})");
+            return false;
+        },
+    };
+    let frame_c: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame(c) failed (error={e:?})");
+            return false;
+        },
+    };
+
+    let frame_a_num: usize = frame_a.address().into_frame_number().into_raw_value();
+    let frame_b_num: usize = frame_b.address().into_frame_number().into_raw_value();
+    let frame_c_num: usize = frame_c.address().into_frame_number().into_raw_value();
+
+    let page_table_allocator = || {
+        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        kframe.clear()?;
+        let kpage: KernelPage = KernelPage::new(kframe);
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        Ok(PageTable::new(pgtable_storage))
+    };
+
+    // Map parent's two writable user pages.
+    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR, page_table_allocator) {
+        error!("parent.map(vaddr_a) failed (error={e:?})");
+        return false;
+    }
+    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+        error!("parent.map(vaddr_b) failed (error={e:?})");
+        return false;
+    }
+
+    // Pre-map child at vaddr_b so the second iteration of `link_user_pages` collides.
+    if let Err(e) = child.map(frame_c, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+        error!("child.map(vaddr_b) failed (error={e:?})");
+        return false;
+    }
+
+    // Invoke the routine under test. Must succeed: the colliding vaddr_b is filtered
+    // out of the snapshot, and vaddr_a is linked into `child`.
+    {
+        let mm_mut: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+        if let Err(e) = mm_mut.link_user_pages(&mut parent, &mut child) {
+            error!("link_user_pages failed unexpectedly (error={e:?})");
+            return false;
+        }
+    }
+
+    // Parent's vaddr_a must be marked CoW: read-only, CoW bit set, original frame.
+    let parent_a: PageTableEntry = match parent.try_find_user_pte(vaddr_a) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("parent PTE at vaddr_a missing after link");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(parent, vaddr_a) failed (error={e:?})");
+            return false;
+        },
+    };
+    if parent_a.flags().is_writable() {
+        error!("parent PTE at vaddr_a is still writable after link");
+        return false;
+    }
+    if !parent_a.is_cow() {
+        error!("parent PTE at vaddr_a is missing the CoW bit after link");
+        return false;
+    }
+    if parent_a.frame_number().into_raw_value() != frame_a_num {
+        error!("parent PTE at vaddr_a points at the wrong frame after link");
+        return false;
+    }
+
+    // Parent's vaddr_b must be untouched: the collision caused it to be skipped.
+    let parent_b: PageTableEntry = match parent.try_find_user_pte(vaddr_b) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("parent PTE at vaddr_b missing after link");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(parent, vaddr_b) failed (error={e:?})");
+            return false;
+        },
+    };
+    if !parent_b.flags().is_writable() {
+        error!("parent PTE at vaddr_b is not writable after link");
+        return false;
+    }
+    if parent_b.is_cow() {
+        error!("parent PTE at vaddr_b unexpectedly carries CoW bit");
+        return false;
+    }
+    if parent_b.frame_number().into_raw_value() != frame_b_num {
+        error!("parent PTE at vaddr_b points at the wrong frame");
+        return false;
+    }
+
+    // Child's vaddr_a must be a CoW alias of the parent's frame_a.
+    let child_a: PageTableEntry = match child.try_find_user_pte(vaddr_a) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("child PTE at vaddr_a missing after link");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(child, vaddr_a) failed (error={e:?})");
+            return false;
+        },
+    };
+    if child_a.flags().is_writable() {
+        error!("child PTE at vaddr_a is unexpectedly writable");
+        return false;
+    }
+    if !child_a.is_cow() {
+        error!("child PTE at vaddr_a is missing the CoW bit");
+        return false;
+    }
+    if child_a.frame_number().into_raw_value() != frame_a_num {
+        error!("child PTE at vaddr_a points at the wrong frame");
+        return false;
+    }
+
+    // Child's pre-existing vaddr_b mapping must still point at frame_c.
+    let child_b: PageTableEntry = match child.try_find_user_pte(vaddr_b) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("child's pre-existing PTE at vaddr_b vanished");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(child, vaddr_b) failed (error={e:?})");
+            return false;
+        },
+    };
+    if child_b.frame_number().into_raw_value() != frame_c_num {
+        error!("child PTE at vaddr_b was overwritten (expected frame_c)");
+        return false;
+    }
+
+    // NOTE: as in `test_cow_resolution_creates_private_frame`, dropping `parent` and
+    // `child` here does not free the frames installed in their page tables. Production
+    // processes release their frames through the explicit harvest/unmap path on exit.
+    drop(parent);
+    drop(child);
+
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies that [`VirtMemoryManager::link_user_pages`] rolls back any pages it had
+/// already linked into `child` when a later iteration fails.
+///
+/// The failure is forced by saturating the reference count of `frame_b` to `u8::MAX`
+/// before invoking the routine. Iteration visits `vaddr_a` first (its page table entry
+/// is at a lower index) and links it into `child` as CoW. The second iteration then
+/// calls `share()` on `frame_b`, which overflows the refcount and returns
+/// `ErrorCode::OutOfMemory`. This triggers the rollback path.
+///
+/// Expected post-conditions after the call returns `Err`:
+///
+/// - parent's `vaddr_a` PTE is writable, not copy-on-write, and still points at
+///   `frame_a` (the partial CoW mark installed before the failure was reverted).
+/// - parent's `vaddr_b` PTE is untouched (writable, not CoW, original frame).
+/// - `child` has no mapping at either `vaddr_a` or `vaddr_b`.
+///
+fn test_link_user_pages_rolls_back_on_partial_failure() -> bool {
+    const VADDR_A_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW;
+    const VADDR_B_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW + ::arch::mem::PAGE_SIZE;
+
+    let vaddr_a: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(VADDR_A_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value(vaddr_a) failed (error={e:?})");
+                return false;
+            },
+        };
+    let vaddr_b: PageAligned<VirtualAddress> =
+        match PageAligned::<VirtualAddress>::from_raw_value(VADDR_B_RAW) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("PageAligned::from_raw_value(vaddr_b) failed (error={e:?})");
+                return false;
+            },
+        };
+
+    // SAFETY: pm/init() runs after the physical and virtual memory managers are
+    // initialized; access is synchronized because the kernel is single-threaded with
+    // interrupts disabled.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+
+    let mut parent: Vmem = {
+        let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+        match mm.new_vmem(pm.current_vmem()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("new_vmem(parent) failed (error={e:?})");
+                return false;
+            },
+        }
+    };
+    let mut child: Vmem = {
+        let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+        match mm.new_vmem(pm.current_vmem()) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("new_vmem(child) failed (error={e:?})");
+                return false;
+            },
+        }
+    };
+
+    let frame_a: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame(a) failed (error={e:?})");
+            return false;
+        },
+    };
+    let frame_b: UserFrame = match unsafe { PhysMemoryManager::get_mut() }.alloc_user_frame() {
+        Ok(f) => f,
+        Err(e) => {
+            error!("alloc_user_frame(b) failed (error={e:?})");
+            return false;
+        },
+    };
+
+    let frame_a_num: usize = frame_a.address().into_frame_number().into_raw_value();
+    let frame_b_num: usize = frame_b.address().into_frame_number().into_raw_value();
+
+    // Saturate frame_b's refcount so the next `share()` overflows. The fresh allocation
+    // starts at refcount 1, so 254 extra references reach u8::MAX. Each new handle is
+    // leaked to keep the bumped refcount in place; we never restore it (production
+    // processes release frames via the explicit harvest/unmap path, mirroring the
+    // disposition note on the CoW resolution tests).
+    for i in 0..254 {
+        match frame_b.share() {
+            Ok(handle) => {
+                handle.leak();
+            },
+            Err(e) => {
+                error!("frame_b.share() failed at iteration {i} (error={e:?})");
+                return false;
+            },
+        }
+    }
+    match frame_b.refcount() {
+        Ok(rc) if rc == u8::MAX => {},
+        Ok(rc) => {
+            error!("frame_b refcount is {rc} after saturation (expected {})", u8::MAX);
+            return false;
+        },
+        Err(e) => {
+            error!("frame_b.refcount() failed (error={e:?})");
+            return false;
+        },
+    }
+
+    let page_table_allocator = || {
+        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        kframe.clear()?;
+        let kpage: KernelPage = KernelPage::new(kframe);
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        Ok(PageTable::new(pgtable_storage))
+    };
+
+    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR, page_table_allocator) {
+        error!("parent.map(vaddr_a) failed (error={e:?})");
+        return false;
+    }
+    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+        error!("parent.map(vaddr_b) failed (error={e:?})");
+        return false;
+    }
+
+    // Invoke the routine under test. Must fail: vaddr_a is linked, then `share()`
+    // on frame_b overflows because its refcount is already u8::MAX.
+    {
+        let mm_mut: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+        match mm_mut.link_user_pages(&mut parent, &mut child) {
+            Ok(()) => {
+                error!("link_user_pages unexpectedly succeeded");
+                return false;
+            },
+            Err(e) if e.code == ErrorCode::OutOfMemory => {},
+            Err(e) => {
+                error!("link_user_pages failed with unexpected error (error={e:?})");
+                return false;
+            },
+        }
+    }
+
+    // Parent's vaddr_a must be rolled back: writable, not CoW, original frame.
+    let parent_a: PageTableEntry = match parent.try_find_user_pte(vaddr_a) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("parent PTE at vaddr_a missing after rollback");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(parent, vaddr_a) failed (error={e:?})");
+            return false;
+        },
+    };
+    if !parent_a.flags().is_writable() {
+        error!("parent PTE at vaddr_a is not writable after rollback");
+        return false;
+    }
+    if parent_a.is_cow() {
+        error!("parent PTE at vaddr_a still carries CoW bit after rollback");
+        return false;
+    }
+    if parent_a.frame_number().into_raw_value() != frame_a_num {
+        error!("parent PTE at vaddr_a points at the wrong frame after rollback");
+        return false;
+    }
+
+    // Parent's vaddr_b must be untouched.
+    let parent_b: PageTableEntry = match parent.try_find_user_pte(vaddr_b) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            error!("parent PTE at vaddr_b missing after rollback");
+            return false;
+        },
+        Err(e) => {
+            error!("try_find_user_pte(parent, vaddr_b) failed (error={e:?})");
+            return false;
+        },
+    };
+    if !parent_b.flags().is_writable() {
+        error!("parent PTE at vaddr_b is not writable after rollback");
+        return false;
+    }
+    if parent_b.is_cow() {
+        error!("parent PTE at vaddr_b unexpectedly carries CoW bit");
+        return false;
+    }
+    if parent_b.frame_number().into_raw_value() != frame_b_num {
+        error!("parent PTE at vaddr_b points at the wrong frame");
+        return false;
+    }
+
+    // Child must have no mappings: vaddr_a was rolled back; vaddr_b was never reached.
+    match child.is_user_page_mapped(vaddr_a) {
+        Ok(false) => {},
+        Ok(true) => {
+            error!("child still has a mapping at vaddr_a after rollback");
+            return false;
+        },
+        Err(e) => {
+            error!("child.is_user_page_mapped(vaddr_a) failed (error={e:?})");
+            return false;
+        },
+    }
+    match child.is_user_page_mapped(vaddr_b) {
+        Ok(false) => {},
+        Ok(true) => {
+            error!("child unexpectedly has a mapping at vaddr_b");
+            return false;
+        },
+        Err(e) => {
+            error!("child.is_user_page_mapped(vaddr_b) failed (error={e:?})");
+            return false;
+        },
+    }
+
+    // NOTE: see the disposition comment on `test_link_user_pages_skips_preexisting_child_mappings`
+    // — dropping `parent` and `child` does not free the frames installed in their page
+    // tables, and the 254 extra references on frame_b deliberately remain to keep that
+    // frame's refcount saturated for the duration of the test.
+    drop(parent);
+    drop(child);
+
+    true
+}
+
+/// Runs all process-management in-kernel tests.
+pub fn test() -> bool {
+    let mut passed: bool = true;
+    passed &= run_test!(test_mailbox_is_empty_tracks_buffered_messages);
+    passed &= run_test!(test_kernel_process_has_no_special_resources);
+    passed &= run_test!(test_cow_resolution_creates_private_frame);
+    passed &= run_test!(test_cow_resolution_fast_path_when_sole_owner);
+    passed &= run_test!(test_link_user_pages_skips_preexisting_child_mappings);
+    passed &= run_test!(test_link_user_pages_rolls_back_on_partial_failure);
+    passed
+}

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -381,6 +381,42 @@ pub fn __kcall_detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Duplicate
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Duplicates the calling process. The child process is created with a clone of the caller's
+/// address space, and its main thread starts executing at the entry point described by `args`
+/// on the user-supplied stack.
+///
+/// The operation is refused when the calling process owns any "special" resources, namely
+/// allocated memory-mapped I/O regions, port-mapped I/O ports, event ownerships, or buffered
+/// in-flight mailbox messages.
+///
+/// # Parameters
+///
+/// - `args`: Thread creation arguments describing the child's main thread entry point and stack.
+///
+/// # Returns
+///
+/// Upon successful completion, the process identifier of the new child process is returned.
+/// Upon failure, an error is returned instead.
+///
+#[unsafe(no_mangle)]
+pub fn __kcall_duplicate(args: &ThreadCreateArgs) -> Result<ProcessIdentifier, Error> {
+    let result: i64 =
+        kcall1!(KcallNumber::Duplicate.into(), args as *const ThreadCreateArgs as usize as u32);
+
+    if unlikely(result < 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to duplicate process"))
+    } else {
+        ProcessIdentifier::try_from(result)
+    }
+}
+
+//==================================================================================================
 // Lock Mutex
 //==================================================================================================
 

--- a/src/libs/sys/src/sys/number.rs
+++ b/src/libs/sys/src/sys/number.rs
@@ -87,6 +87,8 @@ pub enum KcallNumber {
     Snapshot = KcallNumber::NR_SNAPSHOT_SYSCALL,
     /// Detaches a thread so it is auto-harvested on exit.
     DetachThread = KcallNumber::NR_DETACH_THREAD_SYSCALL,
+    /// Duplicates the calling process.
+    Duplicate = KcallNumber::NR_DUPLICATE_SYSCALL,
     /// Invalid kernel call.
     Invalid = KcallNumber::NR_INVALID_SYSCALL,
 }
@@ -130,6 +132,7 @@ impl KcallNumber {
     const NR_PULL_SYSCALL: u32 = 34;
     const NR_SNAPSHOT_SYSCALL: u32 = 35;
     const NR_DETACH_THREAD_SYSCALL: u32 = 36;
+    const NR_DUPLICATE_SYSCALL: u32 = 37;
     const NR_INVALID_SYSCALL: u32 = u32::MAX;
 }
 
@@ -174,6 +177,7 @@ impl From<u32> for KcallNumber {
             Self::NR_PULL_SYSCALL => KcallNumber::Pull,
             Self::NR_SNAPSHOT_SYSCALL => KcallNumber::Snapshot,
             Self::NR_DETACH_THREAD_SYSCALL => KcallNumber::DetachThread,
+            Self::NR_DUPLICATE_SYSCALL => KcallNumber::Duplicate,
             _ => KcallNumber::Invalid,
         }
     }
@@ -220,6 +224,7 @@ impl From<KcallNumber> for u32 {
             KcallNumber::Pull => KcallNumber::NR_PULL_SYSCALL,
             KcallNumber::Snapshot => KcallNumber::NR_SNAPSHOT_SYSCALL,
             KcallNumber::DetachThread => KcallNumber::NR_DETACH_THREAD_SYSCALL,
+            KcallNumber::Duplicate => KcallNumber::NR_DUPLICATE_SYSCALL,
             KcallNumber::Invalid => KcallNumber::NR_INVALID_SYSCALL,
         }
     }

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -1,0 +1,312 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # `duplicate()` Kernel Call CoW Regression Tests
+//!
+//! Exercises the [`__kcall_duplicate`] kernel call end-to-end and verifies that the child
+//! process is created with copy-on-write semantics:
+//!
+//! 1. A write performed by the parent *after* `duplicate()` must not be visible in the child.
+//! 2. A write performed by the child must not be visible in the parent.
+//! 3. The child must observe data that the parent wrote *before* `duplicate()`.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::alloc::Layout;
+use ::arch::mem::PAGE_SIZE;
+use ::core::sync::atomic::{
+    AtomicU32,
+    AtomicU8,
+    Ordering,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    kcall::{
+        ipc,
+        pm,
+        sched,
+    },
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        ThreadCreateArgs,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Ordering used for all atomic operations.
+const ORDER: Ordering = Ordering::SeqCst;
+
+/// Value written by the parent before `duplicate()`.  Both processes should observe this
+/// value until one of them writes a new value.
+const PATTERN_INIT: u8 = 0x11;
+
+/// Value written by the parent *after* `duplicate()`.  Must remain invisible to the child.
+const PATTERN_PARENT: u8 = 0x22;
+
+/// Value written by the child *after* `duplicate()`.  Must remain invisible to the parent.
+const PATTERN_CHILD: u8 = 0x33;
+
+/// Stack size handed to the child's main thread.  Sized to comfortably fit the small
+/// [`child_entry`] frame while keeping the parent's `link_user_pages` mapping count low
+/// enough to fit within the kernel heap.
+const CHILD_STACK_SIZE: usize = 4 * PAGE_SIZE;
+
+/// Stack size used to populate the `user_stack_size` field in the argument-validation tests.
+/// The actual stack pages are never consumed because the kernel is expected to reject these
+/// requests on the basis of their invalid `user_fn`/`user_stack_base` fields.
+const DUMMY_STACK_SIZE: usize = 8192;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Shared byte living in the test program's `.data` segment.  After `duplicate()` the page
+/// backing this byte is mapped copy-on-write into both address spaces.
+static SHARED_BYTE: AtomicU8 = AtomicU8::new(0);
+
+/// Parent process identifier, written before `duplicate()` so that the child can recover it
+/// from the inherited (copy-on-write) memory image.
+static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
+
+//==================================================================================================
+// Child Entry Point
+//==================================================================================================
+
+/// Entry point for the child process spawned by `duplicate()`.
+///
+/// The child:
+///
+/// 1. Blocks on `recv()` to synchronize with the parent's post-`duplicate()` write.
+/// 2. Reads [`SHARED_BYTE`] and confirms it observes the value the parent wrote *before*
+///    `duplicate()`.
+/// 3. Writes [`PATTERN_CHILD`] to [`SHARED_BYTE`] to take a private copy of the page.
+/// 4. Reports both observed values to the parent via IPC.
+/// 5. Spins until the parent terminates it.
+extern "C" fn child_entry(_arg: usize) -> usize {
+    // Recover identifiers.
+    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        Ok(p) => p,
+        Err(_) => return 1,
+    };
+    let parent_pid: ProcessIdentifier =
+        match ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER)) {
+            Ok(p) => p,
+            Err(_) => return 2,
+        };
+
+    // Wait for the parent's go-ahead message.  This barrier guarantees that the parent's
+    // post-`duplicate()` write to SHARED_BYTE has already happened by the time the child reads.
+    if ipc::__kcall_recv().is_err() {
+        return 3;
+    }
+
+    // Observe the byte before mutating it.  Must equal PATTERN_INIT if CoW correctly isolates
+    // the parent's post-duplicate write from the child's view.
+    let observed_before: u8 = SHARED_BYTE.load(ORDER);
+
+    // Mutate the byte; this triggers a private CoW copy in the child.
+    SHARED_BYTE.store(PATTERN_CHILD, ORDER);
+    let observed_after: u8 = SHARED_BYTE.load(ORDER);
+
+    // Report observations to the parent.
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    payload[0] = observed_before;
+    payload[1] = observed_after;
+    let reply: Message = Message::new(
+        MessageSender::from(my_pid),
+        MessageReceiver::from(parent_pid),
+        MessageType::Ipc,
+        None,
+        payload,
+    );
+    if ipc::__kcall_send(&reply).is_err() {
+        return 4;
+    }
+
+    // Spin until the parent terminates us.
+    loop {
+        let _ = sched::__kcall_sched_yield();
+    }
+}
+
+//==================================================================================================
+// Test
+//==================================================================================================
+
+/// Runs the duplicate/CoW correctness scenario described in the module docstring.
+fn test_duplicate_cow() -> Result<(), Error> {
+    // Record the parent's PID where the child can find it via CoW-shared memory.
+    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Prime the shared byte with the pre-duplicate pattern.
+    SHARED_BYTE.store(PATTERN_INIT, ORDER);
+
+    // Allocate a page-aligned stack for the child's main thread.
+    let layout: Layout = Layout::from_size_align(CHILD_STACK_SIZE, PAGE_SIZE)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "bad stack layout"))?;
+    // SAFETY: layout has non-zero size.
+    let stack_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack_ptr.is_null() {
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate child stack"));
+    }
+    let stack_base: VirtualAddress = VirtualAddress::from_raw_value(stack_ptr as usize);
+
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(child_entry as *const () as usize),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: stack_base,
+        user_stack_size: CHILD_STACK_SIZE,
+        user_tda: None,
+    };
+
+    // Duplicate the calling process.
+    let child_pid: ProcessIdentifier = pm::__kcall_duplicate(&args)?;
+    assert!(child_pid != parent_pid, "child_pid must differ from parent_pid");
+
+    // Write a new pattern to SHARED_BYTE.  This must trigger CoW: the parent obtains a private
+    // copy while the child continues to see PATTERN_INIT until it performs its own write.
+    SHARED_BYTE.store(PATTERN_PARENT, ORDER);
+
+    // Release the child to perform its observation.
+    let go: Message = Message::new(
+        MessageSender::from(parent_pid),
+        MessageReceiver::from(child_pid),
+        MessageType::Ipc,
+        None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    ipc::__kcall_send(&go)?;
+
+    // Receive the child's report.
+    let reply: Message = ipc::__kcall_recv()?;
+    let reply_type: MessageType = { reply.message_type };
+    assert!(reply_type == MessageType::Ipc, "expected IPC reply");
+
+    let child_observed_before: u8 = reply.payload[0];
+    let child_observed_after: u8 = reply.payload[1];
+    let parent_observed: u8 = SHARED_BYTE.load(ORDER);
+
+    // CoW invariant 1: parent's post-duplicate write is invisible to the child.
+    assert!(
+        child_observed_before == PATTERN_INIT,
+        "child observed {:#x} before its own write; expected {:#x} (parent->child isolation \
+         broken)",
+        child_observed_before,
+        PATTERN_INIT
+    );
+    // Sanity: the child's own write is visible to itself.
+    assert!(
+        child_observed_after == PATTERN_CHILD,
+        "child observed {:#x} after its own write; expected {:#x}",
+        child_observed_after,
+        PATTERN_CHILD
+    );
+    // CoW invariant 2: child's write is invisible to the parent.
+    assert!(
+        parent_observed == PATTERN_PARENT,
+        "parent observed {:#x} after child's write; expected {:#x} (child->parent isolation \
+         broken)",
+        parent_observed,
+        PATTERN_PARENT
+    );
+
+    // Tear down the child and reclaim the stack.
+    pm::__kcall_terminate(child_pid)?;
+    // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above and the
+    // child is being terminated so it no longer references the parent's mapping of these pages.
+    unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
+
+    Ok(())
+}
+
+//==================================================================================================
+// Public Entry Point
+//==================================================================================================
+
+/// Runs all `duplicate()` regression tests.
+pub fn run() -> Result<(), Error> {
+    ::syslog::info!("test-kernel: duplicate: starting duplicate/CoW regression tests");
+
+    test_duplicate_rejects_invalid_user_fn()?;
+    ::syslog::info!("test-kernel: duplicate: PASS - rejects_invalid_user_fn");
+
+    test_duplicate_rejects_invalid_stack()?;
+    ::syslog::info!("test-kernel: duplicate: PASS - rejects_invalid_stack");
+
+    test_duplicate_cow()?;
+    ::syslog::info!("test-kernel: duplicate: PASS - duplicate_cow");
+
+    ::syslog::info!("test-kernel: duplicate: all tests passed");
+
+    Ok(())
+}
+
+//==================================================================================================
+// Argument-Validation Tests
+//==================================================================================================
+
+/// Verifies that `__kcall_duplicate` rejects an invalid (null) user-space entry point with
+/// [`ErrorCode::InvalidArgument`].
+fn test_duplicate_rejects_invalid_user_fn() -> Result<(), Error> {
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        // Null is not a valid user-space address.
+        user_fn: VirtualAddress::from_raw_value(0),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        // Pick any non-null value; the kernel must short-circuit on the invalid `user_fn` first
+        // and not even reach the stack validation. The address itself does not need to be mapped.
+        user_stack_base: VirtualAddress::from_raw_value(0x4000_0000),
+        user_stack_size: DUMMY_STACK_SIZE,
+        user_tda: None,
+    };
+
+    match pm::__kcall_duplicate(&args) {
+        Err(e) if e.code == ErrorCode::InvalidArgument => Ok(()),
+        Err(e) => Err(Error::new(e.code, "__kcall_duplicate returned unexpected error")),
+        Ok(_) => Err(Error::new(
+            ErrorCode::OperationNotPermitted,
+            "__kcall_duplicate unexpectedly succeeded with null user_fn",
+        )),
+    }
+}
+
+/// Verifies that `__kcall_duplicate` rejects a stack region that lies outside user space with
+/// [`ErrorCode::InvalidArgument`].
+fn test_duplicate_rejects_invalid_stack() -> Result<(), Error> {
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        // Pick a plausible-looking user-space address so validation reaches the stack check.
+        user_fn: VirtualAddress::from_raw_value(0x4000_0000),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        // Null is not a valid user-space address.
+        user_stack_base: VirtualAddress::from_raw_value(0),
+        user_stack_size: DUMMY_STACK_SIZE,
+        user_tda: None,
+    };
+
+    match pm::__kcall_duplicate(&args) {
+        Err(e) if e.code == ErrorCode::InvalidArgument => Ok(()),
+        Err(e) => Err(Error::new(e.code, "__kcall_duplicate returned unexpected error")),
+        Ok(_) => Err(Error::new(
+            ErrorCode::OperationNotPermitted,
+            "__kcall_duplicate unexpectedly succeeded with null stack",
+        )),
+    }
+}

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -24,6 +24,7 @@ use ::sys::error::{
 mod demand_paging;
 mod detach;
 mod direction_flag;
+mod duplicate;
 mod mmio_ramfs;
 mod rendezvous;
 mod tls;
@@ -53,6 +54,8 @@ const EXIT_CODE: i32 = 13;
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
     detach::run()?;
+
+    duplicate::run()?;
 
     mmio_ramfs::run()?;
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the kernel's memory management and inter-process communication (IPC) subsystems, with a primary focus on enabling and supporting copy-on-write (CoW) page handling. Key changes include new page table methods for CoW, frame reference counting for shared pages, and improved page fault handling logic. Additional minor enhancements and test coverage are also included.

**Copy-on-Write (CoW) Support and Page Table Enhancements:**
* Added new methods to `PageTable` for marking, unmarking, and replacing copy-on-write pages (`mark_cow`, `unmark_cow`, `replace_cow_frame`), as well as iterating over present entries and reading present PTEs. These methods ensure correct CoW semantics and TLB invalidation. [[1]](diffhunk://#diff-6a5016dd44bf9bfe9acf8d5704e857b3d3927045b19087c96951ba363d4f4755R334-R502) [[2]](diffhunk://#diff-6a5016dd44bf9bfe9acf8d5704e857b3d3927045b19087c96951ba363d4f4755R619-R664)
* Updated page fault handler logic in `event/manager.rs` to explicitly dispatch between CoW and stack demand paging faults based on the present bit, avoiding handler order dependencies.
* Imported the `CopyOnWriteFlag` and related types for use in page table management.

**Physical Frame Reference Counting and Sharing:**
* Introduced reference counting for physical frames, with new methods to share (`share`) and query (`refcount`) frame ownership. This is essential for safely implementing CoW and ensuring frames are only released when all aliases are dropped. [[1]](diffhunk://#diff-b0008eeaddcd1d974a801e6c379709b613d92ed8237d5a95bc0b1acbca4b13fdR226-R303) [[2]](diffhunk://#diff-b0008eeaddcd1d974a801e6c379709b613d92ed8237d5a95bc0b1acbca4b13fdR549-R558)
* Exposed these frame-sharing APIs at the module level for use by higher-level memory management code.

**User Frame Allocation Improvements:**
* Added a fast-path `alloc_user_frame` method for single-frame user allocations, optimizing hot paths such as CoW fault resolution.
* Refactored watermark checking into a dedicated method to prevent kernel memory exhaustion during user allocations.

**IPC and Process Manager Adjustments:**
* Updated IPC rendezvous code to use mutable references to `ProcessManager`, ensuring proper synchronization and safety for cross-process memory operations. [[1]](diffhunk://#diff-70d428e8ef1afdcfe5bf1a118e1442404c8e269bcefe27a20ecc36a43afe1a26L174-R174) [[2]](diffhunk://#diff-70d428e8ef1afdcfe5bf1a118e1442404c8e269bcefe27a20ecc36a43afe1a26L255-R255) [[3]](diffhunk://#diff-70d428e8ef1afdcfe5bf1a118e1442404c8e269bcefe27a20ecc36a43afe1a26L397-R397)
* Added local handling for the `duplicate` kernel call, improving process management functionality.

**Testing and Minor Enhancements:**
* Added a new test to verify that shared user frames remain allocated until all references are dropped, ensuring the correctness of the new CoW and reference counting logic. [[1]](diffhunk://#diff-8a08cadbd5e402ccfa6fd80268fdbb9a744fad3027d6f1785711a3769f3997a5R137-R191) [[2]](diffhunk://#diff-8a08cadbd5e402ccfa6fd80268fdbb9a744fad3027d6f1785711a3769f3997a5R203)
* Added a convenience method to check if a mailbox is empty.
* Minor import and code cleanup.

These changes lay the groundwork for efficient and safe copy-on-write memory management, improving both robustness and performance in the kernel's memory subsystem.


## Isses

#321 