### PR TITLE
[kernel] Enforce process-management capability on terminate() kernel call

### DIFF
--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -104,6 +104,12 @@ pub fn main() {
         panic!("failed to acquire exception management capability (error={:?})", e);
     }
 
+    // Acquire process management capability so that faulting processes can be terminated.
+    ::syslog::info!("acquiring process management capability...");
+    if let Err(e) = ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true) {
+        panic!("failed to acquire process management capability (error={:?})", e);
+    }
+
     // Signup to the process manager daemon.
     // NOTE: this must happen before subscribing to page faults so that no
     // exception messages arrive during the synchronous signup handshake.

--- a/src/kernel/src/pm/kcall/terminate.rs
+++ b/src/kernel/src/pm/kcall/terminate.rs
@@ -9,11 +9,52 @@ use crate::{
     kcall::KcallResult,
     pm::ProcessManager,
 };
-use ::sys::pm::ProcessIdentifier;
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    pm::{
+        Capability,
+        ProcessIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Terminates a target process on behalf of a calling process.
+///
+/// # Parameters
+///
+/// - `pm`: Reference to the process manager.
+/// - `caller_pid`: Identifier of the calling process.
+/// - `pid`: Identifier of the process to terminate.
+///
+/// # Returns
+///
+/// Upon success, empty is returned. Upon failure, an error is returned instead.
+///
+fn do_terminate(
+    pm: &mut ProcessManager,
+    caller_pid: ProcessIdentifier,
+    pid: ProcessIdentifier,
+) -> Result<(), Error> {
+    trace!("caller_pid={:?}, pid={:?}", caller_pid, pid);
+
+    // Check if the calling process has process-management capabilities.
+    if !pm.has_capability(caller_pid, Capability::ProcessManagement)? {
+        let reason: &str = "process does not have process management capability";
+        error!("{reason}");
+        return Err(Error::new(ErrorCode::PermissionDenied, reason));
+    }
+
+    pm.terminate(pid)
+}
 
 ///
 /// # Description
@@ -33,9 +74,6 @@ pub fn terminate(caller_pid: ProcessIdentifier, arg0: u32) -> KcallResult {
     // SAFETY: the process manager is initialized and access is synchronized.
     let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
 
-    // TODO (#1434): check if calling process has enough privileges to terminate the target process.
-    let _: ProcessIdentifier = caller_pid;
-
     // Unpack kernel call arguments.
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
@@ -44,7 +82,7 @@ pub fn terminate(caller_pid: ProcessIdentifier, arg0: u32) -> KcallResult {
             return KcallResult::Error(error.code.into());
         },
     };
-    match pm.terminate(pid) {
+    match do_terminate(pm, caller_pid, pid) {
         Ok(()) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -39,6 +39,7 @@ use ::sys::{
     },
     mm::VirtualAddress,
     pm::{
+        Capability,
         ProcessIdentifier,
         ThreadCreateArgs,
     },
@@ -227,13 +228,23 @@ fn test_duplicate_cow() -> Result<(), Error> {
         PATTERN_PARENT
     );
 
-    // Tear down the child and reclaim the stack.
-    pm::__kcall_terminate(child_pid)?;
+    // Acquire the process-management capability required to terminate the child, tear it down,
+    // then release the capability. The capability is always released and the stack always
+    // reclaimed, even if the termination fails.
+    let teardown: Result<(), Error> = match pm::__kcall_capctl(Capability::ProcessManagement, true)
+    {
+        Ok(()) => {
+            let result: Result<(), Error> = pm::__kcall_terminate(child_pid);
+            let _ = pm::__kcall_capctl(Capability::ProcessManagement, false);
+            result
+        },
+        Err(e) => Err(e),
+    };
     // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above and the
     // child is being terminated so it no longer references the parent's mapping of these pages.
     unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
 
-    Ok(())
+    teardown
 }
 
 //==================================================================================================

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -229,14 +229,26 @@ fn test_duplicate_cow() -> Result<(), Error> {
     );
 
     // Acquire the process-management capability required to terminate the child, tear it down,
-    // then release the capability. The capability is always released and the stack always
-    // reclaimed, even if the termination fails.
-    let teardown: Result<(), Error> = match pm::__kcall_capctl(Capability::ProcessManagement, true)
-    {
-        Ok(()) => {
-            let result: Result<(), Error> = pm::__kcall_terminate(child_pid);
-            let _ = pm::__kcall_capctl(Capability::ProcessManagement, false);
-            result
+    // then release the capability. The capability is always released (only when this path
+    // acquired it) and the stack always reclaimed, even if the termination fails. A release
+    // failure is surfaced as well so that it does not leave `ProcessManagement` enabled for
+    // subsequent tests. `ResourceBusy` means the capability is already held, so termination must
+    // still proceed without leaving it disabled afterwards.
+    let acquired: Result<bool, Error> =
+        match pm::__kcall_capctl(Capability::ProcessManagement, true) {
+            Ok(()) => Ok(true),
+            Err(e) if e.code == ErrorCode::ResourceBusy => Ok(false),
+            Err(e) => Err(e),
+        };
+    let teardown: Result<(), Error> = match acquired {
+        Ok(acquired) => {
+            let terminate: Result<(), Error> = pm::__kcall_terminate(child_pid);
+            let release: Result<(), Error> = if acquired {
+                pm::__kcall_capctl(Capability::ProcessManagement, false)
+            } else {
+                Ok(())
+            };
+            terminate.and(release)
         },
         Err(e) => Err(e),
     };

--- a/src/tests/test-kernel/src/getppid.rs
+++ b/src/tests/test-kernel/src/getppid.rs
@@ -40,6 +40,7 @@ use ::sys::{
     },
     mm::VirtualAddress,
     pm::{
+        Capability,
         ProcessIdentifier,
         ThreadCreateArgs,
     },
@@ -193,8 +194,17 @@ fn test_getppid_reports_parent() -> Result<(), Error> {
     // spinning process or leak the stack allocation.
     let outcome: Result<(), Error> = observe_child_parent(parent_pid, child_pid);
 
-    // Tear down the child and reclaim the stack regardless of the interaction outcome.
-    let teardown: Result<(), Error> = pm::__kcall_terminate(child_pid);
+    // Tear down the child and reclaim the stack regardless of the interaction outcome. The
+    // process-management capability is acquired only for the termination and released afterwards.
+    let teardown: Result<(), Error> = match pm::__kcall_capctl(Capability::ProcessManagement, true)
+    {
+        Ok(()) => {
+            let result: Result<(), Error> = pm::__kcall_terminate(child_pid);
+            let _ = pm::__kcall_capctl(Capability::ProcessManagement, false);
+            result
+        },
+        Err(e) => Err(e),
+    };
     // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above and the
     // child is being terminated so it no longer references the parent's mapping of these pages.
     unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };

--- a/src/tests/test-kernel/src/getppid.rs
+++ b/src/tests/test-kernel/src/getppid.rs
@@ -195,13 +195,25 @@ fn test_getppid_reports_parent() -> Result<(), Error> {
     let outcome: Result<(), Error> = observe_child_parent(parent_pid, child_pid);
 
     // Tear down the child and reclaim the stack regardless of the interaction outcome. The
-    // process-management capability is acquired only for the termination and released afterwards.
-    let teardown: Result<(), Error> = match pm::__kcall_capctl(Capability::ProcessManagement, true)
-    {
-        Ok(()) => {
-            let result: Result<(), Error> = pm::__kcall_terminate(child_pid);
-            let _ = pm::__kcall_capctl(Capability::ProcessManagement, false);
-            result
+    // process-management capability is acquired only for the termination and released afterwards
+    // (only when this path acquired it). A release failure is surfaced as well so that it does not
+    // leave `ProcessManagement` enabled for subsequent tests. `ResourceBusy` means the capability
+    // is already held, so termination must still proceed without leaving it disabled afterwards.
+    let acquired: Result<bool, Error> =
+        match pm::__kcall_capctl(Capability::ProcessManagement, true) {
+            Ok(()) => Ok(true),
+            Err(e) if e.code == ErrorCode::ResourceBusy => Ok(false),
+            Err(e) => Err(e),
+        };
+    let teardown: Result<(), Error> = match acquired {
+        Ok(acquired) => {
+            let terminate: Result<(), Error> = pm::__kcall_terminate(child_pid);
+            let release: Result<(), Error> = if acquired {
+                pm::__kcall_capctl(Capability::ProcessManagement, false)
+            } else {
+                Ok(())
+            };
+            terminate.and(release)
         },
         Err(e) => Err(e),
     };

--- a/src/tests/testd/src/pm/mod.rs
+++ b/src/tests/testd/src/pm/mod.rs
@@ -8,6 +8,7 @@
 mod capability;
 mod duplicate_burst;
 mod sched;
+mod terminate;
 
 //==================================================================================================
 // Public Standalone Functions
@@ -22,4 +23,5 @@ pub fn test() {
     sched::test();
     capability::test();
     duplicate_burst::test();
+    terminate::test();
 }

--- a/src/tests/testd/src/pm/terminate.rs
+++ b/src/tests/testd/src/pm/terminate.rs
@@ -1,0 +1,254 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # `terminate()` Permission Tests
+//!
+//! Verifies that the [`__kcall_terminate`] kernel call enforces an authorization check: only a
+//! process that holds the [`Capability::ProcessManagement`] capability may terminate another
+//! process. Without this check any process could terminate any other process, which is the bug
+//! tracked by issue #1434.
+//!
+//! The test spawns a spinning child process, then attempts to terminate it *without* holding the
+//! process-management capability. The kernel must reject this request with
+//! [`ErrorCode::PermissionDenied`]. Afterwards the test acquires the capability, terminates the
+//! child for real (which both validates the privileged path and reaps the spinning child), and
+//! reclaims the resources it allocated.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::arch::mem::PAGE_SIZE;
+use ::core::sync::atomic::{
+    AtomicU32,
+    Ordering,
+};
+use ::sys::{
+    error::ErrorCode,
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    kcall::{
+        ipc,
+        mm,
+        pm,
+        sched,
+    },
+    mm::{
+        AccessPermission,
+        VirtualAddress,
+    },
+    pm::{
+        Capability,
+        ProcessIdentifier,
+        ThreadCreateArgs,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Ordering used for all atomic operations.
+const ORDER: Ordering = Ordering::SeqCst;
+
+/// Number of pages backing the child's main-thread stack.
+const STACK_PAGES: usize = 2;
+
+/// Size, in bytes, of the child's main-thread stack.
+const STACK_BYTES: usize = STACK_PAGES * PAGE_SIZE;
+
+/// Base virtual address of the region used to back the child stack.
+///
+/// This lies in the guard region between the unified mmap region and the user stack, matching the
+/// convention used by the other low-level process-management tests. The stack is mapped only for
+/// the duration of the test and unmapped before it returns.
+const STACK_REGION_BASE: usize = ::config::memory_layout::USER_MMAP_END_RAW;
+
+// Compile-time check: ensure the child stack fits within the guard region and does not overflow
+// into the user stack.
+::static_assert::assert_eq!(
+    STACK_REGION_BASE + STACK_BYTES <= ::config::memory_layout::USER_STACK_TOP_RAW
+);
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Parent process identifier, published before the child is spawned so that the child can recover
+/// it from its copy-on-write inherited memory image.
+static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
+
+//==================================================================================================
+// Child Entry Point
+//==================================================================================================
+
+/// Spins forever, yielding the processor on each iteration.
+fn spin() -> ! {
+    loop {
+        let _ = sched::__kcall_sched_yield();
+    }
+}
+
+/// Entry point for the child process spawned by the test.
+///
+/// The child recovers its own and the parent's identifiers, sends a single acknowledgement back to
+/// the parent to prove that it was created and actually executed, then spins until the parent
+/// terminates it.
+extern "C" fn terminate_child_entry(_arg: usize) -> usize {
+    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        Ok(pid) => pid,
+        Err(_) => spin(),
+    };
+    let parent_pid: ProcessIdentifier =
+        match ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER)) {
+            Ok(pid) => pid,
+            Err(_) => spin(),
+        };
+
+    // Acknowledge creation to the parent.
+    let ack: Message = Message::new(
+        MessageSender::from(my_pid),
+        MessageReceiver::from(parent_pid),
+        MessageType::Ipc,
+        None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    let _ = ipc::__kcall_send(&ack);
+
+    // Spin until the parent terminates us.
+    spin()
+}
+
+//==================================================================================================
+// Private Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Verifies that a process lacking the [`Capability::ProcessManagement`] capability cannot
+/// terminate another process, and that a process holding that capability can.
+///
+/// # Returns
+///
+/// If the test passed, `true` is returned. Otherwise, `false` is returned instead.
+///
+fn test_terminate_requires_process_management_capability() -> bool {
+    let parent_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        Ok(pid) => pid,
+        Err(_) => return false,
+    };
+    match u32::try_from(parent_pid) {
+        Ok(raw) => PARENT_PID_RAW.store(raw, ORDER),
+        Err(_) => return false,
+    }
+
+    // Acquire the memory-management capability so that the child's stack can be mapped.
+    if pm::__kcall_capctl(Capability::MemoryManagement, true).is_err() {
+        return false;
+    }
+
+    let stack_base: VirtualAddress = VirtualAddress::from_raw_value(STACK_REGION_BASE);
+    let mut success: bool = true;
+    let mut child: Option<ProcessIdentifier> = None;
+
+    // Map the child's stack.
+    if mm::__kcall_mmap(parent_pid, stack_base, STACK_PAGES, AccessPermission::RDWR).is_err() {
+        success = false;
+    }
+
+    // Spawn a spinning child process.
+    if success {
+        let args: ThreadCreateArgs = ThreadCreateArgs {
+            user_fn: VirtualAddress::from_raw_value(terminate_child_entry as *const () as usize),
+            user_fn_arg0: 0,
+            user_fn_arg1: 0,
+            user_stack_base: stack_base,
+            user_stack_size: STACK_BYTES,
+            user_tda: None,
+        };
+        match pm::__kcall_duplicate(&args) {
+            Ok(spawned) if spawned != parent_pid => child = Some(spawned),
+            _ => success = false,
+        }
+    }
+
+    // Wait for the child to acknowledge that it was created and is running.
+    if success {
+        match ipc::__kcall_recv() {
+            Ok(message) if message.message_type == MessageType::Ipc => {},
+            _ => success = false,
+        }
+    }
+
+    // Core of the test: a process without the process-management capability must NOT be able to
+    // terminate another process. The kernel must reject the request with `PermissionDenied`.
+    if let Some(child) = child {
+        match pm::__kcall_terminate(child) {
+            // Expected behavior: the kernel denies the unprivileged termination request.
+            Err(error) => {
+                if error.code != ErrorCode::PermissionDenied {
+                    success = false;
+                }
+            },
+            // Bug: the kernel allowed an unprivileged process to terminate another process.
+            Ok(()) => success = false,
+        }
+    }
+
+    // Acquire the process-management capability and terminate the child for real. This validates
+    // the privileged path and reaps the spinning child created above. `ResourceBusy` means the
+    // capability is already held, so termination must still proceed; the capability is released
+    // afterwards only when this path acquired it.
+    if let Some(child) = child {
+        let acquired: Option<bool> = match pm::__kcall_capctl(Capability::ProcessManagement, true) {
+            Ok(()) => Some(true),
+            Err(error) if error.code == ErrorCode::ResourceBusy => Some(false),
+            Err(_) => None,
+        };
+        match acquired {
+            Some(acquired) => {
+                if pm::__kcall_terminate(child).is_err() {
+                    success = false;
+                }
+                if acquired && pm::__kcall_capctl(Capability::ProcessManagement, false).is_err() {
+                    success = false;
+                }
+            },
+            None => success = false,
+        }
+    }
+
+    // Reclaim the child's stack. `mmap()` reserves `STACK_PAGES` pages in a single call, but
+    // `munmap()` releases a single page at a time, so every page must be released individually.
+    for page in 0..STACK_PAGES {
+        let page_addr: usize = STACK_REGION_BASE + page * PAGE_SIZE;
+        if mm::__kcall_munmap(parent_pid, VirtualAddress::from_raw_value(page_addr)).is_err() {
+            success = false;
+        }
+    }
+
+    // Release the memory-management capability.
+    if pm::__kcall_capctl(Capability::MemoryManagement, false).is_err() {
+        success = false;
+    }
+
+    success
+}
+
+//==================================================================================================
+// Public Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests permission enforcement of the `terminate()` kernel call.
+///
+pub fn test() {
+    crate::test!(test_terminate_requires_process_management_capability());
+}


### PR DESCRIPTION
## Summary

Previously, the `terminate()` kernel call allowed any process to tear down any other process, with the privilege check left as a TODO (#1434). This PR enforces that the caller holds the `ProcessManagement` capability before a target process can be terminated.

## Changes

### Kernel
- Add `do_terminate()` helper in `pm/kcall/terminate.rs` that verifies the caller holds the `ProcessManagement` capability via `has_capability()`, returning `PermissionDenied` otherwise, before delegating to `pm.terminate()`.
- Remove the resolved TODO (#1434) and the placeholder `caller_pid` check.

### Daemons
- Have `memd` acquire the `ProcessManagement` capability at startup so it can terminate faulting processes.

### Tests
- Update `duplicate` and `getppid` kernel tests to acquire the `ProcessManagement` capability before tearing down their child process and release it afterwards, ensuring the capability is always released and the stack always reclaimed even if termination fails.
- Add a new `terminate` system test under `testd` that:
  - Maps a stack and spawns a spinning child process, waiting for an IPC acknowledgement to confirm the child is running.
  - Attempts to terminate the child *without* the capability and asserts the kernel rejects it with `PermissionDenied`.
  - Acquires the capability, terminates the child to validate the privileged path and reap it, then releases the capability.
  - Reclaims the child's stack and releases the memory-management capability.

## Related

Closes #1434
