### PR TITLE
[networkd] Add per-host egress filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ version = "0.16.61"
 dependencies = [
  "hwloc",
  "linuxd",
+ "net-backend",
  "syscomm",
 ]
 

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -11,6 +11,7 @@ use ::log::{
 };
 use ::net_backend::{
     error::NetError,
+    HostFilter,
     NetBackend,
 };
 use ::sys::{
@@ -24,29 +25,32 @@ use ::sys::{
     pm::ThreadIdentifier,
 };
 use ::syscall::{
-    sys::socket::message::{
-        AcceptSocketRequest,
-        AcceptSocketResponse,
-        BindSocketRequest,
-        BindSocketResponse,
-        ConnectSocketRequest,
-        ConnectSocketResponse,
-        CreateSocketPairRequest,
-        CreateSocketPairResponse,
-        CreateSocketRequest,
-        CreateSocketResponse,
-        GetPeerNameRequest,
-        GetPeerNameResponse,
-        GetSockNameRequest,
-        GetSockNameResponse,
-        ListenSocketRequest,
-        ListenSocketResponse,
-        ReceiveSocketRequest,
-        ReceiveSocketResponse,
-        SendSocketRequest,
-        SendSocketResponse,
-        ShutdownSocketRequest,
-        ShutdownSocketResponse,
+    sys::socket::{
+        message::{
+            AcceptSocketRequest,
+            AcceptSocketResponse,
+            BindSocketRequest,
+            BindSocketResponse,
+            ConnectSocketRequest,
+            ConnectSocketResponse,
+            CreateSocketPairRequest,
+            CreateSocketPairResponse,
+            CreateSocketRequest,
+            CreateSocketResponse,
+            GetPeerNameRequest,
+            GetPeerNameResponse,
+            GetSockNameRequest,
+            GetSockNameResponse,
+            ListenSocketRequest,
+            ListenSocketResponse,
+            ReceiveSocketRequest,
+            ReceiveSocketResponse,
+            SendSocketRequest,
+            SendSocketResponse,
+            ShutdownSocketRequest,
+            ShutdownSocketResponse,
+        },
+        SocketAddr,
     },
     unistd::message::{
         CloseRequest,
@@ -102,6 +106,7 @@ pub fn is_networking_header(header: &SystemCallMessageHeader) -> bool {
 ///
 pub fn dispatch_message(
     backend: &NetBackend,
+    filter: &HostFilter,
     source: MessageSender,
     syscall_msg: SystemCallMessage,
 ) -> Option<Vec<Message>> {
@@ -129,7 +134,7 @@ pub fn dispatch_message(
         SystemCallMessageHeader::ConnectSocketRequest => {
             let request: ConnectSocketRequest =
                 ConnectSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_connect(backend, tid, request)])
+            Some(vec![do_connect(backend, filter, tid, request)])
         },
         SystemCallMessageHeader::CreateSocketPairRequest => {
             let request: CreateSocketPairRequest =
@@ -237,10 +242,41 @@ fn do_bind(backend: &NetBackend, tid: ThreadIdentifier, request: BindSocketReque
 
 fn do_connect(
     backend: &NetBackend,
+    filter: &HostFilter,
     tid: ThreadIdentifier,
     request: ConnectSocketRequest,
 ) -> Message {
     trace!("networkd::connect(): tid={tid:?}, request={request:?}");
+    // Enforce host egress policy before performing the real connect. The guest
+    // never makes the syscall itself, so refusing here is an unbypassable
+    // boundary.
+    //
+    // IPv4 destinations are matched against the filter. Any non-IPv4 destination
+    // (e.g. AF_UNIX, which would otherwise let a guest reach host-local sockets)
+    // or an unparsable address cannot be evaluated by the IPv4 filter, so it is
+    // denied whenever a filter is active and permitted only under `AllowAll`
+    // (preserving unrestricted behavior when no policy is set).
+    //
+    // Connections to the DNS port are exempted in allowlist mode so name
+    // resolution works for the allowed hosts (see `HostFilter::permits_connection`).
+    //
+    // Reject sockaddrs too short to hold a `sockaddr` before parsing. `socklen`
+    // is copied out of the packed request first so the trace below does not take
+    // a reference to an unaligned field; `size_of_val` reuses the in-scope
+    // `sockaddr` value to avoid naming its (private) type path.
+    let socklen: usize = request.socklen as usize;
+    if socklen < core::mem::size_of_val(&request.sockaddr) {
+        trace!("networkd::connect(): invalid sockaddr length (socklen={socklen})");
+        return build_error(tid, ErrorCode::InvalidArgument);
+    }
+    let permitted: bool = match SocketAddr::try_from(&request.sockaddr) {
+        Ok(SocketAddr::V4(addr)) => filter.permits_connection(addr.addr().octets(), addr.port()),
+        _ => filter.is_allow_all(),
+    };
+    if !permitted {
+        trace!("networkd::connect(): destination denied by host egress filter");
+        return build_error(tid, ErrorCode::PermissionDenied);
+    }
     match backend.connect(to_host_fd(request.sockfd), &request.sockaddr, request.socklen) {
         Ok(()) => ConnectSocketResponse::build(tid),
         Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),

--- a/src/daemons/networkd/src/lib.rs
+++ b/src/daemons/networkd/src/lib.rs
@@ -13,6 +13,7 @@ mod dispatch;
 
 use ::net_backend::{
     error::NetError,
+    HostFilter,
     NetBackend,
 };
 use ::sys::ipc::Message;
@@ -36,6 +37,8 @@ use ::syscall::{
 pub struct NetworkDaemon {
     /// Platform-agnostic networking backend.
     backend: NetBackend,
+    /// Host egress filter applied to guest `connect()` destinations.
+    filter: HostFilter,
 }
 
 //==================================================================================================
@@ -48,11 +51,15 @@ impl NetworkDaemon {
     ///
     /// Creates a new `NetworkDaemon` instance.
     ///
+    /// `filter` is the host egress policy enforced on guest `connect()`
+    /// destinations. Pass [`HostFilter::AllowAll`] for unrestricted networking.
+    ///
     /// Returns an error if platform networking initialization fails.
     ///
-    pub fn new() -> Result<Self, NetError> {
+    pub fn new(filter: HostFilter) -> Result<Self, NetError> {
         Ok(Self {
             backend: NetBackend::new()?,
+            filter,
         })
     }
 
@@ -77,7 +84,7 @@ impl NetworkDaemon {
             Err(_) => return None,
         };
 
-        dispatch::dispatch_message(&self.backend, msg.source, syscall_msg)
+        dispatch::dispatch_message(&self.backend, &self.filter, msg.source, syscall_msg)
     }
 
     ///
@@ -93,6 +100,6 @@ impl NetworkDaemon {
 
 impl Default for NetworkDaemon {
     fn default() -> Self {
-        Self::new().expect("platform networking initialization should succeed")
+        Self::new(HostFilter::AllowAll).expect("platform networking initialization should succeed")
     }
 }

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -254,6 +254,7 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
             state.config.snapshot_path().map(|s| s.to_string()),
             state.config.mount_directory().map(|s| s.to_string()),
             state.config.networking_mode(),
+            state.config.host_filter(),
             #[cfg(feature = "gdb")]
             state.config.gdb_port(),
         );

--- a/src/libs/nanvix-sandbox-config/Cargo.toml
+++ b/src/libs/nanvix-sandbox-config/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [dependencies]
 hwloc = { workspace = true }
 linuxd = { workspace = true, optional = true }
+net-backend = { workspace = true }
 syscomm = { workspace = true }
 
 [features]

--- a/src/libs/nanvix-sandbox-config/src/lib.rs
+++ b/src/libs/nanvix-sandbox-config/src/lib.rs
@@ -65,6 +65,15 @@ impl std::str::FromStr for NetworkingMode {
     }
 }
 
+// Host egress filtering types live in `net-backend` (the network daemon's
+// crate) to keep the enforcement type next to the enforcement point and avoid a
+// dependency cycle. They are re-exported here so config consumers can refer to
+// them via `nanvix::sandbox_config`.
+pub use ::net_backend::{
+    HostFilter,
+    Ipv4Cidr,
+};
+
 //==================================================================================================
 // Exports
 //==================================================================================================

--- a/src/libs/nanvix-sandbox-config/src/standalone.rs
+++ b/src/libs/nanvix-sandbox-config/src/standalone.rs
@@ -11,7 +11,10 @@
 // Imports
 //==================================================================================================
 
-use crate::NetworkingMode;
+use crate::{
+    HostFilter,
+    NetworkingMode,
+};
 
 //==================================================================================================
 // Structures
@@ -41,6 +44,9 @@ pub struct StandaloneConfig {
     kernel_args: Option<String>,
     /// Networking mode (disabled or enabled).
     networking_mode: NetworkingMode,
+    /// Host egress filter applied to guest `connect()` destinations. Only
+    /// meaningful when `networking_mode` is enabled.
+    host_filter: HostFilter,
     /// Optional GDB server port for debugging the guest.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -76,6 +82,7 @@ impl StandaloneConfig {
     /// - `mount_directory`: Optional host directory to mount on the guest.
     /// - `kernel_args`: Optional kernel arguments written to guest control registers.
     /// - `networking_mode`: Networking mode for host networking.
+    /// - `host_filter`: Host egress filter applied to guest connections.
     /// - `gdb_port`: Optional GDB server port.
     ///
     #[allow(clippy::too_many_arguments)]
@@ -87,6 +94,7 @@ impl StandaloneConfig {
         mount_directory: Option<String>,
         kernel_args: Option<String>,
         networking_mode: NetworkingMode,
+        host_filter: HostFilter,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
         gateway_sockaddr: Option<String>,
     ) -> Self {
@@ -98,6 +106,7 @@ impl StandaloneConfig {
             mount_directory,
             kernel_args,
             networking_mode,
+            host_filter,
             #[cfg(feature = "gdb")]
             gdb_port,
             gateway_sockaddr,
@@ -137,6 +146,11 @@ impl StandaloneConfig {
     /// Returns the networking mode.
     pub fn networking_mode(&self) -> NetworkingMode {
         self.networking_mode
+    }
+
+    /// Returns the host egress filter.
+    pub fn host_filter(&self) -> HostFilter {
+        self.host_filter.clone()
     }
 
     /// Returns the optional GDB server port.

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -126,6 +126,7 @@ impl Terminal {
             self.config.snapshot_path().map(|s| s.to_string()),
             self.config.mount_directory().map(|s| s.to_string()),
             self.config.networking_mode(),
+            self.config.host_filter(),
             #[cfg(feature = "gdb")]
             self.config.gdb_port(),
         );

--- a/src/libs/net-backend/src/filter.rs
+++ b/src/libs/net-backend/src/filter.rs
@@ -1,0 +1,296 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Host egress filtering for guest network connections.
+//!
+//! Nanvix proxies guest sockets through the host-side network daemon, so the
+//! daemon is the natural enforcement point for per-host egress policy. The types
+//! here carry a resolved IPv4/CIDR allow- or block-set (typically forwarded by a
+//! consumer such as MXC) and answer the single question the daemon asks before
+//! completing a `connect()`: *is this destination permitted?*
+
+//==================================================================================================
+// Ipv4Cidr
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A single IPv4 address or CIDR block.
+///
+/// Stored as a network-order base address and mask so membership tests reduce to
+/// a pair of bitwise operations.
+///
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ipv4Cidr {
+    /// Network address (already masked).
+    base: u32,
+    /// Prefix mask (e.g. `/24` -> `0xffff_ff00`).
+    mask: u32,
+}
+
+impl Ipv4Cidr {
+    ///
+    /// # Description
+    ///
+    /// Parses an entry of the form `a.b.c.d` (a single host, implicit `/32`) or
+    /// `a.b.c.d/n` (a CIDR block).
+    ///
+    /// # Returns
+    ///
+    /// The parsed block, or `None` if the address is malformed or the prefix is
+    /// outside `0..=32`.
+    ///
+    pub fn parse(entry: &str) -> Option<Self> {
+        let (addr_str, prefix): (&str, u8) = match entry.trim().split_once('/') {
+            Some((addr, pfx)) => {
+                let p: u8 = pfx.trim().parse().ok()?;
+                if p > 32 {
+                    return None;
+                }
+                (addr.trim(), p)
+            },
+            None => (entry.trim(), 32u8),
+        };
+        let addr: ::std::net::Ipv4Addr = addr_str.parse().ok()?;
+        let base: u32 = u32::from(addr);
+        let mask: u32 = if prefix == 0 {
+            0
+        } else {
+            u32::MAX << (32 - prefix)
+        };
+        Some(Self {
+            base: base & mask,
+            mask,
+        })
+    }
+
+    /// Returns whether `addr` (network-order octets) falls within this block.
+    pub fn contains(&self, addr: [u8; 4]) -> bool {
+        let ip: u32 = u32::from_be_bytes(addr);
+        (ip & self.mask) == self.base
+    }
+}
+
+//==================================================================================================
+// HostFilter
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Host network egress filter applied to guest `connect()` destinations.
+///
+/// `AllowAll` is used when host networking is enabled with no per-host list and
+/// is the default when no explicit policy has been configured; `Allow`/`Block`
+/// carry the resolved IPv4/CIDR set.
+///
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum HostFilter {
+    /// No filtering: every destination is permitted. Used when host networking
+    /// is enabled with no per-host list, and the default when no explicit policy
+    /// has been configured.
+    #[default]
+    AllowAll,
+    /// Deny all: every destination is blocked. Must be selected explicitly by a
+    /// caller that wants a fully-closed policy.
+    DenyAll,
+    /// Allowlist: only destinations matching one of these blocks are permitted.
+    ///
+    /// `exempt_dns` opts into a DNS carve-out that additionally permits any
+    /// destination on the DNS port (see [`HostFilter::permits_connection`]).
+    /// When `false`, the allowlist is strict and even `:53` must match a block.
+    Allow {
+        /// Allowed IPv4/CIDR blocks.
+        cidrs: Vec<Ipv4Cidr>,
+        /// Whether the DNS carve-out is enabled for this allowlist.
+        exempt_dns: bool,
+    },
+    /// Blocklist: every destination is permitted except those matching a block.
+    Block(Vec<Ipv4Cidr>),
+}
+
+impl HostFilter {
+    /// Destination port used for DNS. Connections to this port are exempted from
+    /// the allowlist when the carve-out is opted into (see
+    /// [`HostFilter::permits_connection`]).
+    const DNS_PORT: u16 = 53;
+
+    ///
+    /// # Description
+    ///
+    /// Builds a filter from the allow / block entry lists.
+    ///
+    /// `allow` takes precedence over `block`; if both are empty, returns
+    /// [`HostFilter::AllowAll`]. Unparsable entries are skipped — callers are
+    /// expected to validate entries upstream.
+    ///
+    /// `exempt_dns` only applies in allowlist mode and opts into the DNS
+    /// carve-out (see [`HostFilter::permits_connection`]); pass `false` for a
+    /// strict allowlist. It is a no-op for block / allow-all results.
+    ///
+    pub fn from_lists(allow: &[String], block: &[String], exempt_dns: bool) -> Self {
+        if !allow.is_empty() {
+            Self::Allow {
+                cidrs: allow.iter().filter_map(|e| Ipv4Cidr::parse(e)).collect(),
+                exempt_dns,
+            }
+        } else if !block.is_empty() {
+            Self::Block(block.iter().filter_map(|e| Ipv4Cidr::parse(e)).collect())
+        } else {
+            Self::AllowAll
+        }
+    }
+
+    /// Returns whether a connection to `addr` (IPv4 octets) is permitted.
+    pub fn permits(&self, addr: [u8; 4]) -> bool {
+        match self {
+            Self::DenyAll => false,
+            Self::AllowAll => true,
+            Self::Allow { cidrs, .. } => cidrs.iter().any(|c| c.contains(addr)),
+            Self::Block(list) => !list.iter().any(|c| c.contains(addr)),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether a connection to `addr`:`port` is permitted, applying an
+    /// opt-in DNS carve-out on top of [`HostFilter::permits`].
+    ///
+    /// In allowlist mode ([`HostFilter::Allow`]) the configured resolver is
+    /// usually not among the allowed destinations, yet name resolution must
+    /// succeed for those hosts to be reachable. When the allowlist opts into the
+    /// carve-out (`exempt_dns == true`), connections to the DNS port are
+    /// permitted regardless of destination IP, mirroring the always-allow `:53`
+    /// rule other Nanvix consumers (e.g. MXC's LXC and WSLC backends) install in
+    /// allowlist mode.
+    ///
+    /// The carve-out is opt-in and scoped to allowlist mode only: a strict
+    /// allowlist (`exempt_dns == false`) still requires `:53` to match a block,
+    /// it never relaxes [`HostFilter::DenyAll`] (networking off stays fully
+    /// closed), and it never overrides an explicit block in
+    /// [`HostFilter::Block`] mode. Restricting the exemption to specific resolver
+    /// IPs is left to the caller, which can encode them as allowlist blocks.
+    ///
+    pub fn permits_connection(&self, addr: [u8; 4], port: u16) -> bool {
+        if port == Self::DNS_PORT
+            && matches!(
+                self,
+                Self::Allow {
+                    exempt_dns: true,
+                    ..
+                }
+            )
+        {
+            return true;
+        }
+        self.permits(addr)
+    }
+
+    /// Returns `true` if this filter applies no restrictions (i.e. is
+    /// [`HostFilter::AllowAll`]). Used to decide whether non-IPv4 destinations,
+    /// which `permits` cannot evaluate, should be permitted.
+    pub fn is_allow_all(&self) -> bool {
+        matches!(self, Self::AllowAll)
+    }
+}
+
+//==================================================================================================
+// Unit tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_all_blocks_everything() {
+        let f = HostFilter::DenyAll;
+        assert!(!f.permits([0, 0, 0, 0]));
+        assert!(!f.permits([8, 8, 8, 8]));
+        assert!(!f.is_allow_all());
+    }
+
+    #[test]
+    fn default_is_allow_all() {
+        assert!(matches!(HostFilter::default(), HostFilter::AllowAll));
+    }
+
+    #[test]
+    fn cidr_host_match() {
+        let c = Ipv4Cidr::parse("192.168.1.10").unwrap();
+        assert!(c.contains([192, 168, 1, 10]));
+        assert!(!c.contains([192, 168, 1, 11]));
+    }
+
+    #[test]
+    fn cidr_block_match() {
+        let c = Ipv4Cidr::parse("10.0.0.0/8").unwrap();
+        assert!(c.contains([10, 1, 2, 3]));
+        assert!(!c.contains([11, 0, 0, 1]));
+    }
+
+    #[test]
+    fn cidr_rejects_bad_input() {
+        assert!(Ipv4Cidr::parse("nope").is_none());
+        assert!(Ipv4Cidr::parse("1.2.3.4/33").is_none());
+        assert!(Ipv4Cidr::parse("256.0.0.1").is_none());
+    }
+
+    #[test]
+    fn allowlist_denies_by_default() {
+        let f = HostFilter::from_lists(&["1.1.1.1".to_string()], &[], false);
+        assert!(f.permits([1, 1, 1, 1]));
+        assert!(!f.permits([8, 8, 8, 8]));
+    }
+
+    #[test]
+    fn blocklist_allows_by_default() {
+        let f = HostFilter::from_lists(&[], &["8.8.8.8".to_string()], false);
+        assert!(!f.permits([8, 8, 8, 8]));
+        assert!(f.permits([1, 1, 1, 1]));
+    }
+
+    #[test]
+    fn empty_is_allow_all() {
+        let f = HostFilter::from_lists(&[], &[], false);
+        assert!(matches!(f, HostFilter::AllowAll));
+        assert!(f.permits([8, 8, 8, 8]));
+    }
+
+    #[test]
+    fn is_allow_all_reflects_filtering() {
+        assert!(HostFilter::AllowAll.is_allow_all());
+        assert!(!HostFilter::from_lists(&["1.1.1.1".to_string()], &[], false).is_allow_all());
+        assert!(!HostFilter::from_lists(&[], &["8.8.8.8".to_string()], false).is_allow_all());
+    }
+
+    #[test]
+    fn allowlist_exempts_dns_port_when_opted_in() {
+        let f = HostFilter::from_lists(&["1.1.1.1".to_string()], &[], true);
+        // A resolver outside the allowlist is reachable on port 53 only.
+        assert!(f.permits_connection([8, 8, 8, 8], 53));
+        assert!(!f.permits_connection([8, 8, 8, 8], 443));
+        // Allowed hosts remain reachable on any port.
+        assert!(f.permits_connection([1, 1, 1, 1], 443));
+    }
+
+    #[test]
+    fn strict_allowlist_denies_dns_port() {
+        // Without the opt-in carve-out, even :53 must match an allowlist block.
+        let f = HostFilter::from_lists(&["1.1.1.1".to_string()], &[], false);
+        assert!(!f.permits_connection([8, 8, 8, 8], 53));
+        assert!(f.permits_connection([1, 1, 1, 1], 53));
+    }
+
+    #[test]
+    fn dns_exemption_scoped_to_allowlist() {
+        // DenyAll stays fully closed, including DNS.
+        assert!(!HostFilter::DenyAll.permits_connection([8, 8, 8, 8], 53));
+        // Blocklist never has the carve-out override an explicit block.
+        let f = HostFilter::from_lists(&[], &["8.8.8.8".to_string()], true);
+        assert!(!f.permits_connection([8, 8, 8, 8], 53));
+        assert!(f.permits_connection([1, 1, 1, 1], 53));
+    }
+}

--- a/src/libs/net-backend/src/lib.rs
+++ b/src/libs/net-backend/src/lib.rs
@@ -6,11 +6,17 @@
 //==================================================================================================
 
 pub mod error;
+pub mod filter;
 pub mod io;
 pub(crate) mod platform;
 pub mod query;
 pub mod socket;
 mod types;
+
+pub use filter::{
+    HostFilter,
+    Ipv4Cidr,
+};
 
 //==================================================================================================
 // NetBackend

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -24,7 +24,10 @@ use ::log::{
     error,
     info,
 };
-use ::nanvix_sandbox_config::NetworkingMode;
+use ::nanvix_sandbox_config::{
+    HostFilter,
+    NetworkingMode,
+};
 #[cfg(target_os = "linux")]
 use ::std::str::FromStr;
 use ::std::{
@@ -203,6 +206,7 @@ async fn run_standalone(
         snapshot_path,
         None,
         NetworkingMode::Disabled,
+        HostFilter::AllowAll,
         #[cfg(feature = "gdb")]
         gdb_port,
     );

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -31,7 +31,10 @@ use ::log::{
     trace,
     warn,
 };
-use ::nanvix_sandbox_config::NetworkingMode;
+use ::nanvix_sandbox_config::{
+    HostFilter,
+    NetworkingMode,
+};
 use ::networkd::NetworkDaemon;
 use ::std::{
     collections::VecDeque,
@@ -195,6 +198,7 @@ impl StandaloneVmHandle {
         snapshot_path: Option<String>,
         mount_directory: Option<String>,
         networking_mode: NetworkingMode,
+        host_filter: HostFilter,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> (Self, StandaloneVmIo) {
         // Create internal VM channels. In standalone mode these are wired directly without an
@@ -248,6 +252,7 @@ impl StandaloneVmHandle {
                 input_rx,
                 io_counters,
                 networking_mode,
+                host_filter,
                 mount_directory,
             )
             .await;
@@ -411,6 +416,7 @@ fn extract_tid(source: ::sys::ipc::MessageSender) -> ThreadIdentifier {
 /// - `output_tx`: Forwards application data written by the guest to the external consumer.
 /// - `input_rx`: Receives application data from the external consumer for guest reads.
 ///
+#[allow(clippy::too_many_arguments)]
 async fn standalone_io_handler(
     mut vm_stdout_rx: mpsc::Receiver<IkcFrame>,
     vm_stdin_tx: mpsc::Sender<IkcFrame>,
@@ -418,6 +424,7 @@ async fn standalone_io_handler(
     mut input_rx: mpsc::Receiver<Vec<u8>>,
     counters: MessageCounters,
     networking_mode: NetworkingMode,
+    host_filter: HostFilter,
     mount_directory: Option<String>,
 ) {
     let mut input_buffer: VecDeque<u8> = VecDeque::new();
@@ -435,7 +442,7 @@ async fn standalone_io_handler(
     let mut worker_long_op_id: Option<::hostfs_api::OperationId> = None;
 
     let network_daemon: Option<Arc<NetworkDaemon>> = if networking_mode.is_enabled() {
-        match NetworkDaemon::new() {
+        match NetworkDaemon::new(host_filter) {
             Ok(nd) => Some(Arc::new(nd)),
             Err(e) => {
                 error!("standalone io_handler: failed to initialize network daemon: {e}");

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -23,7 +23,11 @@ use ::chrono::Local;
 use ::nanvix::{
     hwloc::HwLoc,
     log::DEFAULT_LOG_DIRECTORY,
-    sandbox_config::NetworkingMode,
+    sandbox_config::{
+        HostFilter,
+        Ipv4Cidr,
+        NetworkingMode,
+    },
     syscomm::SocketType,
 };
 use ::std::{
@@ -89,6 +93,12 @@ pub struct Args {
     gdb_port: Option<u16>,
     /// Networking mode (applies to all deployment modes).
     networking_mode: NetworkingMode,
+    /// Allowlist of IPv4/CIDR destinations (`-allow-host`). When non-empty, only
+    /// these destinations are reachable. Mutually exclusive with `block_hosts`.
+    allow_hosts: Vec<String>,
+    /// Blocklist of IPv4/CIDR destinations (`-block-host`). When non-empty, all
+    /// destinations except these are reachable. Mutually exclusive with `allow_hosts`.
+    block_hosts: Vec<String>,
     /// When `true`, route nanvixd's logs to stdout instead of a auto-named file.
     log_to_stdout: bool,
     /// Optional path of the standalone gateway endpoint -- the host-side
@@ -148,6 +158,10 @@ impl Args {
     pub const OPT_GDB_PORT: &'static str = "-gdb-port";
     /// Command-line flag that enables host networking for the guest.
     pub const OPT_ALLOW_HOST_NETWORKING: &'static str = "-allow-host-networking";
+    /// Command-line option (repeatable) adding an IPv4/CIDR to the egress allowlist.
+    pub const OPT_ALLOW_HOST: &'static str = "-allow-host";
+    /// Command-line option (repeatable) adding an IPv4/CIDR to the egress blocklist.
+    pub const OPT_BLOCK_HOST: &'static str = "-block-host";
     /// Command-line flag that routes nanvixd's logs to stdout instead of the auto-named file.
     pub const OPT_LOG_TO_STDOUT: &'static str = "-log-to-stdout";
     /// Command-line option for the standalone gateway endpoint (UDS
@@ -204,6 +218,8 @@ impl Args {
         #[cfg(feature = "gdb")]
         let mut gdb_port: Option<u16> = None;
         let mut networking_mode: NetworkingMode = NetworkingMode::Disabled;
+        let mut allow_hosts: Vec<String> = Vec::new();
+        let mut block_hosts: Vec<String> = Vec::new();
         let mut log_to_stdout: bool = false;
         let mut gateway_sockaddr: Option<String> = None;
 
@@ -368,6 +384,36 @@ impl Args {
                 Self::OPT_ALLOW_HOST_NETWORKING => {
                     networking_mode = NetworkingMode::Enabled;
                 },
+                Self::OPT_ALLOW_HOST => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_ALLOW_HOST));
+                    }
+                    if Ipv4Cidr::parse(&args[i]).is_none() {
+                        return Err(anyhow::anyhow!(
+                            "invalid {} value (expected IPv4 or CIDR): {}",
+                            Self::OPT_ALLOW_HOST,
+                            args[i]
+                        ));
+                    }
+                    allow_hosts.push(args[i].clone());
+                },
+                Self::OPT_BLOCK_HOST => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_BLOCK_HOST));
+                    }
+                    if Ipv4Cidr::parse(&args[i]).is_none() {
+                        return Err(anyhow::anyhow!(
+                            "invalid {} value (expected IPv4 or CIDR): {}",
+                            Self::OPT_BLOCK_HOST,
+                            args[i]
+                        ));
+                    }
+                    block_hosts.push(args[i].clone());
+                },
                 Self::OPT_LOG_TO_STDOUT => {
                     log_to_stdout = true;
                 },
@@ -386,6 +432,41 @@ impl Args {
                 "{} and {} are mutually exclusive",
                 Self::OPT_LOG_TO_STDOUT,
                 Self::OPT_LOG_DIRECTORY,
+            );
+        }
+
+        // Host egress filtering is all-or-list, never both: an allowlist
+        // (deny-by-default) and a blocklist (allow-by-default) express opposite
+        // postures and cannot be combined.
+        if !allow_hosts.is_empty() && !block_hosts.is_empty() {
+            anyhow::bail!(
+                "{} and {} are mutually exclusive",
+                Self::OPT_ALLOW_HOST,
+                Self::OPT_BLOCK_HOST,
+            );
+        }
+
+        // A host filter is meaningless without host networking enabled -- the
+        // guest has no egress to filter. Reject rather than silently ignore.
+        if (!allow_hosts.is_empty() || !block_hosts.is_empty()) && !networking_mode.is_enabled() {
+            anyhow::bail!(
+                "{} / {} require {}",
+                Self::OPT_ALLOW_HOST,
+                Self::OPT_BLOCK_HOST,
+                Self::OPT_ALLOW_HOST_NETWORKING,
+            );
+        }
+
+        // Host egress filtering is only consulted on the standalone network
+        // daemon path. In single-/multi-process builds the flags would be
+        // silently ignored, giving a false sense of policy -- reject them so the
+        // operator is not misled into believing egress is restricted.
+        #[cfg(not(feature = "standalone"))]
+        if !allow_hosts.is_empty() || !block_hosts.is_empty() {
+            anyhow::bail!(
+                "{} / {} are only supported in standalone builds",
+                Self::OPT_ALLOW_HOST,
+                Self::OPT_BLOCK_HOST,
             );
         }
 
@@ -488,6 +569,8 @@ impl Args {
             #[cfg(feature = "gdb")]
             gdb_port,
             networking_mode,
+            allow_hosts,
+            block_hosts,
             log_to_stdout,
             gateway_sockaddr,
         })
@@ -544,6 +627,12 @@ Options:
              (standalone mode only).
   {allow_host_networking}                   Enable host networking for the guest (disabled when \
              omitted).
+  {allow_host} <ip|cidr>                    (Repeatable, standalone mode only) Permit egress to \
+             this IPv4/CIDR (allowlist; requires {allow_host_networking}; mutually exclusive with \
+             {block_host}; DNS on port 53 is also permitted).
+  {block_host} <ip|cidr>                    (Repeatable, standalone mode only) Deny egress to this \
+             IPv4/CIDR (blocklist; requires {allow_host_networking}; mutually exclusive with \
+             {allow_host}).
   {log_to_stdout}                          Route nanvixd's own logrus output to stdout instead of \
              a file in {log_dir} (file logger is otherwise the default).
   {gateway_sockaddr} <path>                 (Standalone) Path at which to expose the gateway \
@@ -573,6 +662,8 @@ Options:
             mount = Self::OPT_MOUNT_DIRECTORY,
             kernel_args = Self::OPT_KERNEL_ARGS,
             allow_host_networking = Self::OPT_ALLOW_HOST_NETWORKING,
+            allow_host = Self::OPT_ALLOW_HOST,
+            block_host = Self::OPT_BLOCK_HOST,
             log_to_stdout = Self::OPT_LOG_TO_STDOUT,
             gateway_sockaddr = Self::OPT_GATEWAY_SOCKADDR,
             gdb_port_line = if cfg!(feature = "gdb") {
@@ -869,6 +960,15 @@ Options:
         self.networking_mode
     }
 
+    /// Returns the host egress filter built from the `-allow-host` /
+    /// `-block-host` lists. Returns [`HostFilter::AllowAll`] when neither is set.
+    ///
+    /// In allowlist mode the DNS carve-out is opted into so name resolution
+    /// keeps working for the allowed hosts, matching the `-allow-host` help text.
+    pub fn host_filter(&self) -> HostFilter {
+        HostFilter::from_lists(&self.allow_hosts, &self.block_hosts, true)
+    }
+
     /// When `true`, nanvixd should route its logrus output to stdout
     /// instead of the file logger. See [`Self::OPT_LOG_TO_STDOUT`].
     pub fn log_to_stdout(&self) -> bool {
@@ -991,5 +1091,99 @@ mod tests {
         assert!(res.is_err(), "expected error when -gateway-sockaddr has no value");
         let msg: String = format!("{:#}", res.err().unwrap());
         assert!(msg.contains("missing value for: -gateway-sockaddr"), "unexpected error: {msg}");
+    }
+
+    #[cfg(feature = "standalone")]
+    #[test]
+    fn allow_host_builds_allowlist_filter() {
+        let args = Args::parse(argv(&[
+            "-allow-host-networking",
+            "-allow-host",
+            "1.2.3.4",
+            "-allow-host",
+            "10.0.0.0/8",
+            "--",
+            "/bin/foo",
+        ]))
+        .expect("parse");
+        let filter = args.host_filter();
+        assert!(filter.permits([1, 2, 3, 4]));
+        assert!(filter.permits([10, 9, 8, 7]));
+        assert!(!filter.permits([8, 8, 8, 8]));
+    }
+
+    #[cfg(feature = "standalone")]
+    #[test]
+    fn block_host_builds_blocklist_filter() {
+        let args = Args::parse(argv(&[
+            "-allow-host-networking",
+            "-block-host",
+            "8.8.8.8",
+            "--",
+            "/bin/foo",
+        ]))
+        .expect("parse");
+        let filter = args.host_filter();
+        assert!(!filter.permits([8, 8, 8, 8]));
+        assert!(filter.permits([1, 2, 3, 4]));
+    }
+
+    #[cfg(feature = "standalone")]
+    #[test]
+    fn allow_and_block_host_are_mutually_exclusive() {
+        let res = Args::parse(argv(&[
+            "-allow-host-networking",
+            "-allow-host",
+            "1.2.3.4",
+            "-block-host",
+            "8.8.8.8",
+            "--",
+            "/bin/foo",
+        ]));
+        let msg: String = format!("{:#}", res.expect_err("expected mutual-exclusion error"));
+        assert!(msg.contains(Args::OPT_ALLOW_HOST), "unexpected error: {msg}");
+        assert!(msg.contains(Args::OPT_BLOCK_HOST), "unexpected error: {msg}");
+    }
+
+    #[cfg(feature = "standalone")]
+    #[test]
+    fn host_filter_requires_networking_enabled() {
+        let res = Args::parse(argv(&["-allow-host", "1.2.3.4", "--", "/bin/foo"]));
+        let msg: String = format!("{:#}", res.expect_err("expected requires-networking error"));
+        assert!(msg.contains(Args::OPT_ALLOW_HOST_NETWORKING), "unexpected error: {msg}");
+    }
+
+    #[cfg(feature = "standalone")]
+    #[test]
+    fn rejects_invalid_host_entry() {
+        let res = Args::parse(argv(&[
+            "-allow-host-networking",
+            "-allow-host",
+            "not-an-ip",
+            "--",
+            "/bin/foo",
+        ]));
+        let msg: String = format!("{:#}", res.expect_err("expected invalid-entry error"));
+        assert!(msg.contains("invalid"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn host_filter_defaults_to_allow_all() {
+        let args = Args::parse(argv(&["-allow-host-networking", "--", "/bin/foo"])).expect("parse");
+        assert!(matches!(args.host_filter(), HostFilter::AllowAll));
+    }
+
+    #[cfg(not(feature = "standalone"))]
+    #[test]
+    fn host_filter_flags_rejected_in_non_standalone_build() {
+        let res = Args::parse(argv(&[
+            "-allow-host-networking",
+            "-allow-host",
+            "1.2.3.4",
+            "--",
+            "/bin/foo",
+        ]));
+        let msg: String = format!("{:#}", res.expect_err("expected standalone-only error"));
+        assert!(msg.contains("standalone"), "unexpected error: {msg}");
     }
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -173,6 +173,7 @@ async fn async_main() -> Result<ExitCode> {
         args.mount_directory().map(|s| s.to_string()),
         args.kernel_args().map(|s| s.to_string()),
         args.networking_mode(),
+        args.host_filter(),
         #[cfg(feature = "gdb")]
         args.gdb_port(),
         args.gateway_sockaddr().map(|s| s.to_string()),


### PR DESCRIPTION
## Pull request overview

Adds a per-host IPv4/CIDR egress policy to Nanvix’s host-side networking stack by introducing a reusable filter type, plumbing it through standalone configuration/CLI, and enforcing it at the network daemon `connect()` boundary.

**Changes:**
- Introduces `net-backend` host egress filtering primitives (`Ipv4Cidr`, `HostFilter`) and re-exports them for config consumers.
- Extends `nanvixd` standalone CLI/config to accept repeatable `-allow-host` / `-block-host` lists (with validation and feature gating).
- Enforces the filter in `networkd` before completing host-side `connect()` calls, denying non-IPv4 destinations when filtering is active.