### PR TITLE
[nvx] E: Add nvx-crt0 startup crate (skeleton)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvx-crt0"
+version = "0.16.13"
+dependencies = [
+ "cfg-if",
+ "config",
+ "nvx",
+ "sys",
+ "sysalloc",
+ "syslog",
+]
+
+[[package]]
 name = "oci-spec"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
         "src/libs/nanvix-terminal",
         "src/libs/no_fail",
         "src/libs/nvx",
+        "src/libs/nvx-crt0",
         "src/libs/posix",
         "src/libs/proc",
         "src/libs/profiler",
@@ -176,6 +177,7 @@ nanvixd = { path = "src/utils/nanvixd", default-features = false }
 no_fail = { path = "src/libs/no_fail", default-features = false }
 num_enum = { version = "0.7.6", default-features = false }
 nvx = { path = "src/libs/nvx", default-features = false }
+nvx-crt0 = { path = "src/libs/nvx-crt0", default-features = false }
 oci-spec = "0.10.0"
 profiler = { path = "src/libs/profiler", default-features = false }
 protobuf = "3.7"

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 export EXEC_FORMAT := elf
 # Libraries
 export LIBPOSIX := $(LIBRARIES_DIR)/libposix.a
+export LIBNVX_CRT0 := $(LIBRARIES_DIR)/libnvx_crt0.a
 
 # Binaries.
 KERNEL := $(BINARIES_DIR)/kernel.$(EXEC_FORMAT)
@@ -325,7 +326,7 @@ export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
 # Top-Level Targets
 #===================================================================================================
 
-ALL_GUEST_STATIC_LIBS := posix
+ALL_GUEST_STATIC_LIBS := posix nvx-crt0
 ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
 ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_string syslog-macros syslog mmio-tag
 
@@ -493,6 +494,7 @@ ifeq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 endif
 endif
 	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
+	@cp ${LIBNVX_CRT0} ${SYSROOT_DIR}/lib/
 	@mkdir -p ${SYSROOT_DIR}/etc/scripts/common
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/common/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -10,15 +10,42 @@ endif
 GUEST_STATICLIB_FEATURES := $(strip $(GUEST_STATICLIB_FEATURES))
 GUEST_STATICLIB_CARGO_FEATURES := $(if $(GUEST_STATICLIB_FEATURES),--features "$(GUEST_STATICLIB_FEATURES)")
 
+#===================================================================================================
+# Per-package feature overrides
+#===================================================================================================
+# Some staticlib packages take a different feature set than the default
+# `staticlib + LOG_LEVEL [+ standalone]` combination above. Define the
+# overrides here as `GUEST_STATICLIB_FEATURES_<package>` and the lookup
+# helper below picks them up.
+#
+# nvx-crt0 is the C-executable startup crate. It is built once with the
+# `c-main` feature (so the sysroot copy of `libnvx_crt0.a` is the variant a
+# C executable like `python.elf` links against). Rust no_std binaries that
+# need the `rust-main` flavour pull `nvx-crt0` in directly via cargo as a
+# normal dependency, with the appropriate feature toggle in their own
+# `Cargo.toml`, so they do not consume the sysroot copy.
+GUEST_STATICLIB_FEATURES_nvx-crt0 := c-main $(LOG_LEVEL)
+GUEST_STATICLIB_FEATURES_nvx-crt0 := $(strip $(GUEST_STATICLIB_FEATURES_nvx-crt0))
+
+# Returns the cargo `--features "..."` arg for the given package, falling
+# back to the default $(GUEST_STATICLIB_CARGO_FEATURES) when no override is
+# defined.
+GUEST_STATICLIB_PKG_FEATURES = $(if $(GUEST_STATICLIB_FEATURES_$(1)),--features "$(GUEST_STATICLIB_FEATURES_$(1))",$(GUEST_STATICLIB_CARGO_FEATURES))
+
+# Cargo crate names with hyphens produce artifacts with underscores (e.g.
+# `nvx-crt0` -> `libnvx_crt0.a`). This helper normalises the package name
+# for `cp` / `rm` paths against the cargo target dir.
+guest_staticlib_artifact = lib$(subst -,_,$(1)).a
+
 # Per-package rules retained for direct invocation (e.g., make all-guest-staticlib-<pkg>).
 define GUEST_STATICLIB_RULES
 all-guest-staticlib-$(1): init
-	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
-	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$(1).a $(LIBRARIES_DIR)/lib$(1).a
+	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
+	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(call guest_staticlib_artifact,$(1)) $(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1))
 
 check-guest-staticlib-$(1):
 	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
-	@$(GUEST_CARGO_CHECK_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
 
 format-guest-staticlib-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1)
@@ -28,40 +55,68 @@ format-check-guest-staticlib-$(1):
 
 clean-guest-staticlib-$(1):
 	$(GUEST_CARGO_CLEAN_CMD) -p $(1)
-	$(RM_CMD) $(LIBRARIES_DIR)/lib$(1).a
+	$(RM_CMD) $(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1))
 
 rust-lint-guest-staticlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1)) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-guest-staticlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1)) -- -D warnings
 endef
 
 $(foreach target,$(ALL_GUEST_STATIC_LIBS),$(eval $(call GUEST_STATICLIB_RULES,$(target))))
 
-# Batched targets: single cargo invocations for all guest staticlibs.
-_GUEST_STATICLIB_PKGS := $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),-p $(pkg))
+# Batched targets: invoke cargo once per distinct feature set so that packages
+# with overrides (e.g. nvx-crt0) get their own feature flags rather than the
+# default $(GUEST_STATICLIB_CARGO_FEATURES) bundle. Per-package override
+# invocations are unrolled at make-time (one cargo call per override package)
+# instead of looping in shell, so that the per-package feature lookup happens
+# at make-time when the package name is statically known.
+_GUEST_STATICLIB_PKGS_DEFAULT := $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),$(if $(GUEST_STATICLIB_FEATURES_$(pkg)),,-p $(pkg)))
+_GUEST_STATICLIB_PKGS_OVERRIDE := $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),$(if $(GUEST_STATICLIB_FEATURES_$(pkg)),$(pkg),))
+
+# Macros that emit the per-override commands for the batched targets.
+define _OVERRIDE_BUILD_CMD
+	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
+endef
+
+define _OVERRIDE_CHECK_CMDS
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
+	@$(GUEST_CARGO_CHECK_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
+endef
+
+define _OVERRIDE_CLIPPY_CMD
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1)) --fix --allow-dirty --allow-no-vcs
+endef
+
+define _OVERRIDE_CLIPPY_CHECK_CMD
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1)) -- -D warnings
+endef
 
 all-guest-staticlibs: init
-	$(GUEST_CARGO_BUILD_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
+	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),$(GUEST_CARGO_BUILD_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES))
+	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_BUILD_CMD,$(pkg)) &&) true
 	@for pkg in $(ALL_GUEST_STATIC_LIBS); do \
-		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$$pkg.a $(LIBRARIES_DIR)/lib$$pkg.a; \
+		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$$(echo $$pkg | sed 's/-/_/g').a $(LIBRARIES_DIR)/lib$$(echo $$pkg | sed 's/-/_/g').a; \
 	done
 
 check-guest-staticlibs:
-	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS)
-	@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
+	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT))
+	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),@$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES))
+	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_CHECK_CMDS,$(pkg)))
 
 format-guest-staticlibs:
-	$(GUEST_CARGO_FMT_CMD) $(_GUEST_STATICLIB_PKGS)
+	$(GUEST_CARGO_FMT_CMD) $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),-p $(pkg))
 
 format-check-guest-staticlibs:
-	$(GUEST_CARGO_FMT_CMD) $(_GUEST_STATICLIB_PKGS) --check
+	$(GUEST_CARGO_FMT_CMD) $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),-p $(pkg)) --check
 
 clean-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),clean-guest-staticlib-$(target))
 
 rust-lint-guest-staticlibs:
-	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs)
+	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_CLIPPY_CMD,$(pkg)) &&) true
 
 rust-lint-check-guest-staticlibs:
-	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings
+	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings)
+	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_CLIPPY_CHECK_CMD,$(pkg)) &&) true

--- a/src/libs/nvx-crt0/Cargo.toml
+++ b/src/libs/nvx-crt0/Cargo.toml
@@ -1,0 +1,52 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nvx-crt0"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Nanvix Guest Runtime Startup (C runtime 0)"
+homepage.workspace = true
+
+# Produced as a staticlib so the resulting `libnvx_crt0.a` can be link-forced
+# (`-Wl,--whole-archive libnvx_crt0.a -Wl,--no-whole-archive`) into an
+# executable's link line. The `lib` crate type is also produced so Rust no_std
+# binaries that depend on this crate via `extern crate nvx_crt0;` get the
+# startup objects through cargo's normal dependency resolution.
+[lib]
+crate-type = ["lib", "staticlib"]
+
+[dependencies]
+cfg-if = { workspace = true }
+config = { workspace = true }
+nvx = { workspace = true }
+syslog = { workspace = true, default-features = true }
+sys = { workspace = true, features = ["kcall"] }
+
+# `sysalloc` provides the memory allocator and thread-data-area (TDA) helpers
+# the startup code uses to bring up the runtime. Platform-gated to match the
+# gating in `nvx` itself.
+[target.'cfg(any(target_os = "none", target_os = "nanvix"))'.dependencies]
+sysalloc = { workspace = true }
+
+[features]
+# Default to `c-main` so a vanilla `cargo build -p nvx-crt0` succeeds without
+# forcing every caller to pass `--features ...`. Consumers that want the Rust
+# trampoline opt out via `default-features = false, features = ["rust-main"]`
+# in their own Cargo.toml.
+default = ["c-main"]
+c-main = []
+rust-main = []
+
+# Logging level pass-through to syslog (mirrors the convention used by `nvx`).
+trace = ["syslog/trace"]
+debug = ["syslog/debug"]
+info = ["syslog/info"]
+warn = ["syslog/warn"]
+error = ["syslog/error"]
+panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/nvx-crt0/src/lib.rs
+++ b/src/libs/nvx-crt0/src/lib.rs
@@ -10,40 +10,58 @@
 #![forbid(clippy::large_stack_arrays)]
 #![no_std]
 
+//! Nanvix guest C runtime 0 (`crt0`).
+//!
+//! Owns the executable entry point (`_do_start`), the `_start` Rust function
+//! it dispatches to, the C / Rust trampolines that bridge to the
+//! application's `main` function, and the argument-vector / environment
+//! parsing logic.  This crate is intended to be linked **only into
+//! executables**.  Libraries (notably `libposix.a`) must **not** depend on
+//! it, so that those libraries can be linked into `.so` files without
+//! pulling in a strong undefined `main` reference.
+
 //==================================================================================================
-// Modules
+// Feature-set guards
 //==================================================================================================
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
-mod panic;
-pub mod pie;
+// Exactly one trampoline flavour must be selected. The C variant brings in
+// `extern "C" fn main(int, char **)` (the standard C ABI entry point used by
+// CPython, hello-c, smoke, ...); the Rust variant brings in
+// `extern "Rust" fn main() -> Result<(), sys::error::Error>` (used by every
+// Rust no_std binary).
+#[cfg(all(feature = "c-main", feature = "rust-main"))]
+compile_error!(
+    "nvx-crt0: features `c-main` and `rust-main` are mutually exclusive; pick exactly one."
+);
+
+#[cfg(not(any(feature = "c-main", feature = "rust-main")))]
+compile_error!("nvx-crt0: one of the features `c-main` or `rust-main` must be enabled.");
 
 //==================================================================================================
 // Imports
 //==================================================================================================
 
-// We link the `alloc` crate when building static libraries to provide heap allocation support.
-#[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
+use ::alloc::vec::Vec;
 use ::config::memory_layout::USER_BASE_RAW;
 
-#[cfg(not(feature = "staticlib"))]
+#[cfg(feature = "rust-main")]
 use ::core::sync::atomic::{
     AtomicI32,
     AtomicPtr,
     Ordering,
 };
 
-use ::alloc::vec::Vec;
-
 //==================================================================================================
 // External Functions
 //==================================================================================================
 
-#[cfg(feature = "staticlib")]
+#[cfg(feature = "c-main")]
 unsafe extern "C" {
-    /// Initializes the environment table from a null-terminated array of "KEY=VALUE" C strings.
+    /// Initialises the environment table from a null-terminated array of "KEY=VALUE"
+    /// C strings.  Provided by `libposix` (`src/libs/posix/src/stdlib/...`) and only
+    /// needed by C executables, which rely on `getenv` / `setenv` / `unsetenv`.
     fn __nanvix_env_init(envp: *const *const core::ffi::c_char);
 }
 
@@ -54,9 +72,9 @@ unsafe extern "C" {
 ///
 /// # Description
 ///
-/// Pointer to environment variables.
+/// Pointer to the environment-variable array installed by `_start()`.
 ///
-/// # Note
+/// # Notes
 ///
 /// - This symbol is not name-mangled so it can be referenced from foreign code (for example C).
 /// - The symbol name is lowercase because external languages expect this conventional name.
@@ -68,24 +86,33 @@ static mut environ: *mut *mut i8 = core::ptr::null_mut();
 ///
 /// # Description
 ///
-/// Pointer to command line arguments.
+/// Number of command-line arguments published by `_start()` for Rust no_std
+/// executables that wish to read them directly (for example
+/// `cmdline-len-rust` / `cmdline-env-rust-nostd`).
 ///
-#[cfg(not(feature = "staticlib"))]
-pub static ARGV: AtomicPtr<*const u8> = AtomicPtr::new(core::ptr::null_mut());
+/// Only meaningful when the `rust-main` feature is enabled. C executables
+/// receive `argc` directly through `c_trampoline`.
+///
+#[cfg(feature = "rust-main")]
+pub static ARGC: AtomicI32 = AtomicI32::new(0);
 
 ///
 /// # Description
 ///
-/// Number of command line arguments in the `argv` array.
+/// Pointer to the command-line argument array published by `_start()`. See
+/// [`ARGC`] for the matching length.
 ///
-#[cfg(not(feature = "staticlib"))]
-pub static ARGC: AtomicI32 = AtomicI32::new(0);
+#[cfg(feature = "rust-main")]
+pub static ARGV: AtomicPtr<*const u8> = AtomicPtr::new(core::ptr::null_mut());
 
 //==================================================================================================
-// Standalone Functions
+// Kernel-Entry Stub
 //==================================================================================================
 
-#[cfg(not(feature = "staticlib"))]
+// Kernel-entry stub set up by the process spawner. The trap frame the kernel
+// installs makes IRET "return" to `_do_start` with `argp` in EDX and `envp`
+// in ECX. The stub aligns the stack to the i386 SysV ABI requirement
+// (ESP = 0 mod 16 before the CALL instruction) and dispatches to `_start`.
 core::arch::global_asm!(
     r#"
     .extern _start
@@ -128,10 +155,18 @@ core::arch::global_asm!(
     "#
 );
 
+//==================================================================================================
+// Rust Entry Point
+//==================================================================================================
+
 ///
 /// # Description
 ///
-/// Entry point of the program.
+/// Rust entry point reached from `_do_start`.  Performs PIE relocation, runs
+/// `nvx`'s runtime initialisation, parses the kernel-supplied `argp` /
+/// `envp` blobs into argv / environ arrays, dispatches to the selected
+/// trampoline (C or Rust `main`), then tears the runtime down and exits via
+/// the `exit` kcall.
 ///
 /// # Parameters
 ///
@@ -144,25 +179,26 @@ core::arch::global_asm!(
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences raw pointers.
+/// This function is unsafe because it dereferences raw pointers supplied by
+/// the kernel trap-frame setup.
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
     // Apply PIE relocations before any global data access.
     unsafe {
-        pie::relocate_pie_binary(USER_BASE_RAW);
+        ::nvx::pie::relocate_pie_binary(USER_BASE_RAW);
     }
 
-    syslog::trace!("_start(): argv: {:?}, envp: {:?}", argp, envp);
+    ::syslog::trace!("_start(): argv: {:?}, envp: {:?}", argp, envp);
 
-    // Initializes the system runtime.
-    init();
+    // Initialise the system runtime (heap, TDA, ...).
+    ::nvx::init();
 
-    // Build vector of command line arguments.
-    let argv: Vec<*const i8> = unsafe { parse_argp(argp) };
-    let argc: i32 = argv.len() as i32 - 1;
-    let argv: *mut *const u8 = argv.as_ptr() as *mut *const u8;
-    #[cfg(not(feature = "staticlib"))]
+    // Build vector of command-line arguments.
+    let mut argv_vec: Vec<*const i8> = unsafe { parse_argp(argp) };
+    let argc: i32 = argv_vec.len() as i32 - 1;
+    let argv: *mut *const u8 = argv_vec.as_mut_ptr() as *mut *const u8;
+    #[cfg(feature = "rust-main")]
     {
         ARGC.store(argc, Ordering::SeqCst);
         ARGV.store(argv, Ordering::SeqCst);
@@ -175,34 +211,80 @@ pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
     }
 
     // Populate the environment table used by getenv()/setenv()/unsetenv().
-    // The `environ` pointer is a null-terminated array of "KEY=VALUE" C strings,
-    // which is exactly the format expected by __nanvix_env_init().
-    #[cfg(feature = "staticlib")]
+    // The `environ` pointer is a null-terminated array of "KEY=VALUE" C
+    // strings, which is exactly the format expected by __nanvix_env_init().
+    #[cfg(feature = "c-main")]
     unsafe {
         __nanvix_env_init(environ as *const *const core::ffi::c_char);
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "staticlib")] {
+        if #[cfg(feature = "c-main")] {
             let status: i32 = c_trampoline(argc, argv);
         } else {
+            // Suppress unused-variable warnings when only the Rust trampoline
+            // is active: argc/argv are stored in ARGC/ARGV above.
+            let _ = (argc, argv);
             let status: i32 = rust_trampoline();
         }
     }
 
-    // Cleans up the system runtime.
-    cleanup();
+    // Clean up the system runtime.
+    ::nvx::cleanup();
 
-    // Exits the runtime.
+    // Exit the runtime.
     let Err(error) = ::sys::kcall::pm::__kcall_exit(status);
     panic!("failed to exit process (error={error:?})");
 }
 
+//==================================================================================================
+// Trampolines
+//==================================================================================================
+
+/// Trampoline for Rust applications.
+///
+/// Calls the `main` symbol exported by the application crate, which must
+/// have the signature `fn main() -> Result<(), sys::error::Error>`.
+#[cfg(feature = "rust-main")]
+fn rust_trampoline() -> i32 {
+    unsafe extern "Rust" {
+        fn main() -> Result<(), ::sys::error::Error>;
+    }
+
+    match unsafe { main() } {
+        Ok(()) => 0,
+        Err(e) => e.code.get(),
+    }
+}
+
+/// Trampoline for C applications.
+///
+/// Calls the standard C `main(int argc, char **argv) -> int` plus `_init`
+/// and `_fini` (the legacy GNU constructor/destructor hooks).
+#[cfg(feature = "c-main")]
+fn c_trampoline(argc: i32, argv: *const *const u8) -> i32 {
+    unsafe extern "C" {
+        fn main(argc: i32, argv: *const *const u8) -> i32;
+        fn _init();
+        fn _fini();
+    }
+
+    unsafe {
+        _init();
+        let ret: i32 = main(argc, argv);
+        _fini();
+        ret
+    }
+}
+
+//==================================================================================================
+// Argument / Environment Parsing
+//==================================================================================================
+
 ///
 /// # Description
 ///
-/// Builds a string table from a a null-terminated string.
-///
+/// Builds a string table from a null-terminated string.
 /// # Parameters
 ///
 /// - `string`: A pointer to a null-terminated string.
@@ -210,6 +292,12 @@ pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
 /// # Returns
 ///
 /// - A vector of pointers to null-terminated strings.
+///
+/// # Safety
+///
+/// This function dereferences `string`.  The caller must ensure that `string`
+/// points to a valid mutable buffer terminated by a single null byte and
+/// containing only ASCII characters (space-separated tokens).
 ///
 unsafe fn build_string_table(string: *mut i8) -> Vec<*mut i8> {
     use core::ptr;
@@ -250,122 +338,23 @@ unsafe fn build_string_table(string: *mut i8) -> Vec<*mut i8> {
     result
 }
 
-///
 /// Wrapper for parsing `argp`.
 ///
+/// # Safety
+///
+/// See [`build_string_table`].
 unsafe fn parse_argp(argp: *mut i8) -> Vec<*const i8> {
-    build_string_table(argp)
+    unsafe { build_string_table(argp) }
         .into_iter()
         .map(|ptr| ptr as *const i8)
         .collect()
 }
 
-///
 /// Wrapper for parsing `envp`.
 ///
+/// # Safety
+///
+/// See [`build_string_table`].
 unsafe fn parse_envp(envp: *mut i8) -> Vec<*mut i8> {
-    build_string_table(envp)
-}
-
-///
-/// Trampoline for Rust applications.
-///
-#[cfg(all(not(feature = "staticlib"), not(feature = "rustc-dep-of-std")))]
-fn rust_trampoline() -> i32 {
-    unsafe extern "Rust" {
-        fn main() -> Result<(), ::sys::error::Error>;
-    }
-
-    // Runs the main function.
-    match unsafe { main() } {
-        Ok(()) => 0,
-        Err(e) => e.code.get(),
-    }
-}
-
-///
-/// Trampoline for Rust applications.
-///
-#[cfg(all(not(feature = "staticlib"), feature = "rustc-dep-of-std"))]
-fn rust_trampoline() -> i32 {
-    unsafe extern "Rust" {
-        fn main();
-    }
-
-    // Runs the main function.
-    unsafe { main() };
-
-    0
-}
-
-///
-/// Trampoline for C applications.
-///
-#[cfg(feature = "staticlib")]
-fn c_trampoline(argc: i32, argv: *const *const u8) -> i32 {
-    unsafe extern "C" {
-        fn main(argc: i32, argv: *const *const u8) -> i32;
-        fn _init();
-        fn _fini();
-    }
-
-    unsafe {
-        _init();
-        let ret: i32 = main(argc, argv);
-        _fini();
-        ret
-    }
-}
-
-/// Initializes system runtime.
-///
-/// Brings up the heap-region reservation, the `sysalloc` allocator, and the
-/// thread-data-area (TDA) used for thread-local storage.  Public so the
-/// startup crate (`nvx-crt0`) can call it from `_start` without duplicating
-/// the logic.
-pub fn init() {
-    #[cfg(any(target_os = "none", target_os = "nanvix"))]
-    {
-        // Reserve virtual address space for the heap from the unified mmap region.
-        let heap_capacity: usize = ::config::memory_layout::USER_HEAP_CAPACITY;
-        let heap_base: ::sys::mm::VirtualAddress = match sysalloc::vaddr::reserve(heap_capacity) {
-            core::prelude::v1::Ok(base) => base,
-            Err(e) => panic!("failed to reserve virtual address space for heap: {:?}", e),
-        };
-
-        if let Err(e) = sysalloc::init(heap_base, heap_capacity) {
-            panic!("failed to initialize memory manager: {:?}", e);
-        }
-    }
-    #[cfg(any(target_os = "none", target_os = "nanvix"))]
-    match sysalloc::tda::alloc() {
-        core::prelude::v1::Ok(Some(tda_ptr)) => {
-            if let Err(error) = ::sys::kcall::pm::__kcall_set_thread_data_area(tda_ptr) {
-                panic!("init(): failed to set thread data area (error={error:?})");
-            }
-            sysalloc::tda::mark_initialized();
-        },
-        core::prelude::v1::Ok(None) => {
-            // No thread-local storage to set.
-        },
-        Err(error) => {
-            panic!("init(): create thread data area (error={error:?})");
-        },
-    }
-}
-
-/// Cleans up system runtime.
-///
-/// Tears down the thread-data-area and the `sysalloc` allocator.  Public so
-/// the startup crate (`nvx-crt0`) can call it from `_start` without
-/// duplicating the logic.
-pub fn cleanup() {
-    #[cfg(any(target_os = "none", target_os = "nanvix"))]
-    if let Err(error) = ::sysalloc::tda::cleanup() {
-        panic!("failed to cleanup thread data area ({error:?})");
-    }
-    #[cfg(any(target_os = "none", target_os = "nanvix"))]
-    if let Err(e) = sysalloc::cleanup() {
-        panic!("failed to cleanup memory manager: {:?}", e);
-    }
+    unsafe { build_string_table(envp) }
 }


### PR DESCRIPTION
## Summary

Introduces a new **`nvx-crt0`** static library that owns the executable entry point (`_do_start`), the `_start` Rust function it dispatches to, the C / Rust trampolines that bridge to the application's `main` function, and the `argc` / `argv` / `environ` parsing logic.

This PR is **purely additive**: the crate is created, registered in the workspace, and built into the sysroot as `libnvx_crt0.a`, but no consumer has been migrated to use it yet. All existing behaviour is unchanged.

## Why

Today the `nvx` runtime crate exposes startup symbols (`_do_start`, `_start`, `c_trampoline`, etc.) behind its `staticlib` feature, and `libposix` enables that feature via its own `staticlib = ["nvx/staticlib"]` wiring. As a result, `libposix.a` embeds a strong undefined reference to `main` (via the `c_trampoline`'s `extern "C" fn main(int, char **)` declaration). That UND is what makes extension `.so` files fail to link against `libposix.a` -- `.so`s never define `main`. The current workaround is a build-harness post-process (`rust-objcopy --weaken-symbol=main libposix.a`) so the UND becomes weak and the System V ABI's "weak undef -> 0" rule (implemented in the dlfcn loader by [#2450](https://github.com/nanvix/nanvix/pull/2450)) can absorb it at dlopen time.

The proper fix is to **stop carrying startup symbols in `libposix.a` at all**. Splitting them into a dedicated `nvx-crt0` crate is step one: executables explicitly link `libnvx_crt0.a`, libraries (notably `libposix`) link only the runtime helpers in `nvx`.

This PR delivers only the new crate. The follow-up PRs cut existing consumers over.

## What this PR contains

| File | Change |
| --- | --- |
| `src/libs/nvx-crt0/Cargo.toml` (new) | New package, `crate-type = [lib, staticlib]`. Direct dependency on `nvx` for the shared `init` / `cleanup` / `pie::relocate_pie_binary` helpers. Features `c-main` (default) and `rust-main` select the trampoline; a `compile_error!` guard rejects builds with neither or both set. |
| `src/libs/nvx-crt0/src/lib.rs` (new, ~340 LOC) | Startup code factored out of `nvx`'s `lib.rs` **without behavioural change**: `global_asm!` defining `_do_start`, `_start`, both trampolines, `ARGC` / `ARGV` / `environ` globals, `build_string_table` / `parse_argp` / `parse_envp` helpers. Doc comments expanded to call out the feature-set contract and the kernel-trap-frame ABI. |
| `src/libs/nvx/src/lib.rs` | Minimal touch: `pub mod pie;` (was `mod pie;`) and `pub fn init() / pub fn cleanup()` (were private) so the new crate can call them. **No symbols are moved out of `nvx` in this PR** -- that happens in the follow-up cut-over PR. |
| `Cargo.toml` (workspace) | Register `src/libs/nvx-crt0` as a member; expose `nvx-crt0 = { path = "src/libs/nvx-crt0", default-features = false }`. |
| `Cargo.lock` | Auto-updated for the new crate. |
| `Makefile` | Add `nvx-crt0` to `ALL_GUEST_STATIC_LIBS` so the sysroot ships `libnvx_crt0.a` for downstream C consumers (e.g. `nanvix/cpython`). |
| `build/make/generic-guest-staticlibs.mk` | Introduce two new building blocks needed to support the new crate alongside `posix`: (1) per-package feature overrides (`GUEST_STATICLIB_FEATURES_<pkg>` -> `GUEST_STATICLIB_PKG_FEATURES` lookup) so `posix` keeps its `staticlib [+ standalone]` features while `nvx-crt0` builds with `c-main`; (2) an artifact-name helper (`lib<pkg-with-_>.a`) so the cargo crate name `nvx-crt0` maps correctly to the produced `libnvx_crt0.a` for `cp` / `rm` paths. |

## Why "modified Option A" (and not the alternatives)

Three approaches were considered:

- **Option A (chosen):** `nvx-crt0` is a thin crate that owns the startup glue and reuses `nvx`'s runtime helpers (heap setup, TDA setup, PIE relocation, panic handler, allocator). One source of truth per concern; `nvx-crt0` depends on `nvx`.
- **Option B:** Make `nvx-crt0` fully self-contained -- duplicate `init`/`cleanup`/`pie` into the new crate, so the crate has no `nvx` dependency. Avoids one dependency edge but doesn't actually eliminate duplicate-symbol risk because `nvx-crt0` and `libposix.a` still share other deps (`sys`, `sysalloc`, `config`, ...). Pure churn.
- **Option C:** Split `nvx` more aggressively into `nvx-rt` + `nvx-crt0`, then have `posix` depend only on `nvx-rt`. Cleanest end-state but a bigger refactor than what's needed to remove the `main` UND, and the boundary between `nvx` and a hypothetical `nvx-rt` isn't obviously well-defined today.

Option A delivers the architectural separation the upstreaming chain needs without changing what `nvx` does for its existing consumers.

## Validation

- **Full `./z build` of the `all` target succeeds**: `[OK] Build complete.`
- **`i686-nanvix-nm libnvx_crt0.a`** reports:
  - `T _do_start` (kernel-entry stub)
  - `T _start` (Rust entry, dispatches to trampoline)
  - `T c_trampoline` (mangled)
  - `B environ`
  - `U main` (the intended undefined reference that an executable's `int main(...)` resolves at link time)
- **`i686-nanvix-nm libposix.a`** is byte-identical to the pre-PR build -- no consumer cut-over yet.
- **CPython 3.12 + numpy 1.26.4** end-to-end on the Nanvix microvm still produces `NUMPY_TEST_OK`.
- **`./z build -- format-check rust-lint-check spellcheck`** all green; pre-commit hook passes.
- Verified the per-package feature override path: `cargo build -p nvx-crt0 --features c-main` works in isolation, and the batched `all-guest-staticlibs` target produces both `libposix.a` (with `staticlib standalone`) and `libnvx_crt0.a` (with `c-main`) without feature unification issues.

## Compatibility

- **No public API change** in `nvx`. `init` / `cleanup` were private; making them `pub` is an extension. The `mod pie;` -> `pub mod pie;` switch exposes the existing public `relocate_pie_binary` function under the conventional path.
- **No consumer touches**. Every Rust no_std binary, every test, every benchmark, `libposix`, `cpython`, downstream `.so`s -- all continue to build exactly as before.
- **No runtime behaviour change**. `libnvx_crt0.a` is produced and installed but nothing links it yet.

## Follow-up PRs

1. **Cut `libposix.a` over**: stop enabling `nvx/staticlib`, add the `libnvx_crt0.a` link directive to the cpython `Makefile.nanvix`.
2. **Cut every Rust no_std executable over**: add `nvx-crt0` as a cargo dependency on the ~14 affected binaries, drop `extern crate nvx;` in favour of `extern crate nvx_crt0;`, remove the startup symbols from `nvx` itself, and delete the temporary `POST_STATICLIB_HOOK_posix` objcopy workaround currently sitting in our local build harness.

