### PR TITLE
[syscall] dlfcn keeps `/` on absolute paths

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -44,8 +44,12 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
 
     // Resolve bare library names (e.g., "libfoo.so") to a canonical path
     // (e.g., "lib/libfoo.so") using the configured search directories.
-    // Paths with leading "/" are normalized to strip it, ensuring
-    // "/lib/libc.so" and "lib/libc.so" are treated as the same library.
+    // Paths that already contain a separator are passed through with only a
+    // leading "./" stripped; a leading "/" is preserved so that absolute
+    // paths stay absolute and resolve against the filesystem root regardless
+    // of the caller's CWD. As a consequence, "/lib/libc.so" and
+    // "lib/libc.so" are distinct keys in the already-loaded-library lookup
+    // below (matching the as-supplied path rather than a canonical form).
     let resolved: String = super::resolve_library_path(filename);
     let filename: &str = resolved.as_str();
 

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -84,23 +84,28 @@ static DLINIT_ONCE: Once = Once::new();
 /// Resolves a library filename to a canonical path.
 ///
 /// If `filename` contains a path separator (`/`), it is treated as an explicit
-/// path (absolute or relative with directory component). The path is normalized
-/// by stripping leading `/` and `./` to produce a canonical form, but no
-/// search-path probing is performed. This matches Linux behavior where absolute
-/// and relative paths bypass `LD_LIBRARY_PATH`.
+/// path (absolute or relative with directory component).  Only a leading
+/// `./` is stripped (`./foo` is equivalent to `foo` for `openat()`
+/// purposes); the leading `/` of an absolute path is preserved as-is.
+/// This matches Linux behavior, where absolute and relative paths bypass
+/// `LD_LIBRARY_PATH` and are passed straight through to `open()`.
 ///
 /// If `filename` is a bare name (no `/`), the function tries each directory in
 /// [`LIBRARY_SEARCH_PATHS`] in order, returning the first path for which the
 /// file exists. If no match is found the bare name is returned so that the
 /// subsequent `open_regular_file` call produces the appropriate error.
 ///
-/// All paths are normalized to a consistent form without leading `/` or `./`,
-/// matching the convention used throughout the Nanvix dlfcn layer and test code
-/// (e.g., `"lib/libmul.so"`). The VFS accepts both relative and absolute paths
-/// and normalizes internally, so stripping the leading `/` is safe and ensures
-/// that `"/lib/libc.so"`, `"./lib/libc.so"`, `"lib/libc.so"`, and the bare
-/// DT_NEEDED name `"libc.so"` all resolve to the same canonical path
-/// `"lib/libc.so"`.
+/// # Absolute paths must stay absolute
+///
+/// Earlier revisions of this function also called `.trim_start_matches('/')`
+/// on absolute paths, on the assumption that the VFS accepted both forms
+/// and that this produced a more canonical form for the
+/// already-loaded-library lookup in `dlopen`.  In practice that conversion
+/// makes the subsequent `openat()` resolve the path against the caller's
+/// CWD instead of the filesystem root, which silently breaks
+/// `dlopen("/lib/foo.so")` for any caller whose CWD is not `/`.
+/// CPython's `regrtest` (which sets `TMPDIR=/tmp` and `chdir`s before
+/// running tests) is the canonical reproducer.
 ///
 /// NOTE: The probe opens and immediately closes a file descriptor per
 /// candidate path. The matched file is re-opened by `DynamicLibrary::open()`.
@@ -110,14 +115,17 @@ pub(super) fn resolve_library_path(filename: &str) -> String {
     // If the original filename contains a path separator, the caller provided
     // an explicit path (absolute or relative with directory). Normalize it
     // but do NOT search configured directories — matching Linux behavior
-    // where absolute/relative paths bypass LD_LIBRARY_PATH.
+    // where absolute/relative paths bypass `LD_LIBRARY_PATH`.
     if filename.contains('/') {
-        // Strip leading "./" and "/" for canonical form.
-        let normalized: &str = filename
-            .strip_prefix("./")
-            .unwrap_or(filename)
-            .trim_start_matches('/');
-        // Guard against pathological input like "/" or "./" becoming empty.
+        // `./foo` is equivalent to `foo` for `openat()` purposes, so strip
+        // a leading `./` if present.  Do NOT strip a leading `/` — that
+        // would convert an absolute path into a relative one and break
+        // resolution when CWD != `/` (see doc comment above).
+        let normalized: &str = match filename.strip_prefix("./") {
+            Some(rest) => rest.trim_start_matches('/'),
+            None => filename,
+        };
+        // Guard against pathological input like `./` becoming empty.
         if normalized.is_empty() {
             return String::from(filename);
         }

--- a/src/tests/dlfcn-rust/src/tests/dlfcn.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn.rs
@@ -5,6 +5,10 @@
 // Imports
 //==================================================================================================
 
+use ::alloc::{
+    format,
+    string::String,
+};
 use ::sys::{
     error::Error,
     mm::{
@@ -12,13 +16,16 @@ use ::sys::{
         VirtualAddress,
     },
 };
-use ::syscall::dlfcn::{
-    DlHandle,
-    DlInfo,
-    dladdr,
-    dlclose,
-    dlopen,
-    dlsym,
+use ::syscall::{
+    dlfcn::{
+        DlHandle,
+        DlInfo,
+        dladdr,
+        dlclose,
+        dlopen,
+        dlsym,
+    },
+    unistd,
 };
 use core::{
     ffi::{
@@ -35,6 +42,11 @@ use core::{
 
 /// Path to the shared library used by the non-PIE dlfcn tests.
 const LIB_PATH: &str = "lib/libmul.so";
+
+/// A non-root directory (relative to the startup CWD) to switch into for the
+/// non-root-CWD regression tests. It holds `libmul.so`, so the relative-path
+/// negative case has a valid directory to stand in.
+const NON_ROOT_DIR: &str = "lib";
 
 //==================================================================================================
 // Compile-Time Assertions
@@ -175,6 +187,69 @@ fn test_dladdr() -> Result<(), Error> {
     Ok(())
 }
 
+/// Regression test for absolute-path resolution when the caller's CWD is not
+/// the startup directory.
+///
+/// A previous revision of `resolve_library_path()` stripped the leading `/`
+/// from absolute paths, turning them into relative ones. The subsequent
+/// `openat(AT_FDCWD, ...)` then resolved them against the caller's CWD instead
+/// of the filesystem root, silently breaking `dlopen("/lib/foo.so")` for any
+/// caller whose CWD was not the directory the path was anchored against.
+///
+/// The absolute path is derived from the startup CWD rather than hard-coded:
+/// under the linuxd-backed deployments the guest filesystem is the host
+/// filesystem rooted at the daemon's CWD, so a literal `/lib/libmul.so` would
+/// escape to the host root. Building the path from `getcwd()` keeps the test
+/// valid across backends while still exercising the bug, since a stripped
+/// leading `/` would re-anchor the path against the (changed) CWD and fail.
+fn test_dlopen_absolute_path_from_non_root_cwd() -> Result<(), Error> {
+    // Build an absolute path to the library from the startup CWD.
+    let start_cwd: String = unistd::getcwd()?;
+    let absolute: String = format!("{}/{}", start_cwd.trim_end_matches('/'), LIB_PATH);
+
+    // Switch into a non-root directory so that a (buggy) relative resolution
+    // would fail to find the library.
+    unistd::chdir(NON_ROOT_DIR)?;
+
+    // Open the library via its absolute path, restore the CWD, and only then
+    // propagate any error so that later tests always run from the start CWD.
+    let result: Result<DlHandle, Error> = open_library(&absolute);
+    unistd::chdir(&start_cwd)?;
+    let handle: DlHandle = result?;
+
+    close_library(&handle)?;
+    Ok(())
+}
+
+/// Companion to [`test_dlopen_absolute_path_from_non_root_cwd`] that pins down
+/// the relative-path side of the contract.
+///
+/// A path with a directory component (`lib/libmul.so`) bypasses the configured
+/// search paths and is resolved against the caller's CWD, just like on Linux.
+/// From a non-root CWD it must therefore *fail*, proving that the fix keeps
+/// absolute and relative paths distinct rather than papering over the bug by
+/// always falling back to the filesystem root.
+fn test_dlopen_relative_path_from_non_root_cwd() -> Result<(), Error> {
+    // From `<cwd>/lib`, the relative path resolves to `<cwd>/lib/lib/libmul.so`,
+    // which does not exist.
+    let start_cwd: String = unistd::getcwd()?;
+    unistd::chdir(NON_ROOT_DIR)?;
+
+    // Attempt the open, restore the CWD, and only then inspect the result so
+    // that later tests always run from the start CWD.
+    let result: Result<DlHandle, Error> = open_library(LIB_PATH);
+    unistd::chdir(&start_cwd)?;
+
+    // The open must fail; if it unexpectedly succeeded, close the handle to
+    // avoid leaking it before reporting the failure.
+    if let Ok(handle) = result {
+        close_library(&handle)?;
+        panic!("dlopen of a relative path from a non-root CWD should fail");
+    }
+
+    Ok(())
+}
+
 //==================================================================================================
 // Public Interface
 //==================================================================================================
@@ -184,5 +259,7 @@ pub fn run() -> Result<(), Error> {
     test_dlopen_dlclose()?;
     test_dlsym()?;
     test_dladdr()?;
+    test_dlopen_absolute_path_from_non_root_cwd()?;
+    test_dlopen_relative_path_from_non_root_cwd()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

`resolve_library_path` previously normalised every path containing a `/` by stripping a leading `/` along with any `./` prefix, on the theory that this produced a canonical form for the already-loaded-library lookup in `dlopen()`.  In practice that conversion turns an absolute path into a relative one, and the subsequent `openat()` then resolves it against the caller's CWD instead of the filesystem root.

## Reproducer

CPython's `regrtest`, when run on a build where `array` (or any other stdlib extension) is loaded via `dlopen`:

1. `python3 -m test ...` is invoked with `TMPDIR=/tmp`.
2. Each test batch's harness `chdir`s into a scratch directory before importing the test module.
3. The test module does `import array`, which triggers `dlopen("/lib/python3.12/lib-dynload/array.cpython-312.so", ...)`.
4. `resolve_library_path` strips the leading `/` and returns `"lib/python3.12/lib-dynload/array.cpython-312.so"`.
5. `openat(dirfd=AT_FDCWD, pathname=...)` resolves against the scratch directory rather than `/`, fails with `ENOENT`, and the import raises `ImportError: openat() failed`.

The CPython hello smoke test (`python3 -B ./test_hello.py`) accidentally sidesteps the bug because its CWD is still `/` at the point of the failing `import array`, so the stripped relative path happens to resolve correctly.

## Fix

Keep the `./`-stripping (correct — `./foo` and `foo` both produce the same `openat()` call) but stop stripping the leading `/`.  Absolute paths now flow through `dlopen()` exactly as the caller supplied them, matching glibc / musl semantics.

## Validation

Tested end-to-end on a downstream CPython build that loads `array` as a `.so`:

- Before the fix: 26 of 40 `regrtest` batches fail at `import array`.
- After the fix: only test_struct's pre-existing subtest failures remain; every other batch passes import-time.
- Existing `lib/libmul.so` dlfcn tests (which call `dlopen("lib/libmul.so", ...)`) continue to pass — the relative-path code path is unchanged.

## Notes

The already-loaded-library lookup in `dlopen()` still uses string equality on the resolved path, so a caller that opens the same library via `/lib/foo.so` and again via `lib/foo.so` will get two distinct handles instead of being deduplicated.  Matching Linux's inode-based identity here is out of scope for this fix; the regression we are addressing is that the absolute form was being silently broken.
