### PR TITLE
[libc_assert] Add C assert() runtime support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libc_assert"
+version = "0.16.80"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.80"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
         "src/libs/syscomm",
         "src/libs/syslog",
         "src/libs/syslog-macros",
+        "src/libs/libc_assert",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/cache",
@@ -210,6 +211,7 @@ slab = { path = "src/libs/slab", package = "nanvix-slab", default-features = fal
 sorted-vec = { path = "src/libs/sorted-vec", default-features = false }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
+libc_assert = { path = "src/libs/libc_assert", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_assert/Cargo.toml
+++ b/src/libs/libc_assert/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_assert"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_assert/header.toml
+++ b/src/libs/libc_assert/header.toml
@@ -1,0 +1,36 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for assert.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/assert.h.
+
+file = "assert.h"
+brief = "Diagnostics."
+description = """
+Provides the assert() macro for runtime assertions. The underlying
+__assert_func() is implemented by the libc_assert Rust crate and matches
+the signature expected by NewLib's <assert.h>."""
+includes = []
+guard = "_NANVIX_ASSERT_H"
+
+[[sections]]
+title = "Internal Functions (do not call directly)"
+functions = ["__assert_func", "__assert"]
+
+# assert macro lives outside include guard — added as raw trailer.
+[trailer]
+text = """
+/*==================================================================================================
+ * assert Macro
+ *==================================================================================================*/
+
+/* The assert macro must be redefinable, so it lives outside the include guard. */
+#undef assert
+
+#ifdef NDEBUG
+#define assert(expr) ((void)0)
+#else
+#define assert(expr) ((expr) ? (void)0 : __assert_func(__FILE__, __LINE__, __func__, #expr))
+#endif
+"""

--- a/src/libs/libc_assert/src/assert_func.rs
+++ b/src/libs/libc_assert/src/assert_func.rs
@@ -1,0 +1,397 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+#[cfg(not(feature = "std"))]
+use ::sysapi::{
+    ffi::c_void,
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of decimal digits required to represent any [`u32`] value.
+const U32_MAX_DIGITS: usize = 10;
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+#[cfg(not(feature = "std"))]
+extern "C" {
+    fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    fn abort() -> !;
+}
+
+//==================================================================================================
+// Output Sink
+//==================================================================================================
+
+/// A minimal byte sink used to emit assertion diagnostics.
+trait Sink {
+    /// Writes all bytes of `buf` to the sink on a best-effort basis.
+    fn write(&mut self, buf: &[u8]);
+}
+
+/// Sink that writes to the guest C runtime's standard error stream (file descriptor 2).
+#[cfg(not(feature = "std"))]
+struct ErrSink;
+
+#[cfg(not(feature = "std"))]
+impl Sink for ErrSink {
+    fn write(&mut self, buf: &[u8]) {
+        let mut remaining: &[u8] = buf;
+        while !remaining.is_empty() {
+            let count: c_size_t = c_size_t::try_from(remaining.len()).unwrap_or(c_size_t::MAX);
+            // SAFETY: `remaining` points to at least `count` valid bytes and 2 is stderr.
+            let written: c_ssize_t =
+                unsafe { write(2, remaining.as_ptr().cast::<c_void>(), count) };
+            // Stop on error (negative) or a zero-length write to avoid spinning forever.
+            let Ok(advanced) = usize::try_from(written) else {
+                break;
+            };
+            if advanced == 0 {
+                break;
+            }
+            match remaining.get(advanced..) {
+                Some(rest) => remaining = rest,
+                None => break,
+            }
+        }
+    }
+}
+
+/// Sink that writes to the host standard error stream. Used for host-side unit tests.
+#[cfg(feature = "std")]
+struct ErrSink;
+
+#[cfg(feature = "std")]
+impl Sink for ErrSink {
+    fn write(&mut self, buf: &[u8]) {
+        use ::std::io::Write as _;
+        // Best-effort: diagnostics are emitted on a failure path, so I/O errors are ignored.
+        let _ = ::std::io::stderr().write_all(buf);
+    }
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns the sink that assertion diagnostics are written to.
+fn err_sink() -> ErrSink {
+    ErrSink
+}
+
+/// Aborts the current process and never returns.
+#[cfg(not(feature = "std"))]
+fn do_abort() -> ! {
+    // SAFETY: `abort()` is provided by the C runtime, has no preconditions, and never returns.
+    unsafe { abort() }
+}
+
+/// Aborts the current process and never returns.
+#[cfg(feature = "std")]
+fn do_abort() -> ! {
+    ::std::process::abort()
+}
+
+/// Formats `n` as decimal ASCII digits into `buf`, returning the populated trailing slice.
+fn format_uint(mut n: u32, buf: &mut [u8; U32_MAX_DIGITS]) -> &[u8] {
+    let mut i: usize = buf.len();
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    &buf[i..]
+}
+
+/// Writes `n` as decimal digits to `sink`.
+fn write_uint<S: Sink>(sink: &mut S, n: u32) {
+    let mut buf: [u8; U32_MAX_DIGITS] = [0; U32_MAX_DIGITS];
+    sink.write(format_uint(n, &mut buf));
+}
+
+/// Writes `n` as a signed decimal integer to `sink`, preserving the sign of negative values.
+fn write_int<S: Sink>(sink: &mut S, n: c_int) {
+    if n < 0 {
+        sink.write(b"-");
+    }
+    write_uint(sink, n.unsigned_abs());
+}
+
+/// Writes a null-terminated C string to `sink`. Does nothing if `s` is null.
+///
+/// # Safety
+///
+/// `s` must either be null or point to a valid null-terminated C string.
+unsafe fn write_cstr<S: Sink>(sink: &mut S, s: *const c_char) {
+    if s.is_null() {
+        return;
+    }
+    let mut len: usize = 0;
+    while *s.add(len) != 0 {
+        len += 1;
+    }
+    if len > 0 {
+        // SAFETY: `s` points to `len` valid bytes that precede the null terminator.
+        let bytes: &[u8] = ::core::slice::from_raw_parts(s.cast::<u8>(), len);
+        sink.write(bytes);
+    }
+}
+
+/// Emits the diagnostic message for a failed `__assert_func` to `sink`, without aborting.
+///
+/// # Safety
+///
+/// `file`, `function`, and `expression` must each be null or point to a valid null-terminated C
+/// string.
+unsafe fn emit_assert_func<S: Sink>(
+    sink: &mut S,
+    file: *const c_char,
+    line: c_int,
+    function: *const c_char,
+    expression: *const c_char,
+) {
+    // Format: "file:line: function: Assertion `expression' failed.\n"
+    write_cstr(sink, file);
+    sink.write(b":");
+    write_int(sink, line);
+    sink.write(b": ");
+    write_cstr(sink, function);
+    sink.write(b": Assertion `");
+    write_cstr(sink, expression);
+    sink.write(b"' failed.\n");
+}
+
+/// Emits the diagnostic message for a failed `__assert` to `sink`, without aborting.
+///
+/// # Safety
+///
+/// `file` and `expression` must each be null or point to a valid null-terminated C string.
+unsafe fn emit_assert<S: Sink>(
+    sink: &mut S,
+    file: *const c_char,
+    line: c_int,
+    expression: *const c_char,
+) {
+    // Format: "file:line: Assertion `expression' failed.\n"
+    write_cstr(sink, file);
+    sink.write(b":");
+    write_int(sink, line);
+    sink.write(b": Assertion `");
+    write_cstr(sink, expression);
+    sink.write(b"' failed.\n");
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Called when a C `assert()` macro fails. Prints an assertion failure message to stderr and
+/// aborts the process.
+///
+/// # Parameters
+///
+/// - `file`: The source file name where the assertion failed.
+/// - `line`: The line number where the assertion failed.
+/// - `function`: The function name where the assertion failed.
+/// - `expression`: The failed assertion expression as a string.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers that must each be null or reference
+/// a valid null-terminated C string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __assert_func(
+    file: *const c_char,
+    line: c_int,
+    function: *const c_char,
+    expression: *const c_char,
+) -> ! {
+    emit_assert_func(&mut err_sink(), file, line, function, expression);
+    do_abort()
+}
+
+///
+/// # Description
+///
+/// Simplified assertion failure handler without function name. Prints an assertion failure message
+/// to stderr and aborts the process.
+///
+/// # Parameters
+///
+/// - `file`: The source file name where the assertion failed.
+/// - `line`: The line number where the assertion failed.
+/// - `expression`: The failed assertion expression as a string.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers that must each be null or reference
+/// a valid null-terminated C string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __assert(
+    file: *const c_char,
+    line: c_int,
+    expression: *const c_char,
+) -> ! {
+    emit_assert(&mut err_sink(), file, line, expression);
+    do_abort()
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        emit_assert,
+        emit_assert_func,
+        format_uint,
+        write_cstr,
+        write_int,
+        Sink,
+        U32_MAX_DIGITS,
+    };
+
+    /// Test sink that accumulates written bytes in memory for inspection.
+    struct VecSink(::std::vec::Vec<u8>);
+
+    impl Sink for VecSink {
+        fn write(&mut self, buf: &[u8]) {
+            self.0.extend_from_slice(buf);
+        }
+    }
+
+    #[test]
+    fn format_uint_zero() {
+        let mut buf = [0u8; U32_MAX_DIGITS];
+        assert_eq!(format_uint(0, &mut buf), b"0");
+    }
+
+    #[test]
+    fn format_uint_single_digit() {
+        let mut buf = [0u8; U32_MAX_DIGITS];
+        assert_eq!(format_uint(7, &mut buf), b"7");
+    }
+
+    #[test]
+    fn format_uint_multi_digit() {
+        let mut buf = [0u8; U32_MAX_DIGITS];
+        assert_eq!(format_uint(1000, &mut buf), b"1000");
+    }
+
+    #[test]
+    fn format_uint_max() {
+        let mut buf = [0u8; U32_MAX_DIGITS];
+        assert_eq!(format_uint(u32::MAX, &mut buf), b"4294967295");
+    }
+
+    #[test]
+    fn assert_func_message_is_well_formed() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: every pointer references a valid null-terminated C string literal.
+        unsafe {
+            emit_assert_func(
+                &mut sink,
+                c"file.c".as_ptr(),
+                42,
+                c"my_func".as_ptr(),
+                c"x == 1".as_ptr(),
+            );
+        }
+        assert_eq!(sink.0, b"file.c:42: my_func: Assertion `x == 1' failed.\n");
+    }
+
+    #[test]
+    fn assert_message_is_well_formed() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: every pointer references a valid null-terminated C string literal.
+        unsafe {
+            emit_assert(&mut sink, c"main.c".as_ptr(), 7, c"ptr != NULL".as_ptr());
+        }
+        assert_eq!(sink.0, b"main.c:7: Assertion `ptr != NULL' failed.\n");
+    }
+
+    #[test]
+    fn write_cstr_ignores_null() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: passing a null pointer is explicitly supported and writes nothing.
+        unsafe {
+            write_cstr(&mut sink, ::core::ptr::null());
+        }
+        assert!(sink.0.is_empty());
+    }
+
+    #[test]
+    fn assert_func_tolerates_null_function() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: file/expression are valid C strings; a null function name is supported.
+        unsafe {
+            emit_assert_func(&mut sink, c"file.c".as_ptr(), 42, ::core::ptr::null(), c"x".as_ptr());
+        }
+        assert_eq!(sink.0, b"file.c:42: : Assertion `x' failed.\n");
+    }
+
+    #[test]
+    fn write_int_preserves_negative_sign() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        write_int(&mut sink, -42);
+        assert_eq!(sink.0, b"-42");
+    }
+
+    #[test]
+    fn write_int_formats_min_value() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        write_int(&mut sink, ::sysapi::ffi::c_int::MIN);
+        assert_eq!(sink.0, b"-2147483648");
+    }
+
+    #[test]
+    fn assert_func_formats_negative_line() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: every pointer references a valid null-terminated C string literal.
+        unsafe {
+            emit_assert_func(
+                &mut sink,
+                c"file.c".as_ptr(),
+                -1,
+                c"my_func".as_ptr(),
+                c"x == 1".as_ptr(),
+            );
+        }
+        assert_eq!(sink.0, b"file.c:-1: my_func: Assertion `x == 1' failed.\n");
+    }
+
+    #[test]
+    fn assert_formats_negative_line() {
+        let mut sink = VecSink(::std::vec::Vec::new());
+        // SAFETY: every pointer references a valid null-terminated C string literal.
+        unsafe {
+            emit_assert(&mut sink, c"main.c".as_ptr(), -7, c"ptr != NULL".as_ptr());
+        }
+        assert_eq!(sink.0, b"main.c:-7: Assertion `ptr != NULL' failed.\n");
+    }
+}

--- a/src/libs/libc_assert/src/lib.rs
+++ b/src/libs/libc_assert/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod assert_func;
+
+//==================================================================================================
+// Exports
+//==================================================================================================
+
+pub use assert_func::{
+    __assert,
+    __assert_func,
+};


### PR DESCRIPTION
## Summary

Introduces the `libc_assert` guest crate implementing the NewLib-compatible
`__assert_func()` and `__assert()` C-ABI handlers that back the C `assert()`
macro. On a failed assertion they print `file:line: func: Assertion `expr`
failed.` to stderr and abort the process.

## Changes

- New `libc_assert` crate with `__assert_func` / `__assert` handlers.
- Output is abstracted behind a minimal `Sink`:
  - Guest (`no_std`) sink writes to stderr (fd 2) via the `write()` syscall and
    tolerates short/partial writes.
  - Under the `std` feature the sink is backed by `std::io` /
    `std::process::abort`, so the message logic is unit-testable on the host
    (including Windows).
- `#[no_mangle]` gated behind `not(feature = "std")` to avoid clashing with the
  host C library during test builds, matching the `libc_stdlib` convention.
- `header.toml` describing `assert.h` for the header generator, with the
  `assert` macro kept outside the include guard so it stays redefinable.
- Registered as a workspace member/dependency and added to
  `ALL_GUEST_RUST_LIBS` and `ALL_GUEST_RUST_LIBS_TEST_LIST` so it is checked,
  linted, and unit-tested by `run-unit-tests`.
- Unit tests for decimal formatting (0, single/multi-digit, `u32::MAX`), the
  exact message layout for both handlers, and null-pointer tolerance.

## Validation

- Host clippy `--tests --features=std -- -D warnings`: clean.
- Host unit tests: 8 passed.
- Guest `no_std` clippy on the `x86-user` target with `-D warnings`: clean.
- `rustfmt --check`: clean.

## Open items (reason for draft)

- The `gen-headers` tool and the generated `include/assert.h` consumer are not
  yet present in the tree, so `header.toml` is not consumed yet.
- Overriding NewLib's own `__assert_func` / `__assert` still needs link-time
  verification (analogous to the malloc `-DMALLOC_PROVIDED` handling), and the
  crate is not yet a dependency of any linked binary.
