### PR TITLE
[libc_ctype] Add C ctype.h character functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_ctype"
+version = "0.16.81"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.81"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
         "src/libs/syslog",
         "src/libs/syslog-macros",
         "src/libs/libc_assert",
+        "src/libs/libc_ctype",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/cache",
@@ -212,6 +213,7 @@ sorted-vec = { path = "src/libs/sorted-vec", default-features = false }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
 libc_assert = { path = "src/libs/libc_assert", default-features = false }
+libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_ctype/Cargo.toml
+++ b/src/libs/libc_ctype/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_ctype"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_ctype/header.toml
+++ b/src/libs/libc_ctype/header.toml
@@ -1,0 +1,37 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for ctype.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/ctype.h.
+
+file = "ctype.h"
+brief = "Character classification and conversion."
+description = """
+Declares functions for testing and mapping characters. All functions operate
+on values representable as unsigned char or the value EOF. Implemented by
+the libc_ctype Rust crate."""
+includes = []
+guard = "_NANVIX_CTYPE_H"
+
+[[sections]]
+title = "Classification"
+functions = [
+    "isalpha",
+    "isdigit",
+    "isalnum",
+    "isspace",
+    "isblank",
+    "isupper",
+    "islower",
+    "isprint",
+    "isgraph",
+    "ispunct",
+    "iscntrl",
+    "isxdigit",
+    "isascii",
+]
+
+[[sections]]
+title = "Conversion"
+functions = ["toupper", "tolower", "toascii"]

--- a/src/libs/libc_ctype/src/isalnum.rs
+++ b/src/libs/libc_ctype/src/isalnum.rs
@@ -1,0 +1,82 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is alphanumeric.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is alphanumeric ('A'-'Z', 'a'-'z', or '0'-'9'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isalnum(c: c_int) -> c_int {
+    if (0x41..=0x5A).contains(&c) || (0x61..=0x7A).contains(&c) || (0x30..=0x39).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isalnum;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isalnum_uppercase() {
+        for c in b'A'..=b'Z' {
+            assert_ne!(
+                isalnum(c_int::from(c)),
+                0,
+                "isalnum should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_isalnum_lowercase() {
+        for c in b'a'..=b'z' {
+            assert_ne!(isalnum(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isalnum_digits() {
+        for c in b'0'..=b'9' {
+            assert_ne!(isalnum(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isalnum_special() {
+        assert_eq!(isalnum(c_int::from(b' ')), 0);
+        assert_eq!(isalnum(c_int::from(b'!')), 0);
+        assert_eq!(isalnum(c_int::from(b'@')), 0);
+        assert_eq!(isalnum(-1), 0); // EOF
+    }
+}

--- a/src/libs/libc_ctype/src/isalpha.rs
+++ b/src/libs/libc_ctype/src/isalpha.rs
@@ -1,0 +1,81 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is alphabetic.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is alphabetic ('A'-'Z' or 'a'-'z'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isalpha(c: c_int) -> c_int {
+    if (0x41..=0x5A).contains(&c) || (0x61..=0x7A).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isalpha;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isalpha_uppercase() {
+        for c in b'A'..=b'Z' {
+            assert_ne!(
+                isalpha(c_int::from(c)),
+                0,
+                "isalpha should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_isalpha_lowercase() {
+        for c in b'a'..=b'z' {
+            assert_ne!(isalpha(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isalpha_digit() {
+        for c in b'0'..=b'9' {
+            assert_eq!(isalpha(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isalpha_special() {
+        assert_eq!(isalpha(c_int::from(b' ')), 0);
+        assert_eq!(isalpha(c_int::from(b'!')), 0);
+        assert_eq!(isalpha(-1), 0); // EOF
+    }
+}

--- a/src/libs/libc_ctype/src/isascii.rs
+++ b/src/libs/libc_ctype/src/isascii.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a 7-bit ASCII character (POSIX extension).
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is in the range 0x00 through 0x7F, zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isascii(c: c_int) -> c_int {
+    if (0x00..=0x7F).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isascii;
+
+    #[test]
+    fn test_isascii_range() {
+        for c in 0x00..=0x7F {
+            assert_ne!(isascii(c), 0, "isascii should return non-zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_isascii_above_range() {
+        assert_eq!(isascii(0x80), 0);
+        assert_eq!(isascii(0xFF), 0);
+        assert_eq!(isascii(0x100), 0);
+    }
+
+    #[test]
+    fn test_isascii_negative() {
+        assert_eq!(isascii(-1), 0); // EOF
+        assert_eq!(isascii(-128), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isblank.rs
+++ b/src/libs/libc_ctype/src/isblank.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a blank character (space or horizontal tab).
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a blank character (' ' or '\\t'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isblank(c: c_int) -> c_int {
+    if c == 0x20 || c == 0x09 {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isblank;
+
+    #[test]
+    fn test_isblank_space() {
+        assert_ne!(isblank(0x20), 0);
+    }
+
+    #[test]
+    fn test_isblank_tab() {
+        assert_ne!(isblank(0x09), 0);
+    }
+
+    #[test]
+    fn test_isblank_newline() {
+        assert_eq!(isblank(0x0A), 0);
+    }
+
+    #[test]
+    fn test_isblank_other_whitespace() {
+        assert_eq!(isblank(0x0B), 0); // '\v'
+        assert_eq!(isblank(0x0C), 0); // '\f'
+        assert_eq!(isblank(0x0D), 0); // '\r'
+    }
+
+    #[test]
+    fn test_isblank_eof() {
+        assert_eq!(isblank(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/iscntrl.rs
+++ b/src/libs/libc_ctype/src/iscntrl.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a control character.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a control character (0x00-0x1F or 0x7F), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn iscntrl(c: c_int) -> c_int {
+    if (0x00..=0x1F).contains(&c) || c == 0x7F {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::iscntrl;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_iscntrl_control_chars() {
+        for c in 0x00..=0x1F {
+            assert_ne!(iscntrl(c), 0, "iscntrl should return non-zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_iscntrl_del() {
+        assert_ne!(iscntrl(0x7F), 0);
+    }
+
+    #[test]
+    fn test_iscntrl_non_control() {
+        assert_eq!(iscntrl(c_int::from(b' ')), 0);
+        assert_eq!(iscntrl(c_int::from(b'A')), 0);
+        assert_eq!(iscntrl(c_int::from(b'0')), 0);
+        assert_eq!(iscntrl(c_int::from(b'~')), 0);
+    }
+
+    #[test]
+    fn test_iscntrl_eof() {
+        assert_eq!(iscntrl(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isdigit.rs
+++ b/src/libs/libc_ctype/src/isdigit.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a decimal digit.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a digit ('0'-'9'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isdigit(c: c_int) -> c_int {
+    if (0x30..=0x39).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isdigit;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isdigit_digits() {
+        for c in b'0'..=b'9' {
+            assert_ne!(
+                isdigit(c_int::from(c)),
+                0,
+                "isdigit should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_isdigit_letters() {
+        for c in b'A'..=b'Z' {
+            assert_eq!(isdigit(c_int::from(c)), 0);
+        }
+        for c in b'a'..=b'z' {
+            assert_eq!(isdigit(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isdigit_special() {
+        assert_eq!(isdigit(c_int::from(b' ')), 0);
+        assert_eq!(isdigit(c_int::from(b'!')), 0);
+        assert_eq!(isdigit(c_int::from(b'/')), 0);
+        assert_eq!(isdigit(c_int::from(b':')), 0);
+        assert_eq!(isdigit(-1), 0); // EOF
+    }
+}

--- a/src/libs/libc_ctype/src/isgraph.rs
+++ b/src/libs/libc_ctype/src/isgraph.rs
@@ -1,0 +1,77 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a printable character other than space.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a graphic character (0x21 through 0x7E), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isgraph(c: c_int) -> c_int {
+    if (0x21..=0x7E).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isgraph;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isgraph_graphic() {
+        for c in 0x21..=0x7E {
+            assert_ne!(isgraph(c), 0, "isgraph should return non-zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_isgraph_space() {
+        assert_eq!(isgraph(c_int::from(b' ')), 0);
+    }
+
+    #[test]
+    fn test_isgraph_control() {
+        for c in 0x00..0x20 {
+            assert_eq!(isgraph(c), 0, "isgraph should return zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_isgraph_del() {
+        assert_eq!(isgraph(0x7F), 0);
+    }
+
+    #[test]
+    fn test_isgraph_eof() {
+        assert_eq!(isgraph(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/islower.rs
+++ b/src/libs/libc_ctype/src/islower.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a lowercase letter.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a lowercase letter ('a'-'z'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn islower(c: c_int) -> c_int {
+    if (0x61..=0x7A).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::islower;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_islower_lowercase() {
+        for c in b'a'..=b'z' {
+            assert_ne!(
+                islower(c_int::from(c)),
+                0,
+                "islower should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_islower_uppercase() {
+        for c in b'A'..=b'Z' {
+            assert_eq!(islower(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_islower_digits() {
+        for c in b'0'..=b'9' {
+            assert_eq!(islower(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_islower_eof() {
+        assert_eq!(islower(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isprint.rs
+++ b/src/libs/libc_ctype/src/isprint.rs
@@ -1,0 +1,71 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a printable character (including space).
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is printable (0x20 through 0x7E), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isprint(c: c_int) -> c_int {
+    if (0x20..=0x7E).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isprint;
+
+    #[test]
+    fn test_isprint_printable() {
+        for c in 0x20..=0x7E {
+            assert_ne!(isprint(c), 0, "isprint should return non-zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_isprint_control_chars() {
+        for c in 0x00..0x20 {
+            assert_eq!(isprint(c), 0, "isprint should return zero for 0x{:02X}", c);
+        }
+    }
+
+    #[test]
+    fn test_isprint_del() {
+        assert_eq!(isprint(0x7F), 0);
+    }
+
+    #[test]
+    fn test_isprint_eof() {
+        assert_eq!(isprint(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/ispunct.rs
+++ b/src/libs/libc_ctype/src/ispunct.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a punctuation character.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is printable but not a space, letter, or digit, zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ispunct(c: c_int) -> c_int {
+    // Printable (0x20..=0x7E) but not space, not alpha, not digit.
+    let is_printable = (0x20..=0x7E).contains(&c);
+    let is_space = c == 0x20;
+    let is_alpha = (0x41..=0x5A).contains(&c) || (0x61..=0x7A).contains(&c);
+    let is_digit = (0x30..=0x39).contains(&c);
+    if is_printable && !is_space && !is_alpha && !is_digit {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ispunct;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_ispunct_punctuation() {
+        let puncts = b"!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+        for &c in puncts {
+            assert_ne!(
+                ispunct(c_int::from(c)),
+                0,
+                "ispunct should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_ispunct_letters() {
+        for c in b'A'..=b'Z' {
+            assert_eq!(ispunct(c_int::from(c)), 0);
+        }
+        for c in b'a'..=b'z' {
+            assert_eq!(ispunct(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_ispunct_digits() {
+        for c in b'0'..=b'9' {
+            assert_eq!(ispunct(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_ispunct_space() {
+        assert_eq!(ispunct(c_int::from(b' ')), 0);
+    }
+
+    #[test]
+    fn test_ispunct_eof() {
+        assert_eq!(ispunct(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isspace.rs
+++ b/src/libs/libc_ctype/src/isspace.rs
@@ -1,0 +1,91 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a white-space character.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a white-space character (' ', '\\t', '\\n', '\\v', '\\f', '\\r'),
+/// zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isspace(c: c_int) -> c_int {
+    if c == 0x20 || (0x09..=0x0D).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isspace;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isspace_space() {
+        assert_ne!(isspace(c_int::from(b' ')), 0);
+    }
+
+    #[test]
+    fn test_isspace_tab() {
+        assert_ne!(isspace(0x09), 0); // '\t'
+    }
+
+    #[test]
+    fn test_isspace_newline() {
+        assert_ne!(isspace(0x0A), 0); // '\n'
+    }
+
+    #[test]
+    fn test_isspace_vertical_tab() {
+        assert_ne!(isspace(0x0B), 0); // '\v'
+    }
+
+    #[test]
+    fn test_isspace_form_feed() {
+        assert_ne!(isspace(0x0C), 0); // '\f'
+    }
+
+    #[test]
+    fn test_isspace_carriage_return() {
+        assert_ne!(isspace(0x0D), 0); // '\r'
+    }
+
+    #[test]
+    fn test_isspace_non_whitespace() {
+        assert_eq!(isspace(c_int::from(b'A')), 0);
+        assert_eq!(isspace(c_int::from(b'0')), 0);
+        assert_eq!(isspace(c_int::from(b'!')), 0);
+    }
+
+    #[test]
+    fn test_isspace_eof() {
+        assert_eq!(isspace(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isupper.rs
+++ b/src/libs/libc_ctype/src/isupper.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is an uppercase letter.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is an uppercase letter ('A'-'Z'), zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isupper(c: c_int) -> c_int {
+    if (0x41..=0x5A).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isupper;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isupper_uppercase() {
+        for c in b'A'..=b'Z' {
+            assert_ne!(
+                isupper(c_int::from(c)),
+                0,
+                "isupper should return non-zero for '{}'",
+                c as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_isupper_lowercase() {
+        for c in b'a'..=b'z' {
+            assert_eq!(isupper(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isupper_digits() {
+        for c in b'0'..=b'9' {
+            assert_eq!(isupper(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isupper_eof() {
+        assert_eq!(isupper(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/isxdigit.rs
+++ b/src/libs/libc_ctype/src/isxdigit.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a character is a hexadecimal digit.
+///
+/// # Parameters
+///
+/// - `c`: Character to test, as an `int`.
+///
+/// # Return Value
+///
+/// Non-zero if the character is a hexadecimal digit ('0'-'9', 'A'-'F', or 'a'-'f'),
+/// zero otherwise.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isxdigit(c: c_int) -> c_int {
+    if (0x30..=0x39).contains(&c) || (0x41..=0x46).contains(&c) || (0x61..=0x66).contains(&c) {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::isxdigit;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_isxdigit_digits() {
+        for c in b'0'..=b'9' {
+            assert_ne!(isxdigit(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isxdigit_upper_hex() {
+        for c in b'A'..=b'F' {
+            assert_ne!(isxdigit(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isxdigit_lower_hex() {
+        for c in b'a'..=b'f' {
+            assert_ne!(isxdigit(c_int::from(c)), 0);
+        }
+    }
+
+    #[test]
+    fn test_isxdigit_non_hex() {
+        assert_eq!(isxdigit(c_int::from(b'G')), 0);
+        assert_eq!(isxdigit(c_int::from(b'g')), 0);
+        assert_eq!(isxdigit(c_int::from(b'Z')), 0);
+        assert_eq!(isxdigit(c_int::from(b'!')), 0);
+    }
+
+    #[test]
+    fn test_isxdigit_eof() {
+        assert_eq!(isxdigit(-1), 0);
+    }
+}

--- a/src/libs/libc_ctype/src/lib.rs
+++ b/src/libs/libc_ctype/src/lib.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod isalnum;
+pub mod isalpha;
+pub mod isascii;
+pub mod isblank;
+pub mod iscntrl;
+pub mod isdigit;
+pub mod isgraph;
+pub mod islower;
+pub mod isprint;
+pub mod ispunct;
+pub mod isspace;
+pub mod isupper;
+pub mod isxdigit;
+pub mod toascii;
+pub mod tolower;
+pub mod toupper;

--- a/src/libs/libc_ctype/src/toascii.rs
+++ b/src/libs/libc_ctype/src/toascii.rs
@@ -1,0 +1,78 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a character to a 7-bit ASCII value by clearing the high-order bits (POSIX extension).
+///
+/// Unlike `tolower`/`toupper`, this function intentionally masks *every* input instead of
+/// preserving out-of-range values: `EOF` and values outside `0..=0xFF` are also reduced to their
+/// low 7 bits. This matches the POSIX/NewLib definition of `toascii` (`c & 0x7F`).
+///
+/// # Parameters
+///
+/// - `c`: Character to convert, as an `int`.
+///
+/// # Return Value
+///
+/// The value of `c` with only the lower 7 bits preserved (`c & 0x7F`).
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn toascii(c: c_int) -> c_int {
+    c & 0x7F
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::toascii;
+
+    #[test]
+    fn test_toascii_ascii_unchanged() {
+        for c in 0x00..=0x7F {
+            assert_eq!(toascii(c), c);
+        }
+    }
+
+    #[test]
+    fn test_toascii_high_bit_stripped() {
+        assert_eq!(toascii(0x80), 0x00);
+        assert_eq!(toascii(0xC1), 0x41); // 0xC1 & 0x7F == 'A'
+        assert_eq!(toascii(0xFF), 0x7F);
+    }
+
+    #[test]
+    fn test_toascii_negative() {
+        // toascii() masks every input, including EOF and other negatives: in two's
+        // complement the low 7 bits are preserved.
+        assert_eq!(toascii(-1), 0x7F); // EOF
+        assert_eq!(toascii(-2), 0x7E);
+        assert_eq!(toascii(-128), 0x00);
+    }
+
+    #[test]
+    fn test_toascii_above_unsigned_char() {
+        // Values greater than 0xFF are also masked to their low 7 bits.
+        assert_eq!(toascii(0x100), 0x00);
+        assert_eq!(toascii(0x1C1), 0x41); // 0x1C1 & 0x7F == 'A'
+        assert_eq!(toascii(0x1FF), 0x7F);
+    }
+}

--- a/src/libs/libc_ctype/src/tolower.rs
+++ b/src/libs/libc_ctype/src/tolower.rs
@@ -1,0 +1,81 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts an uppercase letter to its lowercase equivalent.
+///
+/// # Parameters
+///
+/// - `c`: Character to convert, as an `int`.
+///
+/// # Return Value
+///
+/// The lowercase equivalent if `c` is an uppercase letter ('A'-'Z'), otherwise `c` unchanged.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tolower(c: c_int) -> c_int {
+    if (0x41..=0x5A).contains(&c) {
+        c + 32
+    } else {
+        c
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::tolower;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_tolower_uppercase() {
+        for c in b'A'..=b'Z' {
+            let expected = c + 32;
+            assert_eq!(
+                tolower(c_int::from(c)),
+                c_int::from(expected),
+                "tolower('{}') should return '{}'",
+                c as char,
+                expected as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_tolower_already_lower() {
+        for c in b'a'..=b'z' {
+            assert_eq!(tolower(c_int::from(c)), c_int::from(c));
+        }
+    }
+
+    #[test]
+    fn test_tolower_digit() {
+        for c in b'0'..=b'9' {
+            assert_eq!(tolower(c_int::from(c)), c_int::from(c));
+        }
+    }
+
+    #[test]
+    fn test_tolower_eof() {
+        assert_eq!(tolower(-1), -1);
+    }
+}

--- a/src/libs/libc_ctype/src/toupper.rs
+++ b/src/libs/libc_ctype/src/toupper.rs
@@ -1,0 +1,81 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a lowercase letter to its uppercase equivalent.
+///
+/// # Parameters
+///
+/// - `c`: Character to convert, as an `int`.
+///
+/// # Return Value
+///
+/// The uppercase equivalent if `c` is a lowercase letter ('a'-'z'), otherwise `c` unchanged.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn toupper(c: c_int) -> c_int {
+    if (0x61..=0x7A).contains(&c) {
+        c - 32
+    } else {
+        c
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::toupper;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_toupper_lowercase() {
+        for c in b'a'..=b'z' {
+            let expected = c - 32;
+            assert_eq!(
+                toupper(c_int::from(c)),
+                c_int::from(expected),
+                "toupper('{}') should return '{}'",
+                c as char,
+                expected as char
+            );
+        }
+    }
+
+    #[test]
+    fn test_toupper_already_upper() {
+        for c in b'A'..=b'Z' {
+            assert_eq!(toupper(c_int::from(c)), c_int::from(c));
+        }
+    }
+
+    #[test]
+    fn test_toupper_digit() {
+        for c in b'0'..=b'9' {
+            assert_eq!(toupper(c_int::from(c)), c_int::from(c));
+        }
+    }
+
+    #[test]
+    fn test_toupper_eof() {
+        assert_eq!(toupper(-1), -1);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `no_std` guest library, `libc_ctype`, implementing the C `<ctype.h>`
character classification and conversion API in Rust, following the `libc_assert`
crate pattern.

> **Note:** This PR is stacked on `feature-libs-libc_assert` (the base branch).
> Review/merge that branch first.

## What's added

Provided functions:

- **Classification:** `isalnum`, `isalpha`, `isascii`, `isblank`, `iscntrl`,
  `isdigit`, `isgraph`, `islower`, `isprint`, `ispunct`, `isspace`, `isupper`,
  `isxdigit`.
- **Conversion:** `toupper`, `tolower`, `toascii`.

Each function is exported with the C ABI (`extern "C"`, `no_mangle`) and matches
"C" locale semantics. Inputs are handled defensively over the full `int` range:
`EOF` (`-1`) and out-of-range values return `0` (or the unchanged input for the
conversion functions) without panicking.

A `header.toml` spec describes the generated `include/ctype.h` for the
`gen-headers` tooling, and each function ships `std`-gated unit tests covering
valid, boundary, and `EOF` inputs.

## Wiring

- Registered the crate in the workspace (`members` + `[workspace.dependencies]`).
- Added `libc_ctype` to `ALL_GUEST_RUST_LIBS` and `ALL_GUEST_RUST_LIBS_TEST_LIST`
  so it is built, linted, and tested.

## Validation

- `cargo clippy --locked --tests --features=std -p libc_ctype -- -D warnings` — clean.
- `cargo test --locked --features=std -p libc_ctype` — **69 passed, 0 failed**.
- Guest `no_std` cross-compile for the user target — builds cleanly.
