### PR TITLE
[libc_inttypes] Add C inttypes.h functions

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,numer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_inttypes"
+version = "0.16.83"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.83"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
         "src/libs/syslog-macros",
         "src/libs/libc_assert",
         "src/libs/libc_ctype",
+        "src/libs/libc_inttypes",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/cache",
@@ -214,6 +215,7 @@ spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "
 static_assert = { path = "src/libs/static_assert", default-features = false }
 libc_assert = { path = "src/libs/libc_assert", default-features = false }
 libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
+libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_inttypes/Cargo.toml
+++ b/src/libs/libc_inttypes/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_inttypes"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_inttypes/header.toml
+++ b/src/libs/libc_inttypes/header.toml
@@ -1,0 +1,125 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for inttypes.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/inttypes.h.
+
+file = "inttypes.h"
+brief = "Fixed-width integer types — format conversion."
+description = """
+Declares functions for greatest-width integer arithmetic and conversion,
+plus format macros for printf/scanf with fixed-width types. Implemented by
+the libc_inttypes Rust crate."""
+includes = ["stdint.h"]
+guard = "_NANVIX_INTTYPES_H"
+
+[[types]]
+text = """
+#ifndef _INTMAX_T_DEFINED
+#define _INTMAX_T_DEFINED
+typedef int64_t intmax_t;
+typedef uint64_t uintmax_t;
+#endif
+
+/** @brief Return type for imaxdiv(). */
+typedef struct {
+    intmax_t quot; /**< Quotient.  */
+    intmax_t rem;  /**< Remainder. */
+} imaxdiv_t;
+"""
+
+[[sections]]
+title = "Functions"
+functions = ["imaxabs", "imaxdiv", "strtoimax", "strtoumax"]
+
+# Format macros live outside extern "C" block — added as trailer.
+[trailer]
+text = """
+/*==================================================================================================
+ * printf Format Macros
+ *==================================================================================================*/
+
+/* Signed */
+#define PRId8 "d"
+#define PRId16 "d"
+#define PRId32 "d"
+#define PRId64 "lld"
+#define PRIdMAX "lld"
+#define PRIdPTR "d"
+
+#define PRIi8 "i"
+#define PRIi16 "i"
+#define PRIi32 "i"
+#define PRIi64 "lli"
+#define PRIiMAX "lli"
+#define PRIiPTR "i"
+
+/* Unsigned */
+#define PRIo8 "o"
+#define PRIo16 "o"
+#define PRIo32 "o"
+#define PRIo64 "llo"
+#define PRIoMAX "llo"
+#define PRIoPTR "o"
+
+#define PRIu8 "u"
+#define PRIu16 "u"
+#define PRIu32 "u"
+#define PRIu64 "llu"
+#define PRIuMAX "llu"
+#define PRIuPTR "u"
+
+#define PRIx8 "x"
+#define PRIx16 "x"
+#define PRIx32 "x"
+#define PRIx64 "llx"
+#define PRIxMAX "llx"
+#define PRIxPTR "x"
+
+#define PRIX8 "X"
+#define PRIX16 "X"
+#define PRIX32 "X"
+#define PRIX64 "llX"
+#define PRIXMAX "llX"
+#define PRIXPTR "X"
+
+/*==================================================================================================
+ * scanf Format Macros
+ *==================================================================================================*/
+
+#define SCNd8 "hhd"
+#define SCNd16 "hd"
+#define SCNd32 "d"
+#define SCNd64 "lld"
+#define SCNdMAX "lld"
+#define SCNdPTR "d"
+
+#define SCNi8 "hhi"
+#define SCNi16 "hi"
+#define SCNi32 "i"
+#define SCNi64 "lli"
+#define SCNiMAX "lli"
+#define SCNiPTR "i"
+
+#define SCNo8 "hho"
+#define SCNo16 "ho"
+#define SCNo32 "o"
+#define SCNo64 "llo"
+#define SCNoMAX "llo"
+#define SCNoPTR "o"
+
+#define SCNu8 "hhu"
+#define SCNu16 "hu"
+#define SCNu32 "u"
+#define SCNu64 "llu"
+#define SCNuMAX "llu"
+#define SCNuPTR "u"
+
+#define SCNx8 "hhx"
+#define SCNx16 "hx"
+#define SCNx32 "x"
+#define SCNx64 "llx"
+#define SCNxMAX "llx"
+#define SCNxPTR "x"
+"""

--- a/src/libs/libc_inttypes/src/imaxabs.rs
+++ b/src/libs/libc_inttypes/src/imaxabs.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::inttypes::intmax_t;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the absolute value of `n`.
+///
+/// If `n` is [`i64::MIN`], the result is [`i64::MIN`] due to two's complement wrapping.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn imaxabs(n: intmax_t) -> intmax_t {
+    n.wrapping_abs()
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive() {
+        assert_eq!(imaxabs(42), 42);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert_eq!(imaxabs(-42), 42);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(imaxabs(0), 0);
+    }
+
+    #[test]
+    fn test_min() {
+        // wrapping_abs of i64::MIN returns i64::MIN.
+        assert_eq!(imaxabs(i64::MIN), i64::MIN);
+    }
+}

--- a/src/libs/libc_inttypes/src/imaxdiv.rs
+++ b/src/libs/libc_inttypes/src/imaxdiv.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::inttypes::intmax_t;
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Result of an integer division performed by [`imaxdiv`].
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct imaxdiv_t {
+    /// Quotient of the division.
+    pub quot: intmax_t,
+    /// Remainder of the division.
+    pub rem: intmax_t,
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the quotient and remainder of the division `numer / denom`.
+///
+/// For every division that the C standard defines, the result satisfies
+/// `numer == quot * denom + rem`, with the quotient truncated towards zero.
+///
+/// The C standard leaves division by zero and a non-representable quotient (namely
+/// `INTMAX_MIN / -1`) undefined. To avoid trapping, this function performs no division in those
+/// cases and instead returns `imaxdiv_t { quot: 0, rem: 0 }`; the `numer == quot * denom + rem`
+/// identity does not hold for those inputs.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn imaxdiv(numer: intmax_t, denom: intmax_t) -> imaxdiv_t {
+    match (numer.checked_div(denom), numer.checked_rem(denom)) {
+        (Some(quot), Some(rem)) => imaxdiv_t { quot, rem },
+        _ => imaxdiv_t { quot: 0, rem: 0 },
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normal() {
+        let result = imaxdiv(10, 3);
+        assert_eq!(result.quot, 3);
+        assert_eq!(result.rem, 1);
+    }
+
+    #[test]
+    fn test_negative_numer() {
+        let result = imaxdiv(-10, 3);
+        assert_eq!(result.quot, -3);
+        assert_eq!(result.rem, -1);
+    }
+
+    #[test]
+    fn test_both_negative() {
+        let result = imaxdiv(-10, -3);
+        assert_eq!(result.quot, 3);
+        assert_eq!(result.rem, -1);
+    }
+
+    #[test]
+    fn test_exact() {
+        let result = imaxdiv(12, 4);
+        assert_eq!(result.quot, 3);
+        assert_eq!(result.rem, 0);
+    }
+
+    #[test]
+    fn test_divide_by_zero() {
+        // Division by zero is undefined in C; this implementation returns {0, 0} without trapping.
+        let result = imaxdiv(10, 0);
+        assert_eq!(result.quot, 0);
+        assert_eq!(result.rem, 0);
+    }
+
+    #[test]
+    fn test_overflow() {
+        // INTMAX_MIN / -1 is not representable; this implementation returns {0, 0} without trapping.
+        let result = imaxdiv(intmax_t::MIN, -1);
+        assert_eq!(result.quot, 0);
+        assert_eq!(result.rem, 0);
+    }
+}

--- a/src/libs/libc_inttypes/src/inttypes.rs
+++ b/src/libs/libc_inttypes/src/inttypes.rs
@@ -1,0 +1,14 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Signed integer type of maximum width.
+#[allow(non_camel_case_types)]
+pub type intmax_t = i64;
+
+/// Unsigned integer type of maximum width.
+#[allow(non_camel_case_types)]
+pub type uintmax_t = u64;

--- a/src/libs/libc_inttypes/src/lib.rs
+++ b/src/libs/libc_inttypes/src/lib.rs
@@ -1,0 +1,70 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod imaxabs;
+pub mod imaxdiv;
+pub mod inttypes;
+pub mod strtoimax;
+pub mod strtoumax;
+
+//==================================================================================================
+// Test Support
+//==================================================================================================
+
+// The conversion routines reference `__errno_location` to report `ERANGE`. That symbol is provided
+// by the C library in the guest build, but the MSVC C runtime used for host `std` unit tests on
+// Windows does not export this glibc/musl symbol, so supply a thread-local definition here to let
+// the `errno`-asserting tests link and run. On Linux hosts the system C library already provides
+// the symbol, so the shim is not compiled there.
+#[cfg(all(test, feature = "std", target_os = "windows"))]
+mod windows_errno_shim {
+    use ::core::cell::Cell;
+    use ::sysapi::ffi::c_int;
+
+    std::thread_local! {
+        static ERRNO: Cell<c_int> = const { Cell::new(0) };
+    }
+
+    /// Host-only definition of `__errno_location` for Windows `std` unit tests.
+    ///
+    /// A thread-local backing store keeps `errno` isolated across the test harness's worker
+    /// threads, so concurrently running tests do not observe each other's values.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid for the lifetime of the calling thread.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn __errno_location() -> *mut c_int {
+        ERRNO.with(Cell::as_ptr)
+    }
+}

--- a/src/libs/libc_inttypes/src/strtoimax.rs
+++ b/src/libs/libc_inttypes/src/strtoimax.rs
@@ -1,0 +1,385 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::inttypes::intmax_t;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const CHAR_SPACE: i64 = 0x20;
+const CHAR_TAB: i64 = 0x09;
+const CHAR_NEWLINE: i64 = 0x0A;
+const CHAR_CR: i64 = 0x0D;
+const CHAR_FF: i64 = 0x0C;
+const CHAR_VT: i64 = 0x0B;
+const CHAR_ZERO: i64 = 0x30;
+const CHAR_NINE: i64 = 0x39;
+const CHAR_UPPER_A: i64 = 0x41;
+const CHAR_UPPER_X: i64 = 0x58;
+const CHAR_UPPER_Z: i64 = 0x5A;
+const CHAR_LOWER_A: i64 = 0x61;
+const CHAR_LOWER_X: i64 = 0x78;
+const CHAR_LOWER_Z: i64 = 0x7A;
+const CHAR_PLUS: i64 = 0x2B;
+const CHAR_MINUS: i64 = 0x2D;
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Returns `true` if the given character value represents an ASCII whitespace character.
+pub(crate) fn is_whitespace(c: i64) -> bool {
+    c == CHAR_SPACE
+        || c == CHAR_TAB
+        || c == CHAR_NEWLINE
+        || c == CHAR_CR
+        || c == CHAR_FF
+        || c == CHAR_VT
+}
+
+/// Returns the numeric digit value for the given character value, or [`None`] if it is not a valid
+/// digit character.
+pub(crate) fn digit_value(c: i64) -> Option<i64> {
+    if (CHAR_ZERO..=CHAR_NINE).contains(&c) {
+        Some(c - CHAR_ZERO)
+    } else if (CHAR_UPPER_A..=CHAR_UPPER_Z).contains(&c) {
+        Some(c - CHAR_UPPER_A + 10)
+    } else if (CHAR_LOWER_A..=CHAR_LOWER_Z).contains(&c) {
+        Some(c - CHAR_LOWER_A + 10)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Converts the initial portion of the string pointed to by `nptr` to [`intmax_t`].
+///
+/// Skips leading whitespace, handles an optional `+`/`-` sign, auto-detects the base when `base`
+/// is `0` (hexadecimal for `0x`/`0X` prefix, octal for `0` prefix, decimal otherwise), and parses
+/// digits for bases 2 through 36. On overflow the result is clamped to [`i64::MAX`] or [`i64::MIN`]
+/// depending on the sign.
+///
+/// # Safety
+///
+/// - `nptr` must point to a valid, null-terminated C string.
+/// - If `endptr` is non-null, it must point to a valid, writable `*mut c_char` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoimax(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> intmax_t {
+    debug_assert!(!nptr.is_null());
+
+    // Reject invalid bases per the C contract: `base` must be 0 (auto-detect) or in 2..=36.
+    // An invalid base performs no conversion: POSIX requires `errno` to be set to `EINVAL`, so set
+    // it, set `*endptr` to `nptr`, and return 0.
+    let requested_base: i64 = i64::from(base);
+    if requested_base != 0 && !(2..=36).contains(&requested_base) {
+        // SAFETY: `__errno_location()` returns a valid pointer to thread-local `errno`.
+        *::sysapi::errno::__errno_location() = ::sysapi::errno::EINVAL;
+        if !endptr.is_null() {
+            *endptr = nptr as *mut c_char;
+        }
+        return 0;
+    }
+
+    let mut idx: usize = 0;
+
+    // Skip leading whitespace.
+    loop {
+        let c = i64::from(*nptr.add(idx));
+        if !is_whitespace(c) {
+            break;
+        }
+        idx += 1;
+    }
+
+    // Handle optional sign.
+    let negative = {
+        let c = i64::from(*nptr.add(idx));
+        if c == CHAR_MINUS {
+            idx += 1;
+            true
+        } else {
+            if c == CHAR_PLUS {
+                idx += 1;
+            }
+            false
+        }
+    };
+
+    // Determine effective base.
+    let mut effective_base: i64 = requested_base;
+    let c = i64::from(*nptr.add(idx));
+    if c == CHAR_ZERO {
+        let next = i64::from(*nptr.add(idx + 1));
+        let next_is_x = next == CHAR_LOWER_X || next == CHAR_UPPER_X;
+        // Only honor a `0x`/`0X` prefix when it is immediately followed by at least one
+        // hexadecimal digit. Otherwise the leading `0` is itself the (only) digit and parsing
+        // must stop at `x`, leaving `endptr` pointing at it (e.g. "0x" or "0xG").
+        let prefix_has_hex_digit = next_is_x && {
+            // SAFETY: `next` is `x`/`X` (non-null), so reading `idx + 2` stays within the string.
+            let after = i64::from(*nptr.add(idx + 2));
+            matches!(digit_value(after), Some(d) if d < 16)
+        };
+        if prefix_has_hex_digit && (effective_base == 0 || effective_base == 16) {
+            effective_base = 16;
+            idx += 2;
+        } else if effective_base == 0 {
+            effective_base = 8;
+            // Don't advance past '0' — let the digit loop parse it.
+        }
+    } else if effective_base == 0 {
+        effective_base = 10;
+    }
+
+    // Parse digits. Accumulate as a negative value so that i64::MIN can be represented without
+    // intermediate overflow (the negative range is one wider than the positive range).
+    let mut result: i64 = 0;
+    let mut overflow = false;
+    let mut any_digits = false;
+
+    loop {
+        let c = i64::from(*nptr.add(idx));
+        let digit = match digit_value(c) {
+            Some(d) if d < effective_base => d,
+            _ => break,
+        };
+
+        any_digits = true;
+
+        if !overflow {
+            match result.checked_mul(effective_base) {
+                Some(v) => match v.checked_sub(digit) {
+                    Some(v2) => result = v2,
+                    None => overflow = true,
+                },
+                None => overflow = true,
+            }
+        }
+
+        idx += 1;
+    }
+
+    // Set endptr.
+    if !endptr.is_null() {
+        if any_digits {
+            *endptr = nptr.add(idx) as *mut c_char;
+        } else {
+            *endptr = nptr as *mut c_char;
+        }
+    }
+
+    // Produce the final value.
+    if overflow {
+        // SAFETY: `__errno_location()` returns a valid pointer to thread-local `errno`.
+        *::sysapi::errno::__errno_location() = ::sysapi::errno::ERANGE;
+        if negative {
+            i64::MIN
+        } else {
+            i64::MAX
+        }
+    } else if negative {
+        result
+    } else {
+        // Negate the accumulated negative value back to positive. If the negation overflows
+        // (result == i64::MIN with a positive sign), the magnitude exceeds i64::MAX.
+        match result.checked_neg() {
+            Some(v) => v,
+            None => {
+                // SAFETY: `__errno_location()` returns a valid pointer to thread-local `errno`.
+                *::sysapi::errno::__errno_location() = ::sysapi::errno::ERANGE;
+                i64::MAX
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn test_parse_decimal() {
+        // "123\0"
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn test_parse_negative() {
+        // "-456\0"
+        let s: [c_char; 5] = [0x2D, 0x34, 0x35, 0x36, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, -456);
+    }
+
+    #[test]
+    fn test_parse_hex_base0() {
+        // "0xff\0"
+        let s: [c_char; 5] = [0x30, 0x78, 0x66, 0x66, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 0) };
+        assert_eq!(result, 0xff);
+    }
+
+    #[test]
+    fn test_parse_octal_base0() {
+        // "077\0"
+        let s: [c_char; 4] = [0x30, 0x37, 0x37, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 0) };
+        assert_eq!(result, 0o77);
+    }
+
+    #[test]
+    fn test_endptr() {
+        // "123abc\0"
+        let s: [c_char; 7] = [0x31, 0x32, 0x33, 0x61, 0x62, 0x63, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 10) };
+        assert_eq!(result, 123);
+        // endptr should point to 'a' (0x61).
+        assert_eq!(unsafe { *endptr }, 0x61);
+    }
+
+    #[test]
+    fn test_leading_whitespace() {
+        // " 123\0"
+        let s: [c_char; 5] = [0x20, 0x31, 0x32, 0x33, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn test_empty_string() {
+        // "\0"
+        let s: [c_char; 1] = [0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_invalid_string() {
+        // "abc\0"
+        let s: [c_char; 4] = [0x61, 0x62, 0x63, 0];
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_invalid_base_too_small() {
+        // base 1 is invalid: no conversion, endptr == nptr, returns 0, errno == EINVAL.
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 1) };
+        assert_eq!(result, 0);
+        assert!(::core::ptr::eq(endptr, s.as_ptr()));
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::EINVAL);
+    }
+
+    #[test]
+    fn test_invalid_base_too_large() {
+        // base 37 is invalid: no conversion, endptr == nptr, returns 0, errno == EINVAL.
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 37) };
+        assert_eq!(result, 0);
+        assert!(::core::ptr::eq(endptr, s.as_ptr()));
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::EINVAL);
+    }
+
+    #[test]
+    fn test_overflow_positive_sets_errno() {
+        // "9223372036854775808\0" == i64::MAX + 1
+        let s: [c_char; 20] = [
+            0x39, 0x32, 0x32, 0x33, 0x33, 0x37, 0x32, 0x30, 0x33, 0x36, 0x38, 0x35, 0x34, 0x37,
+            0x37, 0x35, 0x38, 0x30, 0x38, 0,
+        ];
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, i64::MAX);
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::ERANGE);
+    }
+
+    #[test]
+    fn test_overflow_negative_sets_errno() {
+        // "-9223372036854775809\0" == i64::MIN - 1 (magnitude one past the negative range)
+        let s: [c_char; 21] = [
+            0x2D, 0x39, 0x32, 0x32, 0x33, 0x33, 0x37, 0x32, 0x30, 0x33, 0x36, 0x38, 0x35, 0x34,
+            0x37, 0x37, 0x35, 0x38, 0x30, 0x39, 0,
+        ];
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoimax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, i64::MIN);
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::ERANGE);
+    }
+
+    #[test]
+    fn test_hex_prefix_without_digit_base0() {
+        // "0x\0" — the `0x` prefix has no following hex digit, so only the leading `0` is parsed
+        // and `endptr` stops at 'x'.
+        let s: [c_char; 3] = [0x30, 0x78, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 0) };
+        assert_eq!(result, 0);
+        // endptr should point at 'x' (0x78).
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+
+    #[test]
+    fn test_hex_prefix_without_digit_base16() {
+        // "0x\0" with explicit base 16 — the leading `0` is parsed as a hex digit and `endptr`
+        // stops at 'x'.
+        let s: [c_char; 3] = [0x30, 0x78, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 16) };
+        assert_eq!(result, 0);
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+
+    #[test]
+    fn test_hex_prefix_invalid_digit_base16() {
+        // "0xG\0" with explicit base 16 — 'G' is not a hex digit, so the `0x` prefix is not
+        // consumed; the leading `0` is parsed as a hex digit and `endptr` stops at 'x'.
+        let s: [c_char; 4] = [0x30, 0x78, 0x47, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoimax(s.as_ptr(), &mut endptr, 16) };
+        assert_eq!(result, 0);
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+}

--- a/src/libs/libc_inttypes/src/strtoumax.rs
+++ b/src/libs/libc_inttypes/src/strtoumax.rs
@@ -1,0 +1,321 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    inttypes::uintmax_t,
+    strtoimax::{
+        digit_value,
+        is_whitespace,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const CHAR_ZERO: i64 = 0x30;
+const CHAR_UPPER_X: i64 = 0x58;
+const CHAR_LOWER_X: i64 = 0x78;
+const CHAR_PLUS: i64 = 0x2B;
+const CHAR_MINUS: i64 = 0x2D;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Converts the initial portion of the string pointed to by `nptr` to [`uintmax_t`].
+///
+/// Skips leading whitespace, handles an optional `+`/`-` sign, auto-detects the base when `base`
+/// is `0` (hexadecimal for `0x`/`0X` prefix, octal for `0` prefix, decimal otherwise), and parses
+/// digits for bases 2 through 36. On overflow the result is clamped to [`u64::MAX`]. A leading `-`
+/// sign causes the parsed magnitude to be negated using unsigned wrapping arithmetic, matching the
+/// C standard behavior for `strtoumax`.
+///
+/// # Safety
+///
+/// - `nptr` must point to a valid, null-terminated C string.
+/// - If `endptr` is non-null, it must point to a valid, writable `*mut c_char` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoumax(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> uintmax_t {
+    debug_assert!(!nptr.is_null());
+
+    // Reject invalid bases per the C contract: `base` must be 0 (auto-detect) or in 2..=36.
+    // An invalid base performs no conversion: POSIX requires `errno` to be set to `EINVAL`, so set
+    // it, set `*endptr` to `nptr`, and return 0.
+    let requested_base: i64 = i64::from(base);
+    if requested_base != 0 && !(2..=36).contains(&requested_base) {
+        // SAFETY: `__errno_location()` returns a valid pointer to thread-local `errno`.
+        *::sysapi::errno::__errno_location() = ::sysapi::errno::EINVAL;
+        if !endptr.is_null() {
+            *endptr = nptr as *mut c_char;
+        }
+        return 0;
+    }
+
+    let mut idx: usize = 0;
+
+    // Skip leading whitespace.
+    loop {
+        let c = i64::from(*nptr.add(idx));
+        if !is_whitespace(c) {
+            break;
+        }
+        idx += 1;
+    }
+
+    // Handle optional sign.
+    let negative = {
+        let c = i64::from(*nptr.add(idx));
+        if c == CHAR_MINUS {
+            idx += 1;
+            true
+        } else {
+            if c == CHAR_PLUS {
+                idx += 1;
+            }
+            false
+        }
+    };
+
+    // Determine effective base.
+    let mut effective_base: i64 = requested_base;
+    let c = i64::from(*nptr.add(idx));
+    if c == CHAR_ZERO {
+        let next = i64::from(*nptr.add(idx + 1));
+        let next_is_x = next == CHAR_LOWER_X || next == CHAR_UPPER_X;
+        // Only honor a `0x`/`0X` prefix when it is immediately followed by at least one
+        // hexadecimal digit. Otherwise the leading `0` is itself the (only) digit and parsing
+        // must stop at `x`, leaving `endptr` pointing at it (e.g. "0x" or "0xG").
+        let prefix_has_hex_digit = next_is_x && {
+            // SAFETY: `next` is `x`/`X` (non-null), so reading `idx + 2` stays within the string.
+            let after = i64::from(*nptr.add(idx + 2));
+            matches!(digit_value(after), Some(d) if d < 16)
+        };
+        if prefix_has_hex_digit && (effective_base == 0 || effective_base == 16) {
+            effective_base = 16;
+            idx += 2;
+        } else if effective_base == 0 {
+            effective_base = 8;
+            // Don't advance past '0' — let the digit loop parse it.
+        }
+    } else if effective_base == 0 {
+        effective_base = 10;
+    }
+
+    // Convert the effective base to u64 for accumulation.
+    let base_u64: u64 = match u64::try_from(effective_base) {
+        Ok(v) => v,
+        Err(_) => {
+            if !endptr.is_null() {
+                *endptr = nptr as *mut c_char;
+            }
+            return 0;
+        },
+    };
+
+    // Parse digits, accumulating in u64.
+    let mut result: u64 = 0;
+    let mut overflow = false;
+    let mut any_digits = false;
+
+    loop {
+        let c = i64::from(*nptr.add(idx));
+        let digit_i64 = match digit_value(c) {
+            Some(d) if d < effective_base => d,
+            _ => break,
+        };
+
+        // digit_i64 is in 0..=35 so conversion to u64 is infallible.
+        let Ok(digit) = u64::try_from(digit_i64) else {
+            break;
+        };
+
+        any_digits = true;
+
+        if !overflow {
+            match result.checked_mul(base_u64) {
+                Some(v) => match v.checked_add(digit) {
+                    Some(v2) => result = v2,
+                    None => overflow = true,
+                },
+                None => overflow = true,
+            }
+        }
+
+        idx += 1;
+    }
+
+    // Set endptr.
+    if !endptr.is_null() {
+        if any_digits {
+            *endptr = nptr.add(idx) as *mut c_char;
+        } else {
+            *endptr = nptr as *mut c_char;
+        }
+    }
+
+    if overflow {
+        // SAFETY: `__errno_location()` returns a valid pointer to thread-local `errno`.
+        *::sysapi::errno::__errno_location() = ::sysapi::errno::ERANGE;
+        u64::MAX
+    } else if negative {
+        result.wrapping_neg()
+    } else {
+        result
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn test_parse_decimal() {
+        // "123\0"
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let result = unsafe { strtoumax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn test_parse_hex_prefix() {
+        // "0xFFFFFFFF\0"
+        let s: [c_char; 11] = [
+            0x30, 0x78, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0x46, 0,
+        ];
+        let result = unsafe { strtoumax(s.as_ptr(), ::core::ptr::null_mut(), 16) };
+        assert_eq!(result, 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn test_parse_hex_base16() {
+        // "FF\0"
+        let s: [c_char; 3] = [0x46, 0x46, 0];
+        let result = unsafe { strtoumax(s.as_ptr(), ::core::ptr::null_mut(), 16) };
+        assert_eq!(result, 255);
+    }
+
+    #[test]
+    fn test_endptr() {
+        // "123abc\0"
+        let s: [c_char; 7] = [0x31, 0x32, 0x33, 0x61, 0x62, 0x63, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 10) };
+        assert_eq!(result, 123);
+        // endptr should point to 'a' (0x61).
+        assert_eq!(unsafe { *endptr }, 0x61);
+    }
+
+    #[test]
+    fn test_invalid_base_too_small() {
+        // base 1 is invalid: no conversion, endptr == nptr, returns 0, errno == EINVAL.
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 1) };
+        assert_eq!(result, 0);
+        assert!(::core::ptr::eq(endptr, s.as_ptr()));
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::EINVAL);
+    }
+
+    #[test]
+    fn test_invalid_base_too_large() {
+        // base 37 is invalid: no conversion, endptr == nptr, returns 0, errno == EINVAL.
+        let s: [c_char; 4] = [0x31, 0x32, 0x33, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 37) };
+        assert_eq!(result, 0);
+        assert!(::core::ptr::eq(endptr, s.as_ptr()));
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::EINVAL);
+    }
+
+    #[test]
+    fn test_overflow_sets_errno() {
+        // "18446744073709551616\0" == u64::MAX + 1
+        let s: [c_char; 21] = [
+            0x31, 0x38, 0x34, 0x34, 0x36, 0x37, 0x34, 0x34, 0x30, 0x37, 0x33, 0x37, 0x30, 0x39,
+            0x35, 0x35, 0x31, 0x36, 0x31, 0x36, 0,
+        ];
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoumax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, u64::MAX);
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, ::sysapi::errno::ERANGE);
+    }
+
+    #[test]
+    fn test_negative_wraps_without_errno() {
+        // "-1\0"
+        let s: [c_char; 3] = [0x2D, 0x31, 0];
+        unsafe {
+            *::sysapi::errno::__errno_location() = 0;
+        }
+        let result = unsafe { strtoumax(s.as_ptr(), ::core::ptr::null_mut(), 10) };
+        assert_eq!(result, u64::MAX);
+        let errno = unsafe { *::sysapi::errno::__errno_location() };
+        assert_eq!(errno, 0);
+    }
+
+    #[test]
+    fn test_hex_prefix_without_digit_base0() {
+        // "0x\0" — the `0x` prefix has no following hex digit, so only the leading `0` is parsed
+        // and `endptr` stops at 'x'.
+        let s: [c_char; 3] = [0x30, 0x78, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 0) };
+        assert_eq!(result, 0);
+        // endptr should point at 'x' (0x78).
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+
+    #[test]
+    fn test_hex_prefix_without_digit_base16() {
+        // "0x\0" with explicit base 16 — the leading `0` is parsed as a hex digit and `endptr`
+        // stops at 'x'.
+        let s: [c_char; 3] = [0x30, 0x78, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 16) };
+        assert_eq!(result, 0);
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+
+    #[test]
+    fn test_hex_prefix_invalid_digit_base16() {
+        // "0xG\0" — 'G' is not a hex digit, so the `0x` prefix is not consumed; the leading `0`
+        // is parsed and `endptr` stops at 'x'.
+        let s: [c_char; 4] = [0x30, 0x78, 0x47, 0];
+        let mut endptr: *mut c_char = ::core::ptr::null_mut();
+        let result = unsafe { strtoumax(s.as_ptr(), &mut endptr, 16) };
+        assert_eq!(result, 0);
+        assert_eq!(unsafe { *endptr }, 0x78);
+        assert!(::core::ptr::eq(endptr, unsafe { s.as_ptr().add(1) }));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `no_std` guest library `libc_inttypes` implementing the C `<inttypes.h>`
greatest-width integer API in Rust, following the `libc_ctype` / `libc_assert` crate pattern.

> **Stacked PR:** based on top of `feature-libs-libc_ctype`. That branch is the base of this
> PR; review/merge it first. The diff here is a single commit on top of it.

## Provided functions

- **Arithmetic:** `imaxabs`, `imaxdiv`
- **String conversion:** `strtoimax`, `strtoumax`

`intmax_t`/`uintmax_t` are defined as `i64`/`u64`; `imaxdiv` returns the C-compatible
`imaxdiv_t` struct. `imaxabs` uses `wrapping_abs` so `imaxabs(i64::MIN)` is well-defined.

`strtoimax`/`strtoumax` skip leading whitespace, accept an optional `+`/`-` sign, auto-detect
the base when `base == 0` (`0x`/`0X` hex, leading `0` octal, otherwise decimal), and support
bases 2–36. Overflow is clamped (`i64::MIN`/`i64::MAX` for signed, `u64::MAX` for unsigned)
and `endptr` is set per the C contract. `strtoimax` accumulates as a negative value so
`i64::MIN` is representable without intermediate overflow.

## Integration

- C ABI exports gated behind `not(feature = "std")` via `#[cfg_attr(..., unsafe(no_mangle))]`,
  so symbols are emitted only for the guest build and do not collide with the host libc during
  testing. Unit tests are `std`-gated.
- `header.toml` describes the generated `include/inttypes.h` (including `imaxdiv_t` and the
  `PRI*`/`SCN*` printf/scanf format macros for the 32-bit ILP32 guest target).
- Registered in the workspace (members + dependencies) and the Makefile guest lists
  (`ALL_GUEST_RUST_LIBS` and `ALL_GUEST_RUST_LIBS_TEST_LIST`) so it is built, linted, and tested.
- Added `numer` to the codespell ignore list (C-standard `imaxdiv` parameter name).

## Validation

- Guest-target clippy (`-D warnings`): clean.
- Host unit tests (`--features=std`): 19 passed.
- `format-check`, `lint-check`, `spellcheck`: pass.
