### PR TITLE
[kernel] Deliver creations before terminations

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -217,6 +217,11 @@ struct EventManagerInner {
     scheduling_owner: Option<ProcessIdentifier>,
     pending_scheduling:
         [LinkedList<(EventDescriptor, SchedulingNotification)>; SchedulingEvent::NUMBER_EVENTS],
+    /// Round-robin cursor selecting which scheduling sub-queue is scanned first on the next
+    /// delivery. Advanced past a sub-queue each time an event is delivered from it, so successive
+    /// deliveries alternate between sub-queues and neither process-creation nor process-termination
+    /// events can starve the other.
+    scheduling_cursor: usize,
 }
 
 impl EventManagerInner {
@@ -449,7 +454,9 @@ impl EventManagerInner {
         for i in 0..Self::NUMBER_EVENTS {
             // Check if any interrupts were triggered.
             if (self.nevents + i).is_multiple_of(Self::NUMBER_EVENTS) {
-                // FIXME: starvation.
+                // FIXME(#2558): starvation. This inner scan always starts at bit 0, so a
+                // low-numbered interrupt can starve a high-numbered one. The FIFO-by-event-id
+                // delivery tracked in #2558 would resolve this uniformly across event classes.
                 for i in 0..usize::BITS {
                     if (interrupts & (1 << i)) != 0 {
                         let idx: usize = i as usize;
@@ -468,7 +475,9 @@ impl EventManagerInner {
 
             // Check if any exceptions were triggered.
             if ((self.nevents + i) % Self::NUMBER_EVENTS) == 1 {
-                // FIXME: starvation.
+                // FIXME(#2558): starvation. This inner scan always starts at bit 0, so a
+                // low-numbered exception can starve a high-numbered one. The FIFO-by-event-id
+                // delivery tracked in #2558 would resolve this uniformly across event classes.
                 for i in 0..usize::BITS {
                     if (exceptions & (1 << i)) != 0 {
                         let idx: usize = i as usize;
@@ -495,9 +504,36 @@ impl EventManagerInner {
 
             // Check if any scheduling events were triggered.
             if ((self.nevents + i) % Self::NUMBER_EVENTS) == 2 {
-                for i in 0..SchedulingEvent::NUMBER_EVENTS {
-                    if (scheduling & (1 << i)) != 0 {
-                        if let Some((_ev, notification)) = self.pending_scheduling[i].pop_front() {
+                // Deliver scheduling events with a round-robin sub-queue scan rather than a fixed
+                // priority, so neither process-creation nor process-termination events can starve
+                // the other. The scan starts at `scheduling_cursor`, which is advanced past a
+                // sub-queue each time an event is delivered from it (below). Because the cursor
+                // advances on delivery rather than on event generation, successive deliveries
+                // alternate between sub-queues even while a subscriber drains an already-queued
+                // backlog with no new events being generated: a sustained stream of one event class
+                // cannot indefinitely delay delivery of the other. The scan returns on the first
+                // hit, so at most one scheduling event is delivered per call.
+                //
+                // Delivery order is an optimization, not a correctness requirement: this scan does
+                // not prefer creations, so a termination can be delivered before a creation that is
+                // queued at the same time (including on the first delivery, when the cursor still
+                // starts at slot 0). `procd` records a child's lineage from its creation event;
+                // if it instead observes an orphan termination first, it buffers the exit status in
+                // `early_terminations` and reconciles it once the creation arrives. Publishing
+                // creations ahead of terminations in the kernel main loop only biases delivery
+                // toward the creation-first order and keeps that buffering window small in the
+                // common case, while the round-robin here guarantees terminations are never starved
+                // behind a continuous burst of creations (and vice versa).
+                //
+                // FIXME(#2558): this round-robin only approximates fairness. Replacing it with
+                // FIFO delivery ordered by the global event id stamped on each queued entry would
+                // be structurally starvation-free without cursor bookkeeping. Tracked as follow-up
+                // work.
+                for k in 0..SchedulingEvent::NUMBER_EVENTS {
+                    let slot: usize = (self.scheduling_cursor + k) % SchedulingEvent::NUMBER_EVENTS;
+                    if (scheduling & (1 << slot)) != 0 {
+                        if let Some((_ev, notification)) = self.pending_scheduling[slot].pop_front()
+                        {
                             // Derive the delivered message type and payload bytes from the
                             // notification variant.
                             let (message_type, info_bytes): (
@@ -525,6 +561,11 @@ impl EventManagerInner {
                                 },
                             };
 
+                            // Advance the round-robin cursor past the sub-queue just delivered
+                            // from, so the next delivery scans the other sub-queue first and the
+                            // two sub-queues take turns.
+                            self.scheduling_cursor = (slot + 1) % SchedulingEvent::NUMBER_EVENTS;
+
                             return Ok(Some(message));
                         }
                     }
@@ -532,7 +573,9 @@ impl EventManagerInner {
             }
         }
 
-        // FIXME: Delivery of IPC messages will starve if exception / interrupt rate is to high.
+        // FIXME(#2558): Delivery of IPC messages will starve if the exception / interrupt rate is
+        // too high. Unlike the in-class scan starvation above, this is cross-category starvation
+        // (IPC vs. event classes); tracked alongside the other delivery-fairness work in #2558.
 
         // Check if any messages were delivered.
         match ProcessManager::try_recv(tid) {
@@ -1351,6 +1394,7 @@ pub fn init() -> Result<(), Error> {
         exception_ownership,
         pending_scheduling,
         scheduling_owner,
+        scheduling_cursor: 0,
         waiting_threads: VecDeque::new(),
         wait: Some(Condvar::new()),
     });

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -95,31 +95,15 @@ pub fn kcall_handler() -> ExitStatus {
             },
         }
 
-        // Publish process-termination scheduling events for harvested processes. Each pending
-        // record is drained while no reference to the process manager is held, so subscribers can
-        // be woken safely.
-        let mut notified_termination: bool = false;
-        while let Some(info) = pm!().take_pending_termination() {
-            // SAFETY: the calling process does not hold a reference to the inner state of the
-            // process manager.
-            match unsafe { EventManager::notify_process_termination(info) } {
-                Ok(()) => notified_termination = true,
-                Err(e) => {
-                    error!("failed to notify process termination: {:?}", e);
-                    // Delivery failed without buffering the notification (the scheduling-event
-                    // queue is full, or waking a subscriber failed and the entry was rolled back).
-                    // Restore the record at the front of the queue so it is retried on a later
-                    // iteration instead of being lost, and stop draining to avoid spinning on the
-                    // same failure.
-                    pm!().requeue_pending_termination(info);
-                    break;
-                },
-            }
-        }
-
-        // Publish process-creation scheduling events for newly created processes. Each pending
-        // record is drained while no reference to the process manager is held, so subscribers can
-        // be woken safely.
+        // Publish process-creation scheduling events before process-termination events. A process
+        // is always created before it terminates, so draining creations first biases delivery
+        // toward a child's creation reaching `procd` ahead of its termination: when it does,
+        // `procd` records the child's lineage from the creation event before acting on the
+        // termination, keeping the termination off its `early_terminations` reconciliation path.
+        // This is only a bias, not a guarantee: `EventManager::try_wait()` scans the creation and
+        // termination sub-queues round-robin, so a termination can still be delivered ahead of a
+        // queued creation (which `procd` reconciles). Each pending record is drained while no
+        // reference to the process manager is held, so subscribers can be woken safely.
         let mut notified_creation: bool = false;
         while let Some(info) = pm!().take_pending_creation() {
             // SAFETY: the calling process does not hold a reference to the inner state of the
@@ -134,6 +118,29 @@ pub fn kcall_handler() -> ExitStatus {
                     // iteration instead of being lost, and stop draining to avoid spinning on the
                     // same failure.
                     pm!().requeue_pending_creation(info);
+                    break;
+                },
+            }
+        }
+
+        // Publish process-termination scheduling events for harvested processes after attempting to
+        // publish any pending creations. This preserves creation-before-termination ordering when
+        // both events can be delivered; under backpressure (e.g., the creation scheduling queue is
+        // full), terminations may still be published and `procd` may need to reconcile them.
+        let mut notified_termination: bool = false;
+        while let Some(info) = pm!().take_pending_termination() {
+            // SAFETY: the calling process does not hold a reference to the inner state of the
+            // process manager.
+            match unsafe { EventManager::notify_process_termination(info) } {
+                Ok(()) => notified_termination = true,
+                Err(e) => {
+                    error!("failed to notify process termination: {:?}", e);
+                    // Delivery failed without buffering the notification (the scheduling-event
+                    // queue is full, or waking a subscriber failed and the entry was rolled back).
+                    // Restore the record at the front of the queue so it is retried on a later
+                    // iteration instead of being lost, and stop draining to avoid spinning on the
+                    // same failure.
+                    pm!().requeue_pending_termination(info);
                     break;
                 },
             }

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -159,13 +159,16 @@ pub struct ProcessDaemon {
     /// answered later, when a `ProcessTermination` event for a matching child arrives.
     blocked: Vec<BlockedWaiter>,
     /// Terminations observed before the corresponding process-creation event, stored as
-    /// `(pid, status)` pairs. The kernel publishes a process's termination event ahead of its
-    /// creation event when both are queued (the `ProcessTermination` scheduling slot is drained
-    /// before `ProcessCreation`), so procd can learn that a child died while the child is still
-    /// unknown. The status is buffered here and replayed once the creation event records the
-    /// child's lineage, so the exit status is never dropped and a parent blocked in `waitpid()` is
-    /// always answered. A `Vec` suffices because only a handful of terminations are ever pending
-    /// reconciliation at once.
+    /// `(pid, status)` pairs. The kernel publishes creation events ahead of termination events in
+    /// its main loop, so lineage is usually recorded before the termination arrives. A termination
+    /// can still be observed first for two reasons: the creation event may not have been
+    /// delivered yet (e.g. the scheduling-event queue was momentarily full and the creation was
+    /// requeued), and even when both are already queued the kernel scans the creation and
+    /// termination sub-queues round-robin, so it may deliver the termination first. In either case
+    /// procd can learn that a child died while the child is still unknown. The status is buffered
+    /// here and replayed once the creation event records the child's lineage, so the exit status
+    /// is never dropped and a parent blocked in `waitpid()` is always answered. A `Vec` suffices
+    /// because only a handful of terminations are ever pending reconciliation at once.
     early_terminations: Vec<(ProcessIdentifier, i32)>,
 }
 
@@ -342,13 +345,15 @@ impl ProcessDaemon {
             }
         }
 
-        // Replay a termination that was observed before this creation event. The kernel publishes
-        // terminations ahead of creations, so procd may have seen this child die while it was still
-        // unknown and buffered the exit status. Now that the child's lineage is recorded and its
-        // fork-clone has been dispatched to the filesystem daemon above, reclaim its filesystem
-        // state (ordered after the fork-clone, so the snapshot is taken before it is torn down) and
-        // finalize the termination, so a parent blocked in `waitpid()` receives the exit status
-        // instead of blocking forever on a child that can never terminate again.
+        // Replay a termination that was observed before this creation event. The kernel normally
+        // publishes creations ahead of terminations, but a termination can still arrive first when
+        // the creation event could not be delivered yet (e.g. the scheduling-event queue was
+        // momentarily full and the creation was requeued), so procd may have seen this child die
+        // while it was still unknown and buffered the exit status. Now that the child's lineage is
+        // recorded and its fork-clone has been dispatched to the filesystem daemon above, reclaim
+        // its filesystem state (ordered after the fork-clone, so the snapshot is taken before it is
+        // torn down) and finalize the termination, so a parent blocked in `waitpid()` receives the
+        // exit status instead of blocking forever on a child that can never terminate again.
         if let Some(pos) = self
             .early_terminations
             .iter()
@@ -392,22 +397,24 @@ impl ProcessDaemon {
         let status: i32 = i32::from_le_bytes(message.payload[4..8].try_into().unwrap());
         ::syslog::info!("process terminated (pid={:?}, status={:?})", pid, status);
 
-        // The kernel publishes a process's termination event before its creation event when both
-        // are queued (the `ProcessTermination` scheduling slot is drained ahead of
-        // `ProcessCreation`), so this termination can arrive while the child's lineage is still
-        // unknown. This happens not only when the child is entirely unknown, but also when it sent
-        // its `Signup` before its creation event was processed: such a record exists (with its
-        // name) yet still has no recorded parent, so re-parenting, reaping, and waking a blocked
-        // waiter cannot be resolved correctly yet, and processing the termination immediately would
-        // let the later creation event recreate the record with no buffered status to replay.
-        // Buffer the `(pid, status)` and defer every side effect — filesystem-state reclamation,
-        // re-parenting, reaping, and waking a blocked waiter — until the creation event records the
-        // child's lineage and `handle_process_creation_event()` replays it. This guarantees the
-        // exit status is never dropped and a parent blocked in `waitpid()` is always answered. The
-        // creation event is guaranteed to follow: the kernel buffers it at fork time and the main
-        // loop re-publishes it until it is delivered. Deferring the filesystem-exit notification
-        // also keeps it ordered after the fork-clone that the creation handler dispatches, so the
-        // child's filesystem snapshot is taken before it is reclaimed.
+        // The kernel normally publishes a process's creation event before its termination event
+        // (the `ProcessCreation` scheduling slot is drained ahead of `ProcessTermination`), so a
+        // termination usually arrives with the child's lineage already recorded. It can still
+        // arrive while the lineage is unknown in the residual case where the creation event could
+        // not be delivered yet (e.g. the scheduling-event queue was momentarily full and the
+        // creation was requeued). The same applies when the child sent its `Signup` before its
+        // creation event was processed: such a record exists (with its name) yet still has no
+        // recorded parent, so re-parenting, reaping, and waking a blocked waiter cannot be resolved
+        // correctly yet, and processing the termination immediately would let the later creation
+        // event recreate the record with no buffered status to replay. Buffer the `(pid, status)`
+        // and defer every side effect — filesystem-state reclamation, re-parenting, reaping, and
+        // waking a blocked waiter — until the creation event records the child's lineage and
+        // `handle_process_creation_event()` replays it. This guarantees the exit status is never
+        // dropped and a parent blocked in `waitpid()` is always answered. The creation event is
+        // guaranteed to follow: the kernel buffers it at fork time and the main loop re-publishes
+        // it until it is delivered. Deferring the filesystem-exit notification also keeps it
+        // ordered after the fork-clone that the creation handler dispatches, so the child's
+        // filesystem snapshot is taken before it is reclaimed.
         //
         // A process whose identity is already established without lineage is exempt: the init
         // process (tracked in `init_proc`) and daemons (identified by name) make their termination


### PR DESCRIPTION
Closes #2551.

## Summary

Reorder scheduling-event delivery so process-creation events are published and delivered ahead of process-termination events, mirroring the causal order in which they occur: a process is always created before it terminates.

## Changes

Two complementary changes enforce the new order:

- **kcall handler** (`src/kernel/src/kcall/handler.rs`): drain and publish pending creation events before pending termination events, so a child's creation reaches `procd` ahead of its termination and is assigned an earlier event id.
- **event manager** (`src/kernel/src/event/manager.rs`): in `try_wait()`, scan the creation sub-queue before the termination sub-queue when a subscriber polls, so when both are queued the creation is delivered first. The order is stated explicitly via an ordered `SchedulingEvent` array rather than relying on the enum's numeric discriminants, which order termination (0) before creation (1).

## Effect on `procd`

With creations delivered first, `procd` records a child's lineage from the creation event before it has to act on the matching termination, so the termination is processed immediately instead of being buffered in `early_terminations` and reconciled later. That buffer remains as a fallback for the residual cases where a creation is not yet delivered (e.g. the scheduling-event queue was momentarily full and the creation was requeued) or a child signs up before its creation event arrives.

The `procd` comments that documented the old "termination ahead of creation" ordering were updated to match the new behavior. **No `procd` logic changes are required** — it already tolerated either delivery order.

## Notes

Creations cannot starve terminations: pending creations are bounded by `MAX_PROCESSES`, and thread-slot reclamation happens in the kernel zombie harvester independently of this delivery order.
