### PR TITLE
[posix] Add libposix pathconf/fpathconf stubs

### DIFF
--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -10,6 +10,7 @@ use ::sys::error::ErrorCode;
 use ::sysapi::ffi::{
     c_char,
     c_int,
+    c_long,
     c_void,
 };
 use ::syslog::trace_libcall;
@@ -235,6 +236,84 @@ pub unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_cha
     ::syslog::debug!("realpath(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Retrieves the value of a configurable system limit or option associated with the
+/// pathname `path`, as identified by `name` (one of the `_PC_*` selectors defined in
+/// `<unistd.h>`).
+///
+/// # Parameters
+///
+/// - `path`: Null-terminated pathname of the file or directory being queried.
+/// - `name`: A `_PC_*` selector specifying which configurable value to retrieve.
+///
+/// # Returns
+///
+/// On success a non-negative limit value, or `-1` (with `errno` unchanged) when the
+/// queried option has no determinate limit. On failure returns `-1` and sets `errno`.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always returns `-1` with `errno = ENOSYS`,
+/// matching the convention used by the other "not implemented" stubs in this module.
+/// Callers (notably libstdc++'s `std::filesystem`) treat `-1` as "no limit known" and
+/// fall back to compile-time defaults such as `PATH_MAX`, so this stub is sufficient
+/// to satisfy the libstdc++ link without changing behaviour. A future implementation
+/// should return real limits for the selectors it knows about (e.g. `_PC_PATH_MAX`,
+/// `_PC_NAME_MAX`, `_PC_LINK_MAX`), and only set `errno = EINVAL` for genuinely
+/// unrecognised selectors per the POSIX contract.
+///
+/// # Safety
+///
+/// This function is unsafe because it accepts a raw pointer supplied by foreign callers.
+/// It is safe to call this function if `path` (when non-null) points to a valid
+/// null-terminated C string.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pathconf(_path: *const c_char, _name: c_int) -> c_long {
+    ::syslog::debug!("pathconf(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
+/// Retrieves the value of a configurable system limit or option associated with the
+/// open file descriptor `fd`, as identified by `name` (one of the `_PC_*` selectors
+/// defined in `<unistd.h>`).
+///
+/// # Parameters
+///
+/// - `fd`: An open file descriptor to query.
+/// - `name`: A `_PC_*` selector specifying which configurable value to retrieve.
+///
+/// # Returns
+///
+/// On success a non-negative limit value, or `-1` (with `errno` unchanged) when the
+/// queried option has no determinate limit. On failure returns `-1` and sets `errno`.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always returns `-1` with `errno = ENOSYS`.
+/// See `pathconf()` for the rationale on why this stub is acceptable for the current
+/// libstdc++ link requirements.
+///
+/// # Safety
+///
+/// This function is safe to call with any integer; passing a descriptor that is not
+/// currently open does not change the (stub) behaviour.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn fpathconf(_fd: c_int, _name: c_int) -> c_long {
+    ::syslog::debug!("fpathconf(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
 }
 
 ///


### PR DESCRIPTION
## Summary

Adds minimal `extern "C"` stubs for `pathconf(2)` and `fpathconf(2)` to libposix's `src/libs/posix/src/dummy.rs`. Both stubs return `-1` with `errno = ENOSYS`, matching the convention already used by every other "not implemented" stub in that module (`popen`, `wordexp`, `glob`, `ftw`, `realpath`, ...).

## Why this is required

libstdc++'s `std::filesystem` code emits a **strong** undefined reference to `pathconf` from at least two compilation units:

- `libstdc++-v3/src/c++17/cow-fs_ops.cc` — `std::filesystem::current_path(std::error_code&)`
- `libstdc++-v3/src/c++17/fs_ops.cc` — `std::filesystem::current_path[abi:cxx11](std::error_code&)`

`std::filesystem::current_path()` calls `pathconf("/", _PC_PATH_MAX)` to size the buffer it passes to `getcwd()`. Without a definition for `pathconf` anywhere in the link, any executable that links libstdc++ (CPython, any C++ user binary that touches `std::filesystem`) fails with `undefined reference to 'pathconf'`. Concretely, this blocks `./z build` of `nanvix/cpython`:

```
i686-nanvix-ld: libstdc++.a(cow-fs_ops.o): in function `std::filesystem::current_path(std::error_code&)':
cow-fs_ops.cc:(.text.../current_pathERSt10error_code+0x21): undefined reference to `pathconf'
collect2: error: ld returned 1 exit status
configure: error: C compiler cannot create executables
```

There is no existing implementation of either function in libposix today (verified by `grep -r 'fn pathconf' src/libs/posix`).

## What changed

Just `src/libs/posix/src/dummy.rs`: two new public extern "C" functions in the "Standalone Functions" block, with full doc comments (Description / Parameters / Returns / Notes / Safety) and the standard `#[trace_libcall]` attribute. No other files touched. 79 insertions, 0 deletions.

```rust
pub unsafe extern "C" fn pathconf(_path: *const c_char, _name: c_int) -> c_long {
    ::syslog::debug!("pathconf(): not implemented");
    *__errno_location() = ErrorCode::InvalidSysCall.get();
    -1
}

pub unsafe extern "C" fn fpathconf(_fd: c_int, _name: c_int) -> c_long {
    ::syslog::debug!("fpathconf(): not implemented");
    *__errno_location() = ErrorCode::InvalidSysCall.get();
    -1
}
```

## Why this stub is sufficient for libstdc++ today

libstdc++'s `std::filesystem` code path is defensive: it checks `pathconf(...) == -1` and falls back to a compile-time `PATH_MAX` default (`getcwd` is called with a fixed 1024-byte buffer that grows on `ERANGE`). It does not look at `errno`. So returning `-1` with any `errno` value, including the `ENOSYS` we use here, is sufficient to unblock the link without any observable behaviour change vs. "the system advertises no path-conf limit".

## Future work (not in this PR)

A real implementation should return concrete, selector-aware values for the well-defined `_PC_*` selectors and only set `errno = EINVAL` for genuinely unrecognised selectors, following the musl `src/conf/pathconf.c` pattern:

| Selector | Suggested value | Source |
|---|---|---|
| `_PC_PATH_MAX` | 4096 | nanvix `<limits.h>` |
| `_PC_NAME_MAX` | 255 | nanvix `<limits.h>` |
| `_PC_LINK_MAX` | 1 (no hard links today) | nanvix VFS state |
| `_PC_PIPE_BUF` | 4096 | nanvix pipe buffer size |
| `_PC_NO_TRUNC` | 1 | nanvix never truncates names silently |
| ... (others) | `-1` with `errno` *unchanged* per POSIX "no determinate limit" | — |

For now the stub returns `-1` with `errno = ENOSYS` for *every* selector. The doc comment calls this out as a known limitation and points to the future-work direction. Users that rely on real values can follow up separately.

## Validation

- **In-tree CI checks pass locally**: `.\z.ps1 build -- format-check rust-lint-check spellcheck` is green; pre-commit hook passes.
- **End-to-end**: against a Nanvix tree with these stubs applied, CPython 3.12 links against libstdc++ (previously failed on `pathconf` strong UND), the resulting `python.elf` runs `hello.py`, and `import numpy; numpy.array(...).sum()` via `dlopen()` of numpy 1.26.4's extension `.so`s produces `NUMPY_TEST_OK` on the Nanvix microvm.

## Compatibility

- No public API change beyond adding two new C ABI symbols.
- No change to behaviour for any existing caller (the symbols were not defined before).
- The `ENOSYS` errno mirrors every other "not implemented" stub in `dummy.rs` for consistency. A future PR can refine to selector-aware values as described above without breaking this contract.

