### PR TITLE
[vfsd] Reject invalid dirfd in vfsd *at() handlers

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -252,12 +252,12 @@ pub(crate) fn handle_fstatat_with_hostfs(
     request: FileStatAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.path,
-    };
+    let resolved: alloc::string::String =
+        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path) {
+            Some(p) => p,
+            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+        };
+    let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
         // Both stat modes are supported over hostfs. No-follow (`AT_SYMLINK_NOFOLLOW`)
@@ -498,12 +498,12 @@ pub(crate) fn handle_openat_with_hostfs(
     request: OpenAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
-    let path: &str = &request.pathname;
-    let resolved: Option<alloc::string::String> = ::vfs::fd::vfs_resolve_path(request.dirfd, path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => path,
-    };
+    let resolved: alloc::string::String =
+        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
+            Some(p) => p,
+            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+        };
+    let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {
@@ -647,12 +647,12 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     request: MakeDirectoryAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.pathname,
-    };
+    let resolved: alloc::string::String =
+        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
+            Some(p) => p,
+            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+        };
+    let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {
@@ -690,12 +690,12 @@ pub(crate) fn handle_symlinkat_with_hostfs(
 ) -> Option<Vec<Message>> {
     // Routing key is `linkpath` (where the symlink will live). `target` is an opaque
     // string stored verbatim by the host and intentionally not consulted here.
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.linkpath);
-    let final_link: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.linkpath,
-    };
+    let resolved: alloc::string::String =
+        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.linkpath) {
+            Some(p) => p,
+            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+        };
+    let final_link: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_link) {
         if !pending.has_capacity() {
@@ -731,12 +731,12 @@ pub(crate) fn handle_readlinkat_with_hostfs(
     request: ReadLinkAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.path,
-    };
+    let resolved: alloc::string::String =
+        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path) {
+            Some(p) => p,
+            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+        };
+    let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {

--- a/src/daemons/vfsd/src/handler/long.rs
+++ b/src/daemons/vfsd/src/handler/long.rs
@@ -137,14 +137,7 @@ pub(crate) fn handle_getdents(source: ThreadIdentifier, msg: SystemCallMessage) 
 //==================================================================================================
 
 pub(crate) fn handle_openat(source: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> {
-    let path: &str = &request.pathname;
-    let resolved: Option<alloc::string::String> = ::vfs::fd::vfs_resolve_path(request.dirfd, path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => path,
-    };
-
-    match ::vfs::fd::vfs_open(final_path, request.flags) {
+    match ::vfs::fd::vfs_openat(request.dirfd, &request.pathname, request.flags) {
         Ok(fd) => {
             vec![OpenAtResponse::build(
                 source,
@@ -194,14 +187,7 @@ pub(crate) fn handle_mkdirat(
     source: ThreadIdentifier,
     request: MakeDirectoryAtRequest,
 ) -> Vec<Message> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.pathname,
-    };
-
-    match ::vfs::fd::vfs_mkdir(final_path) {
+    match ::vfs::fd::vfs_mkdirat(request.dirfd, &request.pathname) {
         Ok(()) => {
             vec![MakeDirectoryAtResponse::build(
                 source,
@@ -215,15 +201,8 @@ pub(crate) fn handle_mkdirat(
 }
 
 pub(crate) fn handle_fstatat(source: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Message> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.path,
-    };
-
     let mut st = stat::default();
-    match ::vfs::fd::vfs_stat(final_path, &mut st) {
+    match ::vfs::fd::vfs_fstatat(request.dirfd, &request.path, &mut st) {
         Ok(()) => {
             let response: FileStatAtResponse = FileStatAtResponse::new(st);
             match response.into_parts(source, ProcessIdentifier::VFSD, MessageType::Ipc) {
@@ -258,14 +237,7 @@ pub(crate) fn handle_faccessat(
     source: ThreadIdentifier,
     request: FileAccessAtRequest,
 ) -> Vec<Message> {
-    let resolved: Option<alloc::string::String> =
-        ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path);
-    let final_path: &str = match &resolved {
-        Some(p) => p.as_str(),
-        None => &request.path,
-    };
-
-    match ::vfs::fd::vfs_access(final_path) {
+    match ::vfs::fd::vfs_accessat(request.dirfd, &request.path) {
         Ok(()) => {
             vec![FileAccessAtResponse::build(
                 source,

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -589,6 +589,21 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
     FD_TABLE.alloc(handle)
 }
 
+/// Opens a file relative to a directory file descriptor through the VFS.
+///
+/// The `path` is resolved against `dirfd` via [`vfs_resolve_path`] and the
+/// resulting path is opened with [`vfs_open`].
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
+/// example, when it is not a VFS directory file descriptor). The `dirfd` is
+/// never silently ignored.
+pub fn vfs_openat(dirfd: c_int, path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    vfs_open(&resolved, flags)
+}
+
 /// Reads from a VFS file descriptor.
 ///
 /// Uses the virtual position tracker. If the position is at or past EOF,
@@ -748,6 +763,25 @@ pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     Ok(())
 }
 
+/// Gets file status for a path relative to a directory file descriptor through the VFS.
+///
+/// The `path` is resolved against `dirfd` via [`vfs_resolve_path`] and the
+/// resulting path is queried with [`vfs_stat`].
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
+/// example, when it is not a VFS directory file descriptor). The `dirfd` is
+/// never silently ignored.
+pub fn vfs_fstatat(
+    dirfd: c_int,
+    path: &str,
+    buf: &mut ::sysapi::sys_stat::stat,
+) -> Result<(), Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    vfs_stat(&resolved, buf)
+}
+
 /// Renames a file or directory through the VFS.
 ///
 /// Both paths must be on the same VFS mount.
@@ -763,6 +797,21 @@ pub fn vfs_unlink(path: &str) -> Result<(), Fat32Error> {
 /// Creates a directory through the VFS.
 pub fn vfs_mkdir(path: &str) -> Result<(), Fat32Error> {
     crate::mkdir(path)
+}
+
+/// Creates a directory relative to a directory file descriptor through the VFS.
+///
+/// The `path` is resolved against `dirfd` via [`vfs_resolve_path`] and the
+/// resulting directory is created with [`vfs_mkdir`].
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
+/// example, when it is not a VFS directory file descriptor). The `dirfd` is
+/// never silently ignored.
+pub fn vfs_mkdirat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    vfs_mkdir(&resolved)
 }
 
 /// Removes an empty directory through the VFS.
@@ -982,6 +1031,21 @@ pub fn vfs_chmod(path: &str, _mode: ::sysapi::sys_types::mode_t) -> Result<(), F
 /// FAT32 does not have UNIX permissions, so only existence is checked.
 pub fn vfs_access(path: &str) -> Result<(), Fat32Error> {
     crate::stat(path).map(|_| ())
+}
+
+/// Checks the accessibility of a file relative to a directory file descriptor.
+///
+/// The `path` is resolved against `dirfd` via [`vfs_resolve_path`] and the
+/// resulting path is checked with [`vfs_access`].
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
+/// example, when it is not a VFS directory file descriptor). The `dirfd` is
+/// never silently ignored.
+pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    vfs_access(&resolved)
 }
 
 /// File control operation on a VFS file descriptor.

--- a/src/tests/mount-test/src/dirfd_reject.rs
+++ b/src/tests/mount-test/src/dirfd_reject.rs
@@ -1,0 +1,124 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Invalid-`dirfd` rejection tests for the `*at()` operations routed over hostfs.
+//!
+//! When a relative path is paired with a `dirfd` that cannot be resolved to a VFS
+//! directory (for example, a regular-file descriptor), vfsd must reject the request
+//! with `EINVAL` (`InvalidArgument`) instead of silently dropping the `dirfd` and
+//! resolving the path against the current working directory.
+//!
+//! These tests cover the five operations whose hostfs handlers perform this
+//! resolution: `openat`, `mkdirat`, `fstatat`, `symlinkat`, and `readlinkat`. The
+//! rejection happens in vfsd before any host round-trip, so the assertions hold even
+//! on hosts that do not support symbolic links.
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    fcntl::{
+        atflags::AT_FDCWD,
+        file_access_mode::{
+            O_RDONLY,
+            O_WRONLY,
+        },
+        file_creation_flags::{
+            O_CREAT,
+            O_TRUNC,
+        },
+    },
+    ffi::c_int,
+    sys_stat::{
+        file_mode::{
+            S_IRUSR,
+            S_IRWXU,
+            S_IWUSR,
+        },
+        stat,
+    },
+};
+
+pub fn test() -> Result<(), Error> {
+    test_invalid_dirfd_rejected()
+}
+
+/// Asserts that a result is the expected `EINVAL` rejection, panicking otherwise.
+fn expect_reject<T>(op: &str, result: Result<T, Error>) {
+    match result {
+        Ok(_) => {
+            panic!(
+                "dirfd-reject: {op} with a non-directory dirfd must fail with EINVAL, but it \
+                 succeeded"
+            );
+        },
+        Err(e) if e.code == ErrorCode::InvalidArgument => {
+            ::syslog::info!("mount-test: [PASS] {op} rejects a non-directory dirfd with EINVAL");
+        },
+        Err(e) => {
+            let code: ErrorCode = e.code;
+            panic!(
+                "dirfd-reject: {op} with a non-directory dirfd must fail with EINVAL, got {code:?}"
+            );
+        },
+    }
+}
+
+/// Tests that the hostfs-routed `*at()` operations reject a relative path paired
+/// with a non-directory `dirfd` instead of falling back to the cwd.
+fn test_invalid_dirfd_rejected() -> Result<(), Error> {
+    let probe_path: &str = "/mnt/dirfd-reject-probe.txt";
+    let mode: c_int = (S_IRUSR | S_IWUSR) as c_int;
+
+    // Obtain a non-directory descriptor by creating a regular file on the mount.
+    // Using this file descriptor as a `dirfd` must be rejected by every `*at()`
+    // operation below.
+    let file_fd: c_int =
+        ::syscall::fcntl::openat(AT_FDCWD, probe_path, O_CREAT | O_WRONLY | O_TRUNC, mode as u32)?;
+
+    // openat: a stray success would leak a descriptor, so close it before failing.
+    match ::syscall::fcntl::openat(file_fd, "reject-open.txt", O_RDONLY, 0) {
+        Ok(stray) => {
+            let _ = ::syscall::unistd::close(stray);
+            panic!(
+                "dirfd-reject: openat with a non-directory dirfd must fail with EINVAL, but it \
+                 succeeded"
+            );
+        },
+        Err(e) if e.code == ErrorCode::InvalidArgument => {
+            ::syslog::info!("mount-test: [PASS] openat rejects a non-directory dirfd with EINVAL");
+        },
+        Err(e) => {
+            let code: ErrorCode = e.code;
+            panic!(
+                "dirfd-reject: openat with a non-directory dirfd must fail with EINVAL, got \
+                 {code:?}"
+            );
+        },
+    }
+
+    expect_reject("mkdirat", ::syscall::sys::stat::mkdirat(file_fd, "reject-dir", S_IRWXU));
+
+    let mut st: stat = stat::default();
+    expect_reject("fstatat", ::syscall::sys::stat::fstatat(file_fd, "reject-stat.txt", &mut st, 0));
+
+    // symlinkat and readlinkat previously reported "not supported" for an
+    // unresolvable dirfd; they must now report EINVAL like the other operations.
+    expect_reject(
+        "symlinkat",
+        ::syscall::unistd::symlinkat("target.txt", file_fd, "reject-link.lnk"),
+    );
+
+    let mut buf: [u8; 64] = [0u8; 64];
+    expect_reject(
+        "readlinkat",
+        ::syscall::unistd::readlinkat(file_fd, "reject-link.lnk", &mut buf),
+    );
+
+    // Clean up the probe file.
+    ::syscall::unistd::close(file_fd)?;
+    ::syscall::fcntl::unlinkat(AT_FDCWD, probe_path, 0)?;
+
+    Ok(())
+}

--- a/src/tests/mount-test/src/main.rs
+++ b/src/tests/mount-test/src/main.rs
@@ -30,6 +30,7 @@ extern crate nvx;
 extern crate nvx_crt0;
 
 mod cross_fs;
+mod dirfd_reject;
 mod file_ops;
 mod fs_ops;
 mod mount_lifecycle;
@@ -66,6 +67,9 @@ pub fn main() -> Result<(), Error> {
 
     // Phase 3.6: Directory listing operations (getdents/readdir sweep).
     readdir_ops::test()?;
+
+    // Phase 3.7: Invalid-dirfd rejection for hostfs-routed *at() operations.
+    dirfd_reject::test()?;
 
     // Phase 4: Cross-filesystem consistency tests (RAMFS vs HostFS).
     cross_fs::test()?;

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -95,6 +95,10 @@ pub fn main() -> Result<(), Error> {
     test_fchmodat()?;
     test_fchownat()?;
     test_utimensat()?;
+    test_openat()?;
+    test_mkdirat()?;
+    test_accessat()?;
+    test_fstatat()?;
     test_ramfs_mount()?;
 
     Ok(())
@@ -1058,8 +1062,361 @@ fn test_utimensat() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Test: Openat
+//==================================================================================================
+
+/// Tests that `vfs_openat()` resolves paths relative to a directory file
+/// descriptor and refuses to silently fall back to the cwd when the `dirfd`
+/// cannot be resolved.
+fn test_openat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_openat begin");
+
+    vfs::create_mount("/oat", 128 * 1024).map_err(|e| fat_err(e, "create_mount /oat failed"))?;
+    vfs::mkdir("/oat/sub").map_err(|e| fat_err(e, "mkdir /oat/sub"))?;
+
+    // File inside the subdirectory (the dirfd target).
+    create_file("/oat/sub/inside.txt", b"inside")?;
+    // Decoy file in the mount root (the cwd target).
+    create_file("/oat/decoy.txt", b"decoy")?;
+
+    // openat with an absolute path ignores dirfd.
+    let fd_abs: i32 = vfs::fd::vfs_openat(0, "/oat/sub/inside.txt", 0)
+        .map_err(|e| fat_err(e, "openat absolute path"))?;
+    vfs::fd::vfs_close(fd_abs).map_err(|e| fat_err(e, "close fd_abs"))?;
+
+    // openat with AT_FDCWD resolves against the cwd.
+    vfs::chdir("/oat/sub").map_err(|e| fat_err(e, "chdir /oat/sub"))?;
+    let cwd_result = vfs::fd::vfs_openat(::sysapi::fcntl::atflags::AT_FDCWD, "inside.txt", 0);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    let fd_cwd: i32 = cwd_result.map_err(|e| fat_err(e, "openat AT_FDCWD relative"))?;
+    vfs::fd::vfs_close(fd_cwd).map_err(|e| fat_err(e, "close fd_cwd"))?;
+
+    // openat with a directory fd resolves the relative path against that directory.
+    let dir_fd: i32 = vfs::fd::vfs_open("/oat/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /oat/sub O_DIRECTORY"))?;
+    let fd_rel: i32 =
+        vfs::fd::vfs_openat(dir_fd, "inside.txt", 0).map_err(|e| fat_err(e, "openat dirfd rel"))?;
+    vfs::fd::vfs_close(fd_rel).map_err(|e| fat_err(e, "close fd_rel"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir_fd"))?;
+
+    // Bug guard: a non-directory fd must not be usable as a dirfd. With the
+    // dirfd silently dropped, "decoy.txt" would wrongly resolve against the
+    // cwd (/oat) and open successfully.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/oat/decoy.txt", 0).map_err(|e| fat_err(e, "open decoy.txt"))?;
+    vfs::chdir("/oat").map_err(|e| fat_err(e, "chdir /oat"))?;
+    let bug = vfs::fd::vfs_openat(file_fd, "decoy.txt", 0);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file_fd"))?;
+    match bug {
+        Ok(stray) => {
+            let _ = vfs::fd::vfs_close(stray);
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "openat with a non-directory dirfd must fail instead of resolving against the cwd",
+            ));
+        },
+        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(e) => {
+            return Err(fat_err(
+                e,
+                "openat with a non-directory dirfd must fail with EINVAL, not another error",
+            ));
+        },
+    }
+
+    // Clean up.
+    vfs::unlink("/oat/sub/inside.txt").map_err(|e| fat_err(e, "unlink inside.txt"))?;
+    vfs::unlink("/oat/decoy.txt").map_err(|e| fat_err(e, "unlink decoy.txt"))?;
+    vfs::rmdir("/oat/sub").map_err(|e| fat_err(e, "rmdir /oat/sub"))?;
+    vfs::unmount("/oat").map_err(|e| fat_err(e, "unmount /oat"))?;
+
+    ::syslog::info!("vfs-test: test_openat passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Mkdirat
+//==================================================================================================
+
+/// Tests that `vfs_mkdirat()` creates directories relative to a directory file
+/// descriptor and refuses to silently fall back to the cwd when the `dirfd`
+/// cannot be resolved.
+fn test_mkdirat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_mkdirat begin");
+
+    vfs::create_mount("/mat", 128 * 1024).map_err(|e| fat_err(e, "create_mount /mat failed"))?;
+    vfs::mkdir("/mat/sub").map_err(|e| fat_err(e, "mkdir /mat/sub"))?;
+    create_file("/mat/decoy.txt", b"decoy")?;
+
+    // mkdirat with an absolute path ignores dirfd.
+    vfs::fd::vfs_mkdirat(0, "/mat/abs").map_err(|e| fat_err(e, "mkdirat absolute path"))?;
+    if !path_exists("/mat/abs") {
+        return Err(Error::new(ErrorCode::InvalidArgument, "mkdirat absolute: dir not created"));
+    }
+
+    // mkdirat with AT_FDCWD resolves against the cwd.
+    vfs::chdir("/mat").map_err(|e| fat_err(e, "chdir /mat"))?;
+    let cwd_result = vfs::fd::vfs_mkdirat(::sysapi::fcntl::atflags::AT_FDCWD, "cwd_dir");
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    cwd_result.map_err(|e| fat_err(e, "mkdirat AT_FDCWD relative"))?;
+    if !path_exists("/mat/cwd_dir") {
+        return Err(Error::new(ErrorCode::InvalidArgument, "mkdirat AT_FDCWD: dir not in cwd"));
+    }
+
+    // mkdirat with a directory fd resolves the relative path against that directory.
+    let dir_fd: i32 = vfs::fd::vfs_open("/mat/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /mat/sub O_DIRECTORY"))?;
+    vfs::fd::vfs_mkdirat(dir_fd, "made").map_err(|e| fat_err(e, "mkdirat dirfd relative"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir_fd"))?;
+    if !path_exists("/mat/sub/made") {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "mkdirat dirfd: directory created in the wrong place",
+        ));
+    }
+
+    // Bug guard: a non-directory fd must not silently fall back to the cwd.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/mat/decoy.txt", 0).map_err(|e| fat_err(e, "open decoy.txt"))?;
+    vfs::chdir("/mat").map_err(|e| fat_err(e, "chdir /mat"))?;
+    let bug = vfs::fd::vfs_mkdirat(file_fd, "stray");
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file_fd"))?;
+    match bug {
+        Ok(()) => {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "mkdirat with a non-directory dirfd must fail instead of resolving against the cwd",
+            ));
+        },
+        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(e) => {
+            return Err(fat_err(
+                e,
+                "mkdirat with a non-directory dirfd must fail with EINVAL, not another error",
+            ));
+        },
+    }
+    if path_exists("/mat/stray") {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "mkdirat with a non-directory dirfd must not create a directory in the cwd",
+        ));
+    }
+
+    // Clean up.
+    vfs::rmdir("/mat/sub/made").map_err(|e| fat_err(e, "rmdir made"))?;
+    vfs::rmdir("/mat/sub").map_err(|e| fat_err(e, "rmdir /mat/sub"))?;
+    vfs::rmdir("/mat/abs").map_err(|e| fat_err(e, "rmdir abs"))?;
+    vfs::rmdir("/mat/cwd_dir").map_err(|e| fat_err(e, "rmdir cwd_dir"))?;
+    vfs::unlink("/mat/decoy.txt").map_err(|e| fat_err(e, "unlink decoy.txt"))?;
+    vfs::unmount("/mat").map_err(|e| fat_err(e, "unmount /mat"))?;
+
+    ::syslog::info!("vfs-test: test_mkdirat passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Accessat
+//==================================================================================================
+
+/// Tests that `vfs_accessat()` resolves paths relative to a directory file
+/// descriptor and refuses to silently fall back to the cwd when the `dirfd`
+/// cannot be resolved.
+fn test_accessat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_accessat begin");
+
+    vfs::create_mount("/aat", 128 * 1024).map_err(|e| fat_err(e, "create_mount /aat failed"))?;
+    vfs::mkdir("/aat/sub").map_err(|e| fat_err(e, "mkdir /aat/sub"))?;
+    create_file("/aat/sub/inside.txt", b"inside")?;
+    create_file("/aat/decoy.txt", b"decoy")?;
+
+    // accessat with an absolute path ignores dirfd.
+    vfs::fd::vfs_accessat(0, "/aat/sub/inside.txt")
+        .map_err(|e| fat_err(e, "accessat absolute path"))?;
+
+    // accessat with AT_FDCWD resolves against the cwd.
+    vfs::chdir("/aat/sub").map_err(|e| fat_err(e, "chdir /aat/sub"))?;
+    let cwd_result = vfs::fd::vfs_accessat(::sysapi::fcntl::atflags::AT_FDCWD, "inside.txt");
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    cwd_result.map_err(|e| fat_err(e, "accessat AT_FDCWD relative"))?;
+
+    // accessat with a directory fd resolves the relative path against that directory.
+    let dir_fd: i32 = vfs::fd::vfs_open("/aat/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /aat/sub O_DIRECTORY"))?;
+    vfs::fd::vfs_accessat(dir_fd, "inside.txt").map_err(|e| fat_err(e, "accessat dirfd rel"))?;
+
+    // A relative path that only exists in the cwd must NOT be found via the
+    // directory fd (decoy.txt lives in /aat, not in /aat/sub).
+    vfs::chdir("/aat").map_err(|e| fat_err(e, "chdir /aat"))?;
+    let cross = vfs::fd::vfs_accessat(dir_fd, "decoy.txt");
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    if cross.is_ok() {
+        let _ = vfs::fd::vfs_close(dir_fd);
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "accessat resolved against the cwd instead of the directory fd",
+        ));
+    }
+
+    // Bug guard: a non-directory fd must not silently fall back to the cwd.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/aat/decoy.txt", 0).map_err(|e| fat_err(e, "open decoy.txt"))?;
+    vfs::chdir("/aat").map_err(|e| fat_err(e, "chdir /aat"))?;
+    let bug = vfs::fd::vfs_accessat(file_fd, "decoy.txt");
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file_fd"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir_fd"))?;
+    match bug {
+        Ok(()) => {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "accessat with a non-directory dirfd must fail instead of resolving against the \
+                 cwd",
+            ));
+        },
+        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(e) => {
+            return Err(fat_err(
+                e,
+                "accessat with a non-directory dirfd must fail with EINVAL, not another error",
+            ));
+        },
+    }
+
+    // accessat on a non-existent file fails.
+    if vfs::fd::vfs_accessat(0, "/aat/missing.txt").is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "accessat on missing file should fail"));
+    }
+
+    // Clean up.
+    vfs::unlink("/aat/sub/inside.txt").map_err(|e| fat_err(e, "unlink inside.txt"))?;
+    vfs::unlink("/aat/decoy.txt").map_err(|e| fat_err(e, "unlink decoy.txt"))?;
+    vfs::rmdir("/aat/sub").map_err(|e| fat_err(e, "rmdir /aat/sub"))?;
+    vfs::unmount("/aat").map_err(|e| fat_err(e, "unmount /aat"))?;
+
+    ::syslog::info!("vfs-test: test_accessat passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Fstatat
+//==================================================================================================
+
+/// Tests that `vfs_fstatat()` resolves paths relative to a directory file
+/// descriptor and refuses to silently fall back to the cwd when the `dirfd`
+/// cannot be resolved.
+fn test_fstatat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_fstatat begin");
+
+    vfs::create_mount("/sat", 128 * 1024).map_err(|e| fat_err(e, "create_mount /sat failed"))?;
+    vfs::mkdir("/sat/sub").map_err(|e| fat_err(e, "mkdir /sat/sub"))?;
+    create_file("/sat/sub/inside.txt", b"inside")?;
+    create_file("/sat/decoy.txt", b"decoy")?;
+
+    // fstatat with an absolute path ignores dirfd and reports a regular file.
+    let mut st: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_fstatat(0, "/sat/sub/inside.txt", &mut st)
+        .map_err(|e| fat_err(e, "fstatat absolute path"))?;
+    if st.st_mode & file_type::S_IFMT != file_type::S_IFREG {
+        return Err(Error::new(ErrorCode::InvalidArgument, "fstatat absolute: not a regular file"));
+    }
+
+    // fstatat with AT_FDCWD resolves against the cwd.
+    vfs::chdir("/sat/sub").map_err(|e| fat_err(e, "chdir /sat/sub"))?;
+    let mut cwd_st: stat = unsafe { core::mem::zeroed() };
+    let cwd_result =
+        vfs::fd::vfs_fstatat(::sysapi::fcntl::atflags::AT_FDCWD, "inside.txt", &mut cwd_st);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    cwd_result.map_err(|e| fat_err(e, "fstatat AT_FDCWD relative"))?;
+
+    // fstatat with a directory fd resolves the relative path against that directory.
+    let dir_fd: i32 = vfs::fd::vfs_open("/sat/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /sat/sub O_DIRECTORY"))?;
+    let mut rel_st: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_fstatat(dir_fd, "inside.txt", &mut rel_st)
+        .map_err(|e| fat_err(e, "fstatat dirfd rel"))?;
+
+    // A relative path that only exists in the cwd must NOT be found via the
+    // directory fd (decoy.txt lives in /sat, not in /sat/sub).
+    vfs::chdir("/sat").map_err(|e| fat_err(e, "chdir /sat"))?;
+    let mut cross_st: stat = unsafe { core::mem::zeroed() };
+    let cross = vfs::fd::vfs_fstatat(dir_fd, "decoy.txt", &mut cross_st);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    if cross.is_ok() {
+        let _ = vfs::fd::vfs_close(dir_fd);
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "fstatat resolved against the cwd instead of the directory fd",
+        ));
+    }
+
+    // Bug guard: a non-directory fd must not silently fall back to the cwd.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/sat/decoy.txt", 0).map_err(|e| fat_err(e, "open decoy.txt"))?;
+    vfs::chdir("/sat").map_err(|e| fat_err(e, "chdir /sat"))?;
+    let mut bug_st: stat = unsafe { core::mem::zeroed() };
+    let bug = vfs::fd::vfs_fstatat(file_fd, "decoy.txt", &mut bug_st);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file_fd"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir_fd"))?;
+    match bug {
+        Ok(()) => {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "fstatat with a non-directory dirfd must fail instead of resolving against the cwd",
+            ));
+        },
+        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(e) => {
+            return Err(fat_err(
+                e,
+                "fstatat with a non-directory dirfd must fail with EINVAL, not another error",
+            ));
+        },
+    }
+
+    // fstatat on a non-existent file fails.
+    let mut missing_st: stat = unsafe { core::mem::zeroed() };
+    if vfs::fd::vfs_fstatat(0, "/sat/missing.txt", &mut missing_st).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "fstatat on missing file should fail"));
+    }
+
+    // Clean up.
+    vfs::unlink("/sat/sub/inside.txt").map_err(|e| fat_err(e, "unlink inside.txt"))?;
+    vfs::unlink("/sat/decoy.txt").map_err(|e| fat_err(e, "unlink decoy.txt"))?;
+    vfs::rmdir("/sat/sub").map_err(|e| fat_err(e, "rmdir /sat/sub"))?;
+    vfs::unmount("/sat").map_err(|e| fat_err(e, "unmount /sat"))?;
+
+    ::syslog::info!("vfs-test: test_fstatat passed");
+    Ok(())
+}
+
+//==================================================================================================
 // Helpers
 //==================================================================================================
+
+/// Creates a file with the given `contents`, truncating any existing file.
+fn create_file(path: &str, contents: &[u8]) -> Result<(), Error> {
+    let mut file: vfs::File = vfs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| fat_err(e, "failed to create file"))?;
+    file.write(contents)
+        .map_err(|e| fat_err(e, "failed to write file"))?;
+    file.flush()
+        .map_err(|e| fat_err(e, "failed to flush file"))?;
+    Ok(())
+}
+
+/// Returns `true` if a path exists in the VFS.
+fn path_exists(path: &str) -> bool {
+    let mut st: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_stat(path, &mut st).is_ok()
+}
 
 /// Opens a file and verifies its contents match `expected`.
 fn verify_file(path: &str, expected: &[u8]) -> Result<(), Error> {


### PR DESCRIPTION
## Summary

The vfsd `*at()` request handlers resolved the caller-supplied `dirfd` with `vfs_resolve_path()`, but on a `None` result (an unresolvable `dirfd`, such as a regular-file fd or a stale/invalid fd) they fell back to the raw relative request path. That path was then resolved against the current working directory, so an invalid `dirfd` was **silently ignored** and the operation ran against the wrong file instead of failing with `EINVAL`.

This PR enforces resolution at the boundary and adds library- and runtime-level test coverage for the corrected behavior.

## What changed

**Fix (`[vfsd] B:`)**
- `vfs::fd`: add `vfs_openat`, `vfs_fstatat`, `vfs_mkdirat`, and `vfs_accessat`. Each resolves the path via `vfs_resolve_path()` and returns `Fat32Error::InvalidArgument` (EINVAL) when `dirfd` cannot be resolved. The `dirfd` is never silently dropped.
- `vfsd/long.rs`: rewrite `handle_openat`, `handle_mkdirat`, `handle_fstatat`, and `handle_faccessat` to delegate to the new wrappers, removing the inline silent-fallback.
- `vfsd/hostfs_handlers.rs`: rewrite `handle_fstatat_with_hostfs`, `handle_openat_with_hostfs`, `handle_mkdirat_with_hostfs`, `handle_symlinkat_with_hostfs`, and `handle_readlinkat_with_hostfs` to return `ErrorCode::InvalidArgument` on an unresolvable `dirfd`, matching the existing `renameat`/`unlinkat` handlers.

**Tests (`[tests] E:`)**
- `vfs-test`: add `test_openat`, `test_mkdirat`, `test_accessat`, and `test_fstatat`, each exercising the three resolution modes (absolute / `AT_FDCWD` / directory fd) plus a bug guard asserting a non-directory fd used as a `dirfd` fails instead of resolving against the cwd.
- `mount-test`: add a `dirfd_reject` phase (Phase 3.7) asserting the hostfs-routed `openat`, `mkdirat`, `fstatat`, `symlinkat`, and `readlinkat` reject a non-directory `dirfd` with `EINVAL` end-to-end.

## Behavioral note

For `openat`/`mkdirat`/`fstatat` the error stays `EINVAL` but is now raised explicitly at resolution time. For `symlinkat`/`readlinkat` the returned code changes from `NotSupported`/`OperationNotSupported` to `InvalidArgument`, because the `dirfd` is now validated before the unsupported-operation check.

## Testing

- Builds, lints (`-D warnings`), and formats cleanly.
- Ran the standalone `mount-test` end-to-end: all five `dirfd_reject` operations log `[PASS]` and the suite prints `mount-test: all tests passed` (runner exit code 0).

## Files touched

- `src/libs/vfs/src/fd.rs`
- `src/daemons/vfsd/src/handler/long.rs`
- `src/daemons/vfsd/src/handler/hostfs_handlers.rs`
- `src/tests/vfs-test/src/main.rs`
- `src/tests/mount-test/src/main.rs`
- `src/tests/mount-test/src/dirfd_reject.rs`

## Issues

Closes #2285 
