### PR TITLE
[kernel] Make IKC IRQ handler ack-only

### DIFF
--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -16,8 +16,6 @@ mod kcall_success;
 //==================================================================================================
 
 pub use handler::kcall_handler as handler;
-#[cfg(feature = "microvm")]
-pub use handler::poll_ikc_messages;
 pub use kcall_error::KcallError;
 pub use kcall_result::KcallResult;
 pub use kcall_success::KcallSuccess;

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -63,19 +63,30 @@ pub use thread::InterruptReason;
 ///
 /// Interrupt handler for IKC (inter-kernel communication) notifications.
 ///
-/// The VMM injects this interrupt (IRQ 9) whenever a new message is enqueued for the guest.
-/// The handler polls IKC messages immediately so the kernel does not have to wait for the
-/// next timer tick to process newly arrived messages.
+/// The VMM injects this interrupt (IRQ 9) whenever a new message is enqueued for the guest. Its
+/// sole purpose is to break the CPU out of `HLT` early so the kernel does not have to wait for the
+/// next timer tick before it returns to its idle loop.
+///
+/// The handler is intentionally *ack-only*: it does not poll IKC messages here. Message polling
+/// mutates scheduler state (it posts messages and wakes threads, moving processes between run
+/// queues) and is only safe at the kernel's controlled scheduling points — the idle-loop poll and
+/// the kcall trailing-poll — where the running process is the kernel idle context. IRQ 9, by
+/// contrast, is delivered whenever interrupts are enabled, i.e. while a *user* process is the
+/// running process; polling from that context corrupts run-queue bookkeeping and leaks a process
+/// from the scheduler. Acknowledging the interrupt and letting the idle loop perform the poll
+/// preserves the wake-from-`HLT` latency benefit without re-entering the scheduler from interrupt
+/// context.
 ///
 /// # Safety
 ///
-/// Called from interrupt context with interrupts disabled on a single-core system.
-/// At that point the CPU was halted (HLT), so no mutable references to kernel state
-/// are alive and it is safe to re-enter the process manager.
+/// Called from interrupt context with interrupts disabled on a single-core system. The handler
+/// touches no kernel state, so it is safe to invoke regardless of what the interrupted code was
+/// doing.
 ///
 #[cfg(feature = "microvm")]
 unsafe fn ikc_interrupt_handler(_intnum: InterruptNumber) {
-    crate::kcall::poll_ikc_messages();
+    // Ack-only: the actual IKC polling happens at the kernel's controlled scheduling points (idle
+    // loop and kcall trailing-poll). Do not re-enter the scheduler from interrupt context.
 }
 
 //==================================================================================================


### PR DESCRIPTION
## Summary

The IKC notification handler for IRQ 9 called `poll_ikc_messages()` directly from
interrupt context. That routine mutates scheduler state — it posts messages and wakes
threads, moving processes between the run queues. IRQ 9 is delivered whenever interrupts
are enabled, i.e. while a *user* process is the running process, not only during the idle
`HLT` window. Polling from that context corrupts run-queue bookkeeping and leaks a
process: it is dropped from every run queue while still counted in `live_count`, so it
never runs or exits, `procd` never reaps it, and the VM never shuts down (the test harness
times out).

## Fix

Make the handler ack-only. Its sole purpose is to break the CPU out of `HLT` early so the
kernel returns to its idle loop without waiting for the next timer tick. The actual polling
already runs at the kernel's controlled scheduling points — the idle-loop poll and the
kcall trailing-poll — in kernel context where the running slot is the kernel idle context.
This preserves the wake-from-`HLT` latency benefit without re-entering the scheduler from
interrupt context.

Also drops the now-unused `kcall::poll_ikc_messages` re-export; the handler was its only
out-of-module caller, while the idle loop and the kcall dispatcher still reach it through
their own paths.

## Validation

- Production kernel build + clippy (`microvm trace`, `-D warnings`): clean.
- Test-feature kernel build + clippy (`microvm trace test`, `-D warnings`): clean.
- In-kernel regression test (`run-kernel-tests`): a contract test asserts the IKC handler
  never invokes `poll_ikc_messages`. Fails before the fix (`before=0, after=1` → kernel
  panic), passes after the fix (`hello, world!` magic string).

> [!NOTE]
> This branch currently also contains unrelated vfsd `*at()` dirfd commits
> (`[vfsd] B: Reject bad dirfd in *at() handlers` and two `[tests]` commits). Consider
> splitting them out before review if they are not meant to ship together.

Fixes #2499