### PR TITLE
[syscall] B: Fix diamond DT_NEEDED handling

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -12,6 +12,7 @@ use crate::dlfcn::syscall::{
 };
 use ::alloc::{
     collections::btree_map::BTreeMap,
+    string::String,
     sync::Arc,
     vec::Vec,
 };
@@ -70,6 +71,25 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
         // Collect all dependencies of the dynamic library file being closed.
         let mut dep_dlfiles: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
         if let Some((_, dep_dlfile)) = dlfile.pop() {
+            // Snapshot the `.fini_array` descriptor and name under a short
+            // per-library lock, then drop the lock and invoke destructors.
+            // Holding the per-library lock during destructor execution
+            // would deadlock any destructor that calls
+            // `dlsym(self_handle, ...)`. (The outer registry lock is still
+            // held, so destructors that call `dlopen` / `dlclose` / cross-
+            // library `dlsym` are not yet supported; see the loader docs.)
+            let (descriptor, name): (Option<(usize, usize)>, String) = {
+                let lib = dep_dlfile.lock();
+                (lib.fini_array_descriptor(), String::from(lib.name()))
+            };
+            // SAFETY: `descriptor` was produced under the per-library lock
+            // for a library still alive via `dep_dlfile`; the per-library
+            // mutex is released before invocation so destructors that call
+            // `dlsym(self_handle, ...)` do not deadlock.
+            unsafe {
+                DynamicLibrary::invoke_fini_array(descriptor, &name);
+            }
+
             let mut dep_dlfile = dep_dlfile.lock();
             dep_dlfile
                 .take_dependencies()
@@ -105,6 +125,18 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
 
         // Collect all dependencies of the dynamic library file.
         if let Some((_, dep_dlfile)) = dep_dlfile.pop() {
+            // Run `.fini_array` destructors before this dependency is
+            // dropped. See the comment above on lock handling.
+            let (descriptor, name): (Option<(usize, usize)>, String) = {
+                let lib = dep_dlfile.lock();
+                (lib.fini_array_descriptor(), String::from(lib.name()))
+            };
+            // SAFETY: see the comment on the first `invoke_fini_array`
+            // call above.
+            unsafe {
+                DynamicLibrary::invoke_fini_array(descriptor, &name);
+            }
+
             let mut dep_dlfile = dep_dlfile.lock();
             dep_dlfile
                 .take_dependencies()

--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -117,10 +117,28 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
             })
             .collect();
 
+        // `extract_if` may legitimately return zero entries when this
+        // library still has live dependents elsewhere in the dependency
+        // tree. This is the diamond `DT_NEEDED` case --
+        //
+        //   libdiamond.so -> libleft.so  -> libbase.so
+        //                 -> libright.so -> libbase.so
+        //
+        // While unloading libright, BFS pushes libbase onto the work
+        // list. By the time we pop libbase, libleft has not yet unloaded
+        // and still holds an Arc to libbase, so `strong_count` is 3
+        // (registry + libleft.dependencies + our pop). We skip libbase
+        // for now; a later iteration will pop libleft, drop its
+        // dependencies (releasing the extra libbase reference), push
+        // libbase a second time, and the subsequent pop will succeed.
+        if dep_dlfile.is_empty() {
+            continue;
+        }
         assert_eq!(
             dep_dlfile.len(),
             1,
-            "dlclose(): expected to remove exactly one dynamic library file"
+            "dlclose(): expected to remove exactly one dynamic library file (the empty case is \
+             handled above)"
         );
 
         // Collect all dependencies of the dynamic library file.

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -46,7 +46,10 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // (e.g., "lib/libfoo.so") using the configured search directories.
     // Paths with leading "/" are normalized to strip it, ensuring
     // "/lib/libc.so" and "lib/libc.so" are treated as the same library.
-    let resolved: String = super::resolve_library_path(filename);
+    // The top-level dlopen call has no parent runpaths to honour, so pass
+    // `None`; bare-name probes against `DT_RUNPATH` only happen for
+    // transitive `DT_NEEDED` dependencies of an already-loaded library.
+    let resolved: String = super::resolve_library_path(filename, None);
     let filename: &str = resolved.as_str();
 
     let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
@@ -80,37 +83,68 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // Load dependencies and resolve symbols. If either step fails, remove all
     // entries that were added during this call (the library itself and any
     // transitive dependencies) so subsequent dlopen calls start fresh.
-    match load_all_dependencies(&mut registry, new_dlfile)
-        .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
-    {
-        Ok(()) => {
-            // If RTLD_GLOBAL was requested, publish the library's exported
-            // symbols into the global symbol table so subsequently loaded
-            // libraries can resolve them.
-            if global {
-                if let Some(dlfile) = registry.get(&handle) {
-                    super::register_library_in_global_scope(dlfile);
+    let init_order: Vec<Arc<Mutex<DynamicLibrary>>> =
+        match load_all_dependencies(&mut registry, new_dlfile)
+            .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
+        {
+            Ok(order) => {
+                // If RTLD_GLOBAL was requested, publish the library's exported
+                // symbols into the global symbol table so subsequently loaded
+                // libraries can resolve them.
+                if global {
+                    if let Some(dlfile) = registry.get(&handle) {
+                        super::register_library_in_global_scope(dlfile);
+                    }
                 }
-            }
-            Ok(handle)
-        },
-        Err(e) => {
-            let new_handles: Vec<DlHandle> = registry
-                .keys()
-                .filter(|h| !handles_before.contains(h))
-                .copied()
-                .collect();
-            ::syslog::warn!(
-                "dlopen(): rolling back {} entries after failure (error={:?})",
-                new_handles.len(),
-                e
-            );
-            for h in new_handles {
-                registry.remove(&h);
-            }
-            Err(e)
-        },
+                order
+            },
+            Err(e) => {
+                let new_handles: Vec<DlHandle> = registry
+                    .keys()
+                    .filter(|h| !handles_before.contains(h))
+                    .copied()
+                    .collect();
+                ::syslog::warn!(
+                    "dlopen(): rolling back {} entries after failure (error={:?})",
+                    new_handles.len(),
+                    e
+                );
+                for h in new_handles {
+                    registry.remove(&h);
+                }
+                return Err(e);
+            },
+        };
+
+    // Drop the registry lock before invoking `.init_array` constructors so a
+    // constructor may legally call `dlsym` (and, in a future relaxation,
+    // `dlopen`) without deadlocking on `DYNAMIC_LIBRARY_REGISTRY`.
+    drop(registry);
+
+    // Invoke `.init_array` constructors in dependency order (leaves first).
+    // The Arc list was built while the registry was locked, so each entry is
+    // guaranteed to still point to a loaded library.
+    //
+    // Snapshot the constructor descriptor and library name under a short
+    // per-library lock, then drop the lock before invoking constructors.
+    // Holding the per-library lock during constructor execution would
+    // deadlock any constructor that calls `dlsym(self_handle, ...)`, because
+    // `dlsym` re-locks the same library to look up symbols.
+    for dlfile in init_order.iter() {
+        let (descriptor, name): (Option<(usize, usize)>, String) = {
+            let lib: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+            (lib.init_array_descriptor(), String::from(lib.name()))
+        };
+        // SAFETY: `descriptor` was produced under the per-library lock for
+        // a library still held alive by `init_order`'s `Arc`; relocations
+        // have been applied by `resolve_all_symbols`; no dlfcn locks are
+        // held across this call.
+        unsafe {
+            DynamicLibrary::invoke_init_array(descriptor, &name);
+        }
     }
+
+    Ok(handle)
 }
 
 /// Recursively loads all transitive dependencies of a newly opened library.
@@ -129,6 +163,12 @@ fn load_all_dependencies(
         new_dlhandle: &DlHandle,
         new_dlfile: &mut MutexGuard<'_, DynamicLibrary>,
     ) -> Result<(), Error> {
+        // Snapshot the loader's `DT_RUNPATH` entries so they are visible to
+        // `resolve_library_path` while probing every dependency below. The
+        // `DynamicLibrary` mutex is borrowed throughout, so this avoids
+        // re-borrowing it per call.
+        let runpaths: Vec<String> = new_dlfile.runpaths().to_vec();
+
         // Collect the name of all dependencies.
         let mut dependencies: Vec<String> = new_dlfile
             .dependencies()
@@ -140,7 +180,7 @@ fn load_all_dependencies(
         dependencies.retain(|dependency| {
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
-            let resolved_dep: String = super::resolve_library_path(dependency);
+            let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
             for (dlhandle, dlfile) in dlfiles.iter() {
                 // Check if need to skip the dynamic library itself.
                 if dlhandle == new_dlhandle {
@@ -176,7 +216,7 @@ fn load_all_dependencies(
         // Load remaining dependencies.
         while let Some(dependency) = dependencies.pop() {
             // Resolve bare library names to full paths using search directories.
-            let resolved_dep: String = super::resolve_library_path(&dependency);
+            let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));
 
             // Open and pre-load the dynamic library file.
             let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&resolved_dep)?;
@@ -205,15 +245,17 @@ fn load_all_dependencies(
     Ok(())
 }
 
-/// Resolves all relocations for libraries added during this `dlopen` call.
+/// Resolves all relocations for libraries added during this `dlopen` call and
+/// returns them in dependency order (leaves first, root last) so the caller
+/// can invoke `.init_array` constructors in the correct sequence.
 ///
-/// Libraries are resolved in dependency order (leaves first, root last).
-/// This ensures that when a library's relocations reference symbols from
-/// its dependencies, those dependencies are already fully resolved.
+/// Libraries are resolved in dependency order. This ensures that when a
+/// library's relocations reference symbols from its dependencies, those
+/// dependencies are already fully resolved.
 fn resolve_all_symbols(
     dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
     handles_before: &BTreeSet<DlHandle>,
-) -> Result<(), Error> {
+) -> Result<Vec<Arc<Mutex<DynamicLibrary>>>, Error> {
     ::syslog::trace!("resolve_all_symbols()");
 
     // Collect all newly added libraries.
@@ -291,11 +333,13 @@ fn resolve_all_symbols(
     }
 
     // Resolve in dependency order (leaves first).
+    let mut init_order: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::with_capacity(ordered.len());
     for handle in ordered {
         if let Some(dlfile) = dlfiles.get(&handle) {
             dlfile.lock().resolve_all()?;
+            init_order.push(dlfile.clone());
         }
     }
 
-    Ok(())
+    Ok(init_order)
 }

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -162,6 +162,7 @@ fn load_all_dependencies(
         dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
         new_dlhandle: &DlHandle,
         new_dlfile: &mut MutexGuard<'_, DynamicLibrary>,
+        ancestors: &mut BTreeSet<DlHandle>,
     ) -> Result<(), Error> {
         // Snapshot the loader's `DT_RUNPATH` entries so they are visible to
         // `resolve_library_path` while probing every dependency below. The
@@ -177,13 +178,44 @@ fn load_all_dependencies(
             .collect();
 
         // Bind to already loaded dependencies and remove them from the list.
+        //
+        // The closure below calls `dlfile.lock()` on every other entry in the
+        // registry while looking for a matching name. Those locks must skip
+        // BOTH the current library (`new_dlhandle`) AND every ancestor still
+        // held by an outer recursive frame — otherwise any non-trivial
+        // recursive load (e.g. `libA → libB`, and especially diamond graphs
+        // like the one below) deadlocks:
+        //
+        //   dlopen(libdiamond.so)                  // holds libdiamond lock
+        //     -> recurse into libright.so          // also holds libright lock
+        //          -> retain() iterates dlfiles    // tries to lock libdiamond
+        //             ^ blocks forever, libdiamond is still held by the
+        //               outer frame.
+        //
+        // The lookup is purely advisory (we want to know if a sibling already
+        // bound a dependency with the same name), so skipping ancestors is
+        // safe in the common acyclic case: an ancestor by definition cannot
+        // have been loaded by a prior iteration of the same frame's
+        // dependency list.
+        //
+        // Known limitation: a legitimate `DT_NEEDED` *cycle*
+        // (`libA → libB → libA`) is not detected here. With the deadlock
+        // fixed, an inner frame asking for an ancestor's name will fall
+        // through to opening a fresh copy of that library on a new handle,
+        // producing unbounded recursion / duplicate library instances.
+        // Cycles in `DT_NEEDED` are pathological and not produced by any
+        // sane toolchain; detecting and rejecting them cleanly is left as
+        // a follow-up (would require carrying the ancestor *names* through
+        // the recursion to compare without locking, since locking the
+        // ancestor to read its name would reintroduce the deadlock).
         dependencies.retain(|dependency| {
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
             let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
             for (dlhandle, dlfile) in dlfiles.iter() {
-                // Check if need to skip the dynamic library itself.
-                if dlhandle == new_dlhandle {
+                // Skip the dynamic library itself and any ancestor held by
+                // an outer frame's lock — locking them would deadlock.
+                if dlhandle == new_dlhandle || ancestors.contains(dlhandle) {
                     continue;
                 }
 
@@ -218,6 +250,45 @@ fn load_all_dependencies(
             // Resolve bare library names to full paths using search directories.
             let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));
 
+            // Re-check the registry before opening: a prior iteration of
+            // this same loop may have already loaded this dependency
+            // transitively. This is the diamond case --
+            //
+            //   libdiamond.so -> libleft.so  -> libbase.so
+            //                 -> libright.so -> libbase.so
+            //
+            // After processing libleft (and recursing into it, which loads
+            // libbase), libbase is now in the registry. When the outer loop
+            // returns to process libright, the closure-based `retain` above
+            // never ran for libbase because it was not yet loaded at the
+            // time libright's frame started; we must catch the diamond
+            // here instead. Without this check the loader would either
+            // open libbase a second time (producing two distinct
+            // in-memory copies) or trip the `unreachable!()` below when
+            // the VFS reuses the underlying file descriptor.
+            let already_loaded: Option<Arc<Mutex<DynamicLibrary>>> =
+                dlfiles.iter().find_map(|(dlhandle, dlfile)| {
+                    if dlhandle == new_dlhandle || ancestors.contains(dlhandle) {
+                        return None;
+                    }
+                    let loaded_file: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+                    let loaded_name: &str = loaded_file.name();
+                    if loaded_name == dependency.as_str() || loaded_name == resolved_dep {
+                        Some(dlfile.clone())
+                    } else {
+                        None
+                    }
+                });
+            if let Some(existing) = already_loaded {
+                ::syslog::debug!(
+                    "load_all_dependencies_recursive(): dependency '{}' loaded transitively \
+                     during this dlopen call; binding to existing copy",
+                    dependency
+                );
+                new_dlfile.bind_dependency(dependency, existing)?;
+                continue;
+            }
+
             // Open and pre-load the dynamic library file.
             let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&resolved_dep)?;
             let handle: DlHandle = dep_dlfile.handle();
@@ -230,9 +301,15 @@ fn load_all_dependencies(
 
             new_dlfile.bind_dependency(dependency.clone(), dep_dlfile.clone())?;
 
-            // Load dependencies of the new dynamic library file.
+            // Load dependencies of the new dynamic library file. Mark the
+            // current library as an ancestor so the recursive frame does
+            // not try to lock our still-held mutex (would deadlock on
+            // diamond DT_NEEDED graphs).
+            ancestors.insert(*new_dlhandle);
             let mut dlfile: MutexGuard<'_, DynamicLibrary> = dep_dlfile.lock();
-            load_all_dependencies_recursive(dlfiles, &handle, &mut dlfile)?;
+            let result = load_all_dependencies_recursive(dlfiles, &handle, &mut dlfile, ancestors);
+            ancestors.remove(new_dlhandle);
+            result?;
         }
 
         Ok(())
@@ -240,7 +317,8 @@ fn load_all_dependencies(
 
     let mut new_dlfile = new_dlfile.lock();
     let new_dlhandle = new_dlfile.handle();
-    load_all_dependencies_recursive(dlfiles, &new_dlhandle, &mut new_dlfile)?;
+    let mut ancestors: BTreeSet<DlHandle> = BTreeSet::new();
+    load_all_dependencies_recursive(dlfiles, &new_dlhandle, &mut new_dlfile, &mut ancestors)?;
 
     Ok(())
 }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -123,6 +123,12 @@ pub struct DynamicLibrary {
     dynplt: Option<RelocationTable>,
     /// Relocation table for global variables.
     dynrel: Option<RelocationTable>,
+    /// Absolute address of the `.init_array` section and the number of entries.
+    init_array: Option<(usize, usize)>,
+    /// Absolute address of the `.fini_array` section and the number of entries.
+    fini_array: Option<(usize, usize)>,
+    /// `DT_RUNPATH` directories of this library, already split on `:`.
+    runpaths: Vec<String>,
 }
 
 impl DynamicLibrary {
@@ -290,6 +296,23 @@ impl DynamicLibrary {
                     Self::get_dynplt(&section_headers, load_address);
                 let dynrel: Option<RelocationTable> =
                     Self::get_dynrel(&section_headers, load_address);
+                let init_array: Option<(usize, usize)> =
+                    Self::get_init_array(&section_headers, load_address);
+                let fini_array: Option<(usize, usize)> =
+                    Self::get_fini_array(&section_headers, load_address);
+
+                // Collect `DT_RUNPATH` entries (goblin exposes them already
+                // resolved against `.dynstr`). Each entry may be a colon-
+                // separated list of directories; split here so the search
+                // path probe can iterate them directly.
+                let mut runpaths: Vec<String> = Vec::new();
+                for raw in elf.runpaths.iter() {
+                    for component in raw.split(':') {
+                        if !component.is_empty() {
+                            runpaths.push(component.to_string());
+                        }
+                    }
+                }
 
                 Ok(DynamicLibrary {
                     filename,
@@ -301,6 +324,9 @@ impl DynamicLibrary {
                     dynstr,
                     dynplt,
                     dynrel,
+                    init_array,
+                    fini_array,
+                    runpaths,
                 })
             },
             Err(error) => {
@@ -442,6 +468,44 @@ impl DynamicLibrary {
         } else {
             None
         }
+    }
+
+    /// Looks up a function-pointer array section (`.init_array` / `.fini_array`)
+    /// by name, returning the absolute address of the first entry and the
+    /// number of `usize`-sized entries it contains.
+    ///
+    /// Returns `None` when the section is missing or empty. Entries are
+    /// always 4 bytes on i386; if `sh_size` is not a multiple of `usize`
+    /// the trailing bytes are silently truncated (a well-formed ELF should
+    /// never trigger this).
+    fn get_function_pointer_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+        section_name: &str,
+    ) -> Option<(usize, usize)> {
+        let header: &SectionHeader = section_headers.get(section_name)?;
+        let count: usize = (header.sh_size as usize) / mem::size_of::<usize>();
+        if count == 0 {
+            return None;
+        }
+        let base: usize = load_address.into_raw_value() + header.sh_addr as usize;
+        Some((base, count))
+    }
+
+    /// Gets the `.init_array` section descriptor, if present.
+    fn get_init_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+    ) -> Option<(usize, usize)> {
+        Self::get_function_pointer_array(section_headers, load_address, ".init_array")
+    }
+
+    /// Gets the `.fini_array` section descriptor, if present.
+    fn get_fini_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+    ) -> Option<(usize, usize)> {
+        Self::get_function_pointer_array(section_headers, load_address, ".fini_array")
     }
 
     /// Finds a symbol in the dynamic library.
@@ -936,6 +1000,113 @@ impl DynamicLibrary {
             }
         }
         dependencies
+    }
+
+    /// Returns the `DT_RUNPATH` directories of the library, split on `:`.
+    pub fn runpaths(&self) -> &[String] {
+        &self.runpaths
+    }
+
+    /// Returns the loaded `.init_array` descriptor as `(base_address,
+    /// entry_count)`, or `None` if the library has no constructors.
+    ///
+    /// Callers should snapshot this under the library's mutex, drop the
+    /// mutex, and then invoke the entries via [`invoke_init_array`]. The
+    /// descriptor remains valid for as long as the owning
+    /// `Arc<Mutex<DynamicLibrary>>` is alive.
+    pub fn init_array_descriptor(&self) -> Option<(usize, usize)> {
+        self.init_array
+    }
+
+    /// Returns the loaded `.fini_array` descriptor as `(base_address,
+    /// entry_count)`, or `None` if the library has no destructors.
+    ///
+    /// See [`init_array_descriptor`](Self::init_array_descriptor) for the
+    /// expected lock-handling pattern.
+    pub fn fini_array_descriptor(&self) -> Option<(usize, usize)> {
+        self.fini_array
+    }
+
+    /// Invokes every function pointer in the supplied `.init_array`
+    /// descriptor in order, as required by the System V ABI for shared-
+    /// object constructor execution.
+    ///
+    /// `name` is purely for diagnostic logging.
+    ///
+    /// # Locking
+    ///
+    /// This function must be called with **no** dlfcn locks held — neither
+    /// `DYNAMIC_LIBRARY_REGISTRY` nor the per-library mutex. Constructors
+    /// may legally call `dlsym` (and, in a future relaxation, `dlopen`),
+    /// both of which would otherwise re-enter the same locks and deadlock.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that `descriptor` was produced by
+    /// [`init_array_descriptor`](Self::init_array_descriptor) from a
+    /// `DynamicLibrary` whose memory segments are still mapped, that
+    /// `resolve_all` has already applied any `R_386_RELATIVE` patches to
+    /// the section, and that the holding `Arc` lives until this call
+    /// returns. Entry values equal to `0` or `usize::MAX` are treated as
+    /// sentinels and skipped, matching the glibc loader behaviour.
+    pub unsafe fn invoke_init_array(descriptor: Option<(usize, usize)>, name: &str) {
+        let (base, count): (usize, usize) = match descriptor {
+            Some(range) => range,
+            None => return,
+        };
+        ::syslog::debug!("invoke_init_array(): library={:?} entries={}", name, count);
+        for index in 0..count {
+            // SAFETY: `base` points to the loaded `.init_array` section of
+            // the originating library and `count` is the number of
+            // `usize`-sized entries it contains.
+            let entry_ptr: *const usize = (base + index * mem::size_of::<usize>()) as *const usize;
+            let entry: usize = unsafe { entry_ptr.read_unaligned() };
+            if entry == 0 || entry == usize::MAX {
+                continue;
+            }
+            // SAFETY: the .init_array entry is a function pointer with C
+            // calling convention and no arguments per the System V ABI.
+            let func: extern "C" fn() = unsafe { mem::transmute::<usize, extern "C" fn()>(entry) };
+            func();
+        }
+    }
+
+    /// Invokes every function pointer in the supplied `.fini_array`
+    /// descriptor in reverse order, as required by the System V ABI for
+    /// shared-object destructor execution. Must be called before the
+    /// library's memory segments are unmapped.
+    ///
+    /// `name` is purely for diagnostic logging.
+    ///
+    /// # Locking
+    ///
+    /// The per-library mutex of the originating library must **not** be
+    /// held while invoking destructors, so a destructor calling
+    /// `dlsym(self, ...)` does not deadlock. The current `dlclose`
+    /// implementation still holds `DYNAMIC_LIBRARY_REGISTRY`, so
+    /// destructors that call `dlopen` / `dlclose` (or `dlsym` on a
+    /// different library) are not yet supported; see the loader docs for
+    /// the full reentrancy contract.
+    ///
+    /// # Safety
+    ///
+    /// See [`invoke_init_array`](Self::invoke_init_array).
+    pub unsafe fn invoke_fini_array(descriptor: Option<(usize, usize)>, name: &str) {
+        let (base, count): (usize, usize) = match descriptor {
+            Some(range) => range,
+            None => return,
+        };
+        ::syslog::debug!("invoke_fini_array(): library={:?} entries={}", name, count);
+        for index in (0..count).rev() {
+            // SAFETY: see `invoke_init_array`.
+            let entry_ptr: *const usize = (base + index * mem::size_of::<usize>()) as *const usize;
+            let entry: usize = unsafe { entry_ptr.read_unaligned() };
+            if entry == 0 || entry == usize::MAX {
+                continue;
+            }
+            let func: extern "C" fn() = unsafe { mem::transmute::<usize, extern "C" fn()>(entry) };
+            func();
+        }
     }
 }
 

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -90,9 +90,18 @@ static DLINIT_ONCE: Once = Once::new();
 /// and relative paths bypass `LD_LIBRARY_PATH`.
 ///
 /// If `filename` is a bare name (no `/`), the function tries each directory in
-/// [`LIBRARY_SEARCH_PATHS`] in order, returning the first path for which the
-/// file exists. If no match is found the bare name is returned so that the
-/// subsequent `open_regular_file` call produces the appropriate error.
+/// the following order, returning the first path for which the file exists:
+///
+/// 1. The directories listed in `runpaths` (caller-supplied, typically the
+///    `DT_RUNPATH` entries of the library whose dependency is being resolved).
+///    `$ORIGIN` inside an entry is substituted with `"."` (the current
+///    working directory). This is a temporary approximation; the System V
+///    `ld.so` convention is to substitute the directory of the loading
+///    library, which Nanvix does not yet track per-library.
+/// 2. The directories in [`LIBRARY_SEARCH_PATHS`] (currently just `"lib/"`).
+///
+/// If no match is found the bare name is returned so that the subsequent
+/// `open_regular_file` call produces the appropriate error.
 ///
 /// All paths are normalized to a consistent form without leading `/` or `./`,
 /// matching the convention used throughout the Nanvix dlfcn layer and test code
@@ -106,7 +115,11 @@ static DLINIT_ONCE: Once = Once::new();
 /// candidate path. The matched file is re-opened by `DynamicLibrary::open()`.
 /// This double-open is accepted for simplicity; a stat-based probe would
 /// avoid it but is not currently available in the Nanvix VFS API.
-pub(super) fn resolve_library_path(filename: &str) -> String {
+///
+/// `DT_RPATH` (the predecessor to `DT_RUNPATH`) is intentionally not consulted:
+/// it is deprecated by the System V gABI and modern toolchains emit
+/// `DT_RUNPATH` instead.
+pub(super) fn resolve_library_path(filename: &str, runpaths: Option<&[String]>) -> String {
     // If the original filename contains a path separator, the caller provided
     // an explicit path (absolute or relative with directory). Normalize it
     // but do NOT search configured directories — matching Linux behavior
@@ -124,30 +137,101 @@ pub(super) fn resolve_library_path(filename: &str) -> String {
         return String::from(normalized);
     }
 
-    // Bare library name (no path separator) — search configured directories.
+    // Bare library name (no path separator) — search runpaths first, then
+    // the configured default directories.
+    if let Some(runpaths) = runpaths {
+        for dir in runpaths.iter() {
+            let dir: String = substitute_origin(dir);
+            let candidate: String = join_dir(&dir, filename);
+            if probe_exists(&candidate) {
+                // Apply the same canonicalization as the explicit-path
+                // branch above so callers that compare against already-
+                // loaded library names (which are stored canonically)
+                // don't see duplicates like `"./libfoo.so"` vs
+                // `"libfoo.so"`. Strip a single leading "./" and any
+                // leading "/" so DT_RUNPATH entries like `"."`, `"./"`,
+                // or absolute paths still yield a canonical result.
+                let canonical: String = canonicalize(&candidate);
+                ::syslog::debug!(
+                    "resolve_library_path(): resolved '{}' via DT_RUNPATH -> '{}'",
+                    filename,
+                    canonical
+                );
+                return canonical;
+            }
+        }
+    }
+
     // Clone the path list under the lock, then release it before probing
     // the filesystem (which involves I/O and should not hold a spinlock).
     let search_paths: Vec<String> = LIBRARY_SEARCH_PATHS.lock().clone();
     for dir in search_paths.iter() {
-        let candidate: String = alloc::format!("{}{}", dir, filename);
-        // Probe whether the file exists by attempting to open it.
-        if let Ok(_fd) = crate::safe::FileSystem::open_regular_file(
-            // FileSystemPath::new can fail for invalid names; skip on error.
-            &match crate::safe::FileSystemPath::new(&candidate) {
-                Ok(p) => p,
-                Err(_) => continue,
-            },
-            &crate::safe::RegularFileOpenFlags::read_only(),
-            None,
-        ) {
-            ::syslog::debug!("resolve_library_path(): resolved '{}' -> '{}'", filename, candidate);
-            return candidate;
+        let candidate: String = join_dir(dir, filename);
+        if probe_exists(&candidate) {
+            let canonical: String = canonicalize(&candidate);
+            ::syslog::debug!("resolve_library_path(): resolved '{}' -> '{}'", filename, canonical);
+            return canonical;
         }
     }
 
     // Fall back to the original name (will produce a clear error at open time).
     ::syslog::debug!("resolve_library_path(): no match for '{}', using as-is", filename);
     String::from(filename)
+}
+
+/// Strips a single leading `./` and any leading `/` from `path`, matching the
+/// canonical form used throughout the dlfcn layer (e.g. `"lib/libc.so"`).
+/// Returns the input unchanged if normalization would yield an empty string.
+fn canonicalize(path: &str) -> String {
+    let stripped: &str = path
+        .strip_prefix("./")
+        .unwrap_or(path)
+        .trim_start_matches('/');
+    if stripped.is_empty() {
+        String::from(path)
+    } else {
+        String::from(stripped)
+    }
+}
+
+/// Joins a directory and filename without introducing duplicate separators.
+fn join_dir(dir: &str, filename: &str) -> String {
+    if dir.is_empty() {
+        return String::from(filename);
+    }
+    if dir.ends_with('/') {
+        alloc::format!("{}{}", dir, filename)
+    } else {
+        alloc::format!("{}/{}", dir, filename)
+    }
+}
+
+/// Substitutes `$ORIGIN` in a runpath entry. Nanvix has no per-process loader
+/// directory concept yet, so `$ORIGIN` is currently expanded to `"."` (the
+/// current working directory). This is a temporary approximation: the System V
+/// `ld.so` convention is to expand `$ORIGIN` to the directory containing the
+/// loading library, which Nanvix does not yet track per-library. Keeping a
+/// well-formed substitution (rather than the empty string) avoids producing
+/// invalid paths like `"//lib"` from entries such as `"$ORIGIN/lib"`.
+fn substitute_origin(entry: &str) -> String {
+    if !entry.contains("$ORIGIN") {
+        return String::from(entry);
+    }
+    entry.replace("$ORIGIN", ".")
+}
+
+/// Returns `true` if a regular file exists at `candidate`.
+fn probe_exists(candidate: &str) -> bool {
+    let path: crate::safe::FileSystemPath = match crate::safe::FileSystemPath::new(candidate) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    crate::safe::FileSystem::open_regular_file(
+        &path,
+        &crate::safe::RegularFileOpenFlags::read_only(),
+        None,
+    )
+    .is_ok()
 }
 
 /// Populates `GLOBAL_SYMBOL_TABLE` from the executable's `.dynsym`/`.dynstr`


### PR DESCRIPTION
## Summary  Fixes two latent bugs in the dynamic loader that prevent it from handling diamond `DT_NEEDED` graphs — the canonical multi-edge shape that production shared-library chains take:  ``` libdiamond.so ─┬─ DT_NEEDED libleft.so  ──┐                └─ DT_NEEDED libright.so ──┴── DT_NEEDED libbase.so ```  Both bugs only surface once `DT_NEEDED` chains are nontrivial. The existing `dlfcn-needed-c` posix-test exercises a single linear edge, so it never tripped either path. Companion test suite `dlfcn-diamond-c` covering this case is filed at [nanvix/posix-tests#177](https://github.com/nanvix/posix-tests/pull/177).  ## Bug 1 — `dlopen` deadlocks on ancestor mutex  `load_all_dependencies_recursive` holds the parent library's mutex while iterating the registry's already-loaded entries. Each entry gets `.lock()`-ed to compare names. The previous code skipped only the immediate `new_dlhandle` self — **not** ancestors held by outer recursive frames. Loading `libright.so` (depth 1) and then recursing into its deps (depth 2) tried to lock `libdiamond.so` in the inner scan, which deadlocked because `libdiamond.so` was held by the outer frame.  **Fix:** thread a `BTreeSet<DlHandle>` of ancestor handles down the recursion and skip every entry whose handle is in that set. The ancestor is by definition not a candidate for "already loaded by a sibling" so the skip is functionally safe.  ## Bug 2 — `dlopen` races on transitive loads (diamond duplication)  Once the deadlock is gone, a second issue surfaces: the pre-loop `retain` only sees libraries loaded *before* the current frame started. In a diamond, `libbase.so` is loaded by `libleft.so`'s recursion *during* `libdiamond.so`'s frame, **after** `libdiamond.so`'s `retain` has already run. Without a re-check, the outer loop would then open `libbase.so` a second time, producing two distinct in-memory copies with their own globals (or tripping the existing `unreachable!()` when the VFS reuses the file descriptor).  **Fix:** before each `DynamicLibrary::open` call, re-scan the registry for a matching name and bind the existing copy if found.  ## Bug 3 — `dlclose` over-strict refcount assertion  The BFS unload loop extracts each library from the registry when `Arc::strong_count == 2` (registry + current pop). For a diamond, `libbase.so` has **three** `Arc` references at the time it is first popped (registry + `libleft.dependencies` + `libright.dependencies`), so `extract_if` correctly returns 0 entries — but the assertion demanded exactly 1, panicking the kernel. A later iteration of the loop pops `libright`/`libleft`, drops their dependencies (releasing the extra `libbase` ref), pushes `libbase` again, and the second pop succeeds at the now-correct refcount.  **Fix:** replace the strict `assert_eq!(== 1)` with an early `continue` when `extract_if` returns zero entries, keeping the (now relaxed) "at most one" assertion to catch any future runtime invariant violation.  ## What changes  | File | Change | |---|---| | `src/libs/syscall/src/dlfcn/syscall/dlopen.rs` | Thread `ancestors: &mut BTreeSet<DlHandle>` through `load_all_dependencies_recursive`; skip ancestor handles in the `retain` closure and the pre-open re-check; add a pre-open registry re-check for transitive diamond loads. | | `src/libs/syscall/src/dlfcn/syscall/dlclose.rs` | Skip rather than panic when `extract_if` returns 0 entries; relax the assertion message accordingly. |  Net diff: +88 / −6 lines, no API changes.  ## Validation  - `./z build all FEATURES=networking LOG_LEVEL=error RELEASE=yes MEMORY_SIZE=256` — PASS - `./z build format-check`, `rust-lint-check`, `spellcheck` — PASS - New `dlfcn-diamond-c` suite — 3/3 PASS on standalone VM:   ```   === dlfcn diamond DT_NEEDED tests ===     PASS: dlopen(libright.so) [depth-2 chain]     PASS: dlopen(libdiamond.so)     PASS: re-dlopen(libdiamond.so) returns same handle   3 passed, 0 failed   ``` - All previously passing dlfcn tests (`dlfcn-c`, `dlfcn-init-runpath-c`, `dlfcn-pie-c`) still pass. - Full posix-tests suite passes.  ## Why it matters  This bug blocks the loader from handling any non-trivial real-world `.so` chain. As soon as two consumers in the same `dlopen` call share a transitive dependency — the diamond shape, which is the norm rather than the exception in production library stacks — `dlopen` either hangs the guest indefinitely (Bug 1) or panics the kernel on the matching `dlclose` (Bugs 2 + 3). Today this is hidden because no in-tree test exercises a multi-edge graph; `dlfcn-needed-c` is strictly linear. Any consumer that opens a small graph of shared libraries (extension modules, plugin systems, language runtimes) will hit this immediately once `.so` content lands.  ## Stacking  Stacked on top of nanvix/nanvix#2473 (`feat/dlfcn-init-array-and-runpath`). Merge order: #2473 first, then this PR. The diff against `dev` includes #2473's changes until #2473 lands. 