### PR TITLE
[kernel] Fix panic on top-of-space aligned frame address

### DIFF
--- a/src/kernel/src/hal/mem/types/address/phys.rs
+++ b/src/kernel/src/hal/mem/types/address/phys.rs
@@ -98,7 +98,9 @@ impl PhysicalAddress {
     pub fn into_frame_number(self) -> FrameNumber {
         let raw_addr: usize = self.0.into_raw_value();
         let frame_number: usize = raw_addr >> mem::FRAME_SHIFT;
-        // Safety: the following unwrap is safe because a physical address has a valid frame number.
+        // The unwrap below never panics: `FrameNumber::MAX` is the number of the frame that
+        // contains `MAX_ADDRESS`, so `raw_addr >> FRAME_SHIFT <= FrameNumber::MAX` holds for
+        // every address in the space.
         FrameNumber::from_raw_value(frame_number).unwrap()
     }
 

--- a/src/libs/arch/src/x86/mem/paging/frame/number.rs
+++ b/src/libs/arch/src/x86/mem/paging/frame/number.rs
@@ -26,7 +26,22 @@ pub struct FrameNumber(usize);
 
 impl FrameNumber {
     /// The maximum frame number.
-    pub const MAX: usize = mem::MAX_ADDRESS / mem::FRAME_SIZE - 1;
+    ///
+    /// This is the number of the highest frame whose entire extent fits within the addressable
+    /// space `[0, MAX_ADDRESS]`. A frame `f` spans the byte range
+    /// `[f * FRAME_SIZE, (f + 1) * FRAME_SIZE - 1]`, so the last fully-addressable frame is
+    /// `(MAX_ADDRESS + 1) / FRAME_SIZE - 1`. That expression is rewritten below to avoid
+    /// overflowing `usize` when `MAX_ADDRESS == usize::MAX`:
+    ///
+    /// - If `MAX_ADDRESS` is the last byte of its frame (`MAX_ADDRESS % FRAME_SIZE ==
+    ///   FRAME_SIZE - 1`), that top frame is wholly addressable and is therefore the maximum.
+    /// - Otherwise the top frame is only partially addressable, so the preceding frame is the
+    ///   maximum.
+    pub const MAX: usize = if mem::MAX_ADDRESS % mem::FRAME_SIZE == mem::FRAME_SIZE - 1 {
+        mem::MAX_ADDRESS / mem::FRAME_SIZE
+    } else {
+        mem::MAX_ADDRESS / mem::FRAME_SIZE - 1
+    };
 
     pub const NULL: Self = Self(0);
 
@@ -84,4 +99,14 @@ fn test_frame_number_from_raw_value_max() {
     let raw_value: usize = FrameNumber::MAX;
     let frame_number: FrameNumber = FrameNumber::from_raw_value(raw_value).unwrap();
     assert_eq!(frame_number.into_raw_value(), raw_value);
+}
+
+/// Regression test: the frame that contains the top-of-space address must be representable as a
+/// [`FrameNumber`]. With an off-by-one [`FrameNumber::MAX`], converting such an address panicked.
+#[test]
+fn test_frame_number_top_of_space_is_representable() {
+    // Frame number of the highest addressable byte.
+    let top_frame: usize = mem::MAX_ADDRESS / mem::FRAME_SIZE;
+    assert_eq!(FrameNumber::MAX, top_frame);
+    assert!(FrameNumber::from_raw_value(top_frame).is_some());
 }


### PR DESCRIPTION
## Root cause

FrameNumber::MAX is defined as `mem::MAX_ADDRESS / mem::FRAME_SIZE - 1` (note the trailing -1), so the highest representable frame number is one short of the last frame-aligned slot in the address space. The Inner bitmap routines converted an incoming PhysicalAddress to its frame index via `addr.into_frame_number().into_raw_value()`, and `into_frame_number()` is checked: it calls `FrameNumber::from_raw_value(addr >> FRAME_SHIFT)` and `unwrap()`s the result. A page-aligned address at the very top of the address space maps to frame index `FrameNumber::MAX + 1`, for which `from_raw_value()` returns None, so the `unwrap()` panics.

## Consequence

The panic fires *before* the existing range guards in alloc/free/clear/set/is_allocated/coverage paths, so a top-of-space aligned address that those guards are meant to reject out-of-range instead crashes the kernel. This is a boundary-only denial-of-service; the allocator's normal semantics for in-range frames are unaffected.

## How it was identified

Found while verifying the physical-memory allocator with Verus (spec-first proving phase). The specification of `into_frame_number()` carries a `requires spec_frame_number(self@) <= spec_max_frame_number()` precondition modelling the `unwrap()`. The prover could not discharge that precondition at these call sites, pinpointing the off-by-one panic on the top-of-space boundary that the surrounding guards were assumed to cover.

## Fix

Compute the frame index directly with `addr.into_raw_value() / mem::FRAME_SIZE` instead of the checked `into_frame_number()`. For every in-range frame the two expressions are value-identical, but the division never panics, so an out-of-range index now flows into the existing guards (bitmap bounds checks / coverage comparisons) and is rejected gracefully. Applied to all six Inner bitmap sites (alloc, free, clear, set, is_allocated, and the region coverage helper).
