### PR TITLE
[nanvixd-vmm] Add HTTP mode, binaries, and CI

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,extint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,142 @@ jobs:
             **/*.err
 
   # ==========================================================================================
+  # OpenVMM Standalone (Linux)
+  # ==========================================================================================
+
+  # Build the OpenVMM-based standalone daemon (nanvixd-vmm) and validate it as a
+  # drop-in for nanvixd.elf: the standalone test suite (terminal + http + empty
+  # executors) is run against it via nanvix-test, using
+  # test/test-standalone-openvmm.toml. This job fetches the OpenVMM crate tree
+  # from GitHub and needs protoc + KVM, so it is heavier than the other Linux
+  # jobs; it builds and tests in a single job to avoid shuffling the large
+  # (~120 MB) host binaries between jobs.
+  ci-openvmm:
+    name: "OpenVMM Standalone (${{ matrix.build-type }}, ${{ matrix.machine-type }})"
+    needs: [ precheck, checks, lint, verify ]
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        # PRs run debug only (fast feedback); merge queue and dev pushes run
+        # release only; manual dispatch runs both. Mirrors ci-build.
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' ||
+          github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
+          '["release"]') }}
+        machine-type: [ microvm ]
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
+      options: --privileged
+    permissions:
+      contents: read
+      packages: read
+    env:
+      # The CI container runs as root without USER set; nanvixd uses it as
+      # fallback tenant-id and fails when the variable is missing.
+      USER: root
+
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # !failure() ensures the job does not start when checks/lint/verify fail.
+    if: |
+      !cancelled() && !failure() &&
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
+          needs.precheck.outputs.up_to_date == 'true' && (
+            github.event_name != 'push' ||
+            github.event.head_commit == null ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup"
+        uses: ./.github/actions/native-setup
+
+      - name: "Setup sccache"
+        uses: Mozilla-Actions/sccache-action@v0.0.10
+        with:
+          version: "v0.10.0"
+
+      - name: "Install protoc"
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # protoc is required by transitive OpenVMM build dependencies. The CI
+          # container does not ship it, so install it on demand.
+          if ! command -v protoc >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y protobuf-compiler
+          fi
+          protoc --version
+
+      - name: "Setup KVM"
+        uses: ./.github/actions/setup-kvm
+
+      - name: "Build Guests, nanvix-test, and nanvixd-vmm"
+        shell: bash
+        env:
+          MACHINE_TYPE: ${{ matrix.machine-type }}
+          LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
+          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
+        run: |
+          set -Eeuo pipefail
+          # Guests + host tools (kernel, nanvix-test, test images) for standalone,
+          # pinned at 128 MiB to match nanvixd-vmm's runtime guest-RAM default.
+          ./z build -- all \
+            "MACHINE=${MACHINE_TYPE}" \
+            TARGET=x86 \
+            "LOG_LEVEL=${LOG_LEVEL}" \
+            VERBOSE=yes \
+            BUILD_OPT=yes \
+            ${RELEASE_FLAG} \
+            DEPLOYMENT_MODE=standalone \
+            MEMORY_SIZE=128
+          # The OpenVMM-based daemon is opt-in (fetches OpenVMM crates from
+          # GitHub on the first build). The Makefile resolves protoc and exports
+          # MEMORY_SIZE_BYTES for the config crate.
+          PROTOC="$(command -v protoc)" ./z build ${RELEASE_FLAG} -- all-nanvixd-vmm \
+            "MACHINE=${MACHINE_TYPE}" \
+            TARGET=x86 \
+            DEPLOYMENT_MODE=standalone \
+            MEMORY_SIZE=128
+
+      - name: "Lint & Format Check (nanvixd-vmm)"
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PROTOC="$(command -v protoc)" ./z build -- \
+            format-check-nanvixd-vmm rust-lint-check-nanvixd-vmm
+
+      - name: "Standalone Test (terminal + http)"
+        shell: bash
+        env:
+          RUST_LOG: info
+        run: |
+          set -Eeuo pipefail
+          echo "Running: ./bin/nanvix-test.elf test/test-standalone-openvmm.toml"
+          ./bin/nanvix-test.elf test/test-standalone-openvmm.toml
+
+      - name: "Upload logs in case of failures"
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nanvix-openvmm-logs-${{ github.event.pull_request.number ||
+            github.run_number }}-${{ matrix.build-type }}-${{ matrix.machine-type }}
+          overwrite: "true"
+          path: |
+            logs/
+            **/*.log
+            **/*.out
+            **/*.err
+
+  # ==========================================================================================
   # Windows CI (GitHub-Hosted Runners)
   # ==========================================================================================
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ toolchain
 
 # Build artifacts
 .venv/
-bin/
+# Anchored to the repository root so the build-output `bin/` is ignored without
+# also hiding in-tree Cargo binary directories (e.g. a crate's `src/bin/`).
+/bin/
 /lib/
 /logs/
 images/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "nanvixd-vmm"
-version = "0.16.40"
+version = "0.16.49"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",
@@ -3027,15 +3027,22 @@ dependencies = [
  "guestmem",
  "hostfs-api",
  "hostfsd",
+ "http-body-util",
  "hvdef",
+ "hyper",
+ "hyper-util",
  "log",
  "mesh",
  "networkd",
  "pal_async",
+ "serde",
+ "serde_json",
  "sparse_mmap",
  "state_unit",
  "sys",
  "syscall",
+ "tokio",
+ "user-vm-api",
  "virt",
  "virt_kvm",
  "vm_resource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,51 @@
 version = 4
 
 [[package]]
+name = "aarch64defs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "open_enum",
+ "zerocopy",
+]
+
+[[package]]
+name = "acpi"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "acpi_spec",
+ "cxl_spec",
+ "guid",
+ "memory_range",
+ "thiserror 2.0.18",
+ "x86defs",
+ "zerocopy",
+]
+
+[[package]]
+name = "acpi_spec"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "open_enum",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
+name = "address_filter"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +122,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc_cyclic_builder"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+
+[[package]]
 name = "arch"
 version = "0.16.50"
 dependencies = [
@@ -108,6 +158,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +196,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -159,6 +233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ca019570363e800b05ad4fd890734f28ac7b72f563ad8a35079efb793616f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +264,17 @@ dependencies = [
  "raw-array",
  "sys",
  "vstd",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.0"
+source = "git+https://github.com/smalis-msft/bitvec?branch=set-aliased-previous-val#d0aea0cf9e71323f41f1732634edb3aff2bf70f2"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -203,6 +299,11 @@ dependencies = [
 [[package]]
 name = "build-utils"
 version = "0.16.50"
+
+[[package]]
+name = "build_rs_guest_arch"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
 
 [[package]]
 name = "bump-allocator"
@@ -246,6 +347,25 @@ name = "cache"
 version = "0.16.50"
 
 [[package]]
+name = "cache_topology"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "fs-err",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +399,98 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chipset"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "bitfield-struct",
+ "chipset_device",
+ "chipset_device_resources",
+ "chipset_resources",
+ "futures",
+ "input_core",
+ "inspect",
+ "inspect_counters",
+ "jiff",
+ "local_clock",
+ "mesh",
+ "open_enum",
+ "power_resources",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "vmcore",
+ "x86defs",
+]
+
+[[package]]
+name = "chipset_device"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh",
+ "tdisp",
+ "vmcore",
+]
+
+[[package]]
+name = "chipset_device_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "chipset_device",
+ "guestmem",
+ "inspect",
+ "tdisp",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "chipset_legacy"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "chipset",
+ "chipset_device",
+ "chipset_device_resources",
+ "chipset_resources",
+ "floppy",
+ "floppy_pcat_stub",
+ "guestmem",
+ "inspect",
+ "local_clock",
+ "memory_range",
+ "mesh",
+ "open_enum",
+ "pci_bus",
+ "pci_core",
+ "power_resources",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "chipset_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "local_clock",
+ "memory_range",
+ "mesh",
+ "vm_resource",
 ]
 
 [[package]]
@@ -331,6 +543,14 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "closeable_mutex"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "cmdline"
@@ -389,6 +609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.16.50"
 dependencies = [
@@ -437,6 +666,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -570,6 +808,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cvm_tracing"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "cxl_spec"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "bitfield-struct",
+ "chipset_device",
+ "inspect",
+ "mesh",
+ "pci_core",
+ "pci_resources",
+ "thiserror 2.0.18",
+ "tracing",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +912,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "device_emulators"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +925,22 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+]
+
+[[package]]
+name = "disk_backend"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "futures",
+ "guestmem",
+ "inspect",
+ "scsi_buffers",
+ "stackfuture",
+ "thiserror 2.0.18",
+ "vm_resource",
+ "vmcore",
 ]
 
 [[package]]
@@ -737,6 +1023,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env-rust-nostd"
 version = "0.16.50"
 dependencies = [
@@ -802,6 +1108,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fast_select"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,10 +1182,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "firmware_pcat"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "chipset_device",
+ "generation_id",
+ "getrandom 0.4.2",
+ "guestmem",
+ "guid",
+ "inspect",
+ "memory_range",
+ "mesh",
+ "open_enum",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_topology",
+ "vmcore",
+ "zerocopy",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flexi_logger"
@@ -863,6 +1233,42 @@ dependencies = [
  "nu-ansi-term",
  "regex",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "floppy"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "arrayvec",
+ "bitfield-struct",
+ "chipset_device",
+ "disk_backend",
+ "guestmem",
+ "inspect",
+ "mesh",
+ "open_enum",
+ "scsi_buffers",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+]
+
+[[package]]
+name = "floppy_pcat_stub"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "arrayvec",
+ "bitfield-struct",
+ "chipset_device",
+ "inspect",
+ "mesh",
+ "open_enum",
+ "tracelimit",
+ "tracing",
+ "vmcore",
 ]
 
 [[package]]
@@ -885,6 +1291,41 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "framebuffer"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chipset_device",
+ "guestmem",
+ "inspect",
+ "memory_range",
+ "mesh",
+ "parking_lot",
+ "sparse_mmap",
+ "tracing",
+ "video_core",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -912,6 +1353,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1387,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -999,6 +1466,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generation_id"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "getrandom 0.4.2",
+ "guestmem",
+ "inspect",
+ "mesh",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1540,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "guestmem"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "pal_event",
+ "sparse_mmap",
+ "thiserror 2.0.18",
+ "trycopy",
+ "zerocopy",
+]
+
+[[package]]
+name = "guid"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "getrandom 0.4.2",
+ "inspect",
+ "mesh_protobuf",
+ "thiserror 2.0.18",
+ "win_etw_provider",
+ "windows",
+ "windows-sys 0.61.2",
+ "zerocopy",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1614,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hcl_compat_uefi_nvram_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh_protobuf",
+]
+
+[[package]]
+name = "hcl_compat_uefi_nvram_storage"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cvm_tracing",
+ "guid",
+ "hcl_compat_uefi_nvram_resources",
+ "open_enum",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracing",
+ "ucs2",
+ "uefi_nvram_storage",
+ "zerocopy",
+]
+
+[[package]]
+name = "headervec"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1654,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1209,6 +1757,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hv1_emulator"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "aarch64defs",
+ "build_rs_guest_arch",
+ "guestmem",
+ "hv1_structs",
+ "hvdef",
+ "inspect",
+ "parking_lot",
+ "safeatomic",
+ "tracelimit",
+ "tracing",
+ "virt",
+ "vm_topology",
+ "vmcore",
+ "x86defs",
+ "zerocopy",
+]
+
+[[package]]
+name = "hv1_hypercall"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "guestmem",
+ "hv1_structs",
+ "hvdef",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "zerocopy",
+]
+
+[[package]]
+name = "hv1_structs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitvec",
+ "hvdef",
+ "inspect",
+]
+
+[[package]]
+name = "hvdef"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "open_enum",
+ "static_assertions",
+ "zerocopy",
+]
+
+[[package]]
 name = "hwloc"
 version = "0.16.50"
 dependencies = [
@@ -1225,6 +1830,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hybrid_vsock"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "fs-err",
+ "guid",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1388,6 +2003,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ide"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "chipset_device",
+ "disk_backend",
+ "guestmem",
+ "ide_resources",
+ "inspect",
+ "mesh",
+ "open_enum",
+ "pci_core",
+ "safeatomic",
+ "scsi_buffers",
+ "scsi_core",
+ "scsi_defs",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "tracing_helpers",
+ "vmcore",
+ "zerocopy",
+]
+
+[[package]]
+name = "ide_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh",
+ "scsidisk_resources",
+ "vm_resource",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +2103,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "input_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "futures",
+ "mesh",
+ "vm_resource",
+]
+
+[[package]]
+name = "inspect"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "inspect_derive",
+ "mesh",
+ "parking_lot",
+]
+
+[[package]]
+name = "inspect_counters"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+]
+
+[[package]]
+name = "inspect_derive"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,10 +2187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1498,6 +2204,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1560,6 +2281,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvm"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "kvm-bindings",
+ "libc",
+ "nix 0.30.1",
+ "pal",
+ "parking_lot",
+ "signal-hook 0.3.18",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +2316,23 @@ dependencies = [
  "libc",
  "vmm-sys-util",
 ]
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1616,6 +2368,26 @@ name = "libc_string"
 version = "0.16.50"
 dependencies = [
  "sysapi",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1658,7 +2430,7 @@ dependencies = [
  "net-backend",
  "profiler",
  "rand 0.10.1",
- "signal-hook",
+ "signal-hook 0.4.4",
  "static_assert",
  "sys",
  "sysapi",
@@ -1674,6 +2446,21 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "loan_cell"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+
+[[package]]
+name = "local_clock"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "jiff",
+ "parking_lot",
+]
 
 [[package]]
 name = "lock_api"
@@ -1755,6 +2542,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory_range"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh_protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mesh"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "mesh_channel",
+ "mesh_derive",
+ "mesh_node",
+ "mesh_protobuf",
+]
+
+[[package]]
+name = "mesh_channel"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "futures",
+ "mesh_channel_core",
+ "mesh_node",
+ "mesh_protobuf",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "mesh_channel_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "futures",
+ "mesh_node",
+ "mesh_protobuf",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "mesh_derive"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mesh_node"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "futures",
+ "getrandom 0.4.2",
+ "mesh_derive",
+ "mesh_protobuf",
+ "open_enum",
+ "pal",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracing",
+ "zerocopy",
+]
+
+[[package]]
+name = "mesh_protobuf"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "fs-err",
+ "heck 0.5.0",
+ "mesh_derive",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +2656,29 @@ dependencies = [
  "sysapi",
  "syscall",
  "syslog",
+]
+
+[[package]]
+name = "missing_dev"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "chipset_device",
+ "chipset_device_resources",
+ "inspect",
+ "missing_dev_resources",
+ "pci_core",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "missing_dev_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "mesh",
+ "vm_resource",
 ]
 
 [[package]]
@@ -2115,6 +3014,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanvixd-vmm"
+version = "0.16.40"
+dependencies = [
+ "anyhow",
+ "build_rs_guest_arch",
+ "chipset",
+ "chipset_device_resources",
+ "chipset_resources",
+ "config",
+ "env_logger",
+ "guestmem",
+ "hostfs-api",
+ "hostfsd",
+ "hvdef",
+ "log",
+ "mesh",
+ "networkd",
+ "pal_async",
+ "sparse_mmap",
+ "state_unit",
+ "sys",
+ "syscall",
+ "virt",
+ "virt_kvm",
+ "vm_resource",
+ "vm_topology",
+ "vmcore",
+ "vmm_core",
+ "vmotherboard",
+ "x86defs",
+]
+
+[[package]]
 name = "net-backend"
 version = "0.16.50"
 dependencies = [
@@ -2168,6 +3100,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -2194,6 +3138,15 @@ dependencies = [
  "nvx-crt0",
  "sys",
  "sysalloc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2293,6 +3246,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open_enum"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+
+[[package]]
+name = "pal"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "caps",
+ "fs-err",
+ "headervec",
+ "landlock",
+ "libc",
+ "ntapi",
+ "pal_event",
+ "seccompiler",
+ "socket2",
+ "thiserror 2.0.18",
+ "tracing",
+ "widestring",
+ "winapi",
+ "windows",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pal_async"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "cfg-if",
+ "futures",
+ "getrandom 0.4.2",
+ "headervec",
+ "io-uring",
+ "libc",
+ "loan_cell",
+ "once_cell",
+ "pal",
+ "pal_async_test",
+ "pal_event",
+ "parking_lot",
+ "slab",
+ "smallbox",
+ "socket2",
+ "unicycle",
+ "unix_socket",
+ "windows-result",
+ "windows-sys 0.61.2",
+ "zerocopy",
+]
+
+[[package]]
+name = "pal_async_test"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pal_event"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+ "mesh_protobuf",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,10 +3353,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pci_bus"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "chipset_device",
+ "inspect",
+ "mesh",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+ "zerocopy",
+]
+
+[[package]]
+name = "pci_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "bitfield-struct",
+ "chipset_device",
+ "guestmem",
+ "inspect",
+ "mesh",
+ "open_enum",
+ "pal_event",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+ "zerocopy",
+]
+
+[[package]]
+name = "pci_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "chipset_device",
+ "chipset_device_resources",
+ "guestmem",
+ "pci_core",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "pcie"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "chipset_device",
+ "cxl_spec",
+ "inspect",
+ "memory_range",
+ "mesh",
+ "pal_async",
+ "pal_event",
+ "pci_bus",
+ "pci_core",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+ "zerocopy",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2333,8 +3448,38 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
  "indexmap 1.9.3",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2407,12 +3552,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "power_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "mesh",
+ "vm_resource",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2498,7 +3662,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -2512,9 +3686,31 @@ dependencies = [
  "itertools",
  "log",
  "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "petgraph 0.5.1",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.5",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -2533,13 +3729,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -2609,6 +3827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,6 +3878,12 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "range_map_vec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc2191ec1fd850e3ede4cf09ccfd40a33df561111f73e96e1b7c3f9eee31328"
 
 [[package]]
 name = "raw-array"
@@ -2779,6 +4009,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "safe_intrinsics"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "safeatomic"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "save_restore_derive"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +4057,62 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "scsi_buffers"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "event-listener",
+ "guestmem",
+ "safeatomic",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
+name = "scsi_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh",
+ "scsi_buffers",
+ "scsi_defs",
+ "stackfuture",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "scsi_defs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "open_enum",
+ "zerocopy",
+]
+
+[[package]]
+name = "scsidisk_resources"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh",
+ "storage_string",
+ "vm_resource",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2884,6 +4195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +4214,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook"
@@ -2920,6 +4250,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallbox"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca054fd9f8c2ebe8557a2433f307e038c0716124efd045daa0388afa5172189"
 
 [[package]]
 name = "smallvec"
@@ -2967,6 +4303,21 @@ name = "sorted-vec"
 version = "0.16.50"
 
 [[package]]
+name = "sparse_mmap"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+ "pal",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "trycopy",
+ "windows-sys 0.61.2",
+ "zerocopy",
+]
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "git+https://github.com/nanvix/spin-rs?branch=nanvix%2Fv0.10.0#ec00ed314406d2cc8313ef72c06178619ee0b48c"
@@ -2982,11 +4333,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stackfuture"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115beb9c69db2393ff10b75a1b8587a51716e5551d015001e55320ed279d32f9"
+dependencies = [
+ "const_panic",
+]
+
+[[package]]
+name = "state_unit"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "event-listener",
+ "futures",
+ "futures-concurrency",
+ "inspect",
+ "mesh",
+ "pal_async",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tracing",
+ "vmcore",
+]
+
+[[package]]
 name = "static_assert"
 version = "0.16.50"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "storage_string"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh_protobuf",
+ "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3204,6 +4599,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "task_control"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "fast_select",
+ "inspect",
+ "pal_async",
+ "parking_lot",
+]
+
+[[package]]
+name = "tdisp"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "bitfield-struct",
+ "parking_lot",
+ "prost 0.11.9",
+ "static_assertions",
+ "tdisp_proto",
+ "tracing",
+ "zerocopy",
+]
+
+[[package]]
+name = "tdisp_proto"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,6 +4773,15 @@ dependencies = [
  "sysapi",
  "syscall",
  "syslog",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3478,13 +4925,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tracelimit"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "parking_lot",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3494,6 +4962,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing_helpers"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3501,6 +5005,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trycopy"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+ "zerocopy",
+]
 
 [[package]]
 name = "ttrpc"
@@ -3543,9 +5058,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa71f4a44711b3b9cc10ed0c7e239ff0fe4b8e6c900a142fb3bb26401385718"
 dependencies = [
  "derive-new",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
+ "prost-types 0.8.0",
  "protobuf",
  "protobuf-codegen",
  "tempfile",
@@ -3565,6 +5080,48 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
+name = "ucs2"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "uefi_nvram_storage"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "guid",
+ "thiserror 2.0.18",
+ "ucs2",
+ "uefi_specs",
+ "wchar",
+ "zerocopy",
+]
+
+[[package]]
+name = "uefi_specs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "guid",
+ "open_enum",
+ "static_assertions",
+ "ucs2",
+ "wchar",
+ "zerocopy",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3591,10 +5148,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicycle"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ccbaf192caef9a758b9cd7ea2e5d98ffd0e40eb62e5e3fbaa50049df8b841f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+ "uniset",
+]
+
+[[package]]
+name = "uniset"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40789245bbff5f31eb773c9ac4ee5c4e15eab9640d975e124d6ce4c34a6410d7"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unix_socket"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "getrandom 0.4.2",
+ "socket2",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "url"
@@ -3669,6 +5254,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "verus_builtin"
@@ -3802,6 +5393,256 @@ dependencies = [
 ]
 
 [[package]]
+name = "video_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "inspect",
+ "mesh",
+ "vm_resource",
+]
+
+[[package]]
+name = "virt"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "aarch64defs",
+ "anyhow",
+ "build_rs_guest_arch",
+ "guestmem",
+ "hvdef",
+ "inspect",
+ "memory_range",
+ "mesh_protobuf",
+ "pal_event",
+ "parking_lot",
+ "pci_core",
+ "slab",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_topology",
+ "vmcore",
+ "x86defs",
+ "zerocopy",
+]
+
+[[package]]
+name = "virt_kvm"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "aarch64defs",
+ "anyhow",
+ "bitfield-struct",
+ "build_rs_guest_arch",
+ "cfg-if",
+ "guestmem",
+ "hv1_emulator",
+ "hv1_hypercall",
+ "hvdef",
+ "inspect",
+ "jiff",
+ "kvm",
+ "memory_range",
+ "open_enum",
+ "pal_event",
+ "parking_lot",
+ "pci_core",
+ "safe_intrinsics",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "virt",
+ "vm_topology",
+ "vmcore",
+ "x86defs",
+ "zerocopy",
+]
+
+[[package]]
+name = "vm_resource"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "async-trait",
+ "inspect",
+ "linkme",
+ "mesh",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vm_topology"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "aarch64defs",
+ "build_rs_guest_arch",
+ "cfg-if",
+ "cxl_spec",
+ "inspect",
+ "memory_range",
+ "safe_intrinsics",
+ "thiserror 2.0.18",
+ "x86defs",
+]
+
+[[package]]
+name = "vmbus_async"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "futures",
+ "guestmem",
+ "inspect",
+ "inspect_counters",
+ "pal_async",
+ "thiserror 2.0.18",
+ "vmbus_channel",
+ "vmbus_ring",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmbus_channel"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "guestmem",
+ "guid",
+ "inspect",
+ "mesh",
+ "pal_async",
+ "pal_event",
+ "parking_lot",
+ "task_control",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "vmbus_core",
+ "vmbus_ring",
+ "vmcore",
+]
+
+[[package]]
+name = "vmbus_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "futures",
+ "guid",
+ "hvdef",
+ "inspect",
+ "mesh",
+ "open_enum",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmbus_proxy"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "futures",
+ "guestmem",
+ "guid",
+ "mesh",
+ "pal",
+ "pal_async",
+ "pal_event",
+ "tracing",
+ "vmbus_core",
+ "widestring",
+ "windows",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmbus_ring"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "guestmem",
+ "inspect",
+ "safeatomic",
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmbus_server"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "futures-concurrency",
+ "guestmem",
+ "guid",
+ "hvdef",
+ "hybrid_vsock",
+ "inspect",
+ "mesh",
+ "pal_async",
+ "pal_event",
+ "parking_lot",
+ "safeatomic",
+ "slab",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "unicycle",
+ "unix_socket",
+ "vmbus_async",
+ "vmbus_channel",
+ "vmbus_core",
+ "vmbus_proxy",
+ "vmbus_ring",
+ "vmcore",
+ "windows",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmcore"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "futures-concurrency",
+ "hvdef",
+ "inspect",
+ "jiff",
+ "linkme",
+ "loan_cell",
+ "mesh",
+ "pal_async",
+ "pal_event",
+ "parking_lot",
+ "save_restore_derive",
+ "slab",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "zerocopy",
+]
+
+[[package]]
 name = "vmm-sys-util"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +5650,145 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "vmm_core"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "aarch64defs",
+ "acpi",
+ "acpi_spec",
+ "anyhow",
+ "async-trait",
+ "build_rs_guest_arch",
+ "cache_topology",
+ "chipset",
+ "chipset_device_resources",
+ "chipset_resources",
+ "closeable_mutex",
+ "cvm_tracing",
+ "futures",
+ "futures-concurrency",
+ "guestmem",
+ "hcl_compat_uefi_nvram_storage",
+ "hvdef",
+ "input_core",
+ "inspect",
+ "memory_range",
+ "mesh",
+ "pal_async",
+ "parking_lot",
+ "pci_core",
+ "pci_resources",
+ "power_resources",
+ "slab",
+ "state_unit",
+ "thiserror 2.0.18",
+ "tracing",
+ "virt",
+ "vm_resource",
+ "vm_topology",
+ "vmbus_channel",
+ "vmbus_server",
+ "vmcore",
+ "vmm_core_defs",
+ "vmotherboard",
+ "vpci",
+ "x86defs",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmm_core_defs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "inspect",
+ "mesh",
+ "virt",
+]
+
+[[package]]
+name = "vmotherboard"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "address_filter",
+ "anyhow",
+ "arc_cyclic_builder",
+ "async-trait",
+ "chipset",
+ "chipset_device",
+ "chipset_device_resources",
+ "chipset_legacy",
+ "chipset_resources",
+ "closeable_mutex",
+ "cvm_tracing",
+ "firmware_pcat",
+ "framebuffer",
+ "futures",
+ "generation_id",
+ "guestmem",
+ "ide",
+ "inspect",
+ "inspect_counters",
+ "mesh",
+ "missing_dev",
+ "pal_async",
+ "parking_lot",
+ "paste",
+ "pci_bus",
+ "pcie",
+ "range_map_vec",
+ "state_unit",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "vpci"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chipset_device",
+ "closeable_mutex",
+ "device_emulators",
+ "guestmem",
+ "guid",
+ "hvdef",
+ "inspect",
+ "mesh",
+ "parking_lot",
+ "pci_core",
+ "task_control",
+ "tdisp",
+ "thiserror 2.0.18",
+ "tracelimit",
+ "tracing",
+ "vmbus_async",
+ "vmbus_channel",
+ "vmbus_ring",
+ "vmcore",
+ "vpci_protocol",
+ "zerocopy",
+]
+
+[[package]]
+name = "vpci_protocol"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "guid",
+ "open_enum",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3955,6 +5935,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wchar"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8be48fe4c433c0d4aa71bb8759c5f7b1da6dacb1b99998566ebe16503f6a59c"
+dependencies = [
+ "wchar-impl",
+]
+
+[[package]]
+name = "wchar-impl"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075c93156fed21f9dab57af5e81604d0fdb67432c919a8c1f78bb979f06a3d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +5985,55 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "win_etw_metadata"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5113ede807966842887ba64b2bba9e1079e19efaea612b6e83449af29b4b194"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "win_etw_provider"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57b25caee8f665da0fb8c9b47b3b0d34752c90436ea9c6c97030e3bf80ca527"
+dependencies = [
+ "widestring",
+ "win_etw_metadata",
+ "windows-sys 0.61.2",
+ "zerocopy",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -4296,7 +6345,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -4310,7 +6359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4360,6 +6409,26 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x86defs"
+version = "0.0.0"
+source = "git+https://github.com/microsoft/OpenVMM?rev=0c806a77376b71403a4331b617f7fb090484a8a5#0c806a77376b71403a4331b617f7fb090484a8a5"
+dependencies = [
+ "bitfield-struct",
+ "open_enum",
+ "static_assertions",
+ "zerocopy",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "nanvixd-vmm"
-version = "0.16.49"
+version = "0.16.50"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ members = [
         "src/utils/nanvix-bench",
         "src/utils/nanvix-test",
         "src/utils/nanvixd",
+        "src/utils/nanvixd-vmm",
         "src/utils/strace",
         "src/libs/net-backend",
         "src/libs/nanvix-oci",
@@ -288,3 +289,10 @@ all = "deny"
 # nursery = "deny"
 # TODO (#1149): Enable cargo linting rules, once they are fixed.
 # cargo = "deny"
+
+# Patch required to build the OpenVMM virtualization crates that the
+# `nanvixd-vmm` utility depends on. Mirrors OpenVMM's own `[patch.crates-io]`
+# entry for `bitvec`; without it, OpenVMM's Hyper-V emulation crates
+# (`hv1_structs`) fail to resolve `bitvec`.
+[patch.crates-io]
+bitvec = { git = "https://github.com/smalis-msft/bitvec", branch = "set-aliased-previous-val" }

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ export IMAGE ?= nanvix.img
 # Enable WHP backend?
 export WHP ?= no
 
+# Build the OpenVMM-based standalone daemon (nanvixd-vmm) as part of `all`?
+# This is opt-in because it fetches a large set of OpenVMM crates from GitHub
+# (network access required on the first build) and adds significant compile time.
+export WITH_OPENVMM ?= no
+
 # Memory size in megabytes. Exported as MEMORY_SIZE_BYTES for build.rs scripts.
 # Example: make all MEMORY_SIZE=256
 export MEMORY_SIZE ?= 128
@@ -427,6 +432,12 @@ ifneq ($(strip $(filter $(MACHINE),microvm)),)
 all-nanvix: all-nanvix-bench
 endif
 
+# Opt-in: build the OpenVMM-based standalone daemon as part of `all` when
+# WITH_OPENVMM=yes (e.g. `./z build -- WITH_OPENVMM=yes`).
+ifeq ($(WITH_OPENVMM),yes)
+all-nanvix: all-nanvixd-vmm
+endif
+
 # Performs local initialization.
 init: init-repo
 
@@ -455,6 +466,9 @@ endif
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 clean: clean-nanvix-bench
 endif
+
+# The OpenVMM-based daemon is an opt-in build target, but always clean it up.
+clean: clean-nanvixd-vmm
 
 distclean: clean
 ifeq ($(IS_WINDOWS),yes)
@@ -526,6 +540,10 @@ help:
 	@echo "  help         Show this help message"
 	@echo "  test         Run unit and system tests sequentially"
 	@echo ""
+	@echo "Opt-in Build Targets (not part of 'all')"
+	@echo "  all-nanvixd-vmm  Build the OpenVMM-based standalone daemon (fetches OpenVMM"
+	@echo "                   crates from GitHub; network required on first build)"
+	@echo ""
 	@echo "Development Targets"
 	@echo "  check           Run all validation checks (syntax, compilation)"
 	@echo "  format          Fix code formatting issues automatically"
@@ -560,6 +578,7 @@ help:
 	@echo "  TIMEOUT          Execution timeout in seconds (default: $(TIMEOUT))"
 	@echo "  CLH_DIR          Cloud-hypervisor installation directory (default: $(CLH_DIR))"
 	@echo "  MEMORY_SIZE      Memory size in megabytes (default: $(MEMORY_SIZE))"
+	@echo "  WITH_OPENVMM     Include the OpenVMM-based daemon (nanvixd-vmm) in 'all' (default: $(WITH_OPENVMM)) [fetches OpenVMM crates from GitHub]"
 	@echo "  VERUS_EXECUTABLE_DIR  Path to directory containing the verus binary (unset: skip verification)"
 	@echo ""
 	@echo "Parameter Values"
@@ -570,6 +589,7 @@ help:
 	@echo "  LOG_LEVEL       trace, debug, info, warn, error, panic"
 	@echo "  PROFILER        yes, no"
 	@echo "  MAKE_NO_PRINT   yes, no"
+	@echo "  WITH_OPENVMM    yes, no"
 
 # Verifies all Verus-annotated crates.
 .PHONY: verify $(addprefix verify-,$(VERUS_CRATES))
@@ -1112,6 +1132,12 @@ include build/make/nanvix-test.mk
 #===================================================================================================
 
 include build/make/nanvixd.mk
+
+#===================================================================================================
+# Build Rules for Nanvix Daemon on OpenVMM (opt-in; not part of `all`)
+#===================================================================================================
+
+include build/make/nanvixd-vmm.mk
 
 #===================================================================================================
 # Build Rules for Generic Host Binaries

--- a/build/make/nanvixd-vmm.mk
+++ b/build/make/nanvixd-vmm.mk
@@ -1,0 +1,80 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Build rules for the `nanvixd-vmm` crate: the Nanvix standalone daemon running
+# on top of the OpenVMM virtualization stack.
+#
+# This is an OPT-IN target: it is deliberately NOT part of `all-nanvix` unless
+# WITH_OPENVMM=yes, because it pulls a large set of OpenVMM crates from GitHub
+# (network access required on the first build) and adds significant compile
+# time. Build it explicitly with either of:
+#
+#   ./z build -- all-nanvixd-vmm        # build just this crate
+#   ./z build -- WITH_OPENVMM=yes       # include it in the full `all` build
+#
+# The crate is decoupled from the sibling OpenVMM checkout for its *sources*:
+# all OpenVMM libraries are git dependencies pinned to a specific revision (see
+# src/utils/nanvixd-vmm/Cargo.toml), and the `[patch.crates-io]` entries it
+# needs are mirrored in the workspace root Cargo.toml. MEMORY_SIZE_BYTES is
+# exported by this Makefile, so no external wrapper script is required.
+#
+# One external build tool is still required: `protoc` (Protocol Buffers
+# compiler), used by transitive OpenVMM build dependencies (e.g. `tdisp_proto`
+# via `prost-build`). It is resolved at build time in this order:
+#   1. an explicit PROTOC environment variable,
+#   2. a `protoc` on PATH (e.g. `apt-get install protobuf-compiler`),
+#   3. the copy restored under the sibling OpenVMM checkout, if present.
+
+# The crate ships two binaries.
+NANVIXD_VMM_BIN := nanvixd-vmm
+NANVIXD_VMM_WARMSTART_BIN := nanvixd-vmm-warmstart
+
+# Fallback protoc location: the copy OpenVMM restores under its `.packages/`.
+NANVIXD_VMM_OPENVMM_PROTOC := $(ROOT_DIR)/../OpenVMM/.packages/Google.Protobuf.Tools/tools/protoc
+
+# Shell snippet that resolves `protoc` into $$PROTOC_BIN, or fails with a helpful
+# message. Use it at the start of any recipe that compiles the crate, e.g.:
+#   @$(call nanvixd_vmm_resolve_protoc); \
+#   PROTOC="$$PROTOC_BIN" $(HOST_CARGO_BUILD_CMD) -p nanvixd-vmm
+define nanvixd_vmm_resolve_protoc
+PROTOC_BIN="$${PROTOC:-}"; \
+if [ -z "$$PROTOC_BIN" ]; then PROTOC_BIN="$$(command -v protoc || true)"; fi; \
+if [ -z "$$PROTOC_BIN" ] && [ -x "$(NANVIXD_VMM_OPENVMM_PROTOC)" ]; then \
+	PROTOC_BIN="$(NANVIXD_VMM_OPENVMM_PROTOC)"; \
+fi; \
+if [ -z "$$PROTOC_BIN" ]; then \
+	echo "ERROR: protoc not found. Install it (e.g. 'apt-get install protobuf-compiler')," >&2; \
+	echo "       set the PROTOC environment variable, or restore OpenVMM's packages." >&2; \
+	exit 1; \
+fi; \
+echo "[nanvixd-vmm] PROTOC=$$PROTOC_BIN"
+endef
+
+all-nanvixd-vmm: init
+	@$(nanvixd_vmm_resolve_protoc); \
+	PROTOC="$$PROTOC_BIN" $(HOST_CARGO_BUILD_CMD) -p nanvixd-vmm
+	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/$(NANVIXD_VMM_BIN)$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/$(NANVIXD_VMM_BIN).$(HOST_BIN_EXT)
+	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/$(NANVIXD_VMM_WARMSTART_BIN)$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/$(NANVIXD_VMM_WARMSTART_BIN).$(HOST_BIN_EXT)
+
+check-nanvixd-vmm:
+	@$(nanvixd_vmm_resolve_protoc); \
+	PROTOC="$$PROTOC_BIN" $(HOST_CARGO_CHECK_CMD) -p nanvixd-vmm
+
+format-nanvixd-vmm:
+	$(HOST_CARGO_FMT_CMD) -p nanvixd-vmm
+
+format-check-nanvixd-vmm:
+	$(HOST_CARGO_FMT_CMD) -p nanvixd-vmm --check
+
+clean-nanvixd-vmm:
+	$(HOST_CARGO_CLEAN_CMD) -p nanvixd-vmm
+	$(RM_CMD) $(BINARIES_DIR)/$(NANVIXD_VMM_BIN).$(HOST_BIN_EXT)
+	$(RM_CMD) $(BINARIES_DIR)/$(NANVIXD_VMM_WARMSTART_BIN).$(HOST_BIN_EXT)
+
+rust-lint-nanvixd-vmm:
+	@$(nanvixd_vmm_resolve_protoc); \
+	PROTOC="$$PROTOC_BIN" $(HOST_CARGO_CLIPPY_CMD) --tests -p nanvixd-vmm --fix --allow-dirty --allow-no-vcs
+
+rust-lint-check-nanvixd-vmm:
+	@$(nanvixd_vmm_resolve_protoc); \
+	PROTOC="$$PROTOC_BIN" $(HOST_CARGO_CLIPPY_CMD) --tests -p nanvixd-vmm -- -D warnings

--- a/src/utils/nanvix-bench/src/benchmarks/standalone.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/standalone.rs
@@ -292,8 +292,17 @@ impl Benchmark {
         Ok((elapsed.as_micros(), phase_timings))
     }
 
-    /// Returns the platform-specific path to the nanvixd binary.
+    /// Returns the path to the `nanvixd`-compatible binary to benchmark.
+    ///
+    /// When the `NANVIX_BENCH_NANVIXD` environment variable is set, its value is
+    /// used verbatim; this allows the same standalone driver to benchmark an
+    /// alternative VMM front-end (e.g. the OpenVMM-based `nanvixd-vmm`) for a
+    /// side-by-side comparison against the native `nanvixd.elf` (uservm).
+    /// Otherwise it defaults to the platform `nanvixd` binary under `bin/`.
     pub(crate) fn standalone_nanvixd_path(&self) -> PathBuf {
+        if let Some(path) = ::std::env::var_os("NANVIX_BENCH_NANVIXD") {
+            return PathBuf::from(path);
+        }
         let bin_name: &str = if cfg!(windows) {
             "nanvixd.exe"
         } else {

--- a/src/utils/nanvixd-vmm/Cargo.toml
+++ b/src/utils/nanvixd-vmm/Cargo.toml
@@ -26,10 +26,24 @@ syscall = { workspace = true, default-features = false }
 hostfs-api = { workspace = true, features = ["std"] }
 hostfsd = { workspace = true }
 networkd = { workspace = true }
+# Reused for the HTTP control-plane wire types (`UserVmIdentifier`); keeps the
+# NEW/KILL JSON identical to the production `nanvixd` HTTP API without pulling in
+# the `uservm` VMM that this crate replaces.
+user-vm-api = { workspace = true }
 
 anyhow = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
+
+# HTTP (standalone) deployment mode: a tokio + hyper control server that mirrors
+# the production `nanvixd` standalone contract (NEW/KILL over `-http-addr` plus a
+# gateway Unix socket carrying the guest's stdio).
+tokio = { workspace = true, features = ["full"] }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["full"] }
+http-body-util = { workspace = true }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true, features = ["std"] }
 
 # OpenVMM virtualization libraries, consumed from the upstream GitHub repo
 # pinned to a specific revision. These provide the hypervisor backend (KVM

--- a/src/utils/nanvixd-vmm/Cargo.toml
+++ b/src/utils/nanvixd-vmm/Cargo.toml
@@ -1,0 +1,68 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nanvixd-vmm"
+version.workspace = true
+license-file.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Nanvix daemon (standalone) on top of the OpenVMM virtualization stack"
+
+[[bin]]
+name = "nanvixd-vmm"
+path = "src/bin/nanvixd-vmm.rs"
+
+[[bin]]
+name = "nanvixd-vmm-warmstart"
+path = "src/bin/nanvixd-vmm-warmstart.rs"
+
+[dependencies]
+# Nanvix host-side libraries (reused, not reimplemented): IKC/syscall wire
+# types and the host-side daemons.
+config = { workspace = true, features = ["microvm"] }
+sys = { workspace = true, features = ["std"] }
+syscall = { workspace = true, default-features = false }
+hostfs-api = { workspace = true, features = ["std"] }
+hostfsd = { workspace = true }
+networkd = { workspace = true }
+
+anyhow = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+
+# OpenVMM virtualization libraries, consumed from the upstream GitHub repo
+# pinned to a specific revision. These provide the hypervisor backend (KVM
+# partition, vCPU, guest memory) so that this crate does not reimplement
+# low-level virtualization. The pinned rev must stay in sync with the
+# `[patch.crates-io]` entries in the workspace root (bitvec, pbjson-build),
+# which mirror OpenVMM's own patches.
+guestmem = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+virt = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+virt_kvm = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+vm_topology = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+vmcore = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+x86defs = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+hvdef = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+sparse_mmap = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+pal_async = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+
+# Reuse the in-tree chipset device model for the legacy 8259 PIC + 8254 PIT
+# (interrupt controller and timer) instead of hand-rolling them.
+vmotherboard = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+vmm_core = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+chipset = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+chipset_resources = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+chipset_device_resources = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+state_unit = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+vm_resource = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+mesh = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+
+[build-dependencies]
+build_rs_guest_arch = { git = "https://github.com/microsoft/OpenVMM", rev = "0c806a77376b71403a4331b617f7fb090484a8a5" }
+
+# This crate deliberately does not inherit the workspace lints: it ports code
+# that targets OpenVMM's API surface and conventions, which differ from the
+# guest-facing Nanvix crates.
+[lints.rust]
+warnings = "warn"

--- a/src/utils/nanvixd-vmm/README.md
+++ b/src/utils/nanvixd-vmm/README.md
@@ -1,0 +1,159 @@
+# nanvixd-vmm
+
+`nanvixd-vmm` runs the **Nanvix guest** (standalone deployment mode) on top of
+the **OpenVMM** virtualization stack, while **reusing the real Nanvix host-side
+daemons** — `hostfsd` (host filesystem) and `networkd` (host networking) —
+instead of re-implementing their wire protocols.
+
+It boots the 32-bit Nanvix microkernel + an initrd application on KVM,
+implements the MicroVM port-I/O contract, and bridges guest stdin/stdout to the
+host. The crate lives in the **Nanvix** workspace so it can depend directly on
+the production daemon crates and the shared `sys`/`syscall`/`config`/`hostfs-api`
+types.
+
+## Why a dedicated crate?
+
+The host filesystem and networking protocols are non-trivial (the `hostfsd`
+request handler alone is ~2k lines, including multi-part request reassembly).
+Re-implementing them in the OpenVMM workspace would duplicate that logic and let
+it drift. Instead, this crate:
+
+- consumes the OpenVMM virtualization libraries (`virt`, `virt_kvm`,
+  `guestmem`, `vm_topology`, `vmcore`, `x86defs`, `hvdef`, `sparse_mmap`,
+  `pal_async`) via **cross-workspace path dependencies**, and
+- consumes the Nanvix `hostfsd::HostFsHandler` and `networkd::NetworkDaemon`
+  (plus the real IKC/syscall message types) as ordinary workspace dependencies.
+
+The IKC bridge (`src/ikc.rs`) mirrors the dispatch in
+`nanvix/src/uservm/src/standalone.rs`: outbound guest messages are routed to
+host stdio, to `hostfsd` (when the header is a HostFS op), or to `networkd`
+(when addressed to `NETWORKD`). When no mount is configured, HostFS requests get
+a synthesized error response so the guest's `vfsd` drains its pending operation
+instead of blocking.
+
+## Building
+
+The crate's OpenVMM sources are decoupled from any sibling checkout: every
+OpenVMM library is a **git dependency pinned to a specific revision** (see
+`Cargo.toml`), and the `[patch.crates-io]` entries they need are mirrored in the
+Nanvix workspace root. One external build tool is still required: **`protoc`**
+(the Protocol Buffers compiler), used by transitive OpenVMM build dependencies
+(e.g. `tdisp_proto` via `prost-build`). Install it with
+`apt-get install protobuf-compiler`, set `PROTOC`, or rely on OpenVMM's restored
+copy if a sibling checkout is present.
+
+The canonical build goes through the Nanvix build system, as an **opt-in**
+target (it is intentionally not part of the default `./z build`, since it
+fetches the OpenVMM crates from GitHub — network access is required on the first
+build):
+
+```bash
+./z build -- all-nanvixd-vmm              # build just this crate (debug)
+./z build -- WITH_OPENVMM=yes             # include it in the full `all` build
+./z build RELEASE=yes -- WITH_OPENVMM=yes # ... release
+```
+
+The Makefile target resolves `protoc` automatically (explicit `PROTOC`, then a
+system `protoc`, then OpenVMM's restored copy) and sets `MEMORY_SIZE_BYTES`
+(read by the Nanvix `config` build script) for you, dropping the resulting
+binaries into `bin/`.
+
+For quick iteration you can also build the crate directly with cargo via the
+wrapper, which performs the same `protoc`/`MEMORY_SIZE_BYTES` resolution and
+forwards extra args:
+
+```bash
+./build.sh             # debug
+./build.sh --release   # release
+```
+
+The crate is **not** part of the workspace `default-members`, so it does not
+affect the default `./z build` (the guest build).
+
+## Usage
+
+```text
+nanvixd-vmm [-bin-dir DIR] [-console-file PATH] [-ramfs IMG] \
+            [-kernel-args ARGS] [-mount DIR] [-allow-host-networking] \
+            -- PROGRAM [ARGS...]
+```
+
+- `-bin-dir DIR` — directory containing `kernel.elf` (default `./bin`).
+- `-mount DIR` — serve the guest's HostFS requests via `hostfsd`, rooted at `DIR`.
+- `-allow-host-networking` — serve the guest's networking via `networkd`.
+- `-console-file PATH` — route the guest kernel console here (default: stderr).
+- `-ramfs IMG`, `-kernel-args ARGS` — as in the Nanvix daemon.
+- `PROGRAM` after `--` is booted as the initrd; its `ARGS` become the guest
+  command line.
+
+Examples:
+
+```bash
+# Host filesystem mount test.
+nanvixd-vmm -bin-dir ./bin -mount ./bin/mount-test-data -- ./bin/mount-test.initrd
+
+# Host networking test.
+nanvixd-vmm -bin-dir ./bin -allow-host-networking -- ./bin/network-rust.initrd
+```
+
+Set `NANVIXD_VMM_LOG=debug` for verbose host-side logging (emitted to stderr).
+
+## Tests
+
+`run-standalone-tests.py` drives the `terminal`-executor cases from
+`nanvix/test/test-standalone.toml` against the built binary — including the
+host mount and networking cases served by the reused `hostfsd`/`networkd`
+daemons:
+
+```bash
+cargo build -p nanvixd-vmm           # or ./build.sh
+python3 run-standalone-tests.py      # add --verbose to print commands
+```
+
+Expected: all `terminal` cases pass; the only skips are the HTTP/snapshot
+executors and two escaped-semicolon argument cases the harness does not model.
+
+## Benchmarks: OpenVMM vs uservm
+
+`bench-compare.py` produces a side-by-side performance comparison of Nanvix
+running on **OpenVMM** (`nanvixd-vmm`) versus its **own uservm VMM**
+(`bin/nanvixd.elf`). It drives the *native* `nanvix-bench` standalone
+benchmarks with the **same** measurement code for both, selecting the VMM via
+the `NANVIX_BENCH_NANVIXD` environment variable the harness honors — so the
+comparison is apples-to-apples. The standalone-applicable benchmarks are
+`cold-start` (process spawn → boot → first stdin/stdout round trip) and
+`vfs-bench` (per-VFS-operation latency on a dense ramfs). A third benchmark,
+`warm-start`, is implemented directly by `bench-compare.py`: it boots the echo
+guest once and times many host→guest→host stdio round trips, measuring the
+**communication latency in and out of the VMM** (the IKC path) end-to-end
+through the OS pipe. A fourth, `warm-start-vmm`, is the **white-box** form: it
+measures the same round trip *in-process* with no OS pipe, giving parity with
+the native Nanvix `warm-start-vmm` micro-benchmark. For OpenVMM it is driven by
+the `nanvixd-vmm-warmstart` binary, which boots the guest with an in-process
+[`ChannelGuestIo`](src/io.rs) endpoint instead of the host terminal; for uservm
+it is the native `nanvix-bench -benchmark warm-start-vmm`. The OS-pipe transport
+(absent in white-box) is identical for both VMMs, so either form isolates VMM
+IKC overhead.
+
+Build everything in release first (for a fair comparison):
+
+```bash
+./z build --release LOG_LEVEL=panic                  # guests + bin/nanvixd.elf (uservm)
+src/utils/nanvixd-vmm/build.sh --release             # nanvixd-vmm + nanvixd-vmm-warmstart (OpenVMM)
+RELEASE=yes LOG_LEVEL=panic MEMORY_SIZE_BYTES=$((128*1048576)) \
+    cargo build -p nanvix-bench --release --no-default-features --features standalone,microvm
+```
+
+(The release `nanvix-bench` links uservm in release, needed for a fair white-box
+`warm-start-vmm`.) Then run the comparison:
+
+```bash
+python3 src/utils/nanvixd-vmm/bench-compare.py                          # all four
+python3 src/utils/nanvixd-vmm/bench-compare.py --benchmark warm-start-vmm --iterations 1000
+python3 src/utils/nanvixd-vmm/bench-compare.py --benchmark vfs-bench --iterations 1000
+```
+
+The `uvm/ovm` column is the uservm÷OpenVMM latency ratio (>1 means OpenVMM is
+faster). Interactive/streaming benchmarks (`warm-start`, `vfs-bench`) rely on
+this crate streaming host stdin to the guest and blocking guest `read(2)` until
+data arrives (matching uservm semantics) — see `src/stdin.rs`.

--- a/src/utils/nanvixd-vmm/README.md
+++ b/src/utils/nanvixd-vmm/README.md
@@ -75,43 +75,75 @@ affect the default `./z build` (the guest build).
 ```text
 nanvixd-vmm [-bin-dir DIR] [-console-file PATH] [-ramfs IMG] \
             [-kernel-args ARGS] [-mount DIR] [-allow-host-networking] \
-            -- PROGRAM [ARGS...]
+            ( -http-addr HOST:PORT | -- PROGRAM [ARGS...] )
 ```
+
+`nanvixd-vmm` is a drop-in for the production `nanvixd` standalone binary and
+supports the same two mutually exclusive operating modes:
+
+- **terminal** (interactive): a `PROGRAM` is given after `--`; it is booted as
+  the initrd, its `ARGS` become the guest command line, the guest's stdin/stdout
+  are bridged to the daemon's stdin/stdout, and the process exits with the
+  guest's exit code.
+- **http**: `-http-addr HOST:PORT` starts a control server exposing the same
+  `NEW`/`KILL` JSON API as `nanvixd` (selected by the `X-NVX-Message-Type`
+  header) plus a per-VM **gateway Unix socket** carrying the guest's stdio. The
+  gateway path is returned in the `NEW` response; the host-side consumer connects
+  to it to exchange stdin/stdout.
+
+Common options:
 
 - `-bin-dir DIR` — directory containing `kernel.elf` (default `./bin`).
 - `-mount DIR` — serve the guest's HostFS requests via `hostfsd`, rooted at `DIR`.
 - `-allow-host-networking` — serve the guest's networking via `networkd`.
 - `-console-file PATH` — route the guest kernel console here (default: stderr).
 - `-ramfs IMG`, `-kernel-args ARGS` — as in the Nanvix daemon.
-- `PROGRAM` after `--` is booted as the initrd; its `ARGS` become the guest
-  command line.
+
+For drop-in parity, the flags `-clh-bin-path`, `-hwloc`, `-log-dir`, and
+`-netns-pool-size` are accepted and ignored (they are not meaningful for a
+single-vCPU standalone OpenVMM guest); `-l2` is rejected.
 
 Examples:
 
 ```bash
-# Host filesystem mount test.
+# Terminal mode: host filesystem mount test.
 nanvixd-vmm -bin-dir ./bin -mount ./bin/mount-test-data -- ./bin/mount-test.initrd
 
-# Host networking test.
+# Terminal mode: host networking test.
 nanvixd-vmm -bin-dir ./bin -allow-host-networking -- ./bin/network-rust.initrd
+
+# HTTP mode: serve the NEW/KILL control API on 127.0.0.1:9999.
+nanvixd-vmm -bin-dir ./bin -http-addr 127.0.0.1:9999
 ```
 
 Set `NANVIXD_VMM_LOG=debug` for verbose host-side logging (emitted to stderr).
 
 ## Tests
 
-`run-standalone-tests.py` drives the `terminal`-executor cases from
-`nanvix/test/test-standalone.toml` against the built binary — including the
-host mount and networking cases served by the reused `hostfsd`/`networkd`
-daemons:
+Because `nanvixd-vmm` is a drop-in for `nanvixd.elf`, the canonical test path is
+the real Nanvix `nanvix-test` framework driven against it:
+
+```bash
+./z build -- all                       # guests + nanvix-test + test images
+./z build -- all-nanvixd-vmm           # the OpenVMM daemon (-> bin/nanvixd-vmm.elf)
+./bin/nanvix-test.elf test/test-standalone-openvmm.toml
+```
+
+`test/test-standalone-openvmm.toml` mirrors `test/test-standalone.toml` (same
+`empty`, `http`, and `terminal` cases, including the host mount and networking
+cases served by the reused `hostfsd`/`networkd` daemons) but points
+`nanvixd_binary_path` at `./bin/nanvixd-vmm.elf`. The `snapshot-restore` /
+`snapshot-save-exit` cases are omitted because snapshotting is not supported by
+this VMM. This is exactly what the `ci-openvmm` CI job runs.
+
+For quick terminal-only iteration without the full harness, `run-standalone-tests.py`
+drives the `terminal`-executor cases from `test/test-standalone.toml` directly
+against the built binary:
 
 ```bash
 cargo build -p nanvixd-vmm           # or ./build.sh
 python3 run-standalone-tests.py      # add --verbose to print commands
 ```
-
-Expected: all `terminal` cases pass; the only skips are the HTTP/snapshot
-executors and two escaped-semicolon argument cases the harness does not model.
 
 ## Benchmarks: OpenVMM vs uservm
 

--- a/src/utils/nanvixd-vmm/bench-compare.py
+++ b/src/utils/nanvixd-vmm/bench-compare.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Side-by-side performance comparison: Nanvix on OpenVMM vs its own uservm VMM.
+
+This runs the **native** Nanvix `nanvix-bench` standalone benchmarks twice using
+the *same* measurement code, changing only the VMM front-end being driven:
+
+  - uservm  : the native `bin/nanvixd.elf` (Nanvix's own KVM/WHP VMM), and
+  - openvmm : the OpenVMM-based `nanvixd-vmm` (this port),
+
+selected via the `NANVIX_BENCH_NANVIXD` environment variable the harness honors.
+Because one driver measures both, the comparison is apples-to-apples.
+
+Supported benchmarks (the standalone-applicable set): `cold-start`, `vfs-bench`.
+
+Prerequisites (release builds, for a fair comparison):
+  ./z build --release LOG_LEVEL=panic                 # guests + bin/nanvixd.elf
+  src/utils/nanvixd-vmm/build.sh --release             # target/release/nanvixd-vmm
+  RELEASE=yes LOG_LEVEL=panic MEMORY_SIZE_BYTES=$((128*1048576)) \\
+      cargo build -p nanvix-bench --no-default-features --features standalone,microvm
+
+Usage:
+    bench-compare.py [--benchmark cold-start|vfs-bench|all] [--iterations N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+import select
+from pathlib import Path
+
+
+def nanvix_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def percentiles(latencies_us: list[float]) -> dict[str, int]:
+    s = sorted(latencies_us)
+    n = len(s)
+
+    def pick(p: float) -> int:
+        return int(s[min(int(n * p), n - 1)])
+
+    return {
+        "min": int(s[0]),
+        "p50": pick(0.50),
+        "p95": pick(0.95),
+        "p99": pick(0.99),
+        "mean": int(sum(s) / n),
+    }
+
+
+def run_warm_start(
+    vmm: Path | None, iterations: int, warmup: int, payload_size: int, timeout: int
+) -> dict[str, int]:
+    """Measures the warm round-trip latency of one host->guest->host echo cycle.
+
+    Boots the echo guest once, then repeatedly writes `payload_size` bytes to the
+    VMM's stdin and reads them back from its stdout, timing each round trip. This
+    is the subprocess (black-box) analogue of the native `warm-start-vmm`: it
+    measures the communication latency *in and out of the VMM* through its IKC
+    stdio bridge. `vmm=None` uses the native uservm `bin/nanvixd.elf`.
+    """
+    root = nanvix_root()
+    binary = vmm if vmm is not None else (root / "bin" / "nanvixd.elf")
+    program = "./bin/echo-rust-nostd.initrd"
+    payload = bytes((i % 251) for i in range(payload_size))
+
+    proc = subprocess.Popen(
+        [str(binary), "-bin-dir", "./bin", "--", program],
+        cwd=str(root),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        bufsize=0,
+    )
+    out_fd = proc.stdout.fileno()
+
+    def read_exact(n: int, deadline: float) -> bytes:
+        buf = b""
+        while len(buf) < n:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("echo round-trip timed out")
+            r, _, _ = select.select([out_fd], [], [], remaining)
+            if not r:
+                continue
+            chunk = os.read(out_fd, n - len(buf))
+            if not chunk:
+                raise EOFError("guest closed stdout")
+            buf += chunk
+        return buf
+
+    def one_round_trip() -> float:
+        t0 = time.monotonic()
+        proc.stdin.write(payload)
+        proc.stdin.flush()
+        read_exact(len(payload), t0 + timeout)
+        return (time.monotonic() - t0) * 1e6  # microseconds
+
+    try:
+        for _ in range(warmup):
+            one_round_trip()
+        latencies = [one_round_trip() for _ in range(iterations)]
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+    return percentiles(latencies)
+
+
+def compare_warm_start(
+    iters: int, openvmm: Path, timeout: int, payload: int, warmup: int
+) -> None:
+    print(
+        f"\n### warm-start  ({iters} iterations, {payload}-byte payload, "
+        f"{warmup} warmup) — round-trip latency in microseconds\n"
+    )
+    uvm = run_warm_start(None, iters, warmup, payload, timeout)
+    ovm = run_warm_start(openvmm, iters, warmup, payload, timeout)
+    print(f"{'metric':<10} {'uservm':>10} {'openvmm':>10} {'uvm/ovm':>9}")
+    print("-" * 42)
+    for k in ("min", "p50", "p95", "p99", "mean"):
+        print(f"{k:<10} {uvm[k]:>10} {ovm[k]:>10} {ratio(uvm[k], ovm[k]):>9}")
+
+
+def nanvix_bench_binary() -> Path:
+    """Prefers the release nanvix-bench (fair white-box uservm), else debug."""
+    root = nanvix_root()
+    rel = root / "target" / "release" / "nanvix-bench"
+    dbg = root / "target" / "debug" / "nanvix-bench"
+    if rel.exists():
+        return rel
+    if dbg.exists():
+        return dbg
+    sys.exit("error: nanvix-bench not found (build it; see header).")
+
+
+def run_bench(bench: str, iterations: int, nanvixd: Path | None, timeout: int) -> str:
+    """Runs nanvix-bench once; returns its stdout. `nanvixd=None` uses uservm."""
+    root = nanvix_root()
+    binary = nanvix_bench_binary()
+    env = dict(os.environ)
+    if nanvixd is not None:
+        env["NANVIX_BENCH_NANVIXD"] = str(nanvixd)
+    else:
+        env.pop("NANVIX_BENCH_NANVIXD", None)
+    proc = subprocess.run(
+        [str(binary), "-benchmark", bench, "-iterations", str(iterations)],
+        cwd=str(root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=timeout,
+    )
+    return proc.stdout.decode(errors="replace")
+
+
+def parse_latency(text: str) -> dict[str, int]:
+    """Parses any of first/min/p50/p95/p99/mean latency lines (`<key>: N us`)."""
+    out: dict[str, int] = {}
+    for key, label in (
+        ("First req", "first"),
+        ("min", "min"),
+        ("p50", "p50"),
+        ("p95", "p95"),
+        ("p99", "p99"),
+        ("mean", "mean"),
+    ):
+        m = re.search(rf"(?m)^\s*{re.escape(key)}:\s*(\d+)\s*us", text)
+        if m:
+            out[label] = int(m.group(1))
+    return out
+
+
+def run_openvmm_warmstart_inproc(
+    warmstart_bin: Path, iters: int, warmup: int, payload: int, timeout: int
+) -> dict[str, int]:
+    """Runs the in-process (white-box) OpenVMM warm-start binary."""
+    proc = subprocess.run(
+        [
+            str(warmstart_bin),
+            "-bin-dir",
+            "./bin",
+            "-iterations",
+            str(iters),
+            "-warmup",
+            str(warmup),
+            "-payload",
+            str(payload),
+        ],
+        cwd=str(nanvix_root()),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=timeout,
+    )
+    return parse_latency(proc.stdout.decode(errors="replace"))
+
+
+def compare_warm_start_vmm(
+    iters: int, openvmm: Path, timeout: int, payload: int, warmup: int
+) -> None:
+    """White-box: raw in/out-VMM IKC round trip, in-process (no OS pipe)."""
+    print(
+        f"\n### warm-start-vmm  ({iters} iterations) — WHITE-BOX in-process IKC "
+        f"round-trip latency (us)\n"
+    )
+    warmstart_bin = openvmm.with_name("nanvixd-vmm-warmstart")
+    if not warmstart_bin.exists():
+        sys.exit(f"error: {warmstart_bin} not found; run build.sh --release.")
+    # uservm: native in-process `warm-start-vmm` (links uservm; needs release nanvix-bench).
+    uvm = parse_latency(run_bench("warm-start-vmm", iters, None, timeout))
+    # openvmm: in-process ChannelGuestIo round-trip.
+    ovm = run_openvmm_warmstart_inproc(warmstart_bin, iters, warmup, payload, timeout)
+    print(f"{'metric':<10} {'uservm':>10} {'openvmm':>10} {'uvm/ovm':>9}")
+    print("-" * 42)
+    for k in ("p50", "p95", "p99"):
+        if k in uvm and k in ovm:
+            print(f"{k:<10} {uvm[k]:>10} {ovm[k]:>10} {ratio(uvm[k], ovm[k]):>9}")
+
+
+def parse_cold_start(text: str) -> dict[str, int]:
+    return parse_latency(text)
+
+
+def parse_vfs(text: str) -> dict[str, dict[str, int]]:
+    """Returns {"<section>/<op>": {p50,p95,p99}}."""
+    rows: dict[str, dict[str, int]] = {}
+    section = None
+    for line in text.splitlines():
+        if line.startswith("Writable mount"):
+            section = "writable"
+            continue
+        if line.startswith("Read-only mount"):
+            section = "readonly"
+            continue
+        m = re.match(r"^(\S[\S+]*)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*$", line)
+        if m and section:
+            name, _samples, p50, p95, p99 = m.groups()
+            rows[f"{section}/{name}"] = {
+                "p50": int(p50),
+                "p95": int(p95),
+                "p99": int(p99),
+            }
+    return rows
+
+
+def ratio(a: int, b: int) -> str:
+    """uservm/openvmm ratio (>1 means OpenVMM faster)."""
+    if b == 0:
+        return "n/a"
+    return f"{a / b:.2f}x"
+
+
+def compare_cold_start(iters: int, openvmm: Path, timeout: int) -> None:
+    print(f"\n### cold-start  ({iters} iterations) — latency in microseconds\n")
+    uvm = parse_cold_start(run_bench("cold-start", iters, None, timeout))
+    ovm = parse_cold_start(run_bench("cold-start", iters, openvmm, timeout))
+    print(f"{'metric':<10} {'uservm':>10} {'openvmm':>10} {'uvm/ovm':>9}")
+    print("-" * 42)
+    for k in ("first", "p50", "p95", "p99"):
+        if k in uvm and k in ovm:
+            print(f"{k:<10} {uvm[k]:>10} {ovm[k]:>10} {ratio(uvm[k], ovm[k]):>9}")
+
+
+def compare_vfs(iters: int, openvmm: Path, timeout: int) -> None:
+    print(f"\n### vfs-bench  ({iters} iterations) — per-op latency (us), p50\n")
+    uvm = parse_vfs(run_bench("vfs-bench", iters, None, timeout))
+    ovm = parse_vfs(run_bench("vfs-bench", iters, openvmm, timeout))
+    print(f"{'section/op':<30} {'uservm':>8} {'openvmm':>8} {'uvm/ovm':>9}")
+    print("-" * 58)
+    for key in uvm:
+        if key in ovm:
+            a, b = uvm[key]["p50"], ovm[key]["p50"]
+            print(f"{key:<30} {a:>8} {b:>8} {ratio(a, b):>9}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--benchmark",
+        choices=["cold-start", "vfs-bench", "warm-start", "warm-start-vmm", "all"],
+        default="all",
+    )
+    ap.add_argument(
+        "--iterations",
+        type=int,
+        default=0,
+        help="override iterations (default: 100 cold-start, 1000 others)",
+    )
+    ap.add_argument(
+        "--payload",
+        type=int,
+        default=32,
+        help="warm-start round-trip payload size in bytes (default: 32)",
+    )
+    ap.add_argument(
+        "--warmup",
+        type=int,
+        default=50,
+        help="warm-start untimed warmup round trips (default: 50)",
+    )
+    ap.add_argument(
+        "--openvmm",
+        type=Path,
+        default=None,
+        help="path to nanvixd-vmm (default: target/release/nanvixd-vmm)",
+    )
+    ap.add_argument("--timeout", type=int, default=600)
+    args = ap.parse_args()
+
+    openvmm = (
+        args.openvmm or (nanvix_root() / "target" / "release" / "nanvixd-vmm")
+    ).resolve()
+    if not openvmm.exists():
+        sys.exit(
+            f"error: OpenVMM binary not found at {openvmm}; run build.sh --release."
+        )
+
+    print(f"uservm  = {nanvix_root() / 'bin' / 'nanvixd.elf'}")
+    print(f"openvmm = {openvmm}")
+
+    if args.benchmark in ("cold-start", "all"):
+        compare_cold_start(args.iterations or 100, openvmm, args.timeout)
+    if args.benchmark in ("warm-start", "all"):
+        compare_warm_start(
+            args.iterations or 1000,
+            openvmm,
+            min(args.timeout, 30),
+            args.payload,
+            args.warmup,
+        )
+    if args.benchmark in ("warm-start-vmm", "all"):
+        compare_warm_start_vmm(
+            args.iterations or 1000, openvmm, args.timeout, args.payload, args.warmup
+        )
+    if args.benchmark in ("vfs-bench", "all"):
+        compare_vfs(args.iterations or 1000, openvmm, args.timeout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/utils/nanvixd-vmm/build.rs
+++ b/src/utils/nanvixd-vmm/build.rs
@@ -1,0 +1,11 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Build script for nanvixd-vmm.
+//!
+//! Emits the `guest_arch`/`guest_is_native` cfgs expected by the OpenVMM
+//! virtualization crates this crate depends on.
+
+fn main() {
+    build_rs_guest_arch::emit_guest_arch()
+}

--- a/src/utils/nanvixd-vmm/build.sh
+++ b/src/utils/nanvixd-vmm/build.sh
@@ -49,8 +49,8 @@ if [[ -z "${PROTOC:-}" ]]; then
         if [[ -x "${CANDIDATE}" ]]; then
             export PROTOC="${CANDIDATE}"
         else
-            echo "[ERROR] protoc not found. Install it (e.g. 'apt-get install" >&2
-            echo "        protobuf-compiler'), set PROTOC, or restore OpenVMM's packages." >&2
+            echo "[ERROR] protoc not found. Install it (e.g. 'apt-get install protobuf-compiler')," >&2
+            echo "        set PROTOC, or restore OpenVMM's packages." >&2
             exit 1
         fi
     fi

--- a/src/utils/nanvixd-vmm/build.sh
+++ b/src/utils/nanvixd-vmm/build.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# Convenience wrapper to build the `nanvixd-vmm` crate directly with cargo, for
+# quick iteration. The canonical, fully-integrated build goes through the Nanvix
+# build system instead:
+#
+#   ./z build -- all-nanvixd-vmm     # from the Nanvix repo root
+#
+# The crate's OpenVMM sources are git dependencies pinned to a revision in
+# Cargo.toml (no local OpenVMM checkout needed for sources), and the required
+# `[patch.crates-io]` entries live in the workspace root. Two things a bare
+# `cargo build` does not provide on its own:
+#
+#   - MEMORY_SIZE_BYTES : consumed by the Nanvix `config` crate's build script
+#                         (normally exported by the Nanvix Makefile). Defaults
+#                         to 128 MiB here.
+#   - PROTOC            : the Protocol Buffers compiler, required by transitive
+#                         OpenVMM build dependencies (e.g. `tdisp_proto` via
+#                         `prost-build`). Resolved from $PROTOC, then a system
+#                         `protoc`, then OpenVMM's restored copy.
+#
+# Any extra arguments are forwarded to `cargo build` (e.g. `--release`).
+#
+# Usage:
+#   ./build.sh                # debug build
+#   ./build.sh --release      # release build
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NANVIX_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# Memory size (MiB) -> bytes, mirroring the Nanvix Makefile default.
+MEMORY_SIZE_MB="${MEMORY_SIZE:-128}"
+export MEMORY_SIZE_BYTES="${MEMORY_SIZE_BYTES:-$((MEMORY_SIZE_MB * 1048576))}"
+
+# Resolve protoc: explicit PROTOC, then system protoc, then OpenVMM's restored copy.
+if [[ -z "${PROTOC:-}" ]]; then
+    if command -v protoc &>/dev/null; then
+        PROTOC="$(command -v protoc)"
+        export PROTOC
+    else
+        CANDIDATE="${NANVIX_ROOT}/../OpenVMM/.packages/Google.Protobuf.Tools/tools/protoc"
+        if [[ -x "${CANDIDATE}" ]]; then
+            export PROTOC="${CANDIDATE}"
+        else
+            echo "[ERROR] protoc not found. Install it (e.g. 'apt-get install" >&2
+            echo "        protobuf-compiler'), set PROTOC, or restore OpenVMM's packages." >&2
+            exit 1
+        fi
+    fi
+fi
+
+echo "[nanvixd-vmm] MEMORY_SIZE_BYTES=${MEMORY_SIZE_BYTES} PROTOC=${PROTOC}"
+exec cargo build --manifest-path "${NANVIX_ROOT}/Cargo.toml" -p nanvixd-vmm "$@"

--- a/src/utils/nanvixd-vmm/run-standalone-tests.py
+++ b/src/utils/nanvixd-vmm/run-standalone-tests.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Run the Nanvix standalone test suite against the OpenVMM-based ``nanvixd-vmm``.
+
+This harness reads Nanvix's own ``test/test-standalone.toml`` and executes the
+``terminal`` executor test cases against the ``nanvixd-vmm`` binary, which boots
+the Nanvix guest on the OpenVMM virtualization stack while reusing the real
+Nanvix host-side daemons (``hostfsd`` and ``networkd``).
+
+Because it reuses the real host-side daemons, this runner also supports the
+host filesystem mount (``-mount``) and host networking (``-allow-host-networking``)
+cases, so those are executed rather than skipped.
+
+Each case's input is bridged to the guest's stdin, the guest's stdout is
+captured, and the result (and/or exit code) is compared against the expected
+value. Cases requiring the HTTP executor or snapshots remain out of scope and
+are skipped.
+
+Usage:
+    run-standalone-tests.py --nanvix-dir <path-to-nanvix-repo> \\
+        [--vmm <path-to-nanvixd-vmm>] [--timeout <seconds>] [--verbose]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+# Executors this standalone runner does not implement.
+UNSUPPORTED_EXECUTORS = ("http", "snapshot-restore", "snapshot-save-exit")
+
+
+@dataclass
+class Result:
+    name: str
+    status: str  # "pass", "fail", "skip"
+    detail: str = ""
+
+
+def build_initrd_args(
+    program_args: str, program_env: str, padding_len: int
+) -> str | None:
+    """Builds the guest command-line tail (``"<args>;<env>"``)."""
+    args = program_args
+    if padding_len:
+        # The cmdline-length test pads the argument string to a fixed size.
+        pad = padding_len - len(args)
+        if pad > 0:
+            args = args + ("a" * pad if not args else " " + "a" * (pad - 1))
+    if program_env:
+        return f"{args};{program_env}"
+    if args:
+        return args
+    return None
+
+
+def run_case(
+    vmm: Path, nanvix_dir: Path, test: dict, timeout: int, verbose: bool
+) -> Result:
+    name = test.get("name") or test["program"]
+    executor = test.get("executor", "")
+
+    if executor in UNSUPPORTED_EXECUTORS:
+        return Result(name, "skip", f"executor '{executor}' not supported")
+
+    program_args = test.get("program_args", "")
+    program_env = test.get("program_env", "")
+    # Literal ';' in args/env needs an escaping scheme this harness does not model.
+    if ";" in program_args or ";" in program_env:
+        return Result(name, "skip", "escaped-semicolon argument case")
+
+    program = nanvix_dir / test["program"].lstrip("./")
+    if not program.exists():
+        return Result(name, "skip", f"missing program {program}")
+
+    initrd_args = build_initrd_args(
+        program_args, program_env, test.get("program_args_padding_len", 0)
+    )
+
+    # Run from the Nanvix directory so the relative `./bin/...` paths in the
+    # test's `extra_nanvixd_args` (e.g. `-mount ./bin/mount-test-data`) resolve
+    # exactly as the native test runner expects.
+    cmd = [str(vmm), "-bin-dir", "./bin"]
+    extra = test.get("extra_nanvixd_args", "")
+    if extra:
+        cmd += extra.split()
+    cmd += ["--", "./" + test["program"].lstrip("./")]
+    if initrd_args is not None:
+        cmd.append(initrd_args)
+
+    # The terminal executor feeds `input` to the guest's stdin.
+    stdin_data = test.get("input", "")
+    if isinstance(stdin_data, list):
+        stdin_data = ""
+
+    if verbose:
+        print(f"    $ {' '.join(cmd)}", file=sys.stderr)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin_data.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+            cwd=str(nanvix_dir),
+        )
+    except subprocess.TimeoutExpired:
+        return Result(name, "fail", f"timed out after {timeout}s")
+
+    stdout = proc.stdout.decode(errors="replace")
+    exit_code = proc.returncode
+
+    if "expected_exit_code" in test and exit_code != test["expected_exit_code"]:
+        return Result(
+            name, "fail", f"exit {exit_code} != expected {test['expected_exit_code']}"
+        )
+
+    if test.get("expect_empty_output"):
+        if stdout.strip():
+            return Result(name, "fail", f"expected empty output, got {stdout!r}")
+    elif "expected_output" in test:
+        if stdout.strip() != test["expected_output"].strip():
+            return Result(
+                name,
+                "fail",
+                f"output {stdout.strip()!r} != expected "
+                f"{test['expected_output'].strip()!r}",
+            )
+
+    return Result(name, "pass", f"exit={exit_code}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--nanvix-dir",
+        type=Path,
+        default=None,
+        help="Path to the Nanvix repository (with built bin/).",
+    )
+    parser.add_argument(
+        "--vmm", type=Path, default=None, help="Path to the nanvixd-vmm binary."
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=60, help="Per-test timeout in seconds."
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    # Default the Nanvix directory to the workspace root that contains this crate.
+    nanvix_dir = (args.nanvix_dir or Path(__file__).resolve().parents[3]).resolve()
+    kernel = nanvix_dir / "bin" / "kernel.elf"
+    if not kernel.exists():
+        print(
+            f"error: kernel not found at {kernel}; build Nanvix first", file=sys.stderr
+        )
+        return 2
+
+    vmm = (args.vmm or (nanvix_dir / "target" / "debug" / "nanvixd-vmm")).resolve()
+    if not vmm.exists():
+        print(
+            f"error: nanvixd-vmm not found at {vmm}; run "
+            f"`cargo build -p nanvixd-vmm`",
+            file=sys.stderr,
+        )
+        return 2
+
+    toml_path = nanvix_dir / "test" / "test-standalone.toml"
+    with toml_path.open("rb") as f:
+        config = tomllib.load(f)
+    tests = config.get("tests", [])
+
+    print("=== standalone deployment via nanvixd-vmm (reusing hostfsd/networkd) ===")
+    results: list[Result] = []
+    for test in tests:
+        if test.get("executor") != "terminal":
+            continue
+        result = run_case(vmm, nanvix_dir, test, args.timeout, args.verbose)
+        results.append(result)
+        symbol = {"pass": "PASS", "fail": "FAIL", "skip": "SKIP"}[result.status]
+        print(f"[{symbol}] {result.name}  ({result.detail})")
+
+    passed = sum(1 for r in results if r.status == "pass")
+    failed = sum(1 for r in results if r.status == "fail")
+    skipped = sum(1 for r in results if r.status == "skip")
+    print(f"\nnanvixd-vmm: {passed} passed, {failed} failed, {skipped} skipped")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/utils/nanvixd-vmm/src/bin/nanvixd-vmm-warmstart.rs
+++ b/src/utils/nanvixd-vmm/src/bin/nanvixd-vmm-warmstart.rs
@@ -1,0 +1,163 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! White-box warm-start benchmark for the OpenVMM-based Nanvix guest.
+//!
+//! Boots the echo guest once with an in-process [`ChannelGuestIo`] endpoint
+//! (no operating-system pipe) and times many host -> guest -> host stdio round
+//! trips. This isolates the latency *in and out of the VMM* over its IKC path,
+//! giving parity with the native Nanvix `warm-start-vmm` micro-benchmark. It is
+//! driven by `bench-compare.py`, which parses the `<metric>: <N> us` lines this
+//! binary prints to stdout.
+
+use ::nanvixd_vmm::{
+    build_guest_image,
+    init_logging,
+    io::ChannelGuestIo,
+    open_console,
+    vmm,
+    DEFAULT_MEM_SIZE,
+};
+use ::std::{
+    path::PathBuf,
+    process::ExitCode,
+    time::Instant,
+};
+
+/// Environment variable that overrides the host-side log filter.
+const LOG_ENV_VAR: &str = "NANVIXD_VMM_LOG";
+
+/// The echo guest used for the round-trip measurement.
+const ECHO_PROGRAM: &str = "echo-rust-nostd.initrd";
+
+/// Parsed benchmark configuration.
+struct Args {
+    /// Directory containing `kernel.elf` and the echo guest.
+    bin_dir: PathBuf,
+    /// Number of timed round trips.
+    iterations: usize,
+    /// Number of untimed warmup round trips.
+    warmup: usize,
+    /// Payload size, in bytes, per round trip.
+    payload: usize,
+}
+
+impl Args {
+    /// Parses arguments with the defaults `bench-compare.py` relies on.
+    fn parse(mut args: impl Iterator<Item = String>) -> ::anyhow::Result<Self> {
+        let mut parsed = Args {
+            bin_dir: PathBuf::from("./bin"),
+            iterations: 1000,
+            warmup: 100,
+            payload: 1,
+        };
+        let _ = args.next();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "-bin-dir" => parsed.bin_dir = PathBuf::from(value(&mut args, "-bin-dir")?),
+                "-iterations" => parsed.iterations = value(&mut args, "-iterations")?.parse()?,
+                "-warmup" => parsed.warmup = value(&mut args, "-warmup")?.parse()?,
+                "-payload" => parsed.payload = value(&mut args, "-payload")?.parse()?,
+                other => anyhow::bail!("unknown argument: {other}"),
+            }
+        }
+        if parsed.iterations == 0 {
+            anyhow::bail!("-iterations must be greater than zero");
+        }
+        if parsed.payload == 0 {
+            anyhow::bail!("-payload must be greater than zero");
+        }
+        Ok(parsed)
+    }
+}
+
+/// Returns the value following an option, or an error if it is missing.
+fn value(args: &mut impl Iterator<Item = String>, option: &str) -> ::anyhow::Result<String> {
+    args.next()
+        .ok_or_else(|| anyhow::anyhow!("missing value for {option}"))
+}
+
+fn main() -> ExitCode {
+    init_logging(LOG_ENV_VAR);
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            ::log::error!("nanvixd-vmm-warmstart failed: {e:?}");
+            ExitCode::FAILURE
+        },
+    }
+}
+
+fn run() -> ::anyhow::Result<()> {
+    let args: Args = Args::parse(::std::env::args())?;
+
+    let image = build_guest_image(
+        &args.bin_dir,
+        Some(args.bin_dir.join(ECHO_PROGRAM)),
+        None,
+        None,
+        None,
+        DEFAULT_MEM_SIZE,
+    );
+    // Keep the guest console off stdout so it never mixes with the report.
+    let console = open_console(None)?;
+
+    let (guest_io, mut handle) = ChannelGuestIo::pair();
+    let vm_thread = ::std::thread::Builder::new()
+        .name("nanvixd-vmm-warmstart-guest".to_string())
+        .spawn(move || {
+            ::pal_async::DefaultPool::run_with(move |driver| async move {
+                vmm::run(driver, image, Box::new(guest_io), console, None, false).await
+            })
+        })?;
+
+    let payload: Vec<u8> = vec![b'a'; args.payload];
+
+    // Warmup round trips (untimed): also lets the guest finish booting before we
+    // start measuring.
+    for _ in 0..args.warmup {
+        handle.send(&payload);
+        if !handle.read_exact(payload.len()) {
+            anyhow::bail!("guest closed stdout during warmup");
+        }
+    }
+
+    // Timed round trips.
+    let mut latencies_us: Vec<u64> = Vec::with_capacity(args.iterations);
+    for _ in 0..args.iterations {
+        let start = Instant::now();
+        handle.send(&payload);
+        if !handle.read_exact(payload.len()) {
+            anyhow::bail!("guest closed stdout during measurement");
+        }
+        latencies_us.push(start.elapsed().as_micros() as u64);
+    }
+
+    // Signal EOF so the guest exits, then reap the VM thread.
+    handle.close_input();
+    let _ = vm_thread.join();
+
+    report(&mut latencies_us);
+    Ok(())
+}
+
+/// Prints the latency distribution in the `<metric>: <N> us` format the
+/// comparison harness parses.
+fn report(latencies_us: &mut [u64]) {
+    latencies_us.sort_unstable();
+    let n: usize = latencies_us.len();
+    let pick = |p: f64| -> u64 {
+        let index: usize = ((p * (n as f64 - 1.0)).round() as usize).min(n - 1);
+        latencies_us[index]
+    };
+    let sum: u128 = latencies_us.iter().map(|&v| u128::from(v)).sum();
+    let mean: u64 = (sum / n as u128) as u64;
+
+    println!("warm-start-vmm (in-process IKC round trip)");
+    println!("iterations: {n}");
+    println!("min: {} us", latencies_us[0]);
+    println!("p50: {} us", pick(0.50));
+    println!("p95: {} us", pick(0.95));
+    println!("p99: {} us", pick(0.99));
+    println!("mean: {mean} us");
+}

--- a/src/utils/nanvixd-vmm/src/bin/nanvixd-vmm.rs
+++ b/src/utils/nanvixd-vmm/src/bin/nanvixd-vmm.rs
@@ -1,0 +1,227 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! The `nanvixd-vmm` daemon: boots the Nanvix guest in **standalone** deployment
+//! on top of the OpenVMM virtualization stack, reusing the production host-side
+//! daemons (`hostfsd`, `networkd`).
+//!
+//! It is a drop-in for the production `nanvixd` standalone binary and supports
+//! the same two operating modes:
+//!
+//! - **terminal** (interactive): a program is given after `--`; the guest's
+//!   stdin/stdout are bridged to the daemon's stdin/stdout and the process exits
+//!   with the guest's exit code.
+//! - **http**: `-http-addr <host:port>` starts a control server exposing the
+//!   `NEW`/`KILL` API plus a per-VM gateway Unix socket (see [`nanvixd_vmm::http`]).
+//!
+//! The two modes are mutually exclusive.
+
+use ::nanvixd_vmm::{
+    build_guest_image,
+    http::{
+        self,
+        HttpConfig,
+    },
+    init_logging,
+    io::{
+        GuestIo,
+        HostGuestIo,
+    },
+    open_console,
+    stdin::HostStdin,
+    vmm,
+    DEFAULT_MEM_SIZE,
+};
+use ::std::{
+    path::PathBuf,
+    process::ExitCode,
+};
+
+/// Environment variable that overrides the host-side log filter.
+const LOG_ENV_VAR: &str = "NANVIXD_VMM_LOG";
+
+/// Largest POSIX exit code; out-of-range guest codes clamp to this.
+const MAX_EXIT_CODE: i32 = 255;
+
+/// Parsed command-line configuration.
+struct Cli {
+    /// Directory containing `kernel.elf` and guest binaries.
+    bin_dir: PathBuf,
+    /// Optional RAM filesystem image.
+    ramfs: Option<PathBuf>,
+    /// Optional kernel arguments.
+    kernel_args: Option<String>,
+    /// Optional guest console sink file (default: stderr).
+    console_file: Option<PathBuf>,
+    /// Optional host directory served to the guest via `hostfsd`.
+    mount_directory: Option<PathBuf>,
+    /// Whether host networking is served via `networkd`.
+    networking: bool,
+    /// HTTP socket address; when set, the daemon runs in HTTP mode.
+    http_addr: Option<String>,
+    /// Program (initrd) to boot in terminal mode.
+    program: Option<String>,
+    /// Arguments forwarded to the program in terminal mode.
+    program_args: Vec<String>,
+}
+
+impl Cli {
+    /// Parses arguments, accepting (and ignoring where appropriate) the flags
+    /// that the production `nanvixd` accepts so this binary is a drop-in.
+    fn parse(mut args: impl Iterator<Item = String>) -> ::anyhow::Result<Self> {
+        let mut cli = Cli {
+            bin_dir: PathBuf::from("./bin"),
+            ramfs: None,
+            kernel_args: None,
+            console_file: None,
+            mount_directory: None,
+            networking: false,
+            http_addr: None,
+            program: None,
+            program_args: Vec::new(),
+        };
+
+        // Skip the program name.
+        let _ = args.next();
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "-bin-dir" => cli.bin_dir = PathBuf::from(require_value(&mut args, "-bin-dir")?),
+                "-ramfs" => cli.ramfs = Some(PathBuf::from(require_value(&mut args, "-ramfs")?)),
+                "-kernel-args" => cli.kernel_args = Some(require_value(&mut args, "-kernel-args")?),
+                "-console-file" => {
+                    cli.console_file =
+                        Some(PathBuf::from(require_value(&mut args, "-console-file")?))
+                },
+                "-mount" => {
+                    cli.mount_directory = Some(PathBuf::from(require_value(&mut args, "-mount")?))
+                },
+                "-allow-host-networking" => cli.networking = true,
+                "-http-addr" => cli.http_addr = Some(require_value(&mut args, "-http-addr")?),
+                // Flags accepted from the production `nanvixd` for drop-in
+                // compatibility but not meaningful for a single-vCPU standalone
+                // OpenVMM guest. They take a value, which we discard.
+                "-clh-bin-path" | "-hwloc" | "-log-dir" | "-netns-pool-size" => {
+                    let _ = require_value(&mut args, &arg)?;
+                },
+                // L2 deployment is not supported by this standalone VMM.
+                "-l2" => anyhow::bail!("-l2 (L2 deployment) is not supported by nanvixd-vmm"),
+                // Everything after `--` is the program and its arguments.
+                "--" => {
+                    if let Some(program) = args.next() {
+                        cli.program = Some(program);
+                        cli.program_args = args.by_ref().collect();
+                    }
+                    break;
+                },
+                other => anyhow::bail!("unknown argument: {other}"),
+            }
+        }
+
+        if cli.http_addr.is_some() && cli.program.is_some() {
+            anyhow::bail!(
+                "http mode (-http-addr) and interactive mode (-- program) are mutually exclusive"
+            );
+        }
+        if cli.http_addr.is_none() && cli.program.is_none() {
+            anyhow::bail!(
+                "no mode selected: pass -http-addr <host:port> for HTTP mode or `-- <program> \
+                 [args...]` for terminal mode"
+            );
+        }
+
+        Ok(cli)
+    }
+}
+
+/// Returns the value following an option, or an error if it is missing.
+fn require_value(
+    args: &mut impl Iterator<Item = String>,
+    option: &str,
+) -> ::anyhow::Result<String> {
+    args.next()
+        .ok_or_else(|| anyhow::anyhow!("missing value for {option}"))
+}
+
+fn main() -> ExitCode {
+    init_logging(LOG_ENV_VAR);
+
+    let cli: Cli = match Cli::parse(::std::env::args()) {
+        Ok(cli) => cli,
+        Err(e) => {
+            ::log::error!("{e}");
+            return ExitCode::FAILURE;
+        },
+    };
+
+    let result: ::anyhow::Result<ExitCode> = if let Some(http_addr) = cli.http_addr.clone() {
+        run_http(&cli, &http_addr)
+    } else {
+        run_terminal(cli)
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            ::log::error!("nanvixd-vmm failed: {e:?}");
+            ExitCode::FAILURE
+        },
+    }
+}
+
+/// Runs the daemon in terminal (interactive) mode and returns the guest's code.
+fn run_terminal(cli: Cli) -> ::anyhow::Result<ExitCode> {
+    let program: String = cli.program.expect("terminal mode requires a program");
+    let initrd_args: Option<String> = if cli.program_args.is_empty() {
+        None
+    } else {
+        Some(cli.program_args.join(" "))
+    };
+
+    let image = build_guest_image(
+        &cli.bin_dir,
+        Some(PathBuf::from(program)),
+        initrd_args,
+        cli.kernel_args,
+        cli.ramfs,
+        DEFAULT_MEM_SIZE,
+    );
+    let console = open_console(cli.console_file.as_deref())?;
+    let io: Box<dyn GuestIo> = Box::new(HostGuestIo::new(HostStdin::spawn()));
+    let mount_directory: Option<PathBuf> = cli.mount_directory;
+    let networking: bool = cli.networking;
+
+    let exit_code: u16 = ::pal_async::DefaultPool::run_with(move |driver| async move {
+        vmm::run(driver, image, io, console, mount_directory, networking).await
+    })?;
+
+    Ok(ExitCode::from(clamp_exit_code(i32::from(exit_code))))
+}
+
+/// Runs the daemon in HTTP mode until a shutdown signal.
+fn run_http(cli: &Cli, http_addr: &str) -> ::anyhow::Result<ExitCode> {
+    let config = HttpConfig {
+        bin_dir: cli.bin_dir.clone(),
+        ramfs: cli.ramfs.clone(),
+        kernel_args: cli.kernel_args.clone(),
+        console_file: cli.console_file.clone(),
+        mount_directory: cli.mount_directory.clone(),
+        networking: cli.networking,
+        mem_size: DEFAULT_MEM_SIZE,
+    };
+
+    let runtime = ::tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(http::serve(http_addr, config))?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Clamps an exit code to the valid POSIX range `[0, 255]`.
+fn clamp_exit_code(exit_code: i32) -> u8 {
+    if (0..=MAX_EXIT_CODE).contains(&exit_code) {
+        exit_code as u8
+    } else {
+        MAX_EXIT_CODE as u8
+    }
+}

--- a/src/utils/nanvixd-vmm/src/device.rs
+++ b/src/utils/nanvixd-vmm/src/device.rs
@@ -1,0 +1,219 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! The MicroVM device model exposed to the Nanvix guest.
+//!
+//! Nanvix talks to its VMM through three I/O ports (console/stdout, stdin, and
+//! a control port) plus a shared-memory control page. This module implements
+//! the host side of that contract as a [`CpuIo`] device that the OpenVMM
+//! virtualization stack drives on each port-I/O exit, and forwards guest IKC
+//! traffic to the [`IkcBridge`](crate::ikc::IkcBridge) (which in turn reuses the
+//! Nanvix host-side daemons).
+
+use crate::ikc::IkcBridge;
+use ::guestmem::GuestMemory;
+use ::std::sync::{
+    Arc,
+    Mutex,
+};
+use ::sys::ipc::VmBusMessage;
+use ::virt::{
+    io::CpuIo,
+    StopVpSource,
+    VpIndex,
+};
+use ::vmotherboard::Chipset;
+
+/// How the virtual machine stopped.
+#[derive(Copy, Clone, Debug)]
+pub enum ExitReason {
+    /// The guest requested shutdown via the control port; carries the exit code.
+    Shutdown(u16),
+    /// The guest requested a snapshot (unsupported); treated as a clean stop.
+    Snapshot,
+}
+
+/// Line-buffered host sink for guest kernel-console output.
+struct Console {
+    sink: crate::ConsoleSink,
+    buf: Vec<u8>,
+}
+
+/// Host-side MicroVM device model.
+pub struct NanvixDevice<'a> {
+    /// Guest RAM, used to read message envelopes and payloads.
+    gm: GuestMemory,
+    /// Bridge that routes guest IKC traffic to stdio and the host daemons.
+    io: Mutex<IkcBridge>,
+    /// Source used to stop the vCPU when the guest requests shutdown.
+    stop: &'a StopVpSource,
+    /// Reason the VM stopped, populated when a control-port command arrives.
+    exit: Mutex<Option<ExitReason>>,
+    /// Host sink for the guest's kernel console, with a partial-line buffer.
+    console: Mutex<Console>,
+    /// Legacy chipset (8259 PIC + 8254 PIT) that owns the interrupt-controller
+    /// and timer port-I/O, the PIC acknowledge path, and EOI handling.
+    chipset: Arc<Chipset>,
+}
+
+impl<'a> NanvixDevice<'a> {
+    /// Creates a new device model.
+    pub fn new(
+        gm: GuestMemory,
+        io: IkcBridge,
+        stop: &'a StopVpSource,
+        chipset: Arc<Chipset>,
+        console: crate::ConsoleSink,
+    ) -> Self {
+        Self {
+            gm,
+            io: Mutex::new(io),
+            stop,
+            exit: Mutex::new(None),
+            console: Mutex::new(Console {
+                sink: console,
+                buf: Vec::new(),
+            }),
+            chipset,
+        }
+    }
+
+    /// Returns the reason the VM stopped, if a control-port command was seen.
+    pub fn take_exit(&self) -> Option<ExitReason> {
+        self.exit.lock().expect("exit lock").take()
+    }
+
+    /// Records a stop reason and asks the vCPU runner to stop.
+    fn request_stop(&self, reason: ExitReason) {
+        *self.exit.lock().expect("exit lock") = Some(reason);
+        self.stop.stop();
+    }
+
+    /// Emits a single guest console byte to the configured sink, line-buffered.
+    fn console_byte(&self, byte: u8) {
+        use std::io::Write as _;
+        let mut console = self.console.lock().expect("console lock");
+        console.buf.push(byte);
+        if byte == b'\n' {
+            let line = std::mem::take(&mut console.buf);
+            let _ = console.sink.write_all(&line);
+            let _ = console.sink.flush();
+        }
+    }
+
+    /// Handles a write to the control port: decodes the command and acts on it.
+    fn control_command(&self, value: u32) {
+        let command = (value >> 16) as u16;
+        let arg = (value & 0xffff) as u16;
+        match command {
+            config::microvm::DEFAULT_VMM_SHUTDOWN_CMD => {
+                self.request_stop(ExitReason::Shutdown(arg))
+            },
+            config::microvm::DEFAULT_VMM_SNAPSHOT_CMD => self.request_stop(ExitReason::Snapshot),
+            config::microvm::DEFAULT_VMM_PAUSE_CMD => {
+                // Pause is a no-op: there is no host actor to pause for.
+                log::debug!("guest requested pause; ignoring");
+            },
+            config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD => {
+                log::info!("guest boot complete");
+            },
+            other => log::warn!("unknown control-port command {other:#06x}"),
+        }
+    }
+
+    /// Reads a [`VmBusMessage`] envelope from guest memory.
+    fn read_envelope(&self, gpa: u32) -> anyhow::Result<VmBusMessage> {
+        let mut bytes = [0u8; VmBusMessage::SIZE];
+        self.gm.read_at(u64::from(gpa), &mut bytes)?;
+        VmBusMessage::try_from_bytes(bytes)
+            .map_err(|e| anyhow::anyhow!("failed to parse vmbus message: {e:?}"))
+    }
+
+    /// Dispatches an outbound (guest → host) IKC envelope.
+    fn on_stdout(&self, gpa: u32) {
+        match self.read_envelope(gpa) {
+            Ok(envelope) => {
+                let mut bridge = self.io.lock().expect("io lock");
+                if let Err(e) = bridge.guest_stdout(&self.gm, &envelope) {
+                    log::error!("failed to handle guest stdout: {e:?}");
+                }
+            },
+            Err(e) => log::error!("failed to read stdout envelope: {e:?}"),
+        }
+    }
+
+    /// Dispatches an inbound (host → guest) IKC fetch.
+    fn on_stdin(&self, gpa: u32) {
+        match self.read_envelope(gpa) {
+            Ok(envelope) => {
+                let mut bridge = self.io.lock().expect("io lock");
+                if let Err(e) = bridge.guest_stdin(&self.gm, &envelope) {
+                    log::error!("failed to handle guest stdin: {e:?}");
+                }
+            },
+            Err(e) => log::error!("failed to read stdin envelope: {e:?}"),
+        }
+    }
+}
+
+impl CpuIo for NanvixDevice<'_> {
+    fn is_mmio(&self, _address: u64) -> bool {
+        // The guest's only MMIO is the in-kernel local APIC, which the
+        // hypervisor handles directly; nothing is emulated in userspace.
+        false
+    }
+
+    fn acknowledge_pic_interrupt(&self) -> Option<u8> {
+        self.chipset.acknowledge_pic_interrupt()
+    }
+
+    fn handle_eoi(&self, irq: u32) {
+        self.chipset.handle_eoi(irq)
+    }
+
+    async fn read_mmio(&self, vp: VpIndex, address: u64, data: &mut [u8]) {
+        log::warn!("unexpected mmio read vp={} addr={address:#x}", vp.index());
+        data.fill(!0);
+    }
+
+    async fn write_mmio(&self, vp: VpIndex, address: u64, data: &[u8]) {
+        log::warn!("unexpected mmio write vp={} addr={address:#x} len={}", vp.index(), data.len());
+    }
+
+    async fn read_io(&self, vp: VpIndex, port: u16, data: &mut [u8]) {
+        // The Nanvix ports are write-only; everything else (PIC/PIT) is owned
+        // by the legacy chipset.
+        self.chipset.io_read(vp.index(), port, data).await;
+    }
+
+    async fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) {
+        let dword = || -> Option<u32> {
+            (data.len() == 4).then(|| u32::from_le_bytes([data[0], data[1], data[2], data[3]]))
+        };
+        match port {
+            config::microvm::DEFAULT_STDOUT_PORT => match data.len() {
+                1 => self.console_byte(data[0]),
+                4 => self.on_stdout(dword().expect("4-byte dword")),
+                n => log::warn!("unexpected stdout write width {n}"),
+            },
+            config::microvm::DEFAULT_STDIN_PORT => match dword() {
+                Some(gpa) => self.on_stdin(gpa),
+                None => log::warn!("unexpected stdin write width {}", data.len()),
+            },
+            config::microvm::DEFAULT_VMM_PORT => match dword() {
+                Some(value) => self.control_command(value),
+                None => log::warn!("unexpected control-port write width {}", data.len()),
+            },
+            // Everything else (the 8259 PIC and 8254 PIT legacy ports) is owned
+            // by the chipset device model.
+            _ => self.chipset.io_write(vp.index(), port, data).await,
+        }
+    }
+
+    fn fatal_error(&self, error: Box<dyn std::error::Error + Send + Sync>) -> virt::VpHaltReason {
+        log::error!("fatal vcpu error: {error}");
+        virt::VpHaltReason::TripleFault {
+            vtl: hvdef::Vtl::Vtl0,
+        }
+    }
+}

--- a/src/utils/nanvixd-vmm/src/http.rs
+++ b/src/utils/nanvixd-vmm/src/http.rs
@@ -58,13 +58,22 @@ use ::serde::{
 };
 use ::std::{
     future::Future,
-    os::unix::fs::PermissionsExt as _,
+    os::unix::fs::{
+        DirBuilderExt as _,
+        PermissionsExt as _,
+    },
     path::{
         Path,
         PathBuf,
     },
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicU64,
+            Ordering,
+        },
+        Arc,
+    },
     thread::JoinHandle,
 };
 use ::tokio::{
@@ -180,8 +189,9 @@ struct RunningVm {
     vm_thread: JoinHandle<u16>,
     /// Task bridging the gateway socket and the guest's stdio.
     gateway_bridge: ::tokio::task::JoinHandle<()>,
-    /// Filesystem path of the gateway socket (removed on teardown).
-    gateway_path: PathBuf,
+    /// Private (0700) directory holding the gateway socket; removed wholesale on
+    /// teardown.
+    gateway_dir: PathBuf,
 }
 
 /// Shared server state: the static config and the single running VM (if any).
@@ -261,7 +271,7 @@ pub async fn serve(sockaddr: &str, config: HttpConfig) -> ::anyhow::Result<()> {
 async fn teardown(state: &State) {
     if let Some(vm) = state.running.lock().await.take() {
         vm.gateway_bridge.abort();
-        remove_gateway_socket(&vm.gateway_path);
+        remove_gateway_dir(&vm.gateway_dir);
         // The guest thread is detached: it is reaped when the process exits.
     }
 }
@@ -396,8 +406,19 @@ async fn serve_new(state: &State, message: &New) -> ::anyhow::Result<NewResponse
     let mount_directory: Option<PathBuf> = config.mount_directory.clone();
     let networking: bool = config.networking;
 
+    // Bind the gateway socket BEFORE spawning the guest so that a bind failure
+    // cannot leave a running VM untracked (state.running stays None) and leak
+    // resources across subsequent NEW requests. The socket lives inside a
+    // per-VM private 0700 directory created before the bind, so no other local
+    // user can reach it (closing the post-bind chmod TOCTOU window).
+    let (gateway_dir, gateway_path): (PathBuf, PathBuf) = gateway_paths();
+    let listener: UnixListener = bind_gateway(&gateway_dir, &gateway_path)
+        .await
+        .context("failed to bind gateway socket")?;
+    debug!("serve_new(): gateway bound at {}", gateway_path.display());
+
     info!("serve_new(): spawning guest program={}", message.program);
-    let vm_thread: JoinHandle<u16> = ::std::thread::Builder::new()
+    let vm_thread: JoinHandle<u16> = match ::std::thread::Builder::new()
         .name("nanvixd-vmm-guest".to_string())
         .spawn(move || {
             let result = ::pal_async::DefaultPool::run_with(move |driver| async move {
@@ -411,25 +432,21 @@ async fn serve_new(state: &State, message: &New) -> ::anyhow::Result<NewResponse
                     u16::MAX
                 },
             }
-        })
-        .context("failed to spawn guest VM thread")?;
-
-    let gateway_path: PathBuf = default_gateway_path();
-    let listener: UnixListener = match bind_gateway(&gateway_path).await {
-        Ok(listener) => listener,
+        }) {
+        Ok(vm_thread) => vm_thread,
         Err(e) => {
-            // The guest thread is now running with no gateway; let it observe
-            // EOF on stdin (the handle drops here) and reap it on process exit.
-            return Err(e).context("failed to bind gateway socket");
+            // Reclaim the bound gateway so it is not left behind.
+            remove_gateway_dir(&gateway_dir);
+            return Err(e).context("failed to spawn guest VM thread");
         },
     };
-    debug!("serve_new(): gateway bound at {}", gateway_path.display());
+
     let gateway_bridge = ::tokio::spawn(gateway_bridge_task(listener, handle));
 
     *guard = Some(RunningVm {
         vm_thread,
         gateway_bridge,
-        gateway_path: gateway_path.clone(),
+        gateway_dir,
     });
 
     Ok(NewResponse {
@@ -448,7 +465,7 @@ async fn serve_kill(state: &State, _message: &Kill) -> ::anyhow::Result<KillResp
     let RunningVm {
         vm_thread,
         gateway_bridge,
-        gateway_path,
+        gateway_dir,
     } = vm;
 
     // The client closes the gateway write half (EOF to the guest's stdin) before
@@ -458,7 +475,7 @@ async fn serve_kill(state: &State, _message: &Kill) -> ::anyhow::Result<KillResp
 
     // The guest has exited (or its thread panicked); the bridge can stop.
     gateway_bridge.abort();
-    remove_gateway_socket(&gateway_path);
+    remove_gateway_dir(&gateway_dir);
 
     let exit_code: i32 = match join_result {
         Ok(Ok(code)) => i32::from(code),
@@ -547,38 +564,54 @@ async fn gateway_bridge_task(listener: UnixListener, handle: GuestIoHandle) {
 // Gateway socket helpers
 //==================================================================================================
 
-/// Returns a per-process default path for the gateway socket.
-fn default_gateway_path() -> PathBuf {
-    let mut path: PathBuf = ::std::env::temp_dir();
-    path.push(format!("nanvixd-vmm-gw-{}.sock", ::std::process::id()));
-    path
+/// Returns a unique (gateway directory, gateway socket) pair for one VM.
+///
+/// The socket lives inside a per-process, per-VM directory so it can be made
+/// private (0700) before the socket is bound, and removed wholesale on teardown.
+fn gateway_paths() -> (PathBuf, PathBuf) {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id: u64 = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut dir: PathBuf = ::std::env::temp_dir();
+    dir.push(format!("nanvixd-vmm-{}-{}", ::std::process::id(), id));
+    let socket: PathBuf = dir.join("gateway.sock");
+    (dir, socket)
 }
 
-/// Binds the gateway Unix socket, restricting it to the owning user.
-async fn bind_gateway(path: &Path) -> ::anyhow::Result<UnixListener> {
-    match ::std::fs::remove_file(path) {
+/// Binds the gateway Unix socket inside a freshly created private directory.
+///
+/// The directory is created with mode 0700 *before* the socket is bound, so the
+/// socket is never reachable by other local users — closing the TOCTOU window
+/// that a post-bind `chmod` would leave open. The socket itself is also
+/// restricted to 0600 for defense in depth.
+async fn bind_gateway(dir: &Path, socket: &Path) -> ::anyhow::Result<UnixListener> {
+    // Remove any stale directory left by a previous incarnation.
+    match ::std::fs::remove_dir_all(dir) {
         Ok(()) => {},
         Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {},
         Err(e) => {
             return Err(e)
-                .with_context(|| format!("failed to remove stale gateway socket at {path:?}"));
+                .with_context(|| format!("failed to remove stale gateway dir at {dir:?}"));
         },
     }
-    let listener: UnixListener = UnixListener::bind(path)
-        .with_context(|| format!("failed to bind gateway socket at {path:?}"))?;
-    // Restrict the gateway socket to the owning user so no other local user can
-    // attach to the guest's stdin/stdout.
-    let mut perms = ::std::fs::metadata(path)?.permissions();
+    ::std::fs::DirBuilder::new()
+        .mode(0o700)
+        .create(dir)
+        .with_context(|| format!("failed to create gateway dir at {dir:?}"))?;
+
+    let listener: UnixListener = UnixListener::bind(socket)
+        .with_context(|| format!("failed to bind gateway socket at {socket:?}"))?;
+    let mut perms = ::std::fs::metadata(socket)?.permissions();
     perms.set_mode(0o600);
-    ::std::fs::set_permissions(path, perms)?;
+    ::std::fs::set_permissions(socket, perms)?;
     Ok(listener)
 }
 
-/// Removes the gateway socket file, ignoring a missing file.
-fn remove_gateway_socket(path: &Path) {
-    if let Err(e) = ::std::fs::remove_file(path) {
+/// Removes the private gateway directory (and the socket within), ignoring a
+/// missing directory.
+fn remove_gateway_dir(dir: &Path) {
+    if let Err(e) = ::std::fs::remove_dir_all(dir) {
         if e.kind() != ::std::io::ErrorKind::NotFound {
-            error!("failed to remove gateway socket {path:?}: {e}");
+            error!("failed to remove gateway dir {dir:?}: {e}");
         }
     }
 }

--- a/src/utils/nanvixd-vmm/src/http.rs
+++ b/src/utils/nanvixd-vmm/src/http.rs
@@ -1,0 +1,616 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! HTTP (standalone) deployment mode for `nanvixd-vmm`.
+//!
+//! This mirrors the production `nanvixd` standalone HTTP contract so that
+//! existing clients and the `nanvix-test` harness work against `nanvixd-vmm`
+//! unchanged:
+//!
+//! - A tokio + hyper control server listens on `-http-addr <host:port>` and
+//!   serves `POST /` requests selected by the `X-NVX-Message-Type` header:
+//!   `NEW` (spawn a guest) and `KILL` (await its exit). A `GET /ready` probe
+//!   returns `204 No Content`.
+//! - Each `NEW` binds a per-VM **gateway Unix socket** whose path is returned in
+//!   the response; the host-side consumer connects to it to exchange the guest's
+//!   stdin/stdout, exactly as with the real `nanvixd`.
+//!
+//! The guest itself runs on the OpenVMM stack ([`crate::vmm::run`]) on a
+//! dedicated thread driven by `pal_async`, while the control server and gateway
+//! bridge run on the tokio runtime. The two are connected through the in-process
+//! [`ChannelGuestIo`] endpoint: the gateway connection feeds the guest's stdin
+//! and drains its stdout.
+
+use crate::{
+    build_guest_image,
+    io::{
+        ChannelGuestIo,
+        GuestIoHandle,
+    },
+    open_console,
+    vmm,
+};
+use ::anyhow::Context as _;
+use ::http_body_util::{
+    BodyExt as _,
+    Full,
+};
+use ::hyper::{
+    body::{
+        Bytes,
+        Incoming,
+    },
+    service::Service,
+    Method,
+    Request,
+    Response,
+    StatusCode,
+};
+use ::hyper_util::rt::TokioIo;
+use ::log::{
+    debug,
+    error,
+    info,
+};
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
+use ::std::{
+    future::Future,
+    os::unix::fs::PermissionsExt as _,
+    path::{
+        Path,
+        PathBuf,
+    },
+    pin::Pin,
+    sync::Arc,
+    thread::JoinHandle,
+};
+use ::tokio::{
+    io::{
+        AsyncReadExt as _,
+        AsyncWriteExt as _,
+    },
+    net::{
+        TcpListener,
+        UnixListener,
+    },
+    signal::unix::{
+        signal,
+        SignalKind,
+    },
+    sync::Mutex,
+};
+use ::user_vm_api::UserVmIdentifier;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// HTTP header that identifies the control message type (`NEW` / `KILL`).
+const HTTP_HEADER_MESSAGE_TYPE: &str = "X-NVX-Message-Type";
+
+/// Identifier reported for the single standalone VM (matches `nanvix-http`).
+const STANDALONE_VM_ID: UserVmIdentifier = UserVmIdentifier::new(1);
+
+/// Buffer size used when relaying gateway connection bytes to the guest.
+const GATEWAY_BRIDGE_BUFFER_SIZE: usize = 64 * 1024;
+
+//==================================================================================================
+// Wire types (mirror `nanvix-http::message`)
+//==================================================================================================
+
+/// `NEW` request payload: the program to boot and its arguments.
+#[derive(Debug, Deserialize)]
+struct New {
+    /// Tenant identifier (unused in standalone, accepted for compatibility).
+    #[allow(dead_code)]
+    #[serde(default)]
+    tenant_id: String,
+    /// Application name (unused in standalone, accepted for compatibility).
+    #[allow(dead_code)]
+    #[serde(default)]
+    app_name: String,
+    /// Path to the program (initrd) to boot.
+    program: String,
+    /// Command-line arguments forwarded to the program.
+    #[serde(default)]
+    program_args: String,
+}
+
+/// Response to a `NEW` request.
+#[derive(Debug, Serialize)]
+struct NewResponse {
+    /// Identifier assigned to the spawned VM.
+    user_vm_id: UserVmIdentifier,
+    /// Path of the gateway Unix socket carrying the guest's stdio.
+    gateway_sockaddr: String,
+}
+
+/// `KILL` request payload.
+#[derive(Debug, Deserialize)]
+struct Kill {
+    /// Identifier of the VM to terminate (single VM in standalone).
+    #[allow(dead_code)]
+    user_vm_id: UserVmIdentifier,
+}
+
+/// Response to a `KILL` request.
+#[derive(Debug, Serialize)]
+struct KillResponse {
+    /// Exit code of the guest workload (or `-1` on failure).
+    exit_code: i32,
+}
+
+/// Structured error payload returned when a request cannot be fulfilled.
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    /// Short machine-readable error code.
+    code: &'static str,
+    /// Human-readable diagnostic message.
+    message: String,
+}
+
+//==================================================================================================
+// Configuration and state
+//==================================================================================================
+
+/// Static configuration shared by every guest the server spawns.
+pub struct HttpConfig {
+    /// Directory containing `kernel.elf` and guest binaries.
+    pub bin_dir: PathBuf,
+    /// Optional RAM filesystem image.
+    pub ramfs: Option<PathBuf>,
+    /// Optional kernel arguments written to the control page.
+    pub kernel_args: Option<String>,
+    /// Optional file that receives the guest kernel console (default: stderr).
+    pub console_file: Option<PathBuf>,
+    /// Optional host directory served to the guest via `hostfsd`.
+    pub mount_directory: Option<PathBuf>,
+    /// Whether host networking is served via `networkd`.
+    pub networking: bool,
+    /// Guest RAM size in bytes.
+    pub mem_size: u64,
+}
+
+/// A spawned guest and the resources bound to it.
+struct RunningVm {
+    /// Thread running the OpenVMM guest; joins to the guest exit code.
+    vm_thread: JoinHandle<u16>,
+    /// Task bridging the gateway socket and the guest's stdio.
+    gateway_bridge: ::tokio::task::JoinHandle<()>,
+    /// Filesystem path of the gateway socket (removed on teardown).
+    gateway_path: PathBuf,
+}
+
+/// Shared server state: the static config and the single running VM (if any).
+#[derive(Clone)]
+struct State {
+    /// Static guest configuration.
+    config: Arc<HttpConfig>,
+    /// The running VM, or `None` when idle. Standalone serves one VM at a time.
+    running: Arc<Mutex<Option<RunningVm>>>,
+}
+
+//==================================================================================================
+// Server
+//==================================================================================================
+
+/// Runs the HTTP control server on `sockaddr` until a shutdown signal.
+///
+/// Returns once `SIGINT` or `SIGTERM` is received, after tearing down any
+/// running VM. The socket is bound before this returns control to the accept
+/// loop so a client can use a successful TCP connect as a readiness signal.
+pub async fn serve(sockaddr: &str, config: HttpConfig) -> ::anyhow::Result<()> {
+    let state: State = State {
+        config: Arc::new(config),
+        running: Arc::new(Mutex::new(None)),
+    };
+
+    let listener: TcpListener = TcpListener::bind(sockaddr)
+        .await
+        .with_context(|| format!("failed to bind HTTP socket at {sockaddr}"))?;
+    info!("nanvixd-vmm HTTP server listening on {sockaddr}");
+
+    let mut sigint: ::tokio::signal::unix::Signal =
+        signal(SignalKind::interrupt()).context("failed to install SIGINT handler")?;
+    let mut sigterm: ::tokio::signal::unix::Signal =
+        signal(SignalKind::terminate()).context("failed to install SIGTERM handler")?;
+
+    loop {
+        ::tokio::select! {
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _addr)) => {
+                        // Send small JSON control responses immediately.
+                        if let Err(e) = stream.set_nodelay(true) {
+                            error!("failed to set TCP_NODELAY: {e}");
+                        }
+                        let service: HttpService = HttpService { state: state.clone() };
+                        let io: TokioIo<::tokio::net::TcpStream> = TokioIo::new(stream);
+                        // Standalone serves one VM at a time, so connections are
+                        // handled sequentially (the harness uses one connection
+                        // per control request).
+                        if let Err(e) = ::hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await
+                        {
+                            error!("failed to serve connection: {e}");
+                        }
+                    },
+                    Err(e) => error!("failed to accept connection: {e}"),
+                }
+            },
+            _ = sigint.recv() => {
+                info!("received SIGINT, stopping nanvixd-vmm HTTP server");
+                break;
+            },
+            _ = sigterm.recv() => {
+                info!("received SIGTERM, stopping nanvixd-vmm HTTP server");
+                break;
+            },
+        }
+    }
+
+    teardown(&state).await;
+    Ok(())
+}
+
+/// Tears down any running VM on server shutdown.
+async fn teardown(state: &State) {
+    if let Some(vm) = state.running.lock().await.take() {
+        vm.gateway_bridge.abort();
+        remove_gateway_socket(&vm.gateway_path);
+        // The guest thread is detached: it is reaped when the process exits.
+    }
+}
+
+//==================================================================================================
+// Request handling
+//==================================================================================================
+
+/// The hyper service: one instance per accepted connection.
+#[derive(Clone)]
+struct HttpService {
+    /// Shared server state.
+    state: State,
+}
+
+impl Service<Request<Incoming>> for HttpService {
+    type Response = Response<Full<Bytes>>;
+    type Error = ::hyper::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, request: Request<Incoming>) -> Self::Future {
+        let state: State = self.state.clone();
+        Box::pin(async move { Ok(handle_request(state, request).await) })
+    }
+}
+
+/// Dispatches a single HTTP request to the matching handler.
+async fn handle_request(state: State, request: Request<Incoming>) -> Response<Full<Bytes>> {
+    // Readiness probe.
+    if request.method() == Method::GET && request.uri().path() == "/ready" {
+        return empty_response(StatusCode::NO_CONTENT);
+    }
+
+    // Read the message-type header before consuming the body.
+    let message_type: Option<String> = request
+        .headers()
+        .get(HTTP_HEADER_MESSAGE_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|s| s.to_ascii_lowercase());
+
+    let body: Bytes = match request.collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(_) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "BODY_READ_FAILED",
+                "failed to read request body".to_string(),
+            );
+        },
+    };
+
+    match message_type.as_deref() {
+        Some("new") => {
+            let message: New = match serde_json::from_slice(&body) {
+                Ok(message) => message,
+                Err(e) => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "INVALID_NEW_PAYLOAD",
+                        format!("failed to deserialize NEW message: {e}"),
+                    );
+                },
+            };
+            match serve_new(&state, &message).await {
+                Ok(response) => json_response(StatusCode::OK, &response),
+                Err(e) => {
+                    error!("NEW request failed: {e:?}");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "NEW_REQUEST_FAILED",
+                        format!("failed to process NEW request: {e}"),
+                    )
+                },
+            }
+        },
+        Some("kill") => {
+            let message: Kill = match serde_json::from_slice(&body) {
+                Ok(message) => message,
+                Err(e) => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "INVALID_KILL_PAYLOAD",
+                        format!("failed to deserialize KILL message: {e}"),
+                    );
+                },
+            };
+            match serve_kill(&state, &message).await {
+                Ok(response) => json_response(StatusCode::OK, &response),
+                Err(e) => {
+                    error!("KILL request failed: {e:?}");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "KILL_REQUEST_FAILED",
+                        format!("failed to process KILL request: {e}"),
+                    )
+                },
+            }
+        },
+        _ => error_response(
+            StatusCode::BAD_REQUEST,
+            "MISSING_MESSAGE_TYPE",
+            format!("{HTTP_HEADER_MESSAGE_TYPE} is a mandatory header"),
+        ),
+    }
+}
+
+/// Handles a `NEW` request: spawns a guest and binds its gateway socket.
+async fn serve_new(state: &State, message: &New) -> ::anyhow::Result<NewResponse> {
+    let mut guard = state.running.lock().await;
+    if guard.is_some() {
+        anyhow::bail!("a VM is already running in standalone mode");
+    }
+
+    let config: &HttpConfig = &state.config;
+    let initrd_args: Option<String> = if message.program_args.is_empty() {
+        None
+    } else {
+        Some(message.program_args.clone())
+    };
+    let image = build_guest_image(
+        &config.bin_dir,
+        Some(PathBuf::from(&message.program)),
+        initrd_args,
+        config.kernel_args.clone(),
+        config.ramfs.clone(),
+        config.mem_size,
+    );
+    let console = open_console(config.console_file.as_deref())
+        .context("failed to open guest console sink")?;
+
+    let (guest_io, handle): (ChannelGuestIo, GuestIoHandle) = ChannelGuestIo::pair();
+    let mount_directory: Option<PathBuf> = config.mount_directory.clone();
+    let networking: bool = config.networking;
+
+    info!("serve_new(): spawning guest program={}", message.program);
+    let vm_thread: JoinHandle<u16> = ::std::thread::Builder::new()
+        .name("nanvixd-vmm-guest".to_string())
+        .spawn(move || {
+            let result = ::pal_async::DefaultPool::run_with(move |driver| async move {
+                vmm::run(driver, image, Box::new(guest_io), console, mount_directory, networking)
+                    .await
+            });
+            match result {
+                Ok(code) => code,
+                Err(e) => {
+                    error!("guest run failed: {e:?}");
+                    u16::MAX
+                },
+            }
+        })
+        .context("failed to spawn guest VM thread")?;
+
+    let gateway_path: PathBuf = default_gateway_path();
+    let listener: UnixListener = match bind_gateway(&gateway_path).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            // The guest thread is now running with no gateway; let it observe
+            // EOF on stdin (the handle drops here) and reap it on process exit.
+            return Err(e).context("failed to bind gateway socket");
+        },
+    };
+    debug!("serve_new(): gateway bound at {}", gateway_path.display());
+    let gateway_bridge = ::tokio::spawn(gateway_bridge_task(listener, handle));
+
+    *guard = Some(RunningVm {
+        vm_thread,
+        gateway_bridge,
+        gateway_path: gateway_path.clone(),
+    });
+
+    Ok(NewResponse {
+        user_vm_id: STANDALONE_VM_ID,
+        gateway_sockaddr: gateway_path.to_string_lossy().into_owned(),
+    })
+}
+
+/// Handles a `KILL` request: awaits the guest's exit and returns its code.
+async fn serve_kill(state: &State, _message: &Kill) -> ::anyhow::Result<KillResponse> {
+    let vm: RunningVm = match state.running.lock().await.take() {
+        Some(vm) => vm,
+        None => anyhow::bail!("no VM is running in standalone mode"),
+    };
+
+    let RunningVm {
+        vm_thread,
+        gateway_bridge,
+        gateway_path,
+    } = vm;
+
+    // The client closes the gateway write half (EOF to the guest's stdin) before
+    // issuing KILL, so the guest exits on its own; join its thread to collect the
+    // exit code. Joining blocks, so do it off the async runtime.
+    let join_result = ::tokio::task::spawn_blocking(move || vm_thread.join()).await;
+
+    // The guest has exited (or its thread panicked); the bridge can stop.
+    gateway_bridge.abort();
+    remove_gateway_socket(&gateway_path);
+
+    let exit_code: i32 = match join_result {
+        Ok(Ok(code)) => i32::from(code),
+        Ok(Err(_)) => {
+            error!("serve_kill(): guest thread panicked");
+            -1
+        },
+        Err(e) => {
+            error!("serve_kill(): failed to join guest thread: {e}");
+            -1
+        },
+    };
+    debug!("serve_kill(): guest exited (exit_code={exit_code})");
+    Ok(KillResponse { exit_code })
+}
+
+//==================================================================================================
+// Gateway bridge
+//==================================================================================================
+
+/// Bridges the gateway socket to the guest's in-process stdio endpoint.
+///
+/// Accepts exactly one connection, then relays bidirectionally:
+/// - connection reads -> guest stdin (via [`crate::io::GuestStdinSender`]);
+/// - guest stdout (via [`crate::io::GuestStdoutReceiver`]) -> connection writes.
+///
+/// The guest's output channel is drained on a blocking task because the
+/// underlying receiver blocks the calling thread until the guest writes.
+async fn gateway_bridge_task(listener: UnixListener, handle: GuestIoHandle) {
+    let stream = match listener.accept().await {
+        Ok((stream, _addr)) => stream,
+        Err(e) => {
+            error!("gateway_bridge_task(): accept failed: {e}");
+            // Dropping `handle` signals EOF to the guest's stdin and closes its
+            // stdout channel, so it does not block on a connection that never
+            // arrives.
+            return;
+        },
+    };
+    debug!("gateway_bridge_task(): connection accepted");
+
+    let (mut reader, mut writer) = stream.into_split();
+    let (sender, receiver) = handle.split();
+
+    // Connection -> guest stdin.
+    let input_task = ::tokio::spawn(async move {
+        let mut buffer: Vec<u8> = vec![0u8; GATEWAY_BRIDGE_BUFFER_SIZE];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(0) => break,
+                Ok(n) => sender.send(&buffer[..n]),
+                Err(e) => {
+                    debug!("gateway_bridge_task(): read error: {e}");
+                    break;
+                },
+            }
+        }
+        sender.close();
+    });
+
+    // Guest stdout -> connection. The blocking receiver is drained on a blocking
+    // task that forwards to an async channel consumed below.
+    let (tx, mut rx) = ::tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    let drain_task = ::tokio::task::spawn_blocking(move || {
+        while let Some(data) = receiver.recv() {
+            if tx.blocking_send(data).is_err() {
+                break;
+            }
+        }
+    });
+
+    while let Some(data) = rx.recv().await {
+        if let Err(e) = writer.write_all(&data).await {
+            debug!("gateway_bridge_task(): write error: {e}");
+            break;
+        }
+    }
+
+    let _ = writer.shutdown().await;
+    input_task.abort();
+    drain_task.abort();
+    debug!("gateway_bridge_task(): bridge closed");
+}
+
+//==================================================================================================
+// Gateway socket helpers
+//==================================================================================================
+
+/// Returns a per-process default path for the gateway socket.
+fn default_gateway_path() -> PathBuf {
+    let mut path: PathBuf = ::std::env::temp_dir();
+    path.push(format!("nanvixd-vmm-gw-{}.sock", ::std::process::id()));
+    path
+}
+
+/// Binds the gateway Unix socket, restricting it to the owning user.
+async fn bind_gateway(path: &Path) -> ::anyhow::Result<UnixListener> {
+    match ::std::fs::remove_file(path) {
+        Ok(()) => {},
+        Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {},
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("failed to remove stale gateway socket at {path:?}"));
+        },
+    }
+    let listener: UnixListener = UnixListener::bind(path)
+        .with_context(|| format!("failed to bind gateway socket at {path:?}"))?;
+    // Restrict the gateway socket to the owning user so no other local user can
+    // attach to the guest's stdin/stdout.
+    let mut perms = ::std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    ::std::fs::set_permissions(path, perms)?;
+    Ok(listener)
+}
+
+/// Removes the gateway socket file, ignoring a missing file.
+fn remove_gateway_socket(path: &Path) {
+    if let Err(e) = ::std::fs::remove_file(path) {
+        if e.kind() != ::std::io::ErrorKind::NotFound {
+            error!("failed to remove gateway socket {path:?}: {e}");
+        }
+    }
+}
+
+//==================================================================================================
+// Response helpers
+//==================================================================================================
+
+/// Builds a JSON response with the given status and serializable payload.
+fn json_response<T: Serialize>(status: StatusCode, payload: &T) -> Response<Full<Bytes>> {
+    match serde_json::to_vec(payload) {
+        Ok(body) => Response::builder()
+            .status(status)
+            .header("Content-Type", "application/json")
+            .body(Full::new(Bytes::from(body)))
+            .unwrap_or_else(|_| empty_response(StatusCode::INTERNAL_SERVER_ERROR)),
+        Err(_) => empty_response(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+/// Builds an empty response with the given status code.
+fn empty_response(status: StatusCode) -> Response<Full<Bytes>> {
+    let mut response: Response<Full<Bytes>> = Response::new(Full::new(Bytes::new()));
+    *response.status_mut() = status;
+    response
+}
+
+/// Builds a JSON error response.
+fn error_response(
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+) -> Response<Full<Bytes>> {
+    json_response(status, &ErrorResponse { code, message })
+}

--- a/src/utils/nanvixd-vmm/src/ikc.rs
+++ b/src/utils/nanvixd-vmm/src/ikc.rs
@@ -160,9 +160,11 @@ impl IkcBridge {
     pub fn guest_stdin(&mut self, gm: &GuestMemory, envelope: &VmBusMessage) -> anyhow::Result<()> {
         let Some(frame) = self.outbound.pop_front() else {
             // The guest only fetches when CREDITS is positive, so this is not
-            // expected; nothing to deliver.
+            // expected. Re-sync CREDITS (now 0) before returning so the guest
+            // observes an empty queue and stops fetching instead of spinning on
+            // a stale, nonzero value.
             log::warn!("guest fetched IKC message with empty queue");
-            return Ok(());
+            return self.sync_credits(gm);
         };
 
         match frame {

--- a/src/utils/nanvixd-vmm/src/ikc.rs
+++ b/src/utils/nanvixd-vmm/src/ikc.rs
@@ -1,0 +1,454 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Host-side IKC dispatch and daemon integration.
+//!
+//! This module is the host-side counterpart of the guest's inter-kernel
+//! communication (IKC) channel. It mirrors the Nanvix `uservm` standalone I/O
+//! handler, but instead of re-implementing the host-side daemons it **reuses**
+//! them directly:
+//!
+//! - `read(2)`/`write(2)` against stdio are bridged to the host's
+//!   stdin/stdout (the terminal role of standalone `nanvixd`);
+//! - filesystem requests (`vfsd` → `hostfsd`) are dispatched to the real
+//!   [`hostfsd::HostFsHandler`];
+//! - networking requests (`→ networkd`) are dispatched to the real
+//!   [`networkd::NetworkDaemon`].
+//!
+//! The guest emits a message by writing the guest-physical address of a
+//! [`VmBusMessage`] envelope to the stdout port (`0xe9`); it fetches a queued
+//! host response by writing an envelope to the stdin port (`0xea`) while the
+//! shared `CREDITS` register is positive. Because the device runs on the single
+//! vCPU thread, all dispatch happens synchronously here.
+
+use crate::io::GuestIo;
+use ::anyhow::Context as _;
+use ::guestmem::GuestMemory;
+use ::hostfs_api::{
+    get_op_id,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+    HOSTFS_ERR_IO,
+};
+use ::std::{
+    collections::VecDeque,
+    path::PathBuf,
+};
+use ::sys::{
+    ipc::{
+        DataChunkHeader,
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+        VmBusMessage,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::syscall::{
+    message::SystemCallMessagePart,
+    unistd::message::{
+        ReadResponse,
+        WriteRequest,
+        WriteResponse,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+
+/// Size of a serialized IPC [`Message`] in bytes.
+const MESSAGE_SIZE: usize = Message::HEADER_SIZE + Message::PAYLOAD_SIZE;
+
+/// A host-produced frame awaiting delivery to the guest via the stdin port.
+enum HostFrame {
+    /// A complete IPC message to copy into the guest's message buffer.
+    Message(Message),
+    /// A bulk payload to write at `data_addr`, paired with the pull-completion
+    /// header used to synthesize the guest's `PullResponse` notification.
+    Bulk {
+        data: Vec<u8>,
+        data_addr: u32,
+        header: DataChunkHeader,
+    },
+}
+
+/// A guest stdio request awaiting its following bulk frame.
+enum Pending {
+    /// A `write(2)`: the next bulk frame carries the bytes to emit.
+    Write { tid: ThreadIdentifier, fd: i32 },
+    /// A `read(2)`: the next bulk frame is the pull header naming the guest
+    /// destination buffer and maximum length.
+    Read { tid: ThreadIdentifier },
+}
+
+/// Bridges guest IKC traffic to host stdio and the host-side daemons.
+pub struct IkcBridge {
+    /// The stdio request whose bulk frame is expected next, if any.
+    pending: Option<Pending>,
+    /// Frames queued for delivery to the guest.
+    outbound: VecDeque<HostFrame>,
+    /// Guest standard-I/O endpoint (host terminal or in-process channel).
+    io: Box<dyn GuestIo>,
+    /// Host filesystem daemon, present when a mount directory is configured.
+    hostfs: Option<hostfsd::HostFsHandler>,
+    /// Host network daemon, present when host networking is enabled.
+    network: Option<networkd::NetworkDaemon>,
+}
+
+impl IkcBridge {
+    /// Creates a new bridge.
+    ///
+    /// `io` is the guest standard-I/O endpoint (see [`crate::io`]). When
+    /// `mount_directory` is set, a [`hostfsd::HostFsHandler`] rooted there serves
+    /// guest filesystem requests. When `networking` is true, a
+    /// [`networkd::NetworkDaemon`] serves guest networking requests.
+    pub fn new(io: Box<dyn GuestIo>, mount_directory: Option<PathBuf>, networking: bool) -> Self {
+        let hostfs =
+            mount_directory.and_then(|dir| match hostfsd::HostFsHandler::new(dir.clone()) {
+                Ok(h) => {
+                    log::info!("hostfsd: serving mount root {}", dir.display());
+                    Some(h)
+                },
+                Err(e) => {
+                    log::error!("hostfsd: failed to initialize for {}: {e}", dir.display());
+                    None
+                },
+            });
+
+        let network = if networking {
+            match networkd::NetworkDaemon::new() {
+                Ok(nd) => {
+                    log::info!("networkd: host networking enabled");
+                    Some(nd)
+                },
+                Err(e) => {
+                    log::error!("networkd: failed to initialize: {e:?}");
+                    None
+                },
+            }
+        } else {
+            None
+        };
+
+        Self {
+            pending: None,
+            outbound: VecDeque::new(),
+            io,
+            hostfs,
+            network,
+        }
+    }
+
+    /// Handles a guest write to the stdout port (an outbound IKC envelope).
+    pub fn guest_stdout(
+        &mut self,
+        gm: &GuestMemory,
+        envelope: &VmBusMessage,
+    ) -> anyhow::Result<()> {
+        if envelope.is_ikc() {
+            self.handle_message(gm, envelope.message_addr())
+        } else {
+            self.handle_bulk(gm, envelope.message_addr())
+        }
+    }
+
+    /// Handles a guest read from the stdin port: delivers one queued frame.
+    pub fn guest_stdin(&mut self, gm: &GuestMemory, envelope: &VmBusMessage) -> anyhow::Result<()> {
+        let Some(frame) = self.outbound.pop_front() else {
+            // The guest only fetches when CREDITS is positive, so this is not
+            // expected; nothing to deliver.
+            log::warn!("guest fetched IKC message with empty queue");
+            return Ok(());
+        };
+
+        match frame {
+            HostFrame::Message(msg) => {
+                gm.write_at(u64::from(envelope.message_addr()), &msg.to_bytes())
+                    .context("failed to deliver IKC message")?;
+            },
+            HostFrame::Bulk {
+                data,
+                data_addr,
+                header,
+            } => {
+                gm.write_at(u64::from(data_addr), &data)
+                    .context("failed to write bulk payload")?;
+                let msg = pull_response(header);
+                gm.write_at(u64::from(envelope.message_addr()), &msg.to_bytes())
+                    .context("failed to deliver pull response")?;
+            },
+        }
+
+        self.sync_credits(gm)
+    }
+
+    /// Parses an outbound IPC message and routes it to stdio or a daemon.
+    fn handle_message(&mut self, gm: &GuestMemory, addr: u32) -> anyhow::Result<()> {
+        let mut bytes = [0u8; MESSAGE_SIZE];
+        gm.read_at(u64::from(addr), &mut bytes)
+            .context("failed to read IKC message")?;
+        let message = Message::try_from_bytes(bytes)
+            .map_err(|e| anyhow::anyhow!("failed to parse IKC message: {e:?}"))?;
+
+        let syscall_msg = match SystemCallMessage::try_from_bytes(message.payload) {
+            Ok(m) => m,
+            Err(e) => {
+                log::warn!("ignoring unparsable system-call message: {e:?}");
+                return Ok(());
+            },
+        };
+        let header = syscall_msg.header;
+        let tid = extract_tid(message.source);
+
+        match header {
+            SystemCallMessageHeader::WriteRequest => {
+                let req = WriteRequest::from_bytes(syscall_msg.payload);
+                self.pending = Some(Pending::Write { tid, fd: req.fd });
+            },
+            SystemCallMessageHeader::ReadRequest => {
+                self.pending = Some(Pending::Read { tid });
+            },
+            h if h.is_hostfs() => self.handle_hostfs(&message, h, &syscall_msg.payload),
+            _ => {
+                // Copy out of the packed message struct before comparing.
+                let destination = message.destination;
+                if destination == MessageReceiver::NETWORKD {
+                    self.handle_networking(message);
+                } else {
+                    log::warn!("ignoring IKC message with unsupported header {header:?}");
+                }
+            },
+        }
+        self.sync_credits(gm)
+    }
+
+    /// Dispatches a filesystem request to the reused `hostfsd` handler.
+    ///
+    /// When no mount directory is configured, emits a hostfs error response so
+    /// the guest's `vfsd` can drain its pending operation and report the failure
+    /// to the caller instead of blocking forever (mirroring the Nanvix `uservm`
+    /// standalone handler's no-mount path).
+    fn handle_hostfs(
+        &mut self,
+        message: &Message,
+        header: SystemCallMessageHeader,
+        syscall_payload: &[u8; SystemCallMessage::PAYLOAD_SIZE],
+    ) {
+        if let Some(handler) = self.hostfs.as_mut() {
+            if let Some(response) = handler.handle_request(&message.payload) {
+                self.outbound
+                    .push_back(HostFrame::Message(hostfs_response(response)));
+                while let Some(extra) = handler.take_next_response_part() {
+                    self.outbound
+                        .push_back(HostFrame::Message(hostfs_response(extra)));
+                }
+            }
+            // `None` means an intermediate multi-part request; no response yet.
+            return;
+        }
+
+        if let Some(op_id) = hostfs_error_target(header, &message.payload, syscall_payload) {
+            log::warn!("hostfs request received but no mount configured; sending error response");
+            if let Some(err) = build_hostfs_error(header, op_id) {
+                self.outbound.push_back(HostFrame::Message(err));
+            }
+        }
+    }
+
+    /// Dispatches a networking request to the reused `networkd` daemon.
+    fn handle_networking(&mut self, message: Message) {
+        let Some(daemon) = self.network.as_ref() else {
+            log::warn!("networking request received but host networking is disabled");
+            return;
+        };
+        if let Some(responses) = daemon.handle_message(message) {
+            for response in responses {
+                self.outbound.push_back(HostFrame::Message(response));
+            }
+        }
+    }
+
+    /// Processes the bulk frame following a stdio request message.
+    fn handle_bulk(&mut self, gm: &GuestMemory, addr: u32) -> anyhow::Result<()> {
+        let mut header_bytes = [0u8; DataChunkHeader::SIZE];
+        gm.read_at(u64::from(addr), &mut header_bytes)
+            .context("failed to read data chunk header")?;
+        let header = DataChunkHeader::try_from_bytes(header_bytes)
+            .map_err(|e| anyhow::anyhow!("failed to parse data chunk header: {e:?}"))?;
+
+        match self.pending.take() {
+            Some(Pending::Write { tid, fd }) => {
+                let mut data = vec![0u8; header.data_len() as usize];
+                gm.read_at(u64::from(header.data_addr()), &mut data)
+                    .context("failed to read write payload")?;
+                self.complete_write(tid, fd, &data);
+            },
+            Some(Pending::Read { tid }) => {
+                self.complete_read(tid, &header);
+            },
+            None => log::warn!("received bulk frame without a pending stdio request"),
+        }
+        self.sync_credits(gm)
+    }
+
+    /// Emits write data to the guest-I/O endpoint and queues a `WriteResponse`.
+    fn complete_write(&mut self, tid: ThreadIdentifier, fd: i32, data: &[u8]) {
+        let written = self.io.write_stdout(fd, data);
+        let response =
+            WriteResponse::build(tid, written, ProcessIdentifier::KERNEL, MessageType::Ikc);
+        self.outbound.push_back(HostFrame::Message(response));
+    }
+
+    /// Satisfies a guest `read(2)` from streaming host input.
+    ///
+    /// Blocks until host stdin has data or reaches end-of-file, matching the
+    /// blocking-read semantics of the Nanvix `uservm` standalone handler. An
+    /// empty result (EOF) is surfaced to the guest as a zero-length read.
+    fn complete_read(&mut self, tid: ThreadIdentifier, pull_header: &DataChunkHeader) {
+        let max = pull_header.data_len() as usize;
+        let data: Vec<u8> = self.io.read_stdin(max);
+        let actual_len = data.len() as u32;
+
+        let response_header = DataChunkHeader::new(
+            pull_header.source_pid(),
+            pull_header.source_tid(),
+            pull_header.destination_pid(),
+            pull_header.destination_tid(),
+            pull_header.data_addr(),
+            actual_len,
+        );
+        let empty = [0u8; ReadResponse::BUFFER_SIZE];
+        let response = ReadResponse::build(
+            tid,
+            actual_len as i32,
+            empty,
+            ProcessIdentifier::KERNEL,
+            MessageType::Ikc,
+        );
+
+        self.outbound.push_back(HostFrame::Bulk {
+            data,
+            data_addr: pull_header.data_addr(),
+            header: response_header,
+        });
+        self.outbound.push_back(HostFrame::Message(response));
+    }
+
+    /// Writes the current outbound-queue depth to the shared `CREDITS` register.
+    fn sync_credits(&self, gm: &GuestMemory) -> anyhow::Result<()> {
+        let credits = self.outbound.len() as u32;
+        gm.write_at(config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as u64, &credits.to_le_bytes())
+            .context("failed to update credits register")
+    }
+}
+
+/// Wraps a `hostfsd` response payload in an IPC message addressed to `vfsd`.
+fn hostfs_response(payload: [u8; Message::PAYLOAD_SIZE]) -> Message {
+    Message::new(
+        MessageSender::from(ProcessIdentifier::KERNEL),
+        MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageType::Ikc,
+        None,
+        payload,
+    )
+}
+
+/// Returns the operation id an error response should target, or `None` if the
+/// frame should be silently dropped (a non-first part of a long request).
+///
+/// For single-message requests the op id lives at `Message.payload[2..6]`. For
+/// the multi-part "request part" frames only part 0 yields an error, carrying
+/// the logical op id from the first four bytes of its chunk.
+fn hostfs_error_target(
+    header: SystemCallMessageHeader,
+    message_payload: &[u8; Message::PAYLOAD_SIZE],
+    syscall_payload: &[u8; SystemCallMessage::PAYLOAD_SIZE],
+) -> Option<OperationId> {
+    let is_request_part = matches!(
+        header,
+        SystemCallMessageHeader::HostFsOpenRequestPart
+            | SystemCallMessageHeader::HostFsRenameRequestPart
+            | SystemCallMessageHeader::HostFsUnlinkRequestPart
+            | SystemCallMessageHeader::HostFsMkdirRequestPart
+            | SystemCallMessageHeader::HostFsRmdirRequestPart
+            | SystemCallMessageHeader::HostFsSymlinkRequestPart
+            | SystemCallMessageHeader::HostFsReadlinkRequestPart
+            | SystemCallMessageHeader::HostFsLstatRequestPart
+    );
+
+    if is_request_part {
+        let part = SystemCallMessagePart::from_bytes(*syscall_payload);
+        if { part.part_number } != 0 {
+            return None;
+        }
+        let declared = { part.payload_size } as usize;
+        if declared < core::mem::size_of::<OperationId>() {
+            return Some(OperationId::INVALID);
+        }
+        let chunk = &part.payload;
+        Some(OperationId::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+    } else {
+        Some(get_op_id(message_payload))
+    }
+}
+
+/// Builds the hostfs error response message for `header`, echoing `op_id`.
+///
+/// Each hostfs operation detects failure differently: most check a leading
+/// `i32`, `lseek` checks an `i64` offset, and `stat`/`readdir` use an all-zero
+/// payload as their error/end sentinel. Returns `None` if the request header has
+/// no corresponding response header.
+fn build_hostfs_error(header: SystemCallMessageHeader, op_id: OperationId) -> Option<Message> {
+    let resp_header = header.hostfs_response_header()?;
+
+    let mut payload = [0u8; Message::PAYLOAD_SIZE];
+    payload[0..2].copy_from_slice(&(resp_header as u16).to_ne_bytes());
+    set_op_id(&mut payload, op_id);
+
+    let ds = HOSTFS_DATA_START;
+    match resp_header {
+        SystemCallMessageHeader::HostFsLseekResponse => {
+            payload[ds..ds + 8].copy_from_slice(&(HOSTFS_ERR_IO as i64).to_le_bytes());
+        },
+        SystemCallMessageHeader::HostFsStatResponse
+        | SystemCallMessageHeader::HostFsReadDirResponse => {
+            // All-zero payload is the error/end-of-directory sentinel.
+        },
+        _ => {
+            payload[ds..ds + 4].copy_from_slice(&HOSTFS_ERR_IO.to_le_bytes());
+        },
+    }
+
+    Some(Message::new(
+        MessageSender::from(ProcessIdentifier::KERNEL),
+        MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageType::Ikc,
+        None,
+        payload,
+    ))
+}
+
+/// Builds a `PullResponse` notification message wrapping a completion header.
+fn pull_response(header: DataChunkHeader) -> Message {
+    let mut payload = [0u8; Message::PAYLOAD_SIZE];
+    payload[..DataChunkHeader::SIZE].copy_from_slice(&header.to_bytes());
+    Message::new(
+        MessageSender::from(ProcessIdentifier::KERNEL),
+        MessageReceiver::from(ProcessIdentifier::KERNEL),
+        MessageType::PullResponse,
+        None,
+        payload,
+    )
+}
+
+/// Recovers the originating thread identifier from a message source.
+fn extract_tid(source: MessageSender) -> ThreadIdentifier {
+    match source.as_id() {
+        Err(tid) => tid,
+        Ok(_pid) => ThreadIdentifier::from(1i32),
+    }
+}

--- a/src/utils/nanvixd-vmm/src/io.rs
+++ b/src/utils/nanvixd-vmm/src/io.rs
@@ -1,0 +1,166 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! The guest's standard-I/O endpoint for the IKC bridge.
+//!
+//! The IKC bridge ([`crate::ikc`]) routes the guest's `read(2)`/`write(2)` on
+//! the standard file descriptors to a [`GuestIo`] endpoint. Two implementations
+//! are provided:
+//!
+//! - [`HostGuestIo`] — the default: guest stdout/stderr go to the host's
+//!   stdout/stderr, and guest stdin is fed by the streaming [`HostStdin`]
+//!   reader. This is the terminal role of standalone `nanvixd`.
+//! - [`ChannelGuestIo`] — an in-process endpoint that connects guest stdio to a
+//!   pair of channels, letting a host-side harness exchange raw payloads with
+//!   the guest with no operating-system pipe in between. This is what gives the
+//!   warm-start benchmark white-box parity with the Nanvix `warm-start-vmm`
+//!   micro-benchmark (which measures the round-trip latency in and out of the
+//!   VMM over its in-process IKC channels).
+
+use crate::stdin::HostStdin;
+use ::std::{
+    collections::VecDeque,
+    io::Write as _,
+    sync::mpsc::{
+        Receiver,
+        Sender,
+    },
+};
+
+/// Standard output / standard error file descriptors.
+const STDOUT_FILENO: i32 = 1;
+const STDERR_FILENO: i32 = 2;
+
+/// The guest's standard-I/O endpoint.
+///
+/// Implementations are driven on the single vCPU thread, so methods take
+/// `&mut self` and may block (a blocking `read_stdin` parks the vCPU until input
+/// is available, matching the guest's blocking-read semantics).
+pub trait GuestIo: Send {
+    /// Handles `data` the guest wrote to `fd`; returns the count written, or
+    /// `-1` for an unsupported descriptor.
+    fn write_stdout(&mut self, fd: i32, data: &[u8]) -> i32;
+
+    /// Returns up to `max` bytes for a guest stdin read, blocking until data is
+    /// available or end-of-file. An empty result signals EOF.
+    fn read_stdin(&mut self, max: usize) -> Vec<u8>;
+}
+
+/// Default endpoint: bridges guest stdio to the host terminal.
+pub struct HostGuestIo {
+    stdin: HostStdin,
+}
+
+impl HostGuestIo {
+    /// Creates a host endpoint fed by the given streaming stdin reader.
+    pub fn new(stdin: HostStdin) -> Self {
+        Self { stdin }
+    }
+}
+
+impl GuestIo for HostGuestIo {
+    fn write_stdout(&mut self, fd: i32, data: &[u8]) -> i32 {
+        match fd {
+            STDOUT_FILENO => {
+                let mut out = std::io::stdout().lock();
+                let _ = out.write_all(data);
+                let _ = out.flush();
+                data.len() as i32
+            },
+            STDERR_FILENO => {
+                let mut err = std::io::stderr().lock();
+                let _ = err.write_all(data);
+                let _ = err.flush();
+                data.len() as i32
+            },
+            other => {
+                log::warn!("rejecting write to unsupported fd {other}");
+                -1
+            },
+        }
+    }
+
+    fn read_stdin(&mut self, max: usize) -> Vec<u8> {
+        self.stdin.read_up_to(max)
+    }
+}
+
+/// In-process endpoint that connects guest stdio to a [`GuestIoHandle`].
+///
+/// Guest writes are forwarded to the handle; guest reads block until the handle
+/// supplies bytes (or is dropped, which signals EOF).
+pub struct ChannelGuestIo {
+    from_handle: Receiver<Vec<u8>>,
+    to_handle: Sender<Vec<u8>>,
+    pending: VecDeque<u8>,
+}
+
+/// The host-side counterpart of a [`ChannelGuestIo`].
+pub struct GuestIoHandle {
+    to_guest: Option<Sender<Vec<u8>>>,
+    from_guest: Receiver<Vec<u8>>,
+}
+
+impl ChannelGuestIo {
+    /// Creates a VM-side endpoint and its paired host-side handle.
+    pub fn pair() -> (ChannelGuestIo, GuestIoHandle) {
+        let (to_guest, from_handle) = ::std::sync::mpsc::channel();
+        let (to_handle, from_guest) = ::std::sync::mpsc::channel();
+        (
+            ChannelGuestIo {
+                from_handle,
+                to_handle,
+                pending: VecDeque::new(),
+            },
+            GuestIoHandle {
+                to_guest: Some(to_guest),
+                from_guest,
+            },
+        )
+    }
+}
+
+impl GuestIo for ChannelGuestIo {
+    fn write_stdout(&mut self, _fd: i32, data: &[u8]) -> i32 {
+        let _ = self.to_handle.send(data.to_vec());
+        data.len() as i32
+    }
+
+    fn read_stdin(&mut self, max: usize) -> Vec<u8> {
+        if self.pending.is_empty() {
+            match self.from_handle.recv() {
+                Ok(data) => self.pending.extend(data),
+                Err(_) => return Vec::new(), // handle dropped => EOF
+            }
+        }
+        let n = self.pending.len().min(max);
+        self.pending.drain(..n).collect()
+    }
+}
+
+impl GuestIoHandle {
+    /// Feeds `data` to the guest's subsequent stdin read(s).
+    pub fn send(&self, data: &[u8]) {
+        if let Some(tx) = &self.to_guest {
+            let _ = tx.send(data.to_vec());
+        }
+    }
+
+    /// Blocks until the guest has written `n` bytes in total. Returns `false` if
+    /// the guest closed its output (EOF) before `n` bytes arrived.
+    pub fn read_exact(&self, n: usize) -> bool {
+        let mut got = 0usize;
+        while got < n {
+            match self.from_guest.recv() {
+                Ok(chunk) => got += chunk.len(),
+                Err(_) => return false,
+            }
+        }
+        true
+    }
+
+    /// Closes the guest's input, causing its next blocking read to see EOF.
+    pub fn close_input(&mut self) {
+        self.to_guest = None;
+    }
+}

--- a/src/utils/nanvixd-vmm/src/io.rs
+++ b/src/utils/nanvixd-vmm/src/io.rs
@@ -163,4 +163,55 @@ impl GuestIoHandle {
     pub fn close_input(&mut self) {
         self.to_guest = None;
     }
+
+    /// Splits the handle into independent sender/receiver halves.
+    ///
+    /// This is what the HTTP-mode gateway bridge uses: the sender half is moved
+    /// into the task that forwards the gateway connection to the guest's stdin,
+    /// while the receiver half is drained (on a blocking task) to forward the
+    /// guest's stdout back to the connection. Splitting is required because the
+    /// two directions run concurrently and the underlying channels are not
+    /// `Sync`.
+    pub fn split(self) -> (GuestStdinSender, GuestStdoutReceiver) {
+        (
+            GuestStdinSender {
+                to_guest: self.to_guest,
+            },
+            GuestStdoutReceiver {
+                from_guest: self.from_guest,
+            },
+        )
+    }
+}
+
+/// The stdin-feeding half of a split [`GuestIoHandle`].
+pub struct GuestStdinSender {
+    to_guest: Option<Sender<Vec<u8>>>,
+}
+
+impl GuestStdinSender {
+    /// Feeds `data` to the guest's subsequent stdin read(s).
+    pub fn send(&self, data: &[u8]) {
+        if let Some(tx) = &self.to_guest {
+            let _ = tx.send(data.to_vec());
+        }
+    }
+
+    /// Closes the guest's input, causing its next blocking read to see EOF.
+    pub fn close(self) {
+        drop(self.to_guest);
+    }
+}
+
+/// The stdout-draining half of a split [`GuestIoHandle`].
+pub struct GuestStdoutReceiver {
+    from_guest: Receiver<Vec<u8>>,
+}
+
+impl GuestStdoutReceiver {
+    /// Blocks until the guest writes the next chunk of output. Returns `None`
+    /// when the guest has closed its output (EOF).
+    pub fn recv(&self) -> Option<Vec<u8>> {
+        self.from_guest.recv().ok()
+    }
 }

--- a/src/utils/nanvixd-vmm/src/lib.rs
+++ b/src/utils/nanvixd-vmm/src/lib.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Boots the Nanvix guest in standalone mode on top of the OpenVMM
+//! virtualization stack, while reusing the real Nanvix host-side daemons.
+//!
+//! This crate lives in the Nanvix workspace so it can depend directly on the
+//! production `hostfsd` and `networkd` crates (and the shared
+//! `sys`/`syscall`/`config` types) instead of re-implementing their wire
+//! protocols. The OpenVMM virtualization libraries (`virt`, `virt_kvm`,
+//! `guestmem`, ...) are consumed via cross-workspace path dependencies.
+//!
+//! The single binary it ships, `nanvixd-vmm`, mirrors the Nanvix `nanvixd`
+//! standalone deployment CLI, adding `-mount <dir>` (served by the reused
+//! `hostfsd`) and `-allow-host-networking` (served by the reused `networkd`).
+
+pub mod device;
+pub mod ikc;
+pub mod io;
+pub mod load;
+pub mod stdin;
+pub mod vmm;
+
+// Make the in-tree legacy 8259 PIC and 8254 PIT chipset devices resolvable by
+// any `ResourceResolver` in this binary, so the VM core can instantiate them
+// from their device handles.
+vm_resource::register_static_resolvers! {
+    chipset::pic::resolver::PicResolver,
+    chipset::pit::resolver::PitResolver,
+}
+
+/// Default guest RAM size: 128 MiB, matching the Nanvix microvm default.
+pub const DEFAULT_MEM_SIZE: u64 = 128 * 1024 * 1024;
+
+/// A host-side sink for the guest's kernel console output.
+pub type ConsoleSink = Box<dyn std::io::Write + Send>;
+
+/// Initializes host-side logging, reading its filter from `env_var`.
+///
+/// Logs are emitted to stderr so they never intermingle with guest application
+/// output on stdout. The default level is `info`; it can be overridden through
+/// the given environment variable (e.g. `NANVIXD_VMM_LOG=debug`).
+pub fn init_logging(env_var: &str) {
+    let mut builder = env_logger::Builder::new();
+    builder
+        .target(env_logger::Target::Stderr)
+        .filter_level(log::LevelFilter::Info);
+    if let Ok(filter) = std::env::var(env_var) {
+        builder.parse_filters(&filter);
+    }
+    let _ = builder.try_init();
+}
+
+/// Returns the host TSC base frequency in MHz, used by the guest to calibrate
+/// its LAPIC timer via `RDTSC`.
+///
+/// Prefers CPUID leaf `0x16` (processor frequency information); falls back to
+/// parsing `/proc/cpuinfo`, and finally to a conservative default. The guest's
+/// calibration is self-correcting, so an approximate value is sufficient as
+/// long as it is nonzero and in the right ballpark.
+pub fn host_tsc_freq_mhz() -> u32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // `__cpuid` is part of the x86_64 baseline; the leaves read here have no
+        // side effects and the results are only used as a calibration hint.
+        let leaf = std::arch::x86_64::__cpuid(0);
+        if leaf.eax >= 0x16 {
+            let freq = std::arch::x86_64::__cpuid(0x16);
+            let mhz = freq.eax & 0xffff;
+            if mhz != 0 {
+                return mhz;
+            }
+        }
+    }
+
+    if let Some(mhz) = cpuinfo_mhz() {
+        return mhz;
+    }
+
+    // Conservative default (2 GHz); calibration corrects for the real rate.
+    2000
+}
+
+/// Parses the first `cpu MHz` value from `/proc/cpuinfo`, if available.
+fn cpuinfo_mhz() -> Option<u32> {
+    let text = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    for line in text.lines() {
+        if let Some((key, value)) = line.split_once(':') {
+            if key.trim() == "cpu MHz" {
+                if let Ok(mhz) = value.trim().parse::<f64>() {
+                    if mhz > 0.0 {
+                        return Some(mhz as u32);
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/utils/nanvixd-vmm/src/lib.rs
+++ b/src/utils/nanvixd-vmm/src/lib.rs
@@ -15,6 +15,7 @@
 //! `hostfsd`) and `-allow-host-networking` (served by the reused `networkd`).
 
 pub mod device;
+pub mod http;
 pub mod ikc;
 pub mod io;
 pub mod load;
@@ -34,6 +35,39 @@ pub const DEFAULT_MEM_SIZE: u64 = 128 * 1024 * 1024;
 
 /// A host-side sink for the guest's kernel console output.
 pub type ConsoleSink = Box<dyn std::io::Write + Send>;
+
+/// Opens the host-side sink for the guest's kernel console.
+///
+/// When `path` is `Some`, the console is written to that file (truncating it);
+/// otherwise it falls back to the host's stderr, keeping it off stdout so it
+/// never intermingles with guest application output.
+pub fn open_console(path: Option<&std::path::Path>) -> std::io::Result<ConsoleSink> {
+    match path {
+        Some(path) => Ok(Box::new(std::fs::File::create(path)?)),
+        None => Ok(Box::new(std::io::stderr())),
+    }
+}
+
+/// Builds the [`load::GuestImage`] for a boot, resolving the kernel ELF from
+/// `bin_dir` and stamping the host TSC frequency for guest timer calibration.
+pub fn build_guest_image(
+    bin_dir: &std::path::Path,
+    initrd: Option<std::path::PathBuf>,
+    initrd_args: Option<String>,
+    kernel_args: Option<String>,
+    ramfs: Option<std::path::PathBuf>,
+    mem_size: u64,
+) -> load::GuestImage {
+    load::GuestImage {
+        kernel: bin_dir.join("kernel.elf"),
+        initrd,
+        initrd_args,
+        kernel_args,
+        ramfs,
+        mem_size,
+        tsc_freq_mhz: host_tsc_freq_mhz(),
+    }
+}
 
 /// Initializes host-side logging, reading its filter from `env_var`.
 ///

--- a/src/utils/nanvixd-vmm/src/load.rs
+++ b/src/utils/nanvixd-vmm/src/load.rs
@@ -190,6 +190,15 @@ fn load_initrd(
     // The guest locates the command line at the page-rounded end of the initrd
     // region (it derives the region size in pages from the boot register), so
     // the length-prefixed string must be written there, not at the raw end.
+    // The check above only bounds the initrd payload; ensure the trailing
+    // command line (a `u16` length followed by its bytes) also fits in guest RAM.
+    let cmdline_end = end + 2 + args.len() as u64;
+    if cmdline_end > mem_size {
+        anyhow::bail!(
+            "initrd command line does not fit in guest memory (cmdline_end={cmdline_end:#x}, \
+             mem_size={mem_size:#x})"
+        );
+    }
     write_initrd_args(gm, base + size_rounded, &args)?;
 
     Ok((base, size_rounded))

--- a/src/utils/nanvixd-vmm/src/load.rs
+++ b/src/utils/nanvixd-vmm/src/load.rs
@@ -1,0 +1,286 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Loading of the Nanvix guest into VM memory.
+//!
+//! This replicates the layout produced by the Nanvix `uservm` standalone path:
+//! a 32-bit x86 kernel ELF loaded by virtual address, an optional initial RAM
+//! disk at a fixed address, an optional RAM filesystem at the top of guest RAM,
+//! and the shared control / pvclock pages. The MicroVM contract constants come
+//! from the shared `config` crate, so this loader stays in lock-step with the
+//! guest kernel.
+
+use ::anyhow::Context as _;
+use ::guestmem::GuestMemory;
+
+/// Guest physical page size (the Nanvix guest is a 32-bit x86 kernel).
+const PAGE_SIZE: u64 = 0x1000;
+
+/// Description of the guest images to load.
+pub struct GuestImage {
+    /// Path to the 32-bit kernel ELF.
+    pub kernel: std::path::PathBuf,
+    /// Optional path to the initial RAM disk (a single guest application ELF).
+    pub initrd: Option<std::path::PathBuf>,
+    /// Optional command-line arguments forwarded to the initrd application.
+    pub initrd_args: Option<String>,
+    /// Optional kernel arguments written to the control page.
+    pub kernel_args: Option<String>,
+    /// Optional path to a RAM filesystem image.
+    pub ramfs: Option<std::path::PathBuf>,
+    /// Size of guest RAM in bytes.
+    pub mem_size: u64,
+    /// Host TSC base frequency in MHz, written to the control page for the
+    /// guest's LAPIC timer calibration.
+    pub tsc_freq_mhz: u32,
+}
+
+/// State produced by loading the guest, needed to set the boot registers.
+pub struct LoadedGuest {
+    /// Kernel entry point (guest physical / virtual address; identity-mapped).
+    pub entry: u64,
+    /// Base address of the initrd, or 0 if none.
+    pub initrd_base: u64,
+    /// Size of the initrd in bytes (page-rounded), or 0 if none.
+    pub initrd_size: u64,
+}
+
+/// Rounds `value` up to the next multiple of [`PAGE_SIZE`].
+fn page_round_up(value: u64) -> u64 {
+    (value + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)
+}
+
+/// Loads the kernel, initrd, RAMFS, and control/pvclock pages into guest memory.
+pub fn load(gm: &GuestMemory, image: &GuestImage) -> anyhow::Result<LoadedGuest> {
+    let entry = load_kernel(gm, &image.kernel)?;
+
+    let (initrd_base, initrd_size) = match &image.initrd {
+        Some(path) => load_initrd(gm, path, image.initrd_args.as_deref(), image.mem_size)?,
+        None => (0, 0),
+    };
+
+    // The control and pvclock pages live inside the kernel ELF's zero-filled
+    // low memory, so all VMM-written control values must be written *after* the
+    // kernel has been loaded.
+    if let Some(ramfs) = &image.ramfs {
+        let (base, size) = load_ramfs(gm, ramfs, initrd_base + initrd_size, image.mem_size)?;
+        write_u32(gm, config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_BASE as u64, base as u32)?;
+        write_u32(gm, config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_SIZE as u64, size as u32)?;
+    }
+
+    // Credits start at zero (no host messages pending).
+    write_u32(gm, config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as u64, 0)?;
+    // Running state (not paused).
+    write_u32(
+        gm,
+        config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+        config::microvm::RUNNING,
+    )?;
+    // TSC frequency for RDTSC-based LAPIC timer calibration.
+    write_u32(gm, config::microvm::DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ as u64, image.tsc_freq_mhz)?;
+
+    if let Some(args) = &image.kernel_args {
+        write_kernel_args(gm, args)?;
+    }
+
+    write_pvclock_boot_time(gm)?;
+
+    Ok(LoadedGuest {
+        entry,
+        initrd_base,
+        initrd_size,
+    })
+}
+
+/// Loads a 32-bit ELF kernel into guest memory by virtual address.
+///
+/// A minimal hand-rolled ELF32 parser is used (rather than a general ELF crate)
+/// to keep this utility free of extra dependencies: the Nanvix kernel is always
+/// a static 32-bit little-endian executable with a small number of `PT_LOAD`
+/// segments.
+fn load_kernel(gm: &GuestMemory, path: &std::path::Path) -> anyhow::Result<u64> {
+    /// `PT_LOAD` program-header type.
+    const PT_LOAD: u32 = 1;
+    /// Size of an ELF32 program-header entry.
+    const PHDR_SIZE: usize = 32;
+
+    let data = std::fs::read(path).context("failed to read kernel")?;
+    if data.len() < 52 || &data[0..4] != b"\x7fELF" {
+        anyhow::bail!("kernel is not an ELF file");
+    }
+    // ELFCLASS32, ELFDATA2LSB.
+    if data[4] != 1 || data[5] != 1 {
+        anyhow::bail!("kernel is not a 32-bit little-endian ELF");
+    }
+
+    let rd_u32 = |off: usize| -> u32 {
+        u32::from_le_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]])
+    };
+    let rd_u16 = |off: usize| -> u16 { u16::from_le_bytes([data[off], data[off + 1]]) };
+
+    let entry = rd_u32(24);
+    let phoff = rd_u32(28) as usize;
+    let phentsize = rd_u16(42) as usize;
+    let phnum = rd_u16(44) as usize;
+    if phentsize < PHDR_SIZE {
+        anyhow::bail!("unexpected ELF program-header entry size {phentsize}");
+    }
+
+    for i in 0..phnum {
+        let base = phoff + i * phentsize;
+        if base + PHDR_SIZE > data.len() {
+            anyhow::bail!("ELF program header {i} out of bounds");
+        }
+        if rd_u32(base) != PT_LOAD {
+            continue;
+        }
+        let p_offset = rd_u32(base + 4) as usize;
+        let p_vaddr = u64::from(rd_u32(base + 8));
+        let p_filesz = rd_u32(base + 16) as usize;
+        if p_filesz == 0 {
+            continue;
+        }
+        let end = p_offset
+            .checked_add(p_filesz)
+            .filter(|&e| e <= data.len())
+            .context("ELF segment file range out of bounds")?;
+        gm.write_at(p_vaddr, &data[p_offset..end])
+            .with_context(|| {
+                format!("failed to write kernel segment at {p_vaddr:#x} ({p_filesz} bytes)")
+            })?;
+        // The trailing BSS (`p_memsz > p_filesz`) is left to the demand-zero
+        // guest RAM mapping, matching the Nanvix uservm loader.
+    }
+
+    Ok(u64::from(entry))
+}
+
+/// Loads the initrd at the fixed base address and, for a single-binary initrd,
+/// writes a length-prefixed command-line string immediately after it.
+fn load_initrd(
+    gm: &GuestMemory,
+    path: &std::path::Path,
+    initrd_args: Option<&str>,
+    mem_size: u64,
+) -> anyhow::Result<(u64, u64)> {
+    let base = config::microvm::DEFAULT_INITRD_BASE as u64;
+    let data = std::fs::read(path).context("failed to read initrd")?;
+    let size = data.len() as u64;
+    let size_rounded = page_round_up(size);
+
+    let end = base + size_rounded;
+    if end > mem_size {
+        anyhow::bail!(
+            "initrd does not fit in guest memory (initrd_end={end:#x}, mem_size={mem_size:#x})"
+        );
+    }
+
+    gm.write_at(base, &data).context("failed to write initrd")?;
+
+    // Build the command line: "<basename> <args>".
+    let mut args = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+    if let Some(extra) = initrd_args {
+        args.push(' ');
+        args.push_str(extra);
+    }
+    // The guest locates the command line at the page-rounded end of the initrd
+    // region (it derives the region size in pages from the boot register), so
+    // the length-prefixed string must be written there, not at the raw end.
+    write_initrd_args(gm, base + size_rounded, &args)?;
+
+    Ok((base, size_rounded))
+}
+
+/// Writes a `u16` little-endian length followed by the argument bytes, just
+/// past the end of the initrd region.
+fn write_initrd_args(gm: &GuestMemory, initrd_end: u64, args: &str) -> anyhow::Result<()> {
+    let bytes = args.as_bytes();
+    if bytes.len() > config::system::MAX_CMDLINE_ARGS_LEN {
+        anyhow::bail!(
+            "initrd command line too long (len={}, max={})",
+            bytes.len(),
+            config::system::MAX_CMDLINE_ARGS_LEN
+        );
+    }
+    let len = bytes.len() as u16;
+    gm.write_at(initrd_end, &len.to_le_bytes())
+        .context("failed to write initrd args length")?;
+    gm.write_at(initrd_end + 2, bytes)
+        .context("failed to write initrd args data")?;
+    Ok(())
+}
+
+/// Loads a RAM filesystem image at the top of guest RAM and returns its base
+/// and (page-rounded) size.
+fn load_ramfs(
+    gm: &GuestMemory,
+    path: &std::path::Path,
+    initrd_end: u64,
+    mem_size: u64,
+) -> anyhow::Result<(u64, u64)> {
+    /// Minimum gap required between the end of the initrd and the RAMFS.
+    const RAMFS_MIN_SLACK_BYTES: u64 = 4 * 1024 * 1024;
+
+    let data = std::fs::read(path).context("failed to read ramfs")?;
+    let size = page_round_up(data.len() as u64);
+
+    if initrd_end + RAMFS_MIN_SLACK_BYTES > mem_size {
+        anyhow::bail!(
+            "guest memory ({mem_size:#x}) too small for initrd end plus slack ({:#x})",
+            initrd_end + RAMFS_MIN_SLACK_BYTES
+        );
+    }
+    let base = mem_size
+        .checked_sub(size)
+        .context("ramfs image does not fit in guest memory")?;
+    if base < initrd_end {
+        anyhow::bail!("ramfs would overlap the initrd region");
+    }
+
+    gm.write_at(base, &data).context("failed to write ramfs")?;
+    Ok((base, size))
+}
+
+/// Writes the kernel-arguments length and data into the control page.
+fn write_kernel_args(gm: &GuestMemory, args: &str) -> anyhow::Result<()> {
+    let bytes = args.as_bytes();
+    if bytes.len() > config::microvm::MAX_KERNEL_ARGS_LEN {
+        anyhow::bail!(
+            "kernel arguments too long (len={}, max={})",
+            bytes.len(),
+            config::microvm::MAX_KERNEL_ARGS_LEN
+        );
+    }
+    let len = bytes.len() as u16;
+    gm.write_at(config::microvm::DEFAULT_MICROVM_CTRL_KERNEL_ARGS_LEN as u64, &len.to_le_bytes())
+        .context("failed to write kernel args length")?;
+    if !bytes.is_empty() {
+        gm.write_at(config::microvm::DEFAULT_MICROVM_CTRL_KERNEL_ARGS_DATA as u64, bytes)
+            .context("failed to write kernel args data")?;
+    }
+    Ok(())
+}
+
+/// Writes the current wall-clock time (UTC nanoseconds since the Unix epoch)
+/// into the pvclock page so the guest can derive wall-clock time.
+fn write_pvclock_boot_time(gm: &GuestMemory) -> anyhow::Result<()> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let boot_time_ns = now.as_secs() * 1_000_000_000 + u64::from(now.subsec_nanos());
+    let offset = (config::microvm::DEFAULT_PVCLOCK_PAGE
+        + config::microvm::PVCLOCK_BOOT_TIME_NS_OFFSET) as u64;
+    gm.write_at(offset, &boot_time_ns.to_le_bytes())
+        .context("failed to write pvclock boot time")?;
+    Ok(())
+}
+
+/// Writes a little-endian `u32` to the given guest physical address.
+fn write_u32(gm: &GuestMemory, gpa: u64, value: u32) -> anyhow::Result<()> {
+    gm.write_at(gpa, &value.to_le_bytes())
+        .with_context(|| format!("failed to write u32 at {gpa:#x}"))
+}

--- a/src/utils/nanvixd-vmm/src/stdin.rs
+++ b/src/utils/nanvixd-vmm/src/stdin.rs
@@ -1,0 +1,100 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Streaming host-stdin channel for the guest's `read(2)` bridge.
+//!
+//! The guest reads its standard input through the IKC bridge. To support
+//! interactive and streaming workloads (e.g. the VFS benchmark, which sends one
+//! request at a time and waits for the reply before sending the next), host
+//! stdin must be delivered to the guest *incrementally* rather than buffered up
+//! front. A background thread reads the host's standard input and appends it to
+//! a shared queue; the guest's blocking `read` waits on a condition variable
+//! until data is available or stdin reaches end-of-file.
+//!
+//! This mirrors the Nanvix `uservm` standalone handler, whose read path waits on
+//! its input channel when the buffer is empty and the channel is still open, and
+//! reports EOF once it closes.
+
+use ::std::{
+    collections::VecDeque,
+    sync::{
+        Arc,
+        Condvar,
+        Mutex,
+    },
+};
+
+/// Shared, growable buffer of host stdin bytes plus an end-of-file flag.
+struct State {
+    data: VecDeque<u8>,
+    closed: bool,
+}
+
+struct Inner {
+    state: Mutex<State>,
+    cond: Condvar,
+}
+
+/// A handle to the host's standard input, fed by a background reader thread.
+#[derive(Clone)]
+pub struct HostStdin {
+    inner: Arc<Inner>,
+}
+
+impl HostStdin {
+    /// Spawns the background reader thread and returns a handle.
+    ///
+    /// The thread reads the process's standard input in chunks until EOF (or an
+    /// error), making each chunk immediately available to [`Self::read_up_to`].
+    pub fn spawn() -> Self {
+        let inner = Arc::new(Inner {
+            state: Mutex::new(State {
+                data: VecDeque::new(),
+                closed: false,
+            }),
+            cond: Condvar::new(),
+        });
+
+        let reader = inner.clone();
+        std::thread::spawn(move || {
+            use std::io::Read as _;
+            let mut stdin = std::io::stdin();
+            let mut buf = [0u8; 4096];
+            loop {
+                match stdin.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let mut state = reader.state.lock().expect("host stdin lock");
+                        state.data.extend(&buf[..n]);
+                        reader.cond.notify_all();
+                    },
+                    Err(_) => break,
+                }
+            }
+            let mut state = reader.state.lock().expect("host stdin lock");
+            state.closed = true;
+            reader.cond.notify_all();
+        });
+
+        Self { inner }
+    }
+
+    /// Returns up to `max` bytes of host stdin.
+    ///
+    /// Blocks until at least one byte is available, returning it immediately
+    /// (without waiting to fill `max`). Returns an empty vector only once stdin
+    /// has reached end-of-file, which the caller surfaces to the guest as EOF.
+    pub fn read_up_to(&self, max: usize) -> Vec<u8> {
+        let mut state = self.inner.state.lock().expect("host stdin lock");
+        loop {
+            if !state.data.is_empty() {
+                let n = state.data.len().min(max);
+                return state.data.drain(..n).collect();
+            }
+            if state.closed {
+                return Vec::new();
+            }
+            state = self.inner.cond.wait(state).expect("host stdin wait");
+        }
+    }
+}

--- a/src/utils/nanvixd-vmm/src/vmm.rs
+++ b/src/utils/nanvixd-vmm/src/vmm.rs
@@ -28,6 +28,7 @@ use chipset_resources::{
 };
 use guestmem::GuestMemory;
 use hvdef::Vtl;
+use state_unit::StateUnits;
 use std::{
     future::{
         poll_fn,
@@ -90,7 +91,6 @@ use vmotherboard::{
     Chipset,
     ChipsetDeviceHandle,
 };
-use state_unit::StateUnits;
 
 /// Runs the Nanvix guest to completion and returns its exit code.
 ///
@@ -244,8 +244,7 @@ pub async fn run(
         Arc::new(ApicLintLineTarget::new(partition.clone(), Vtl::Vtl0)),
     );
 
-    let (chipset, _chipset_devices) =
-        chipset_builder.build().context("failed to build chipset")?;
+    let (chipset, _chipset_devices) = chipset_builder.build().context("failed to build chipset")?;
 
     // Start the device model (PIC/PIT) and the vmtime clock.
     state_units.start().await;

--- a/src/utils/nanvixd-vmm/src/vmm.rs
+++ b/src/utils/nanvixd-vmm/src/vmm.rs
@@ -489,7 +489,10 @@ trait RequestYield: Send + Sync {
 
 impl<T: Partition> RequestYield for T {
     fn request_yield(&self, vp_index: VpIndex) {
-        self.request_yield(vp_index)
+        // Forward explicitly to the `Partition` method via UFCS: a plain
+        // `self.request_yield(..)` is ambiguous with (and could resolve back
+        // to) this trait method.
+        Partition::request_yield(self, vp_index)
     }
 }
 

--- a/src/utils/nanvixd-vmm/src/vmm.rs
+++ b/src/utils/nanvixd-vmm/src/vmm.rs
@@ -1,0 +1,552 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Builds and runs a KVM-backed partition that boots the Nanvix guest.
+//!
+//! The flow mirrors OpenVMM's host VMMs: create a proto-partition from the KVM
+//! hypervisor, allocate and map guest RAM, load the guest, set the boot register
+//! state, and run the single vCPU, dispatching its port-I/O exits to the
+//! [`NanvixDevice`].
+
+// UNSAFETY: needed to map guest memory into the partition.
+#![expect(unsafe_code)]
+
+use crate::{
+    device::{
+        ExitReason,
+        NanvixDevice,
+    },
+    ikc::IkcBridge,
+    load,
+    load::GuestImage,
+};
+use anyhow::Context as _;
+use chipset_device_resources::BSP_LINT_LINE_SET;
+use chipset_resources::{
+    pic::PicDeviceHandle,
+    pit::PitDeviceHandle,
+};
+use guestmem::GuestMemory;
+use hvdef::Vtl;
+use std::{
+    future::{
+        poll_fn,
+        Future,
+    },
+    path::PathBuf,
+    pin::pin,
+    sync::{
+        Arc,
+        Weak,
+    },
+    task::{
+        Context,
+        Waker,
+    },
+};
+use virt::{
+    vp::AccessVpState as _,
+    BindProcessor,
+    Hypervisor,
+    Partition,
+    PartitionConfig,
+    PartitionMemoryMapper,
+    Processor,
+    ProtoPartition,
+    ProtoPartitionConfig,
+    StopVpSource,
+    VpIndex,
+};
+use vm_resource::{
+    IntoResource as _,
+    ResourceId as _,
+    ResourceResolver,
+};
+use vm_topology::{
+    memory::MemoryLayout,
+    processor::{
+        x86::X2ApicState,
+        TopologyBuilder,
+    },
+};
+use vmcore::{
+    vm_task::{
+        SingleDriverBackend,
+        VmTaskDriverSource,
+    },
+    vmtime::{
+        VmTime,
+        VmTimeKeeper,
+    },
+};
+use vmm_core::emuplat::apic::ApicLintLineTarget;
+use vmotherboard::{
+    options::{
+        BaseChipsetDevices,
+        BaseChipsetFoundation,
+    },
+    BaseChipsetBuilder,
+    BaseChipsetBuilderOutput,
+    Chipset,
+    ChipsetDeviceHandle,
+};
+use state_unit::StateUnits;
+
+/// Runs the Nanvix guest to completion and returns its exit code.
+///
+/// `stdin` is the buffered host input forwarded to the guest, and `console`
+/// receives the guest's kernel console output. When `mount_directory` is set the
+/// guest's HostFS requests are served by the reused `hostfsd` daemon rooted at
+/// that path; when `networking` is enabled, networking IKC traffic is served by
+/// the reused `networkd` daemon.
+pub async fn run(
+    driver: pal_async::DefaultDriver,
+    image: GuestImage,
+    io: Box<dyn crate::io::GuestIo>,
+    console: crate::ConsoleSink,
+    mount_directory: Option<PathBuf>,
+    networking: bool,
+) -> anyhow::Result<u16> {
+    // Single-vCPU x86 topology, advertising x2apic support like a modern PC.
+    let processor_topology = TopologyBuilder::new_x86()
+        .x2apic(X2ApicState::Supported)
+        .build(1)
+        .context("failed to build processor topology")?;
+
+    let memory_layout = MemoryLayout::new(image.mem_size, &[], &[], &[], None)
+        .context("failed to build memory layout")?;
+
+    // Task/driver plumbing shared by the vmtime keeper, the chipset's device
+    // tasks (the PIT poll loop), and the state-unit machinery.
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
+    let mut state_units = StateUnits::new();
+
+    // The vmtime keeper drives the virtual clock that the PIT samples. It is
+    // owned by a state unit so that the device model can start/stop it in
+    // lockstep with the rest of the chipset.
+    let vmtime_keeper = VmTimeKeeper::new(&driver_source.simple(), VmTime::from_100ns(0));
+    let vmtime_source = vmtime_keeper
+        .builder()
+        .build(&driver_source.simple())
+        .await
+        .context("failed to build vmtime source")?;
+    let vmtime_unit = state_units
+        .add("vmtime")
+        .spawn(driver_source.simple(), |recv| {
+            let mut vmtime_keeper = vmtime_keeper;
+            async move {
+                vmm_core::vmtime_unit::run_vmtime(&mut vmtime_keeper, recv).await;
+                vmtime_keeper
+            }
+        })
+        .context("failed to spawn vmtime unit")?;
+
+    let mut hv = virt_kvm::Kvm::new().context("failed to create KVM hypervisor")?;
+    let proto = hv
+        .new_partition(ProtoPartitionConfig {
+            processor_topology: &processor_topology,
+            hv_config: None,
+            vmtime: &vmtime_source,
+            isolation: virt::IsolationType::None,
+        })
+        .context("failed to create proto partition")?;
+
+    // Back guest RAM with a lazily-committed anonymous mapping: pages are
+    // demand-zero and fault in only on first touch, so a large guest RAM size
+    // costs almost nothing to "allocate" (matching the host `mmap` behavior the
+    // Nanvix uservm relies on, rather than eagerly zeroing the whole region).
+    let ram = sparse_mmap::SparseMapping::new(image.mem_size as usize)
+        .context("failed to reserve guest memory")?;
+    ram.alloc(0, ram.len())
+        .context("failed to allocate guest memory")?;
+    let ram_ptr = ram.as_ptr().cast::<u8>();
+    let guest_memory = GuestMemory::new("nanvix-guest-ram", ram);
+
+    let (partition, vps) = proto
+        .build(PartitionConfig {
+            mem_layout: &memory_layout,
+            guest_memory: &guest_memory,
+            cpuid: &[],
+            vtl0_alias_map: None,
+        })
+        .context("failed to build partition")?;
+
+    let partition = Arc::new(partition);
+
+    // Map guest RAM into the partition.
+    for r in memory_layout.ram() {
+        let range = r.range;
+        // SAFETY: `ram_ptr` is the base of the guest RAM mapping, kept alive by
+        // `guest_memory` until the vCPU thread joins below.
+        unsafe {
+            partition
+                .memory_mapper(Vtl::Vtl0)
+                .map_range(
+                    ram_ptr.add(range.start() as usize).cast(),
+                    range.len() as usize,
+                    range.start(),
+                    true,
+                    true,
+                )
+                .context("failed to map guest memory")?;
+        }
+    }
+
+    // Load the kernel, initrd, RAMFS, and control/pvclock pages.
+    let loaded = load::load(&guest_memory, &image)?;
+
+    // Build the real-mode boot register state.
+    let regs = boot_registers(&loaded);
+
+    // Build the legacy chipset: an 8259 PIC and an 8254 PIT, reusing the
+    // in-tree device implementations. The PIT raises its timer line into the
+    // PIC, whose `ready` output is wired (below) into the BSP's APIC LINT0 so
+    // the guest sees periodic IRQ 0 interrupts in virtual-wire mode.
+    let resolver = ResourceResolver::new();
+    let noop_handler = Arc::new(NoopChipsetHandler);
+    let BaseChipsetBuilderOutput {
+        chipset_builder,
+        device_interfaces: _,
+    } = BaseChipsetBuilder::new(
+        BaseChipsetFoundation {
+            is_restoring: false,
+            untrusted_dma_memory: guest_memory.clone(),
+            trusted_vtl0_dma_memory: guest_memory.clone(),
+            power_event_handler: noop_handler.clone(),
+            debug_event_handler: noop_handler.clone(),
+            vmtime: &vmtime_source,
+            vmtime_unit: vmtime_unit.handle(),
+            doorbell_registration: None,
+        },
+        BaseChipsetDevices::empty(),
+    )
+    .with_device_handles(vec![
+        ChipsetDeviceHandle {
+            name: PicDeviceHandle::ID.to_owned(),
+            resource: PicDeviceHandle.into_resource(),
+        },
+        ChipsetDeviceHandle {
+            name: PitDeviceHandle::ID.to_owned(),
+            resource: PitDeviceHandle.into_resource(),
+        },
+    ])
+    .build(&driver_source, &state_units, &resolver)
+    .await
+    .context("failed to build chipset")?;
+
+    // Route the BSP's local APIC LINT lines so the PIC's output reaches the
+    // guest as an interrupt (LINT0 in ExtINT mode, configured per-vCPU below).
+    chipset_builder.add_external_line_target(
+        BSP_LINT_LINE_SET,
+        0..=1,
+        0,
+        "bsp",
+        Arc::new(ApicLintLineTarget::new(partition.clone(), Vtl::Vtl0)),
+    );
+
+    let (chipset, _chipset_devices) =
+        chipset_builder.build().context("failed to build chipset")?;
+
+    // Start the device model (PIC/PIT) and the vmtime clock.
+    state_units.start().await;
+
+    // Run the single vCPU on its own thread; KVM requires the vCPU ioctls to be
+    // issued from the thread that owns the vCPU file descriptor.
+    let [vp] = vps
+        .try_into()
+        .ok()
+        .context("expected exactly one vCPU binder")?;
+
+    // The vCPU thread reports its result over a oneshot channel rather than via
+    // a blocking `join`, so this task can keep yielding to the single-threaded
+    // executor (which must keep servicing the PIT poll and vmtime tasks).
+    let (result_tx, result_rx) = mesh::oneshot();
+    let vp_thread = run_vp(
+        partition.clone(),
+        vp,
+        regs,
+        guest_memory.clone(),
+        chipset.clone(),
+        io,
+        console,
+        mount_directory,
+        networking,
+        result_tx,
+    );
+
+    let exit = result_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("vcpu thread panicked"))?;
+    let _ = vp_thread.join();
+
+    // Stop the device model and release the partition.
+    state_units.stop().await;
+    drop(chipset);
+    drop(partition);
+
+    match exit? {
+        ExitReason::Shutdown(code) => Ok(code),
+        ExitReason::Snapshot => Ok(0),
+    }
+}
+
+/// No-op power/debug event handler for the chipset.
+///
+/// The Nanvix guest drives shutdown through its own control port, and there is
+/// no debugger attached, so neither chipset event is acted upon.
+struct NoopChipsetHandler;
+
+impl vmotherboard::PowerEventHandler for NoopChipsetHandler {
+    fn on_power_event(&self, _evt: vmotherboard::PowerEvent) {}
+}
+
+impl vmotherboard::DebugEventHandler for NoopChipsetHandler {
+    fn on_debug_break(&self, _vp: Option<u32>) {}
+}
+
+/// Builds the initial register state for booting the Nanvix kernel.
+///
+/// The kernel's entry point is 16-bit real-mode trampoline code at physical
+/// `0x8000`. The guest expects the VMM identification magic in `RAX` and an
+/// encoded description of the initrd in `RBX`.
+fn boot_registers(loaded: &load::LoadedGuest) -> virt::vp::Registers {
+    use virt::x86::{
+        SegmentRegister,
+        TableRegister,
+    };
+
+    // Real-mode code segment with a zero base, so the linear fetch address
+    // equals the instruction pointer.
+    let cs = SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x9b,
+    };
+    let data = SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x93,
+    };
+    let tr = SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x8b,
+    };
+    let ldtr = SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x82,
+    };
+    let table = TableRegister {
+        base: 0,
+        limit: 0xffff,
+    };
+
+    virt::vp::Registers {
+        rip: loaded.entry,
+        rax: u64::from(config::microvm::DEFAULT_BOOT_MAGIC),
+        rbx: encode_initrd(loaded.initrd_base, loaded.initrd_size),
+        // Bit 1 is reserved-as-one; interrupts remain disabled until the kernel
+        // installs its IDT and enables them itself.
+        rflags: 0x2,
+        cs,
+        ds: data,
+        es: data,
+        fs: data,
+        gs: data,
+        ss: data,
+        tr,
+        ldtr,
+        gdtr: table,
+        idtr: table,
+        // Standard x86 reset control-register state: protected mode disabled.
+        cr0: x86defs::X64_CR0_ET | x86defs::X64_CR0_CD | x86defs::X64_CR0_NW,
+        ..Default::default()
+    }
+}
+
+/// Encodes the initrd base address and size into the value placed in `RBX`.
+///
+/// The low bits (below the alignment of the initrd base) hold the size in 4 KiB
+/// pages; the high bits hold the base address.
+fn encode_initrd(base: u64, size: u64) -> u64 {
+    if size == 0 {
+        return 0;
+    }
+    let nzeros = (config::microvm::DEFAULT_INITRD_BASE as u64).trailing_zeros();
+    let mask = (1u64 << nzeros) - 1;
+    (base & !mask) | ((size >> 12) & mask)
+}
+
+/// Spawns the vCPU thread, reporting the guest exit reason over `result_tx`.
+///
+/// The returned join handle is only used for cleanup; the result is delivered
+/// through the channel so the caller can await it without blocking the executor
+/// thread that services the chipset's timer tasks.
+#[expect(clippy::too_many_arguments)]
+fn run_vp(
+    partition: Arc<dyn RequestYield>,
+    mut binder: impl 'static + BindProcessor + Send,
+    regs: virt::vp::Registers,
+    guest_memory: GuestMemory,
+    chipset: Arc<Chipset>,
+    io: Box<dyn crate::io::GuestIo>,
+    console: crate::ConsoleSink,
+    mount_directory: Option<PathBuf>,
+    networking: bool,
+    result_tx: mesh::OneshotSender<anyhow::Result<ExitReason>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let result = run_vp_inner(
+            &partition,
+            &mut binder,
+            regs,
+            guest_memory,
+            chipset,
+            io,
+            console,
+            mount_directory,
+            networking,
+        );
+        result_tx.send(result);
+    })
+}
+
+/// Body of the vCPU thread, factored out so the result can be captured and sent
+/// over the oneshot channel by [`run_vp`].
+#[expect(clippy::too_many_arguments)]
+fn run_vp_inner(
+    partition: &Arc<dyn RequestYield>,
+    binder: &mut (impl 'static + BindProcessor + Send),
+    regs: virt::vp::Registers,
+    guest_memory: GuestMemory,
+    chipset: Arc<Chipset>,
+    io: Box<dyn crate::io::GuestIo>,
+    console: crate::ConsoleSink,
+    mount_directory: Option<PathBuf>,
+    networking: bool,
+) -> anyhow::Result<ExitReason> {
+    let vp_index = VpIndex::BSP;
+    let mut vp = binder.bind().context("failed to bind vcpu")?;
+
+    // Install the boot register state and configure the local APIC for
+    // legacy "virtual wire" mode.
+    {
+        let mut state = vp.access_state(Vtl::Vtl0);
+        state
+            .set_registers(&regs)
+            .context("failed to set registers")?;
+
+        // The Nanvix guest boots without an ACPI MADT and never initializes
+        // the local APIC, expecting legacy 8259 PIC interrupts on the INTR
+        // pin. With KVM's split IRQ chip those interrupts are delivered
+        // through the in-kernel APIC's LINT0 in ExtINT mode, so configure
+        // that here (as platform firmware normally would): software-enable
+        // the APIC and route LINT0 as an unmasked ExtINT source.
+        let mut apic = state.apic().context("failed to read apic state")?;
+        let mut apic_regs = virt::vp::ApicRegisters::from_array(apic.registers);
+        apic_regs.svr |= 0x100;
+        apic_regs.lvt_lint0 = 0x700;
+        apic.registers = *apic_regs.as_array();
+        state.set_apic(&apic).context("failed to set apic state")?;
+
+        state.commit().context("failed to commit vp state")?;
+    }
+
+    let stop = StopVpSource::new();
+    let bridge = IkcBridge::new(io, mount_directory, networking);
+    let device = NanvixDevice::new(guest_memory, bridge, &stop, chipset, console);
+    let result = block_on(async {
+        let mut run = pin!(vp.run_vp(stop.checker(), &device));
+        poll_fn(|cx| {
+            let waker = Waker::from(Arc::new(VpWaker::new(
+                Arc::downgrade(partition),
+                vp_index,
+                cx.waker().clone(),
+            )));
+            run.as_mut().poll(&mut Context::from_waker(&waker))
+        })
+        .await
+    });
+
+    match result {
+        Err(reason) => match device.take_exit() {
+            Some(exit) => Ok(exit),
+            None => Err(anyhow::anyhow!("guest faulted: {reason:?}")),
+        },
+    }
+}
+
+/// Trait object wrapper so the vCPU waker can request a yield without naming the
+/// concrete partition type.
+trait RequestYield: Send + Sync {
+    /// Forces the `run_vp` call to yield to the scheduler.
+    fn request_yield(&self, vp_index: VpIndex);
+}
+
+impl<T: Partition> RequestYield for T {
+    fn request_yield(&self, vp_index: VpIndex) {
+        self.request_yield(vp_index)
+    }
+}
+
+/// Waker that nudges a blocked vCPU out of its run call when woken.
+struct VpWaker {
+    partition: Weak<dyn RequestYield>,
+    vp: VpIndex,
+    inner: Waker,
+}
+
+impl VpWaker {
+    fn new(partition: Weak<dyn RequestYield>, vp: VpIndex, waker: Waker) -> Self {
+        Self {
+            partition,
+            vp,
+            inner: waker,
+        }
+    }
+}
+
+impl std::task::Wake for VpWaker {
+    fn wake_by_ref(self: &Arc<Self>) {
+        if let Some(partition) = self.partition.upgrade() {
+            partition.request_yield(self.vp);
+        }
+        self.inner.wake_by_ref();
+    }
+
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref()
+    }
+}
+
+/// Minimal single-thread executor: polls `fut` to completion, parking the
+/// current thread between wakeups. Equivalent to `futures::executor::block_on`
+/// but without pulling in the `futures` crate.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    use std::task::Poll;
+
+    struct ThreadWaker(std::thread::Thread);
+    impl std::task::Wake for ThreadWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let mut fut = pin!(fut);
+    let waker = Waker::from(Arc::new(ThreadWaker(std::thread::current())));
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => std::thread::park(),
+        }
+    }
+}

--- a/test/test-standalone-openvmm.toml
+++ b/test/test-standalone-openvmm.toml
@@ -1,0 +1,352 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Standalone test suite for the OpenVMM-based daemon (`nanvixd-vmm`).
+#
+# This mirrors `test-standalone.toml` but points `nanvixd_binary_path` at
+# `./bin/nanvixd-vmm.elf` so the exact same terminal/http/empty cases run
+# against the OpenVMM VMM as a drop-in for the uservm-based `nanvixd`. The
+# `snapshot-restore` / `snapshot-save-exit` cases are intentionally omitted:
+# snapshotting is not supported by this VMM.
+[runner]
+nanvixd_binary_path = "./bin/nanvixd-vmm.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+[[tests]]
+executor = "empty"
+name = "empty/1"
+iterations = 1
+
+[[tests]]
+executor = "empty"
+name = "empty/2"
+iterations = 2
+
+#===================================================================================================
+# HTTP Executor Tests (Non-Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 13
+
+[[tests]]
+executor = "http"
+program = "./bin/test-mmio-fault.elf"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 3
+
+[[tests]]
+executor = "http"
+program = "./bin/vfs-test.elf"
+extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 0
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-rust-nostd.initrd"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/thread-rust.initrd"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/test-fork-kcall.initrd"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 13
+
+[[tests]]
+executor = "http"
+program = "./bin/stress-rust.initrd"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/arch-rust.initrd"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/linux-app.initrd"
+extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
+input = "[]"
+expected_output = "ok"
+
+#===================================================================================================
+# Terminal Executor Tests (Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 13
+
+[[tests]]
+executor = "terminal"
+program = "./bin/test-mmio-fault.elf"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 3
+
+[[tests]]
+executor = "terminal"
+program = "./bin/vfs-test.elf"
+extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 0
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-rust-nostd.initrd"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/thread-rust.initrd"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/test-fork-kcall.initrd"
+expect_empty_output = true
+expected_exit_code = 13
+
+[[tests]]
+executor = "terminal"
+program = "./bin/stress-rust.initrd"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/arch-rust.initrd"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/linux-app.initrd"
+extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-len-rust.elf"
+# 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
+program_args_padding_len = 4071
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-len-rust.elf"
+# 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
+program_args_padding_len = 4071
+expected_output = "ok"
+
+
+#===================================================================================================
+# Host Mount Tests
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/mount-test.initrd"
+extra_nanvixd_args = "-mount ./bin/mount-test-data"
+input = "[]"
+expected_output = "ok"
+expected_exit_code = 0
+runs_on = ["microvm"]
+
+[[tests]]
+executor = "terminal"
+program = "./bin/mount-multipart-test.initrd"
+input = "[]"
+expected_output = "ok"
+expected_exit_code = 0
+runs_on = ["microvm"]
+
+#===================================================================================================
+# Networking Tests
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/network-rust.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/network-rust.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+expected_output = "ok"
+
+#===================================================================================================
+# Environment Variable Tests
+#===================================================================================================
+
+# Single environment variable.
+[[tests]]
+executor = "http"
+program = "./bin/env-rust-nostd.elf"
+program_env = "TEST_VAR=hello"
+input = "[]"
+expected_output = "TEST_VAR=hello\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/env-rust-nostd.elf"
+program_env = "TEST_VAR=hello"
+expected_output = "TEST_VAR=hello\nok"
+
+# Multiple environment variables.
+[[tests]]
+executor = "http"
+program = "./bin/env-rust-nostd.elf"
+program_env = "FOO=bar BAZ=qux"
+input = "[]"
+expected_output = "FOO=bar\nBAZ=qux\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/env-rust-nostd.elf"
+program_env = "FOO=bar BAZ=qux"
+expected_output = "FOO=bar\nBAZ=qux\nok"
+
+# Environment variable with special characters in value.
+[[tests]]
+executor = "http"
+program = "./bin/env-rust-nostd.elf"
+program_env = "SPECIAL=a/b:c-d_e.f"
+input = "[]"
+expected_output = "SPECIAL=a/b:c-d_e.f\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/env-rust-nostd.elf"
+program_env = "SPECIAL=a/b:c-d_e.f"
+expected_output = "SPECIAL=a/b:c-d_e.f\nok"
+
+#===================================================================================================
+# Combined Command-Line Argument and Environment Variable Tests
+#===================================================================================================
+
+# Program with args and environment variables.
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello world"
+program_env = "FOO=bar"
+input = "[]"
+expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello world"
+program_env = "FOO=bar"
+expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
+
+# Program with args and no environment variables.
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello world"
+input = "[]"
+expected_output = "ARGS:hello world\nENV:\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello world"
+expected_output = "ARGS:hello world\nENV:\nok"
+
+# Program with no args and with environment variables.
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_env = "FOO=bar"
+input = "[]"
+expected_output = "ARGS:\nENV:FOO=bar\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_env = "FOO=bar"
+expected_output = "ARGS:\nENV:FOO=bar\nok"
+
+# Program with escaped args (literal semicolon in arguments).
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "a;b"
+program_env = "X=1"
+input = "[]"
+expected_output = "ARGS:a;b\nENV:X=1\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "a;b"
+program_env = "X=1"
+expected_output = "ARGS:a;b\nENV:X=1\nok"
+
+# Program with escaped environment variables (literal semicolon in env value).
+[[tests]]
+executor = "http"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello"
+program_env = "PATH=a;b"
+input = "[]"
+expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/cmdline-env-rust-nostd.elf"
+program_args = "hello"
+program_env = "PATH=a;b"
+expected_output = "ARGS:hello\nENV:PATH=a;b\nok"

--- a/z.py
+++ b/z.py
@@ -72,6 +72,7 @@ KNOWN_MAKE_VARS: frozenset[str] = frozenset(
         "SCCACHE",
         "SYSROOT_DIR",
         "VERUS_EXECUTABLE_DIR",
+        "WITH_OPENVMM",
     }
 )
 


### PR DESCRIPTION
## Summary

The `feature-openvmm` branch introduced the OpenVMM-based standalone daemon (`nanvixd-vmm`) as a replacement for `uservm`, but only as a **library** with terminal-only stdio and no CI. This PR completes it into a drop-in for the standalone `nanvixd.elf` supporting **both terminal and HTTP modes**, validated by the real `nanvix-test` framework and an always-on CI job.

## What was missing / fixed

- **The crate could not build.** Its two declared binaries live under `src/bin/`, but the unanchored `bin/` rule in `.gitignore` also matched the crate's `src/bin/` directory, so the binary sources were never committed. Fixed by anchoring the rule (`bin/` → `/bin/`).
- **No binaries.** Added the `nanvixd-vmm` daemon binary and the `nanvixd-vmm-warmstart` benchmark binary (the latter matches `bench-compare.py` / README).
- **No HTTP mode.** Added it.
- **No CI.**

## Changes

- **`.gitignore`** — anchor the build-output ignore so the crate's `src/bin/` is tracked.
- **`src/bin/nanvixd-vmm.rs`** — daemon entry point. Parses the drop-in CLI (accepting/ignoring `nanvixd`'s flags), dispatches **terminal** mode (`-- program`, stdio bridged, exits with the guest code) or **HTTP** mode (`-http-addr`).
- **`src/http.rs`** — tokio + hyper control server replicating `nanvixd`'s standalone contract: `POST /` selected by `X-NVX-Message-Type` (`NEW`/`KILL`), a per-VM **gateway Unix socket** carrying the guest's stdio, graceful `SIGINT`/`SIGTERM` shutdown, `GET /ready`. Wire shape matches `nanvix-http::message`.
- **`src/io.rs`** — additive `GuestIoHandle::split()` for the gateway bridge.
- **`src/bin/nanvixd-vmm-warmstart.rs`** — white-box warm-start benchmark.
- **`test/test-standalone-openvmm.toml`** — drop-in copy of `test-standalone.toml` pointing at `./bin/nanvixd-vmm.elf`, minus the snapshot cases (unsupported by this VMM).
- **`.github/workflows/ci.yml`** — new always-on `ci-openvmm` job: installs `protoc`, sets up KVM, builds guests + `nanvix-test` + `nanvixd-vmm`, lint/format-checks the crate, and runs the terminal + http suite via `nanvix-test`.

## Validation

Locally, `./bin/nanvix-test.elf test/test-standalone-openvmm.toml` runs **42/42** standalone cases green (2 empty, 19 http, 21 terminal — incl. host mount and networking). `cargo clippy -- -D warnings`, `cargo fmt --check`, and repo `spellcheck`/`format-check` all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>