### PR TITLE
[syscall] Run ELF init/fini arrays in dlfcn

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -12,6 +12,7 @@ use crate::dlfcn::syscall::{
 };
 use ::alloc::{
     collections::btree_map::BTreeMap,
+    string::String,
     sync::Arc,
     vec::Vec,
 };
@@ -32,93 +33,119 @@ use ::sys::error::{
 pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
     ::syslog::trace!("dlclose(): handle={:?}", handle);
 
-    let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
-        DYNAMIC_LIBRARY_REGISTRY.lock();
+    // Order in which `.fini_array` destructors must run: the closing library
+    // first, then its dependencies (the reverse of constructor order). The
+    // libraries are removed from the registry while `DYNAMIC_LIBRARY_REGISTRY`
+    // is held, but their destructors run *after* the lock is released so a
+    // destructor may legally call back into `dlsym`/`dlopen`/`dlclose` without
+    // self-deadlocking on the registry mutex.
+    let fini_order: Vec<Arc<Mutex<DynamicLibrary>>> = {
+        let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
+            DYNAMIC_LIBRARY_REGISTRY.lock();
 
-    // Check if dynamic library file is opened.
-    if !registry.contains_key(handle) {
-        let reason: &str = "dynamic library file not open";
-        ::syslog::warn!("dlclose(): {}", reason);
-        return Err(Error::new(ErrorCode::BadFile, reason));
-    }
+        // Check if dynamic library file is opened.
+        if !registry.contains_key(handle) {
+            let reason: &str = "dynamic library file not open";
+            ::syslog::warn!("dlclose(): {}", reason);
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        }
 
-    let mut dep_dlfiles: Vec<Arc<Mutex<DynamicLibrary>>> = {
-        let mut dlfile: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
-        // Check if dynamic library should be removed from registry.
-            .extract_if(.., |dlhandle, dlfile| {
-                // Check if the handle matches the dynamic library name.
-                if handle == dlhandle {
-                    // Check if this is the only remaining reference to the dynamic library file.
-                    Arc::strong_count(dlfile) == 1
-                } else {
-                    false
-                }
-            })
+        // Remove the closing library from the registry, but only if this is the
+        // last reference to it (i.e., no other loaded library still depends on
+        // it). If it is still referenced, there is nothing to unload yet.
+        let mut extracted: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
+            .extract_if(.., |dlhandle, dlfile| handle == dlhandle && Arc::strong_count(dlfile) == 1)
             .collect();
+
+        // A handle is unique, so at most one entry can match.
+        debug_assert!(extracted.len() <= 1);
 
         // Dynamic library file is still in use.
-        if dlfile.is_empty() {
-            return Ok(());
+        let root: Arc<Mutex<DynamicLibrary>> = match extracted.pop() {
+            Some((_, root)) => root,
+            None => return Ok(()),
+        };
+
+        // Walk the dependency graph, removing every library that becomes
+        // unreferenced once its dependents are removed, recording the unload
+        // order (dependents before dependencies). `take_dependencies` detaches
+        // a library's dependency edges, so recording a library here drops its
+        // hold on its dependencies; a dependency is only unloaded once *all* of
+        // its dependents -- inside and outside this `dlclose` call -- have
+        // released it.
+        let mut fini_order: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
+        let mut worklist: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
+
+        for (_dlname, dep) in root.lock().take_dependencies() {
+            worklist.push(dep);
+        }
+        fini_order.push(root);
+
+        while let Some(candidate) = worklist.pop() {
+            let candidate_handle: DlHandle = candidate.lock().handle();
+
+            // Remove the candidate from the registry only if the registry and
+            // this worklist entry hold the last two references to it. A higher
+            // count means another not-yet-removed dependent (e.g., the other
+            // arm of a diamond dependency) or a library outside this unload set
+            // still references it: skip it now and let the remaining dependent
+            // re-enqueue it once that dependent is removed. An empty result
+            // means the candidate was already unloaded via another path.
+            let mut extracted: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
+                .extract_if(.., |dlhandle, dlfile| {
+                    *dlhandle == candidate_handle && Arc::strong_count(dlfile) == 2
+                })
+                .collect();
+
+            // A handle is unique, so at most one entry can match.
+            debug_assert!(extracted.len() <= 1);
+
+            let dep: Arc<Mutex<DynamicLibrary>> = match extracted.pop() {
+                Some((_, dep)) => dep,
+                None => continue,
+            };
+
+            {
+                let mut lib: MutexGuard<'_, DynamicLibrary> = dep.lock();
+                for (_dlname, dlfile) in lib.take_dependencies() {
+                    worklist.push(dlfile);
+                }
+                ::syslog::debug!(
+                    "dlclose(): unloading dependency (name={:?}, registry.len={:?})",
+                    lib.name(),
+                    registry.len()
+                );
+            }
+            fini_order.push(dep);
         }
 
-        assert_eq!(
-            dlfile.len(),
-            1,
-            "dlclose(): expected to remove exactly one dynamic library file"
-        );
-
-        // Collect all dependencies of the dynamic library file being closed.
-        let mut dep_dlfiles: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
-        if let Some((_, dep_dlfile)) = dlfile.pop() {
-            let mut dep_dlfile = dep_dlfile.lock();
-            dep_dlfile
-                .take_dependencies()
-                .iter()
-                .for_each(|(_dlname, dlfile)| {
-                    dep_dlfiles.push(dlfile.clone());
-                });
-        }
-
-        dep_dlfiles
+        fini_order
     };
 
-    while let Some(dep_dlfile) = dep_dlfiles.pop() {
-        // Check if dynamic library should be removed from registry.
-        let mut dep_dlfile: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
-            .extract_if(.., |dlhandle, dlfile| {
-                // Check if the handle matches the dynamic library.
-                if &dep_dlfile.lock().handle() == dlhandle {
-                    // Check if this is the only remaining reference to the dynamic library file.
-                    // One reference in the registry and one hold by this loop.
-                    Arc::strong_count(dlfile) == 2
-                } else {
-                    false
-                }
-            })
-            .collect();
-
-        assert_eq!(
-            dep_dlfile.len(),
-            1,
-            "dlclose(): expected to remove exactly one dynamic library file"
-        );
-
-        // Collect all dependencies of the dynamic library file.
-        if let Some((_, dep_dlfile)) = dep_dlfile.pop() {
-            let mut dep_dlfile = dep_dlfile.lock();
-            dep_dlfile
-                .take_dependencies()
-                .iter()
-                .for_each(|(_dlname, dlfile)| {
-                    dep_dlfiles.push(dlfile.clone());
-                });
-            ::syslog::debug!(
-                "dlclose(): closing dependency (name={:?}, registry.len={:?})",
-                dep_dlfile.name(),
-                registry.len()
-            );
+    // The registry lock is now released. Run `.fini_array` destructors in
+    // dependents-first order with no dlfcn locks held.
+    for dlfile in fini_order.iter() {
+        // Snapshot the destructor descriptor and name under a short per-library
+        // lock, then drop the lock before invoking destructors. Holding the
+        // per-library lock during destructor execution would deadlock any
+        // destructor that re-enters the same library's libposix/alloc paths.
+        let (descriptor, name): (Option<(usize, usize)>, String) = {
+            let lib: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+            (lib.fini_array_descriptor(), String::from(lib.name()))
+        };
+        // SAFETY: `descriptor` was produced under the per-library lock for a
+        // library still held alive by `fini_order`'s `Arc`; its segments stay
+        // mapped until `fini_order` is dropped below; and no dlfcn locks are
+        // held across this call, so a destructor may re-enter the loader
+        // without deadlocking.
+        unsafe {
+            DynamicLibrary::invoke_fini_array(descriptor, &name);
         }
     }
+
+    // Drop the libraries now that all destructors have run, unmapping their
+    // segments and releasing their file descriptors.
+    drop(fini_order);
 
     Ok(())
 }

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -50,7 +50,11 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // of the caller's CWD. As a consequence, "/lib/libc.so" and
     // "lib/libc.so" are distinct keys in the already-loaded-library lookup
     // below (matching the as-supplied path rather than a canonical form).
-    let resolved: String = super::resolve_library_path(filename);
+    //
+    // A direct `dlopen()` has no loading-library context, so no `DT_RUNPATH`
+    // entries are supplied here; only the configured default search paths are
+    // consulted for bare names.
+    let resolved: String = super::resolve_library_path(filename, None);
     let filename: &str = resolved.as_str();
 
     let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
@@ -84,37 +88,68 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // Load dependencies and resolve symbols. If either step fails, remove all
     // entries that were added during this call (the library itself and any
     // transitive dependencies) so subsequent dlopen calls start fresh.
-    match load_all_dependencies(&mut registry, new_dlfile)
-        .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
-    {
-        Ok(()) => {
-            // If RTLD_GLOBAL was requested, publish the library's exported
-            // symbols into the global symbol table so subsequently loaded
-            // libraries can resolve them.
-            if global {
-                if let Some(dlfile) = registry.get(&handle) {
-                    super::register_library_in_global_scope(dlfile);
+    let init_order: Vec<Arc<Mutex<DynamicLibrary>>> =
+        match load_all_dependencies(&mut registry, new_dlfile)
+            .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
+        {
+            Ok(order) => {
+                // If RTLD_GLOBAL was requested, publish the library's exported
+                // symbols into the global symbol table so subsequently loaded
+                // libraries can resolve them.
+                if global {
+                    if let Some(dlfile) = registry.get(&handle) {
+                        super::register_library_in_global_scope(dlfile);
+                    }
                 }
-            }
-            Ok(handle)
-        },
-        Err(e) => {
-            let new_handles: Vec<DlHandle> = registry
-                .keys()
-                .filter(|h| !handles_before.contains(h))
-                .copied()
-                .collect();
-            ::syslog::warn!(
-                "dlopen(): rolling back {} entries after failure (error={:?})",
-                new_handles.len(),
-                e
-            );
-            for h in new_handles {
-                registry.remove(&h);
-            }
-            Err(e)
-        },
+                order
+            },
+            Err(e) => {
+                let new_handles: Vec<DlHandle> = registry
+                    .keys()
+                    .filter(|h| !handles_before.contains(h))
+                    .copied()
+                    .collect();
+                ::syslog::warn!(
+                    "dlopen(): rolling back {} entries after failure (error={:?})",
+                    new_handles.len(),
+                    e
+                );
+                for h in new_handles {
+                    registry.remove(&h);
+                }
+                return Err(e);
+            },
+        };
+
+    // Drop the registry lock before invoking `.init_array` constructors so a
+    // constructor may legally call `dlsym` (and, in a future relaxation,
+    // `dlopen`) without deadlocking on `DYNAMIC_LIBRARY_REGISTRY`.
+    drop(registry);
+
+    // Invoke `.init_array` constructors in dependency order (leaves first).
+    // The Arc list was built while the registry was locked, so each entry is
+    // guaranteed to still point to a loaded library.
+    //
+    // Snapshot the constructor descriptor and library name under a short
+    // per-library lock, then drop the lock before invoking constructors.
+    // Holding the per-library lock during constructor execution would
+    // deadlock any constructor that calls `dlsym(self_handle, ...)`, because
+    // `dlsym` re-locks the same library to look up symbols.
+    for dlfile in init_order.iter() {
+        let (descriptor, name): (Option<(usize, usize)>, String) = {
+            let lib: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+            (lib.init_array_descriptor(), String::from(lib.name()))
+        };
+        // SAFETY: `descriptor` was produced under the per-library lock for
+        // a library still held alive by `init_order`'s `Arc`; relocations
+        // have been applied by `resolve_all_symbols`; no dlfcn locks are
+        // held across this call.
+        unsafe {
+            DynamicLibrary::invoke_init_array(descriptor, &name);
+        }
     }
+
+    Ok(handle)
 }
 
 /// Recursively loads all transitive dependencies of a newly opened library.
@@ -133,6 +168,12 @@ fn load_all_dependencies(
         new_dlhandle: &DlHandle,
         new_dlfile: &mut MutexGuard<'_, DynamicLibrary>,
     ) -> Result<(), Error> {
+        // Snapshot the loader's `DT_RUNPATH` entries so they are visible to
+        // `resolve_library_path` while probing every dependency below. The
+        // `DynamicLibrary` mutex is borrowed throughout, so this avoids
+        // re-borrowing it per call.
+        let runpaths: Vec<String> = new_dlfile.runpaths().to_vec();
+
         // Collect the name of all dependencies.
         let mut dependencies: Vec<String> = new_dlfile
             .dependencies()
@@ -144,7 +185,7 @@ fn load_all_dependencies(
         dependencies.retain(|dependency| {
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
-            let resolved_dep: String = super::resolve_library_path(dependency);
+            let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
             for (dlhandle, dlfile) in dlfiles.iter() {
                 // Check if need to skip the dynamic library itself.
                 if dlhandle == new_dlhandle {
@@ -180,7 +221,7 @@ fn load_all_dependencies(
         // Load remaining dependencies.
         while let Some(dependency) = dependencies.pop() {
             // Resolve bare library names to full paths using search directories.
-            let resolved_dep: String = super::resolve_library_path(&dependency);
+            let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));
 
             // Open and pre-load the dynamic library file.
             let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&resolved_dep)?;
@@ -209,15 +250,17 @@ fn load_all_dependencies(
     Ok(())
 }
 
-/// Resolves all relocations for libraries added during this `dlopen` call.
+/// Resolves all relocations for libraries added during this `dlopen` call and
+/// returns them in dependency order (leaves first, root last) so the caller
+/// can invoke `.init_array` constructors in the correct sequence.
 ///
-/// Libraries are resolved in dependency order (leaves first, root last).
-/// This ensures that when a library's relocations reference symbols from
-/// its dependencies, those dependencies are already fully resolved.
+/// Libraries are resolved in dependency order. This ensures that when a
+/// library's relocations reference symbols from its dependencies, those
+/// dependencies are already fully resolved.
 fn resolve_all_symbols(
     dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
     handles_before: &BTreeSet<DlHandle>,
-) -> Result<(), Error> {
+) -> Result<Vec<Arc<Mutex<DynamicLibrary>>>, Error> {
     ::syslog::trace!("resolve_all_symbols()");
 
     // Collect all newly added libraries.
@@ -295,11 +338,13 @@ fn resolve_all_symbols(
     }
 
     // Resolve in dependency order (leaves first).
+    let mut init_order: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::with_capacity(ordered.len());
     for handle in ordered {
         if let Some(dlfile) = dlfiles.get(&handle) {
             dlfile.lock().resolve_all()?;
+            init_order.push(dlfile.clone());
         }
     }
 
-    Ok(())
+    Ok(init_order)
 }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -123,6 +123,12 @@ pub struct DynamicLibrary {
     dynplt: Option<RelocationTable>,
     /// Relocation table for global variables.
     dynrel: Option<RelocationTable>,
+    /// Absolute address of the `.init_array` section and the number of entries.
+    init_array: Option<(usize, usize)>,
+    /// Absolute address of the `.fini_array` section and the number of entries.
+    fini_array: Option<(usize, usize)>,
+    /// `DT_RUNPATH` directories of this library, already split on `:`.
+    runpaths: Vec<String>,
 }
 
 impl DynamicLibrary {
@@ -290,6 +296,23 @@ impl DynamicLibrary {
                     Self::get_dynplt(&section_headers, load_address);
                 let dynrel: Option<RelocationTable> =
                     Self::get_dynrel(&section_headers, load_address);
+                let init_array: Option<(usize, usize)> =
+                    Self::get_init_array(&section_headers, load_address);
+                let fini_array: Option<(usize, usize)> =
+                    Self::get_fini_array(&section_headers, load_address);
+
+                // Collect `DT_RUNPATH` entries (goblin exposes them already
+                // resolved against `.dynstr`). Each entry may be a colon-
+                // separated list of directories; split here so the search
+                // path probe can iterate them directly.
+                let mut runpaths: Vec<String> = Vec::new();
+                for raw in elf.runpaths.iter() {
+                    for component in raw.split(':') {
+                        if !component.is_empty() {
+                            runpaths.push(component.to_string());
+                        }
+                    }
+                }
 
                 Ok(DynamicLibrary {
                     filename,
@@ -301,6 +324,9 @@ impl DynamicLibrary {
                     dynstr,
                     dynplt,
                     dynrel,
+                    init_array,
+                    fini_array,
+                    runpaths,
                 })
             },
             Err(error) => {
@@ -442,6 +468,44 @@ impl DynamicLibrary {
         } else {
             None
         }
+    }
+
+    /// Looks up a function-pointer array section (`.init_array` / `.fini_array`)
+    /// by name, returning the absolute address of the first entry and the
+    /// number of `usize`-sized entries it contains.
+    ///
+    /// Returns `None` when the section is missing or empty. Entries are
+    /// always 4 bytes on i386; if `sh_size` is not a multiple of `usize`
+    /// the trailing bytes are silently truncated (a well-formed ELF should
+    /// never trigger this).
+    fn get_function_pointer_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+        section_name: &str,
+    ) -> Option<(usize, usize)> {
+        let header: &SectionHeader = section_headers.get(section_name)?;
+        let count: usize = (header.sh_size as usize) / mem::size_of::<usize>();
+        if count == 0 {
+            return None;
+        }
+        let base: usize = load_address.into_raw_value() + header.sh_addr as usize;
+        Some((base, count))
+    }
+
+    /// Gets the `.init_array` section descriptor, if present.
+    fn get_init_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+    ) -> Option<(usize, usize)> {
+        Self::get_function_pointer_array(section_headers, load_address, ".init_array")
+    }
+
+    /// Gets the `.fini_array` section descriptor, if present.
+    fn get_fini_array(
+        section_headers: &BTreeMap<String, SectionHeader>,
+        load_address: VirtualAddress,
+    ) -> Option<(usize, usize)> {
+        Self::get_function_pointer_array(section_headers, load_address, ".fini_array")
     }
 
     /// Finds a symbol in the dynamic library.
@@ -927,15 +991,130 @@ impl DynamicLibrary {
         }
     }
 
-    /// Takes all dependencies of the dynamic library.
+    /// Detaches and returns all bound dependencies of the dynamic library.
+    ///
+    /// Each returned dependency edge is removed from this library, so the
+    /// `Arc` references it held are released to the caller. `dlclose` relies
+    /// on this to drop a dependent's hold on its dependencies before deciding
+    /// whether those dependencies have become unreferenced and can be
+    /// unloaded.
     pub fn take_dependencies(&mut self) -> Vec<(String, Arc<Mutex<Self>>)> {
         let mut dependencies: Vec<(String, Arc<Mutex<Self>>)> = Vec::new();
-        for (name, library) in self.dependencies.iter() {
-            if let Some(library) = library {
-                dependencies.push((name.clone(), library.clone()));
+        for (name, library) in self.dependencies.iter_mut() {
+            if let Some(library) = library.take() {
+                dependencies.push((name.clone(), library));
             }
         }
         dependencies
+    }
+
+    /// Returns the `DT_RUNPATH` directories of the library, split on `:`.
+    pub fn runpaths(&self) -> &[String] {
+        &self.runpaths
+    }
+
+    /// Returns the loaded `.init_array` descriptor as `(base_address,
+    /// entry_count)`, or `None` if the library has no constructors.
+    ///
+    /// Callers should snapshot this under the library's mutex, drop the
+    /// mutex, and then invoke the entries via [`invoke_init_array`]. The
+    /// descriptor remains valid for as long as the owning
+    /// `Arc<Mutex<DynamicLibrary>>` is alive.
+    pub fn init_array_descriptor(&self) -> Option<(usize, usize)> {
+        self.init_array
+    }
+
+    /// Returns the loaded `.fini_array` descriptor as `(base_address,
+    /// entry_count)`, or `None` if the library has no destructors.
+    ///
+    /// See [`init_array_descriptor`](Self::init_array_descriptor) for the
+    /// expected lock-handling pattern.
+    pub fn fini_array_descriptor(&self) -> Option<(usize, usize)> {
+        self.fini_array
+    }
+
+    /// Invokes every function pointer in the supplied `.init_array`
+    /// descriptor in order, as required by the System V ABI for shared-
+    /// object constructor execution.
+    ///
+    /// `name` is purely for diagnostic logging.
+    ///
+    /// # Locking
+    ///
+    /// This function must be called with **no** dlfcn locks held — neither
+    /// `DYNAMIC_LIBRARY_REGISTRY` nor the per-library mutex. Constructors
+    /// may legally call `dlsym` (and, in a future relaxation, `dlopen`),
+    /// both of which would otherwise re-enter the same locks and deadlock.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that `descriptor` was produced by
+    /// [`init_array_descriptor`](Self::init_array_descriptor) from a
+    /// `DynamicLibrary` whose memory segments are still mapped, that
+    /// `resolve_all` has already applied any `R_386_RELATIVE` patches to
+    /// the section, and that the holding `Arc` lives until this call
+    /// returns. Entry values equal to `0` or `usize::MAX` are treated as
+    /// sentinels and skipped, matching the glibc loader behaviour.
+    pub unsafe fn invoke_init_array(descriptor: Option<(usize, usize)>, name: &str) {
+        let (base, count): (usize, usize) = match descriptor {
+            Some(range) => range,
+            None => return,
+        };
+        ::syslog::debug!("invoke_init_array(): library={:?} entries={}", name, count);
+        for index in 0..count {
+            // SAFETY: `base` points to the loaded `.init_array` section of
+            // the originating library and `count` is the number of
+            // `usize`-sized entries it contains.
+            let entry_ptr: *const usize = (base + index * mem::size_of::<usize>()) as *const usize;
+            let entry: usize = unsafe { entry_ptr.read_unaligned() };
+            if entry == 0 || entry == usize::MAX {
+                continue;
+            }
+            // SAFETY: the .init_array entry is a function pointer with C
+            // calling convention and no arguments per the System V ABI.
+            let func: extern "C" fn() = unsafe { mem::transmute::<usize, extern "C" fn()>(entry) };
+            func();
+        }
+    }
+
+    /// Invokes every function pointer in the supplied `.fini_array`
+    /// descriptor in reverse order, as required by the System V ABI for
+    /// shared-object destructor execution. Must be called before the
+    /// library's memory segments are unmapped.
+    ///
+    /// `name` is purely for diagnostic logging.
+    ///
+    /// # Locking
+    ///
+    /// This function must be called with **no** dlfcn locks held -- neither
+    /// `DYNAMIC_LIBRARY_REGISTRY` nor the per-library mutex of the
+    /// originating library. The current `dlclose()` caller removes every
+    /// library it is going to unload from the registry and then releases
+    /// `DYNAMIC_LIBRARY_REGISTRY` before invoking any destructor, so a
+    /// destructor may legally call back into `dlopen`/`dlclose`/`dlsym`
+    /// without deadlocking. One caveat remains: `dlsym(self_handle, ...)`
+    /// fails with `NoSuchEntry` rather than succeeding, because the closing
+    /// library has already been removed from the registry.
+    ///
+    /// # Safety
+    ///
+    /// See [`invoke_init_array`](Self::invoke_init_array).
+    pub unsafe fn invoke_fini_array(descriptor: Option<(usize, usize)>, name: &str) {
+        let (base, count): (usize, usize) = match descriptor {
+            Some(range) => range,
+            None => return,
+        };
+        ::syslog::debug!("invoke_fini_array(): library={:?} entries={}", name, count);
+        for index in (0..count).rev() {
+            // SAFETY: see `invoke_init_array`.
+            let entry_ptr: *const usize = (base + index * mem::size_of::<usize>()) as *const usize;
+            let entry: usize = unsafe { entry_ptr.read_unaligned() };
+            if entry == 0 || entry == usize::MAX {
+                continue;
+            }
+            let func: extern "C" fn() = unsafe { mem::transmute::<usize, extern "C" fn()>(entry) };
+            func();
+        }
     }
 }
 

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -91,9 +91,18 @@ static DLINIT_ONCE: Once = Once::new();
 /// `LD_LIBRARY_PATH` and are passed straight through to `open()`.
 ///
 /// If `filename` is a bare name (no `/`), the function tries each directory in
-/// [`LIBRARY_SEARCH_PATHS`] in order, returning the first path for which the
-/// file exists. If no match is found the bare name is returned so that the
-/// subsequent `open_regular_file` call produces the appropriate error.
+/// the following order, returning the first path for which the file exists:
+///
+/// 1. The directories listed in `runpaths` (caller-supplied, typically the
+///    `DT_RUNPATH` entries of the library whose dependency is being resolved).
+///    `$ORIGIN` inside an entry is substituted with `"."` (the current
+///    working directory). This is a temporary approximation; the System V
+///    `ld.so` convention is to substitute the directory of the loading
+///    library, which Nanvix does not yet track per-library.
+/// 2. The directories in [`LIBRARY_SEARCH_PATHS`] (currently just `"lib/"`).
+///
+/// If no match is found the bare name is returned so that the subsequent
+/// `open_regular_file` call produces the appropriate error.
 ///
 /// # Absolute paths must stay absolute
 ///
@@ -111,7 +120,11 @@ static DLINIT_ONCE: Once = Once::new();
 /// candidate path. The matched file is re-opened by `DynamicLibrary::open()`.
 /// This double-open is accepted for simplicity; a stat-based probe would
 /// avoid it but is not currently available in the Nanvix VFS API.
-pub(super) fn resolve_library_path(filename: &str) -> String {
+///
+/// `DT_RPATH` (the predecessor to `DT_RUNPATH`) is intentionally not consulted:
+/// it is deprecated by the System V gABI and modern toolchains emit
+/// `DT_RUNPATH` instead.
+pub(super) fn resolve_library_path(filename: &str, runpaths: Option<&[String]>) -> String {
     // If the original filename contains a path separator, the caller provided
     // an explicit path (absolute or relative with directory). Normalize it
     // but do NOT search configured directories — matching Linux behavior
@@ -132,30 +145,106 @@ pub(super) fn resolve_library_path(filename: &str) -> String {
         return String::from(normalized);
     }
 
-    // Bare library name (no path separator) — search configured directories.
+    // Bare library name (no path separator) — search runpaths first, then
+    // the configured default directories.
+    if let Some(runpaths) = runpaths {
+        for dir in runpaths.iter() {
+            let dir: String = substitute_origin(dir);
+            let candidate: String = join_dir(&dir, filename);
+            if probe_exists(&candidate) {
+                // Apply the same canonicalization as the explicit-path
+                // branch above so callers that compare against already-
+                // loaded library names (which are stored canonically)
+                // don't see duplicates like `"./libfoo.so"` vs
+                // `"libfoo.so"`. A single leading "./" is stripped, but a
+                // leading "/" is preserved so that an absolute DT_RUNPATH
+                // entry (e.g. `"/usr/lib"`) keeps resolving against the
+                // filesystem root rather than the caller's CWD.
+                let canonical: String = canonicalize(&candidate);
+                ::syslog::debug!(
+                    "resolve_library_path(): resolved '{}' via DT_RUNPATH -> '{}'",
+                    filename,
+                    canonical
+                );
+                return canonical;
+            }
+        }
+    }
+
     // Clone the path list under the lock, then release it before probing
     // the filesystem (which involves I/O and should not hold a spinlock).
     let search_paths: Vec<String> = LIBRARY_SEARCH_PATHS.lock().clone();
     for dir in search_paths.iter() {
-        let candidate: String = alloc::format!("{}{}", dir, filename);
-        // Probe whether the file exists by attempting to open it.
-        if let Ok(_fd) = crate::safe::FileSystem::open_regular_file(
-            // FileSystemPath::new can fail for invalid names; skip on error.
-            &match crate::safe::FileSystemPath::new(&candidate) {
-                Ok(p) => p,
-                Err(_) => continue,
-            },
-            &crate::safe::RegularFileOpenFlags::read_only(),
-            None,
-        ) {
-            ::syslog::debug!("resolve_library_path(): resolved '{}' -> '{}'", filename, candidate);
-            return candidate;
+        let candidate: String = join_dir(dir, filename);
+        if probe_exists(&candidate) {
+            let canonical: String = canonicalize(&candidate);
+            ::syslog::debug!("resolve_library_path(): resolved '{}' -> '{}'", filename, canonical);
+            return canonical;
         }
     }
 
     // Fall back to the original name (will produce a clear error at open time).
     ::syslog::debug!("resolve_library_path(): no match for '{}', using as-is", filename);
     String::from(filename)
+}
+
+/// Normalizes a resolved candidate path to the canonical form used throughout
+/// the dlfcn layer (e.g. `"lib/libc.so"`), matching the explicit-path branch of
+/// [`resolve_library_path`]: a single leading `./` is stripped, but a leading
+/// `/` is preserved so that absolute paths (such as those produced from an
+/// absolute `DT_RUNPATH` entry) stay absolute and resolve against the
+/// filesystem root regardless of the caller's CWD. Returns the input unchanged
+/// if normalization would yield an empty string.
+fn canonicalize(path: &str) -> String {
+    let stripped: &str = match path.strip_prefix("./") {
+        Some(rest) => rest.trim_start_matches('/'),
+        None => path,
+    };
+    if stripped.is_empty() {
+        String::from(path)
+    } else {
+        String::from(stripped)
+    }
+}
+
+/// Joins a directory and filename without introducing duplicate separators.
+fn join_dir(dir: &str, filename: &str) -> String {
+    if dir.is_empty() {
+        return String::from(filename);
+    }
+    if dir.ends_with('/') {
+        alloc::format!("{}{}", dir, filename)
+    } else {
+        alloc::format!("{}/{}", dir, filename)
+    }
+}
+
+/// Substitutes `$ORIGIN` in a runpath entry. Nanvix has no per-process loader
+/// directory concept yet, so `$ORIGIN` is currently expanded to `"."` (the
+/// current working directory). This is a temporary approximation: the System V
+/// `ld.so` convention is to expand `$ORIGIN` to the directory containing the
+/// loading library, which Nanvix does not yet track per-library. Keeping a
+/// well-formed substitution (rather than the empty string) avoids producing
+/// invalid paths like `"//lib"` from entries such as `"$ORIGIN/lib"`.
+fn substitute_origin(entry: &str) -> String {
+    if !entry.contains("$ORIGIN") {
+        return String::from(entry);
+    }
+    entry.replace("$ORIGIN", ".")
+}
+
+/// Returns `true` if a regular file exists at `candidate`.
+fn probe_exists(candidate: &str) -> bool {
+    let path: crate::safe::FileSystemPath = match crate::safe::FileSystemPath::new(candidate) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    crate::safe::FileSystem::open_regular_file(
+        &path,
+        &crate::safe::RegularFileOpenFlags::read_only(),
+        None,
+    )
+    .is_ok()
 }
 
 /// Populates `GLOBAL_SYMBOL_TABLE` from the executable's `.dynsym`/`.dynstr`


### PR DESCRIPTION
## Summary

Shared objects loaded through `dlopen` never ran their `.init_array` constructors, and `dlclose` never ran their `.fini_array` destructors, so C++ static initializers and `__attribute__((constructor))` routines in dynamically loaded libraries were silently skipped. This PR wires up constructor/destructor execution and, while in the loader, also adds `DT_RUNPATH` support to dependency resolution.

## Changes

### `.init_array` / `.fini_array` execution
- Parse the `.init_array` and `.fini_array` section descriptors when a `DynamicLibrary` is opened, recording each as an `(address, count)` pair.
- Add `invoke_init_array()` / `invoke_fini_array()` to walk them: constructors run in array order, destructors in reverse, per the System V ABI. Entries equal to `0` or `usize::MAX` are treated as sentinels and skipped.
- `resolve_all_symbols()` now returns the newly added libraries in dependency order (leaves first); `dlopen` invokes their constructors after relocations are applied, and `dlclose` runs the destructors before the library is unmapped.

### Locking / reentrancy
- Both arrays are invoked with **no** dlfcn locks held. The registry lock is dropped, and only a short per-library lock is taken to snapshot the descriptor and name before release, so a constructor that calls `dlsym` (or, in a future relaxation, `dlopen`) cannot deadlock on `DYNAMIC_LIBRARY_REGISTRY` or on the library's own mutex.
- `dlclose` still holds the registry lock and has already removed the closing library, so destructors cannot re-enter any dlfcn API today; the `unsafe` contracts document this and the planned relaxation.

### `DT_RUNPATH` resolution
- `DynamicLibrary` collects its runpath entries (split on `:`), and `resolve_library_path()` takes an optional runpath list probed ahead of the default `LIBRARY_SEARCH_PATHS`.
- `$ORIGIN` is provisionally expanded to `"."` since Nanvix does not yet track the loading library's directory; the deprecated `DT_RPATH` is intentionally ignored.
- Path handling is factored into `canonicalize()`, `join_dir()`, `substitute_origin()`, and `probe_exists()` helpers; matched runpath results are canonicalized so they do not create duplicate registry entries against libraries opened by full path.

## Files touched
- `src/libs/syscall/src/dlfcn/syscall/dynlib.rs`
- `src/libs/syscall/src/dlfcn/syscall/dlopen.rs`
- `src/libs/syscall/src/dlfcn/syscall/dlclose.rs`
- `src/libs/syscall/src/dlfcn/syscall/mod.rs`

## Status
Draft — opening for early review/feedback on approach.