### PR TITLE
[kernel] Handle already-CoW parent pages on re-fork

### DIFF
--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -74,6 +74,16 @@ const ORDER: Ordering = Ordering::Relaxed;
 /// parent's user mappings to a small number of passes for typical user processes.
 const LINK_CHUNK: usize = 32;
 
+/// Snapshot entry for one parent user mapping consumed by
+/// [`VirtMemoryManager::link_user_pages`].
+type LinkUserMapping = (PageAligned<VirtualAddress>, FrameAddress, bool, bool);
+
+/// Uninitialized slot in a link snapshot chunk.
+type LinkUserMappingSlot = MaybeUninit<LinkUserMapping>;
+
+/// Fixed-size chunk buffer used while linking user pages.
+type LinkUserMappingBuf = [LinkUserMappingSlot; LINK_CHUNK];
+
 //==================================================================================================
 // Global Variables
 //==================================================================================================
@@ -237,14 +247,18 @@ impl VirtMemoryManager {
     ///
     /// For each present user mapping in `parent`, this function adds a new reference to
     /// the underlying physical frame and installs the same mapping in `child` at the same
-    /// virtual address. If the parent mapping is writable, both the parent and child PTEs
-    /// are then marked copy-on-write (read-only in hardware + AVL bit set), so that the
-    /// first write from either side triggers a page fault. The in-kernel page-fault
-    /// handler resolves such faults by allocating a private frame and pointing the
-    /// faulting PTE at it.
+    /// virtual address. A mapping is treated as *logically writable* when it is writable in
+    /// hardware or already copy-on-write (the latter arises when the page was shared
+    /// writable by an earlier fork, leaving it read-only with the AVL CoW bit set). For a
+    /// logically-writable mapping the child is mapped RDWR and then marked copy-on-write,
+    /// and the parent is marked copy-on-write too unless it already was, so that the first
+    /// write from any sharer triggers a page fault. The in-kernel page-fault handler
+    /// resolves such faults by allocating a private frame and pointing the faulting PTE at
+    /// it.
     ///
-    /// Read-only mappings (e.g. the text segment) are shared without the copy-on-write
-    /// bit set: a write to them must continue to fault as a regular protection fault.
+    /// Genuinely read-only mappings (e.g. the text segment) are shared without the
+    /// copy-on-write bit set: a write to them must continue to fault as a regular
+    /// protection fault.
     ///
     /// # Parameters
     ///
@@ -273,13 +287,21 @@ impl VirtMemoryManager {
         // robust against the parent's iteration revisiting entries we have already
         // processed (e.g. writable entries that are now CoW-marked but still present).
         loop {
-            let mut buf: [MaybeUninit<(PageAligned<VirtualAddress>, FrameAddress, bool)>;
-                LINK_CHUNK] = [const { MaybeUninit::uninit() }; LINK_CHUNK];
+            let mut buf: LinkUserMappingBuf = [const { MaybeUninit::uninit() }; LINK_CHUNK];
             let mut count: usize = 0;
             parent.for_each_user_mapping(|vaddr, pte: PageTableEntry| {
                 if count < LINK_CHUNK && child.try_find_user_pte(vaddr)?.is_none() {
                     let frame: FrameAddress = FrameAddress::from_frame_number(pte.frame_number())?;
-                    buf[count].write((vaddr, frame, pte.flags().is_writable()));
+                    // A page that is already copy-on-write (read-only in hardware with the
+                    // AVL CoW bit set) was shared writable by a prior fork and is therefore
+                    // logically writable. Classify it as writable so the new child is shared
+                    // copy-on-write too, rather than as a plain read-only mapping that would
+                    // fault fatally on the child's first write. The parent's current CoW
+                    // state is carried alongside so the link step can skip re-marking an
+                    // already-CoW parent (mark_cow requires a writable PTE).
+                    let parent_cow: bool = pte.is_cow();
+                    let writable: bool = pte.flags().is_writable() || parent_cow;
+                    buf[count].write((vaddr, frame, writable, parent_cow));
                     count += 1;
                 }
                 Ok(())
@@ -291,8 +313,10 @@ impl VirtMemoryManager {
 
             for slot in buf.iter().take(count) {
                 // SAFETY: `slot` was written above for indices < count.
-                let (vaddr, frame, writable) = unsafe { slot.assume_init_read() };
-                if let Err(e) = Self::link_one_user_page(parent, child, vaddr, frame, writable) {
+                let (vaddr, frame, writable, parent_cow) = unsafe { slot.assume_init_read() };
+                if let Err(e) =
+                    Self::link_one_user_page(parent, child, vaddr, frame, writable, parent_cow)
+                {
                     Self::rollback_linked_pages(parent, child);
                     return Err(e);
                 }
@@ -317,6 +341,7 @@ impl VirtMemoryManager {
         vaddr: PageAligned<VirtualAddress>,
         frame: FrameAddress,
         writable: bool,
+        parent_cow: bool,
     ) -> Result<(), Error> {
         // Wrap the parent's already-owned frame in a [`ManuallyDrop`] handle so that
         // we can call [`UserFrame::share`] on it without risking a spurious decrement
@@ -326,12 +351,11 @@ impl VirtMemoryManager {
         let parent_handle: ManuallyDrop<UserFrame> = ManuallyDrop::new(UserFrame::new(frame));
         let child_handle: UserFrame = parent_handle.share()?;
 
-        // The child installs the shared frame at the same virtual address. If the
-        // page is writable the mapping is created RDWR so the subsequent CoW marking
-        // can switch it to RO+CoW (mark_cow requires the entry to be writable);
-        // otherwise the page is plain read-only with no CoW bit on either side. If
-        // `map` fails it drops `child_handle`, releasing the refcount just acquired
-        // by `share`.
+        // The child installs the shared frame at the same virtual address. If the page is
+        // logically writable the mapping is created RDWR so the subsequent CoW marking can
+        // switch it to RO+CoW (mark_cow requires the entry to be writable); otherwise the
+        // page is plain read-only with no CoW bit on either side. If `map` fails it drops
+        // `child_handle`, releasing the refcount just acquired by `share`.
         let access: AccessPermission = if writable {
             AccessPermission::RDWR
         } else {
@@ -340,21 +364,32 @@ impl VirtMemoryManager {
         child.map(child_handle, vaddr, access)?;
 
         if writable {
-            if let Err(e) = parent.mark_user_page_cow(vaddr) {
-                if let Err(re) = child.unmap(vaddr) {
-                    warn!(
-                        "link_user_pages(): partial rollback unmap failed (vaddr={vaddr:?}, \
-                         error={re:?})"
-                    );
+            // Mark the parent copy-on-write only if it is not already so. A page that is
+            // already CoW was shared writable by an earlier fork; re-marking it would fail
+            // because mark_cow requires a writable PTE. The child is still mapped RDWR
+            // (above) and marked CoW (below) so that a later write from the child resolves
+            // as a copy-on-write fault instead of faulting fatally.
+            if !parent_cow {
+                if let Err(e) = parent.mark_user_page_cow(vaddr) {
+                    if let Err(re) = child.unmap(vaddr) {
+                        warn!(
+                            "link_user_pages(): partial rollback unmap failed (vaddr={vaddr:?}, \
+                             error={re:?})"
+                        );
+                    }
+                    return Err(e);
                 }
-                return Err(e);
             }
             if let Err(e) = child.mark_user_page_cow(vaddr) {
-                if let Err(re) = parent.unmark_user_page_cow(vaddr) {
-                    warn!(
-                        "link_user_pages(): partial rollback unmark failed (vaddr={vaddr:?}, \
-                         error={re:?})"
-                    );
+                // Only undo the parent's mark if this call installed it; a parent that was
+                // already copy-on-write must be left untouched.
+                if !parent_cow {
+                    if let Err(re) = parent.unmark_user_page_cow(vaddr) {
+                        warn!(
+                            "link_user_pages(): partial rollback unmark failed (vaddr={vaddr:?}, \
+                             error={re:?})"
+                        );
+                    }
                 }
                 if let Err(re) = child.unmap(vaddr) {
                     warn!(
@@ -372,22 +407,50 @@ impl VirtMemoryManager {
     /// Rolls back pages already linked by [`Self::link_user_pages`] on the error path.
     ///
     /// Iterates `child`'s user mappings in fixed-size chunks (avoiding any allocation
-    /// proportional to the mapping set) and, for each one: unmaps it from `child`
-    /// (releasing the shared refcount via the returned `UserFrame`'s `Drop`) and, if the
-    /// child PTE was marked copy-on-write, clears the matching mark on `parent`. The
-    /// child's CoW bit unambiguously identifies pages this call installed because
-    /// `link_user_pages` is invoked on a freshly created `child` with no pre-existing
-    /// user mappings, and the only path that sets the child's CoW bit also marked the
-    /// parent's. Steps log and continue on failure to make a best-effort restoration.
+    /// proportional to the mapping set) and unmaps each page that this call could have
+    /// linked, releasing the shared refcount via the returned `UserFrame`'s `Drop`. A
+    /// child page is unmapped only when `parent` still has a present user mapping at the
+    /// same virtual address: every page linked by [`Self::link_user_pages`] is a copy of a
+    /// parent mapping, so a child page with no counterpart in `parent` is skipped.
+    ///
+    /// This `parent`-presence filter is a coarse heuristic, not exact provenance tracking:
+    /// it cannot tell a page this call installed from a pre-existing `child` mapping that
+    /// merely happens to overlap a `parent` mapping at the same address — such a page would
+    /// still be unmapped. That ambiguity is harmless given [`Self::link_user_pages`]'s
+    /// contract that `child` must not already contain user mappings overlapping `parent`'s,
+    /// so under correct use the only `child` pages overlapping `parent` are exactly those
+    /// this call linked. The filter simply avoids tearing down any non-overlapping
+    /// pre-existing mappings.
+    ///
+    /// The parent's copy-on-write marks are intentionally left untouched. A parent page
+    /// that this call marked copy-on-write could in principle be restored to writable, but
+    /// distinguishing such a page from one that was already copy-on-write before this call
+    /// (a re-fork of a frame still shared with an earlier child) cannot be done reliably:
+    /// PTE state alone is ambiguous, and the shared frame's reference count is not either
+    /// (e.g. a frame may have had a refcount of 2 from a different child while this child
+    /// never linked it). Wrongly unmarking a page that another sharer still relies on would
+    /// break copy-on-write for that sharer, whereas leaving a page copy-on-write that could
+    /// have been writable merely costs one extra copy-on-write fault on the next write.
+    /// Since this rollback path is taken only on a rare allocation/mapping failure, that
+    /// extra fault is negligible, so the safe choice is to never unmark. Steps log and
+    /// continue on failure to make a best-effort restoration.
     fn rollback_linked_pages(parent: &mut Vmem, child: &mut Vmem) {
         loop {
-            let mut buf: [MaybeUninit<(PageAligned<VirtualAddress>, bool)>; LINK_CHUNK] =
+            let mut buf: [MaybeUninit<PageAligned<VirtualAddress>>; LINK_CHUNK] =
                 [const { MaybeUninit::uninit() }; LINK_CHUNK];
             let mut count: usize = 0;
-            let walk: Result<(), Error> = child.for_each_user_mapping(|vaddr, pte| {
+            let walk: Result<(), Error> = child.for_each_user_mapping(|vaddr, _pte| {
                 if count < LINK_CHUNK {
-                    buf[count].write((vaddr, pte.is_cow()));
-                    count += 1;
+                    // Only consider pages that also exist in `parent`; a child mapping
+                    // without a parent counterpart was not installed by this call.
+                    match parent.is_user_page_mapped(vaddr) {
+                        Ok(true) => {
+                            buf[count].write(vaddr);
+                            count += 1;
+                        },
+                        Ok(false) => {},
+                        Err(e) => return Err(e),
+                    }
                 }
                 Ok(())
             });
@@ -400,15 +463,7 @@ impl VirtMemoryManager {
             }
             for slot in buf.iter().take(count) {
                 // SAFETY: `slot` was written above for indices < count.
-                let (vaddr, was_cow) = unsafe { slot.assume_init_read() };
-                if was_cow {
-                    if let Err(re) = parent.unmark_user_page_cow(vaddr) {
-                        warn!(
-                            "link_user_pages(): rollback unmark failed (vaddr={vaddr:?}, \
-                             error={re:?})"
-                        );
-                    }
-                }
+                let vaddr = unsafe { slot.assume_init_read() };
                 if let Err(re) = child.unmap(vaddr) {
                     warn!(
                         "link_user_pages(): rollback unmap failed (vaddr={vaddr:?}, error={re:?})"

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -623,8 +623,10 @@ fn test_link_user_pages_skips_preexisting_child_mappings() -> bool {
 ///
 /// Expected post-conditions after the call returns `Err`:
 ///
-/// - parent's `vaddr_a` PTE is writable, not copy-on-write, and still points at
-///   `frame_a` (the partial CoW mark installed before the failure was reverted).
+/// - parent's `vaddr_a` PTE is read-only and copy-on-write, still pointing at `frame_a`.
+///   The rollback deliberately leaves the parent's CoW mark in place because it cannot
+///   reliably tell a page it marked from one that was already shared copy-on-write before
+///   the call.
 /// - parent's `vaddr_b` PTE is untouched (writable, not CoW, original frame).
 /// - `child` has no mapping at either `vaddr_a` or `vaddr_b`.
 ///
@@ -747,7 +749,8 @@ fn test_link_user_pages_rolls_back_on_partial_failure() -> bool {
         }
     }
 
-    // Parent's vaddr_a must be rolled back: writable, not CoW, original frame.
+    // Parent's vaddr_a: the child mapping is rolled back, but the parent's CoW mark is
+    // intentionally left in place, so it is read-only + CoW, still pointing at frame_a.
     let parent_a: PageTableEntry = match parent.try_find_user_pte(vaddr_a) {
         Ok(Some(p)) => p,
         Ok(None) => {
@@ -759,12 +762,12 @@ fn test_link_user_pages_rolls_back_on_partial_failure() -> bool {
             return false;
         },
     };
-    if !parent_a.flags().is_writable() {
-        error!("parent PTE at vaddr_a is not writable after rollback");
+    if parent_a.flags().is_writable() {
+        error!("parent PTE at vaddr_a is unexpectedly writable after rollback");
         return false;
     }
-    if parent_a.is_cow() {
-        error!("parent PTE at vaddr_a still carries CoW bit after rollback");
+    if !parent_a.is_cow() {
+        error!("parent PTE at vaddr_a lost its CoW bit after rollback");
         return false;
     }
     if parent_a.frame_number().into_raw_value() != frame_a_num {

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -259,6 +259,179 @@ fn test_duplicate_cow() -> Result<(), Error> {
     teardown
 }
 
+/// Regression test for chained-fork copy-on-write (issue #2512).
+///
+/// Reproduces the scenario where a page that is *already* copy-on-write — because it was
+/// shared by an earlier `duplicate()` — is forked again before any sharer writes to it.
+/// The historical bug snapshotted only the parent PTE's hardware writable bit, so the
+/// already-CoW page (read-only in hardware) was shared with the new child as a plain
+/// read-only mapping with no copy-on-write bit. The new child's first write was then
+/// mistaken for a genuine protection fault and the process was killed instead of taking a
+/// private copy.
+///
+/// Sequence:
+///
+/// 1. The parent primes [`SHARED_BYTE`] with [`PATTERN_INIT`] while the page is private.
+/// 2. A first `duplicate()` (`first_child`) turns the page read-only + copy-on-write in the
+///    parent. The parent deliberately does **not** write to it, so it stays copy-on-write.
+/// 3. A second `duplicate()` (`second_child`) re-forks the now-CoW page. With the bug
+///    present, `second_child` receives a read-only mapping with no copy-on-write bit.
+/// 4. The parent writes [`PATTERN_PARENT`], taking its own private copy.
+/// 5. `second_child` is released; it must observe [`PATTERN_INIT`] (the parent's write must
+///    be invisible to it), then write [`PATTERN_CHILD`] — which must resolve as a
+///    copy-on-write fault rather than killing it — and report both values.
+///
+/// `first_child` is kept alive (blocked in `recv()`) throughout so the re-forked frame
+/// stays shared exactly as in the issue's reproduction; both children are torn down at the
+/// end. With the bug present, `second_child` is killed on its first write and never
+/// replies, so the parent's `recv()` never returns and the test fails by timing out.
+fn test_duplicate_cow_refork() -> Result<(), Error> {
+    // Record the parent's PID where the children can find it via CoW-shared memory.
+    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Prime the shared byte with the pre-duplicate pattern while the page is still private.
+    SHARED_BYTE.store(PATTERN_INIT, ORDER);
+
+    // Allocate page-aligned stacks for the two children's main threads.
+    let layout: Layout = Layout::from_size_align(CHILD_STACK_SIZE, PAGE_SIZE)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "bad stack layout"))?;
+    // SAFETY: layout has non-zero size.
+    let stack1_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack1_ptr.is_null() {
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate first child stack"));
+    }
+    // SAFETY: layout has non-zero size.
+    let stack2_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack2_ptr.is_null() {
+        // SAFETY: `stack1_ptr`/`layout` came from the matching allocation just above.
+        unsafe { ::alloc::alloc::dealloc(stack1_ptr, layout) };
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate second child stack"));
+    }
+
+    let args1: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(child_entry as *const () as usize),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: VirtualAddress::from_raw_value(stack1_ptr as usize),
+        user_stack_size: CHILD_STACK_SIZE,
+        user_tda: None,
+    };
+    let args2: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(child_entry as *const () as usize),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: VirtualAddress::from_raw_value(stack2_ptr as usize),
+        user_stack_size: CHILD_STACK_SIZE,
+        user_tda: None,
+    };
+
+    // First fork: turns SHARED_BYTE's page read-only + copy-on-write in the parent.
+    let first_child: ProcessIdentifier = pm::__kcall_duplicate(&args1)?;
+    // Second fork: re-forks the now-CoW page (the parent has not written to it yet, so it
+    // is still read-only + copy-on-write at this point).
+    let second_child: ProcessIdentifier = pm::__kcall_duplicate(&args2)?;
+
+    // Both children now exist. Run the observation scenario, capturing its result so that
+    // both children and both stacks are always reclaimed afterwards.
+    let scenario: Result<(), Error> = (|| {
+        assert!(second_child != parent_pid, "second_child must differ from parent_pid");
+        assert!(second_child != first_child, "second_child must differ from first_child");
+
+        // The parent takes its own private copy now; this must remain invisible to the
+        // re-forked child.
+        SHARED_BYTE.store(PATTERN_PARENT, ORDER);
+
+        // Release the second child to perform its observation and write.
+        let go: Message = Message::new(
+            MessageSender::from(parent_pid),
+            MessageReceiver::from(second_child),
+            MessageType::Ipc,
+            None,
+            [0u8; Message::PAYLOAD_SIZE],
+        );
+        ipc::__kcall_send(&go)?;
+
+        // Receive the second child's report. With the bug present the child is killed on
+        // its first write and never replies, so a missing reply (test timeout) also flags
+        // the regression.
+        let reply: Message = ipc::__kcall_recv()?;
+        let reply_type: MessageType = { reply.message_type };
+        assert!(reply_type == MessageType::Ipc, "expected IPC reply");
+
+        let child_observed_before: u8 = reply.payload[0];
+        let child_observed_after: u8 = reply.payload[1];
+        let parent_observed: u8 = SHARED_BYTE.load(ORDER);
+
+        // CoW invariant 1: the parent's post-duplicate write is invisible to the re-forked
+        // child. A wrong value here means the re-fork shared a stale/private frame.
+        assert!(
+            child_observed_before == PATTERN_INIT,
+            "re-forked child observed {:#x} before its own write; expected {:#x} (re-fork CoW \
+             sharing broken)",
+            child_observed_before,
+            PATTERN_INIT
+        );
+        // The child's own write must succeed and be visible to itself, proving the page was
+        // mapped copy-on-write rather than as a fatal read-only mapping.
+        assert!(
+            child_observed_after == PATTERN_CHILD,
+            "re-forked child observed {:#x} after its own write; expected {:#x}",
+            child_observed_after,
+            PATTERN_CHILD
+        );
+        // CoW invariant 2: the child's write is invisible to the parent.
+        assert!(
+            parent_observed == PATTERN_PARENT,
+            "parent observed {:#x} after child's write; expected {:#x} (child->parent isolation \
+             broken)",
+            parent_observed,
+            PATTERN_PARENT
+        );
+
+        Ok(())
+    })();
+
+    // Acquire the process-management capability to terminate the children, tear them down,
+    // then release it. The capability is released only when this path acquired it.
+    // `ResourceBusy` means it is already held, so termination must still proceed without
+    // leaving it disabled afterwards.
+    let acquired: Result<bool, Error> =
+        match pm::__kcall_capctl(Capability::ProcessManagement, true) {
+            Ok(()) => Ok(true),
+            Err(e) if e.code == ErrorCode::ResourceBusy => Ok(false),
+            Err(e) => Err(e),
+        };
+    let teardown: Result<(), Error> = match acquired {
+        Ok(acquired) => {
+            let terminate_first: Result<(), Error> = pm::__kcall_terminate(first_child);
+            let terminate_second: Result<(), Error> = pm::__kcall_terminate(second_child);
+            let release: Result<(), Error> = if acquired {
+                pm::__kcall_capctl(Capability::ProcessManagement, false)
+            } else {
+                Ok(())
+            };
+            terminate_first.and(terminate_second).and(release)
+        },
+        Err(e) => Err(e),
+    };
+
+    // Reclaim the child stacks only once teardown has confirmed both children were
+    // terminated. If teardown failed a child may still be running on its stack, so freeing
+    // it would risk a use-after-free; leak the stacks in that case instead.
+    if teardown.is_ok() {
+        // SAFETY: both pointers/layout came from the matching `alloc::alloc::alloc` calls
+        // above and teardown confirmed the children are terminated, so they no longer
+        // reference these stack pages.
+        unsafe {
+            ::alloc::alloc::dealloc(stack1_ptr, layout);
+            ::alloc::alloc::dealloc(stack2_ptr, layout);
+        }
+    }
+
+    scenario.and(teardown)
+}
+
 //==================================================================================================
 // Public Entry Point
 //==================================================================================================
@@ -275,6 +448,9 @@ pub fn run() -> Result<(), Error> {
 
     test_duplicate_cow()?;
     ::syslog::info!("test-kernel: duplicate: PASS - duplicate_cow");
+
+    test_duplicate_cow_refork()?;
+    ::syslog::info!("test-kernel: duplicate: PASS - duplicate_cow_refork");
 
     ::syslog::info!("test-kernel: duplicate: all tests passed");
 


### PR DESCRIPTION
## Summary

Fixes a fatal page fault when a process is forked more than once and a shared
page is re-forked while still copy-on-write (CoW) from an earlier fork
(issue #2512).

Such pages are read-only in hardware with the AVL CoW bit set. The previous
link logic snapshotted only the parent PTE's hardware writable bit, so it
classified the already-CoW page as a plain read-only mapping and shared it with
the new child without arming copy-on-write. The child's first write was then
misclassified as a genuine protection fault and the process was killed instead
of taking a private copy.

## Changes

### Kernel (`src/kernel/src/mm/virt/manager.rs`)

- Treat a mapping as logically writable when it is writable in hardware *or*
  already copy-on-write, and carry the parent's current CoW state through the
  link snapshot.
- In `link_one_user_page`, map the child RDWR and arm CoW on it, but mark the
  parent CoW only when it is not already CoW (`mark_cow` requires a writable
  PTE). The partial-rollback path mirrors this: only unmark the parent if this
  call installed the mark.
- In `rollback_linked_pages`, unmap the child pages this call linked, restricted
  to addresses that still have a present mapping in `parent` so unrelated
  pre-existing child mappings are not torn down. Parent CoW marks are
  intentionally **left untouched** during rollback: a newly-marked parent cannot
  be reliably told apart from one that was already CoW before this call (PTE
  state is ambiguous and the shared frame's refcount is not a reliable signal
  either), and wrongly unmarking a page another sharer relies on would break its
  copy-on-write. Leaving a page CoW that could have been writable costs at most
  one extra CoW fault on a rare rollback path, so never unmarking is the safe
  choice.
- Add `LinkUserMapping`, `LinkUserMappingSlot`, and `LinkUserMappingBuf` type
  aliases and expand the surrounding doc comments.

### Tests (`src/tests/test-kernel/src/duplicate.rs`)

- Add `test_duplicate_cow_refork`, a regression test that:
  - Primes a shared byte while the page is private.
  - Forks a first child (kept blocked in `recv()`) to turn the page CoW in the
    parent.
  - Forks a second child to re-fork the now-CoW page.
  - Has the parent take a private copy, then releases the second child, which
    must observe the pre-fork value, write via a CoW fault rather than being
    killed, and report back.
  - Asserts both CoW isolation invariants. With the bug present, the second
    child is killed on its first write and never replies, so the test fails by
    timing out.

## Issues

Closes #2512