### PR TITLE
[hostfsd] List directories over hostfs

### DIFF
--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -672,6 +672,46 @@ fn test_readdir_past_end_returns_empty() {
     assert_eq!(entry.name_len, 0, "expected end-of-directory signal");
 }
 
+#[test]
+fn test_readdir_reports_directory_flag_and_size() {
+    let (mut handler, tmp) = setup();
+    fs::create_dir(tmp.path().join("subdir")).unwrap();
+    fs::write(tmp.path().join("data.bin"), b"hello world").unwrap();
+
+    let fd: i32 = open_file(&mut handler, "/", O_RDONLY | O_DIRECTORY);
+    assert!(fd > 0);
+
+    // Collect every entry, recording the is_dir flag and size reported by hostfsd.
+    // vfsd's getdents conversion (step_getdents) consumes only is_dir to set d_type;
+    // size is exercised here to confirm hostfsd reports it correctly for files.
+    let mut seen: Vec<(String, bool, u64)> = Vec::new();
+    for offset in 0u32..10 {
+        let payload: [u8; Message::PAYLOAD_SIZE] = make_readdir_request_at(fd, offset);
+        let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
+        let entry: ReadDirEntry = ReadDirEntry::decode(&response);
+        if entry.name_len == 0 {
+            break;
+        }
+        let name: String = core::str::from_utf8(&entry.name[..entry.name_len as usize])
+            .expect("valid utf8")
+            .to_string();
+        seen.push((name, entry.is_dir != 0, entry.size));
+    }
+
+    let subdir: &(String, bool, u64) = seen
+        .iter()
+        .find(|(n, _, _)| n == "subdir")
+        .expect("subdir listed");
+    assert!(subdir.1, "subdir should be flagged as a directory");
+
+    let data: &(String, bool, u64) = seen
+        .iter()
+        .find(|(n, _, _)| n == "data.bin")
+        .expect("data.bin listed");
+    assert!(!data.1, "data.bin should not be flagged as a directory");
+    assert_eq!(data.2, 11, "data.bin size should be reported");
+}
+
 //==================================================================================================
 // Tests: Sandbox Security
 //==================================================================================================

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -419,31 +419,78 @@ use alloc::{
 
 /// Handles getdents with hostfs awareness.
 ///
-/// If the FD is backed by hostfs, returns `OperationNotSupported`. Directory listing
-/// over hostfs requires multiple sequential IKC round-trips (one per entry), which
-/// cannot be performed synchronously within the single-message getdents handler without
-/// blocking the event loop.
+/// If the FD is backed by hostfs, the directory listing is served by an async sweep:
+/// hostfsd returns one entry per IKC round-trip, so a single `getdents` call issues
+/// repeated readdir requests (under one op_id) until the requested entry count is
+/// reached or the directory is exhausted. The per-FD iteration cursor is persisted in
+/// the VFS handle so successive `getdents` calls resume where the previous one stopped.
 ///
-/// # Known limitation
+/// # Concurrency
 ///
-/// `getdents` on hostfs-backed file descriptors is not yet supported. This means that
-/// `ls /mnt/` (or any readdir-based directory listing) will fail with
-/// `OperationNotSupported` for paths served by hostfsd. Users must access individual
-/// files by full path.
+/// Like POSIX `readdir`, concurrent directory reads on a *shared* FD are unspecified:
+/// the per-FD cursor advances only when a sweep completes, so two overlapping
+/// `getdents` calls on the same FD may observe duplicated or skipped entries. Programs
+/// must not share a directory FD across threads doing simultaneous reads.
 ///
-/// TODO(#hostfs-getdents): convert getdents into an async multi-step operation via the
-/// pending queue so that `ls /mnt/` works from the guest.
+/// Returns `None` when the request was forwarded to hostfsd (the response is sent later
+/// from the event loop). Non-hostfs FDs fall through to the synchronous VFS handler.
 pub(crate) fn handle_getdents_with_hostfs(
     source: ThreadIdentifier,
     msg: SystemCallMessage,
-) -> Vec<Message> {
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
     let req: GetDirectoryEntriesRequest = GetDirectoryEntriesRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
-    if ::vfs::fd::is_hostfs_fd(fd) {
-        ::syslog::warn!("getdents on hostfs fd {} not supported (use hostfs readdir protocol)", fd);
-        return vec![build_error(source, ErrorCode::OperationNotSupported)];
+
+    if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
+        // Reject getdents on hostfs non-directory FDs (e.g. regular files). The cursor
+        // accessor returns `Some(_)` only for hostfs directory handles, so a `None`
+        // here means the FD is a hostfs file. Fail rather than forward to hostfsd (which
+        // would look like an empty directory). `InvalidDirectory` (ENOTDIR) is the
+        // POSIX-correct error for `getdents` on a non-directory; note this differs from
+        // the non-hostfs FAT path, which surfaces `InvalidArgument` for the same case.
+        let Some(start_offset) = ::vfs::fd::vfs_hostfs_readdir_offset(fd) else {
+            return Some(vec![build_error(source, ErrorCode::InvalidDirectory)]);
+        };
+        let count: usize = req.count as usize;
+        if count == 0 {
+            return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+        }
+        // Do not trust the guest-supplied count: cap it to the protocol maximum so a
+        // malformed request cannot drive an unbounded sweep.
+        if count > GetDirectoryEntriesRequest::MAX_ENTRIES {
+            return Some(vec![build_error(source, ErrorCode::TooBig)]);
+        }
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if hostfs::send_readdir_request(remote_fd, start_offset, op_id).is_err() {
+            return Some(vec![build_error(source, ErrorCode::IoErr)]);
+        }
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    source_tid: source,
+                    source_pid: None,
+                    kind: PendingOpKind::Getdents {
+                        remote_fd,
+                        guest_fd: fd,
+                        next_offset: start_offset,
+                        target_count: count,
+                        entries: alloc::vec::Vec::new(),
+                    },
+                },
+            )
+            .is_err()
+        {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        return None;
     }
-    super::long::handle_getdents(source, msg)
+
+    Some(super::long::handle_getdents(source, msg))
 }
 
 pub(crate) fn handle_openat_with_hostfs(

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -351,6 +351,31 @@ pub fn send_stat_request(
     }
 }
 
+/// Sends a READDIR request to hostfsd for a single directory entry at `offset`.
+///
+/// hostfsd serves directory listings via offset-based iteration, returning one
+/// [`ReadDirEntry`](::hostfs_api::ReadDirEntry) per request (`name_len == 0` signals
+/// end-of-directory). vfsd drives this as an async sweep, issuing one request per
+/// entry until the caller's requested count is satisfied or the directory is exhausted.
+pub fn send_readdir_request(
+    remote_fd: i32,
+    offset: u32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let payload: [u8; Message::PAYLOAD_SIZE] = ::hostfs_api::ReadDirRequest {
+        fd: remote_fd,
+        _reserved: 0,
+        offset,
+    }
+    .serialize(SystemCallMessageHeader::HostFsReadDirRequest as u16, op_id);
+
+    if send_request(&payload) {
+        Ok(())
+    } else {
+        Err(::sys::error::ErrorCode::IoErr)
+    }
+}
+
 /// Sends a RENAME request to hostfsd as a multi-part IKC message.
 pub fn send_rename_request(
     old_path: &str,

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -246,10 +246,12 @@ pub(crate) fn handle_ipc_message(
             }
         },
         SystemCallMessageHeader::GetDirectoryEntriesRequest => {
-            let responses: Vec<Message> =
-                handler::handle_getdents_with_hostfs(source_tid, syscall_msg);
-            for response in responses {
-                send_response(&response);
+            if let Some(responses) =
+                handler::handle_getdents_with_hostfs(source_tid, syscall_msg, pending)
+            {
+                for response in responses {
+                    send_response(&response);
+                }
             }
         },
 

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -280,6 +280,41 @@ pub fn main() {
                         if header.is_hostfs_response() {
                             let op_id: ::hostfs_api::OperationId =
                                 ::hostfs_api::get_op_id(&message.payload);
+                            // Getdents over hostfs is an async sweep: one readdir entry
+                            // per round-trip. Keep the op buffered and re-arm another
+                            // request until the directory is exhausted or the requested
+                            // entry count is reached.
+                            if header == SystemCallMessageHeader::HostFsReadDirResponse {
+                                if let Some(op) = pending.get_mut(op_id) {
+                                    if matches!(op.kind, pending::PendingOpKind::Getdents { .. }) {
+                                        match pending::step_getdents(op, &message.payload) {
+                                            pending::GetdentsStep::Continue {
+                                                remote_fd,
+                                                offset,
+                                            } => {
+                                                if hostfs::send_readdir_request(
+                                                    remote_fd, offset, op_id,
+                                                )
+                                                .is_err()
+                                                {
+                                                    if let Some(op) = pending.remove(op_id) {
+                                                        pending::cancel_pending_op(
+                                                            op,
+                                                            ErrorCode::IoErr,
+                                                        );
+                                                    }
+                                                }
+                                            },
+                                            pending::GetdentsStep::Done => {
+                                                if let Some(op) = pending.remove(op_id) {
+                                                    pending::finish_getdents(op);
+                                                }
+                                            },
+                                        }
+                                        continue;
+                                    }
+                                }
+                            }
                             if let Some(op) = pending.remove(op_id) {
                                 pending::complete_pending_op(op, &message.payload);
                             } else {

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -100,6 +100,24 @@ pub(crate) enum PendingOpKind {
     /// Path-based stat that follows the final symbolic link (default `stat(2)` semantics).
     /// Shares the `lstat` response wire format and completion path.
     PathStat,
+    /// getdents — directory listing over hostfs.
+    ///
+    /// hostfsd returns one entry per IKC round-trip, so a single guest `getdents`
+    /// call is served by an async sweep that issues repeated readdir requests under
+    /// the same op_id until `target_count` entries are collected or the directory is
+    /// exhausted. The accumulated entries are buffered here across round-trips.
+    Getdents {
+        /// Remote (hostfsd) directory file descriptor.
+        remote_fd: i32,
+        /// Guest-visible FD, used to persist the iteration cursor after completion.
+        guest_fd: i32,
+        /// Offset of the next directory entry to request.
+        next_offset: u32,
+        /// Number of entries the guest asked for in this `getdents` call.
+        target_count: usize,
+        /// Entries collected so far in this sweep.
+        entries: ::alloc::vec::Vec<::sysapi::dirent::posix_dent>,
+    },
 }
 
 //==================================================================================================
@@ -213,6 +231,14 @@ impl PendingQueue {
         self.ops.remove(&op_id)
     }
 
+    /// Returns a mutable reference to the pending operation for the given `op_id`.
+    ///
+    /// Used by multi-round-trip operations (e.g. getdents) that mutate buffered state
+    /// in place across IKC responses without removing the op until the sweep completes.
+    pub fn get_mut(&mut self, op_id: OperationId) -> Option<&mut PendingOp> {
+        self.ops.get_mut(&op_id)
+    }
+
     /// Returns true if there are no pending operations.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
@@ -311,6 +337,141 @@ pub(crate) fn complete_pending_op(
         },
         PendingOpKind::Lstat => complete_lstat(pending.source_tid, response_payload),
         PendingOpKind::PathStat => complete_lstat(pending.source_tid, response_payload),
+        PendingOpKind::Getdents { .. } => {
+            // Getdents sweeps are driven entirely by the main event loop, which keeps
+            // the op buffered across round-trips and finalizes it via `finish_getdents`.
+            // Reaching here means a single-shot completion was attempted for a getdents
+            // op, which is a logic error.
+            ::syslog::error!("getdents pending op routed to single-shot completion");
+            send_response(&build_error(pending.source_tid, ErrorCode::IoErr));
+        },
+    }
+}
+
+/// Outcome of advancing a getdents sweep with one hostfs readdir response.
+pub(crate) enum GetdentsStep {
+    /// More entries are required; issue another readdir request for `remote_fd` at `offset`.
+    Continue {
+        /// Remote (hostfsd) directory file descriptor to query.
+        remote_fd: i32,
+        /// Offset of the next directory entry to request.
+        offset: u32,
+    },
+    /// The sweep is complete; call [`finish_getdents`] to send the response.
+    Done,
+}
+
+/// Advances a getdents sweep with a single hostfs readdir response.
+///
+/// Decodes one directory entry from `response_payload` and appends it to the op's
+/// buffer. A zero-length entry name marks end-of-directory. Returns whether another
+/// round-trip is required or the sweep is finished.
+///
+/// # Panics
+///
+/// Panics if `op` is not a [`PendingOpKind::Getdents`]; callers must route only getdents
+/// ops here.
+pub(crate) fn step_getdents(
+    op: &mut PendingOp,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+) -> GetdentsStep {
+    use ::sysapi::{
+        dirent::{
+            dirent_file_type,
+            posix_dent,
+        },
+        limits::NAME_MAX,
+    };
+
+    let PendingOpKind::Getdents {
+        remote_fd,
+        next_offset,
+        target_count,
+        entries,
+        ..
+    } = &mut op.kind
+    else {
+        unreachable!("step_getdents invoked with non-Getdents pending op");
+    };
+
+    let entry: ::hostfs_api::ReadDirEntry = ::hostfs_api::ReadDirEntry::decode(response_payload);
+
+    // A zero-length name marks the end of the directory.
+    if entry.name_len == 0 {
+        return GetdentsStep::Done;
+    }
+
+    // Inline names are bounded by the wire format; clamp to the guest NAME_MAX as well.
+    let name_len: usize = (entry.name_len as usize).min(::hostfs_api::MAX_DIR_ENTRY_NAME_LEN);
+    let copy_len: usize = name_len.min(NAME_MAX);
+
+    let mut dent: posix_dent = posix_dent {
+        // hostfs has no stable inode numbers; use a synthetic 1-based index.
+        d_ino: (*next_offset as u64) + 1,
+        d_reclen: core::mem::size_of::<posix_dent>() as u16,
+        d_type: if entry.is_dir != 0 {
+            dirent_file_type::DT_DIR
+        } else {
+            dirent_file_type::DT_REG
+        },
+        ..posix_dent::default()
+    };
+    dent.d_name[..copy_len].copy_from_slice(&entry.name[..copy_len]);
+    dent.d_name[copy_len] = 0;
+    entries.push(dent);
+
+    *next_offset += 1;
+
+    if entries.len() >= *target_count {
+        GetdentsStep::Done
+    } else {
+        GetdentsStep::Continue {
+            remote_fd: *remote_fd,
+            offset: *next_offset,
+        }
+    }
+}
+
+/// Finalizes a getdents sweep: persists the directory cursor and sends the response.
+///
+/// # Panics
+///
+/// Panics if `op` is not a [`PendingOpKind::Getdents`].
+pub(crate) fn finish_getdents(op: PendingOp) {
+    use ::syscall::{
+        dirent::message::GetDirectoryEntriesResponse,
+        message::MessagePartitioner,
+    };
+
+    let PendingOpKind::Getdents {
+        remote_fd,
+        guest_fd,
+        next_offset,
+        entries,
+        ..
+    } = op.kind
+    else {
+        unreachable!("finish_getdents invoked with non-Getdents pending op");
+    };
+
+    // Persist the iteration cursor so the next getdents call resumes where this left off.
+    // Guard against FD reuse: if the guest FD was closed and re-bound to a different host
+    // file while this sweep was in flight, do not clobber the unrelated handle's cursor.
+    if ::vfs::fd::vfs_hostfs_remote_fd(guest_fd) == Some(remote_fd) {
+        ::vfs::fd::vfs_hostfs_set_readdir_offset(guest_fd, next_offset);
+    }
+
+    let response: GetDirectoryEntriesResponse = GetDirectoryEntriesResponse::new(entries);
+    match response.into_parts(op.source_tid, ProcessIdentifier::VFSD, MessageType::Ipc) {
+        Ok(parts) => {
+            for part in parts {
+                send_response(&part);
+            }
+        },
+        Err(e) => {
+            ::syslog::error!("finish_getdents: into_parts failed (error={:?})", e);
+            send_response(&build_error(op.source_tid, ErrorCode::IoErr));
+        },
     }
 }
 
@@ -344,6 +505,7 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Readlink { .. }, SystemCallMessageHeader::HostFsReadlinkResponse)
             | (PendingOpKind::Lstat, SystemCallMessageHeader::HostFsLstatResponse)
             | (PendingOpKind::PathStat, SystemCallMessageHeader::HostFsPathStatResponse)
+            | (PendingOpKind::Getdents { .. }, SystemCallMessageHeader::HostFsReadDirResponse)
     )
 }
 

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -197,6 +197,12 @@ pub struct HostFsHandle {
     is_dir: bool,
     /// Absolute path used to open this handle (stored only for directories to support dirfd).
     path: Option<String>,
+    /// Next directory entry index to return on the following `getdents` call.
+    ///
+    /// hostfsd serves directory listings via offset-based iteration (one entry per
+    /// `offset`), so vfsd tracks the per-FD cursor here. It advances as entries are
+    /// consumed and is meaningful only for directory handles.
+    readdir_offset: u32,
 }
 
 impl HostFsHandle {
@@ -209,6 +215,7 @@ impl HostFsHandle {
             remote_fd,
             is_dir,
             path: if is_dir { path } else { None },
+            readdir_offset: 0,
         }
     }
 
@@ -225,6 +232,16 @@ impl HostFsHandle {
     /// Returns the path used to open this handle (only available for directories).
     pub fn path(&self) -> Option<&str> {
         self.path.as_deref()
+    }
+
+    /// Returns the current directory iteration cursor.
+    pub fn readdir_offset(&self) -> u32 {
+        self.readdir_offset
+    }
+
+    /// Sets the directory iteration cursor.
+    pub fn set_readdir_offset(&mut self, offset: u32) {
+        self.readdir_offset = offset;
     }
 }
 
@@ -450,6 +467,37 @@ pub fn vfs_hostfs_remote_fd(fd: c_int) -> Option<i32> {
 /// Returns `true` if the given FD is backed by the host filesystem.
 pub fn is_hostfs_fd(fd: c_int) -> bool {
     vfs_hostfs_remote_fd(fd).is_some()
+}
+
+/// Returns the current directory iteration cursor for a hostfs directory FD.
+///
+/// Returns `None` if the FD is not a hostfs directory handle (including hostfs
+/// regular files), so callers can use this to distinguish hostfs directories from
+/// hostfs files.
+pub fn vfs_hostfs_readdir_offset(fd: c_int) -> Option<u32> {
+    let slot: spin::MutexGuard<'_, Option<VfsEntry>> = FD_TABLE.lock(fd).ok()?;
+    let entry: &VfsEntry = slot.as_ref()?;
+    match &entry.handle {
+        VfsFileHandle::HostFs(h) if h.is_dir() => Some(h.readdir_offset()),
+        _ => None,
+    }
+}
+
+/// Updates the directory iteration cursor for a hostfs directory FD.
+///
+/// Returns `true` if the FD is a hostfs directory handle and the cursor was updated.
+/// The cursor is left untouched for non-directory hostfs handles (regular files).
+pub fn vfs_hostfs_set_readdir_offset(fd: c_int, offset: u32) -> bool {
+    let Ok(mut slot) = FD_TABLE.lock(fd) else {
+        return false;
+    };
+    match slot.as_mut().map(|e| &mut e.handle) {
+        Some(VfsFileHandle::HostFs(h)) if h.is_dir() => {
+            h.set_readdir_offset(offset);
+            true
+        },
+        _ => false,
+    }
 }
 
 //==================================================================================================
@@ -1026,8 +1074,10 @@ pub fn vfs_renameat(
     newdirfd: c_int,
     newpath: &str,
 ) -> Result<(), Fat32Error> {
-    let old_resolved: String = vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
-    let new_resolved: String = vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
+    let old_resolved: String =
+        vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
+    let new_resolved: String =
+        vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
     crate::rename(&old_resolved, &new_resolved)
 }
 

--- a/src/tests/mount-test/src/main.rs
+++ b/src/tests/mount-test/src/main.rs
@@ -32,6 +32,7 @@ mod cross_fs;
 mod file_ops;
 mod fs_ops;
 mod mount_lifecycle;
+mod readdir_ops;
 mod symlink_ops;
 
 //==================================================================================================
@@ -61,6 +62,9 @@ pub fn main() -> Result<(), Error> {
 
     // Phase 3.5: Symbolic link operations (symlink, readlink, lstat).
     symlink_ops::test()?;
+
+    // Phase 3.6: Directory listing operations (getdents/readdir sweep).
+    readdir_ops::test()?;
 
     // Phase 4: Cross-filesystem consistency tests (RAMFS vs HostFS).
     cross_fs::test()?;

--- a/src/tests/mount-test/src/readdir_ops.rs
+++ b/src/tests/mount-test/src/readdir_ops.rs
@@ -1,0 +1,262 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Directory listing tests over hostfs: `getdents` (a.k.a. `readdir`).
+//!
+//! These tests drive the guest-visible directory-iteration API over a `/mnt` hostfs mount
+//! and, in doing so, exercise vfsd's asynchronous `getdents` sweep end to end: hostfsd
+//! returns one entry per IKC round-trip, so vfsd issues repeated readdir requests under a
+//! single pending op and persists a per-FD cursor between `getdents` calls (see
+//! `step_getdents`/`finish_getdents` in vfsd). Because vfsd is a `no_std`/`no_main` guest
+//! binary that the build system does not host-unit-test, these integration tests are the
+//! practical coverage for that sweep logic:
+//!
+//! - listing completeness and per-entry type reporting (directory vs. regular file);
+//! - cursor resumption across many single-entry `readdir` calls (no duplicates or skips);
+//! - the multi-entry sweep's "requested count reached" vs. "directory exhausted" exits;
+//! - rejection of `getdents` on a non-directory hostfs FD (ENOTDIR).
+
+use ::core::ffi::CStr;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    dirent::posix_dent,
+    fcntl::{
+        atflags::{
+            AT_FDCWD,
+            AT_REMOVEDIR,
+        },
+        file_access_mode::{
+            O_RDONLY,
+            O_WRONLY,
+        },
+        file_creation_flags::{
+            O_CREAT,
+            O_DIRECTORY,
+            O_TRUNC,
+        },
+    },
+    ffi::c_int,
+    sys_stat::file_mode::{
+        S_IRUSR,
+        S_IRWXU,
+        S_IWUSR,
+    },
+};
+use ::syscall::safe::{
+    dir::{
+        closedir,
+        opendir,
+        readdir,
+        RawDirectory,
+    },
+    FileSystemPath,
+    FileType,
+};
+use alloc::{
+    string::{
+        String,
+        ToString,
+    },
+    vec::Vec,
+};
+
+/// Upper bound on directory-iteration steps before a test gives up.
+///
+/// A correct sweep terminates once the directory is exhausted; this cap turns a
+/// hypothetical non-terminating cursor bug into a clean failure instead of a hang.
+const ITERATION_GUARD: usize = 128;
+
+pub fn test() -> Result<(), Error> {
+    test_list_and_types()?;
+    test_empty_directory()?;
+    test_sweep_count_and_eof()?;
+    test_getdents_on_regular_file_fails()?;
+    Ok(())
+}
+
+/// Creates an empty regular file at `path` over hostfs.
+fn create_file(path: &str) -> Result<(), Error> {
+    let mode: c_int = (S_IRUSR | S_IWUSR) as c_int;
+    let fd: c_int =
+        ::syscall::fcntl::openat(AT_FDCWD, path, O_CREAT | O_WRONLY | O_TRUNC, mode as u32)?;
+    ::syscall::unistd::close(fd)?;
+    Ok(())
+}
+
+/// Extracts the entry name from a `posix_dent`, or `None` if it is not valid UTF-8.
+fn dent_name(dent: &posix_dent) -> Option<String> {
+    let cstr: &CStr = CStr::from_bytes_until_nul(&dent.d_name).ok()?;
+    ::core::str::from_utf8(cstr.to_bytes())
+        .ok()
+        .map(ToString::to_string)
+}
+
+/// Lists a directory and verifies every created entry is reported exactly once with the
+/// correct type.
+///
+/// The guest `readdir` wrapper requests a single entry per `getdents`, so reading the whole
+/// directory drives many cursor-resuming sweeps; a broken cursor would surface here as a
+/// duplicated or missing entry (caught by the exact-count check below).
+fn test_list_and_types() -> Result<(), Error> {
+    let dir: &str = "/mnt/readdir-list";
+    ::syscall::sys::stat::mkdir(dir, S_IRWXU)?;
+    create_file("/mnt/readdir-list/file-a.txt")?;
+    create_file("/mnt/readdir-list/file-b.txt")?;
+    ::syscall::sys::stat::mkdir("/mnt/readdir-list/sub-dir", S_IRWXU)?;
+
+    let dirname: FileSystemPath = FileSystemPath::new(dir)?;
+    let mut handle: RawDirectory = opendir(&dirname)?;
+
+    let mut names: Vec<String> = Vec::new();
+    let mut a_is_file: bool = false;
+    let mut b_is_file: bool = false;
+    let mut sub_is_dir: bool = false;
+    while let Some(entry) = readdir(&mut handle)? {
+        let name: String = entry.file_name()?.to_string();
+        match name.as_str() {
+            "file-a.txt" => a_is_file = entry.file_type() == FileType::RegularFile,
+            "file-b.txt" => b_is_file = entry.file_type() == FileType::RegularFile,
+            "sub-dir" => sub_is_dir = entry.file_type() == FileType::Directory,
+            other => panic!("unexpected entry in {dir}: {other}"),
+        }
+        names.push(name);
+        if names.len() > ITERATION_GUARD {
+            panic!("readdir did not terminate for {dir} (possible cursor bug)");
+        }
+    }
+    closedir(&handle)?;
+
+    // Exactly the three created entries — no `.`/`..`, no duplicates, none skipped.
+    if names.len() != 3 {
+        panic!("expected exactly 3 entries in {dir}, found {}", names.len());
+    }
+    if !a_is_file {
+        panic!("file-a.txt missing or not reported as a regular file");
+    }
+    if !b_is_file {
+        panic!("file-b.txt missing or not reported as a regular file");
+    }
+    if !sub_is_dir {
+        panic!("sub-dir missing or not reported as a directory");
+    }
+    ::syslog::info!("mount-test: [PASS] readdir lists all entries with correct types");
+
+    // Cleanup.
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-list/file-a.txt", 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-list/file-b.txt", 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-list/sub-dir", AT_REMOVEDIR)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, dir, AT_REMOVEDIR)?;
+    Ok(())
+}
+
+/// Verifies that listing an empty directory yields no entries (immediate end-of-directory).
+fn test_empty_directory() -> Result<(), Error> {
+    let dir: &str = "/mnt/readdir-empty";
+    ::syscall::sys::stat::mkdir(dir, S_IRWXU)?;
+
+    let dirname: FileSystemPath = FileSystemPath::new(dir)?;
+    let mut handle: RawDirectory = opendir(&dirname)?;
+    let mut count: usize = 0;
+    while readdir(&mut handle)?.is_some() {
+        count += 1;
+        if count > ITERATION_GUARD {
+            panic!("empty directory {dir} kept yielding entries (possible end-of-dir bug)");
+        }
+    }
+    closedir(&handle)?;
+    if count != 0 {
+        panic!("expected 0 entries in empty {dir}, found {count}");
+    }
+    ::syslog::info!("mount-test: [PASS] readdir on empty directory returns no entries");
+
+    ::syscall::fcntl::unlinkat(AT_FDCWD, dir, AT_REMOVEDIR)?;
+    Ok(())
+}
+
+/// Drives `getdents` directly with a multi-entry count to exercise both sweep exits.
+///
+/// With three entries present, a `count == 2` request stops because the requested count is
+/// reached, the next request stops because the directory is exhausted before the count is
+/// met, and a third request observes immediate end-of-directory. The names gathered across
+/// the non-empty requests must equal the created set with no duplicates, proving the per-FD
+/// cursor resumes correctly between calls.
+fn test_sweep_count_and_eof() -> Result<(), Error> {
+    let dir: &str = "/mnt/readdir-sweep";
+    ::syscall::sys::stat::mkdir(dir, S_IRWXU)?;
+    create_file("/mnt/readdir-sweep/s0")?;
+    create_file("/mnt/readdir-sweep/s1")?;
+    create_file("/mnt/readdir-sweep/s2")?;
+
+    let fd: c_int = ::syscall::fcntl::openat(AT_FDCWD, dir, O_RDONLY | O_DIRECTORY, 0)?;
+
+    // First sweep: capped at 2 → stops on "requested count reached".
+    let first: Vec<posix_dent> = ::syscall::dirent::posix_getdents(fd, 2)?;
+    // Second sweep: only one entry left → stops on "directory exhausted" before count.
+    let second: Vec<posix_dent> = ::syscall::dirent::posix_getdents(fd, 2)?;
+    // Third sweep: cursor already at the end → immediate end-of-directory.
+    let third: Vec<posix_dent> = ::syscall::dirent::posix_getdents(fd, 2)?;
+    ::syscall::unistd::close(fd)?;
+
+    if first.len() != 2 {
+        panic!("expected 2 entries from a count=2 sweep, got {}", first.len());
+    }
+    if second.len() != 1 {
+        panic!("expected 1 trailing entry from the second sweep, got {}", second.len());
+    }
+    if !third.is_empty() {
+        panic!("expected 0 entries past end-of-directory, got {}", third.len());
+    }
+
+    // Names across the two non-empty sweeps must be exactly {s0, s1, s2}, each once.
+    let mut names: Vec<String> = Vec::new();
+    for dent in first.iter().chain(second.iter()) {
+        match dent_name(dent) {
+            Some(name) => names.push(name),
+            None => panic!("getdents returned an entry with an invalid name"),
+        }
+    }
+    for expected in ["s0", "s1", "s2"] {
+        let seen: usize = names.iter().filter(|n| n.as_str() == expected).count();
+        if seen != 1 {
+            panic!("entry {expected} should appear exactly once across sweeps, saw {seen}");
+        }
+    }
+    ::syslog::info!(
+        "mount-test: [PASS] getdents count-reached vs end-of-directory with cursor resumption"
+    );
+
+    // Cleanup.
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-sweep/s0", 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-sweep/s1", 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, "/mnt/readdir-sweep/s2", 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, dir, AT_REMOVEDIR)?;
+    Ok(())
+}
+
+/// Verifies that `getdents` on a hostfs *regular file* FD is rejected with ENOTDIR rather
+/// than being forwarded to hostfsd (which would masquerade as an empty directory).
+fn test_getdents_on_regular_file_fails() -> Result<(), Error> {
+    let path: &str = "/mnt/readdir-not-a-dir.txt";
+    create_file(path)?;
+
+    let fd: c_int = ::syscall::fcntl::openat(AT_FDCWD, path, O_RDONLY, 0)?;
+    let result: Result<Vec<posix_dent>, Error> = ::syscall::dirent::posix_getdents(fd, 4);
+    ::syscall::unistd::close(fd)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, path, 0)?;
+
+    match result {
+        Ok(entries) => {
+            panic!("getdents on a regular file should fail, got {} entries", entries.len());
+        },
+        Err(error) => {
+            if error.code != ErrorCode::InvalidDirectory {
+                panic!("expected InvalidDirectory (ENOTDIR), got {:?}", error.code);
+            }
+        },
+    }
+    ::syslog::info!("mount-test: [PASS] getdents on a regular-file FD is rejected with ENOTDIR");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Directory listing (`getdents` / `readdir`) over hostfs paths previously returned `OperationNotSupported`, so `ls` and any readdir-based traversal failed for host-backed directories. This implements directory listing over hostfs.

## Details

- hostfsd serves directory listings one entry per request via offset-based iteration. A single guest `getdents` call is now served by an **async sweep**: vfsd issues repeated readdir requests under one operation id, accumulating entries until the requested count is reached or the directory is exhausted (a zero-length entry name signals end-of-directory).
- The per-FD iteration cursor is persisted on the VFS handle so successive `getdents` calls resume where the previous one stopped, matching how the local filesystem path tracks its directory cursor.
- The guest-supplied entry count is bounded to the protocol maximum, and the cursor write-back is guarded against FD reuse during an in-flight sweep.

## Concurrency

As with POSIX `readdir`, concurrent directory reads on a *shared* FD are unspecified: the cursor advances only when a sweep completes, so overlapping `getdents` calls on the same FD may observe duplicated or skipped entries. This is documented on the handler.

## Tests

Adds a hostfsd test asserting the directory flag and entry size that the new entry conversion consumes.
