### PR TITLE
[syscall] Honour STB_WEAK undefined symbols

### DIFF
--- a/src/libs/elf/src/elf32.rs
+++ b/src/libs/elf/src/elf32.rs
@@ -357,6 +357,23 @@ pub const STT_OBJECT: u8 = 1;
 pub const STT_FUNC: u8 = 2;
 
 //==================================================================================================
+// Symbol Bindings (high 4 bits of `st_info`)
+//==================================================================================================
+
+/// Right-shift required to extract the symbol binding from `st_info`.
+pub const ST_BIND_SHIFT: u8 = 4;
+/// Local symbol — not visible outside the object file containing its definition.
+pub const STB_LOCAL: u8 = 0;
+/// Global symbol — visible to all object files being combined.
+pub const STB_GLOBAL: u8 = 1;
+/// Weak symbol — resembles a global symbol but has lower precedence. Per the System V ABI
+/// (gABI, chapter "Symbol Table"), an undefined weak symbol that cannot be resolved at
+/// dynamic-link time is taken to have address zero (or `NULL` for function symbols). This
+/// is the contract every mainstream ELF dynamic loader (glibc, musl, FreeBSD `rtld-elf`,
+/// Android Bionic) implements, and which our `dlfcn` loader honours.
+pub const STB_WEAK: u8 = 2;
+
+//==================================================================================================
 // ELF32 Section Header
 //==================================================================================================
 
@@ -436,6 +453,11 @@ impl Elf32Sym {
     /// Returns the symbol type (low 4 bits of `st_info`).
     pub fn st_type(&self) -> u8 {
         self.st_info & ST_TYPE_MASK
+    }
+
+    /// Returns the symbol binding (high 4 bits of `st_info`).
+    pub fn st_bind(&self) -> u8 {
+        self.st_info >> ST_BIND_SHIFT
     }
 }
 

--- a/src/libs/elf/src/relocation.rs
+++ b/src/libs/elf/src/relocation.rs
@@ -62,7 +62,11 @@ use ::goblin::{
         },
         section_header::SHN_UNDEF,
         sym::{
+            st_bind,
             st_type,
+            STB_GLOBAL,
+            STB_LOCAL,
+            STB_WEAK,
             STT_FUNC,
             STT_OBJECT,
         },
@@ -344,6 +348,44 @@ pub enum SymbolType {
 }
 
 //==================================================================================================
+// Symbol Binding
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A high-level representation of the binding attribute encoded in the high 4 bits of an
+/// ELF symbol's `st_info` field.
+///
+/// Bindings control how the link editor and the dynamic loader treat a symbol when multiple
+/// definitions are visible and when no definition can be found.
+///
+/// Per the System V ABI (gABI, chapter "Symbol Table"):
+/// - `STB_LOCAL` — definitions are not visible to other object files.
+/// - `STB_GLOBAL` — definitions are visible to all combined object files; an undefined
+///   global reference that cannot be resolved is an error.
+/// - `STB_WEAK` — like global, but with lower precedence; **an undefined weak reference
+///   that cannot be resolved at dynamic-link time is silently taken to be the value zero**
+///   (or `NULL` for function symbols). The dynamic loader is required to honour this rule.
+///
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive)]
+pub enum SymbolBinding {
+    /// Local symbol — invisible outside the defining object file.
+    Local = STB_LOCAL,
+    /// Global symbol — visible to all object files.
+    Global = STB_GLOBAL,
+    /// Weak symbol — global with lower precedence; an unresolved weak undefined reference
+    /// is resolved to address zero per the System V ABI.
+    Weak = STB_WEAK,
+    /// Any other binding value defined by the platform or the processor supplement
+    /// (for example reserved or processor-specific bindings) that we do not interpret
+    /// further.
+    #[num_enum(default)]
+    Other,
+}
+
+//==================================================================================================
 // Symbol
 //==================================================================================================
 
@@ -389,6 +431,20 @@ impl Symbol {
     ///
     /// # Description
     ///
+    /// Returns the binding attribute of the symbol (high 4 bits of `st_info`).
+    ///
+    /// # Returns
+    ///
+    /// A [`SymbolBinding`] value. Bindings the loader does not interpret further are
+    /// returned as [`SymbolBinding::Other`].
+    ///
+    pub fn binding(&self) -> SymbolBinding {
+        st_bind(self.0.st_info).into()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Get the value of the symbol.
     ///
     /// # Returns
@@ -423,6 +479,23 @@ impl Symbol {
     ///
     pub fn is_undefined(&self) -> bool {
         self.0.st_shndx as u32 == SHN_UNDEF
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests if the symbol has weak binding (`STB_WEAK`).
+    ///
+    /// Per the System V ABI, a weak undefined symbol that cannot be resolved at
+    /// dynamic-link time is silently resolved to address zero. Loaders that consume this
+    /// helper are expected to follow that rule rather than reporting a lookup failure.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the symbol's binding is `STB_WEAK`, `false` otherwise.
+    ///
+    pub fn is_weak(&self) -> bool {
+        self.binding() == SymbolBinding::Weak
     }
 
     ///
@@ -597,5 +670,84 @@ impl RelocationEntry {
     ///
     pub fn offset(&self) -> u32 {
         self.0.r_offset
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::elf32::STT_NOTYPE;
+    use ::goblin::elf32::sym::Sym;
+
+    /// Builds a Symbol with the given binding (high 4 bits) and type (low 4 bits),
+    /// and the given section index.
+    fn make_symbol(binding: u8, sym_type: u8, st_shndx: u16) -> Symbol {
+        Symbol(Sym {
+            st_name: 0,
+            st_value: 0,
+            st_size: 0,
+            st_info: (binding << 4) | (sym_type & 0xf),
+            st_other: 0,
+            st_shndx,
+        })
+    }
+
+    #[test]
+    fn binding_decodes_local_global_weak() {
+        let local = make_symbol(STB_LOCAL, STT_FUNC, 1);
+        let global = make_symbol(STB_GLOBAL, STT_FUNC, 1);
+        let weak = make_symbol(STB_WEAK, STT_FUNC, 1);
+
+        assert_eq!(local.binding(), SymbolBinding::Local);
+        assert_eq!(global.binding(), SymbolBinding::Global);
+        assert_eq!(weak.binding(), SymbolBinding::Weak);
+    }
+
+    #[test]
+    fn binding_falls_back_to_other_for_unknown_values() {
+        // Reserved/processor-specific binding values must not be classified as a known
+        // binding; the loader is expected to treat them conservatively (i.e., not weak).
+        let exotic = make_symbol(10, STT_FUNC, 1);
+        assert_eq!(exotic.binding(), SymbolBinding::Other);
+        assert!(!exotic.is_weak());
+    }
+
+    #[test]
+    fn is_weak_matches_stb_weak_only() {
+        assert!(!make_symbol(STB_LOCAL, STT_FUNC, 0).is_weak());
+        assert!(!make_symbol(STB_GLOBAL, STT_FUNC, 0).is_weak());
+        assert!(make_symbol(STB_WEAK, STT_FUNC, 0).is_weak());
+        assert!(make_symbol(STB_WEAK, STT_OBJECT, 0).is_weak());
+    }
+
+    #[test]
+    fn is_undefined_and_is_weak_are_independent() {
+        // Weak + undefined is the case the dynamic loader must resolve to 0.
+        let weak_undef = make_symbol(STB_WEAK, STT_NOTYPE, SHN_UNDEF as u16);
+        assert!(weak_undef.is_undefined());
+        assert!(weak_undef.is_weak());
+
+        // Weak + defined: a definition that may be overridden by a strong one.
+        let weak_def = make_symbol(STB_WEAK, STT_FUNC, 1);
+        assert!(!weak_def.is_undefined());
+        assert!(weak_def.is_weak());
+
+        // Strong + undefined: must remain an error in the loader.
+        let strong_undef = make_symbol(STB_GLOBAL, STT_NOTYPE, SHN_UNDEF as u16);
+        assert!(strong_undef.is_undefined());
+        assert!(!strong_undef.is_weak());
+    }
+
+    #[test]
+    fn binding_does_not_depend_on_type_nibble() {
+        // The low 4 bits encode the symbol type; the high 4 bits encode the binding.
+        // Changing the type must not affect the binding decoding.
+        for sym_type in [STT_NOTYPE, STT_OBJECT, STT_FUNC] {
+            assert_eq!(make_symbol(STB_WEAK, sym_type, 1).binding(), SymbolBinding::Weak);
+        }
     }
 }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -559,6 +559,29 @@ impl DynamicLibrary {
         let symbol_value: usize = match self.lookup(symbol_name)? {
             Some((base, symbol_value)) => base + symbol_value,
             None => {
+                // Per the System V ABI (gABI, chapter "Symbol Table"), an undefined
+                // symbol whose binding is `STB_WEAK` and which cannot be resolved at
+                // dynamic-link time is silently taken to have the value zero (or `NULL`
+                // for function symbols). Every mainstream ELF dynamic loader (glibc
+                // `elf/dl-lookup.c`, musl `ldso/dynlink.c`, FreeBSD `rtld-elf/rtld.c`,
+                // Android Bionic `linker/linker_relocate.cpp`) implements this rule,
+                // and we follow them here.
+                //
+                // Substituting zero is safe across the relocation types we currently
+                // handle (R_386_32, R_386_PC32, R_386_JMP_SLOT, R_386_GLOB_DAT): the
+                // resulting GOT/PLT entry or in-place 32-bit slot will be null, so any
+                // code path that actually dereferences the symbol traps deterministically
+                // — matching the contract the spec puts on the program (it must
+                // null-check before use).
+                if sym.is_undefined() && sym.is_weak() {
+                    ::syslog::debug!(
+                        "get_symbol_value(): resolving unresolved weak undefined symbol to zero \
+                         per System V ABI (symbol_name={:?})",
+                        symbol_name
+                    );
+                    return Ok(0);
+                }
+
                 let reason: &str = "symbol not found";
                 ::syslog::warn!(
                     "get_symbol_value(): {} (symbol_name={:?}, symbol={:?})",
@@ -584,6 +607,17 @@ impl DynamicLibrary {
             None;
 
         for sym in self.dynsym.iter() {
+            // Skip undefined symbols: with the STB_WEAK handling in
+            // `get_symbol_value()`, an unresolved weak undefined symbol resolves
+            // to 0 — that's the right behaviour for relocation but would cause
+            // `dladdr()` to report a ghost symbol at address 0 for every weak
+            // undefined entry in the dynsym.  Symbols that have an in-module
+            // definition (or that resolved to a real address elsewhere) are
+            // never `SHN_UNDEF` in this DSO's dynsym, so this filter only
+            // excludes references the loader had to substitute zero for.
+            if sym.is_undefined() {
+                continue;
+            }
             if let Ok(symbol_value) = self.get_symbol_value(sym) {
                 let sym_addr: VirtualAddress = VirtualAddress::from_raw_value(symbol_value);
                 if sym_addr <= symbol_addr {
@@ -743,7 +777,12 @@ impl DynamicLibrary {
     ///
     unsafe fn resolve_r_386_32(mut storage_unit: UnalignedPointer<u32>, symbol_value: u32) {
         let symbol_addend: i32 = storage_unit.read_unaligned() as i32;
-        let final_value: u32 = symbol_value.strict_add_signed(symbol_addend);
+        // ELF arithmetic (System V ABI): `S + A` is performed with wrapping
+        // 32-bit semantics.  Use `wrapping_add_signed` instead of
+        // `strict_add_signed` so that the loader does not panic when
+        // resolving a weak undefined symbol (`S == 0`) against a negative
+        // addend, which is legal per spec.
+        let final_value: u32 = symbol_value.wrapping_add_signed(symbol_addend);
         storage_unit.write_unaligned(final_value);
     }
 
@@ -809,7 +848,12 @@ impl DynamicLibrary {
     unsafe fn resolve_r_386_pc32(mut storage_unit: UnalignedPointer<u32>, symbol_value: u32) {
         let symbol_addend: i32 = storage_unit.read_unaligned() as i32;
         let relocation_offset: u32 = storage_unit.as_ptr() as u32;
-        let tmp: u32 = symbol_value.strict_add_signed(symbol_addend);
+        // ELF arithmetic (System V ABI): `S + A - P` is performed with
+        // wrapping 32-bit semantics.  Use `wrapping_add_signed` instead of
+        // `strict_add_signed` so that the loader does not panic when
+        // resolving a weak undefined symbol (`S == 0`) against a negative
+        // addend, which is legal per spec.
+        let tmp: u32 = symbol_value.wrapping_add_signed(symbol_addend);
 
         let final_value: i32 = if tmp > relocation_offset {
             (tmp - relocation_offset) as i32


### PR DESCRIPTION
## Summary

Teaches the in-process Nanvix dynamic loader to honour the System V ABI's STB_WEAK contract: an **undefined weak** symbol that cannot be resolved at dynamic-link time resolves to value `0`, not to a loader error. This matches every mainstream ELF loader and is a prerequisite for `.so` files produced by GCC/Clang — the C++ runtime, TLS bootstrap, and many GNU extensions all carry weak refs that may or may not be present at load time.

## Why this is required

The current loader rejects any `.so` containing **any** undefined weak symbol that no loaded module defines. In practice that breaks:

- **libstdc++**: emits weak refs to `pthread_*` (so a static link to a single-threaded program still works), `__gmon_start__`, and several `_ITM_*` items. When the consumer of a libstdc++ `.so` is itself a static binary, none of those are defined anywhere — the spec expects them to fold to 0; we expected them to be resolvable.
- **TLS bootstrap**: GCC emits weak refs to `__cxa_thread_atexit_impl` and friends so that the C++ runtime can optionally hook into glibc's per-thread cleanup machinery. On Nanvix there is no glibc, so these stay undefined; the program is designed to fall through, but only if the loader complies with the ABI.
- **CPython + numpy**: the numpy `.so` (and most pip-installed wheels) ship weak refs to glibc-isms via libstdc++. These prevented us from running anything beyond pure-Python code on Nanvix and forced the toolchain wrapper to pass `-Wl,--allow-shlib-undefined` as a workaround, which papered over weak **and** strong undefined refs alike — defeating the linker's diagnostic value.

After this patch, `.so`s that exercise any of the above just work, and the toolchain wrapper can stop hiding link-time errors.

## What changed

| File | Change |
| --- | --- |
| `src/libs/elf/src/elf32.rs` | Add `STB_LOCAL` / `STB_GLOBAL` / `STB_WEAK` constants, `ST_BIND_SHIFT`, and `Elf32Sym::st_bind()` accessor. |
| `src/libs/elf/src/relocation.rs` | Add typed `SymbolBinding` enum, `Symbol::binding()`, `Symbol::is_weak()`. Unknown bindings fall through to `Other` so they are never silently treated as weak. Five unit tests cover the helper. |
| `src/libs/syscall/src/dlfcn/syscall/dynlib.rs` | (1) In `get_symbol_value()`, when `lookup() == None`, return `Ok(0)` if the referring symbol is `SHN_UNDEF` *and* `STB_WEAK`. Strong undefined refs still error. (2) In `query()`, skip `SHN_UNDEF` entries before consulting `get_symbol_value()` so `dladdr()` does not report ghost symbols at address `0`. |

Substituting zero is safe across the relocation types the loader currently implements (`R_386_32`, `R_386_PC32`, `R_386_JMP_SLOT`, `R_386_GLOB_DAT`): the resulting GOT / PLT entry (or, for `R_386_PC32`, the encoded PC-relative displacement that targets address `0 + A`) sends any actual dereference to address zero, which traps deterministically — matching the contract the spec puts on the program (it must null-check before use). The relocation arithmetic itself uses wrapping 32-bit semantics (`wrapping_add_signed`) so that a weak undefined symbol (`S = 0`) combined with a negative addend does not panic the loader.

## Specification

System V ABI ("gABI"), chapter *Symbol Table*:

> Weak symbols resemble global symbols, but their definitions have lower precedence. [...] Undefined weak symbols do not generate an error if no resolving definition is found at link time, and references take the value zero.

## Precedent in mainstream loaders

Every well-known ELF dynamic loader implements this rule. The contract is uniform; only the surrounding code style varies.

- **glibc** ([`elf/dl-lookup.c`](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/dl-lookup.c;hb=HEAD), `_dl_lookup_symbol_x`): after iterating every scope, if `current_value.s == NULL`, glibc inspects the *reference* symbol's binding. If it is `STB_WEAK`, glibc fills the lookup result with a synthesized `sym_val { 0, 0 }` and proceeds; otherwise it raises an unresolved-symbol error. The i386 machine-specific reloc handler [`sysdeps/i386/dl-machine.h`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/i386/dl-machine.h;hb=HEAD) writes the resulting zero through `R_386_GLOB_DAT` / `R_386_JMP_SLOT` like any other relocation.
- **musl** ([`ldso/dynlink.c`](https://git.musl-libc.org/cgit/musl/tree/ldso/dynlink.c), `find_sym2` and the relocation loop in `do_relocs`): `find_sym2` returns a sentinel with `.sym = 0` on lookup failure; the relocation loop then checks `ELF_ST_BIND(sym->st_info) == STB_WEAK` and skips the error path entirely when the binding is weak.
- **FreeBSD `rtld-elf`** ([`libexec/rtld-elf/rtld.c`](https://cgit.freebsd.org/src/tree/libexec/rtld-elf/rtld.c)): `find_symdef()` returns a `sym_zero` placeholder for unresolved weak references, populated at rtld startup as a zero-valued symbol. All architecture-specific reloc handlers (`reloc.c`) treat that placeholder as a normal zero-valued definition.
- **Android Bionic** ([`linker/linker_relocate.cpp`](https://cs.android.com/android/platform/superproject/main/+/main:bionic/linker/linker_relocate.cpp)): `lookup_symbol()` returns a null `sym` for unresolved refs, and the relocation loop branches on `is_weak`. Weak unresolved refs proceed with `sym_addr = 0`; strong unresolved refs report an error via `DL_ERR`.

The behaviour we now implement is the intersection of all four: **unresolved weak undef → value 0; unresolved strong undef → loader error.** Nothing more, nothing less.

## Validation

- **In-tree unit tests** in `src/libs/elf/src/relocation.rs::tests` cover binding decoding, the `Other` fallback for unknown bindings, the independence of the binding nibble from the type nibble, and that `is_weak()` and `is_undefined()` are orthogonal predicates.
- **`dlfcn-weak-c` regression suite** (proposed for nanvix/posix-tests (separate PR)) drives all the observable contract through the public `dlfcn` API:

  | # | Fixture                       | Reloc            | Symbol                | Expected |
  |---|-------------------------------|------------------|-----------------------|----------|
  | 5 | `libstrong-missing.so`        | `R_386_JUMP_SLOT`| `strong_missing`      | `dlopen(RTLD_NOW)` **fails** |
  | 1 | `libweak-func-resolved.so`    | `R_386_GLOB_DAT` | `main_callback`       | resolves to main exe |
  | 2 | `libweak-func-missing.so`     | `R_386_GLOB_DAT` | `missing_callback`    | `&fn == NULL` |
  | 3 | `libweak-data-resolved.so`    | `R_386_GLOB_DAT` | `weak_data`           | resolves to main exe |
  | 4 | `libweak-data-missing.so`     | `R_386_GLOB_DAT` | `missing_weak_data`   | `&data == NULL` |
  | 6 | `libweak-plt-resolved.so`     | `R_386_JUMP_SLOT`| `main_callback`       | resolves to main exe |
  | 7 | `libweak-plt-missing.so`      | `R_386_JUMP_SLOT`| `missing_plt_callback`| `dlopen(RTLD_NOW)` succeeds (no call) |

  Case 5 — the strong-undefined regression guard — runs first and passes both before and after this patch, confirming that strong undef behaviour is unchanged. Cases 1-4 and 6-7 only pass with this patch applied. All 7 pass end-to-end on the Nanvix microvm against this branch.
- **CPython 3.12 + numpy 1.26.4 end-to-end**: cpython links against libstdc++ (weak `pthread_*` etc. left unresolved at .so-load time), runs `hello.py`, then `import numpy; numpy.array(...).sum()` via `dlopen()` of the numpy `.so` family; the test harness prints `NUMPY_TEST_OK`.

## Compatibility

- No public API change. `SymbolBinding` is new but does not displace any existing helper.
- The pre-existing strong-undef error path is preserved verbatim; only the previously-uniform error is split into "weak undef → 0" and "strong undef → error".
- No change to relocation semantics for resolved symbols.
- `dladdr()` behaviour improves (no more ghost zero-address symbols from undefined dynsym entries).

