### PR TITLE
[hostfsd] Follow stat over hostfs paths

### DIFF
--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -170,7 +170,8 @@ impl HostFsHandler {
             | SystemCallMessageHeader::HostFsRmdirRequestPart
             | SystemCallMessageHeader::HostFsSymlinkRequestPart
             | SystemCallMessageHeader::HostFsReadlinkRequestPart
-            | SystemCallMessageHeader::HostFsLstatRequestPart => {
+            | SystemCallMessageHeader::HostFsLstatRequestPart
+            | SystemCallMessageHeader::HostFsPathStatRequestPart => {
                 self.handle_long_part(syscall_msg.header, &syscall_msg.payload)
             },
             // Single-message requests: dispatch inline.
@@ -196,6 +197,7 @@ impl HostFsHandler {
             SystemCallMessageHeader::HostFsFlushRequest => run(self, Self::handle_flush),
             SystemCallMessageHeader::HostFsReadlinkRequest => run(self, Self::handle_readlink),
             SystemCallMessageHeader::HostFsLstatRequest => run(self, Self::handle_lstat),
+            SystemCallMessageHeader::HostFsPathStatRequest => run(self, Self::handle_pathstat),
             other => {
                 log::error!("hostfsd: unexpected message header: {:?}", other);
                 let mut response = [0u8; Message::PAYLOAD_SIZE];
@@ -347,6 +349,18 @@ impl HostFsHandler {
                 } else {
                     log::error!("hostfsd: failed to deserialize long lstat request");
                     set_header(&mut response, SystemCallMessageHeader::HostFsLstatResponse as u16);
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageHeader::HostFsPathStatRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_lstat(&assembled) {
+                    self.handle_long_pathstat(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long pathstat request");
+                    set_header(
+                        &mut response,
+                        SystemCallMessageHeader::HostFsPathStatResponse as u16,
+                    );
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
@@ -656,6 +670,19 @@ impl HostFsHandler {
         self.do_lstat(&req.path, response);
     }
 
+    /// Handles a fully assembled long path-based following STAT request.
+    ///
+    /// Reuses the lstat wire format ([`long_msg::LongLstatRequest`]) because the request
+    /// shape is identical (a single path). The distinguishing behavior is in
+    /// [`Self::do_pathstat`], which follows symbolic links.
+    fn handle_long_pathstat(
+        &mut self,
+        req: long_msg::LongLstatRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        self.do_pathstat(&req.path, response);
+    }
+
     /// Handles an inline single-message READLINK request.
     fn handle_readlink(
         &mut self,
@@ -728,6 +755,48 @@ impl HostFsHandler {
             },
         };
         self.do_lstat(path_str, response);
+    }
+
+    /// Handles an inline single-message path-based following STAT request.
+    ///
+    /// Reuses the [`LstatRequest`] wire format (a single inline path). Unlike
+    /// [`Self::handle_lstat`], the resolution follows symbolic links (see
+    /// [`Self::do_pathstat`]).
+    fn handle_pathstat(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        let req: LstatRequest = match LstatRequest::decode(payload) {
+            Some(r) => r,
+            None => {
+                set_header(response, SystemCallMessageHeader::HostFsPathStatResponse as u16);
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        let path_len: usize = (req.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        let path_str: &str = match core::str::from_utf8(&req.path[..path_len]) {
+            Ok(s) => s,
+            Err(_) => {
+                set_header(response, SystemCallMessageHeader::HostFsPathStatResponse as u16);
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_INVALID,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+        self.do_pathstat(path_str, response);
     }
 
     /// Shared `readlink` implementation used by both the inline and multi-part
@@ -928,6 +997,60 @@ impl HostFsHandler {
         };
 
         match fs::symlink_metadata(&host_path) {
+            Ok(meta) => {
+                let kind: u8 = metadata_kind(&meta);
+                let mode: u32 = metadata_mode(&meta, kind);
+                let resp = LstatResponse {
+                    status: 0,
+                    size: meta.len(),
+                    mode,
+                    kind,
+                };
+                resp.encode(response);
+            },
+            Err(e) => {
+                let err = LstatResponse {
+                    status: io_error_to_code(&e),
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+            },
+        }
+    }
+
+    /// Shared path-based *following* stat implementation used by both the inline and
+    /// multi-part request handlers.
+    ///
+    /// This is the following counterpart to [`Self::do_lstat`]: it resolves the path
+    /// with [`Sandbox::resolve`] (which follows symbolic links within the sandbox) and
+    /// queries [`fs::metadata`] (which follows the final component). It is the host-side
+    /// implementation of a following `fstatat`/`stat(2)` over hostfs.
+    ///
+    /// The response reuses [`LstatResponse`] (identical wire shape: status, size, mode,
+    /// kind) but is tagged with the [`SystemCallMessageHeader::HostFsPathStatResponse`]
+    /// header. Because the final component is followed, [`metadata_kind`] never reports
+    /// [`file_kind::SYMLINK`]: a dangling final link surfaces as the host `ENOENT`, and a
+    /// resolved link reports the target's kind.
+    fn do_pathstat(&mut self, path_str: &str, response: &mut [u8; Message::PAYLOAD_SIZE]) {
+        set_header(response, SystemCallMessageHeader::HostFsPathStatResponse as u16);
+
+        let host_path: PathBuf = match self.sandbox.resolve(path_str) {
+            Some(p) => p,
+            None => {
+                let err = LstatResponse {
+                    status: HOSTFS_ERR_PERMISSION,
+                    size: 0,
+                    mode: 0,
+                    kind: file_kind::OTHER,
+                };
+                err.encode(response);
+                return;
+            },
+        };
+
+        match fs::metadata(&host_path) {
             Ok(meta) => {
                 let kind: u8 = metadata_kind(&meta);
                 let mode: u32 = metadata_mode(&meta, kind);

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -1272,6 +1272,20 @@ fn make_pathstat_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
     )
 }
 
+/// Serializes a long PATHSTAT (following stat) request: `[op_id:4][path_len:2][path:N]`.
+///
+/// Reuses the lstat wire body but tags the parts with the PathStat part header so the
+/// handler dispatches to `handle_long_pathstat` (the multi-part following-stat path).
+fn make_long_pathstat_parts(path: &str, op_id: OperationId) -> Vec<[u8; Message::PAYLOAD_SIZE]> {
+    let path_bytes: &[u8] = path.as_bytes();
+    let path_len: u16 = path_bytes.len() as u16;
+    let mut data: Vec<u8> = Vec::new();
+    data.extend_from_slice(&op_id.to_le_bytes());
+    data.extend_from_slice(&path_len.to_le_bytes());
+    data.extend_from_slice(path_bytes);
+    split_into_parts(SystemCallMessageHeader::HostFsPathStatRequestPart, &data)
+}
+
 /// Builds an inline Readlink request payload.
 fn make_readlink_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
     let req: ReadlinkRequest =
@@ -1496,6 +1510,38 @@ fn test_pathstat_dangling_symlink_fails() {
         r.status, HOSTFS_ERR_NOT_FOUND,
         "following a dangling symlink must surface the target's ENOENT"
     );
+}
+
+#[test]
+fn test_pathstat_long_path_multipart_follows_symlink() {
+    let (mut handler, tmp) = setup();
+    // Use a link name long enough that the request body exceeds the inline limit,
+    // forcing the multi-part assembler / `handle_long_pathstat` dispatch path.
+    let link_name: &str = "long-pathstat-link-name-padding-AAAAAAAAAAAA";
+    assert!(
+        link_name.len() > MAX_INLINE_PATH_LEN,
+        "link name must exceed the inline path limit to exercise the multi-part path"
+    );
+    fs::write(tmp.path().join("target.txt"), b"contents").unwrap();
+    if let Err(e) = host_symlink(std::path::Path::new("target.txt"), &tmp.path().join(link_name)) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let parts = make_long_pathstat_parts(link_name, OperationId::from_raw(77));
+    assert!(parts.len() >= 2, "long pathstat should require multiple parts, got {}", parts.len());
+    let response = feed_parts(&mut handler, &parts);
+    assert_eq!(get_op_id(&response), OperationId::from_raw(77));
+    let r = LstatResponse::decode(&response).expect("decode");
+    assert_eq!(r.status, 0, "long pathstat should succeed");
+    assert_eq!(
+        r.kind,
+        file_kind::REGULAR,
+        "multi-part pathstat must FOLLOW the symlink and report the target's kind"
+    );
+    assert_eq!(r.size, 8, "size should be the target file's size");
 }
 
 #[test]

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -1262,6 +1262,16 @@ fn make_lstat_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
     )
 }
 
+/// Builds an inline path-based following-stat request payload.
+fn make_pathstat_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
+    let req: LstatRequest =
+        LstatRequest::from_path(path.as_bytes()).expect("test path fits in MAX_INLINE_PATH_LEN");
+    req.serialize(
+        SystemCallMessageHeader::HostFsPathStatRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
+}
+
 /// Builds an inline Readlink request payload.
 fn make_readlink_request(path: &str) -> [u8; Message::PAYLOAD_SIZE] {
     let req: ReadlinkRequest =
@@ -1304,6 +1314,22 @@ fn host_symlink(target: &std::path::Path, link: &std::path::Path) -> std::io::Re
     {
         // Use symlink_file by default; tests that need dir links create them explicitly.
         std::os::windows::fs::symlink_file(target, link)
+    }
+}
+
+/// Creates a symbolic link to a directory on the host.
+///
+/// On Windows, directory symlinks are a distinct object type from file symlinks
+/// (`symlink_dir` vs `symlink_file`); using the file variant for a directory target
+/// produces a link the OS will not traverse. On Unix there is a single `symlink(2)`.
+fn host_symlink_dir(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, link)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(target, link)
     }
 }
 
@@ -1372,6 +1398,104 @@ fn test_lstat_symlink_does_not_follow() {
     let r = LstatResponse::decode(&resp).expect("decode");
     assert_eq!(r.status, 0, "lstat should succeed");
     assert_eq!(r.kind, file_kind::SYMLINK, "lstat must NOT follow the symlink");
+}
+
+#[test]
+fn test_pathstat_regular_file() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("file.txt"), b"hello").unwrap();
+    let req = make_pathstat_request("file.txt");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "pathstat should succeed");
+    assert_eq!(r.kind, file_kind::REGULAR);
+    assert_eq!(r.size, 5);
+}
+
+#[test]
+fn test_pathstat_directory() {
+    let (mut handler, tmp) = setup();
+    fs::create_dir(tmp.path().join("dir")).unwrap();
+    let req = make_pathstat_request("dir");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "pathstat should succeed");
+    assert_eq!(r.kind, file_kind::DIRECTORY);
+}
+
+#[test]
+fn test_pathstat_nonexistent_fails() {
+    let (mut handler, _tmp) = setup();
+    let req = make_pathstat_request("missing");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, HOSTFS_ERR_NOT_FOUND);
+}
+
+#[test]
+fn test_pathstat_symlink_follows_to_target() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("target.txt"), b"contents").unwrap();
+    if let Err(e) = host_symlink(std::path::Path::new("target.txt"), &tmp.path().join("link")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_pathstat_request("link");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "pathstat should succeed");
+    assert_eq!(
+        r.kind,
+        file_kind::REGULAR,
+        "pathstat must FOLLOW the symlink and report the target's kind"
+    );
+    assert_eq!(r.size, 8, "size should be the target file's size");
+}
+
+#[test]
+fn test_pathstat_symlink_to_directory_follows() {
+    let (mut handler, tmp) = setup();
+    fs::create_dir(tmp.path().join("realdir")).unwrap();
+    if let Err(e) = host_symlink_dir(std::path::Path::new("realdir"), &tmp.path().join("dlink")) {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_pathstat_request("dlink");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(r.status, 0, "pathstat should succeed");
+    assert_eq!(
+        r.kind,
+        file_kind::DIRECTORY,
+        "pathstat must follow a symlink that points at a directory"
+    );
+}
+
+#[test]
+fn test_pathstat_dangling_symlink_fails() {
+    let (mut handler, tmp) = setup();
+    if let Err(e) =
+        host_symlink(std::path::Path::new("does_not_exist"), &tmp.path().join("dangling"))
+    {
+        if is_privilege_error(&e) {
+            println!("skipping: host cannot create symlinks ({})", e);
+            return;
+        }
+        panic!("host_symlink failed: {}", e);
+    }
+    let req = make_pathstat_request("dangling");
+    let resp = handler.handle_request(&req).expect("response expected");
+    let r = LstatResponse::decode(&resp).expect("decode");
+    assert_eq!(
+        r.status, HOSTFS_ERR_NOT_FOUND,
+        "following a dangling symlink must surface the target's ENOENT"
+    );
 }
 
 #[test]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -260,21 +260,22 @@ pub(crate) fn handle_fstatat_with_hostfs(
     };
 
     if hostfs::is_hostfs_path(final_path) {
-        // Only forward when the caller explicitly requested no-follow semantics. For
-        // following stat (the default for `stat(2)`), there is no path-based stat IKC
-        // yet, so we report `OperationNotSupported` and the caller is expected to use
-        // `fstat` on an already-opened FD.
-        //
-        // TODO(#hostfs-statat-follow): add a path-based following stat operation so
-        // both modes of `fstatat` are supported uniformly over hostfs.
-        if request.flag & ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW == 0 {
-            return Some(vec![build_error(source, ErrorCode::OperationNotSupported)]);
-        }
+        // Both stat modes are supported over hostfs. No-follow (`AT_SYMLINK_NOFOLLOW`)
+        // maps to a path-based lstat; following stat (the default for `stat(2)`) maps to
+        // a path-based following stat. Both reuse the same response wire format
+        // (`LstatResponse`) and completion path (`complete_lstat`); only the host-side
+        // resolution differs (no-follow vs follow of the final component).
+        let no_follow: bool = request.flag & ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW != 0;
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
-        match hostfs::send_lstat_request(final_path, op_id) {
+        let (send_result, kind) = if no_follow {
+            (hostfs::send_lstat_request(final_path, op_id), PendingOpKind::Lstat)
+        } else {
+            (hostfs::send_pathstat_request(final_path, op_id), PendingOpKind::PathStat)
+        };
+        match send_result {
             Ok(()) => {
                 if pending
                     .insert(
@@ -282,7 +283,7 @@ pub(crate) fn handle_fstatat_with_hostfs(
                         PendingOp {
                             source_tid: source,
                             source_pid: None,
-                            kind: PendingOpKind::Lstat,
+                            kind,
                         },
                     )
                     .is_err()

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -452,3 +452,36 @@ pub fn send_lstat_request(path: &str, op_id: OperationId) -> Result<(), ::sys::e
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsLstatRequestPart)
 }
+
+/// Sends a path-based *following* STAT request to hostfsd.
+///
+/// This is the following counterpart to [`send_lstat_request`]: it stats the path after
+/// following any final symbolic link (the default `stat(2)`/`fstatat` semantics). It
+/// reuses the lstat request wire format (path in, [`LstatResponse`] out) and is
+/// distinguished only by the `HostFsPathStat*` headers. Uses the single-message inline
+/// form when the path fits within [`MAX_INLINE_PATH_LEN`], and falls back to a
+/// multi-part request otherwise.
+pub fn send_pathstat_request(
+    path: &str,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path);
+    let path_bytes: &[u8] = relative.as_bytes();
+
+    // Inline fast path: avoids the multi-part assembler when the path fits.
+    if let Some(req) = LstatRequest::from_path(path_bytes) {
+        let payload: [u8; Message::PAYLOAD_SIZE] =
+            req.serialize(SystemCallMessageHeader::HostFsPathStatRequest as u16, op_id);
+        return if send_request(&payload) {
+            Ok(())
+        } else {
+            Err(::sys::error::ErrorCode::IoErr)
+        };
+    }
+
+    // Serialize the multi-part body via hostfs-api (reuses the lstat wire format).
+    let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_lstat_request(op_id, path_bytes)
+        .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageHeader::HostFsPathStatRequestPart)
+}

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -97,6 +97,9 @@ pub(crate) enum PendingOpKind {
     },
     /// lstat — path-based stat that does not follow the final symbolic link.
     Lstat,
+    /// Path-based stat that follows the final symbolic link (default `stat(2)` semantics).
+    /// Shares the `lstat` response wire format and completion path.
+    PathStat,
 }
 
 //==================================================================================================
@@ -307,6 +310,7 @@ pub(crate) fn complete_pending_op(
             complete_readlink(pending.source_tid, response_payload, bufsiz)
         },
         PendingOpKind::Lstat => complete_lstat(pending.source_tid, response_payload),
+        PendingOpKind::PathStat => complete_lstat(pending.source_tid, response_payload),
     }
 }
 
@@ -339,6 +343,7 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Symlink, SystemCallMessageHeader::HostFsSymlinkResponse)
             | (PendingOpKind::Readlink { .. }, SystemCallMessageHeader::HostFsReadlinkResponse)
             | (PendingOpKind::Lstat, SystemCallMessageHeader::HostFsLstatResponse)
+            | (PendingOpKind::PathStat, SystemCallMessageHeader::HostFsPathStatResponse)
     )
 }
 

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -262,6 +262,9 @@ pub enum SystemCallMessageHeader {
     HostFsLstatRequest,
     HostFsLstatRequestPart,
     HostFsLstatResponse,
+    HostFsPathStatRequest,
+    HostFsPathStatRequestPart,
+    HostFsPathStatResponse,
     HostMountRequestPart,
     HostMountResponse,
     HostUmountRequestPart,
@@ -424,6 +427,9 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == HostFsLstatRequest as u16 => Ok(HostFsLstatRequest),
             x if x == HostFsLstatRequestPart as u16 => Ok(HostFsLstatRequestPart),
             x if x == HostFsLstatResponse as u16 => Ok(HostFsLstatResponse),
+            x if x == HostFsPathStatRequest as u16 => Ok(HostFsPathStatRequest),
+            x if x == HostFsPathStatRequestPart as u16 => Ok(HostFsPathStatRequestPart),
+            x if x == HostFsPathStatResponse as u16 => Ok(HostFsPathStatResponse),
             _ => Err(()),
         }
     }
@@ -474,6 +480,9 @@ impl SystemCallMessageHeader {
                 | Self::HostFsLstatRequest
                 | Self::HostFsLstatRequestPart
                 | Self::HostFsLstatResponse
+                | Self::HostFsPathStatRequest
+                | Self::HostFsPathStatRequestPart
+                | Self::HostFsPathStatResponse
         )
     }
 
@@ -511,6 +520,9 @@ impl SystemCallMessageHeader {
             Self::HostFsLstatRequest | Self::HostFsLstatRequestPart => {
                 Some(Self::HostFsLstatResponse)
             },
+            Self::HostFsPathStatRequest | Self::HostFsPathStatRequestPart => {
+                Some(Self::HostFsPathStatResponse)
+            },
             _ => None,
         }
     }
@@ -543,6 +555,7 @@ impl SystemCallMessageHeader {
                 | Self::HostFsSymlinkResponse
                 | Self::HostFsReadlinkResponse
                 | Self::HostFsLstatResponse
+                | Self::HostFsPathStatResponse
         )
     }
 

--- a/src/tests/mount-test/src/symlink_ops.rs
+++ b/src/tests/mount-test/src/symlink_ops.rs
@@ -58,6 +58,7 @@ pub fn test() -> Result<(), Error> {
     // readlink/lstat take the single-message fast path.
     test_symlink_create_readlink()?;
     test_lstat_does_not_follow()?;
+    test_stat_follows_symlink()?;
     test_unlink_removes_symlink_not_target(&target_path)?;
     test_symlink_to_nonexistent_target()?;
 
@@ -107,6 +108,32 @@ fn test_lstat_does_not_follow() -> Result<(), Error> {
         panic!("lstat: expected SymbolicLink, got {:?}", attr.file_type());
     }
     ::syslog::info!("mount-test: [PASS] lstat reports SymbolicLink without following");
+
+    ::syscall::safe::fs::unlink(&link_path)?;
+    Ok(())
+}
+
+/// Tests that `stat` follows a symlink while `lstat` does not, exercising both
+/// hostfs stat paths (following pathstat vs. no-follow lstat) over the same link.
+fn test_stat_follows_symlink() -> Result<(), Error> {
+    let link_path: FileSystemPath = FileSystemPath::new("/mnt/symlink-stat.lnk")?;
+    let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;
+    let _ = ::syscall::safe::fs::unlink(&link_path);
+
+    ::syscall::safe::fs::symlink(&target, &link_path)?;
+
+    // No-follow path: lstat reports the link itself.
+    let lattr = ::syscall::safe::fs::lstat(&link_path)?;
+    if lattr.file_type() != FileType::SymbolicLink {
+        panic!("lstat: expected SymbolicLink, got {:?}", lattr.file_type());
+    }
+
+    // Following path: stat resolves the link and reports the target's type.
+    let sattr = ::syscall::safe::fs::stat(&link_path)?;
+    if sattr.file_type() != FileType::RegularFile {
+        panic!("stat: expected RegularFile (followed target), got {:?}", sattr.file_type());
+    }
+    ::syslog::info!("mount-test: [PASS] stat follows symlink while lstat does not");
 
     ::syscall::safe::fs::unlink(&link_path)?;
     Ok(())

--- a/src/tests/mount-test/src/symlink_ops.rs
+++ b/src/tests/mount-test/src/symlink_ops.rs
@@ -192,11 +192,12 @@ fn test_symlink_to_nonexistent_target() -> Result<(), Error> {
     Ok(())
 }
 
-/// Tests that readlink/lstat work over the multi-part wire format.
+/// Tests that readlink/lstat/stat work over the multi-part wire format.
 ///
 /// Uses a link path whose wire form (after the `/mnt/` prefix is stripped) exceeds
 /// `hostfs_api::MAX_INLINE_PATH_LEN` (36 bytes), so vfsd sends the request through
-/// the multi-part assembler rather than the inline single-message fast path.
+/// the multi-part assembler rather than the inline single-message fast path. This
+/// covers both no-follow (`lstat`) and follow (`stat`) multi-part dispatch paths.
 fn test_long_path_multipart() -> Result<(), Error> {
     // Stripped wire path: "long-symlink-name-padding-AAAAAAAAAAAA.lnk" (42 bytes > 36).
     let link_path: FileSystemPath =
@@ -223,6 +224,17 @@ fn test_long_path_multipart() -> Result<(), Error> {
         panic!("lstat (multi-part request): expected SymbolicLink, got {:?}", attr.file_type());
     }
     ::syslog::info!("mount-test: [PASS] lstat works over multi-part request path");
+
+    // Following stat over the multi-part request path: `stat` must resolve the link
+    // and report the target's type (RegularFile), exercising `handle_long_pathstat`.
+    let sattr = ::syscall::safe::fs::stat(&link_path)?;
+    if sattr.file_type() != FileType::RegularFile {
+        panic!(
+            "stat (multi-part request): expected RegularFile (followed target), got {:?}",
+            sattr.file_type()
+        );
+    }
+    ::syslog::info!("mount-test: [PASS] stat follows symlink over multi-part request path");
 
     ::syscall::safe::fs::unlink(&link_path)?;
     Ok(())


### PR DESCRIPTION
## Summary

Path-based `stat()` / `fstatat()` (without `AT_SYMLINK_NOFOLLOW`) over hostfs paths previously returned `OperationNotSupported`. This adds a path-based **following-stat** operation so that following stat now works over hostfs.

## Details

- The follow branch resolves symlinks within the sandbox and follows the final path component, mirroring the existing `lstat` path but using `metadata()` instead of `symlink_metadata()`.
- The new operation reuses the existing `lstat` wire format (`LstatRequest` / `LongLstatRequest` / `LstatResponse`) and the `lstat` completion path, so only the host-side resolution differs. This keeps the change small and avoids a new response decoder.
- The no-follow branch (`AT_SYMLINK_NOFOLLOW`) is unchanged and continues to use `lstat`.

## Tests

Adds hostfsd unit tests covering: regular files, directories, symlinks to files, symlinks to directories, dangling symlinks (host `ENOENT`), and nonexistent paths.
