### PR TITLE
[build] Localize libm wrappers in compiler_builtins for guest staticlibs

### DIFF
--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -116,7 +116,7 @@ guest_staticlib_artifact = lib$(subst -,_,$(1)).a
 # the `full_availability` block in `src/math/mod.rs` is skipped at the
 # source. No such field exists today and no upstream PR is in flight;
 # until one lands, this post-build localization is the canonical
-# nanvix fix.
+# Nanvix fix.
 #
 # Safety of localization: no Nanvix Rust no_std guest code calls these
 # C math symbols. `core`'s `f64::sqrt()` etc. lower to LLVM intrinsics
@@ -144,7 +144,10 @@ guest_staticlib_artifact = lib$(subst -,_,$(1)).a
 # Tooling: rust-objcopy comes from cargo-binutils, a build prerequisite
 # (see build/make/kernel.mk for an identical fallback pattern). The
 # command is a no-op on staticlibs that don't define these symbols.
-GUEST_STATICLIB_OBJCOPY := $(shell command -v rust-objcopy 2>/dev/null || command -v objcopy 2>/dev/null)
+# The tool is looked up at command time (via `command -v` in the recipe
+# below) rather than at make parse time, so it picks up `rust-objcopy`
+# even if it becomes available between make startup and recipe
+# execution. Archive paths are quoted to tolerate spaces.
 
 # C99 libm wrapper names that newlib's libm.a defines as STRONG DEFAULT and
 # that compiler_builtins shadows as WEAK HIDDEN. Stable; effectively pinned
@@ -158,8 +161,10 @@ GUEST_STATICLIB_LIBM_LOCALIZE_ARGS := \
 	$(addprefix --localize-symbol=,$(GUEST_STATICLIB_LIBM_WRAPPERS))
 
 define GUEST_STATICLIB_LIBM_FIX_CMD
-	if [ -n "$(GUEST_STATICLIB_OBJCOPY)" ]; then \
-	    $(GUEST_STATICLIB_OBJCOPY) $(GUEST_STATICLIB_LIBM_LOCALIZE_ARGS) $(1); \
+	if command -v rust-objcopy >/dev/null 2>&1; then \
+	    rust-objcopy $(GUEST_STATICLIB_LIBM_LOCALIZE_ARGS) "$(1)"; \
+	elif command -v objcopy >/dev/null 2>&1; then \
+	    objcopy $(GUEST_STATICLIB_LIBM_LOCALIZE_ARGS) "$(1)"; \
 	else \
 	    echo "WARNING: rust-objcopy/objcopy not found; skipping libm visibility fix on $(1)"; \
 	fi;

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -37,11 +37,140 @@ GUEST_STATICLIB_PKG_FEATURES = $(if $(GUEST_STATICLIB_FEATURES_$(1)),--features 
 # for `cp` / `rm` paths against the cargo target dir.
 guest_staticlib_artifact = lib$(subst -,_,$(1)).a
 
+#===================================================================================================
+# Guest staticlib libm visibility fix
+#===================================================================================================
+# Rust's `compiler_builtins` crate (pulled in transitively by `core` for every
+# guest staticlib) emits ~28 libm wrapper symbols as `STB_WEAK + STV_HIDDEN`
+# on every non-Windows, non-Apple target. Source: `compiler-builtins`
+# `src/macros.rs` (linkage = "weak" for non-Windows/Apple) and
+# `src/math/mod.rs` (the `full_availability` block).
+#
+# Most of compiler_builtins is integer-arithmetic / soft-float helpers
+# (`__adddf3`, `__divdi3`, `__bswapdi2`, ...) that newlib's libc / libm do
+# NOT provide. They MUST stay WEAK HIDDEN where they are — they are the
+# canonical providers for any C or Rust code that needs them.
+#
+# The libm wrappers (the 28 names below) are different. Newlib's libm
+# defines all of them as `STB_GLOBAL + STV_DEFAULT`. Under normal archive
+# linking this is harmless: WEAK loses to STRONG. But Nanvix guest
+# executables that dlopen extension modules (CPython, future plugins) link
+# with:
+#
+#   -Wl,--whole-archive libnvx_crt0.a libposix.a libc.a libm.a ...
+#   -Wl,--allow-multiple-definition
+#   -Wl,--export-dynamic
+#
+# so dlopen'd modules can resolve libm names at runtime against the main
+# executable's `.dynsym`. With this combination GNU ld merges the two
+# `sqrt` definitions body-from-strong-visibility-from-most-restrictive. The
+# result is STRONG HIDDEN, demoted to LOCAL after link. `--export-dynamic`
+# cannot put a LOCAL symbol into `.dynsym`, so dlopen'd modules fail at
+# runtime with "symbol not found" on `sqrt`/`cbrt`/etc.
+#
+# The fix: after each guest staticlib is built, run `rust-objcopy
+# --localize-symbol=<sym>` on each libm wrapper name it defines. LOCAL
+# symbols don't participate in cross-object resolution, so libm.a's STRONG
+# DEFAULT definitions become the only visible-to-the-linker definitions.
+# `--export-dynamic` works as intended. Symbols not in the list are
+# untouched, so integer/soft-float intrinsics keep their WEAK HIDDEN
+# semantics.
+#
+# Why a hardcoded list rather than autodiscovery: the 28 names below
+# are the C99 math.h public API. That contract is frozen — newlib's
+# libm has all of them, every other libm (glibc, musl, picolibc, ...)
+# has all of them, and the set has not changed in decades. Hardcoding
+# against a stable specification is the most robust option here: the
+# list will not drift under us, and the localization step has no
+# build-time dependency on any other artifact.
+#
+# A "diff against libm.a" alternative was considered and rejected for
+# two reasons:
+#
+#   1. libm.a is not available at libposix.a build time in any of the
+#      build paths nanvix itself uses:
+#
+#        - Windows native (`z.ps1`, dev + CI `windows-latest`): no C
+#          cross-toolchain installed, libm.a does not exist on the host.
+#        - Linux native without `./z setup --nanvix-sdk`: same — newlib
+#          is only built when the SDK target is requested.
+#        - Linux CI (`ghcr.io/nanvix/ci:ubuntu-24.04`): the nanvix CI
+#          image carries the Rust toolchain only; no newlib, no libm.a.
+#
+#      libm.a only exists in the separate full-SDK Docker image
+#      (`nanvix/toolchain` / `ghcr.io/nanvix/toolchain-*`) that is
+#      consumed by downstream projects like cpython. Those projects
+#      link against the libposix.a we ship, but they build *after*
+#      libposix.a, so they cannot influence its localization step.
+#
+#   2. Even on a setup that does have libm.a available, introspecting
+#      it at libposix.a build time would couple two otherwise
+#      independent build stages and add machinery (locate libm.a, run
+#      `nm`, filter visibility — `nm`'s single-letter format does not
+#      distinguish HIDDEN from DEFAULT, so this needs care) without
+#      removing the need for a stable list as fallback. The
+#      cost/benefit does not justify the complexity.
+#
+# A proper long-term fix lives upstream in `compiler-builtins`: add a
+# target-spec field like `has-system-libm` to `i686-unknown-nanvix` so
+# the `full_availability` block in `src/math/mod.rs` is skipped at the
+# source. No such field exists today and no upstream PR is in flight;
+# until one lands, this post-build localization is the canonical
+# nanvix fix.
+#
+# Safety of localization: no Nanvix Rust no_std guest code calls these
+# C math symbols. `core`'s `f64::sqrt()` etc. lower to LLVM intrinsics
+# (`@llvm.sqrt.f64` -> hardware FSQRT/SQRTSD), bypassing extern "C"
+# entirely. The `std` variants that DO call C math (`sin`, `cos`, `tan`,
+# ...) are absent from `-Zbuild-std=core,alloc`. So the WEAK HIDDEN math
+# symbols have no Rust caller; localizing them affects only the
+# cross-archive visibility merge.
+#
+# Note on the 11 newlib-internal `__math_*` helpers (`__math_invalid`,
+# `__math_oflow`, ...): those are GLOBAL HIDDEN at source in
+# `newlib/libm/common/math_config.h` (ported from ARM optimized-routines,
+# same as glibc and musl). They are deliberately library-private and
+# called only from inside libm's own internals (e.g. `__ieee754_sqrt` ->
+# `__math_invalid`). In a Nanvix executable, those internals live inside
+# the executable alongside the helpers themselves; the PC-relative call
+# between them is resolved at static-link time and never touches
+# `.dynsym`. dlopen'd modules don't need them — they call public names
+# like `sqrt`, which dispatches to the executable's `sqrt`, which
+# internally calls `__math_invalid` if needed. This is identical to how
+# Linux ships libm.so.6 with the same HIDDEN attribute on the same
+# helpers, and dlopen'd code on Linux never needs them either. NOT
+# exporting them is the correct behaviour, not a bug.
+#
+# Tooling: rust-objcopy comes from cargo-binutils, a build prerequisite
+# (see build/make/kernel.mk for an identical fallback pattern). The
+# command is a no-op on staticlibs that don't define these symbols.
+GUEST_STATICLIB_OBJCOPY := $(shell command -v rust-objcopy 2>/dev/null || command -v objcopy 2>/dev/null)
+
+# C99 libm wrapper names that newlib's libm.a defines as STRONG DEFAULT and
+# that compiler_builtins shadows as WEAK HIDDEN. Stable; effectively pinned
+# by the C99 math.h public API.
+GUEST_STATICLIB_LIBM_WRAPPERS := \
+	cbrt cbrtf ceil ceilf copysign copysignf fabs fabsf \
+	fdim fdimf floor floorf fma fmaf fmax fmaxf fmin fminf \
+	fmod fmodf rint rintf round roundf sqrt sqrtf trunc truncf
+
+GUEST_STATICLIB_LIBM_LOCALIZE_ARGS := \
+	$(addprefix --localize-symbol=,$(GUEST_STATICLIB_LIBM_WRAPPERS))
+
+define GUEST_STATICLIB_LIBM_FIX_CMD
+	if [ -n "$(GUEST_STATICLIB_OBJCOPY)" ]; then \
+	    $(GUEST_STATICLIB_OBJCOPY) $(GUEST_STATICLIB_LIBM_LOCALIZE_ARGS) $(1); \
+	else \
+	    echo "WARNING: rust-objcopy/objcopy not found; skipping libm visibility fix on $(1)"; \
+	fi;
+endef
+
 # Per-package rules retained for direct invocation (e.g., make all-guest-staticlib-<pkg>).
 define GUEST_STATICLIB_RULES
 all-guest-staticlib-$(1): init
 	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
 	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(call guest_staticlib_artifact,$(1)) $(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1))
+	@$(call GUEST_STATICLIB_LIBM_FIX_CMD,$(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1)))
 
 check-guest-staticlib-$(1):
 	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
@@ -97,7 +226,9 @@ all-guest-staticlibs: init
 	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),$(GUEST_CARGO_BUILD_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES))
 	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_BUILD_CMD,$(pkg)) &&) true
 	@for pkg in $(ALL_GUEST_STATIC_LIBS); do \
-		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$$(echo $$pkg | sed 's/-/_/g').a $(LIBRARIES_DIR)/lib$$(echo $$pkg | sed 's/-/_/g').a; \
+		artifact=lib$$(echo $$pkg | sed 's/-/_/g').a; \
+		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$$artifact $(LIBRARIES_DIR)/$$artifact; \
+		$(call GUEST_STATICLIB_LIBM_FIX_CMD,$(LIBRARIES_DIR)/$$artifact) \
 	done
 
 check-guest-staticlibs:


### PR DESCRIPTION
## Summary

Rust's `compiler_builtins` crate (pulled in transitively by `core` for every guest staticlib via `-Zbuild-std=core,alloc`) emits the 28 libm wrapper symbols (`sqrt`, `cbrt`, `fma`, `ceil`, `floor`, `fabs`, `fmod`, `copysign`, `round`, `trunc`, `rint`, `fmax`, `fmin`, `fdim` and their `f32` variants) as `STB_WEAK + STV_HIDDEN` on every non-Windows, non-Apple target. Newlib's libm.a defines the same symbols as `STB_GLOBAL + STV_DEFAULT`.

Under normal archive linking this is harmless: WEAK loses to STRONG. But Nanvix guest executables that dlopen extension modules (CPython, future plugins) link with `--whole-archive`, `--allow-multiple-definition`, and `--export-dynamic` so dlopen'd modules can resolve libm names at runtime against the main executable's `.dynsym`. With that combination, GNU ld's ELF visibility merge rule kicks in: the merged sqrt is STRONG HIDDEN, demoted to LOCAL after link, and `--export-dynamic` cannot put a LOCAL symbol into `.dynsym`. Dlopen'd modules fail at runtime with "symbol not found".

This PR adds a one-time `rust-objcopy --localize-symbol=<sym>` step to every guest staticlib (`libposix.a`, `libnvx_crt0.a`, ...) after Cargo emits it. LOCAL symbols don't participate in cross-object resolution, so libm.a's STRONG DEFAULT definitions become the only definitions the linker sees. `--export-dynamic` then works as intended.

The change is ~100 lines added to `build/make/generic-guest-staticlibs.mk` — mostly documentation explaining the visibility merge mechanics, why this is needed, and what the safety story is. The functional code is a tiny Make macro that runs `rust-objcopy` with the hardcoded list of 28 C99 math.h wrapper names.

## What is and isn't touched

- ✅ **The 28 libm wrappers** (`sqrt`, `cbrt`, ...) — localized so libm.a's versions win.
- ❌ **The other 192 WEAK HIDDEN symbols in compiler_builtins** (integer/soft-float intrinsics like `__adddf3`, `__divdi3`, `__bswapdi2`, ...) — untouched. They are the canonical providers, libm doesn't have them, and C code linked against libposix relies on them.
- ❌ **Newlib's 11 internal `__math_*` helpers** (`__math_invalid`, `__math_oflow`, ...) — untouched. They are GLOBAL HIDDEN at source in `newlib/libm/common/math_config.h` (ported from ARM optimized-routines, same as glibc and musl). They are called only from inside libm's own internals (e.g. `__ieee754_sqrt` → `__math_invalid`); the PC-relative call between them is resolved at static-link time and never touches `.dynsym`. dlopen'd modules don't need them — they call public names like `sqrt`, which dispatches to the executable's `sqrt`, which internally calls `__math_invalid` if needed. This is identical to how Linux ships libm.so.6 with the same HIDDEN attribute on the same helpers. NOT exporting these is correct behaviour, not a bug.

## Safety analysis

No Nanvix Rust no_std guest code calls these C math symbols:

- `core`'s `f64::sqrt()` etc. lower to LLVM intrinsics (`@llvm.sqrt.f64` → hardware FSQRT/SQRTSD), bypassing extern "C" entirely. Verified in `rust/library/core/src/num/f64.rs` and `rust/library/core/src/intrinsics.rs`.
- The `std` variants that DO call C math (`sin`, `cos`, `tan`, ...) are absent from `-Zbuild-std=core,alloc`. Verified by searching `src/libs/posix/`, `src/libs/nvx-crt0/`, and all other guest crates — no floating-point operations.

So the WEAK HIDDEN libm symbols have no Rust caller; localizing them affects only the cross-archive visibility merge for C code that goes through newlib's libm.

## Validation

With this patch applied to `libposix.a` and `libnvx_crt0.a`:

- `readelf -s libposix.a` shows `sqrt`, `cbrt`, `fma`, `ceil`, `fabs`, `fmod` as `LOCAL HIDDEN` (previously `WEAK HIDDEN`). The other 192 WEAK HIDDEN intrinsics are untouched.
- CPython `math.cpython-312.so` / `cmath.cpython-312.so` / `_statistics.cpython-312.so` build successfully **without `libm.a`** on their link line. They dlopen cleanly into `python.elf`, resolving sqrt / cbrt / etc. against `python.elf`'s `.dynsym`.
- `readelf --dyn-syms python.elf | grep sqrt` shows `GLOBAL DEFAULT sqrt` (previously not present).
- Full CPython regrtest (160/160 modules) continues to pass; Phase 1B math/cmath/_statistics import probe succeeds.
- All existing Nanvix guest tests continue to pass — the WEAK HIDDEN integer/soft-float intrinsics they rely on are untouched.

## Why a hardcoded list

The 28 names are the **C99 math.h public API** — a frozen contract. Every libm (newlib, glibc, musl, picolibc, ...) defines all of them, and the set has not changed in decades. Hardcoding against a stable specification is the most robust option here: the list will not drift under us, and the localization step has no build-time dependency on any other artifact.

A "diff against `libm.a`" alternative was considered and rejected for two reasons:

1. **`libm.a` is not available at `libposix.a` build time in any of the build paths nanvix itself uses:**
   - Windows native (`z.ps1`, dev + CI `windows-latest`): no C cross-toolchain installed, `libm.a` does not exist on the host.
   - Linux native without `./z setup --nanvix-sdk`: same — newlib is only built when the SDK target is requested.
   - Linux CI (`ghcr.io/nanvix/ci:ubuntu-24.04`): the nanvix CI image carries the Rust toolchain only; no newlib, no `libm.a`.

   `libm.a` only exists in the separate full-SDK Docker image (`nanvix/toolchain` / `ghcr.io/nanvix/toolchain-*`) that is consumed by downstream projects like cpython. Those projects link against the `libposix.a` we ship, but they build *after* `libposix.a`, so they cannot influence its localization step.

2. **Even on a setup that does have `libm.a` available, introspecting it would couple two otherwise independent build stages** and add machinery (locate `libm.a`, run `nm`, filter visibility — `nm`'s single-letter format does not distinguish HIDDEN from DEFAULT, so this needs care) without removing the need for a stable list as fallback. The cost/benefit does not justify the complexity.

If `compiler-builtins` ever adds non-C99 math names that should also be localized, this list needs one-line additions. In practice this hasn't happened in any compiler-builtins release.

## Long-term direction

A proper upstream fix lives in `compiler-builtins`: add a target-spec field like `"has-system-libm": true` to `i686-unknown-nanvix` and have `compiler-builtins` skip the `full_availability` block in `src/math/mod.rs` when that field is set. No such field exists today and no upstream PR is in flight. Until one lands, this post-build localization is the canonical Nanvix fix.

## Files changed

- `build/make/generic-guest-staticlibs.mk`: +100 lines (the docs are most of it).

## Risk

Low. The fix is a no-op for any staticlib that doesn't carry these specific symbols. For staticlibs that do carry them (libposix, libnvx_crt0), only the 28 named symbols are touched; everything else stays exactly as Cargo emitted it.
