### PR TITLE
[proc] Add waitpid support

### DIFF
--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -13,6 +13,8 @@ use crate::{
     ProcessManagementMessage,
     ProcessManagementMessageHeader,
     SignupMessage,
+    WaitMessage,
+    WaitTarget,
 };
 use ::alloc::{
     collections::btree_map::BTreeMap,
@@ -50,6 +52,13 @@ use ::sys::{
 // Structures
 //==================================================================================================
 
+/// `WNOHANG` wait option carried in the `options` field of a `Wait` protocol message. A request
+/// carrying this flag makes `waitpid()` poll without blocking. This is the daemon's local copy of
+/// the wire-protocol flag; its value is POSIX-compatible (matching the `WNOHANG` constant exposed
+/// to user space), kept in sync by convention rather than by a shared definition, as this crate
+/// does not depend on the user-space API crate.
+const WNOHANG: i32 = 1;
+
 ///
 /// # Description
 ///
@@ -69,6 +78,9 @@ struct ProcessRecord {
     /// Used to acknowledge a fork-sync request regardless of whether it races ahead of the
     /// process-creation event.
     fork_clone_done: bool,
+    /// Termination status once the process has terminated and is awaiting reap by `waitpid()`.
+    /// `Some(status)` marks a zombie; `None` marks a live (or not-yet-terminated) process.
+    zombie: Option<i32>,
 }
 
 impl ProcessRecord {
@@ -80,8 +92,43 @@ impl ProcessRecord {
             parent,
             children: Vec::new(),
             fork_clone_done: false,
+            zombie: None,
         }
     }
+}
+
+///
+/// # Description
+///
+/// Selects which child(ren) a blocked waiter is waiting for.
+///
+enum WaitSelector {
+    /// Any child of the waiter.
+    Any,
+    /// A specific child of the waiter.
+    Pid(ProcessIdentifier),
+}
+
+impl WaitSelector {
+    /// Returns `true` if `child` matches this selector.
+    fn matches(&self, child: ProcessIdentifier) -> bool {
+        match self {
+            WaitSelector::Any => true,
+            WaitSelector::Pid(pid) => *pid == child,
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// A parent process blocked in a `Wait` operation, awaiting a deferred reply.
+///
+struct BlockedWaiter {
+    /// Process identifier of the blocked waiter.
+    waiter: ProcessIdentifier,
+    /// Children that the waiter is waiting for.
+    selector: WaitSelector,
 }
 
 //==================================================================================================
@@ -101,6 +148,18 @@ pub struct ProcessDaemon {
     /// used rather than a map because only a handful of fork operations are ever pending
     /// concurrently, so a linear scan is cheaper than the overhead of an ordered map.
     pending_fork_syncs: Vec<(ProcessIdentifier, ProcessIdentifier)>,
+    /// Parents currently blocked in a `Wait` operation. A blocking `waitpid()` is parked here and
+    /// answered later, when a `ProcessTermination` event for a matching child arrives.
+    blocked: Vec<BlockedWaiter>,
+    /// Terminations observed before the corresponding process-creation event, stored as
+    /// `(pid, status)` pairs. The kernel publishes a process's termination event ahead of its
+    /// creation event when both are queued (the `ProcessTermination` scheduling slot is drained
+    /// before `ProcessCreation`), so procd can learn that a child died while the child is still
+    /// unknown. The status is buffered here and replayed once the creation event records the
+    /// child's lineage, so the exit status is never dropped and a parent blocked in `waitpid()` is
+    /// always answered. A `Vec` suffices because only a handful of terminations are ever pending
+    /// reconciliation at once.
+    early_terminations: Vec<(ProcessIdentifier, i32)>,
 }
 
 impl ProcessDaemon {
@@ -129,6 +188,8 @@ impl ProcessDaemon {
             processes: BTreeMap::new(),
             init_proc: None,
             pending_fork_syncs: Vec::new(),
+            blocked: Vec::new(),
+            early_terminations: Vec::new(),
         })
     }
 
@@ -266,6 +327,29 @@ impl ProcessDaemon {
             }
         }
 
+        // Replay a termination that was observed before this creation event. The kernel publishes
+        // terminations ahead of creations, so procd may have seen this child die while it was still
+        // unknown and buffered the exit status. Now that the child's lineage is recorded and its
+        // fork-clone has been dispatched to the filesystem daemon above, reclaim its filesystem
+        // state (ordered after the fork-clone, so the snapshot is taken before it is torn down) and
+        // finalize the termination, so a parent blocked in `waitpid()` receives the exit status
+        // instead of blocking forever on a child that can never terminate again.
+        if let Some(pos) = self
+            .early_terminations
+            .iter()
+            .position(|(p, _)| *p == child)
+        {
+            let (_, status) = self.early_terminations.swap_remove(pos);
+            ::syslog::info!(
+                "reconciling buffered termination (child={:?}, status={:?})",
+                child,
+                status
+            );
+            self.pending_fork_syncs.retain(|(c, _)| *c != child);
+            self.notify_process_exit(child);
+            self.finalize_forked_child_termination(child, status)?;
+        }
+
         Ok(())
     }
 
@@ -293,6 +377,48 @@ impl ProcessDaemon {
         let status: i32 = i32::from_le_bytes(message.payload[4..8].try_into().unwrap());
         ::syslog::info!("process terminated (pid={:?}, status={:?})", pid, status);
 
+        // The kernel publishes a process's termination event before its creation event when both
+        // are queued (the `ProcessTermination` scheduling slot is drained ahead of
+        // `ProcessCreation`), so this termination can arrive while the child's lineage is still
+        // unknown. This happens not only when the child is entirely unknown, but also when it sent
+        // its `Signup` before its creation event was processed: such a record exists (with its
+        // name) yet still has no recorded parent, so re-parenting, reaping, and waking a blocked
+        // waiter cannot be resolved correctly yet, and processing the termination immediately would
+        // let the later creation event recreate the record with no buffered status to replay.
+        // Buffer the `(pid, status)` and defer every side effect — filesystem-state reclamation,
+        // re-parenting, reaping, and waking a blocked waiter — until the creation event records the
+        // child's lineage and `handle_process_creation_event()` replays it. This guarantees the
+        // exit status is never dropped and a parent blocked in `waitpid()` is always answered. The
+        // creation event is guaranteed to follow: the kernel buffers it at fork time and the main
+        // loop re-publishes it until it is delivered. Deferring the filesystem-exit notification
+        // also keeps it ordered after the fork-clone that the creation handler dispatches, so the
+        // child's filesystem snapshot is taken before it is reclaimed.
+        //
+        // A process whose identity is already established without lineage is exempt: the init
+        // process (tracked in `init_proc`) and daemons (identified by name) make their termination
+        // decisions — shutdown and deregistration — without a recorded parent, so they are handled
+        // immediately rather than buffered.
+        let lineage_pending: bool = match self.processes.get(&pid) {
+            None => true,
+            Some(record) => {
+                record.parent.is_none()
+                    && self.init_proc != Some(pid)
+                    && !Self::is_daemon(&record.name)
+            },
+        };
+        if lineage_pending {
+            ::syslog::info!(
+                "termination observed before creation (pid={:?}, status={:?}) — buffering",
+                pid,
+                status
+            );
+            // Replace any stale entry for this pid before recording the new status, preserving an
+            // at-most-one-entry-per-pid invariant across pid reuse.
+            self.early_terminations.retain(|(p, _)| *p != pid);
+            self.early_terminations.push((pid, status));
+            return Ok(None);
+        }
+
         // Drop any stale fork-sync bookkeeping and notify the filesystem daemon to reclaim the
         // process's per-process state (open file descriptors and working directory). Unlike the
         // fork-clone notification — which is skipped for kernel-spawned processes that have no
@@ -301,6 +427,10 @@ impl ProcessDaemon {
         // state must be reclaimed too. The notification is a no-op in the filesystem daemon for a
         // process that never registered any state, so the extra message is harmless.
         self.pending_fork_syncs.retain(|(child, _)| *child != pid);
+        // Drop any blocked-wait bookkeeping owned by the terminating process. A process that was
+        // itself parked in `waitpid()` can never be answered once it is gone, so leaving its entry
+        // behind would leak memory and strand a stale waiter.
+        self.blocked.retain(|waiter| waiter.waiter != pid);
         self.notify_process_exit(pid);
 
         // Look up the terminating process in the registry.
@@ -341,38 +471,76 @@ impl ProcessDaemon {
                 return Ok(Some(status));
             }
 
-            // A forked child terminated. Re-parent its surviving children to the init
-            // process (orphan adoption by init), then drop its bookkeeping. Without
-            // `waitpid()` there is no reaping step, so the record is removed immediately.
-            let parent: Option<ProcessIdentifier> = record.parent;
-
-            self.reparent_children(pid);
-
-            if let Some(parent) = parent {
-                if let Some(record) = self.processes.get_mut(&parent) {
-                    record.children.retain(|child| *child != pid);
-                }
-            }
-            self.processes.remove(&pid);
+            // A forked child terminated. Finalize it through the shared helper, which auto-reaps
+            // its zombie children, re-parents its live children, and either retains it as a reapable
+            // zombie (waking a blocked parent) or drops it. The same finalization runs when a
+            // child's creation event is observed only after its termination event, so it lives in a
+            // shared helper rather than being duplicated here.
+            self.finalize_forked_child_termination(pid, status)?;
 
             return Ok(None);
         }
 
-        // The terminating process is unknown to the registry: its process-creation event was never
-        // observed. This is always a transient forked child, never the init process, so it is
-        // reaped without triggering shutdown. The init process is spawned directly by the kernel
-        // before any user workload runs, and procd subscribes to scheduling events at startup, so
-        // init's creation event (recorded with parent == KERNEL) is always observed long before
-        // init can terminate. Init therefore always terminates as a *known* process, handled by the
-        // lineage check above. An unknown process, by contrast, can only be a child that forked and
-        // exited before its creation event was processed; with no `waitpid()` to reap it, the event
-        // is simply ignored. Treating it as init here would spuriously shut the whole system down.
-        ::syslog::info!(
-            "unregistered process terminated (pid={:?}, status={:?}) — ignoring",
-            pid,
-            status
-        );
+        // Unreachable in practice: the early-termination buffer check at the top of this function
+        // returns for any pid that is not yet in the registry, so a process reaching this point is
+        // always known and was handled by one of the branches above. Return without action as a
+        // safe guard rather than panicking.
         Ok(None)
+    }
+
+    /// Finalizes the termination of a forked child `pid` whose lineage is known. Auto-reaps any of
+    /// its own children that are already zombies (only this terminating process could ever have
+    /// reaped them, so re-homing them to init — which never calls `waitpid()` — would leak them
+    /// until shutdown), re-parents its surviving live children to the init process, then decides
+    /// reapability: if a live parent can still reap it, it is retained as a zombie and a parent
+    /// already blocked in `waitpid()` is woken; otherwise it is dropped rather than left as an
+    /// unreapable zombie. Shared by the termination handler and the early-termination reconciliation
+    /// in `handle_process_creation_event()`.
+    fn finalize_forked_child_termination(
+        &mut self,
+        pid: ProcessIdentifier,
+        status: i32,
+    ) -> Result<(), Error> {
+        let parent: Option<ProcessIdentifier> =
+            self.processes.get(&pid).and_then(|record| record.parent);
+
+        self.reap_zombie_children(pid);
+        self.reparent_children(pid);
+
+        // Determine whether any live process can ever reap this one. Only a parent that is still
+        // alive and has not itself terminated can call `waitpid()`, so a process whose parent is
+        // unknown, is the kernel (which never waits), is gone, or is already a zombie can never
+        // be reaped. Retaining such a process as a zombie would leak it forever — precisely what
+        // happens to grandchildren when `init_proc` is unset and orphan adoption is a no-op — so
+        // auto-reap it instead.
+        let reaper: Option<ProcessIdentifier> = parent.filter(|parent| {
+            *parent != ProcessIdentifier::KERNEL
+                && self
+                    .processes
+                    .get(parent)
+                    .map(|record| record.zombie.is_none())
+                    .unwrap_or(false)
+        });
+
+        match reaper {
+            // A live parent may reap it: retain it as a zombie (clearing its now re-parented
+            // children list) and wake the parent if it is already blocked in `waitpid()`, which
+            // reaps the zombie immediately. Otherwise the zombie is kept until a future
+            // `waitpid()` collects it.
+            Some(parent) => {
+                if let Some(record) = self.processes.get_mut(&pid) {
+                    record.children.clear();
+                    record.zombie = Some(status);
+                }
+                self.wake_waiter(parent, pid, status)?;
+            },
+            // No live process can ever reap it: drop it rather than leak an unreapable zombie.
+            None => {
+                self.processes.remove(&pid);
+            },
+        }
+
+        Ok(())
     }
 
     /// Re-parents the surviving children of `pid` to the init process.
@@ -402,6 +570,141 @@ impl ProcessDaemon {
                 }
             }
         }
+    }
+
+    /// Auto-reaps the zombie children of a terminating process `pid`. A zombie can only be reaped by
+    /// its parent, but `pid` is itself terminating and will never call `waitpid()`, so its zombie
+    /// children would otherwise linger until shutdown (re-homing them to init does not help, as init
+    /// never reaps). A process clears its own children list when it becomes a zombie, so a zombie
+    /// has no descendants and dropping it orphans nothing.
+    fn reap_zombie_children(&mut self, pid: ProcessIdentifier) {
+        let children: Vec<ProcessIdentifier> = match self.processes.get(&pid) {
+            Some(record) => record.children.clone(),
+            None => return,
+        };
+
+        for child in children {
+            let is_zombie: bool = self
+                .processes
+                .get(&child)
+                .map(|record| record.zombie.is_some())
+                .unwrap_or(false);
+            if is_zombie {
+                self.reap(pid, child);
+            }
+        }
+    }
+
+    /// Handles a `Wait` request from `caller` selecting `(pid, options)`. Returns
+    /// `Ok(Some(reply))` for an immediate reply, or `Ok(None)` when the waiter blocks (the reply is
+    /// then produced later by the process-termination handler).
+    fn handle_wait(
+        &mut self,
+        caller: ProcessIdentifier,
+        message: WaitMessage,
+    ) -> Result<Option<Message>, Error> {
+        let options: i32 = message.options;
+
+        // Resolve the strongly-typed selector. The wire encoding folds the POSIX process-group
+        // selectors (`pid == 0` and `pid < -1`) into `WaitTarget::Any` because Nanvix has no
+        // process groups yet (see the `waitpid()` limitations). Since only parent/child lineage is
+        // tracked, every eligible child is already a child of the caller, so this is a harmless
+        // superset.
+        let selector: WaitSelector = match message.target() {
+            WaitTarget::Any => WaitSelector::Any,
+            WaitTarget::Pid(pid) => WaitSelector::Pid(pid),
+        };
+
+        // Enumerate the eligible children of the caller.
+        let children: Vec<ProcessIdentifier> = match self.processes.get(&caller) {
+            Some(record) => record
+                .children
+                .iter()
+                .copied()
+                .filter(|child| selector.matches(*child))
+                .collect(),
+            None => Vec::new(),
+        };
+
+        // The caller has no eligible children: report `ECHILD`.
+        if children.is_empty() {
+            let reply: Message = message::wait_response(
+                caller,
+                ProcessIdentifier::from(0),
+                0,
+                ErrorCode::NoChildProcess.get(),
+            )?;
+            return Ok(Some(reply));
+        }
+
+        // Look for a ready zombie among the eligible children (lowest pid for determinism).
+        let mut zombies: Vec<(ProcessIdentifier, i32)> = children
+            .iter()
+            .filter_map(|child| {
+                self.processes
+                    .get(child)
+                    .and_then(|record| record.zombie.map(|status| (*child, status)))
+            })
+            .collect();
+        zombies.sort_by_key(|(child, _)| *child);
+
+        if let Some((child, status)) = zombies.first().copied() {
+            // Reap the zombie and reply immediately.
+            self.reap(caller, child);
+            let reply: Message = message::wait_response(caller, child, status, 0)?;
+            return Ok(Some(reply));
+        }
+
+        // No zombie is ready.
+        if options & WNOHANG != 0 {
+            // Non-blocking poll: report that no child is ready (child pid of zero, no error).
+            let reply: Message = message::wait_response(caller, ProcessIdentifier::from(0), 0, 0)?;
+            return Ok(Some(reply));
+        }
+
+        // Block the waiter; the reply is deferred until a matching child terminates.
+        // Keep at most one blocked wait per waiter to avoid unbounded growth / stale deferred replies.
+        self.blocked.retain(|w| w.waiter != caller);
+        self.blocked.push(BlockedWaiter {
+            waiter: caller,
+            selector,
+        });
+
+        Ok(None)
+    }
+
+    /// Wakes a parent blocked in `waitpid()` that is waiting for `child` (a child of `parent`) and
+    /// reaps the zombie. If no waiter is blocked, the zombie is left in place until a future
+    /// `waitpid()` reaps it.
+    fn wake_waiter(
+        &mut self,
+        parent: ProcessIdentifier,
+        child: ProcessIdentifier,
+        status: i32,
+    ) -> Result<(), Error> {
+        if let Some(index) = self
+            .blocked
+            .iter()
+            .position(|waiter| waiter.waiter == parent && waiter.selector.matches(child))
+        {
+            let waiter_pid: ProcessIdentifier = self.blocked[index].waiter;
+            let reply: Message = message::wait_response(waiter_pid, child, status, 0)?;
+            ::sys::kcall::ipc::__kcall_send(&reply)?;
+
+            self.blocked.swap_remove(index);
+            self.reap(parent, child);
+        }
+
+        Ok(())
+    }
+
+    /// Reaps a zombie `child` of `parent`, removing it from the registry and from the parent's list
+    /// of children.
+    fn reap(&mut self, parent: ProcessIdentifier, child: ProcessIdentifier) {
+        if let Some(record) = self.processes.get_mut(&parent) {
+            record.children.retain(|c| *c != child);
+        }
+        self.processes.remove(&child);
     }
 
     /// Returns `true` if `name` belongs to a system daemon that should not trigger shutdown.
@@ -442,6 +745,14 @@ impl ProcessDaemon {
                 ProcessManagementMessageHeader::ForkSync => {
                     let message: ForkSyncMessage = ForkSyncMessage::from_bytes(message.payload);
                     self.handle_fork_sync(destination, message.child);
+                },
+                ProcessManagementMessageHeader::Wait => {
+                    let message: WaitMessage = WaitMessage::from_bytes(message.payload);
+                    // The reply is deferred (no send here) when the waiter blocks; it is produced
+                    // later by the process-termination handler.
+                    if let Some(reply) = self.handle_wait(destination, message)? {
+                        ::sys::kcall::ipc::__kcall_send(&reply)?;
+                    }
                 },
                 // Ignore all other messages.
                 _ => {},
@@ -727,8 +1038,14 @@ impl ProcessDaemon {
             },
         };
 
-        // Search the registry for a process whose name matches the requested name.
+        // Search the registry for a live process whose name matches the requested name. Zombies are
+        // skipped: a terminated process awaiting reap is not a valid lookup target, and a forked
+        // zombie still carries its parent's inherited name, which would otherwise alias the parent.
         for (pid, record) in self.processes.iter() {
+            if record.zombie.is_some() {
+                continue;
+            }
+
             ::syslog::info!("looking up process (name={:?}, pname={:?})", name, record.name);
 
             if record.name == name {
@@ -749,7 +1066,9 @@ impl ProcessDaemon {
         ::syslog::info!("shutting down process manager daemon...");
 
         // Drop bookkeeping for forked children: only live daemons need to be shut down cleanly,
-        // and dead processes will never produce further termination events.
+        // and dead processes will never produce further termination events. Any parent still
+        // blocked in `waitpid()` is torn down with the VM, so its blocked-waiter entry is dropped.
+        self.blocked.clear();
         self.processes
             .retain(|_pid, record| Self::is_daemon(&record.name));
 

--- a/src/libs/proc/src/lib.rs
+++ b/src/libs/proc/src/lib.rs
@@ -40,6 +40,8 @@ pub use message::{
     shutdown_request,
     signup_request,
     signup_response,
+    wait_request,
+    wait_response,
     ForkCloneMessage,
     ForkSyncMessage,
     LookupMessage,
@@ -50,6 +52,9 @@ pub use message::{
     ShutdownMessage,
     SignupMessage,
     SignupResponseMessage,
+    WaitMessage,
+    WaitResponseMessage,
+    WaitTarget,
 };
 
 #[cfg(feature = "syscall")]
@@ -60,6 +65,8 @@ pub use syscall::{
     getuid,
     lookup,
     signup,
+    wait,
+    WaitOutcome,
 };
 
 #[cfg(feature = "daemon")]

--- a/src/libs/proc/src/message/mod.rs
+++ b/src/libs/proc/src/message/mod.rs
@@ -11,6 +11,7 @@ mod lookup;
 mod process_exit;
 mod shutdown;
 mod signup;
+mod wait;
 
 //==================================================================================================
 // Exports
@@ -22,6 +23,7 @@ pub use lookup::*;
 pub use process_exit::*;
 pub use shutdown::*;
 pub use signup::*;
+pub use wait::*;
 
 //==================================================================================================
 // Imports
@@ -58,7 +60,11 @@ pub enum ProcessManagementMessageHeader {
     Lookup = 4,
     /// Lookup response.
     LookupResponse = 5,
-    // Discriminants 6-9 are reserved for future core process-management operations so that the
+    /// Wait operation (a parent asks the process manager daemon to wait for and reap a child).
+    Wait = 6,
+    /// Wait response (the process manager daemon reports a reaped child's pid and status).
+    WaitResponse = 7,
+    // Discriminants 8-9 are reserved for future core process-management operations so that the
     // fork-related variants below remain grouped in a stable, contiguous block.
     /// Fork-clone operation (used to notify other daemons to clone a parent's resources onto a
     /// freshly forked child).
@@ -84,6 +90,8 @@ impl TryFrom<u8> for ProcessManagementMessageHeader {
             3 => Ok(ProcessManagementMessageHeader::SignupResponse),
             4 => Ok(ProcessManagementMessageHeader::Lookup),
             5 => Ok(ProcessManagementMessageHeader::LookupResponse),
+            6 => Ok(ProcessManagementMessageHeader::Wait),
+            7 => Ok(ProcessManagementMessageHeader::WaitResponse),
             10 => Ok(ProcessManagementMessageHeader::ForkClone),
             11 => Ok(ProcessManagementMessageHeader::ForkSync),
             12 => Ok(ProcessManagementMessageHeader::ForkSyncAck),
@@ -101,6 +109,8 @@ impl From<&ProcessManagementMessageHeader> for u8 {
             ProcessManagementMessageHeader::SignupResponse => 3,
             ProcessManagementMessageHeader::Lookup => 4,
             ProcessManagementMessageHeader::LookupResponse => 5,
+            ProcessManagementMessageHeader::Wait => 6,
+            ProcessManagementMessageHeader::WaitResponse => 7,
             ProcessManagementMessageHeader::ForkClone => 10,
             ProcessManagementMessageHeader::ForkSync => 11,
             ProcessManagementMessageHeader::ForkSyncAck => 12,

--- a/src/libs/proc/src/message/wait.rs
+++ b/src/libs/proc/src/message/wait.rs
@@ -1,0 +1,343 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::message::{
+    ProcessManagementMessage,
+    ProcessManagementMessageHeader,
+};
+use ::core::mem;
+use ::sys::{
+    error::Error,
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+        SystemMessage,
+        SystemMessageHeader,
+    },
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Selects which child a wait operation targets, following POSIX `waitpid()` semantics.
+///
+pub enum WaitTarget {
+    /// Wait for any child of the caller.
+    Any,
+    /// Wait for the specific child with the given process identifier.
+    Pid(ProcessIdentifier),
+}
+
+///
+/// # Description
+///
+/// A message that encodes a wait operation. It is sent by a process to the process manager daemon
+/// to wait for the termination of a child process (`waitpid()`).
+///
+#[repr(C, packed)]
+pub struct WaitMessage {
+    /// Wire encoding of the child selector. This is a raw `i32` rather than a [`ProcessIdentifier`]
+    /// because the non-positive selector values that POSIX `waitpid()` allows (`-1`, `0`, `< -1`)
+    /// are not valid process identifiers. The field is private so callers cannot build an invalid
+    /// selector directly: use [`WaitMessage::new`] to construct one from a [`WaitTarget`] and
+    /// [`WaitMessage::target`] to decode it back.
+    selector: i32,
+    /// Wait options.
+    pub options: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+
+// NOTE: The size of a wait message must match the size of a process management message payload.
+::static_assert::assert_eq_size!(WaitMessage, ProcessManagementMessage::PAYLOAD_SIZE);
+
+///
+/// # Description
+///
+/// A message that encodes the response of a wait operation.
+///
+#[repr(C, packed)]
+pub struct WaitResponseMessage {
+    /// Process identifier of the reaped child (`0` when no child was ready and `WNOHANG` was set).
+    pub child: ProcessIdentifier,
+    /// Termination status of the reaped child.
+    pub status: i32,
+    /// Error code of the wait operation (`0` on success).
+    pub error: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+
+// NOTE: The size of a wait response message must match the size of a process management message payload.
+::static_assert::assert_eq_size!(WaitResponseMessage, ProcessManagementMessage::PAYLOAD_SIZE);
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl WaitTarget {
+    /// Encodes this selector into its wire representation. [`WaitTarget::Any`] is encoded as `-1`,
+    /// because process groups are not supported yet.
+    pub fn into_raw(self) -> i32 {
+        match self {
+            WaitTarget::Any => -1,
+            WaitTarget::Pid(pid) => i32::from(pid),
+        }
+    }
+
+    /// Decodes a wire selector. A positive value selects that specific child; any non-positive
+    /// value (`-1`, `0`, or `< -1`) selects any child of the caller. The POSIX process-group
+    /// selectors (`0` and `< -1`) are folded into [`WaitTarget::Any`] because Nanvix has no process
+    /// groups yet.
+    pub fn from_raw(raw: i32) -> Self {
+        if raw > 0 {
+            WaitTarget::Pid(ProcessIdentifier::from(raw))
+        } else {
+            WaitTarget::Any
+        }
+    }
+}
+
+impl WaitMessage {
+    /// Size of padding.
+    pub const PADDING_SIZE: usize =
+        ProcessManagementMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<i32>();
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new wait message.
+    ///
+    /// # Parameters
+    ///
+    /// - `target`: Selects which child to wait for.
+    /// - `options`: Wait options.
+    ///
+    pub fn new(target: WaitTarget, options: i32) -> Self {
+        Self {
+            selector: target.into_raw(),
+            options,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Decodes the strongly-typed child selector carried by this message.
+    ///
+    /// # Returns
+    ///
+    /// The wait target that this message selects.
+    ///
+    pub fn target(&self) -> WaitTarget {
+        // Copy the field out of the packed struct before decoding to avoid an unaligned reference.
+        let selector: i32 = self.selector;
+        WaitTarget::from_raw(selector)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a byte array into a wait message.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Byte array.
+    ///
+    /// # Returns
+    ///
+    /// A wait message.
+    ///
+    pub fn from_bytes(bytes: [u8; ProcessManagementMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a wait message into a byte array.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding byte array.
+    ///
+    pub fn into_bytes(self) -> [u8; ProcessManagementMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl WaitResponseMessage {
+    /// Size of padding.
+    pub const PADDING_SIZE: usize = ProcessManagementMessage::PAYLOAD_SIZE
+        - mem::size_of::<ProcessIdentifier>()
+        - mem::size_of::<i32>()
+        - mem::size_of::<i32>();
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new wait response message.
+    ///
+    /// # Parameters
+    ///
+    /// - `child`: Process identifier of the reaped child.
+    /// - `status`: Termination status of the reaped child.
+    /// - `error`: Error code of the wait operation.
+    ///
+    pub fn new(child: ProcessIdentifier, status: i32, error: i32) -> Self {
+        Self {
+            child,
+            status,
+            error,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a byte array into a wait response message.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Byte array.
+    ///
+    /// # Returns
+    ///
+    /// A wait response message.
+    ///
+    pub fn from_bytes(bytes: [u8; ProcessManagementMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a wait response message into a byte array.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding byte array.
+    ///
+    pub fn into_bytes(self) -> [u8; ProcessManagementMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Builds a wait request message.
+///
+/// # Parameters
+///
+/// - `caller`: Process identifier of the calling process (and message sender).
+/// - `target`: Selects which child to wait for.
+/// - `options`: Wait options.
+///
+/// # Returns
+///
+/// Upon successful completion, a wait request message is returned. Otherwise, an error is returned
+/// instead.
+///
+pub fn wait_request(
+    caller: ProcessIdentifier,
+    target: WaitTarget,
+    options: i32,
+) -> Result<Message, Error> {
+    // Reject invalid `Pid` selectors: on the wire, any non-positive value is treated as "any child".
+    if let WaitTarget::Pid(pid) = &target {
+        if i32::from(*pid) <= 0 {
+            return Err(Error::new(
+                ::sys::error::ErrorCode::InvalidArgument,
+                "invalid wait target pid",
+            ));
+        }
+    }
+
+    // Construct a wait message.
+    let wait_message: WaitMessage = WaitMessage::new(target, options);
+
+    // Construct a process management message.
+    let pm_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::Wait,
+        wait_message.into_bytes(),
+    );
+
+    // Construct a system message.
+    let system_message: SystemMessage =
+        SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
+
+    // Construct an IPC message.
+    let ipc_message: Message = Message::new(
+        MessageSender::from(caller),
+        MessageReceiver::from(ProcessIdentifier::PROCD),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    );
+
+    Ok(ipc_message)
+}
+
+///
+/// # Description
+///
+/// Builds a wait response message.
+///
+/// # Parameters
+///
+/// - `destination`: Destination process.
+/// - `child`: Process identifier of the reaped child.
+/// - `status`: Termination status of the reaped child.
+/// - `error`: Error code of the wait operation.
+///
+/// # Returns
+///
+/// Upon successful completion, a wait response message is returned. Otherwise, an error is returned
+/// instead.
+///
+pub fn wait_response(
+    destination: ProcessIdentifier,
+    child: ProcessIdentifier,
+    status: i32,
+    error: i32,
+) -> Result<Message, Error> {
+    // Construct a wait response message.
+    let wait_response_message: WaitResponseMessage = WaitResponseMessage::new(child, status, error);
+
+    // Construct a process management message.
+    let pm_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::WaitResponse,
+        wait_response_message.into_bytes(),
+    );
+
+    // Construct a system message.
+    let system_message: SystemMessage =
+        SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
+
+    // Construct an IPC message.
+    let ipc_message: Message = Message::new(
+        MessageSender::from(ProcessIdentifier::PROCD),
+        MessageReceiver::from(destination),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    );
+
+    Ok(ipc_message)
+}

--- a/src/libs/proc/src/syscall/mod.rs
+++ b/src/libs/proc/src/syscall/mod.rs
@@ -11,6 +11,7 @@ mod getgid;
 mod getuid;
 mod lookup;
 mod signup;
+mod wait;
 
 //==================================================================================================
 // Exports
@@ -22,3 +23,7 @@ pub use getgid::getgid;
 pub use getuid::getuid;
 pub use lookup::lookup;
 pub use signup::signup;
+pub use wait::{
+    wait,
+    WaitOutcome,
+};

--- a/src/libs/proc/src/syscall/wait.rs
+++ b/src/libs/proc/src/syscall/wait.rs
@@ -1,0 +1,129 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::message::{
+    self,
+    ProcessManagementMessage,
+    ProcessManagementMessageHeader,
+    WaitResponseMessage,
+    WaitTarget,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        Message,
+        MessageType,
+        SystemMessage,
+        SystemMessageHeader,
+    },
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Outcome of a wait operation.
+///
+pub enum WaitOutcome {
+    /// A child process was reaped.
+    Reaped {
+        /// Process identifier of the reaped child.
+        child: ProcessIdentifier,
+        /// Termination status of the reaped child.
+        status: i32,
+    },
+    /// No child process was ready to be reaped. This is only returned when `WNOHANG` is set.
+    NoneReady,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Waits for the termination of a child process (`waitpid()`).
+///
+/// # Parameters
+///
+/// - `target`: Selects which child to wait for. [`WaitTarget::Pid`] waits for that specific child;
+///   [`WaitTarget::Any`] waits for any child of the caller.
+/// - `options`: Wait options.
+///
+/// # Returns
+///
+/// Upon successful completion, the outcome of the wait operation is returned. Upon failure, an
+/// error is returned instead.
+///
+pub fn wait(target: WaitTarget, options: i32) -> Result<WaitOutcome, Error> {
+    // Retrieve process identifier of the calling process.
+    let caller: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
+
+    // Build wait message and send it.
+    let message: Message = message::wait_request(caller, target, options)?;
+    ::sys::kcall::ipc::__kcall_send(&message)?;
+
+    // Wait response from the process manager daemon.
+    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+
+    // Parse response.
+    match message.message_type {
+        MessageType::Ipc => {
+            let message: SystemMessage = SystemMessage::from_bytes(message.payload)?;
+
+            // Parse message.
+            match message.header {
+                // Parse process management message.
+                SystemMessageHeader::ProcessManagement => {
+                    let message: ProcessManagementMessage =
+                        ProcessManagementMessage::from_bytes(message.payload)?;
+
+                    // Parse operation.
+                    match message.header {
+                        ProcessManagementMessageHeader::WaitResponse => {
+                            let message: WaitResponseMessage =
+                                WaitResponseMessage::from_bytes(message.payload);
+
+                            // Check for errors.
+                            if message.error != 0 {
+                                return Err(Error::new(
+                                    ErrorCode::try_from(message.error)?,
+                                    "failed to wait for child process",
+                                ));
+                            }
+
+                            // A child process identifier of zero signals that no child was ready.
+                            let child: ProcessIdentifier = message.child;
+                            if child == ProcessIdentifier::from(0) {
+                                Ok(WaitOutcome::NoneReady)
+                            } else {
+                                Ok(WaitOutcome::Reaped {
+                                    child,
+                                    status: message.status,
+                                })
+                            }
+                        },
+                        _ => Err(Error::new(
+                            ErrorCode::InvalidMessage,
+                            "unexpected process management message",
+                        )),
+                    }
+                },
+                _ => Err(Error::new(ErrorCode::InvalidMessage, "invalid system message type")),
+            }
+        },
+        _ => Err(Error::new(ErrorCode::InvalidMessage, "invalid message type")),
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `Wait` operation in the process manager daemon (`procd`), letting a
parent wait for and reap a terminated child (`waitpid()`). This PR contains the
`src/libs/proc` slice of the feature: the wire protocol, the client-side syscall,
and zombie/reaping bookkeeping in the daemon.

> [!NOTE]
> Draft. This is the `proc`-library foundation only. The `sysapi`/`syscall`
> bindings (`waitpid`), the `waitpid-rust` integration test, and the build wiring
> land in follow-up commits/PRs.

## Changes

**Wire protocol**
- New `WaitMessage` (child pid + options) and `WaitResponseMessage` (reaped child
  pid, status, error), both `#[repr(C, packed)]` and guarded by static size
  assertions, with `wait_request()`/`wait_response()` IPC builders.
- New `Wait` (6) and `WaitResponse` (7) process-management message headers;
  discriminants 8-9 reserved to keep the fork-related block contiguous.

**Client syscall**
- New `proc::wait()` that sends a wait request to `PROCD` and blocks on the reply.
  The child to wait for is selected via a dedicated `WaitTarget` enum (`Any` to wait
  for any child of the caller, or `Pid` for a specific child) rather than a raw
  `ProcessIdentifier`, avoiding construction of invalid PIDs and conflation of the
  `0` selector with the kernel PID constant. Results are reported via `WaitOutcome`:
  `Reaped { child, status }` or `NoneReady` (a `WNOHANG` poll with no ready child;
  encoded as a child pid of zero).

**Daemon bookkeeping**
- `ProcessRecord` gains a `zombie: Option` field marking a terminated-but-
  unreaped process and its exit status.
- New `WaitSelector` (Any / Pid) and a `blocked` list of parked waiters awaiting a
  deferred reply.
- `handle_wait()`: resolve the selector (positive pid selects that child; any
  non-positive value selects any child, as process groups are not yet supported),
  report `ECHILD` when there is no eligible child, reap a ready zombie immediately
  (lowest pid for determinism), return `NoneReady` for a `WNOHANG` poll, or block
  and defer otherwise.
- On termination, retain the process as a zombie when a live parent can still reap
  it (waking any matching blocked waiter), or auto-reap when no live process ever
  could (parent unknown, the kernel, gone, or itself a zombie) to avoid leaking an
  unreapable zombie.
- `reap_zombie_children()`: auto-reap a terminating process's own zombie children
  (only it could have reaped them; init never calls `waitpid()`), preventing them
  from lingering until shutdown.
- `handle_lookup()` skips zombies so a terminated process awaiting reap (which still
  carries its parent's inherited name) cannot alias a live process.
- Drop a parent's blocked-waiter entry on its termination; clear all blocked waiters
  on shutdown.

## Limitations

Accepted deviations from full POSIX semantics for this initial implementation:
- Process groups are not supported, so the `pid == 0` and `pid < -1` selectors are
  treated as "any child of the caller".
- Job control is not supported (`WUNTRACED`/`WCONTINUED` accepted but inert).
- Signals are not supported, so every reaped child appears as a normal exit and a
  blocking wait cannot be interrupted (`EINTR` is never returned).

## Testing

- Validated with rust-analyzer (no errors). Full `lint-check` deferred because the
  working tree carries the unstaged remainder of the feature (`--locked` would fail
  for unrelated reasons).