### PR TITLE
[libs] E: Split sys-ffi crate to isolate #[no_mangle] FFI exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ version = "0.16.24"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -1134,11 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1478,9 +1478,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1491,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2317,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -2390,6 +2390,7 @@ dependencies = [
  "spin",
  "static_assert",
  "sys",
+ "sys-ffi",
  "sysalloc",
  "sysapi",
  "syscall",
@@ -3089,6 +3090,13 @@ dependencies = [
  "error",
  "rustc-std-workspace-core",
  "static_assert",
+]
+
+[[package]]
+name = "sys-ffi"
+version = "0.16.24"
+dependencies = [
+ "sys",
 ]
 
 [[package]]
@@ -3852,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3865,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3875,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3885,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3898,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3941,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4090,6 +4098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
         "src/libs/multiimage",
         "src/libs/mmio-tag",
         "src/libs/sys",
+        "src/libs/sys-ffi",
         "src/libs/type-safe",
         "src/libs/user-vm-api",
         "src/libs/vfs",
@@ -206,6 +207,7 @@ libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }
+sys-ffi = { path = "src/libs/sys-ffi", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }
 sysalloc = { path = "src/libs/sysalloc", default-features = false }
 syscall = { path = "src/libs/syscall", default-features = false }

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["lib", "staticlib"]
 # bug — see `nanvix-todo/dlopen-load-address-conflict.md`.
 nvx = { workspace = true }
 sys = { workspace = true }
+sys-ffi = { workspace = true }
 cfg-if = { workspace = true }
 config = { workspace = true }
 num_enum = { workspace = true }

--- a/src/libs/posix/src/lib.rs
+++ b/src/libs/posix/src/lib.rs
@@ -14,6 +14,29 @@
 
 extern crate nvx;
 
+// Force `sys-ffi`'s `#[no_mangle]` kernel-call wrappers into the
+// `libposix.a` staticlib so other archives that link `libposix` can
+// resolve the unmangled `__kcall_*` / `_do_exit_thread` /
+// `__kcall_snapshot` / `_do_start_thread` names at link time.  Most
+// of these wrappers are Rust ABI (they take and return
+// `Result<T, Error>`, `&mut T`, etc.) -- this is about link-time
+// symbol resolution, not C callability -- but the unmangled name is
+// what the rest of the static-archive graph (libnvx_crt0 thread
+// stubs, port-library glue) expects to find.  Without this
+// `extern crate`, cargo metadata alone is not enough to force a leaf
+// crate with no `pub` re-exports to be linked into the final
+// staticlib.
+//
+// DO NOT REMOVE this `extern crate` line.  It looks unused to tools
+// like `cargo fix` or `unused_extern_crates` lints, but removing it
+// silently drops every `__kcall_*` symbol from `libposix.a` and
+// breaks every executable that resolves these symbols by their
+// unmangled name at link time.  Verify any change to this line with:
+//   nm <libposix.a> | grep -E ' T (__kcall_|_do_exit_thread|_do_start_thread)' | wc -l
+// which must report 36.
+#[allow(unused_extern_crates)]
+extern crate sys_ffi;
+
 extern crate alloc;
 
 #[cfg(feature = "syscall")]

--- a/src/libs/sys-ffi/Cargo.toml
+++ b/src/libs/sys-ffi/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "sys-ffi"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Unmangled-symbol shim re-exporting sys kernel-call wrappers for link-time resolution"
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sys = { workspace = true, features = ["kcall"] }
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/src/libs/sys-ffi/src/lib.rs
+++ b/src/libs/sys-ffi/src/lib.rs
@@ -1,0 +1,382 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+#![forbid(clippy::large_stack_frames)]
+#![forbid(clippy::large_stack_arrays)]
+#![feature(never_type)]
+#![no_std]
+
+//! Nanvix unmangled-symbol shim for `sys::kcall::*`.
+//!
+//! This crate exists solely to expose the kernel-call thunks defined in
+//! the `sys::kcall` module hierarchy as unmangled (`#[no_mangle]`) globals
+//! so that consumers can resolve them at link time by their canonical
+//! names (`__kcall_*`, `_do_exit_thread`, `_do_start_thread`,
+//! `__kcall_snapshot`).
+//!
+//! Most exports use Rust ABI (taking and returning Rust types such as
+//! `Result<T, Error>`, `&mut T`, `Duration`, etc.) -- only
+//! `_do_exit_thread`, `__kcall_snapshot`, and the `_do_start_thread`
+//! `global_asm!` stub are `extern "C"`.  The `#[no_mangle]` attribute
+//! affects the symbol's *name*, not its calling convention: this crate
+//! is therefore a link-time-resolution shim, not a C-callable ABI.
+//! Consumers that link these symbols by `extern` declaration must
+//! match the Rust ABI signatures.
+//!
+//! Splitting the unmangled surface into its own crate avoids the
+//! duplicate-symbol issue that arose when `libnvx_crt0.a` and
+//! `libposix.a` BOTH baked the `sys` crate's `#[no_mangle]` exports
+//! into their static archives.  Now only the consumers that explicitly
+//! depend on `sys-ffi` (notably `libposix`) end up with the unmangled
+//! symbols in their archive; `libnvx_crt0` stays free of them.
+//!
+//! Each wrapper here is a thin trampoline that immediately forwards to
+//! the Rust-mangled equivalent in `sys::kcall::*`.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::{
+    option::Option,
+    time::Duration,
+};
+use ::sys::{
+    error::Error,
+    event::{
+        Event,
+        EventCtrlRequest,
+        EventDescriptor,
+    },
+    ipc::Message,
+    mm::{
+        AccessPermission,
+        MmioRegionInfo,
+        VirtualAddress,
+    },
+    pm::{
+        Capability,
+        ConditionAddress,
+        MutexAddress,
+        ProcessIdentifier,
+        ThreadCreateArgs,
+        ThreadIdentifier,
+    },
+    time::SystemTime,
+};
+
+//==================================================================================================
+// debug
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_debug(buf: *const u8, size: usize) -> Result<(), Error> {
+    ::sys::kcall::debug::__kcall_debug(buf, size)
+}
+
+//==================================================================================================
+// event
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_resume(event: EventDescriptor) -> Result<(), Error> {
+    ::sys::kcall::event::__kcall_resume(event)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_evctrl(ev: Event, req: EventCtrlRequest) -> Result<(), Error> {
+    ::sys::kcall::event::__kcall_evctrl(ev, req)
+}
+
+//==================================================================================================
+// ipc
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_send(message: &Message) -> Result<(), Error> {
+    ::sys::kcall::ipc::__kcall_send(message)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_recv() -> Result<Message, Error> {
+    ::sys::kcall::ipc::__kcall_recv()
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_push(
+    destination_pid: ProcessIdentifier,
+    destination_tid: ThreadIdentifier,
+    buffer: &[u8],
+) -> Result<(), Error> {
+    ::sys::kcall::ipc::__kcall_push(destination_pid, destination_tid, buffer)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_pull(
+    sender_pid: ProcessIdentifier,
+    sender_tid: ThreadIdentifier,
+    buffer: &mut [u8],
+) -> Result<usize, Error> {
+    ::sys::kcall::ipc::__kcall_pull(sender_pid, sender_tid, buffer)
+}
+
+//==================================================================================================
+// mm
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_mmap(
+    pid: ProcessIdentifier,
+    vaddr: VirtualAddress,
+    npages: usize,
+    access: AccessPermission,
+) -> Result<(), Error> {
+    ::sys::kcall::mm::__kcall_mmap(pid, vaddr, npages, access)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error> {
+    ::sys::kcall::mm::__kcall_munmap(pid, vaddr)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_mprotect(
+    pid: ProcessIdentifier,
+    vaddr: VirtualAddress,
+    access: AccessPermission,
+) -> Result<(), Error> {
+    ::sys::kcall::mm::__kcall_mprotect(pid, vaddr, access)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_alloc(tag: u64) -> Result<(), Error> {
+    ::sys::kcall::mm::__kcall_mmio_alloc(tag)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_free(tag: u64) -> Result<(), Error> {
+    ::sys::kcall::mm::__kcall_mmio_free(tag)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_mmio_info(tag: u64) -> Result<MmioRegionInfo, Error> {
+    ::sys::kcall::mm::__kcall_mmio_info(tag)
+}
+
+//==================================================================================================
+// pm
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
+    ::sys::kcall::pm::__kcall_getpid()
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_gettid() -> Result<ThreadIdentifier, Error> {
+    ::sys::kcall::pm::__kcall_gettid()
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_exit(status: i32) -> Result<!, Error> {
+    ::sys::kcall::pm::__kcall_exit(status)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_capctl(capability: Capability, value: bool) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_capctl(capability, value)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_terminate(pid)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _do_exit_thread(status: usize) -> ! {
+    ::sys::kcall::pm::_do_exit_thread(status)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
+    ::sys::kcall::pm::__kcall_create_thread(args)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_exit_thread(status: usize) -> Result<!, Error> {
+    ::sys::kcall::pm::__kcall_exit_thread(status)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_join_thread(tid, retval)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_detach_thread(tid)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_duplicate(args: &ThreadCreateArgs) -> Result<ProcessIdentifier, Error> {
+    ::sys::kcall::pm::__kcall_duplicate(args)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_lock_mutex(
+    mutex_addr: MutexAddress,
+    timeout: Option<SystemTime>,
+) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_lock_mutex(mutex_addr, timeout)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_unlock_mutex(mutex_addr)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_signal_cond(
+    cond_addr: ConditionAddress,
+    broadcast: bool,
+) -> Result<usize, Error> {
+    ::sys::kcall::pm::__kcall_signal_cond(cond_addr, broadcast)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_wait_cond(
+    cond_addr: ConditionAddress,
+    mutex_addr: MutexAddress,
+    timeout: Option<SystemTime>,
+) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_wait_cond(cond_addr, mutex_addr, timeout)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_gettime(buffer: &mut SystemTime) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_gettime(buffer)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_sleep(timeout: Duration) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_sleep(timeout)
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_get_thread_data_area() -> Result<*mut u8, Error> {
+    ::sys::kcall::pm::__kcall_get_thread_data_area()
+}
+
+#[unsafe(no_mangle)]
+pub fn __kcall_set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
+    ::sys::kcall::pm::__kcall_set_thread_data_area(user_tda)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __kcall_snapshot() -> i32 {
+    ::sys::kcall::pm::__kcall_snapshot()
+}
+
+//==================================================================================================
+// sched
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn __kcall_sched_yield() -> Result<(), Error> {
+    ::sys::kcall::sched::__kcall_sched_yield()
+}
+
+//==================================================================================================
+// Thread bootstrap stub
+//==================================================================================================
+
+// `_do_start_thread` is the kernel-supplied entry point for newly created
+// threads.  The kernel sets up a trap frame so that IRET "returns" here
+// with the user thread function pointer in EDX and its argument in ECX.
+//
+// The asm lives here in `sys-ffi` (not `sys`) so the
+// `.global _do_start_thread` symbol exists in a single static archive
+// (`libposix.a`), avoiding the duplicate-strong-symbol clash that would
+// otherwise occur when both `libnvx_crt0.a` and `libposix.a` link the
+// `sys` crate.
+//
+// `__kcall_create_thread` (in `sys::kcall::pm`) references this symbol
+// via `extern "C" fn _do_start_thread()`; the link resolves it from
+// `libposix.a` at link time.
+//
+// The `global_asm!` is unconditional (no `cfg(target_arch = ...)`)
+// because Nanvix is x86-only today and `__kcall_create_thread`
+// declares `extern "C" fn _do_start_thread()` unconditionally; a
+// conditional asm here would surface as a link-time unresolved-symbol
+// error rather than a build-time error on any future non-x86 port.
+::core::arch::global_asm!(
+    r#"
+    .global _do_start_thread
+    .extern _do_exit_thread
+    .type _do_start_thread, @function
+
+    _do_start_thread:
+        #
+        # Entry point for newly created threads.
+        #
+        # The kernel sets up a trap frame so that IRET "returns" to this function.
+        # The kernel passes the thread function pointer in EDX and its argument
+        # in ECX.
+        #
+        # This stub calls func(arg) and then _do_exit_thread(status) directly,
+        # enforcing 16-byte stack alignment before each CALL instruction. This
+        # avoids routing through a Rust intermediate function whose compiler-
+        # generated prologue may not preserve 16-byte alignment (the Nanvix Rust
+        # target disables SSE, so LLVM omits alignment-preserving prologues).
+        # The callee func may require 16-byte-aligned stack frames (e.g.,
+        # movaps) when SSE instructions are present.
+        #
+
+        # Save func and arg into callee-saved registers.
+        # This is the thread root frame so there is no caller state to preserve.
+        mov esi, edx        # ESI = func
+        mov edi, ecx        # EDI = arg
+
+        # Set up frame pointer and force 16-byte alignment.
+        and esp, -16
+        mov ebp, esp
+
+        #
+        # Call func(arg).
+        #
+        # Stack alignment arithmetic (i386 SysV ABI):
+        #   and esp,-16 -> ESP = 0 (mod 16)   (force-aligned)
+        #   sub esp, 12 -> ESP = 4 (mod 16)   (alignment padding)
+        #   push edi    -> ESP = 0 (mod 16)   (push arg)
+        #   call esi    -> ESP = 12 (mod 16)  (return address pushed by CALL)
+        #
+        sub esp, 12
+        push edi
+        call esi
+
+        #
+        # Call _do_exit_thread(status).
+        #
+        # func() returned status in EAX.  Re-align the stack for the next call.
+        #
+        # Stack alignment arithmetic:
+        #   and esp,-16 -> ESP = 0 (mod 16)   (force-aligned)
+        #   sub esp, 12 -> ESP = 4 (mod 16)   (alignment padding)
+        #   push eax    -> ESP = 0 (mod 16)   (push status)
+        #   call        -> ESP = 12 (mod 16)  (return address pushed by CALL)
+        #
+        and esp, -16
+        sub esp, 12
+        push eax
+        call _do_exit_thread
+
+    # Safety net: _do_exit_thread() calls exit_thread() and never returns.
+    # If it somehow does, spin forever rather than falling through.
+    1: jmp 1b
+    "#
+);

--- a/src/libs/sys/src/sys/kcall/debug.rs
+++ b/src/libs/sys/src/sys/kcall/debug.rs
@@ -31,7 +31,6 @@ use crate::{
 ///
 /// Upon success, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_debug(buf: *const u8, size: usize) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::Debug.into(), buf as u32, size as u32);
 

--- a/src/libs/sys/src/sys/kcall/event.rs
+++ b/src/libs/sys/src/sys/kcall/event.rs
@@ -24,7 +24,6 @@ use crate::{
 // Resume Event
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_resume(event: EventDescriptor) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Resume.into(), usize::from(event) as u32);
 
@@ -39,7 +38,6 @@ pub fn __kcall_resume(event: EventDescriptor) -> Result<(), Error> {
 // Controls an Event
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_evctrl(ev: Event, req: EventCtrlRequest) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::EventCtrl.into(), u32::from(ev), u32::from(req));
 

--- a/src/libs/sys/src/sys/kcall/ipc.rs
+++ b/src/libs/sys/src/sys/kcall/ipc.rs
@@ -24,7 +24,6 @@ use crate::{
 // Send Message
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_send(message: &Message) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Send.into(), message as *const Message as usize as u32);
 
@@ -39,7 +38,6 @@ pub fn __kcall_send(message: &Message) -> Result<(), Error> {
 // Receive Message
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_recv() -> Result<Message, Error> {
     let mut message: Message = Default::default();
 
@@ -77,7 +75,6 @@ pub fn __kcall_recv() -> Result<Message, Error> {
 /// - [`ErrorCode::InvalidArgument`]: Invalid destination identifiers, self-push, or transfer
 ///   length exceeds `u32::MAX`.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_push(
     destination_pid: ProcessIdentifier,
     destination_tid: ThreadIdentifier,
@@ -130,7 +127,6 @@ pub fn __kcall_push(
 /// - [`ErrorCode::InvalidArgument`]: Invalid sender identifiers, self-pull, or transfer length
 ///   exceeds `u32::MAX`.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_pull(
     sender_pid: ProcessIdentifier,
     sender_tid: ThreadIdentifier,

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -37,7 +37,6 @@ fn split_tag(tag: u64) -> (u32, u32) {
 // Map Memory Pages
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_mmap(
     pid: ProcessIdentifier,
     vaddr: VirtualAddress,
@@ -65,7 +64,6 @@ pub fn __kcall_mmap(
 // Unmap Memory Page
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::MemoryUnmap.into(), pid.try_into()?, vaddr.into_raw_value() as u32);
@@ -81,7 +79,6 @@ pub fn __kcall_munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(
 // Change Memory Protection
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_mprotect(
     pid: ProcessIdentifier,
     vaddr: VirtualAddress,
@@ -120,7 +117,6 @@ pub fn __kcall_mprotect(
 ///
 /// `Ok(())` on success, or an error describing why the allocation failed.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_mmio_alloc(tag: u64) -> Result<(), Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let result: i64 = kcall2!(KcallNumber::AllocMmio.into(), lower, upper);
@@ -150,7 +146,6 @@ pub fn __kcall_mmio_alloc(tag: u64) -> Result<(), Error> {
 ///
 /// `Ok(())` on success, or an error describing why the release failed.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_mmio_free(tag: u64) -> Result<(), Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let result: i64 = kcall2!(KcallNumber::FreeMmio.into(), lower, upper);
@@ -180,7 +175,6 @@ pub fn __kcall_mmio_free(tag: u64) -> Result<(), Error> {
 ///
 /// On success, returns an [`MmioRegionInfo`] structure populated by the kernel.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_mmio_info(tag: u64) -> Result<MmioRegionInfo, Error> {
     let (lower, upper): (u32, u32) = split_tag(tag);
     let mut info: MmioRegionInfo = MmioRegionInfo::default();

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -46,7 +46,6 @@ use ::core::{
 /// Upon successful completion, the process identifier of the calling process is returned. Upon
 /// failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetPid.into());
 
@@ -72,7 +71,6 @@ pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
 /// Upon successful completion, the thread identifier of the calling thread is returned. Upon
 /// failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_gettid() -> Result<ThreadIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetTid.into());
 
@@ -102,7 +100,6 @@ pub fn __kcall_gettid() -> Result<ThreadIdentifier, Error> {
 /// Upon successful completion, this function does not return. Upon failure, an error is returned
 /// instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_exit(status: i32) -> Result<!, Error> {
     let result: i64 = kcall1!(KcallNumber::Exit.into(), status as u32);
     Err(Error::new(ErrorCode::try_from(result)?, "failed to terminate process"))
@@ -126,7 +123,6 @@ pub fn __kcall_exit(status: i32) -> Result<!, Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_capctl(capability: Capability, value: bool) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::CapCtl.into(), capability as u32, value as u32);
 
@@ -155,7 +151,6 @@ pub fn __kcall_capctl(capability: Capability, value: bool) -> Result<(), Error> 
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Terminate.into(), u32::try_from(pid)?);
 
@@ -171,73 +166,6 @@ pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
 // Create Thread
 //==================================================================================================
 
-::core::arch::global_asm!(
-    r#"
-    .global _do_start_thread
-    .extern _do_exit_thread
-    .type _do_start_thread, @function
-
-    _do_start_thread:
-        #
-        # Entry point for newly created threads.
-        #
-        # The kernel sets up a trap frame so that IRET "returns" to this function.
-        # The kernel passes the thread function pointer in EDX and its argument
-        # in ECX.
-        #
-        # This stub calls func(arg) and then _do_exit_thread(status) directly,
-        # enforcing 16-byte stack alignment before each CALL instruction. This
-        # avoids routing through a Rust intermediate function whose compiler-
-        # generated prologue may not preserve 16-byte alignment (the Nanvix Rust
-        # target disables SSE, so LLVM omits alignment-preserving prologues).
-        # The callee func may require 16-byte-aligned stack frames (e.g.,
-        # movaps) when SSE instructions are present.
-        #
-
-        # Save func and arg into callee-saved registers.
-        # This is the thread root frame so there is no caller state to preserve.
-        mov esi, edx        # ESI = func
-        mov edi, ecx        # EDI = arg
-
-        # Set up frame pointer and force 16-byte alignment.
-        and esp, -16
-        mov ebp, esp
-
-        #
-        # Call func(arg).
-        #
-        # Stack alignment arithmetic (i386 SysV ABI):
-        #   and esp,-16 -> ESP = 0 (mod 16)   (force-aligned)
-        #   sub esp, 12 -> ESP = 4 (mod 16)   (alignment padding)
-        #   push edi    -> ESP = 0 (mod 16)   (push arg)
-        #   call esi    -> ESP = 12 (mod 16)  (return address pushed by CALL)
-        #
-        sub esp, 12
-        push edi
-        call esi
-
-        #
-        # Call _do_exit_thread(status).
-        #
-        # func() returned status in EAX.  Re-align the stack for the next call.
-        #
-        # Stack alignment arithmetic:
-        #   and esp,-16 -> ESP = 0 (mod 16)   (force-aligned)
-        #   sub esp, 12 -> ESP = 4 (mod 16)   (alignment padding)
-        #   push eax    -> ESP = 0 (mod 16)   (push status)
-        #   call        -> ESP = 12 (mod 16)  (return address pushed by CALL)
-        #
-        and esp, -16
-        sub esp, 12
-        push eax
-        call _do_exit_thread
-
-    # Safety net: _do_exit_thread() calls exit_thread() and never returns.
-    # If it somehow does, spin forever rather than falling through.
-    1: jmp 1b
-    "#
-);
-
 ///
 /// # Description
 ///
@@ -248,7 +176,6 @@ pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
 ///
 /// - `status`: Exit status returned by the thread function.
 ///
-#[unsafe(no_mangle)]
 pub extern "C" fn _do_exit_thread(status: usize) -> ! {
     let _ = __kcall_exit_thread(status);
     unreachable!("failed to exit thread");
@@ -269,7 +196,6 @@ pub extern "C" fn _do_exit_thread(status: usize) -> ! {
 /// Upon successful completion, the thread identifier of the new thread is returned. Upon failure,
 /// an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
     unsafe extern "C" {
         fn _do_start_thread() -> !;
@@ -313,7 +239,6 @@ pub fn __kcall_create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdenti
 /// Upon successful completion, this function does not return. Upon failure, an error is returned
 /// instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_exit_thread(status: usize) -> Result<!, Error> {
     let result: i64 = kcall1!(KcallNumber::ExitThread.into(), status as u32);
 
@@ -338,7 +263,6 @@ pub fn __kcall_exit_thread(status: usize) -> Result<!, Error> {
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
@@ -369,7 +293,6 @@ pub fn __kcall_join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::DetachThread.into(), i32::from(tid) as u32);
 
@@ -404,7 +327,6 @@ pub fn __kcall_detach_thread(tid: ThreadIdentifier) -> Result<(), Error> {
 /// Upon successful completion, the process identifier of the new child process is returned.
 /// Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_duplicate(args: &ThreadCreateArgs) -> Result<ProcessIdentifier, Error> {
     let result: i64 =
         kcall1!(KcallNumber::Duplicate.into(), args as *const ThreadCreateArgs as usize as u32);
@@ -435,7 +357,6 @@ pub fn __kcall_duplicate(args: &ThreadCreateArgs) -> Result<ProcessIdentifier, E
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_lock_mutex(
     mutex_addr: MutexAddress,
     timeout: Option<SystemTime>,
@@ -484,7 +405,6 @@ pub fn __kcall_lock_mutex(
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::MutexUnlock.into(), usize::from(mutex_addr) as u32);
 
@@ -515,7 +435,6 @@ pub fn __kcall_unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
 /// Upon successful completion, the number of threads awakened is returned. Upon failure, an error
 /// is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize, Error> {
     let result: i64 = kcall4!(
         KcallNumber::CondSignal.into(),
@@ -553,7 +472,6 @@ pub fn __kcall_signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Resu
 ///
 /// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_wait_cond(
     cond_addr: ConditionAddress,
     mutex_addr: MutexAddress,
@@ -605,7 +523,6 @@ pub fn __kcall_wait_cond(
 /// Upon successful completion, `gettime()` returns empty. Upon failure, it returns an `Error` to
 /// indicate the error.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_gettime(buffer: &mut SystemTime) -> Result<(), Error> {
     let result: i64 =
         kcall1!(KcallNumber::GetTime.into(), buffer as *mut SystemTime as usize as u32);
@@ -635,7 +552,6 @@ pub fn __kcall_gettime(buffer: &mut SystemTime) -> Result<(), Error> {
 ///
 /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_sleep(timeout: Duration) -> Result<(), Error> {
     let seconds: u32 = timeout
         .as_secs()
@@ -676,7 +592,6 @@ pub fn __kcall_sleep(timeout: Duration) -> Result<(), Error> {
 /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_get_thread_data_area() -> Result<*mut u8, Error> {
     let result: i64 = kcall0!(KcallNumber::GetThreadDataArea.into());
 
@@ -715,7 +630,6 @@ pub fn __kcall_get_thread_data_area() -> Result<*mut u8, Error> {
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
 ///
-#[unsafe(no_mangle)]
 pub fn __kcall_set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::SetThreadDataArea.into(), user_tda as usize as u32);
 
@@ -762,7 +676,6 @@ pub fn snapshot() -> Result<(), Error> {
 ///
 /// Returns 0 on success, or a negative error code on failure.
 ///
-#[unsafe(no_mangle)]
 pub extern "C" fn __kcall_snapshot() -> i32 {
     match snapshot() {
         Ok(()) => 0,

--- a/src/libs/sys/src/sys/kcall/sched.rs
+++ b/src/libs/sys/src/sys/kcall/sched.rs
@@ -17,7 +17,6 @@ use crate::{
 // Scheduler Yield
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 pub fn __kcall_sched_yield() -> Result<(), Error> {
     let result: i64 = kcall0!(KcallNumber::SchedulerYield.into());
 


### PR DESCRIPTION
## Summary

Introduces a new `sys-ffi` crate that owns all `#[unsafe(no_mangle)]` re-exports of the `sys::kcall::*` thunks, eliminating duplicate-strong-symbol clashes between `libposix.a` and `libnvx_crt0.a`.

## Background

Both `libposix.a` and `libnvx_crt0.a` bake the `sys` crate's FFI surface (34 `__kcall_*` exports + `_do_exit_thread` + `_do_start_thread` asm) into their static archives as strong `T` symbols. Every test ELF link line that pulls both archives has to use `-Wl,--allow-multiple-definition` to coalesce them, which silently hides legitimate symbol collisions.

## Design

1. **New `src/libs/sys-ffi/` crate** — thin C-ABI shim. Each wrapper is a one-line trampoline like:
   ```rust
   #[unsafe(no_mangle)]
   pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
       ::sys::kcall::pm::__kcall_getpid()
   }
   ```
2. **`src/libs/sys/src/sys/kcall/*.rs`** — `#[unsafe(no_mangle)]` is dropped from 34 `__kcall_*` definitions and from `_do_exit_thread`. The functions stay where they are with the same names and signatures; their 725 internal Rust callers continue to work unchanged because `sys::kcall::pm::__kcall_foo` still resolves — just to a Rust-mangled symbol now.
3. **`_do_start_thread` asm stub** lives in `sys-ffi`. The `.global _do_start_thread` symbol now exists in only one archive.
4. **`src/libs/posix/Cargo.toml`** — adds `sys-ffi` dep.
5. **`src/libs/posix/src/lib.rs`** — `extern crate sys_ffi;` to force the FFI exports into `libposix.a`. (Guarded with an inline comment and `#[allow(unused_extern_crates)]` because the `extern crate` looks dead to lints but is load-bearing for linkage.)

## Verification

```
$ nm libnvx_crt0.a | grep -E ' T (__kcall_|_do_exit_thread|_do_start_thread)'
(empty)
$ nm libposix.a    | grep -E ' T (__kcall_|_do_exit_thread|_do_start_thread)' | wc -l
36
```

Full posix-tests suite (18 binaries — `c-bindings` + 4 dlfcn variants + `echo-c`/`cpp` + `file-c` + `hello-c`/`cpp` + `memory-c` + `misc-c` + `network-c` + `noop-c`/`cpp` + `thread-c`) passes.

## Scope — what this PR does and does not resolve

This PR removes **36 of the 37** duplicate strong symbols that force `-Wl,--allow-multiple-definition` on guest test-ELF link lines. The 37th remaining duplicate is `_do_start`, which collides between `libnvx_crt0.a` and newlib's prebuilt `crt0.o` (auto-pulled by the gcc spec). That collision is a separate toolchain-level concern outside the scope of this PR and requires changes in `nanvix/newlib` (`_do_start` declared `.weak` in `crt0.S`) plus a toolchain image rebuild in `nanvix/toolchain-gcc`. This PR is independent of that work in build terms; once both land, per-port cleanup commits in the consumer repositories (`nanvix/posix-tests`, `nanvix/libxml2`, `nanvix/libxslt`, `nanvix/lxml`, `nanvix/libffi`, `nanvix/openssl`) can drop `-Wl,--allow-multiple-definition` entirely.
