### PR TITLE
[build] E: Run in-kernel tests in test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -954,6 +954,7 @@ standalone-images-clean:
 test:
 	@$(MAKE) run-unit-tests
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	@$(MAKE) run-kernel-tests
 	@$(MAKE) run-smoke-test
 	@$(MAKE) run-nanvix-tests
 endif


### PR DESCRIPTION
## Summary

The `test` Makefile target (invoked by `./z test`) ran `run-unit-tests`, `run-smoke-test`, and `run-nanvix-tests`, but never `run-kernel-tests`. As a result, the in-kernel integration tests (kernel built with the `test` feature and booted via the standalone UserVM) were silently skipped by local `./z test` runs.

This adds `run-kernel-tests` to the `test` target, inside the existing `MACHINE=microvm` guard alongside the other VM-booting tests, ordered before the smoke and system integration tests so foundational kernel regressions surface first.

## Details

- Affects only the local `test` target; CI already runs `run-kernel-tests` directly via its integration-test steps, so this brings local `./z test` in line with CI coverage.
- Works on both Linux (`./z test`) and Windows (the standalone UserVM is supported on both hosts).

## Validation

- `make -n test` confirms the new invocation order: `run-unit-tests` → `run-kernel-tests` → `run-smoke-test` → `run-nanvix-tests`.