### PR TITLE
[build] Update Rust toolchain 1.97.0-nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-04-16"
+channel = "nightly-2026-05-21"
 components = [
     "rust-src",
 ]

--- a/src/libs/syscall/src/dlfcn/syscall/dladdr.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dladdr.rs
@@ -45,7 +45,7 @@ pub fn dladdr(addr: VirtualAddress, dlinfo: &mut DlInfo) -> Result<(), Error> {
     let registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
         DYNAMIC_LIBRARY_REGISTRY.lock();
 
-    for (_dlname, library) in registry.iter() {
+    for library in registry.values() {
         let library = library.lock();
         if let Some((dname, fbase, sname, saddr)) = library.query(addr) {
             dlinfo.dli_fname = dname;

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -518,28 +518,26 @@ impl DynamicLibrary {
         // Symbol is either undefined in this library or not in its dynsym at
         // all. Per POSIX, dlsym must search the full dependency tree regardless
         // of whether the root library references the symbol.
-        for (_dlname, dlfile) in self.dependencies.iter() {
-            if let Some(dlfile) = dlfile {
-                // Guard against deadlock: if the mutex is held by an ancestor
-                // in our call chain (true cycle back to a locked parent) or by
-                // a concurrent lookup, skip rather than spinning forever.
-                if dlfile.is_locked() {
-                    continue;
-                }
+        for dlfile in self.dependencies.values().flatten() {
+            // Guard against deadlock: if the mutex is held by an ancestor
+            // in our call chain (true cycle back to a locked parent) or by
+            // a concurrent lookup, skip rather than spinning forever.
+            if dlfile.is_locked() {
+                continue;
+            }
 
-                // Use the Arc's heap allocation address as a unique,
-                // lock-free identifier for this dependency. Skip if already
-                // traversed in this lookup (diamond-shaped dependency).
-                let id: usize = Arc::as_ptr(dlfile) as usize;
-                if !visited.insert(id) {
-                    continue;
-                }
+            // Use the Arc's heap allocation address as a unique,
+            // lock-free identifier for this dependency. Skip if already
+            // traversed in this lookup (diamond-shaped dependency).
+            let id: usize = Arc::as_ptr(dlfile) as usize;
+            if !visited.insert(id) {
+                continue;
+            }
 
-                let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+            let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
 
-                if let Some(result) = dlfile.lookup_in_load_group(symbol_name, visited)? {
-                    return Ok(Some(result));
-                }
+            if let Some(result) = dlfile.lookup_in_load_group(symbol_name, visited)? {
+                return Ok(Some(result));
             }
         }
 

--- a/src/libs/syscall/src/safe/file/file_control_request.rs
+++ b/src/libs/syscall/src/safe/file/file_control_request.rs
@@ -148,37 +148,37 @@ impl<'a> TryFrom<(c_int, VaList<'a>)> for FileControlRequest {
         let (cmd, mut arg) = value;
         match cmd {
             F_DUPFD => {
-                let fd: c_int = unsafe { arg.arg() };
+                let fd: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_DUPFD: fd={fd:?}");
                 Ok(FileControlRequest::Duplicate(fd))
             },
             F_DUPFD_CLOEXEC => {
-                let fd: c_int = unsafe { arg.arg() };
+                let fd: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_DUPFD_CLOEXEC: fd={fd:?}");
                 Ok(FileControlRequest::DuplicateWithCloseOnExec(fd))
             },
             F_DUPFD_CLOFORK => {
-                let fd: c_int = unsafe { arg.arg() };
+                let fd: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_DUPFD_CLOFORK: fd={fd:?}");
                 Ok(FileControlRequest::DuplicateWithCloseOnFork(fd))
             },
             F_GETFD => Ok(FileControlRequest::GetFileDescriptorFlags),
             F_SETFD => {
-                let flags: c_int = unsafe { arg.arg() };
+                let flags: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_SETFD: flags={flags:?}");
                 let fd_flags: FileDescriptorFlags = FileDescriptorFlags::try_from(flags)?;
                 Ok(FileControlRequest::SetFileDescriptorFlags(fd_flags))
             },
             F_GETFL => Ok(FileControlRequest::GetFileStatusFlags),
             F_SETFL => {
-                let flags: c_int = unsafe { arg.arg() };
+                let flags: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_SETFL: flags={flags:?}");
                 let status_flags: FileStatusFlags = FileStatusFlags::try_from(flags)?;
                 Ok(FileControlRequest::SetFileStatusFlags(status_flags))
             },
             F_GETOWN => Ok(FileControlRequest::GetSocketOwner),
             F_SETOWN => {
-                let owner: c_int = unsafe { arg.arg() };
+                let owner: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_SETOWN: owner={owner:?}");
                 Ok(FileControlRequest::SetSocketOwner(SocketOwner::from(owner)))
             },

--- a/src/libs/syscall/src/sys/socket/message/bind.rs
+++ b/src/libs/syscall/src/sys/socket/message/bind.rs
@@ -81,7 +81,7 @@ impl Debug for BindSocketRequest {
             f,
             "BindSocketRequest {{ sockfd: {}, sockaddr: {:?} }}",
             { self.sockfd },
-            &self.sockaddr
+            self.sockaddr
         )
     }
 }

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -53,12 +53,8 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
         // Check whether system call succeeded or not.
         if response.status != 0 {
             // System call failed, parse error code and return it.
-            match ErrorCode::try_from(response.status) {
-                Ok(error_code) => {
-                    return Err(Error::new(error_code, "failed to receive data on socket"))
-                },
-                Err(e) => return Err(e),
-            };
+            let error_code = ErrorCode::try_from(response.status)?;
+            return Err(Error::new(error_code, "failed to receive data on socket"));
         } else {
             // System call succeeded, parse response.
             match SystemCallMessage::try_from_bytes(response.payload) {

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -58,12 +58,8 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
         // Check whether system call succeeded or not.
         if response.status != 0 {
             // System call failed, parse error code and return it.
-            match ErrorCode::try_from(response.status) {
-                Ok(error_code) => {
-                    return Err(Error::new(error_code, "failed to send data through socket"))
-                },
-                Err(e) => return Err(e),
-            }
+            let error_code = ErrorCode::try_from(response.status)?;
+            return Err(Error::new(error_code, "failed to send data through socket"));
         } else {
             // System call succeeded, parse response.
             match SystemCallMessage::try_from_bytes(response.payload) {

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -113,7 +113,7 @@ pub async fn main() -> Result<ExitCode> {
         "main(): starting user VM (user_vm_id={:?}, kernel={:?}, initrd={:?}, ramfs={:?}, \
          standalone={})",
         user_vm_id,
-        &kernel_filename,
+        kernel_filename,
         initrd_filename.as_deref().unwrap_or("none"),
         ramfs_filename.as_deref().unwrap_or("none"),
         standalone
@@ -378,7 +378,7 @@ async fn run_managed(
     // Run virtual machine and check exit status code.
     debug!(
         "main(): launching uservm (kernel={:?}, initrd={:?}, ramfs={:?})",
-        &kernel_filename,
+        kernel_filename,
         initrd_filename.as_deref().unwrap_or("none"),
         ramfs_filename.as_deref().unwrap_or("none"),
     );

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -694,7 +694,7 @@ impl Guest {
     /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
     ///
     pub fn reset(&mut self, vmem: &mut VirtualMemory, vcpu: &mut VirtualProcessor) -> Result<()> {
-        trace!("reset(): {:?}", &self);
+        trace!("reset(): {:?}", self);
         let rax: u64 = ::config::microvm::DEFAULT_BOOT_MAGIC as u64;
 
         self.reset_credits(vmem)?;

--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -1554,13 +1554,7 @@ fn read_optional_non_empty_string(
     key: &str,
     field_name: &str,
 ) -> Result<Option<String>> {
-    Ok(read_optional_string(table, key, field_name)?.and_then(|value| {
-        if value.trim().is_empty() {
-            None
-        } else {
-            Some(value)
-        }
-    }))
+    Ok(read_optional_string(table, key, field_name)?.filter(|value| !value.trim().is_empty()))
 }
 
 ///


### PR DESCRIPTION
Bump the pinned nightly toolchain from nightly-2026-04-16 to nightly-2026-05-21, the last snapshot of the 1.97.0-nightly line before the train branched to 1.97 beta on 2026-05-22. Closes #2443.

Compiler API change
-------------------
core::ffi::VaList::arg was renamed to next_arg upstream. Update the six call sites in the fcntl request decoder accordingly:

  * src/libs/syscall/src/safe/file/file_control_request.rs

New clippy lints triggered under #![deny(clippy::all)] / #![forbid(clippy::all)]
---------------------------------------------------------
* clippy::for_kv_map -- iterate maps with .values() when the key is unused:
    - src/libs/syscall/src/dlfcn/syscall/dladdr.rs
    - src/libs/syscall/src/dlfcn/syscall/dynlib.rs

* clippy::manual_flatten -- collapse `for x in opt_iter { if let Some(x) = x { ... } }` into `for x in opt_iter.flatten()`:
    - src/libs/syscall/src/dlfcn/syscall/dynlib.rs

* clippy::useless_borrows_in_formatting -- drop redundant `&` in formatting macros (Debug/Display already take a reference):
    - src/libs/syscall/src/sys/socket/message/bind.rs
    - src/uservm/src/vmm/microvm/guest.rs
    - src/uservm/src/main.rs

* clippy::question_mark -- replace a `match` that just forwards the Err arm with the `?` operator:
    - src/libs/syscall/src/sys/socket/syscall/recv.rs
    - src/libs/syscall/src/sys/socket/syscall/send.rs

* clippy::manual_filter -- replace `Option::and_then` with `Option::filter` when the closure only filters:
    - src/utils/nanvix-test/src/config.rs