### PR TITLE
[syscall] Skip zero-size PT_LOAD segments on load

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -190,6 +190,19 @@ impl DynamicLibrary {
                 for phdr in elf.program_headers.iter() {
                     // Check if program header is loadable.
                     if phdr.p_type == goblin::elf::program_header::PT_LOAD {
+                        // Skip zero-size loadable segments. They contribute nothing to the
+                        // in-memory image, and mapping a zero-capacity region would fail.
+                        // Some linkers (e.g. lld at higher optimization levels) emit an empty
+                        // PT_LOAD as section-alignment padding between the text and data
+                        // segments; a conforming loader ignores such entries.
+                        if phdr.p_memsz == 0 {
+                            ::syslog::debug!(
+                                "load(): skipping zero-size PT_LOAD (vaddr={:#x})",
+                                phdr.p_vaddr
+                            );
+                            continue;
+                        }
+
                         ::syslog::debug!(
                             "load(): loadable program header (vaddr={:#x}, paddr={:#x}, \
                              filesz={}, memsz={})",


### PR DESCRIPTION
## Summary

The dynamic library loader's second pass mapped every `PT_LOAD` program header unconditionally. A segment with `p_memsz == 0` contributes nothing to the in-memory image, and reserving/mapping a zero-capacity region fails, aborting an otherwise valid `dlopen()`.

Some linkers (e.g. `lld` at higher optimization levels) emit an empty `PT_LOAD` as section-alignment padding between the text and data segments. A conforming loader ignores such entries, so this change skips any `PT_LOAD` whose `p_memsz` is zero before mapping it, logging the skip at debug level.

## Changes

- `src/libs/syscall/src/dlfcn/syscall/dynlib.rs`: skip zero-size `PT_LOAD` segments during load.