### PR TITLE
[uservm] Skip BSS zero-filling

### DIFF
--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -6,6 +6,7 @@ USERVM_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
 USERVM_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 USERVM_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 USERVM_FEATURES += $(if $(filter yes,$(WHP)),whp,)
+USERVM_FEATURES += $(if $(filter yes,$(RELEASE)),nightly-performance-optimizations,)
 USERVM_FEATURES := $(strip $(USERVM_FEATURES))
 USERVM_CARGO_FEATURES := $(if $(USERVM_FEATURES),--features "$(USERVM_FEATURES)")
 

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -63,6 +63,11 @@ whp = ["microvm", "config/whp"]
 # Enables fine-grained time profiling.
 profile-time = ["dep:serde_json"]
 timestamp-messages = ["profiler/timestamp-messages"]
+# Enables nightly performance optimizations that trade defensive guarantees for
+# speed. Enabled automatically for release builds (RELEASE=yes). Currently this
+# skips zero-filling the BSS region of loaded ELF segments, relying on the VMM
+# backends allocating zero-filled guest physical memory.
+nightly-performance-optimizations = []
 
 [lints]
 workspace = true

--- a/src/uservm/src/elf.rs
+++ b/src/uservm/src/elf.rs
@@ -239,6 +239,11 @@ pub fn memory_footprint(source: &[u8]) -> Result<MemoryFootprint> {
 /// - The `destination` address is valid.
 /// - The `source` address is valid.
 /// - The `max_offset` is valid.
+/// - When the `nightly-performance-optimizations` feature is enabled, the `destination` memory
+///   is zero-filled. With that feature this function copies only `p_filesz` bytes per segment and
+///   does not zero the trailing BSS region (`p_memsz > p_filesz`); the caller must therefore
+///   guarantee that the destination memory is already zero. Without the feature the BSS region is
+///   zeroed explicitly and no such guarantee is required.
 ///
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn load(
@@ -322,7 +327,13 @@ pub unsafe fn load(
             let dst: *mut u8 = dst.add(vaddr);
             std::ptr::copy_nonoverlapping(src, dst, filesz);
 
-            // Zero out the BSS section.
+            // Zero out the BSS section (`p_memsz > p_filesz`).
+            //
+            // When the `nightly-performance-optimizations` feature is enabled this is skipped:
+            // the caller guarantees that the destination memory is already zero-filled (both
+            // supported VMM backends allocate zero-filled guest physical memory), so the
+            // trailing range is already zero and the explicit write would be redundant.
+            #[cfg(not(feature = "nightly-performance-optimizations"))]
             if memsz > filesz {
                 let bss_size: usize = memsz - filesz;
                 let bss_dst: *mut u8 = dst.add(filesz);
@@ -438,7 +449,7 @@ mod tests {
     }
 
     #[test]
-    fn load_copies_segment_and_zeroes_bss() -> Result<()> {
+    fn load_copies_segment_and_handles_bss() -> Result<()> {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
         let phdr_size: usize = mem::size_of::<Elf32Phdr>();
         let segment_offset: usize = header_size + phdr_size;
@@ -466,7 +477,15 @@ mod tests {
         }
         image[segment_offset..segment_offset + filesz].copy_from_slice(&segment_data);
 
+        // The `load()` safety contract requires zero-filled destination memory when the
+        // `nightly-performance-optimizations` feature is enabled (the loader skips zeroing the
+        // BSS region and relies on the caller providing zeroed memory). Honor that precondition
+        // here. Without the feature, pre-fill with a sentinel (`0xaa`) so the test can verify that
+        // the loader explicitly zeroes the BSS region.
+        #[cfg(not(feature = "nightly-performance-optimizations"))]
         let mut memory: Vec<u8> = vec![0xaa; VADDR + memsz + 0x1000];
+        #[cfg(feature = "nightly-performance-optimizations")]
+        let mut memory: Vec<u8> = vec![0; VADDR + memsz + 0x1000];
         let destination: *mut c_void = memory.as_mut_ptr().cast::<c_void>();
 
         let (entry, first_address, size): (usize, usize, usize) =
@@ -476,6 +495,11 @@ mod tests {
         assert_eq!(first_address, VADDR);
         assert_eq!(size, memsz);
         assert_eq!(&memory[VADDR..VADDR + filesz], &segment_data);
+
+        // The loaded image must expose a zero-filled BSS region (`p_filesz..p_memsz`). By default
+        // the loader zeroes it explicitly; with the `nightly-performance-optimizations` feature it
+        // skips that write and relies on the caller-provided zeroed memory. Either way the range
+        // must read as zero.
         assert!(
             memory[VADDR + filesz..VADDR + memsz]
                 .iter()

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -613,7 +613,10 @@ impl Guest {
     /// The length (u16 LE) is written at
     /// [`config::microvm::DEFAULT_MICROVM_CTRL_KERNEL_ARGS_LEN`] and the UTF-8 data at
     /// [`config::microvm::DEFAULT_MICROVM_CTRL_KERNEL_ARGS_DATA`]. Both offsets reside inside
-    /// the kernel ELF `.zero` section and must therefore be written **after** `load_kernel()`.
+    /// the kernel ELF `.zero` section, which `load_kernel()` zero-fills by default, so these
+    /// offsets must be written **after** it. (With the `nightly-performance-optimizations`
+    /// feature the loader skips that zeroing and relies on the freshly allocated guest memory
+    /// already being zero, but writing after `load_kernel()` remains correct.)
     ///
     /// # Parameters
     ///
@@ -662,10 +665,12 @@ impl Guest {
     ///
     /// The credits register at [`config::microvm::DEFAULT_MICROVM_CTRL_CREDITS`] (GPA `0x4`)
     /// falls inside the kernel ELF's `.zero` section (`LOAD` segment at GPA `0x0` with
-    /// `MemSiz=0x8000`). The ELF loader zero-fills this range when `load_kernel()` runs.
-    /// This method — and all other writes to the control registers at GPA `0x0`–`0x10` — must
-    /// therefore execute **after** the ELF has been loaded, so that the VMM-written values
-    /// are not overwritten.
+    /// `MemSiz=0x8000`), which `load_kernel()` zero-fills by default. This method — and all
+    /// other writes to the control registers at GPA `0x0`–`0x10` — must therefore execute
+    /// **after** the ELF has been loaded, so that the VMM-written values are not overwritten.
+    /// (With the `nightly-performance-optimizations` feature the loader skips that zeroing and
+    /// relies on the freshly allocated guest memory already being zero, but running after
+    /// `load_kernel()` remains correct.)
     ///
     /// # Returns
     ///

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -470,8 +470,11 @@ impl Vmm {
             #[allow(clippy::cast_possible_truncation)]
             perf_timings.set_kernel_load(kernel_load_start.elapsed().as_micros() as u64);
 
-            // Write kernel arguments to guest control registers (must happen after
-            // load_kernel because the ELF .zero section overwrites this region).
+            // Write kernel arguments to guest control registers. These registers reside in
+            // the kernel ELF's `.zero` section, which `load_kernel()` zero-fills by default, so
+            // this write must happen after it. (With the `nightly-performance-optimizations`
+            // feature the loader skips that zeroing and relies on the freshly allocated guest
+            // memory already being zero, but writing after `load_kernel()` remains correct.)
             if let Some(ref kargs) = args.kernel_args {
                 Guest::write_kernel_args(&mut vmem, kargs)?;
             }
@@ -547,11 +550,13 @@ impl Vmm {
             //
             // NOTE: The pvclock page at DEFAULT_PVCLOCK_PAGE (GPA 0x1000) falls inside
             // the kernel ELF's `.zero` section (LOAD segment at GPA 0x0 with MemSiz
-            // 0x8000). The ELF loader zero-fills this range when `load_kernel()` runs
-            // above. Both `setup_pvclock()` (which causes KVM to populate the page)
-            // and the boot-time write below must therefore execute **after** the ELF
-            // has been loaded. This is the same pattern used by the microvm control
-            // registers at GPA 0x0–0x10 (credits, pause-requested, ramfs).
+            // 0x8000), which `load_kernel()` zero-fills by default. `setup_pvclock()`
+            // (which causes KVM to populate the page) and the boot-time write below must
+            // therefore run after kernel loading, alongside the microvm control registers
+            // at GPA 0x0–0x10 (credits, pause-requested, ramfs). (With the
+            // `nightly-performance-optimizations` feature the loader skips that zeroing and
+            // relies on the freshly allocated guest memory already being zero, but running
+            // after `load_kernel()` remains correct.)
             let pvclock_gpa: u64 = ::config::microvm::DEFAULT_PVCLOCK_PAGE as u64;
             vcpu.setup_pvclock(pvclock_gpa)?;
 

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -330,9 +330,12 @@ impl RamFs {
     /// # Note
     ///
     /// The RAMFS registers at GPA `0xC` and GPA `0x10` fall inside the kernel ELF's `.zero`
-    /// section (`LOAD` segment at GPA `0x0` with `MemSiz=0x8000`). The ELF loader zero-fills
-    /// this range when `load_kernel()` runs. This method must therefore execute **after** the
-    /// ELF has been loaded, so that the VMM-written values are not overwritten.
+    /// section (`LOAD` segment at GPA `0x0` with `MemSiz=0x8000`), which `load_kernel()`
+    /// zero-fills by default. This method must therefore execute **after** the ELF has been
+    /// loaded, so that the VMM-written values are not overwritten. (With the
+    /// `nightly-performance-optimizations` feature the loader skips that zeroing and relies on
+    /// the freshly allocated guest memory already being zero, but running after `load_kernel()`
+    /// remains correct.)
     ///
     /// # Parameters
     ///

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -464,8 +464,11 @@ impl Vmm {
             #[cfg(feature = "profile-time")]
             perf_timings.set_kernel_load(kernel_load_start.elapsed().as_micros() as u64);
 
-            // Write kernel arguments to guest control registers (must happen after
-            // load_kernel because the ELF .zero section overwrites this region).
+            // Write kernel arguments to guest control registers. These registers reside in
+            // the kernel ELF's `.zero` section, which `load_kernel()` zero-fills by default, so
+            // this write must happen after it. (With the `nightly-performance-optimizations`
+            // feature the loader skips that zeroing and relies on the freshly allocated guest
+            // memory already being zero, but writing after `load_kernel()` remains correct.)
             if let Some(ref kargs) = args.kernel_args {
                 Guest::write_kernel_args(&mut vmem, kargs)?;
             }
@@ -591,8 +594,12 @@ impl Vmm {
             guest.reset(&mut vmem, &mut vcpu)?;
 
             // Populate the pvclock page so the kernel uses TSC-based time instead
-            // of PIT tick counting. This must run AFTER load_kernel() because the
-            // ELF loader zero-fills the page at DEFAULT_PVCLOCK_PAGE.
+            // of PIT tick counting. The page at DEFAULT_PVCLOCK_PAGE resides in the
+            // kernel ELF's `.zero` section, which `load_kernel()` zero-fills by default,
+            // so this must run after it. (With the `nightly-performance-optimizations`
+            // feature the loader skips that zeroing and relies on the freshly allocated
+            // guest memory already being zero, but running after `load_kernel()` remains
+            // correct.)
             Self::setup_pvclock(&mut vmem)?;
 
             #[cfg(feature = "profile-time")]


### PR DESCRIPTION
## Summary

Introduce a `nightly-performance-optimizations` Cargo feature for the `uservm` crate that trades defensive guarantees for speed. It is enabled automatically for release builds (`RELEASE=yes`) via `uservm.mk`.

The first optimization gated behind this feature skips zero-filling the BSS region (`p_memsz > p_filesz`) of loaded ELF segments. Both supported VMM backends (KVM and WHP) allocate zero-filled guest physical memory, so the ELF loader can copy only `p_filesz` bytes and rely on the pre-zeroed destination instead of writing the trailing range explicitly.

## Changes

- **build/make/uservm.mk**: enable the feature for release builds.
- **src/uservm/Cargo.toml**: declare the feature and document its semantics.
- **src/uservm/src/elf.rs**: gate BSS zeroing behind the feature; update the safety contract requiring callers to provide zero-filled memory, and rename/extend the unit test to cover both default and optimized paths.
- **src/uservm/src/vmm/microvm/{guest,mod,ramfs}.rs** and **src/uservm/src/vmm/microvm/whp/mod.rs**: clarify the documentation around control-register, ramfs, and pvclock writes that depend on `load_kernel()` ordering, noting that writing after `load_kernel()` remains correct even when the loader skips zeroing.

## Notes

No behavioral change for default (debug) builds.

## Issues

Closes #1883