### PR TITLE
[kernel] Add getppid() kernel call

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -60,6 +60,11 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
     let result: KcallResult = match KcallNumber::from(number) {
         // Handle `getpid()` locally.
         KcallNumber::GetPid => KcallResult::Success(<i64>::from(pid).into()),
+        // Handle `getppid()` locally.
+        KcallNumber::GetPpid => {
+            let ppid: ProcessIdentifier = unsafe { ProcessManager::get() }.get_ppid();
+            KcallResult::Success(<i64>::from(ppid).into())
+        },
         // Handle `gettid()` locally.
         KcallNumber::GetTid => KcallResult::Success(<i64>::from(tid).into()),
         KcallNumber::Exit => {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -183,7 +183,12 @@ impl ProcessManager {
         root: Vmem,
         tm: ThreadManager,
     ) -> Self {
-        let kernel: RunnableProcess = RunnableProcess::new(ProcessIdentifier::KERNEL, kernel, root);
+        let kernel: RunnableProcess = RunnableProcess::new(
+            ProcessIdentifier::KERNEL,
+            ProcessIdentifier::KERNEL,
+            kernel,
+            root,
+        );
 
         let (kernel, reason, _, _user_tda): (
             RunningProcess,
@@ -670,7 +675,7 @@ impl ProcessManager {
             self.tm.commit_next_tid(next_tid);
             self.live_count += 1;
             let parent_pid: ProcessIdentifier = self.get_running().state().pid();
-            let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
+            let process: RunnableProcess = RunnableProcess::new(pid, parent_pid, thread, vmem);
 
             // Add process to the queue of ready processes.
             self.ready.push_back(process);
@@ -819,7 +824,7 @@ impl ProcessManager {
             self.tm.commit_next_tid(next_tid);
             self.live_count += 1;
 
-            let process: RunnableProcess = RunnableProcess::new(child_pid, thread, vmem);
+            let process: RunnableProcess = RunnableProcess::new(child_pid, pid, thread, vmem);
             self.ready.push_back(process);
 
             // Record the creation so the kernel main loop can publish a process-creation
@@ -2032,6 +2037,19 @@ impl ProcessManager {
     ///
     pub fn get_pid(&self) -> ProcessIdentifier {
         self.get_running().state().pid()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the ID of the parent of the calling process.
+    ///
+    /// # Returns
+    ///
+    /// The ID of the parent of the calling process.
+    ///
+    pub fn get_ppid(&self) -> ProcessIdentifier {
+        self.get_running().state().ppid()
     }
 
     ///

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -184,6 +184,8 @@ impl ProcessRef<'_> {
 pub struct ProcessState {
     /// Process identifier.
     pid: ProcessIdentifier,
+    /// Process identifier of the parent process.
+    parent: ProcessIdentifier,
     /// Capabilities.
     capabilities: Capabilities,
     /// Memory address space.
@@ -205,9 +207,10 @@ pub struct ProcessState {
 }
 
 impl ProcessState {
-    pub fn new(pid: ProcessIdentifier, vmem: Vmem) -> Self {
+    pub fn new(pid: ProcessIdentifier, parent: ProcessIdentifier, vmem: Vmem) -> Self {
         Self {
             pid,
+            parent,
             capabilities: Capabilities::default(),
             vmem,
             events: LinkedList::new(),
@@ -222,6 +225,10 @@ impl ProcessState {
 
     pub fn pid(&self) -> ProcessIdentifier {
         self.pid
+    }
+
+    pub fn ppid(&self) -> ProcessIdentifier {
+        self.parent
     }
 
     ///

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -59,9 +59,14 @@ pub struct RunnableProcess {
 }
 
 impl RunnableProcess {
-    pub fn new(pid: ProcessIdentifier, ready_thread: ReadyThread, vmem: Vmem) -> Self {
+    pub fn new(
+        pid: ProcessIdentifier,
+        parent: ProcessIdentifier,
+        ready_thread: ReadyThread,
+        vmem: Vmem,
+    ) -> Self {
         Self {
-            state: Box::new(ProcessState::new(pid, vmem)),
+            state: Box::new(ProcessState::new(pid, parent, vmem)),
             ready_threads: NonEmptyVecDeque::new(ready_thread),
             interrupted_threads: None,
             sleeping_threads: None,

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -59,6 +59,32 @@ pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
 }
 
 //==================================================================================================
+// Get Parent Process Identifier
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the process identifier of the parent of the calling process.
+///
+/// # Returns
+///
+/// Upon successful completion, the process identifier of the parent of the calling process is
+/// returned. Upon failure, an error is returned instead.
+///
+#[unsafe(no_mangle)]
+pub fn __kcall_getppid() -> Result<ProcessIdentifier, Error> {
+    let result: i64 = kcall0!(KcallNumber::GetPpid.into());
+
+    // NOTE: errors are unlikely because getppid() always succeeds for a valid calling process.
+    if unlikely(result < 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to getppid()"))
+    } else {
+        ProcessIdentifier::try_from(result)
+    }
+}
+
+//==================================================================================================
 // Get Thread Identifier
 //==================================================================================================
 

--- a/src/libs/sys/src/sys/number.rs
+++ b/src/libs/sys/src/sys/number.rs
@@ -17,6 +17,8 @@ pub enum KcallNumber {
     Debug = KcallNumber::NR_DEBUG_SYSCALL,
     /// Get process identifier.
     GetPid = KcallNumber::NR_GET_PID_SYSCALL,
+    /// Get parent process identifier.
+    GetPpid = KcallNumber::NR_GET_PPID_SYSCALL,
     /// Get thread identifier.
     GetTid = KcallNumber::NR_GET_TID_SYSCALL,
     /// Terminate the calling process.
@@ -133,6 +135,7 @@ impl KcallNumber {
     const NR_SNAPSHOT_SYSCALL: u32 = 35;
     const NR_DETACH_THREAD_SYSCALL: u32 = 36;
     const NR_DUPLICATE_SYSCALL: u32 = 37;
+    const NR_GET_PPID_SYSCALL: u32 = 38;
     const NR_INVALID_SYSCALL: u32 = u32::MAX;
 }
 
@@ -142,6 +145,7 @@ impl From<u32> for KcallNumber {
         match value {
             Self::NR_DEBUG_SYSCALL => KcallNumber::Debug,
             Self::NR_GET_PID_SYSCALL => KcallNumber::GetPid,
+            Self::NR_GET_PPID_SYSCALL => KcallNumber::GetPpid,
             Self::NR_GET_TID_SYSCALL => KcallNumber::GetTid,
             Self::NR_EXIT_SYSCALL => KcallNumber::Exit,
             Self::NR_CAP_CTL_SYSCALL => KcallNumber::CapCtl,
@@ -189,6 +193,7 @@ impl From<KcallNumber> for u32 {
         match k {
             KcallNumber::Debug => KcallNumber::NR_DEBUG_SYSCALL,
             KcallNumber::GetPid => KcallNumber::NR_GET_PID_SYSCALL,
+            KcallNumber::GetPpid => KcallNumber::NR_GET_PPID_SYSCALL,
             KcallNumber::GetTid => KcallNumber::NR_GET_TID_SYSCALL,
             KcallNumber::Exit => KcallNumber::NR_EXIT_SYSCALL,
             KcallNumber::CapCtl => KcallNumber::NR_CAP_CTL_SYSCALL,

--- a/src/libs/syscall/src/unistd/bindings/getppid.rs
+++ b/src/libs/syscall/src/unistd/bindings/getppid.rs
@@ -1,0 +1,41 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::unistd;
+use ::sysapi::sys_types::pid_t;
+use ::syslog::trace_syscall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the process ID of the parent of the calling process. The parent relationship is
+/// established by the kernel when a process is created and is queried directly through a kernel
+/// call.
+///
+/// # Returns
+///
+/// Upon successful completion, `getppid()` returns the process ID of the parent of the calling
+/// process. On failure, it returns `-1` cast to `pid_t`.
+///
+#[trace_syscall]
+#[unsafe(no_mangle)]
+pub extern "C" fn getppid() -> pid_t {
+    match unistd::getppid() {
+        Ok(parent) => parent.into(),
+        Err(e) => {
+            // POSIX does not allow us to modify `errno`. So we just emit a warning.
+            ::syslog::warn!("getppid(): failed (error={:?})", e);
+            // POSIX does not reserve specific values for errors. We workaround it and return `-1`
+            // to indicate an error.
+            -1 as pid_t
+        },
+    }
+}

--- a/src/libs/syscall/src/unistd/bindings/mod.rs
+++ b/src/libs/syscall/src/unistd/bindings/mod.rs
@@ -29,6 +29,7 @@ pub mod geteuid;
 pub mod getgid;
 pub mod gethostname;
 pub mod getpid;
+pub mod getppid;
 pub mod getuid;
 pub mod isatty;
 pub mod lchown;

--- a/src/libs/syscall/src/unistd/mod.rs
+++ b/src/libs/syscall/src/unistd/mod.rs
@@ -32,6 +32,7 @@ cfg_if::cfg_if! {
             geteuid,
             getgid,
             getpid,
+            getppid,
             getuid,
             gethostname,
             link,

--- a/src/libs/syscall/src/unistd/syscall/getppid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getppid.rs
@@ -1,0 +1,24 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::{
+    error::Error,
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================///
+
+///
+/// # Description
+///
+/// `getppid()` returns the process ID (PID) of the parent of the calling process.
+///
+pub fn getppid() -> Result<ProcessIdentifier, Error> {
+    ::sys::kcall::pm::__kcall_getppid()
+}

--- a/src/libs/syscall/src/unistd/syscall/mod.rs
+++ b/src/libs/syscall/src/unistd/syscall/mod.rs
@@ -21,6 +21,7 @@ mod geteuid;
 mod getgid;
 mod gethostname;
 mod getpid;
+mod getppid;
 mod getuid;
 mod isatty;
 mod link;
@@ -59,6 +60,7 @@ pub use self::{
     getgid::getgid,
     gethostname::gethostname,
     getpid::getpid,
+    getppid::getppid,
     getuid::getuid,
     isatty::isatty,
     link::link,

--- a/src/tests/test-kernel/src/getppid.rs
+++ b/src/tests/test-kernel/src/getppid.rs
@@ -1,0 +1,260 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # `getppid()` Kernel Call Regression Tests
+//!
+//! Exercises the [`__kcall_getppid`] kernel call end-to-end and verifies that the parent
+//! process identifier reported to a child created via `duplicate()` matches the identifier of
+//! the process that performed the duplication:
+//!
+//! 1. The calling process records its own PID in copy-on-write shared memory.
+//! 2. It duplicates itself, producing a child whose kernel-tracked parent is the caller.
+//! 3. The child calls `getppid()` and reports the result back to the parent via IPC.
+//! 4. The parent asserts that the child observed the caller's PID as its parent.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::alloc::Layout;
+use ::arch::mem::PAGE_SIZE;
+use ::core::sync::atomic::{
+    AtomicU32,
+    Ordering,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    kcall::{
+        ipc,
+        pm,
+        sched,
+    },
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        ThreadCreateArgs,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Ordering used for all atomic operations.
+const ORDER: Ordering = Ordering::SeqCst;
+
+/// Stack size handed to the child's main thread.
+const CHILD_STACK_SIZE: usize = 4 * PAGE_SIZE;
+
+/// Child exit code: failed to query its own PID via `getpid()`.
+const CHILD_ERR_GETPID: usize = 1;
+
+/// Child exit code: failed to recover the parent's PID from CoW-shared memory.
+const CHILD_ERR_PARENT_PID: usize = 2;
+
+/// Child exit code: failed to receive the parent's go-ahead message.
+const CHILD_ERR_RECV: usize = 3;
+
+/// Child exit code: failed to query the parent PID via `getppid()`.
+const CHILD_ERR_GETPPID: usize = 4;
+
+/// Child exit code: failed to convert the observed parent PID to a raw value.
+const CHILD_ERR_PPID_CONVERT: usize = 5;
+
+/// Child exit code: failed to send the report back to the parent.
+const CHILD_ERR_SEND: usize = 6;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Parent process identifier, written before `duplicate()` so that the child can recover it from
+/// the inherited (copy-on-write) memory image and compare it against `getppid()`.
+static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
+
+//==================================================================================================
+// Child Entry Point
+//==================================================================================================
+
+/// Entry point for the child process spawned by `duplicate()`.
+///
+/// The child:
+///
+/// 1. Recovers its own PID and the parent's PID (the latter from CoW-shared memory).
+/// 2. Blocks on `recv()` to synchronize with the parent.
+/// 3. Calls `getppid()` and reports the raw result back to the parent via IPC.
+/// 4. Spins until the parent terminates it.
+extern "C" fn child_entry(_arg: usize) -> usize {
+    // Recover identifiers.
+    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        Ok(p) => p,
+        Err(_) => return CHILD_ERR_GETPID,
+    };
+    let parent_pid: ProcessIdentifier =
+        match ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER)) {
+            Ok(p) => p,
+            Err(_) => return CHILD_ERR_PARENT_PID,
+        };
+
+    // Wait for the parent's go-ahead message before reporting back.
+    if ipc::__kcall_recv().is_err() {
+        return CHILD_ERR_RECV;
+    }
+
+    // Query the parent process identifier via the kernel call under test.
+    let ppid: ProcessIdentifier = match pm::__kcall_getppid() {
+        Ok(p) => p,
+        Err(_) => return CHILD_ERR_GETPPID,
+    };
+    let ppid_raw: i32 = match u32::try_from(ppid).ok().and_then(|v| i32::try_from(v).ok()) {
+        Some(v) => v,
+        None => return CHILD_ERR_PPID_CONVERT,
+    };
+
+    // Report the observed parent PID to the parent.
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    payload[0..4].copy_from_slice(&ppid_raw.to_le_bytes());
+    let reply: Message = Message::new(
+        MessageSender::from(my_pid),
+        MessageReceiver::from(parent_pid),
+        MessageType::Ipc,
+        None,
+        payload,
+    );
+    if ipc::__kcall_send(&reply).is_err() {
+        return CHILD_ERR_SEND;
+    }
+
+    // Spin until the parent terminates us.
+    loop {
+        let _ = sched::__kcall_sched_yield();
+    }
+}
+
+//==================================================================================================
+// Test
+//==================================================================================================
+
+/// Verifies that a child created via `duplicate()` observes the duplicating process as its parent
+/// through the `getppid()` kernel call.
+fn test_getppid_reports_parent() -> Result<(), Error> {
+    // Record the parent's PID where the child can find it via CoW-shared memory.
+    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Allocate a page-aligned stack for the child's main thread.
+    let layout: Layout = Layout::from_size_align(CHILD_STACK_SIZE, PAGE_SIZE)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "bad stack layout"))?;
+    // SAFETY: layout has non-zero size.
+    let stack_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack_ptr.is_null() {
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate child stack"));
+    }
+    let stack_base: VirtualAddress = VirtualAddress::from_raw_value(stack_ptr as usize);
+
+    // Pre-fault every page of the child's stack so that the pages are present in the parent's
+    // address space at `duplicate()` time. This guarantees they are inherited copy-on-write by the
+    // child; otherwise the child's first stack write would fault on a page that the kernel cannot
+    // resolve (no demand-fill metadata is inherited for never-touched pages).
+    // SAFETY: `stack_ptr` points to a freshly allocated `CHILD_STACK_SIZE`-byte region.
+    unsafe { ::core::ptr::write_bytes(stack_ptr, 0, CHILD_STACK_SIZE) };
+
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(child_entry as *const () as usize),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: stack_base,
+        user_stack_size: CHILD_STACK_SIZE,
+        user_tda: None,
+    };
+
+    // Duplicate the calling process. The child's kernel-tracked parent is this process.
+    let child_pid: ProcessIdentifier = match pm::__kcall_duplicate(&args) {
+        Ok(child_pid) => child_pid,
+        Err(e) => {
+            // The duplication failed, so no child references the parent's mapping of these pages.
+            // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above.
+            unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
+            return Err(e);
+        },
+    };
+
+    // Interact with the child. The interaction is fallible, but the child must always be torn
+    // down and its stack reclaimed afterwards so that a failure does not leave an orphaned
+    // spinning process or leak the stack allocation.
+    let outcome: Result<(), Error> = observe_child_parent(parent_pid, child_pid);
+
+    // Tear down the child and reclaim the stack regardless of the interaction outcome.
+    let teardown: Result<(), Error> = pm::__kcall_terminate(child_pid);
+    // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above and the
+    // child is being terminated so it no longer references the parent's mapping of these pages.
+    unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
+
+    // Surface the interaction error first, then any teardown error.
+    outcome.and(teardown)
+}
+
+/// Releases the child, receives its `getppid()` report, and verifies that the child observed the
+/// duplicating process as its parent.
+fn observe_child_parent(
+    parent_pid: ProcessIdentifier,
+    child_pid: ProcessIdentifier,
+) -> Result<(), Error> {
+    assert!(child_pid != parent_pid, "child_pid must differ from parent_pid");
+
+    // Release the child to perform its observation.
+    let go: Message = Message::new(
+        MessageSender::from(parent_pid),
+        MessageReceiver::from(child_pid),
+        MessageType::Ipc,
+        None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    ipc::__kcall_send(&go)?;
+
+    // Receive the child's report.
+    let reply: Message = ipc::__kcall_recv()?;
+    let reply_type: MessageType = { reply.message_type };
+    assert!(reply_type == MessageType::Ipc, "expected IPC reply");
+
+    let mut ppid_bytes: [u8; 4] = [0u8; 4];
+    ppid_bytes.copy_from_slice(&reply.payload[0..4]);
+    let child_ppid_raw: i32 = i32::from_le_bytes(ppid_bytes);
+
+    // The child must observe the duplicating process as its parent.
+    let parent_pid_raw: i32 = i32::try_from(u32::try_from(parent_pid)?)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "parent pid out of range"))?;
+    assert!(
+        child_ppid_raw == parent_pid_raw,
+        "child getppid() returned {}; expected {} (parent lineage broken)",
+        child_ppid_raw,
+        parent_pid_raw
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
+// Public Entry Point
+//==================================================================================================
+
+/// Runs all `getppid()` regression tests.
+pub fn run() -> Result<(), Error> {
+    ::syslog::info!("test-kernel: getppid: starting getppid() regression tests");
+
+    test_getppid_reports_parent()?;
+    ::syslog::info!("test-kernel: getppid: PASS - getppid_reports_parent");
+
+    ::syslog::info!("test-kernel: getppid: all tests passed");
+
+    Ok(())
+}

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -26,6 +26,7 @@ mod demand_paging;
 mod detach;
 mod direction_flag;
 mod duplicate;
+mod getppid;
 mod mmio_ramfs;
 mod rendezvous;
 mod tls;
@@ -57,6 +58,8 @@ pub fn main() -> Result<(), Error> {
     detach::run()?;
 
     duplicate::run()?;
+
+    getppid::run()?;
 
     mmio_ramfs::run()?;
 


### PR DESCRIPTION
## Summary

Adds a `getppid()` kernel call that returns the parent process identifier of the calling process, along with an end-to-end regression test.

## Changes

- **`[kernel]`** Add the `getppid()` kernel call.
- **`[tests]`** Add a `getppid()` regression test to `test-kernel` that verifies a child created via `duplicate()` observes the duplicating process as its parent.

## Test Details

The test:
- Records the parent's PID in copy-on-write shared memory before duplicating, so the child can recover it from its inherited image.
- Pre-faults the child's stack pages so they are inherited copy-on-write rather than faulting on never-touched, demand-fill pages.
- Synchronizes parent and child over IPC: the parent releases the child, the child reports the result of `getppid()`, and the parent asserts it matches the caller's PID.
- Reports distinct exit codes for each child failure path via named constants for easier diagnosis.

## Validation

- `./z test` passes.
