### PR TITLE
[kernel] E: No callbacks for page table alloc

### DIFF
--- a/src/kernel/src/mm/kernel_vas.rs
+++ b/src/kernel/src/mm/kernel_vas.rs
@@ -152,18 +152,7 @@ pub fn init(
                     mm.alloc_kpage(false)?
                 };
 
-                let page_table_allocator = || {
-                    let kpage: KernelPage = {
-                        // SAFETY: the memory manager is initialized and access is synchronized.
-                        let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
-                        mm.alloc_kpage(true)?
-                    };
-                    let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-                    let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-                    Ok(page_table)
-                };
-
-                vmem.map_kpage(kpage, vaddr, page_table_allocator)?;
+                vmem.map_kpage(kpage, vaddr)?;
 
                 match vaddr.into_raw_value().checked_add(mem::PAGE_SIZE) {
                     Some(raw_addr) => vaddr = PageAligned::from_raw_value(raw_addr)?,

--- a/src/kernel/src/mm/kernel_vas.rs
+++ b/src/kernel/src/mm/kernel_vas.rs
@@ -142,10 +142,6 @@ pub fn init(
 
         {
             while vaddr.into_inner() < end {
-                // NOTE: each `VirtMemoryManager::get_mut()` borrow is scoped to its own inner
-                // block so that the mutable reference is dropped before any subsequent borrow,
-                // including the borrow that may occur when `page_table_allocator` is invoked
-                // inside `map_kpage`.
                 let kpage: KernelPage = {
                     // SAFETY: the memory manager is initialized and access is synchronized.
                     let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -260,18 +260,6 @@ impl VirtMemoryManager {
     /// copy-on-write marks installed on `parent` are cleared.
     ///
     pub fn link_user_pages(&mut self, parent: &mut Vmem, child: &mut Vmem) -> Result<(), Error> {
-        let page_table_allocator = || {
-            // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
-            // concurrent or re-entrant access to the physical memory manager is possible.
-            let mut kframe: KernelFrame =
-                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-            kframe.clear()?;
-            let kpage: KernelPage = KernelPage::new(kframe);
-            let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-            let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-            Ok(page_table)
-        };
-
         // Process the parent's user mappings in fixed-size chunks. We cannot mutate
         // `parent` while borrowing its page tables via `for_each_user_mapping`, so each
         // chunk first snapshots up to LINK_CHUNK entries into a stack-resident buffer,
@@ -304,14 +292,7 @@ impl VirtMemoryManager {
             for slot in buf.iter().take(count) {
                 // SAFETY: `slot` was written above for indices < count.
                 let (vaddr, frame, writable) = unsafe { slot.assume_init_read() };
-                if let Err(e) = Self::link_one_user_page(
-                    parent,
-                    child,
-                    vaddr,
-                    frame,
-                    writable,
-                    &page_table_allocator,
-                ) {
+                if let Err(e) = Self::link_one_user_page(parent, child, vaddr, frame, writable) {
                     Self::rollback_linked_pages(parent, child);
                     return Err(e);
                 }
@@ -330,17 +311,13 @@ impl VirtMemoryManager {
     /// On failure the caller is expected to invoke [`Self::rollback_linked_pages`] to
     /// undo any prior fully-linked iterations; this helper itself leaves no partial
     /// per-iteration state behind.
-    fn link_one_user_page<F>(
+    fn link_one_user_page(
         parent: &mut Vmem,
         child: &mut Vmem,
         vaddr: PageAligned<VirtualAddress>,
         frame: FrameAddress,
         writable: bool,
-        page_table_allocator: &F,
-    ) -> Result<(), Error>
-    where
-        F: Fn() -> Result<PageTable<PageTableStorage>, Error>,
-    {
+    ) -> Result<(), Error> {
         // Wrap the parent's already-owned frame in a [`ManuallyDrop`] handle so that
         // we can call [`UserFrame::share`] on it without risking a spurious decrement
         // of the parent's refcount if `share` itself returns an error. The parent's
@@ -360,7 +337,7 @@ impl VirtMemoryManager {
         } else {
             AccessPermission::RDONLY
         };
-        child.map(child_handle, vaddr, access, page_table_allocator)?;
+        child.map(child_handle, vaddr, access)?;
 
         if writable {
             if let Err(e) = parent.mark_user_page_cow(vaddr) {
@@ -593,18 +570,6 @@ impl VirtMemoryManager {
             )?;
         }
 
-        let page_table_allocator = || {
-            // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
-            // concurrent or re-entrant access to the physical memory manager is possible.
-            let mut kframe: KernelFrame =
-                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-            kframe.clear()?;
-            let kpage: KernelPage = KernelPage::new(kframe);
-            let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-            let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-            Ok(page_table)
-        };
-
         // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
         // or re-entrant access to the physical memory manager is possible.
         let alloc_result: Result<(), Error> =
@@ -619,7 +584,7 @@ impl VirtMemoryManager {
         let mut map_error: Result<(), Error> = Ok(());
 
         for uframe in uframes.drain(..) {
-            if let Err(e) = vmem.map(uframe, vaddr, access, page_table_allocator) {
+            if let Err(e) = vmem.map(uframe, vaddr, access) {
                 map_error = Err(e);
                 break;
             }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -29,6 +29,7 @@ use crate::{
     },
     mm::{
         phys::{
+            KernelFrame,
             PhysMemoryManager,
             UserFrame,
         },
@@ -37,6 +38,7 @@ use crate::{
             page_table_allocator::PAGE_TABLE_ALLOCATOR,
             PageDirectoryStorage,
             PageTableStorage,
+            VirtMemoryManager,
         },
     },
 };
@@ -235,11 +237,10 @@ impl Vmem {
     ///
     /// Upon success, empty is returned. Upon failure, an error code is returned instead.
     ///
-    pub fn map_kpage<T: Fn() -> Result<PageTable<PageTableStorage>, Error>>(
+    pub fn map_kpage(
         &mut self,
         kpage: KernelPage,
         vaddr: PageAligned<VirtualAddress>,
-        page_table_allocator: T,
     ) -> Result<(), Error> {
         let pt_vaddr: PageTableAddress = PageTableAddress::new(PageTableAligned::from_raw_value(
             ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
@@ -257,7 +258,7 @@ impl Vmem {
 
         // Check if page table does not exist.
         if !pde.is_present() {
-            let page_table: PageTable<PageTableStorage> = page_table_allocator()?;
+            let page_table: PageTable<PageTableStorage> = Self::allocate_kernel_page_table()?;
 
             // FIXME: do not be so open about permissions.
             self.pgdir.map(
@@ -305,13 +306,53 @@ impl Vmem {
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 
+    ///
+    /// # Description
+    ///
+    /// Allocate a page table for mapping kernel memory.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(page_table)` is returned. Upon failure, an error is returned.
+    ///
+    fn allocate_kernel_page_table() -> Result<PageTable<PageTableStorage>, Error> {
+        let kpage: KernelPage = {
+            // SAFETY: the memory manager is initialized and access is synchronized.
+            let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+            mm.alloc_kpage(true)?
+        };
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
+        Ok(page_table)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Allocate a page table for mapping user memory.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(page_table)` is returned. Upon failure, an error is returned.
+    ///
+    fn allocate_user_page_table() -> Result<PageTable<PageTableStorage>, Error> {
+        // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
+        // concurrent or re-entrant access to the physical memory manager is possible.
+        let mut kframe: KernelFrame =
+            unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        kframe.clear()?;
+        let kpage: KernelPage = KernelPage::new(kframe);
+        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+        let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
+        Ok(page_table)
+    }
+
     /// Maps a page to the target virtual address space.
-    pub fn map<T: Fn() -> Result<PageTable<PageTableStorage>, Error>>(
+    pub fn map(
         &mut self,
         uframe: UserFrame,
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
-        page_table_allocator: T,
     ) -> Result<(), Error> {
         // Check if the provided address lies outside the user space.
         if !Self::is_user_addr(vaddr.into_inner()) {
@@ -339,7 +380,7 @@ impl Vmem {
             // Get corresponding page table.
             // Check if corresponding page table does not exist.
             if !pde.is_present() {
-                let page_table: PageTable<PageTableStorage> = page_table_allocator()?;
+                let page_table: PageTable<PageTableStorage> = Self::allocate_user_page_table()?;
 
                 let page_table_address: FrameAddress = page_table.physical_address()?;
                 // FIXME: do not be so open about permissions.

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -156,14 +156,7 @@ fn test_cow_resolution_creates_private_frame() -> bool {
 
     // Map the first handle into `parent` at the test address. `Vmem::map` leaks the handle
     // into the page table, so it must not be referenced again from this function.
-    let page_table_allocator = || {
-        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-        kframe.clear()?;
-        let kpage: KernelPage = KernelPage::new(kframe);
-        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-        Ok(PageTable::new(pgtable_storage))
-    };
-    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR) {
         error!("Vmem::map failed (error={e:?})");
         drop(uframe2);
         return false;
@@ -316,14 +309,7 @@ fn test_cow_resolution_fast_path_when_sole_owner() -> bool {
         },
     };
 
-    let page_table_allocator = || {
-        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-        kframe.clear()?;
-        let kpage: KernelPage = KernelPage::new(kframe);
-        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-        Ok(PageTable::new(pgtable_storage))
-    };
-    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(uframe1, vaddr, AccessPermission::RDWR) {
         error!("Vmem::map failed (error={e:?})");
         drop(uframe2);
         return false;
@@ -501,26 +487,18 @@ fn test_link_user_pages_skips_preexisting_child_mappings() -> bool {
     let frame_b_num: usize = frame_b.address().into_frame_number().into_raw_value();
     let frame_c_num: usize = frame_c.address().into_frame_number().into_raw_value();
 
-    let page_table_allocator = || {
-        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-        kframe.clear()?;
-        let kpage: KernelPage = KernelPage::new(kframe);
-        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-        Ok(PageTable::new(pgtable_storage))
-    };
-
     // Map parent's two writable user pages.
-    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR) {
         error!("parent.map(vaddr_a) failed (error={e:?})");
         return false;
     }
-    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR) {
         error!("parent.map(vaddr_b) failed (error={e:?})");
         return false;
     }
 
     // Pre-map child at vaddr_b so the second iteration of `link_user_pages` collides.
-    if let Err(e) = child.map(frame_c, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = child.map(frame_c, vaddr_b, AccessPermission::RDWR) {
         error!("child.map(vaddr_b) failed (error={e:?})");
         return false;
     }
@@ -748,19 +726,11 @@ fn test_link_user_pages_rolls_back_on_partial_failure() -> bool {
         },
     }
 
-    let page_table_allocator = || {
-        let mut kframe = unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
-        kframe.clear()?;
-        let kpage: KernelPage = KernelPage::new(kframe);
-        let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-        Ok(PageTable::new(pgtable_storage))
-    };
-
-    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(frame_a, vaddr_a, AccessPermission::RDWR) {
         error!("parent.map(vaddr_a) failed (error={e:?})");
         return false;
     }
-    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR, page_table_allocator) {
+    if let Err(e) = parent.map(frame_b, vaddr_b, AccessPermission::RDWR) {
         error!("parent.map(vaddr_b) failed (error={e:?})");
         return false;
     }

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -6,13 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::{
-        arch::x86::mem::mmu::page_table::PageTable,
-        mem::{
-            AccessPermission,
-            PageAligned,
-            VirtualAddress,
-        },
+    hal::mem::{
+        AccessPermission,
+        PageAligned,
+        VirtualAddress,
     },
     ipc::Mailbox,
     mm::{
@@ -20,8 +17,6 @@ use crate::{
             PhysMemoryManager,
             UserFrame,
         },
-        KernelPage,
-        PageTableStorage,
         VirtMemoryManager,
         Vmem,
     },


### PR DESCRIPTION
Some functions take a page-table-allocator callback as an input, but the callback is always the same. This PR simplifies the code to make it just directly call the function.