### PR TITLE
[vfsd] Clone and reclaim per-process fs state

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -64,6 +64,12 @@ pub(crate) fn handle_close_with_hostfs(
     let fd: i32 = req.fd;
 
     if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
+        // A forked child may share this open file description with its parent. Only forward the
+        // close to hostfsd when this is the last descriptor referencing it; otherwise just drop the
+        // local descriptor and acknowledge.
+        if !::vfs::fd::vfs_hostfs_is_last_ref(fd) {
+            return Some(super::short::handle_close(source, msg));
+        }
         if !pending.has_capacity() {
             return Some(build_error(source, ErrorCode::ResourceBusy));
         }

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -15,9 +15,12 @@ use crate::{
         send_response,
     },
     handler,
+    hostfs,
     pending::PendingQueue,
 };
 use ::proc::{
+    ForkCloneMessage,
+    ProcessExitMessage,
     ProcessManagementMessage,
     ProcessManagementMessageHeader,
     ShutdownMessage,
@@ -29,6 +32,7 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageSender,
         SystemMessage,
         SystemMessageHeader,
     },
@@ -48,15 +52,16 @@ use alloc::{
 };
 
 //==================================================================================================
-// Helper: Extract caller TID from message source
+// Helpers: Extract caller identity from message source
 //==================================================================================================
 
 /// Extracts the caller's thread identifier from an IPC message.
 ///
-/// When the message source encodes a PID (as is the case for messages routed through the kernel),
-/// the TID is derived by casting the PID value to a TID. This is correct only for single-threaded
-/// processes where TID == PID. Multi-threaded callers would require the source to encode the TID
-/// directly.
+/// Guest syscall requests encode their source as the caller's thread id (`MessageSender::from` a
+/// `ThreadIdentifier`) because vfsd needs the TID to route the reply, so this almost always takes
+/// the TID branch and returns it as-is. A PID-encoded source (e.g. a message routed with a
+/// `ProcessIdentifier`) is handled by deriving a TID from the PID value, which is correct only for
+/// single-threaded processes where TID == PID.
 fn caller_tid(message: &Message) -> ThreadIdentifier {
     let source = message.source;
     match source.as_id() {
@@ -68,11 +73,43 @@ fn caller_tid(message: &Message) -> ThreadIdentifier {
     }
 }
 
+/// Extracts the caller's process identifier from an IPC message.
+///
+/// Guest syscall requests encode their source as the caller's *thread* id (vfsd needs the TID to
+/// route the reply), so this almost always takes the TID branch and derives the PID by casting the
+/// TID value. That cast resolves to the correct process only for single-threaded callers where
+/// TID == PID; a request issued from a non-main thread of a multi-threaded process would be
+/// misattributed, keying its per-process VFS state (fd table and cwd) by the wrong identifier.
+///
+/// TODO(#2529): derive the caller PID from an authoritative value supplied by the kernel (e.g. a
+/// PID carried alongside the TID in the IPC metadata) instead of casting the TID, so
+/// multi-threaded callers are attributed to the correct process.
+fn caller_pid(message: &Message) -> ProcessIdentifier {
+    let sender: MessageSender = message.source;
+    match sender.as_id() {
+        Ok(pid) => pid,
+        Err(tid) => ProcessIdentifier::from(i32::from(tid)),
+    }
+}
+
 //==================================================================================================
 // SystemMessage Handler (procd shutdown)
 //==================================================================================================
 
 fn handle_system_message(message: Message) -> Result<bool, Error> {
+    // State-mutating process-management messages are privileged: only procd may direct them. The
+    // caller (handle_ipc_message) routes here only when the message source is procd, which is the
+    // runtime gate. Note that this trusts `message.source`: the kernel currently only *logs* an
+    // invalid source and still delivers the message (see `src/kernel/src/ipc/send.rs`), so it does
+    // not by itself stop another process from spoofing a procd source. Robustly closing that gap
+    // would require the kernel to reject messages whose source does not match the real sender,
+    // tracked in issue #2527. The debug-assert below is a development sanity check of the routing
+    // invariant, not a security control.
+    debug_assert_eq!(
+        caller_pid(&message),
+        ProcessIdentifier::PROCD,
+        "handle_system_message invoked with non-procd source"
+    );
     let sys_msg: SystemMessage = SystemMessage::from_bytes(message.payload)?;
     match sys_msg.header {
         SystemMessageHeader::ProcessManagement => {
@@ -83,6 +120,62 @@ fn handle_system_message(message: Message) -> Result<bool, Error> {
                     let shutdown: ShutdownMessage = ShutdownMessage::from_bytes(pm_msg.payload);
                     ::syslog::info!("shutting down (code={:?})...", shutdown.code);
                     Ok(true)
+                },
+                ProcessManagementMessageHeader::ForkClone => {
+                    let fork_clone: ForkCloneMessage = ForkCloneMessage::from_bytes(pm_msg.payload);
+                    let parent: ProcessIdentifier = fork_clone.parent;
+                    let child: ProcessIdentifier = fork_clone.child;
+                    // Duplicate the parent's filesystem state onto the child: its open file
+                    // descriptors (sharing the underlying open file descriptions, and therefore
+                    // file offsets, as POSIX requires) together with a private copy of its current
+                    // working directory.
+                    if let Err(e) = ::vfs::fd::vfs_fork_clone(parent, child) {
+                        ::syslog::error!(
+                            "failed to clone filesystem state (parent={:?}, child={:?}, \
+                             error={:?})",
+                            parent,
+                            child,
+                            e
+                        );
+                    } else {
+                        ::syslog::info!(
+                            "cloned filesystem state (parent={:?}, child={:?})",
+                            parent,
+                            child
+                        );
+                    }
+                    Ok(false)
+                },
+                ProcessManagementMessageHeader::ProcessExit => {
+                    let exit: ProcessExitMessage = ProcessExitMessage::from_bytes(pm_msg.payload);
+                    let pid: ProcessIdentifier = exit.pid;
+                    // Reclaim the terminated process's per-process filesystem state, dropping its
+                    // open file descriptors so that surviving siblings retain correct last-reference
+                    // accounting. Any host-backed descriptors for which the process held the final
+                    // reference can no longer be closed by the process itself, so close them on
+                    // hostfsd here to avoid leaking remote handles.
+                    let orphaned: Vec<i32> = ::vfs::fd::vfs_process_exit(pid);
+                    for remote_fd in orphaned {
+                        // Fire-and-forget close: the requesting process is gone, so there is no
+                        // caller to acknowledge. As in the leak-avoidance path in `complete_open`,
+                        // the request is tagged with the `FIRE_AND_FORGET` sentinel op_id and no
+                        // pending op is registered; the main event loop recognizes that sentinel on
+                        // hostfsd's response and discards it without logging.
+                        if let Err(e) = hostfs::send_close_request(
+                            remote_fd,
+                            ::hostfs_api::OperationId::FIRE_AND_FORGET,
+                        ) {
+                            ::syslog::warn!(
+                                "failed to close orphaned hostfs fd on process exit (pid={:?}, \
+                                 remote_fd={}, error={:?})",
+                                pid,
+                                remote_fd,
+                                e
+                            );
+                        }
+                    }
+                    ::syslog::info!("reclaimed filesystem state (pid={:?})", pid);
+                    Ok(false)
                 },
                 _ => {
                     ::syslog::warn!("received unknown process management message, ignoring...");
@@ -110,17 +203,22 @@ pub(crate) fn handle_ipc_message(
     assemblers: &mut BTreeMap<(i32, u16), AssemblerEntry>,
     pending: &mut PendingQueue,
 ) -> Result<bool, Error> {
-    let msg_source = message.source;
     let source_tid: ThreadIdentifier = caller_tid(&message);
-    let source_pid: ProcessIdentifier = match msg_source.as_id() {
-        Ok(pid) => pid,
-        Err(tid) => ProcessIdentifier::from(i32::from(tid)),
-    };
+    let source_pid: ProcessIdentifier = caller_pid(&message);
 
     // Route messages from the process manager daemon (PROCD).
     if source_pid == ProcessIdentifier::PROCD {
         return handle_system_message(message);
     }
+
+    // Bind the VFS to the requesting process so that descriptor and working-directory operations
+    // resolve against its per-process state. Guest syscall messages encode their source as the
+    // caller's thread id, so `source_pid` is obtained by casting that TID to a PID (see
+    // `caller_pid`). This resolves to the correct process only for single-threaded callers where
+    // TID == PID; a request from a non-main thread of a multi-threaded process would be
+    // misattributed (see the TODO in `caller_pid` for the authoritative-PID fix). vfsd being
+    // single-threaded is what makes mutating this global current-process selector race-free.
+    ::vfs::fd::set_current_process(source_pid);
 
     // Parse as SystemCallMessage from user processes.
     let syscall_msg: SystemCallMessage = match SystemCallMessage::try_from_bytes(message.payload) {

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -314,6 +314,10 @@ pub fn main() {
                             }
                             if let Some(op) = pending.remove(op_id) {
                                 pending::complete_pending_op(op, &message.payload);
+                            } else if op_id == ::hostfs_api::OperationId::FIRE_AND_FORGET {
+                                // Expected: response to a fire-and-forget request (e.g. a
+                                // best-effort close on process exit or open-failure cleanup) for
+                                // which no pending op was registered. Discard it silently.
                             } else {
                                 ::syslog::warn!(
                                     "hostfs response with no pending op (header={:?}, op_id={})",

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -47,10 +47,11 @@ use ::sys::{
 pub(crate) struct PendingOp {
     /// Thread that initiated the request (to send the response back).
     pub source_tid: ThreadIdentifier,
-    /// Process that initiated the request (needed for push/pull in read).
-    /// `None` for operations that do not transfer data buffers (close, seek, etc.),
-    /// since those handlers only have a `ThreadIdentifier` and constructing a
-    /// `ProcessIdentifier` from a TID is incorrect.
+    /// Process that initiated the request, recorded for operations that need a PID to transfer
+    /// data buffers (the push/pull in read/write). Like every caller PID in vfsd it is derived by
+    /// casting the caller's TID (see `caller_pid` in `ipc.rs`), so it is correct only when
+    /// TID == PID. `None` for operations that never push/pull (close, seek, etc.) and therefore
+    /// need no PID at all.
     pub source_pid: Option<ProcessIdentifier>,
     /// The kind of operation, which determines how to interpret the IKC response.
     pub kind: PendingOpKind,
@@ -281,6 +282,26 @@ pub(crate) fn complete_pending_op(
     pending: PendingOp,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
 ) {
+    // Bind the VFS to the requesting process so that descriptor allocation (e.g. for a completed
+    // open) and directory-cursor updates land in its per-process state. Use the PID recorded on the
+    // pending op, falling back to deriving it from the source TID for operations that do not carry
+    // a PID (close, seek, etc.). Both paths rely on the same TID == PID assumption: the recorded
+    // `source_pid` is itself obtained by casting the caller's TID in `handle_ipc_message` (guest
+    // syscalls encode their source as a TID), so neither is correct for a request issued from a
+    // non-main thread of a multi-threaded process. See the TODO in `caller_pid` (ipc.rs) for the
+    // authoritative-PID fix. vfsd being single-threaded is what makes mutating this global
+    // current-process selector race-free.
+    //
+    // The caller is guaranteed to still be registered here: guest syscalls are synchronous, so it
+    // stays blocked awaiting this very response and cannot exit, and the only involuntary
+    // termination path (memd killing a faulting process) cannot target a process parked in a
+    // syscall. Completion therefore never resurrects an exited process — which would re-create an
+    // empty placeholder and leak any host handle this op allocates (e.g. a completed open).
+    let current_pid: ProcessIdentifier = pending
+        .source_pid
+        .unwrap_or_else(|| ProcessIdentifier::from(i32::from(pending.source_tid)));
+    ::vfs::fd::set_current_process(current_pid);
+
     // Validate that the response header matches the expected operation kind.
     if !validate_response_header(&pending.kind, response_payload) {
         ::syslog::error!("hostfs pending op: response header does not match expected operation");
@@ -703,12 +724,13 @@ fn complete_open(
         },
         Err(_) => {
             // Issue a best-effort close to hostfsd so the remote FD does not leak.
-            // We use a dummy op_id (obtained from a zeroed payload) and do not register
-            // a pending op — the response (if any) will be silently dropped by the main
-            // loop since no pending entry exists.
-            let zeroed: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
-            let dummy_op_id: ::hostfs_api::OperationId = ::hostfs_api::get_op_id(&zeroed);
-            let _ = crate::hostfs::send_close_request(resp.fd, dummy_op_id);
+            // We tag the request with the `FIRE_AND_FORGET` sentinel op_id and do not register
+            // a pending op; the main loop recognizes that sentinel on hostfsd's response and
+            // discards it without logging, since no pending entry exists.
+            let _ = crate::hostfs::send_close_request(
+                resp.fd,
+                ::hostfs_api::OperationId::FIRE_AND_FORGET,
+            );
             send_response(&build_error(source_tid, ErrorCode::TooManyOpenFiles));
         },
     }

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -116,6 +116,16 @@ impl OperationId {
     /// collide with any live operation.
     pub const INVALID: Self = Self(u32::MAX);
 
+    /// Sentinel value used for fire-and-forget requests that expect no completion,
+    /// such as best-effort closes issued when the originating caller is gone (e.g. on
+    /// process exit, or when an open completes but the local descriptor cannot be
+    /// allocated). No pending op is registered for these, and vfsd's main loop
+    /// recognizes responses carrying this id and discards them without logging.
+    ///
+    /// [`OperationIdAllocator::alloc`] explicitly skips `0`, so this value is guaranteed not to
+    /// collide with any live operation — including after the allocator's counter wraps around.
+    pub const FIRE_AND_FORGET: Self = Self(0);
+
     /// Size in bytes of the little-endian wire representation of an `OperationId`.
     ///
     /// Matches the length of the array produced by [`to_le_bytes`](Self::to_le_bytes)
@@ -193,9 +203,8 @@ impl Default for OperationIdAllocator {
 impl OperationIdAllocator {
     /// Creates a new allocator starting at identifier 1.
     ///
-    /// Identifier 0 is a valid wire value (the set/get helpers accept it) but is
-    /// skipped by the allocator to reserve it as a potential sentinel in future
-    /// protocol extensions.
+    /// Identifier `0` is a valid wire value (the set/get helpers accept it) but is reserved as the
+    /// [`OperationId::FIRE_AND_FORGET`] sentinel, so [`alloc`](Self::alloc) never issues it.
     pub const fn new() -> Self {
         Self { next_id: 1 }
     }
@@ -204,11 +213,16 @@ impl OperationIdAllocator {
     ///
     /// The `in_use` predicate is called to skip identifiers that are currently active
     /// (e.g., present in a pending-operation map). This guarantees the returned ID does
-    /// not collide with any live operation. The allocator also skips [`OperationId::INVALID`]
-    /// (`u32::MAX`) which is reserved as a sentinel for error responses.
+    /// not collide with any live operation. The allocator also skips the reserved sentinels
+    /// [`OperationId::INVALID`] (`u32::MAX`, used for error responses) and
+    /// [`OperationId::FIRE_AND_FORGET`] (`0`, used for completion-less requests), so a returned
+    /// identifier never collides with either reserved value — including after wrap-around.
     pub fn alloc(&mut self, in_use: impl Fn(&OperationId) -> bool) -> OperationId {
         let mut id: u32 = self.next_id;
-        while id == u32::MAX || in_use(&OperationId(id)) {
+        while id == OperationId::INVALID.raw()
+            || id == OperationId::FIRE_AND_FORGET.raw()
+            || in_use(&OperationId(id))
+        {
             id = id.wrapping_add(1);
         }
         self.next_id = id.wrapping_add(1);


### PR DESCRIPTION
## Summary

Wires VFSD into the process lifecycle so that open file descriptors and the
current working directory follow POSIX fork/exit semantics. VFSD now handles the
`ForkClone` and `ProcessExit` messages from PROCD, binds the VFS to the
requesting process before servicing requests, and makes host-backed closes
reference-count aware so open file descriptions shared across a fork are not torn
down early.

## Changes

- **`[vfsd] E: Clone and reclaim per-process fs state`**
  - Handle `ForkClone`: duplicate the parent's filesystem state onto the child
    via `vfs_fork_clone`. Child descriptors share the parent's underlying open
    file descriptions (and therefore file offsets), while the current working
    directory is copied privately.
  - Handle `ProcessExit`: reclaim the terminated process's filesystem state via
    `vfs_process_exit`. Host-backed descriptors for which the exiting process
    held the final reference are closed on hostfsd with a fire-and-forget request
    (dummy op_id, no pending op) to avoid leaking remote handles.
  - Bind the VFS to the requesting process via `set_current_process` before
    servicing requests (`source_pid`) and completions (`source_tid as pid`), so
    descriptor and working-directory operations resolve against the correct
    per-process state.
  - Make hostfs close reference-count aware (`vfs_hostfs_is_last_ref`): only
    forward a close to hostfsd when it is the last descriptor referencing the
    open file description; otherwise drop the local descriptor and acknowledge.
  - Add a `caller_pid` helper to extract the caller's PID from a message source,
    and `debug_assert` that `handle_system_message` is only invoked with a PROCD
    source.

## Validation

- [ ] `z build`
- [ ] `z test`
