### PR TITLE
[hostfsd] Return full directory entry names over hostfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ version = "0.16.19"
 dependencies = [
  "cc",
  "cfg-if",
+ "hostfs-api",
  "libc_string",
  "nvx",
  "nvx-crt0",

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -1424,42 +1424,130 @@ impl HostFsHandler {
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
         let req: ReadDirRequest = ReadDirRequest::decode(payload);
-        let entry: &mut FdEntry = match self.fd_table.get_mut(req.fd) {
-            Some(e) => e,
+
+        // Copy the entry out of the cache so the mutable borrow of `self.fd_table` is
+        // released before we may need `&mut self` to emit a multi-part response.
+        let cached: Option<(String, bool, u64)> = match self.fd_table.get_mut(req.fd) {
+            Some(entry) => entry
+                .readdir_at(req.offset as usize)
+                .map(|c| (c.name.to_string_lossy().into_owned(), c.is_dir, c.size)),
             None => {
-                // Return empty readdir (name_len=0 signals end).
+                log::warn!("hostfsd: readdir on unknown fd {} (offset={})", req.fd, req.offset);
+                None
+            },
+        };
+
+        let (name, is_dir, size) = match cached {
+            Some(t) => t,
+            None => {
+                // Missing FD or past end of directory: name_len=0 signals end.
                 set_header(response, SystemCallMessageHeader::HostFsReadDirResponse as u16);
                 set_payload_data(response, &[0u8; 2]);
                 return;
             },
         };
 
-        // Use the cached directory listing (populated on first access).
-        if let Some(cached) = entry.readdir_at(req.offset as usize) {
-            let name: String = cached.name.to_string_lossy().into_owned();
-            let name_bytes: &[u8] = name.as_bytes();
-            let name_len: usize = name_bytes.len().min(MAX_DIR_ENTRY_NAME_LEN);
-
-            if name_bytes.len() > MAX_DIR_ENTRY_NAME_LEN {
-                log::warn!("hostfsd: filename truncated in readdir: {:?}", name);
-            }
-
+        let name_bytes: &[u8] = name.as_bytes();
+        if name_bytes.len() <= MAX_DIR_ENTRY_NAME_LEN {
+            // Inline fast path: the name fits in a single response message.
             let mut entry_name: [u8; MAX_DIR_ENTRY_NAME_LEN] = [0u8; MAX_DIR_ENTRY_NAME_LEN];
-            entry_name[..name_len].copy_from_slice(&name_bytes[..name_len]);
+            entry_name[..name_bytes.len()].copy_from_slice(name_bytes);
 
             let resp: ReadDirEntry = ReadDirEntry {
-                name_len: name_len as u16,
-                is_dir: if cached.is_dir { 1 } else { 0 },
-                size: cached.size,
+                name_len: name_bytes.len() as u16,
+                is_dir: if is_dir { 1 } else { 0 },
+                size,
                 name: entry_name,
             };
             resp.encode(response);
             set_header(response, SystemCallMessageHeader::HostFsReadDirResponse as u16);
         } else {
-            // No more entries at this offset.
-            set_header(response, SystemCallMessageHeader::HostFsReadDirResponse as u16);
-            set_payload_data(response, &[0u8; 2]);
+            // Multi-part response: the name exceeds the inline capacity, so emit a
+            // `HostFsReadDirResponsePart` stream carrying the full name.
+            let op_id: OperationId = get_op_id(payload);
+            self.emit_long_readdir_response(response, op_id, is_dir, size, name_bytes);
         }
+    }
+
+    /// Builds a multi-part `HostFsReadDirResponsePart` stream for a directory entry
+    /// whose name exceeds the inline `ReadDirEntry` capacity.
+    ///
+    /// Wire-format details (body layout, per-part framing, chunk size) live in
+    /// [`long_msg::serialize_long_readdir_response`] and
+    /// [`long_msg::chunk_long_response`]. The first chunk is written into
+    /// `first_response`, and the remaining chunks are queued in `extra_responses` for
+    /// the caller to drain via [`Self::take_next_response_part`].
+    ///
+    /// As with the readlink multi-part response, `op_id` is recorded *only* in the
+    /// first 4 bytes of the assembled body; the outer-frame bytes `[2..6]` carry the
+    /// `SystemCallMessagePart` framing, so `set_op_id` is intentionally not applied to
+    /// multi-part responses (see `run` in `handle_request`).
+    fn emit_long_readdir_response(
+        &mut self,
+        first_response: &mut [u8; Message::PAYLOAD_SIZE],
+        op_id: OperationId,
+        is_dir: bool,
+        size: u64,
+        name_bytes: &[u8],
+    ) {
+        let body: Vec<u8> =
+            match long_msg::serialize_long_readdir_response(op_id, is_dir, size, name_bytes) {
+                Some(body) => body,
+                None => {
+                    // Unreachable in practice: host filenames are bounded far below the u16
+                    // name-length limit. Guard against emitting a zeroed (and therefore
+                    // malformed) frame by falling back to a single-message end-of-directory
+                    // marker, so the getdents sweep terminates cleanly instead of leaving the
+                    // caller hung on a frame it cannot parse. The op_id is stamped by the
+                    // caller (`run` in `handle_request`) because this is not a multi-part
+                    // response header.
+                    debug_assert!(
+                        false,
+                        "serialize_long_readdir_response failed: name len {} exceeds wire limit",
+                        name_bytes.len()
+                    );
+                    log::error!(
+                        "hostfsd: readdir entry name ({} bytes) exceeds the wire-format limit; \
+                         ending directory listing early",
+                        name_bytes.len()
+                    );
+                    set_header(
+                        first_response,
+                        SystemCallMessageHeader::HostFsReadDirResponse as u16,
+                    );
+                    set_payload_data(first_response, &[0u8; 2]);
+                    return;
+                },
+            };
+
+        let parts_vec: Vec<[u8; Message::PAYLOAD_SIZE]> = match long_msg::chunk_long_response(
+            SystemCallMessageHeader::HostFsReadDirResponsePart as u16,
+            &body,
+        ) {
+            Some(v) => v,
+            None => {
+                debug_assert!(
+                    false,
+                    "chunk_long_response rejected body of {} bytes (exceeds wire-format limit)",
+                    body.len()
+                );
+                log::error!(
+                    "hostfsd: dropping readdir response body ({} bytes) that exceeds the \
+                     long-response part limit",
+                    body.len()
+                );
+                // Fall back to a well-formed single-message end-of-directory marker so the
+                // caller's getdents sweep terminates cleanly.
+                set_header(first_response, SystemCallMessageHeader::HostFsReadDirResponse as u16);
+                set_payload_data(first_response, &[0u8; 2]);
+                return;
+            },
+        };
+        let mut parts: std::vec::IntoIter<[u8; Message::PAYLOAD_SIZE]> = parts_vec.into_iter();
+        if let Some(first) = parts.next() {
+            *first_response = first;
+        }
+        self.extra_responses.extend(parts);
     }
 
     fn handle_mkdir(

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -712,6 +712,41 @@ fn test_readdir_reports_directory_flag_and_size() {
     assert_eq!(data.2, 11, "data.bin size should be reported");
 }
 
+#[test]
+fn test_readdir_long_name_multipart_response() {
+    let (mut handler, tmp) = setup();
+    // A name longer than the inline `ReadDirEntry` capacity forces the multi-part
+    // response path. Use a name that comfortably exceeds MAX_DIR_ENTRY_NAME_LEN (29).
+    let long_name: String = "l".repeat(180) + ".txt";
+    assert!(long_name.len() > MAX_DIR_ENTRY_NAME_LEN, "test name must exceed the inline cap");
+    fs::write(tmp.path().join(&long_name), b"payload!!").unwrap();
+
+    let fd: i32 = open_file(&mut handler, "/", O_RDONLY | O_DIRECTORY);
+    assert!(fd > 0);
+
+    let payload: [u8; Message::PAYLOAD_SIZE] = make_readdir_request_at(fd, 0);
+    let first: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
+
+    // The entry must be returned as a `HostFsReadDirResponsePart` stream.
+    let header_raw: u16 = u16::from_ne_bytes([first[0], first[1]]);
+    assert_eq!(
+        header_raw,
+        SystemCallMessageHeader::HostFsReadDirResponsePart as u16,
+        "long-name readdir must use the multi-part response header"
+    );
+
+    let body: Vec<u8> = drain_multipart_response(
+        &mut handler,
+        first,
+        SystemCallMessageHeader::HostFsReadDirResponsePart,
+    );
+    let resp = hostfs_api::long_msg::deserialize_long_readdir_response(&body)
+        .expect("readdir long response must deserialize");
+    assert!(!resp.is_dir, "regular file should not be flagged as a directory");
+    assert_eq!(resp.size, 9, "file size should be reported");
+    assert_eq!(resp.name, long_name.as_bytes(), "full name must round-trip");
+}
+
 //==================================================================================================
 // Tests: Sandbox Security
 //==================================================================================================

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -140,6 +140,16 @@ pub fn main() {
         ::hostfs_api::OperationId,
     )> = None;
 
+    // In-flight multi-part hostfs *readdir* response assembler. A directory entry whose
+    // name exceeds the inline `ReadDirEntry` capacity is returned as a stream of
+    // `HostFsReadDirResponsePart` messages. As with the readlink assembler above,
+    // hostfsd's single-threaded worker guarantees at most one multi-part response stream
+    // is in flight at any moment, so a single slot suffices.
+    let mut readdir_response_asm: Option<(
+        ::syscall::message::SystemCallLongMessage,
+        ::hostfs_api::OperationId,
+    )> = None;
+
     // Process any messages that were buffered during the signup phase.
     while let Some(message) = buffered_messages.pop_front() {
         match ipc::handle_ipc_message(message, &mut assemblers, &mut pending) {
@@ -185,96 +195,95 @@ pub fn main() {
                                 ::syscall::message::SystemCallMessagePart::from_bytes(
                                     syscall_msg.payload,
                                 );
-                            // A fresh stream starts at part 0.
-                            if part.part_number == 0 {
-                                if part.payload_size < 4 {
-                                    ::syslog::error!(
-                                        "readlink response part 0 too short to carry op_id \
-                                         (payload_size={})",
-                                        part.payload_size
-                                    );
-                                    continue;
-                                }
-                                let op_id: ::hostfs_api::OperationId =
-                                    ::hostfs_api::OperationId::from_le_bytes([
-                                        part.payload[0],
-                                        part.payload[1],
-                                        part.payload[2],
-                                        part.payload[3],
-                                    ]);
-                                if let Some((_, stale_op_id)) = readlink_response_asm.take() {
+                            if let Some((body, op_id)) = pending::accumulate_response_part(
+                                &mut readlink_response_asm,
+                                &mut pending,
+                                part,
+                                "readlink",
+                            ) {
+                                // op_id is known from part 0; the body still carries it
+                                // in bytes [0..4] for `complete_readlink_long`.
+                                if let Some(op) = pending.remove(op_id) {
+                                    pending::complete_readlink_long(op, &body);
+                                } else {
                                     ::syslog::warn!(
-                                        "discarding incomplete readlink response stream on new \
-                                         part-0 arrival (cancelling stale op_id={})",
-                                        stale_op_id
+                                        "long readlink response with no pending op (op_id={})",
+                                        op_id,
                                     );
-                                    if let Some(op) = pending.remove(stale_op_id) {
-                                        pending::cancel_pending_op(op, ErrorCode::IoErr);
-                                    }
-                                }
-                                let capacity: usize = part.total_parts.max(1) as usize;
-                                match ::syscall::message::SystemCallLongMessage::new(capacity) {
-                                    Ok(asm) => {
-                                        readlink_response_asm = Some((asm, op_id));
-                                    },
-                                    Err(e) => {
-                                        // Allocation failure: cancel the caller now rather
-                                        // than letting the pending op linger until eviction.
-                                        ::syslog::error!(
-                                            "failed to allocate readlink response assembler \
-                                             (op_id={}, capacity={}, error={:?})",
-                                            op_id,
-                                            capacity,
-                                            e
-                                        );
-                                        readlink_response_asm = None;
-                                        if let Some(op) = pending.remove(op_id) {
-                                            pending::cancel_pending_op(op, ErrorCode::IoErr);
-                                        }
-                                        continue;
-                                    },
                                 }
                             }
-                            if let Some((asm, op_id)) = readlink_response_asm.as_mut() {
-                                let op_id_copy: ::hostfs_api::OperationId = *op_id;
-                                if let Err(e) = asm.add_part(part) {
-                                    ::syslog::error!(
-                                        "failed to add readlink response part (op_id={}, \
-                                         error={:?})",
-                                        op_id_copy,
-                                        e
-                                    );
-                                    readlink_response_asm = None;
-                                    if let Some(op) = pending.remove(op_id_copy) {
-                                        pending::cancel_pending_op(op, ErrorCode::IoErr);
-                                    }
-                                    continue;
-                                }
-                                if asm.is_complete() {
-                                    let (asm_done, _) = readlink_response_asm.take().unwrap();
-                                    let mut body: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
-                                    for p in asm_done.take_parts() {
-                                        let n: usize = p.payload_size as usize;
-                                        body.extend_from_slice(&p.payload[..n]);
-                                    }
-                                    // op_id is already known from part 0; the body still
-                                    // carries it in bytes [0..4] for `complete_readlink_long`.
-                                    if let Some(op) = pending.remove(op_id_copy) {
-                                        pending::complete_readlink_long(op, &body);
-                                    } else {
-                                        ::syslog::warn!(
-                                            "long readlink response with no pending op (op_id={})",
-                                            op_id_copy,
-                                        );
-                                    }
-                                }
-                            } else {
-                                let pn: u16 = part.part_number;
-                                ::syslog::warn!(
-                                    "readlink response part received without active assembler \
-                                     (part_number={})",
-                                    pn,
+                            continue;
+                        }
+                        if header == SystemCallMessageHeader::HostFsReadDirResponsePart {
+                            let part: ::syscall::message::SystemCallMessagePart =
+                                ::syscall::message::SystemCallMessagePart::from_bytes(
+                                    syscall_msg.payload,
                                 );
+                            if let Some((body, op_id)) = pending::accumulate_response_part(
+                                &mut readdir_response_asm,
+                                &mut pending,
+                                part,
+                                "readdir",
+                            ) {
+                                // Decode the long directory entry and fold it into the
+                                // in-progress getdents sweep, then advance the sweep
+                                // (request the next entry or send the final response).
+                                let decoded =
+                                    ::hostfs_api::long_msg::deserialize_long_readdir_response(
+                                        &body,
+                                    );
+                                let step: Option<pending::GetdentsStep> =
+                                    match (decoded, pending.get_mut(op_id)) {
+                                        (Some(entry), Some(op))
+                                            if matches!(
+                                                op.kind,
+                                                pending::PendingOpKind::Getdents { .. }
+                                            ) =>
+                                        {
+                                            Some(pending::push_getdents_entry(
+                                                op,
+                                                entry.name,
+                                                entry.is_dir,
+                                            ))
+                                        },
+                                        (None, _) => {
+                                            ::syslog::error!(
+                                                "failed to deserialize long readdir response \
+                                                 (op_id={}, body_len={})",
+                                                op_id,
+                                                body.len(),
+                                            );
+                                            if let Some(op) = pending.remove(op_id) {
+                                                pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                            }
+                                            None
+                                        },
+                                        (Some(_), Some(_)) => {
+                                            // Deserialized cleanly, but the buffered op is
+                                            // not a getdents sweep — a protocol desync. Fail
+                                            // the caller now rather than leaving it hung.
+                                            ::syslog::error!(
+                                                "long readdir response for non-getdents op \
+                                                 (op_id={})",
+                                                op_id,
+                                            );
+                                            if let Some(op) = pending.remove(op_id) {
+                                                pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                            }
+                                            None
+                                        },
+                                        (Some(_), None) => {
+                                            ::syslog::warn!(
+                                                "long readdir response with no matching getdents \
+                                                 op (op_id={})",
+                                                op_id,
+                                            );
+                                            None
+                                        },
+                                    };
+                                if let Some(step) = step {
+                                    pending::drive_getdents(&mut pending, op_id, step);
+                                }
                             }
                             continue;
                         }
@@ -286,34 +295,21 @@ pub fn main() {
                             // request until the directory is exhausted or the requested
                             // entry count is reached.
                             if header == SystemCallMessageHeader::HostFsReadDirResponse {
-                                if let Some(op) = pending.get_mut(op_id) {
-                                    if matches!(op.kind, pending::PendingOpKind::Getdents { .. }) {
-                                        match pending::step_getdents(op, &message.payload) {
-                                            pending::GetdentsStep::Continue {
-                                                remote_fd,
-                                                offset,
-                                            } => {
-                                                if hostfs::send_readdir_request(
-                                                    remote_fd, offset, op_id,
-                                                )
-                                                .is_err()
-                                                {
-                                                    if let Some(op) = pending.remove(op_id) {
-                                                        pending::cancel_pending_op(
-                                                            op,
-                                                            ErrorCode::IoErr,
-                                                        );
-                                                    }
-                                                }
-                                            },
-                                            pending::GetdentsStep::Done => {
-                                                if let Some(op) = pending.remove(op_id) {
-                                                    pending::finish_getdents(op);
-                                                }
-                                            },
-                                        }
-                                        continue;
-                                    }
+                                let step: Option<pending::GetdentsStep> =
+                                    match pending.get_mut(op_id) {
+                                        Some(op)
+                                            if matches!(
+                                                op.kind,
+                                                pending::PendingOpKind::Getdents { .. }
+                                            ) =>
+                                        {
+                                            Some(pending::step_getdents(op, &message.payload))
+                                        },
+                                        _ => None,
+                                    };
+                                if let Some(step) = step {
+                                    pending::drive_getdents(&mut pending, op_id, step);
+                                    continue;
                                 }
                             }
                             if let Some(op) = pending.remove(op_id) {

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -361,20 +361,17 @@ pub(crate) enum GetdentsStep {
     Done,
 }
 
-/// Advances a getdents sweep with a single hostfs readdir response.
+/// Appends one directory entry to a getdents sweep and reports whether the sweep is done.
 ///
-/// Decodes one directory entry from `response_payload` and appends it to the op's
-/// buffer. A zero-length entry name marks end-of-directory. Returns whether another
-/// round-trip is required or the sweep is finished.
+/// Shared by the inline ([`step_getdents`]) and multi-part long-name readdir paths.
+/// `name` is the raw entry name (already extracted from whichever wire form delivered
+/// it). Names longer than the guest `NAME_MAX` cannot be represented in a `posix_dent`,
+/// so they are clamped (and a warning is logged) rather than corrupting the buffer.
 ///
 /// # Panics
 ///
-/// Panics if `op` is not a [`PendingOpKind::Getdents`]; callers must route only getdents
-/// ops here.
-pub(crate) fn step_getdents(
-    op: &mut PendingOp,
-    response_payload: &[u8; Message::PAYLOAD_SIZE],
-) -> GetdentsStep {
+/// Panics if `op` is not a [`PendingOpKind::Getdents`].
+pub(crate) fn push_getdents_entry(op: &mut PendingOp, name: &[u8], is_dir: bool) -> GetdentsStep {
     use ::sysapi::{
         dirent::{
             dirent_file_type,
@@ -391,32 +388,30 @@ pub(crate) fn step_getdents(
         ..
     } = &mut op.kind
     else {
-        unreachable!("step_getdents invoked with non-Getdents pending op");
+        unreachable!("push_getdents_entry invoked with non-Getdents pending op");
     };
 
-    let entry: ::hostfs_api::ReadDirEntry = ::hostfs_api::ReadDirEntry::decode(response_payload);
-
-    // A zero-length name marks the end of the directory.
-    if entry.name_len == 0 {
-        return GetdentsStep::Done;
+    let copy_len: usize = name.len().min(NAME_MAX);
+    if name.len() > NAME_MAX {
+        ::syslog::warn!(
+            "getdents: directory entry name exceeds NAME_MAX ({} > {}), clamping",
+            name.len(),
+            NAME_MAX
+        );
     }
-
-    // Inline names are bounded by the wire format; clamp to the guest NAME_MAX as well.
-    let name_len: usize = (entry.name_len as usize).min(::hostfs_api::MAX_DIR_ENTRY_NAME_LEN);
-    let copy_len: usize = name_len.min(NAME_MAX);
 
     let mut dent: posix_dent = posix_dent {
         // hostfs has no stable inode numbers; use a synthetic 1-based index.
         d_ino: (*next_offset as u64) + 1,
         d_reclen: core::mem::size_of::<posix_dent>() as u16,
-        d_type: if entry.is_dir != 0 {
+        d_type: if is_dir {
             dirent_file_type::DT_DIR
         } else {
             dirent_file_type::DT_REG
         },
         ..posix_dent::default()
     };
-    dent.d_name[..copy_len].copy_from_slice(&entry.name[..copy_len]);
+    dent.d_name[..copy_len].copy_from_slice(&name[..copy_len]);
     dent.d_name[copy_len] = 0;
     entries.push(dent);
 
@@ -430,6 +425,32 @@ pub(crate) fn step_getdents(
             offset: *next_offset,
         }
     }
+}
+
+/// Advances a getdents sweep with a single inline hostfs readdir response.
+///
+/// Decodes one directory entry from `response_payload` and appends it to the op's
+/// buffer. A zero-length entry name marks end-of-directory. Returns whether another
+/// round-trip is required or the sweep is finished. Long entry names are delivered via
+/// a multi-part stream and handled separately (see [`push_getdents_entry`]).
+///
+/// # Panics
+///
+/// Panics if `op` is not a [`PendingOpKind::Getdents`]; callers must route only getdents
+/// ops here.
+pub(crate) fn step_getdents(
+    op: &mut PendingOp,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+) -> GetdentsStep {
+    let entry: ::hostfs_api::ReadDirEntry = ::hostfs_api::ReadDirEntry::decode(response_payload);
+
+    // A zero-length name marks the end of the directory.
+    if entry.name_len == 0 {
+        return GetdentsStep::Done;
+    }
+
+    let name_len: usize = (entry.name_len as usize).min(::hostfs_api::MAX_DIR_ENTRY_NAME_LEN);
+    push_getdents_entry(op, &entry.name[..name_len], entry.is_dir != 0)
 }
 
 /// Finalizes a getdents sweep: persists the directory cursor and sends the response.
@@ -472,6 +493,149 @@ pub(crate) fn finish_getdents(op: PendingOp) {
             ::syslog::error!("finish_getdents: into_parts failed (error={:?})", e);
             send_response(&build_error(op.source_tid, ErrorCode::IoErr));
         },
+    }
+}
+
+/// Drives a getdents sweep forward after an entry (or end-of-directory) was processed.
+///
+/// On [`GetdentsStep::Continue`], issues the next readdir request reusing `op_id` and
+/// leaves the pending op buffered for the next response. On [`GetdentsStep::Done`],
+/// removes the op and sends the assembled directory listing. If issuing the next
+/// request fails, the pending op is cancelled so the caller is not left blocked.
+pub(crate) fn drive_getdents(queue: &mut PendingQueue, op_id: OperationId, step: GetdentsStep) {
+    match step {
+        GetdentsStep::Continue { remote_fd, offset } => {
+            if let Err(e) = crate::hostfs::send_readdir_request(remote_fd, offset, op_id) {
+                ::syslog::error!(
+                    "drive_getdents: send_readdir_request failed (op_id={}, remote_fd={}, \
+                     offset={}, error={:?})",
+                    op_id,
+                    remote_fd,
+                    offset,
+                    e
+                );
+                if let Some(op) = queue.remove(op_id) {
+                    cancel_pending_op(op, ErrorCode::IoErr);
+                }
+            }
+        },
+        GetdentsStep::Done => {
+            if let Some(op) = queue.remove(op_id) {
+                finish_getdents(op);
+            }
+        },
+    }
+}
+
+/// Accumulates one part of a multi-part hostfs *response* stream into `slot`.
+///
+/// Shared by the long-target `readlink` and long-name `readdir` response paths, which
+/// use identical framing: part 0 carries the op_id in its first 4 bytes, and the
+/// assembled body is the concatenation of every part's payload. `label` names the
+/// stream in log messages (e.g. `"readlink"`).
+///
+/// `slot` holds the single in-flight assembler (hostfsd's single-threaded worker
+/// guarantees at most one stream is in flight at a time). On a fresh
+/// `part_number == 0`, any incomplete stream already in `slot` is discarded and its
+/// pending op cancelled. Allocation or `add_part` failures also cancel the pending op
+/// and clear `slot`.
+///
+/// Returns `Some((body, op_id))` once the stream is complete and ready for dispatch,
+/// or `None` when more parts are required or the part was dropped (all error handling,
+/// including pending-op cancellation, is performed internally).
+pub(crate) fn accumulate_response_part(
+    slot: &mut Option<(::syscall::message::SystemCallLongMessage, OperationId)>,
+    queue: &mut PendingQueue,
+    part: ::syscall::message::SystemCallMessagePart,
+    label: &str,
+) -> Option<(::alloc::vec::Vec<u8>, OperationId)> {
+    // A fresh stream starts at part 0: validate, extract the op_id, drop any stale
+    // stream, and allocate the assembler.
+    if part.part_number == 0 {
+        if (part.payload_size as usize) < OperationId::SERIALIZED_SIZE {
+            ::syslog::error!(
+                "{} response part 0 too short to carry op_id (payload_size={})",
+                label,
+                part.payload_size
+            );
+            return None;
+        }
+        let op_id: OperationId = OperationId::from_le_bytes([
+            part.payload[0],
+            part.payload[1],
+            part.payload[2],
+            part.payload[3],
+        ]);
+        if let Some((_, stale_op_id)) = slot.take() {
+            ::syslog::warn!(
+                "discarding incomplete {} response stream on new part-0 arrival (cancelling stale \
+                 op_id={})",
+                label,
+                stale_op_id
+            );
+            if let Some(op) = queue.remove(stale_op_id) {
+                cancel_pending_op(op, ErrorCode::IoErr);
+            }
+        }
+        let capacity: usize = part.total_parts.max(1) as usize;
+        match ::syscall::message::SystemCallLongMessage::new(capacity) {
+            Ok(asm) => {
+                *slot = Some((asm, op_id));
+            },
+            Err(e) => {
+                // Allocation failure: cancel the caller now rather than letting the
+                // pending op linger until eviction.
+                ::syslog::error!(
+                    "failed to allocate {} response assembler (op_id={}, capacity={}, error={:?})",
+                    label,
+                    op_id,
+                    capacity,
+                    e
+                );
+                *slot = None;
+                if let Some(op) = queue.remove(op_id) {
+                    cancel_pending_op(op, ErrorCode::IoErr);
+                }
+                return None;
+            },
+        }
+    }
+
+    if let Some((asm, op_id)) = slot.as_mut() {
+        let op_id_copy: OperationId = *op_id;
+        if let Err(e) = asm.add_part(part) {
+            ::syslog::error!(
+                "failed to add {} response part (op_id={}, error={:?})",
+                label,
+                op_id_copy,
+                e
+            );
+            *slot = None;
+            if let Some(op) = queue.remove(op_id_copy) {
+                cancel_pending_op(op, ErrorCode::IoErr);
+            }
+            return None;
+        }
+        if asm.is_complete() {
+            let (asm_done, _) = slot.take().unwrap();
+            let mut body: ::alloc::vec::Vec<u8> = ::alloc::vec::Vec::new();
+            for p in asm_done.take_parts() {
+                let n: usize = p.payload_size as usize;
+                body.extend_from_slice(&p.payload[..n]);
+            }
+            return Some((body, op_id_copy));
+        }
+        None
+    } else {
+        // Copy the field out of the packed `SystemCallMessagePart` before logging:
+        // taking a reference to a misaligned packed field is undefined behavior.
+        let pn: u16 = part.part_number;
+        ::syslog::warn!(
+            "{} response part received without active assembler (part_number={})",
+            label,
+            pn
+        );
+        None
     }
 }
 

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -116,6 +116,12 @@ impl OperationId {
     /// collide with any live operation.
     pub const INVALID: Self = Self(u32::MAX);
 
+    /// Size in bytes of the little-endian wire representation of an `OperationId`.
+    ///
+    /// Matches the length of the array produced by [`to_le_bytes`](Self::to_le_bytes)
+    /// and consumed by [`from_le_bytes`](Self::from_le_bytes).
+    pub const SERIALIZED_SIZE: usize = core::mem::size_of::<u32>();
+
     /// Creates a new operation identifier from a raw `u32` value.
     ///
     /// This is crate-internal: only [`get_op_id`] and [`OperationIdAllocator`] should

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -33,6 +33,12 @@
 //!   response capacity. Errors are always reported via the single-message
 //!   `HostFsReadlinkResponse` form; the multi-part response is only emitted for a
 //!   successful `readlink` whose target does not fit inline.
+//! - **ReadDir response**: `[op_id:4][is_dir:1][size:8][name_len:2][name:N]`. Used by
+//!   `HostFsReadDirResponsePart` messages when a directory entry name exceeds the
+//!   inline `ReadDirEntry` name capacity. The single-message `HostFsReadDirResponse`
+//!   form (one inline entry, `name_len == 0` signalling end-of-directory) continues to
+//!   carry short names and the end marker; the multi-part response is only emitted for
+//!   a single entry whose name does not fit inline.
 
 extern crate alloc;
 
@@ -76,6 +82,10 @@ pub const LSTAT_HEADER_SIZE: usize = 6;
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
 pub const READLINK_RESPONSE_HEADER_SIZE: usize = 10;
+
+/// Header size for the long ReadDir *response* body:
+/// `op_id(4) + is_dir(1) + size(8) + name_len(2) = 15`.
+pub const READDIR_RESPONSE_HEADER_SIZE: usize = 15;
 
 /// Maximum number of body bytes that can be carried by a single multi-part
 /// long-response message.
@@ -242,6 +252,73 @@ pub fn serialize_long_readlink_response(
     buf.extend_from_slice(&target_len.to_le_bytes());
     buf.extend_from_slice(target);
     Some(buf)
+}
+
+/// Result of deserializing the body of a long READDIR *response*.
+///
+/// The `name` field borrows directly from the input buffer; no allocation is
+/// performed, making the helper usable from `no_std` callers (e.g., vfsd).
+pub struct LongReaddirResponse<'a> {
+    /// Operation identifier echoed by hostfsd. Matches the request's `op_id`.
+    pub op_id: crate::OperationId,
+    /// Whether the entry is a directory.
+    pub is_dir: bool,
+    /// File size in bytes.
+    pub size: u64,
+    /// Entry name bytes, exactly `name_len` long.
+    pub name: &'a [u8],
+}
+
+/// Serializes the body of a long READDIR *response*.
+///
+/// Wire format: `[op_id:4][is_dir:1][size:8][name_len:2][name:N]` (see
+/// [`READDIR_RESPONSE_HEADER_SIZE`]). This is the inverse of
+/// [`deserialize_long_readdir_response`]. Returns `None` if `name` is longer than
+/// [`MAX_PATH_LEN`] (the `u16` name-length field cannot represent it).
+pub fn serialize_long_readdir_response(
+    op_id: OperationId,
+    is_dir: bool,
+    size: u64,
+    name: &[u8],
+) -> Option<Vec<u8>> {
+    let name_len: u16 = u16::try_from(name.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(READDIR_RESPONSE_HEADER_SIZE + name.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.push(if is_dir { 1 } else { 0 });
+    buf.extend_from_slice(&size.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(name);
+    Some(buf)
+}
+
+/// Deserializes the body of a long READDIR response.
+///
+/// `bytes` is the assembled body in wire format
+/// `[op_id:4][is_dir:1][size:8][name_len:2][name:N]`. Returns `None` if the buffer is
+/// shorter than the declared header, or if the declared `name_len` exceeds the
+/// remainder of the buffer.
+pub fn deserialize_long_readdir_response(bytes: &[u8]) -> Option<LongReaddirResponse<'_>> {
+    if bytes.len() < READDIR_RESPONSE_HEADER_SIZE {
+        return None;
+    }
+    let op_id: crate::OperationId =
+        crate::OperationId::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let is_dir: bool = bytes[4] != 0;
+    let size: u64 = u64::from_le_bytes([
+        bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12],
+    ]);
+    let name_len: usize = u16::from_le_bytes([bytes[13], bytes[14]]) as usize;
+    let name_start: usize = READDIR_RESPONSE_HEADER_SIZE;
+    let name_end: usize = name_start.checked_add(name_len)?;
+    if bytes.len() < name_end {
+        return None;
+    }
+    Some(LongReaddirResponse {
+        op_id,
+        is_dir,
+        size,
+        name: &bytes[name_start..name_end],
+    })
 }
 
 //==================================================================================================

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -269,6 +269,10 @@ pub enum SystemCallMessageHeader {
     HostMountResponse,
     HostUmountRequestPart,
     HostUmountResponse,
+    // New variants must be appended here to preserve the on-the-wire discriminant
+    // values of existing variants (this enum is `#[repr(u16)]` with implicit,
+    // sequential discriminants used directly as IPC/IKC message tags).
+    HostFsReadDirResponsePart,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -399,6 +403,7 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == HostFsStatResponse as u16 => Ok(HostFsStatResponse),
             x if x == HostFsReadDirRequest as u16 => Ok(HostFsReadDirRequest),
             x if x == HostFsReadDirResponse as u16 => Ok(HostFsReadDirResponse),
+            x if x == HostFsReadDirResponsePart as u16 => Ok(HostFsReadDirResponsePart),
             x if x == HostFsMkdirRequest as u16 => Ok(HostFsMkdirRequest),
             x if x == HostFsMkdirResponse as u16 => Ok(HostFsMkdirResponse),
             x if x == HostFsRmdirRequest as u16 => Ok(HostFsRmdirRequest),
@@ -452,6 +457,7 @@ impl SystemCallMessageHeader {
                 | Self::HostFsStatResponse
                 | Self::HostFsReadDirRequest
                 | Self::HostFsReadDirResponse
+                | Self::HostFsReadDirResponsePart
                 | Self::HostFsMkdirRequest
                 | Self::HostFsMkdirResponse
                 | Self::HostFsRmdirRequest
@@ -529,13 +535,14 @@ impl SystemCallMessageHeader {
 
     /// Returns `true` if this header is a hostfs response variant.
     ///
-    /// Note: `HostFsReadlinkResponsePart` is intentionally excluded because of its
-    /// framing, not because vfsd lacks a multi-part assembler (it now has one). For
-    /// these parts, bytes `[2..6]` carry `total_parts`/`part_number`, while the
-    /// logical op_id lives in the first 4 bytes of the assembled body. Treating
-    /// them as regular hostfs responses would make `get_op_id` read the framing
-    /// bytes and remove the wrong entry from the pending queue. They are dispatched
-    /// through `is_hostfs_multipart_response` and the dedicated assembler in vfsd.
+    /// Note: `HostFsReadlinkResponsePart` and `HostFsReadDirResponsePart` are
+    /// intentionally excluded because of their framing, not because vfsd lacks a
+    /// multi-part assembler (it now has one). For these parts, bytes `[2..6]` carry
+    /// `total_parts`/`part_number`, while the logical op_id lives in the first 4 bytes
+    /// of the assembled body. Treating them as regular hostfs responses would make
+    /// `get_op_id` read the framing bytes and remove the wrong entry from the pending
+    /// queue. They are dispatched through `is_hostfs_multipart_response` and the
+    /// dedicated assemblers in vfsd.
     pub fn is_hostfs_response(&self) -> bool {
         matches!(
             self,
@@ -561,7 +568,7 @@ impl SystemCallMessageHeader {
 
     /// Returns `true` if this header represents a *part* of a multi-part hostfs *response* stream.
     pub fn is_hostfs_multipart_response(&self) -> bool {
-        matches!(self, Self::HostFsReadlinkResponsePart)
+        matches!(self, Self::HostFsReadlinkResponsePart | Self::HostFsReadDirResponsePart)
     }
 }
 

--- a/src/tests/mount-test/Cargo.toml
+++ b/src/tests/mount-test/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 name = "mount-test"
 
 [dependencies]
+hostfs-api = { workspace = true }
 libc_string = { workspace = true }
 nvx = { workspace = true }
 nvx-crt0 = { workspace = true, features = ["rust-main", "provides-allocator"] }

--- a/src/tests/mount-test/src/readdir_ops.rs
+++ b/src/tests/mount-test/src/readdir_ops.rs
@@ -14,7 +14,9 @@
 //! - listing completeness and per-entry type reporting (directory vs. regular file);
 //! - cursor resumption across many single-entry `readdir` calls (no duplicates or skips);
 //! - the multi-entry sweep's "requested count reached" vs. "directory exhausted" exits;
-//! - rejection of `getdents` on a non-directory hostfs FD (ENOTDIR).
+//! - rejection of `getdents` on a non-directory hostfs FD (ENOTDIR);
+//! - full round-trip of entry names that exceed the inline `ReadDirEntry` capacity,
+//!   delivered via the multi-part long-name response path (this change's core fix).
 
 use ::core::ffi::CStr;
 use ::sys::error::{
@@ -56,6 +58,7 @@ use ::syscall::safe::{
     FileType,
 };
 use alloc::{
+    format,
     string::{
         String,
         ToString,
@@ -71,6 +74,7 @@ const ITERATION_GUARD: usize = 128;
 
 pub fn test() -> Result<(), Error> {
     test_list_and_types()?;
+    test_long_names()?;
     test_empty_directory()?;
     test_sweep_count_and_eof()?;
     test_getdents_on_regular_file_fails()?;
@@ -92,6 +96,96 @@ fn dent_name(dent: &posix_dent) -> Option<String> {
     ::core::str::from_utf8(cstr.to_bytes())
         .ok()
         .map(ToString::to_string)
+}
+
+/// Largest entry name that still fits in the inline `ReadDirEntry` name field.
+///
+/// Entries up to this length use the single-message readdir fast path, while longer ones
+/// are delivered via the multi-part `HostFsReadDirResponsePart` stream that this change
+/// adds.
+const INLINE_NAME_CAP: usize = ::hostfs_api::MAX_DIR_ENTRY_NAME_LEN;
+
+/// Asserts that `listing` contains exactly one entry equal to `name` with the `expected`
+/// type.
+///
+/// Matching on the full string is the round-trip check: a name truncated to the inline cap
+/// (the pre-change behavior) would no longer compare equal and would surface here as a
+/// missing entry.
+fn expect_entry(listing: &[(String, FileType)], name: &str, expected: FileType) {
+    let mut found: usize = 0;
+    let mut type_ok: bool = false;
+    for (entry_name, entry_type) in listing {
+        if entry_name == name {
+            found += 1;
+            type_ok = *entry_type == expected;
+        }
+    }
+    if found != 1 {
+        panic!("expected exactly one entry of length {}, found {found}", name.len());
+    }
+    if !type_ok {
+        panic!("entry of length {} reported the wrong file type", name.len());
+    }
+}
+
+/// Lists a directory whose entries have names longer than the inline `ReadDirEntry`
+/// capacity and verifies that the full names round-trip with the correct type.
+///
+/// This is the core behavior this change adds: an entry whose name exceeds
+/// `INLINE_NAME_CAP` (29 bytes) is returned as a multi-part `HostFsReadDirResponsePart`
+/// stream carrying the complete name, instead of being truncated to the inline field. vfsd
+/// reassembles each long entry and folds it into the in-progress getdents sweep, so a
+/// regression (a truncated or corrupted name, or a dropped entry) surfaces here as a name
+/// that fails to compare equal to the one created. A short name in the same directory keeps
+/// the single-message fast path, so listing the mix also proves the two paths coexist
+/// within one sweep. Distinct fill characters per name keep any truncated form from
+/// accidentally matching another entry.
+fn test_long_names() -> Result<(), Error> {
+    let dir: &str = "/mnt/readdir-longnames";
+    ::syscall::sys::stat::mkdir(dir, S_IRWXU)?;
+
+    // Largest name that still fits inline — exercises the single-message boundary.
+    let inline_max: String = "i".repeat(INLINE_NAME_CAP);
+    // One byte over the inline cap — the smallest name that needs the multi-part path.
+    let over_by_one: String = "o".repeat(INLINE_NAME_CAP + 1);
+    // A long file name spanning several response parts (well beyond one chunk).
+    let long_file: String = "f".repeat(184);
+    // A long *directory* name — verifies the entry type survives the multi-part path.
+    let long_dir: String = "d".repeat(120);
+
+    create_file(&format!("{dir}/{inline_max}"))?;
+    create_file(&format!("{dir}/{over_by_one}"))?;
+    create_file(&format!("{dir}/{long_file}"))?;
+    ::syscall::sys::stat::mkdir(&format!("{dir}/{long_dir}"), S_IRWXU)?;
+
+    let dirname: FileSystemPath = FileSystemPath::new(dir)?;
+    let mut handle: RawDirectory = opendir(&dirname)?;
+    let mut listing: Vec<(String, FileType)> = Vec::new();
+    while let Some(entry) = readdir(&mut handle)? {
+        listing.push((entry.file_name()?.to_string(), entry.file_type()));
+        if listing.len() > ITERATION_GUARD {
+            panic!("readdir did not terminate for {dir} (possible cursor bug)");
+        }
+    }
+    closedir(&handle)?;
+
+    // Exactly the four created entries — no `.`/`..`, no duplicates, none dropped.
+    if listing.len() != 4 {
+        panic!("expected exactly 4 entries in {dir}, found {}", listing.len());
+    }
+    expect_entry(&listing, &inline_max, FileType::RegularFile);
+    expect_entry(&listing, &over_by_one, FileType::RegularFile);
+    expect_entry(&listing, &long_file, FileType::RegularFile);
+    expect_entry(&listing, &long_dir, FileType::Directory);
+    ::syslog::info!("mount-test: [PASS] readdir returns full long entry names with correct types");
+
+    // Cleanup.
+    ::syscall::fcntl::unlinkat(AT_FDCWD, &format!("{dir}/{inline_max}"), 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, &format!("{dir}/{over_by_one}"), 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, &format!("{dir}/{long_file}"), 0)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, &format!("{dir}/{long_dir}"), AT_REMOVEDIR)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, dir, AT_REMOVEDIR)?;
+    Ok(())
 }
 
 /// Lists a directory and verifies every created entry is reported exactly once with the

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -439,10 +439,11 @@ async fn standalone_io_handler(
                             // Build the first response message and any queued
                             // multi-part follow-ups together so the entire response
                             // stream is delivered before the next request is
-                            // processed. Hostfs multi-part responses (currently the
-                            // long-target `readlink` form) leave additional payloads
-                            // in the handler's queue that must be drained via
-                            // `take_next_response_part` immediately after the head.
+                            // processed. Hostfs multi-part responses (the long-target
+                            // `readlink` and long-name `readdir` forms) leave
+                            // additional payloads in the handler's queue that must be
+                            // drained via `take_next_response_part` immediately after
+                            // the head.
                             let mut response_payloads: std::vec::Vec<[u8; Message::PAYLOAD_SIZE]> =
                                 std::vec::Vec::new();
                             response_payloads.push(response_payload);


### PR DESCRIPTION
## Summary

Directory entries whose name exceeds the inline ReadDirEntry capacity (29 bytes) were previously truncated when listed over the host-shared filesystem, so long file names were returned corrupted. This makes directory listing return the full entry name regardless of length.

### What changed

- **hostfsd**: when an entry name fits inline, the original single-message fast path is kept. When it exceeds the inline cap, the entry is serialized (op_id, is_dir, size, 
ame) and emitted as a multi-part `HostFsReadDirResponsePart` stream, exactly mirroring the existing long-eadlink response path.
- **vfsd**: reassembles the multi-part stream in a dedicated single-slot assembler (the host worker replies to one request at a time, so at most one stream is in flight) and folds the decoded entry into the in-progress directory sweep, then advances the sweep as usual.
- **hostfs-api**: adds the long-readdir wire format (`serialize_long_readdir_response` / `deserialize_long_readdir_response`) and the new response-part header.
- The inline and multi-part paths share the same entry-accumulation and sweep-advancement helpers, so both code paths stay in lockstep.

### Notes

- Names longer than the guest `NAME_MAX` (255) cannot be represented in a `posix_dent`, so they are clamped with a warning rather than aborting the entire listing for a single pathological entry. This is strictly better than the previous unconditional 29-byte truncation.
- New unit test covers the long-name multi-part readdir round-trip; existing inline readdir tests continue to pass.

> Note: stacked on `fix/hostfs-getdents` for a clean, self-contained diff. Retarget to `dev` once that branch merges.