### PR TITLE
[kernel] Fix per-thread timer-alarm starvation in scheduler

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -920,6 +920,15 @@ impl ProcessManager {
 
         // Set the list of sleeping processes.
         self.suspended = suspended;
+
+        // Service per-thread alarms for processes that remain runnable because they still have
+        // other ready threads. Such a sleeping thread is parked inside the process's own
+        // sleeping-thread list (it never reaches `self.suspended`), so without this its alarm would
+        // never be serviced until the whole process quiesced — letting one CPU-bound sibling thread
+        // starve another thread's timed wait.
+        for process in self.ready.iter_mut() {
+            process.wakeup_expired_alarms(now);
+        }
     }
 
     ///
@@ -1006,36 +1015,58 @@ impl ProcessManager {
     /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
     ///
     pub fn do_wakeup(&mut self, tid: ThreadIdentifier) -> Result<(), Error> {
+        if self.try_wakeup_thread(tid) {
+            Ok(())
+        } else {
+            let reason: &str = "thread not found";
+            error!("{reason} (tid={tid:?})");
+            Err(Error::new(ErrorCode::NoSuchEntry, reason))
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Best-effort wakeup of a single thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: ID of the thread to wake up.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if a sleeping thread with the given identifier was woken, or `false` if no
+    /// such thread is currently in a sleeping state (for example, because it already timed out or
+    /// was woken by another notifier). Unlike [`Self::do_wakeup`], the not-sleeping case is reported
+    /// through the return value rather than an error, so that synchronization primitives can skip
+    /// stale waiters without producing spurious error logs.
+    ///
+    fn try_wakeup_thread(&mut self, tid: ThreadIdentifier) -> bool {
         // Check if thread belongs to the running process.
         if self.get_running().find_thread(tid).is_some() {
             let running_process: RunningProcess = self.take_running();
             match running_process.wakeup(tid) {
                 Ok(running_process) => {
                     self.running = Some(running_process);
-                    return Ok(());
+                    return true;
                 },
                 Err(running_process) => {
+                    // The thread exists in the running process but is not sleeping (e.g., it was
+                    // already woken). Report this as a no-op rather than an error.
                     self.running = Some(running_process);
-                    let reason: &str = "thread not found";
-                    error!("{reason} (tid={tid:?})");
-                    return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+                    return false;
                 },
             }
         }
 
-        // Check if thread belongs to a suspended process.
-        let runnable_process: RunnableProcess = match self.try_wakeup(tid) {
-            Some(runnable_process) => runnable_process,
-            None => {
-                let reason: &str = "thread not found";
-                error!("{reason} (tid={tid:?})");
-                return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+        // Check if thread belongs to a suspended or ready process.
+        match self.try_wakeup(tid) {
+            Some(runnable_process) => {
+                self.ready.push_back(runnable_process);
+                true
             },
-        };
-
-        self.ready.push_back(runnable_process);
-
-        Ok(())
+            None => false,
+        }
     }
 
     fn try_wakeup(&mut self, tid: ThreadIdentifier) -> Option<RunnableProcess> {

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -840,6 +840,35 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Best-effort wakeup of a thread used by synchronization primitives.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: ID of the thread to wake up.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if a sleeping thread with the given identifier was woken, or `false` if no
+    /// such thread is currently sleeping (e.g., it already timed out before this call). Unlike
+    /// [`Self::wakeup`], the not-sleeping case is not treated as an error, so a stale waiter neither
+    /// consumes a notification nor produces a spurious error log.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it operates on global variables.
+    ///
+    /// This function is safe to use if and only if the following conditions are met:
+    ///
+    /// - The calling process does not hold a reference to the process manager.
+    ///
+    pub unsafe fn wakeup_waiter(tid: ThreadIdentifier) -> bool {
+        PERF_SCHED_WAKEUP.fetch_add(1, ORDER);
+        Self::get_mut().try_wakeup_thread(tid)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Takes a mutex guard from a thread.
     ///
     /// # Parameters

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -29,7 +29,10 @@ use crate::{
         },
     },
 };
-use ::alloc::boxed::Box;
+use ::alloc::{
+    boxed::Box,
+    collections::vec_deque::VecDeque,
+};
 use ::sys::pm::ProcessIdentifier;
 use ::type_safe::NonEmptyVecDeque;
 use sys::{
@@ -212,6 +215,54 @@ impl RunnableProcess {
             .map(|thread| thread.admission_time())
             .min()
             .unwrap_or(clock::now())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Wakes every sleeping thread of this process whose alarm has expired, moving it into the
+    /// ready set with an [`InterruptReason::TimedOut`] reason.
+    ///
+    /// This services per-thread timer alarms while the process remains runnable because it still
+    /// has other ready threads. Without it, a sleeping thread parked inside a runnable process
+    /// would never have its alarm serviced until the whole process quiesced, allowing a CPU-bound
+    /// sibling thread to starve another thread's timed wait.
+    ///
+    /// # Parameters
+    ///
+    /// - `now`: The current system time.
+    ///
+    pub fn wakeup_expired_alarms(&mut self, now: SystemTime) {
+        // Take the sleeping-thread list, returning early when there is nothing to service.
+        let mut sleeping_threads: VecDeque<SleepingThread> = match self.sleeping_threads.take() {
+            Some(sleeping_threads) => VecDeque::from(sleeping_threads),
+            None => return,
+        };
+
+        // Visit each currently-sleeping thread exactly once, reusing the existing allocation.
+        // Threads whose alarm has expired are woken and moved to the ready set; the rest are
+        // rotated to the back of the same deque so they stay asleep without being revisited.
+        // The counter bounds the loop to the initial length, so re-queued threads are skipped.
+        let mut remaining: usize = sleeping_threads.len();
+        while remaining > 0 {
+            remaining -= 1;
+            let Some(thread) = sleeping_threads.pop_front() else {
+                break;
+            };
+            match thread.alarm() {
+                Some(alarm) if now >= alarm => {
+                    // Wake the thread carrying the TimedOut reason so the blocking kernel call
+                    // returns Interrupted(TimedOut), mirroring the suspended-process alarm path.
+                    let ready_thread: ReadyThread =
+                        thread.interrupt(InterruptReason::TimedOut).resume();
+                    self.ready_threads.push_back(ready_thread);
+                },
+                _ => sleeping_threads.push_back(thread),
+            }
+        }
+
+        // Restore the threads that are still sleeping (None when all of them were woken).
+        self.sleeping_threads = NonEmptyVecDeque::from(sleeping_threads);
     }
 
     ///

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -101,8 +101,11 @@ impl Condvar {
     ///
     /// # Return Value
     ///
-    /// Upon successful completion, this function returns the number of threads that were awakened.
-    /// Otherwise, it returns an error object that specifying the reason of failure.
+    /// This function always returns `Ok` with the number of threads that were awakened (`1` if a
+    /// genuinely waiting thread was woken, or `0` if the sleeping queue was empty or contained only
+    /// stale waiters). Stale entries — whose thread already left the sleeping state (e.g., it timed
+    /// out before this notification) — are skipped on a best-effort basis rather than reported as
+    /// errors.
     ///
     /// # Safety
     ///
@@ -113,15 +116,17 @@ impl Condvar {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn notify_first(&self) -> Result<u32, Error> {
-        let mut awakened: u32 = 0;
-
-        // Attempt to wake up the first thread in the sleeping queue.
-        if let Some(tid) = self.inner.sleeping.borrow_mut().pop_front() {
-            ProcessManager::wakeup(tid)?;
-            awakened += 1;
+        // Wake the first thread that is still genuinely waiting. Stale entries — whose thread
+        // already left the sleeping state (e.g., it timed out before this notification) — are
+        // discarded as they are encountered, so the notification is delivered to a thread that is
+        // actually waiting.
+        while let Some(tid) = self.inner.sleeping.borrow_mut().pop_front() {
+            if ProcessManager::wakeup_waiter(tid) {
+                return Ok(1);
+            }
         }
 
-        Ok(awakened)
+        Ok(0)
     }
 
     ///
@@ -135,7 +140,9 @@ impl Condvar {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+    /// This function always returns `Ok(())`. If the target thread already left the sleeping state
+    /// (e.g., it timed out before this notification), the wakeup is a best-effort no-op rather than
+    /// an error.
     ///
     /// # Safety
     ///
@@ -157,7 +164,9 @@ impl Condvar {
                     "notify_thread(): tid does not match (expected: tid={tid:?}, got \
                      tid={notified_tid:?})",
                 );
-                ProcessManager::wakeup(tid)?;
+                // Best-effort: if the thread already left the sleeping state (e.g., it timed out),
+                // there is nothing to wake and this is not an error.
+                let _ = ProcessManager::wakeup_waiter(tid);
             }
         }
 
@@ -171,11 +180,10 @@ impl Condvar {
     ///
     /// # Return Value
     ///
-    /// Upon successful completion, this function returns the number of threads that were awakened.
-    /// Otherwise, it returns an error object that specifying the reason of failure.  If an error
-    /// occurs while waking up a thread, it is logged and the function continues trying to wake up
-    /// the remaining threads. If no threads were successfully awakened and at least one error
-    /// occurred, the first encountered error is returned.
+    /// This function always returns `Ok` with the number of threads that were awakened. Stale
+    /// entries — whose thread already left the sleeping state (e.g., it timed out before this
+    /// notification) — are skipped on a best-effort basis and not counted, rather than reported as
+    /// errors.
     ///
     /// # Safety
     ///
@@ -187,26 +195,17 @@ impl Condvar {
     ///
     pub unsafe fn notify_all(&self) -> Result<u32, Error> {
         let mut awakened: u32 = 0; // Number of awakened threads.
-        let mut first_error: Option<Error> = None; // First error encountered (if any).
 
-        // Traverse the sleeping queue, waking up all threads.
+        // Traverse the sleeping queue, waking up every thread that is still genuinely waiting.
+        // Stale entries — whose thread already left the sleeping state (e.g., it timed out before
+        // this notification) — are skipped rather than reported as errors.
         while let Some(tid) = self.inner.sleeping.borrow_mut().pop_front() {
-            // Attempt to wake up thread and check for errors.
-            if let Err(error) = ProcessManager::wakeup(tid) {
-                // Failed to wake up thread, log a warning, store the first error, and continue.
-                warn!("{error:?} (tid={tid:?})");
-                if first_error.is_none() {
-                    first_error = Some(error);
-                }
-            } else {
-                // Only count successful wake-ups.
+            if ProcessManager::wakeup_waiter(tid) {
                 awakened += 1;
             }
         }
-        match first_error {
-            Some(error) if awakened == 0 => Err(error),
-            None | Some(_) => Ok(awakened),
-        }
+
+        Ok(awakened)
     }
 
     ///

--- a/src/tests/thread-rust/src/tests/alarm_starvation.rs
+++ b/src/tests/thread-rust/src/tests/alarm_starvation.rs
@@ -1,0 +1,214 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::runtime::{
+    KernelThread,
+    deadline_from_now,
+    monotonic_now,
+};
+use ::core::{
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
+    time::Duration,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        pm::__kcall_sleep,
+        sched::__kcall_sched_yield,
+    },
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Timed-sleep duration for the sleeper thread. Kept short so the test completes quickly once the
+/// scheduler services per-thread alarms correctly.
+const SLEEPER_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Wall-clock budget for the CPU-bound sibling. Chosen an order of magnitude larger than
+/// `SLEEPER_TIMEOUT`: when the sleeper's alarm is serviced correctly, the sibling is still running
+/// when the sleeper wakes. The sibling self-limits to this budget so that the test still terminates
+/// on a buggy kernel, where the sleeper cannot wake until the sibling stops.
+const BUSY_BUDGET: Duration = Duration::from_millis(1000);
+
+/// Value returned by the sibling worker on success.
+const WORKER_OK: usize = 0xa1a1;
+
+/// Value returned by the sibling worker on failure.
+const WORKER_FAILURE: usize = usize::MAX;
+
+//==================================================================================================
+// Globals
+//==================================================================================================
+
+/// Set once the sibling worker has started executing.
+static WORKER_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Set by the main thread to release the sibling worker from its busy loop.
+static WORKER_RELEASE: AtomicBool = AtomicBool::new(false);
+
+/// Set by the sibling worker right before it returns (i.e., it exhausted its busy budget).
+static WORKER_FINISHED: AtomicBool = AtomicBool::new(false);
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Runs the per-thread timer-alarm starvation regression test.
+pub fn run() -> Result<(), Error> {
+    test_timed_sleep_with_busy_sibling()
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Verifies that a thread's timed `sleep()` fires from its own alarm even while a sibling thread in
+/// the same process is continuously runnable (CPU-bound).
+///
+/// Before the fix, the scheduler serviced alarms only for fully-suspended processes. A busy sibling
+/// kept the process in the ready queue, so the sleeper's alarm was never serviced until the sibling
+/// stopped — turning an independent timed sleep into a process-wide barrier.
+///
+/// The sleeper sleeps for `SLEEPER_TIMEOUT` while the sibling stays runnable for up to
+/// `BUSY_BUDGET` (much longer). If the alarm is serviced correctly, the sleeper wakes while the
+/// sibling is still running. If the bug is present, the sleeper cannot wake until the sibling
+/// exhausts its budget and exits — by which point the sibling has already finished.
+fn test_timed_sleep_with_busy_sibling() -> Result<(), Error> {
+    WORKER_STARTED.store(false, Ordering::SeqCst);
+    WORKER_RELEASE.store(false, Ordering::SeqCst);
+    WORKER_FINISHED.store(false, Ordering::SeqCst);
+
+    let worker: KernelThread = KernelThread::spawn(busy_sibling, 0)?;
+
+    // Ensure the sibling is always released and joined, even if a fallible operation below returns
+    // early via `?`. Otherwise the busy sibling could keep running until `BUSY_BUDGET` elapses and
+    // interfere with subsequent tests.
+    let mut guard: WorkerGuard = WorkerGuard::new(worker);
+
+    // Wait until the sibling is actually running so that it is in the ready set before we sleep.
+    while !WORKER_STARTED.load(Ordering::SeqCst) {
+        __kcall_sched_yield()?;
+    }
+
+    // Sleep for a short, fixed duration while the sibling keeps the process runnable.
+    let before: SystemTime = monotonic_now()?;
+    __kcall_sleep(SLEEPER_TIMEOUT)?;
+    let after: SystemTime = monotonic_now()?;
+
+    // Capture whether the sibling already finished. Its budget is far larger than our sleep, so it
+    // must still be running unless our alarm was starved until the sibling exited.
+    let sibling_finished_early: bool = WORKER_FINISHED.load(Ordering::SeqCst);
+
+    // Release the sibling and join it so the thread is cleaned up regardless of the outcome.
+    let retval: usize = guard.release_and_join()?;
+
+    // Primary check: the timed sleep must not have been starved by the busy sibling.
+    if sibling_finished_early {
+        return Err(Error::new(
+            ErrorCode::OperationTimedOut,
+            "timed sleep was starved by a busy sibling thread (per-thread alarm not serviced)",
+        ));
+    }
+
+    // Secondary check: the sleep must not return before its requested deadline.
+    match after.checked_sub(&before) {
+        Ok(elapsed) => {
+            if elapsed < SLEEPER_TIMEOUT {
+                return Err(Error::new(
+                    ErrorCode::OperationTimedOut,
+                    "timed sleep returned before its deadline",
+                ));
+            }
+        },
+        Err(_) => {
+            return Err(Error::new(ErrorCode::TryAgain, "monotonic clock regressed during sleep"));
+        },
+    }
+
+    // Sanity: the sibling worker completed successfully.
+    if retval != WORKER_OK {
+        return Err(Error::new(ErrorCode::InvalidArgument, "sibling worker reported failure"));
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Worker Functions
+//==================================================================================================
+
+/// RAII guard that releases and joins the sibling worker thread on drop, guaranteeing the worker is
+/// cleaned up even when the test returns early via `?`.
+struct WorkerGuard {
+    worker: Option<KernelThread>,
+}
+
+impl WorkerGuard {
+    /// Creates a new guard taking ownership of the spawned worker thread.
+    fn new(worker: KernelThread) -> Self {
+        Self {
+            worker: Some(worker),
+        }
+    }
+
+    /// Releases the worker from its busy loop and joins it, returning its exit value. After this
+    /// call the guard's drop is a no-op.
+    fn release_and_join(&mut self) -> Result<usize, Error> {
+        WORKER_RELEASE.store(true, Ordering::SeqCst);
+        match self.worker.take() {
+            Some(worker) => worker.join(),
+            None => Ok(WORKER_OK),
+        }
+    }
+}
+
+impl Drop for WorkerGuard {
+    fn drop(&mut self) {
+        WORKER_RELEASE.store(true, Ordering::SeqCst);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+/// Entry point for the CPU-bound sibling worker.
+extern "C" fn busy_sibling(_arg: usize) -> usize {
+    busy_sibling_impl().unwrap_or(WORKER_FAILURE)
+}
+
+/// Stays continuously runnable (CPU-bound) until released by the main thread or until `BUSY_BUDGET`
+/// elapses, whichever comes first. Yielding each iteration keeps the thread in the ready set,
+/// reproducing the exact condition that starves a sibling's timed alarm on a buggy kernel.
+fn busy_sibling_impl() -> Result<usize, Error> {
+    // Signal that the worker is running before any fallible call, so the main thread never spins
+    // indefinitely in its `WORKER_STARTED` wait loop if an early operation fails.
+    WORKER_STARTED.store(true, Ordering::SeqCst);
+
+    let deadline: SystemTime = deadline_from_now(BUSY_BUDGET)?;
+
+    loop {
+        if WORKER_RELEASE.load(Ordering::SeqCst) {
+            break;
+        }
+        if monotonic_now()? >= deadline {
+            break;
+        }
+        __kcall_sched_yield()?;
+    }
+
+    WORKER_FINISHED.store(true, Ordering::SeqCst);
+    Ok(WORKER_OK)
+}

--- a/src/tests/thread-rust/src/tests/mod.rs
+++ b/src/tests/thread-rust/src/tests/mod.rs
@@ -7,6 +7,7 @@ use ::sys::error::Error;
 // Modules
 //==================================================================================================
 
+mod alarm_starvation;
 mod attributes;
 mod cond_timedwait;
 mod condvars;
@@ -39,6 +40,7 @@ pub fn run_all() -> Result<(), Error> {
     timers::run()?;
     tda::run()?;
     scheduler::run()?;
+    alarm_starvation::run()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes a scheduler defect where per-thread timer alarms were serviced **only for fully-suspended processes**. When a thread issued a timed wait (e.g. `sleep`, timed `cond_timedwait`, timed mutex lock) while a sibling thread in the same process remained runnable, the sleeping thread was parked inside `RunnableProcess.sleeping_threads` and its alarm was checked nowhere. As a result, a CPU-bound sibling could delay another thread's timed wakeup unboundedly, degrading independent per-thread timed waits into a process-wide barrier.

## Changes

The branch is split into three focused commits:

1. **`[kernel] Service per-thread timer alarms`**
   - Add `RunnableProcess::wakeup_expired_alarms(now)`, which moves every sleeping thread whose alarm has expired into the ready set carrying `InterruptReason::TimedOut`, mirroring the suspended-process alarm path so the blocking kernel call returns `Interrupted(TimedOut)`.
   - Call it from `check_alarm()` for each process in `self.ready`, after the existing suspended-process pass.
   - Refactor `do_wakeup()` into `try_wakeup_thread()` returning a `bool` for the "thread exists but is not sleeping" case (already timed out / woken by another notifier). `do_wakeup()` preserves prior behaviour by logging and returning `NoSuchEntry` on a false result.
   - No functional change for fully-suspended processes.

2. **`[kernel] Skip stale condvar waiters`**
   - Because alarms now fire while a process is still runnable, a timed condvar waiter can leave the sleeping state before a `notify` pops its tid. The old path called `ProcessManager::wakeup(tid)` → `NoSuchEntry`, causing a lost notification (`notify_first`) or spurious error logs (`notify_all`/`notify_thread`).
   - Add `ProcessManager::wakeup_waiter(tid) -> bool`, a best-effort wrapper over `try_wakeup_thread()`.
   - `notify_first` now loops past stale entries to wake the first genuine waiter; `notify_all` counts only genuine wake-ups and drops the first-error bookkeeping; `notify_thread` treats an already-woken thread as a no-op.

3. **`[test] Per-thread alarm starvation test`**
   - Add a regression test (`thread-rust`) that spawns a CPU-bound sibling staying runnable for up to 1000 ms while the main thread sleeps 100 ms. With the fix, the sleeper wakes while the sibling is still running; on a buggy kernel it cannot wake until the sibling exits.
   - The sibling self-limits to its busy budget so the test terminates (as a clean `OperationTimedOut` failure) rather than hanging on a buggy kernel. Registered in `run_all()`.

## Testing

- [ ] Full test suite (`./z test`)

> Draft — opening for early review/CI.