### PR TITLE
[posix] Support `pthread_once`

### DIFF
--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -5,19 +5,37 @@
 // Imports
 //==================================================================================================
 
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use ::core::sync::atomic::{
+    AtomicI32,
+    AtomicUsize,
+    Ordering,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        pm::{
+            __kcall_gettid,
+            __kcall_lock_mutex,
+            __kcall_unlock_mutex,
+        },
+        sched::__kcall_sched_yield,
+    },
+    pm::MutexAddress,
 };
 use ::sysapi::{
     ffi::{
         c_int,
         c_void,
     },
+    pthread::PTHREAD_MUTEX_INITIALIZER,
     sched::sched_param,
     sys_types::{
         c_size_t,
         pthread_attr_t,
+        pthread_mutex_t,
         pthread_once_t,
         pthread_t,
     },
@@ -368,6 +386,219 @@ pub extern "C" fn pthread_equal(thread1: pthread_t, thread2: pthread_t) -> c_int
 // pthread_once()
 //==================================================================================================
 
+/// State constants used internally by `pthread_once()` for the
+/// `init_executed` field of `pthread_once_t`.
+///
+/// # Description
+///
+/// `init_executed` doubles as a small state-machine word:
+///
+/// - `ONCE_NEVER_RUN`: the initializer has not started.
+/// - `ONCE_IN_PROGRESS`: some thread is currently running the initializer.
+/// - `ONCE_DONE`: the initializer has completed and its effects are visible.
+///
+/// All reads and writes of this word are serialized by [`once_guard_addr()`]'s
+/// process-global mutex.  The initializer itself runs *outside* that lock so that
+/// (a) `pthread_once()` calls on unrelated control words can still make progress, and
+/// (b) a call may recurse onto the same control word from within `init_routine`
+/// without dead-locking (the recursive call observes `ONCE_IN_PROGRESS` and that the
+/// current thread owns the in-flight init -- see [`ONCE_OWNERS`]).
+const ONCE_NEVER_RUN: c_int = 0;
+const ONCE_DONE: c_int = 1;
+const ONCE_IN_PROGRESS: c_int = 2;
+
+/// Process-global mutex serializing every `pthread_once()` state-word transition.
+///
+/// Only its *address* is meaningful: the kernel lazily creates a mutex keyed by the address on
+/// first lock and never reads or writes the backing storage.  The static is therefore immutable;
+/// all access goes through the raw `__kcall_lock_mutex` / `__kcall_unlock_mutex` kernel calls using
+/// the address returned by [`once_guard_addr()`].
+static ONCE_GUARD_MUTEX: pthread_mutex_t = PTHREAD_MUTEX_INITIALIZER;
+
+/// Maximum number of `pthread_once_t` control words that may be running their
+/// initializer simultaneously, summed across all threads (each distinct control counts
+/// once, including nested/recursive inits started by the same thread).  Exceeding this
+/// is pathological; callers receive `EAGAIN` and may retry.
+const ONCE_OWNERS_MAX: usize = ::config::kernel::MAX_THREADS;
+
+/// One slot of the in-progress owner table.
+///
+/// `control == 0` marks an empty slot.  Otherwise `control` is the `pthread_once_t`
+/// pointer (as `usize`) whose initializer is running and `owner` is the raw identifier
+/// of the thread running it.  A `pthread_once_t` is never at address `0` (it is
+/// null-checked), so `0` is a safe empty sentinel.
+struct OnceOwnerSlot {
+    control: AtomicUsize,
+    owner: AtomicI32,
+}
+
+/// Table tracking which thread is currently running the initializer for each in-flight
+/// control word, used to distinguish a recursive self-call (return without re-running)
+/// from a concurrent call by a different thread (wait until `ONCE_DONE`).
+///
+/// The table is only ever accessed while the once-guard mutex is held, so `Relaxed`
+/// ordering is sufficient: the kernel mutex provides the happens-before edges between
+/// threads, and Nanvix is single-core.  The atomics exist solely to share this `static`
+/// across threads without forming a `&mut` to a `static mut`.
+static ONCE_OWNERS: [OnceOwnerSlot; ONCE_OWNERS_MAX] = [const {
+    OnceOwnerSlot {
+        control: AtomicUsize::new(0),
+        owner: AtomicI32::new(0),
+    }
+}; ONCE_OWNERS_MAX];
+
+/// Returns the address of the once-guard mutex as a [`MutexAddress`].
+///
+/// The kernel keys mutexes by address and creates them on demand, so the value and type
+/// of the backing static are irrelevant -- only its (stable, unique) address matters.
+fn once_guard_addr() -> MutexAddress {
+    // SAFETY: taking the address of a static never forms a reference and is always valid.
+    MutexAddress::from(::core::ptr::addr_of!(ONCE_GUARD_MUTEX) as usize)
+}
+
+/// Releases the once-guard mutex.
+///
+/// On failure this logs and returns the kernel error number so the caller can surface it instead
+/// of silently leaving the guard locked, which would wedge every later `pthread_once()` call that
+/// contends on the process-global guard.
+fn once_guard_unlock(guard_addr: MutexAddress) -> Result<(), c_int> {
+    __kcall_unlock_mutex(guard_addr).map_err(|error| {
+        ::syslog::warn!("pthread_once(): failed to release once guard ({error:?})");
+        error.code.get()
+    })
+}
+
+/// Records that thread `tid` is running the initializer for `control`.
+///
+/// Returns `false` if the table is full.  Must be called with the once-guard held.
+fn once_owner_insert(control: usize, tid: i32) -> bool {
+    for slot in ONCE_OWNERS.iter() {
+        if slot.control.load(Ordering::Relaxed) == 0 {
+            slot.control.store(control, Ordering::Relaxed);
+            slot.owner.store(tid, Ordering::Relaxed);
+            return true;
+        }
+    }
+    false
+}
+
+/// Clears the owner entry for `control`, if present.
+///
+/// Must be called with the once-guard held.
+fn once_owner_remove(control: usize) {
+    for slot in ONCE_OWNERS.iter() {
+        if slot.control.load(Ordering::Relaxed) == control {
+            slot.control.store(0, Ordering::Relaxed);
+            slot.owner.store(0, Ordering::Relaxed);
+            return;
+        }
+    }
+}
+
+/// Returns the identifier of the thread running the initializer for `control`, if any.
+///
+/// Must be called with the once-guard held.
+fn once_owner_of(control: usize) -> Option<i32> {
+    for slot in ONCE_OWNERS.iter() {
+        if slot.control.load(Ordering::Relaxed) == control {
+            return Some(slot.owner.load(Ordering::Relaxed));
+        }
+    }
+    None
+}
+
+/// In-flight guard for the `init_routine` call.
+///
+/// While `init_routine` runs, the control word is `ONCE_IN_PROGRESS` and this guard owns the
+/// pending transition.  The in-flight init can end in one of two ways:
+///
+/// - **Normal completion.**  `pthread_once()` calls [`OnceGuard::finish()`], which re-acquires the
+///   once-guard and, in one critical section, publishes `ONCE_DONE` and releases ownership.  This
+///   is the only fallible finalization step, and its result is propagated to the caller so a kernel
+///   mutex failure surfaces as an error number instead of a bogus success.
+/// - **Unwind / cancellation.**  If `init_routine` does not return normally, `finish()` never runs
+///   and the guard is still *armed*; its [`Drop`] then rolls the control word back to
+///   `ONCE_NEVER_RUN` and releases ownership, honoring the POSIX contract that a canceled
+///   `init_routine` leaves the control "as if `pthread_once()` was never called".
+///
+/// `Drop` is a best-effort fallback only: it cannot return a value, so it logs kernel errors
+/// instead of propagating them.  The unwind path is effectively dead code today (release builds
+/// compile with `panic = "abort"`, `init_routine` is `extern "C"` so a panic across it is UB rather
+/// than a clean unwind, and Nanvix has no `pthread_cancel`), but is retained so the contract is
+/// honored automatically if any of those change.  Re-acquiring the guard in either path is safe
+/// because the lock is *not* held while `init_routine` runs.
+struct OnceGuard {
+    guard_addr: MutexAddress,
+    state_ptr: *mut c_int,
+    control_key: usize,
+    /// `true` while `init_routine` is in flight, meaning `drop` must roll the control word back to
+    /// `ONCE_NEVER_RUN`.  [`OnceGuard::finish()`] clears it after publishing `ONCE_DONE` on the
+    /// normal-completion path, turning the subsequent `drop` into a no-op.
+    armed: bool,
+}
+
+impl OnceGuard {
+    /// Publishes `ONCE_DONE` and releases ownership on the normal-completion path.
+    ///
+    /// In one critical section, writes `ONCE_DONE` and clears the owner entry, then disarms the
+    /// guard so the `drop` that runs as `self` falls out of scope does not roll the completed init
+    /// back.  The guard is disarmed only *after* `ONCE_DONE` has been published and ownership has
+    /// been released: if re-acquiring the once-guard fails, `self` stays armed so the `drop`
+    /// rollback remains available instead of leaving the control word stuck at `ONCE_IN_PROGRESS`
+    /// with a leaked owner-table entry.  Any kernel mutex error is returned so `pthread_once()` can
+    /// surface it to the caller instead of reporting a bogus success.
+    fn finish(mut self) -> Result<(), c_int> {
+        // Re-acquire the guard *before* disarming.  If this fails, `self` is still armed, so the
+        // `drop` that runs as it unwinds attempts the rollback rather than silently leaving the
+        // control word stuck at `ONCE_IN_PROGRESS` with a leaked owner-table entry.
+        __kcall_lock_mutex(self.guard_addr, None).map_err(|error| {
+            ::syslog::warn!(
+                "pthread_once(): failed to acquire once guard while publishing ONCE_DONE \
+                 ({error:?})"
+            );
+            error.code.get()
+        })?;
+        // SAFETY: the guard is held, granting exclusive access to the state word.
+        // `write_unaligned` because `pthread_once_t` is `#[repr(C, packed)]`.
+        unsafe { ::core::ptr::write_unaligned(self.state_ptr, ONCE_DONE) };
+        once_owner_remove(self.control_key);
+        // Only now disarm: `ONCE_DONE` is published and ownership released, so the `drop` that runs
+        // when `self` falls out of scope must not roll the completed init back.
+        self.armed = false;
+        once_guard_unlock(self.guard_addr)
+    }
+}
+
+impl ::core::ops::Drop for OnceGuard {
+    fn drop(&mut self) {
+        // Best-effort fallback for the unwind/cancellation path only.  If `finish()` already ran
+        // (normal completion) the guard is disarmed and there is nothing to do.  Otherwise
+        // `init_routine` did not return normally, so roll the control word back to `ONCE_NEVER_RUN`
+        // and release ownership, leaving the control "as if `pthread_once()` was never called".
+        if !self.armed {
+            return;
+        }
+
+        if let Err(error) = __kcall_lock_mutex(self.guard_addr, None) {
+            ::syslog::warn!(
+                "pthread_once(): failed to acquire once guard while rolling back init ({error:?})"
+            );
+            return;
+        }
+        // SAFETY: the guard is held, granting exclusive access to the state word.
+        // `write_unaligned` because `pthread_once_t` is `#[repr(C, packed)]`.
+        unsafe {
+            ::core::ptr::write_unaligned(self.state_ptr, ONCE_NEVER_RUN);
+        }
+        once_owner_remove(self.control_key);
+        if let Err(error) = __kcall_unlock_mutex(self.guard_addr) {
+            ::syslog::warn!(
+                "pthread_once(): failed to release once guard while rolling back init ({error:?})"
+            );
+        }
+    }
+}
+
 ///
 /// # Description
 ///
@@ -396,9 +627,142 @@ pub unsafe extern "C" fn pthread_once(
     once_control: *mut pthread_once_t,
     init_routine: Option<unsafe extern "C" fn()>,
 ) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/513
-    ::syslog::debug!("pthread_once(): not implemented");
-    0
+    // Argument validation.
+    if once_control.is_null() {
+        ::syslog::warn!("pthread_once(): null once_control");
+        return ErrorCode::InvalidArgument.get();
+    }
+    let Some(init_fn) = init_routine else {
+        ::syslog::warn!("pthread_once(): null init_routine");
+        return ErrorCode::InvalidArgument.get();
+    };
+
+    // `once_control` must have been initialized with `PTHREAD_ONCE_INIT`.  We deliberately do
+    // NOT materialize a `&mut pthread_once_t`: a recursive call on the same control word from
+    // inside `init_routine` is supported, and two live `&mut` to one object is UB.  All field
+    // access goes through raw-pointer accessors.
+    //
+    // SAFETY: `once_control` was checked non-null above and is assumed to point to a valid
+    // `pthread_once_t` per the POSIX contract.
+    if unsafe { pthread_once_t::is_initialized_raw(once_control) }
+        != pthread_once_t::IS_INITIALIZED_VALUE
+    {
+        ::syslog::warn!("pthread_once(): once_control not initialized with PTHREAD_ONCE_INIT");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Identify the calling thread; used to distinguish a recursive self-call from a concurrent
+    // call by a different thread.
+    let tid: i32 = match __kcall_gettid() {
+        Ok(tid) => i32::from(tid),
+        Err(error) => {
+            ::syslog::warn!("pthread_once(): gettid() failed ({error:?})");
+            return error.code.get();
+        },
+    };
+
+    let control_key: usize = once_control as usize;
+    // SAFETY: `once_control` is valid per the contract above; the accessor never forms a
+    // reference to the (`#[repr(C, packed)]`) object.
+    let state_ptr: *mut c_int = unsafe { pthread_once_t::init_executed_ptr_raw(once_control) };
+    let guard_addr: MutexAddress = once_guard_addr();
+
+    loop {
+        // Serialize all state-word transitions behind the process-global guard.
+        if let Err(error) = __kcall_lock_mutex(guard_addr, None) {
+            ::syslog::warn!("pthread_once(): failed to acquire once guard ({error:?})");
+            return error.code.get();
+        }
+
+        // SAFETY: the guard is held, granting exclusive access to the state word.
+        // `read_unaligned` because `pthread_once_t` is `#[repr(C, packed)]`.
+        let state: c_int = unsafe { ::core::ptr::read_unaligned(state_ptr) };
+
+        // Fast path: initialization already completed.  Holding the guard across this read
+        // provides the happens-before edge that makes `init_routine`'s effects visible to this
+        // thread on return, as POSIX requires.
+        if state == ONCE_DONE {
+            if let Err(code) = once_guard_unlock(guard_addr) {
+                return code;
+            }
+            return 0;
+        }
+
+        // A thread is currently running the initializer.
+        if state == ONCE_IN_PROGRESS {
+            let owner: Option<i32> = once_owner_of(control_key);
+            if let Err(code) = once_guard_unlock(guard_addr) {
+                return code;
+            }
+
+            // Recursive call on the same control from within `init_routine`.  POSIX leaves this
+            // undefined; we return success without re-running rather than dead-lock or recurse
+            // without bound.  The in-flight init finishes when control unwinds.
+            if owner == Some(tid) {
+                ::syslog::warn!(
+                    "pthread_once(): recursive call on the same once_control (in-progress) -- not \
+                     re-running init"
+                );
+                return 0;
+            }
+
+            // A different thread owns the in-flight init.  Yield and retry until it reaches
+            // `ONCE_DONE`; the initializer runs outside the guard, so it makes progress.
+            if let Err(error) = __kcall_sched_yield() {
+                ::syslog::warn!("pthread_once(): sched_yield() failed ({error:?})");
+                return error.code.get();
+            }
+            continue;
+        }
+
+        // If the state word contains an unexpected value, treat it as an invalid control rather
+        // than silently re-running the initializer.
+        if state != ONCE_NEVER_RUN {
+            if let Err(code) = once_guard_unlock(guard_addr) {
+                return code;
+            }
+            ::syslog::warn!("pthread_once(): invalid once_control state ({state})");
+            return ErrorCode::InvalidArgument.get();
+        }
+
+        // `ONCE_NEVER_RUN`: become the initializer. Record ownership before publishing
+        // `ONCE_IN_PROGRESS` so a recursive self-call is always recognized.
+        if !once_owner_insert(control_key, tid) {
+            if let Err(code) = once_guard_unlock(guard_addr) {
+                return code;
+            }
+            ::syslog::warn!("pthread_once(): in-progress owner table full -- retry later");
+            return ErrorCode::TryAgain.get();
+        }
+        // SAFETY: guard held; `write_unaligned` because the struct is packed.
+        unsafe { ::core::ptr::write_unaligned(state_ptr, ONCE_IN_PROGRESS) };
+        if let Err(code) = once_guard_unlock(guard_addr) {
+            return code;
+        }
+
+        // Run the initializer OUTSIDE the guard so that (a) `pthread_once()` on unrelated
+        // controls can proceed and (b) a recursive self-call can acquire the guard, observe our
+        // ownership, and return.  While `init_routine` is in flight the guard is armed, so it
+        // reverts the state word if `init_routine` unwinds.
+        let guard = OnceGuard {
+            guard_addr,
+            state_ptr,
+            control_key,
+            armed: true,
+        };
+        // SAFETY: `init_fn` is a valid `extern "C" fn()` per the POSIX contract; the caller is
+        // responsible for ensuring it does not violate Rust's aliasing rules on shared state.
+        unsafe { init_fn() };
+
+        // Normal completion: publish `ONCE_DONE` and release ownership explicitly so a kernel mutex
+        // failure is propagated to the caller instead of being swallowed by `drop` (which cannot
+        // return a value).  `finish()` disarms the guard, so its `drop` rollback runs only if
+        // `init_routine` unwound before reaching this point.
+        return match guard.finish() {
+            Ok(()) => 0,
+            Err(code) => code,
+        };
+    }
 }
 
 //==================================================================================================

--- a/src/libs/sysapi/src/pthread.rs
+++ b/src/libs/sysapi/src/pthread.rs
@@ -14,6 +14,7 @@
 use crate::sys_types::{
     pthread_cond_t,
     pthread_mutex_t,
+    pthread_once_t,
     pthread_rwlock_t,
     pthread_t,
 };
@@ -30,6 +31,9 @@ pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0xffffffff;
 
 /// Used to initialize a mutex statically.
 pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0xffffffff;
+
+/// Used to initialize a once-control variable statically.
+pub const PTHREAD_ONCE_INIT: pthread_once_t = pthread_once_t::INIT;
 
 /// Type of mutex in [`crate::sys::types::pthread_mutexattr_t`].
 pub mod pthread_mutex_type {

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -301,6 +301,89 @@ impl pthread_once_t {
 
     /// Size of `pthread_once_t` structure.
     pub const SIZE: usize = Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_INIT_EXECUTED;
+
+    /// Sentinel value of `is_initialized` set by `PTHREAD_ONCE_INIT`.
+    pub const IS_INITIALIZED_VALUE: c_int = 1;
+
+    /// Statically-initialized `pthread_once_t`, equivalent to POSIX `PTHREAD_ONCE_INIT`.
+    ///
+    /// `is_initialized` is set to the sentinel recognized by `pthread_once()`, and `init_executed`
+    /// is `0`, meaning the initializer has not yet run (the `ONCE_NEVER_RUN` state).
+    pub const INIT: pthread_once_t = pthread_once_t {
+        is_initialized: Self::IS_INITIALIZED_VALUE,
+        init_executed: 0,
+    };
+
+    ///
+    /// # Description
+    ///
+    /// Reads the `is_initialized` field through a raw pointer without constructing a Rust reference
+    /// to `pthread_once_t`.
+    ///
+    /// `is_initialized` is set to `1` by `PTHREAD_ONCE_INIT`.  A non-`1` value indicates that the
+    /// caller forgot to use `PTHREAD_ONCE_INIT` and the `pthread_once_t` is uninitialized.
+    ///
+    /// This is provided as an associated function on `*const Self` (rather than `&self`) so callers
+    /// like `pthread_once()` can inspect the field without ever materialising a Rust reference.
+    /// Materialising a `&mut pthread_once_t` and then re-entering `pthread_once()` recursively on
+    /// the same control word would create a second `&mut` to the same object, which is
+    /// Stacked-Borrows UB even though the implementation explicitly handles the recursive case.
+    ///
+    /// # Parameters
+    ///
+    /// `once` - A pointer to the `pthread_once_t` to read.
+    ///
+    /// # Returns
+    ///
+    /// The value of the `is_initialized` field, which is `1` if the `pthread_once_t` is initialized
+    /// and a non-`1` value if it is uninitialized.
+    ///
+    /// # Safety
+    ///
+    /// `once` must be non-null and point to a valid `pthread_once_t`.
+    ///
+    pub unsafe fn is_initialized_raw(once: *const pthread_once_t) -> c_int {
+        // SAFETY: caller guarantees `once` is valid.  `read_unaligned` is used because
+        // `pthread_once_t` is `#[repr(C, packed)]`, so `addr_of!` produces an alignment-1 pointer
+        // from Rust's perspective.
+        unsafe { ::core::ptr::addr_of!((*once).is_initialized).read_unaligned() }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a mutable raw pointer to the `init_executed` field without constructing a Rust
+    /// reference to `pthread_once_t`.
+    ///
+    /// `pthread_once()` uses this pointer with `ptr::read_unaligned` / `ptr::write_unaligned` to
+    /// implement the state-machine transitions without the compiler optimising the loads or stores
+    /// away.  Unaligned accessors are used because `pthread_once_t` is `#[repr(C, packed)]`, so
+    /// this pointer has alignment 1 from Rust's perspective even though the underlying address is
+    /// usually naturally aligned; `volatile` reads/writes would be UB on a (potentially) unaligned
+    /// pointer.  Concurrent transitions are serialized by the process-global kernel mutex that
+    /// `pthread_once()` holds while it reads and writes this word, so plain unaligned loads and
+    /// stores -- rather than atomics -- are sufficient here.
+    ///
+    /// See `is_initialized_raw()` for why this is a raw-pointer function rather than a method on
+    /// `&mut self`.
+    ///
+    /// # Parameters
+    ///
+    /// - `once` - A pointer to the `pthread_once_t` to access.
+    ///
+    /// # Returns
+    ///
+    /// A mutable raw pointer to the `init_executed` field of the `pthread_once_t`.
+    ///
+    /// # Safety
+    ///
+    /// `once` must be non-null and point to a valid `pthread_once_t`
+    /// whose lifetime exceeds the use of the returned pointer.
+    ///
+    pub unsafe fn init_executed_ptr_raw(once: *mut pthread_once_t) -> *mut c_int {
+        // SAFETY: caller guarantees `once` is valid.  No Rust reference is constructed.
+        unsafe { ::core::ptr::addr_of_mut!((*once).init_executed) }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/tests/thread-rust/src/tests/mod.rs
+++ b/src/tests/thread-rust/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod identity;
 mod mutex_timedlock;
 mod mutexes;
 mod nowait;
+mod once;
 mod rwlocks;
 mod scheduler;
 mod tda;
@@ -33,6 +34,7 @@ pub fn run_all() -> Result<(), Error> {
     attributes::run()?;
     mutexes::run()?;
     mutex_timedlock::run()?;
+    once::run()?;
     condvars::run()?;
     cond_timedwait::run()?;
     rwlocks::run()?;

--- a/src/tests/thread-rust/src/tests/once.rs
+++ b/src/tests/thread-rust/src/tests/once.rs
@@ -1,0 +1,309 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::runtime::KernelThread;
+use ::core::{
+    ptr,
+    sync::atomic::{
+        AtomicBool,
+        AtomicI32,
+        AtomicUsize,
+        Ordering,
+    },
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::sched::__kcall_sched_yield,
+};
+use ::sysapi::{
+    ffi::c_int,
+    pthread::PTHREAD_ONCE_INIT,
+    sys_types::pthread_once_t,
+};
+
+//==================================================================================================
+// External Bindings
+//==================================================================================================
+
+unsafe extern "C" {
+    /// `pthread_once()` as exported by libposix. These integration tests drive it through its C
+    /// ABI, exactly as a C caller would.
+    fn pthread_once(
+        once_control: *mut pthread_once_t,
+        init_routine: Option<unsafe extern "C" fn()>,
+    ) -> c_int;
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of worker threads that race on the shared control word.
+const MULTI_WORKERS: usize = 8;
+
+/// Number of times the multi-threaded initializer yields, widening the window during which a
+/// concurrent caller can observe the in-progress state (and, if `pthread_once()` were buggy,
+/// wrongly return before initialization completes).
+const MULTI_INIT_YIELDS: usize = 256;
+
+/// Value published by the multi-threaded initializer as its very last step.  Every worker must
+/// observe it after `pthread_once()` returns.
+const MULTI_VALUE_SENTINEL: usize = 0x00c0_ffee;
+
+/// Sentinel stored in [`RECURSIVE_INNER_RET`] until the recursive initializer records the return
+/// value of its nested `pthread_once()` call.
+const RECURSIVE_RET_SENTINEL: c_int = c_int::MIN;
+
+//==================================================================================================
+// Globals
+//==================================================================================================
+
+// State for the single-threaded test.
+static mut ONCE_SINGLE: pthread_once_t = PTHREAD_ONCE_INIT;
+static SINGLE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+// State for the single-threaded recursive test.
+static mut ONCE_RECURSIVE: pthread_once_t = PTHREAD_ONCE_INIT;
+static RECURSIVE_COUNT: AtomicUsize = AtomicUsize::new(0);
+static RECURSIVE_INNER_RET: AtomicI32 = AtomicI32::new(RECURSIVE_RET_SENTINEL);
+
+// State for the multi-threaded test.
+static mut ONCE_MULTI: pthread_once_t = PTHREAD_ONCE_INIT;
+/// Number of times the initializer body ran (must end at exactly 1).
+static MULTI_COUNT: AtomicUsize = AtomicUsize::new(0);
+/// Number of threads currently executing the initializer (must never exceed 1).
+static MULTI_CONCURRENT: AtomicUsize = AtomicUsize::new(0);
+/// Set to `true` as the initializer's final step; read by every worker after `pthread_once()`
+/// returns to confirm the initializer's effects are visible.
+static MULTI_INIT_DONE: AtomicBool = AtomicBool::new(false);
+/// Value published by the initializer; every worker must observe the sentinel on return.
+static MULTI_VALUE: AtomicUsize = AtomicUsize::new(0);
+/// Release gate so all workers begin contending at roughly the same time.
+static MULTI_START_GATE: AtomicBool = AtomicBool::new(false);
+/// Count of detected races (overlapping init, or initialization not visible on return).
+static MULTI_ANOMALIES: AtomicUsize = AtomicUsize::new(0);
+/// Set if `sched_yield()` ever failed inside the initializer.  Surfaced as a test failure rather
+/// than being silently ignored: a failed yield stops widening the race window this test relies on.
+static MULTI_INIT_YIELD_FAILED: AtomicBool = AtomicBool::new(false);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Exercises `pthread_once()` on a single thread, recursively from within the initializer, and
+/// across multiple threads sharing one control word.
+pub fn run() -> Result<(), Error> {
+    test_single_thread()?;
+    test_single_thread_recursive()?;
+    test_multi_thread()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Single-threaded test
+//==================================================================================================
+
+/// Initializer for the single-threaded test.
+unsafe extern "C" fn single_init() {
+    SINGLE_COUNT.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Verifies that repeated calls on one thread run the initializer exactly once.
+fn test_single_thread() -> Result<(), Error> {
+    // Reset shared state so the test is re-runnable and order-independent.
+    // SAFETY: this single-threaded test owns `ONCE_SINGLE`; no other thread accesses it here.
+    unsafe { ONCE_SINGLE = PTHREAD_ONCE_INIT };
+    SINGLE_COUNT.store(0, Ordering::SeqCst);
+
+    let control: *mut pthread_once_t = ptr::addr_of_mut!(ONCE_SINGLE);
+
+    // Repeated calls must be idempotent: only the first one runs the initializer.
+    for _ in 0..3 {
+        // SAFETY: `control` points to a valid, statically-initialized `pthread_once_t`, and
+        // `single_init` is a valid initialization routine.
+        let ret: c_int = unsafe { pthread_once(control, Some(single_init)) };
+        assert_eq!(ret, 0, "pthread_once() must return 0 on success");
+    }
+
+    assert_eq!(
+        SINGLE_COUNT.load(Ordering::SeqCst),
+        1,
+        "initializer must run exactly once on a single thread"
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
+// Single-threaded recursive test
+//==================================================================================================
+
+/// Initializer for the recursive test. It re-enters `pthread_once()` on the same control word.
+unsafe extern "C" fn recursive_init() {
+    RECURSIVE_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    // The control word is in the IN_PROGRESS state while this runs, so a nested call on the same
+    // control must return without re-running the initializer, rather than deadlocking or recursing
+    // forever.
+    let control: *mut pthread_once_t = ptr::addr_of_mut!(ONCE_RECURSIVE);
+    // SAFETY: `control` points to a valid `pthread_once_t` that is currently being initialized;
+    // re-entrancy on the same control is explicitly supported by `pthread_once()`.
+    let inner_ret: c_int = unsafe { pthread_once(control, Some(recursive_init)) };
+    RECURSIVE_INNER_RET.store(inner_ret, Ordering::SeqCst);
+}
+
+/// Verifies that a recursive call from within the initializer neither deadlocks nor re-runs it.
+fn test_single_thread_recursive() -> Result<(), Error> {
+    // Reset shared state so the test is re-runnable and order-independent.
+    // SAFETY: this single-threaded test owns `ONCE_RECURSIVE`; no other thread accesses it here.
+    unsafe { ONCE_RECURSIVE = PTHREAD_ONCE_INIT };
+    RECURSIVE_COUNT.store(0, Ordering::SeqCst);
+    RECURSIVE_INNER_RET.store(RECURSIVE_RET_SENTINEL, Ordering::SeqCst);
+
+    let control: *mut pthread_once_t = ptr::addr_of_mut!(ONCE_RECURSIVE);
+    // SAFETY: see `single_init`'s call site.
+    let ret: c_int = unsafe { pthread_once(control, Some(recursive_init)) };
+    assert_eq!(ret, 0, "outer pthread_once() must return 0 on success");
+
+    assert_eq!(
+        RECURSIVE_COUNT.load(Ordering::SeqCst),
+        1,
+        "initializer must run exactly once despite recursive re-entry"
+    );
+    assert_eq!(
+        RECURSIVE_INNER_RET.load(Ordering::SeqCst),
+        0,
+        "recursive pthread_once() must return 0 without re-running the initializer"
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
+// Multi-threaded test
+//==================================================================================================
+
+/// Initializer for the multi-threaded test.
+///
+/// It deliberately yields many times so that, while it runs, the other workers are scheduled and
+/// call `pthread_once()` on the same (in-progress) control word.  A correct implementation makes
+/// them wait until this returns; a racy one would let them proceed before initialization is done.
+unsafe extern "C" fn multi_init() {
+    // Detect overlapping execution: if more than one thread is ever inside the initializer at
+    // once, the exactly-once contract has been violated.
+    if MULTI_CONCURRENT.fetch_add(1, Ordering::SeqCst) != 0 {
+        MULTI_ANOMALIES.fetch_add(1, Ordering::SeqCst);
+    }
+    MULTI_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    // Widen the initialization window so concurrent callers have time to observe the in-progress
+    // state and contend.
+    for _ in 0..MULTI_INIT_YIELDS {
+        if __kcall_sched_yield().is_err() {
+            // Record the failure so the test reports it; a broken yield narrows the race window
+            // this test depends on, so stop spinning on it.
+            MULTI_INIT_YIELD_FAILED.store(true, Ordering::SeqCst);
+            break;
+        }
+    }
+
+    // Publish the initialized value, then mark completion as the very last step.
+    MULTI_VALUE.store(MULTI_VALUE_SENTINEL, Ordering::SeqCst);
+    MULTI_INIT_DONE.store(true, Ordering::SeqCst);
+    MULTI_CONCURRENT.fetch_sub(1, Ordering::SeqCst);
+}
+
+/// Entry point for a worker thread in the multi-threaded test.
+extern "C" fn multi_worker(_arg: usize) -> usize {
+    multi_worker_impl().unwrap_or_else(|err| panic!("multi_worker: {err:?}"))
+}
+
+fn multi_worker_impl() -> Result<usize, Error> {
+    // Wait at the gate so all workers start contending together, maximizing the chance of a race.
+    while !MULTI_START_GATE.load(Ordering::Acquire) {
+        __kcall_sched_yield()?;
+    }
+
+    let control: *mut pthread_once_t = ptr::addr_of_mut!(ONCE_MULTI);
+    // SAFETY: `control` points to a valid, statically-initialized `pthread_once_t` shared by every
+    // worker, and `multi_init` is a valid initialization routine.
+    let ret: c_int = unsafe { pthread_once(control, Some(multi_init)) };
+    if ret != 0 {
+        // Preserve the actual error number so test failures report the real cause.
+        let code: ErrorCode = ErrorCode::try_from(ret).unwrap_or(ErrorCode::TryAgain);
+        return Err(Error::new(code, "pthread_once() failed in worker"));
+    }
+
+    // POSIX requires that on return from `pthread_once()` the initializer's effects are visible.
+    // If a worker observes initialization as incomplete here, the implementation returned before
+    // the initializer finished -- a multi-threading race.
+    if !MULTI_INIT_DONE.load(Ordering::SeqCst)
+        || MULTI_VALUE.load(Ordering::SeqCst) != MULTI_VALUE_SENTINEL
+    {
+        MULTI_ANOMALIES.fetch_add(1, Ordering::SeqCst);
+    }
+
+    Ok(0)
+}
+
+/// Verifies that the initializer runs exactly once, never overlaps itself, and is fully visible
+/// to every thread on return when several threads race on one control word.
+fn test_multi_thread() -> Result<(), Error> {
+    // Reset shared state so the test is re-runnable and order-independent.
+    // SAFETY: workers are spawned only after this and the start gate is still closed, so no other
+    // thread accesses `ONCE_MULTI` concurrently here.
+    unsafe { ONCE_MULTI = PTHREAD_ONCE_INIT };
+    MULTI_COUNT.store(0, Ordering::SeqCst);
+    MULTI_CONCURRENT.store(0, Ordering::SeqCst);
+    MULTI_INIT_DONE.store(false, Ordering::SeqCst);
+    MULTI_VALUE.store(0, Ordering::SeqCst);
+    MULTI_ANOMALIES.store(0, Ordering::SeqCst);
+    MULTI_START_GATE.store(false, Ordering::SeqCst);
+    MULTI_INIT_YIELD_FAILED.store(false, Ordering::SeqCst);
+
+    let mut workers: [Option<KernelThread>; MULTI_WORKERS] = [const { None }; MULTI_WORKERS];
+
+    // Spawn every worker before releasing the gate so they coexist and contend on the shared
+    // control word as simultaneously as possible.
+    for slot in workers.iter_mut() {
+        *slot = Some(KernelThread::spawn(multi_worker, 0)?);
+    }
+    MULTI_START_GATE.store(true, Ordering::Release);
+
+    for slot in workers.iter_mut() {
+        if let Some(handle) = slot.take() {
+            let retval: usize = handle.join()?;
+            assert_eq!(retval, 0, "worker reported a pthread_once() failure");
+        }
+    }
+
+    assert_eq!(
+        MULTI_COUNT.load(Ordering::SeqCst),
+        1,
+        "initializer must run exactly once across all threads"
+    );
+    assert!(MULTI_INIT_DONE.load(Ordering::SeqCst), "initializer must have completed");
+    assert_eq!(
+        MULTI_VALUE.load(Ordering::SeqCst),
+        MULTI_VALUE_SENTINEL,
+        "initializer must have published its value"
+    );
+    assert_eq!(
+        MULTI_ANOMALIES.load(Ordering::SeqCst),
+        0,
+        "detected a pthread_once() race: overlapping init or init not visible on return"
+    );
+    assert!(
+        !MULTI_INIT_YIELD_FAILED.load(Ordering::SeqCst),
+        "sched_yield() failed inside the initializer"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Reimplements `pthread_once()` to be correct under concurrent callers and adds the supporting `sysapi` building blocks and integration tests.

The previous `pthread_once()` was a single-threaded-model placeholder. Because the Nanvix scheduler is preemptive, two defects were reachable whenever threads raced on one control word:

- **Double initialization** — the non-atomic read-then-write let two threads both observe `NEVER_RUN` and each run `init_routine`, violating the exactly-once contract.
- **Use-before-init** — a thread observing `IN_PROGRESS` owned by a *different* thread returned before `init_routine` had finished, so it could use a half-initialized resource, violating the "effects visible on return" contract.

Nanvix has no futex (the prior code only referenced one in comments), so this builds on the only blocking primitive available — the kernel mutex.

## Approach

- A process-global guard mutex serializes every state-word transition, addressed by raw `__kcall_lock_mutex` / `__kcall_unlock_mutex` (the kernel keys mutexes by address and creates them lazily), so no Rust reference is ever formed to the `static`.
- `init_routine` runs **outside** the guard, so `pthread_once()` on unrelated controls keeps progressing and a recursive self-call can re-acquire the guard instead of dead-locking the non-recursive kernel mutex.
- An owner table (sized to `MAX_THREADS`) records which thread runs each in-flight initializer: a recursive call by the owning thread returns `0` without re-running; a concurrent call by another thread yields and retries until `ONCE_DONE`; a full table degrades to `EAGAIN`.
- An unwind guard reverts the control word and releases ownership if `init_routine` unwinds, preserving the cancellation-as-if-never-called contract.

Behaviour for the single-threaded and recursive cases is unchanged; the fix only affects concurrent callers.

## Commits

- `[sysapi] E: Add pthread_once_t accessors and INIT`
- `[sysapi] E: Add PTHREAD_ONCE_INIT initializer`
- `[posix] B: Make pthread_once multi-thread safe`
- `[tests] F: Add pthread_once integration tests`

## Tests

Adds a `thread-rust` module covering single-thread, single-thread recursive, and multi-thread scenarios. The multi-threaded case is hardened to actually catch races: workers start on a gate, the initializer yields to widen the in-progress window, overlapping execution is flagged, and each worker verifies the initializer's effects are visible after return.

## Issues

Closes #513.