### PR TITLE
[kernel] B: Saturate diagnostic address math in Inner::alloc_range

### DIFF
--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -371,7 +371,10 @@ impl Inner {
         // This loop runs only at boot when booking memory regions, so the overhead is negligible.
         for index in start_frame_number..=end_frame_number {
             if index >= self.bitmap.number_of_bits() {
-                let uncovered_addr: usize = index * mem::FRAME_SIZE;
+                // `index` is out of range here, so `index * FRAME_SIZE` can overflow `usize`
+                // (e.g. on 32-bit targets), panicking in debug builds on the very error path
+                // meant to report the problem. Saturate: the value only feeds a diagnostic.
+                let uncovered_addr: usize = index.saturating_mul(mem::FRAME_SIZE);
                 let reason: &str = "frame index not covered by the bitmap";
                 error!("{} (frame={:#010x}, region={:?})", reason, uncovered_addr, region);
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -379,7 +382,7 @@ impl Inner {
             match self.bitmap.test(index) {
                 Ok(false) => {},
                 Ok(true) => {
-                    let conflicting_addr: usize = index * mem::FRAME_SIZE;
+                    let conflicting_addr: usize = index.saturating_mul(mem::FRAME_SIZE);
                     let region_start: usize = region.start().into_raw_value();
                     let region_end: usize = region_start.saturating_add(region.size());
                     let reason: &str = "frame is already allocated";


### PR DESCRIPTION
## Root cause

The coverage loop in `Inner::alloc_range` computed the offending physical address for its two error diagnostics with `index * mem::FRAME_SIZE`. In the "uncovered" branch the loop index is `>= number_of_bits()` and is not bounded by the addressable range, so the multiplication can exceed `usize`.

## Consequence

On 32-bit targets (TARGET=x86, the default/CI target) the multiply overflows `usize` and panics in debug builds (overflow_checks = true) — on the very error path meant to report the memory-layout problem, turning a recoverable diagnostic into a kernel panic / DoS.

## How it was identified

Verus verification of the loop's exec arithmetic could not prove `index * FRAME_SIZE` total for `index >= num_bits`, surfacing the unbounded multiplication on the uncovered branch.

## Fix

Use `index.saturating_mul(mem::FRAME_SIZE)` for both diagnostic addresses, matching the already-saturating `region_end`. The value only feeds a log message, so clamping at `usize::MAX` is a benign, informative result. No change to allocation logic or to the success path.