### PR TITLE
[ci] Tolerate transient API errors when posting benchmark PR comments

### DIFF
--- a/.github/actions/benchmark-report/action.yml
+++ b/.github/actions/benchmark-report/action.yml
@@ -84,6 +84,9 @@ runs:
         'pull_request_target') && steps.pr.outputs.pr_number != '' &&
         steps.comment-strategy.outputs.can_comment_directly == 'true' }}
       id: fc
+      # Posting the PR comment is best-effort: a transient GitHub API hiccup
+      # (e.g. an intermittent 401) must not fail the benchmark finalize job.
+      continue-on-error: true
       with:
         token: ${{ inputs.github-token }}
         issue-number: ${{ steps.pr.outputs.pr_number }}
@@ -94,8 +97,12 @@ runs:
       if: ${{ (github.event_name == 'pull_request' || github.event_name ==
         'pull_request_target') && steps.pr.outputs.pr_number != '' &&
         steps.comment-strategy.outputs.can_comment_directly == 'true' &&
+        steps.fc.outcome == 'success' &&
         steps.fc.outputs.comment-id == '' }}
       uses: peter-evans/create-or-update-comment@v5
+      # Posting the PR comment is best-effort: a transient GitHub API hiccup
+      # (e.g. an intermittent 401) must not fail the benchmark finalize job.
+      continue-on-error: true
       with:
         token: ${{ inputs.github-token }}
         issue-number: ${{ steps.pr.outputs.pr_number }}
@@ -107,8 +114,12 @@ runs:
       if: ${{ (github.event_name == 'pull_request' || github.event_name ==
         'pull_request_target') &&
         steps.comment-strategy.outputs.can_comment_directly == 'true' &&
+        steps.fc.outcome == 'success' &&
         steps.fc.outputs.comment-id != '' }}
       uses: peter-evans/create-or-update-comment@v5
+      # Posting the PR comment is best-effort: a transient GitHub API hiccup
+      # (e.g. an intermittent 401) must not fail the benchmark finalize job.
+      continue-on-error: true
       with:
         token: ${{ inputs.github-token }}
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
## Summary

The `Benchmark Finalize` job intermittently failed while posting the benchmark results comment to a PR. The `peter-evans/find-comment` and `create-or-update-comment` actions can hit transient GitHub API errors (e.g. an intermittent `401 Requires authentication`) even when the token and permissions are correct. Because the comment steps ran before the performance gate, such a hiccup failed the whole job and masked the actual benchmark outcome.

Observed in run [27288456564](https://github.com/nanvix/nanvix/actions/runs/27288456564/job/80605499518) (PR #2500): `find-comment` succeeded, but the follow-up comment update returned `401`, failing finalize before the regression gate ran.

## Changes

- Mark the three PR-comment steps in the `benchmark-report` composite action with `continue-on-error: true`:
  - Find benchmark results comment
  - Post comment to PR (Create)
  - Post comment to PR (Update)

Posting the comment is now best-effort, so a transient API failure no longer fails the finalize job or blocks the regression gate.

## Notes

- `post-benchmark-comment.yml` was intentionally left unchanged, since that standalone workflow exists specifically to post comments for forked PRs where a failure is meaningful.