### PR TITLE
[libc_locale] locale.h and langinfo.h functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_langinfo"
+version = "0.16.84"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
+name = "libc_locale"
+version = "0.16.84"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.84"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ members = [
         "src/libs/libc_assert",
         "src/libs/libc_ctype",
         "src/libs/libc_inttypes",
+        "src/libs/libc_langinfo",
+        "src/libs/libc_locale",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/cache",
@@ -216,6 +218,8 @@ static_assert = { path = "src/libs/static_assert", default-features = false }
 libc_assert = { path = "src/libs/libc_assert", default-features = false }
 libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
 libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
+libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
+libc_locale = { path = "src/libs/libc_locale", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_langinfo/Cargo.toml
+++ b/src/libs/libc_langinfo/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_langinfo"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_langinfo/header.toml
+++ b/src/libs/libc_langinfo/header.toml
@@ -1,0 +1,228 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for langinfo.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/langinfo.h.
+
+file = "langinfo.h"
+brief = "Language information constants."
+description = """
+Declares nl_langinfo() and the nl_item constants used to query locale-specific
+data. Only the C/POSIX locale is supported. Implemented by the libc_langinfo
+Rust crate."""
+includes = []
+guard = "_NANVIX_LANGINFO_H"
+
+[[types]]
+text = """
+#ifndef _NL_ITEM_DEFINED
+#define _NL_ITEM_DEFINED
+/** @brief Identifier for an item of locale-specific data. */
+typedef int nl_item;
+#endif
+"""
+
+[[macros]]
+name = "CODESET"
+value = "0"
+
+[[macros]]
+name = "D_T_FMT"
+value = "1"
+
+[[macros]]
+name = "D_FMT"
+value = "2"
+
+[[macros]]
+name = "T_FMT"
+value = "3"
+
+[[macros]]
+name = "T_FMT_AMPM"
+value = "4"
+
+[[macros]]
+name = "AM_STR"
+value = "5"
+
+[[macros]]
+name = "PM_STR"
+value = "6"
+
+[[macros]]
+name = "DAY_1"
+value = "7"
+
+[[macros]]
+name = "DAY_2"
+value = "8"
+
+[[macros]]
+name = "DAY_3"
+value = "9"
+
+[[macros]]
+name = "DAY_4"
+value = "10"
+
+[[macros]]
+name = "DAY_5"
+value = "11"
+
+[[macros]]
+name = "DAY_6"
+value = "12"
+
+[[macros]]
+name = "DAY_7"
+value = "13"
+
+[[macros]]
+name = "ABDAY_1"
+value = "14"
+
+[[macros]]
+name = "ABDAY_2"
+value = "15"
+
+[[macros]]
+name = "ABDAY_3"
+value = "16"
+
+[[macros]]
+name = "ABDAY_4"
+value = "17"
+
+[[macros]]
+name = "ABDAY_5"
+value = "18"
+
+[[macros]]
+name = "ABDAY_6"
+value = "19"
+
+[[macros]]
+name = "ABDAY_7"
+value = "20"
+
+[[macros]]
+name = "MON_1"
+value = "21"
+
+[[macros]]
+name = "MON_2"
+value = "22"
+
+[[macros]]
+name = "MON_3"
+value = "23"
+
+[[macros]]
+name = "MON_4"
+value = "24"
+
+[[macros]]
+name = "MON_5"
+value = "25"
+
+[[macros]]
+name = "MON_6"
+value = "26"
+
+[[macros]]
+name = "MON_7"
+value = "27"
+
+[[macros]]
+name = "MON_8"
+value = "28"
+
+[[macros]]
+name = "MON_9"
+value = "29"
+
+[[macros]]
+name = "MON_10"
+value = "30"
+
+[[macros]]
+name = "MON_11"
+value = "31"
+
+[[macros]]
+name = "MON_12"
+value = "32"
+
+[[macros]]
+name = "ABMON_1"
+value = "33"
+
+[[macros]]
+name = "ABMON_2"
+value = "34"
+
+[[macros]]
+name = "ABMON_3"
+value = "35"
+
+[[macros]]
+name = "ABMON_4"
+value = "36"
+
+[[macros]]
+name = "ABMON_5"
+value = "37"
+
+[[macros]]
+name = "ABMON_6"
+value = "38"
+
+[[macros]]
+name = "ABMON_7"
+value = "39"
+
+[[macros]]
+name = "ABMON_8"
+value = "40"
+
+[[macros]]
+name = "ABMON_9"
+value = "41"
+
+[[macros]]
+name = "ABMON_10"
+value = "42"
+
+[[macros]]
+name = "ABMON_11"
+value = "43"
+
+[[macros]]
+name = "ABMON_12"
+value = "44"
+
+[[macros]]
+name = "RADIXCHAR"
+value = "45"
+
+[[macros]]
+name = "THOUSEP"
+value = "46"
+
+[[macros]]
+name = "YESEXPR"
+value = "47"
+
+[[macros]]
+name = "NOEXPR"
+value = "48"
+
+[[macros]]
+name = "CRNCYSTR"
+value = "49"
+
+[[sections]]
+title = "Functions"
+functions = ["nl_langinfo"]

--- a/src/libs/libc_langinfo/src/lib.rs
+++ b/src/libs/libc_langinfo/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod nl_langinfo;

--- a/src/libs/libc_langinfo/src/nl_langinfo.rs
+++ b/src/libs/libc_langinfo/src/nl_langinfo.rs
@@ -1,0 +1,216 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// `nl_langinfo()` item identifier.
+pub type nl_item = c_int;
+
+// Item identifiers (kept in sync with <langinfo.h>).
+const CODESET: nl_item = 0;
+const D_T_FMT: nl_item = 1;
+const D_FMT: nl_item = 2;
+const T_FMT: nl_item = 3;
+const T_FMT_AMPM: nl_item = 4;
+const AM_STR: nl_item = 5;
+const PM_STR: nl_item = 6;
+const DAY_1: nl_item = 7;
+const DAY_7: nl_item = 13;
+const ABDAY_1: nl_item = 14;
+const ABDAY_7: nl_item = 20;
+const MON_1: nl_item = 21;
+const MON_12: nl_item = 32;
+const ABMON_1: nl_item = 33;
+const ABMON_12: nl_item = 44;
+const RADIXCHAR: nl_item = 45;
+const THOUSEP: nl_item = 46;
+const YESEXPR: nl_item = 47;
+const NOEXPR: nl_item = 48;
+const CRNCYSTR: nl_item = 49;
+
+//==================================================================================================
+// Locale Data (C/POSIX locale, UTF-8 codeset)
+//==================================================================================================
+
+static DAYS: [&[u8]; 7] = [
+    b"Sunday\0",
+    b"Monday\0",
+    b"Tuesday\0",
+    b"Wednesday\0",
+    b"Thursday\0",
+    b"Friday\0",
+    b"Saturday\0",
+];
+
+static ABDAYS: [&[u8]; 7] = [
+    b"Sun\0", b"Mon\0", b"Tue\0", b"Wed\0", b"Thu\0", b"Fri\0", b"Sat\0",
+];
+
+static MONTHS: [&[u8]; 12] = [
+    b"January\0",
+    b"February\0",
+    b"March\0",
+    b"April\0",
+    b"May\0",
+    b"June\0",
+    b"July\0",
+    b"August\0",
+    b"September\0",
+    b"October\0",
+    b"November\0",
+    b"December\0",
+];
+
+static ABMONTHS: [&[u8]; 12] = [
+    b"Jan\0", b"Feb\0", b"Mar\0", b"Apr\0", b"May\0", b"Jun\0", b"Jul\0", b"Aug\0", b"Sep\0",
+    b"Oct\0", b"Nov\0", b"Dec\0",
+];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns locale-specific information for the current (C/POSIX) locale.
+///
+/// # Parameters
+///
+/// - `item`: Identifier of the locale item to query, as an `nl_item`.
+///
+/// # Returns
+///
+/// A pointer to a null-terminated string describing `item`. Unrecognized items yield an empty
+/// string. The codeset is reported as UTF-8 to match the libc multibyte conversions.
+///
+/// # Safety
+///
+/// This function is safe for all input values. The returned pointer refers to static, read-only
+/// storage and the caller must not modify the pointed-to data.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn nl_langinfo(item: nl_item) -> *mut c_char {
+    let s: &'static [u8] = match item {
+        CODESET => b"UTF-8\0",
+        D_T_FMT => b"%a %b %e %H:%M:%S %Y\0",
+        D_FMT => b"%m/%d/%y\0",
+        T_FMT => b"%H:%M:%S\0",
+        T_FMT_AMPM => b"%I:%M:%S %p\0",
+        AM_STR => b"AM\0",
+        PM_STR => b"PM\0",
+        RADIXCHAR => b".\0",
+        THOUSEP => b"\0",
+        YESEXPR => b"^[yY]\0",
+        NOEXPR => b"^[nN]\0",
+        CRNCYSTR => b"\0",
+        DAY_1..=DAY_7 => index(&DAYS, item - DAY_1),
+        ABDAY_1..=ABDAY_7 => index(&ABDAYS, item - ABDAY_1),
+        MON_1..=MON_12 => index(&MONTHS, item - MON_1),
+        ABMON_1..=ABMON_12 => index(&ABMONTHS, item - ABMON_1),
+        _ => b"\0",
+    };
+    s.as_ptr() as *mut c_char
+}
+
+/// Returns the `idx`-th entry of `table`, or an empty string if `idx` is out of range.
+fn index(table: &'static [&'static [u8]], idx: nl_item) -> &'static [u8] {
+    match usize::try_from(idx) {
+        Ok(i) => match table.get(i) {
+            Some(entry) => entry,
+            None => b"\0",
+        },
+        Err(_) => b"\0",
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        nl_item,
+        nl_langinfo,
+    };
+    use ::sysapi::ffi::c_char;
+
+    // Item identifiers mirrored from the implementation for test readability.
+    const CODESET: nl_item = 0;
+    const D_FMT: nl_item = 2;
+    const RADIXCHAR: nl_item = 45;
+    const THOUSEP: nl_item = 46;
+    const DAY_1: nl_item = 7;
+    const DAY_7: nl_item = 13;
+    const ABDAY_1: nl_item = 14;
+    const MON_1: nl_item = 21;
+    const MON_12: nl_item = 32;
+    const ABMON_1: nl_item = 33;
+
+    /// Compares a C string returned by `nl_langinfo` against an expected byte slice (no NUL).
+    fn c_str_eq(ptr: *mut c_char, expected: &[u8]) -> bool {
+        assert!(!ptr.is_null());
+        for (i, &byte) in expected.iter().enumerate() {
+            let want: c_char = c_char::try_from(byte).expect("ASCII fits in c_char");
+            if unsafe { *ptr.add(i) } != want {
+                return false;
+            }
+        }
+        // The returned string must terminate right after the expected bytes.
+        unsafe { *ptr.add(expected.len()) == 0 }
+    }
+
+    #[test]
+    fn test_codeset_is_utf8() {
+        assert!(c_str_eq(nl_langinfo(CODESET), b"UTF-8"));
+    }
+
+    #[test]
+    fn test_date_format() {
+        assert!(c_str_eq(nl_langinfo(D_FMT), b"%m/%d/%y"));
+    }
+
+    #[test]
+    fn test_radixchar_and_thousep() {
+        assert!(c_str_eq(nl_langinfo(RADIXCHAR), b"."));
+        assert!(c_str_eq(nl_langinfo(THOUSEP), b""));
+    }
+
+    #[test]
+    fn test_day_names() {
+        assert!(c_str_eq(nl_langinfo(DAY_1), b"Sunday"));
+        assert!(c_str_eq(nl_langinfo(DAY_7), b"Saturday"));
+        assert!(c_str_eq(nl_langinfo(ABDAY_1), b"Sun"));
+    }
+
+    #[test]
+    fn test_month_names() {
+        assert!(c_str_eq(nl_langinfo(MON_1), b"January"));
+        assert!(c_str_eq(nl_langinfo(MON_12), b"December"));
+        assert!(c_str_eq(nl_langinfo(ABMON_1), b"Jan"));
+    }
+
+    #[test]
+    fn test_unknown_item_is_empty() {
+        assert!(c_str_eq(nl_langinfo(9999), b""));
+        assert!(c_str_eq(nl_langinfo(-1), b""));
+    }
+}

--- a/src/libs/libc_locale/Cargo.toml
+++ b/src/libs/libc_locale/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_locale"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_locale/header.toml
+++ b/src/libs/libc_locale/header.toml
@@ -1,0 +1,71 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for locale.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/locale.h.
+
+file = "locale.h"
+brief = "Localization."
+description = """
+Declares functions and types for locale-specific formatting. Only the
+C/POSIX locale is supported. Implemented by the libc_locale Rust crate."""
+includes = ["stddef.h"]
+guard = "_NANVIX_LOCALE_H"
+
+[[macros]]
+name = "LC_CTYPE"
+value = "0"
+
+[[macros]]
+name = "LC_NUMERIC"
+value = "1"
+
+[[macros]]
+name = "LC_TIME"
+value = "2"
+
+[[macros]]
+name = "LC_COLLATE"
+value = "3"
+
+[[macros]]
+name = "LC_MONETARY"
+value = "4"
+
+[[macros]]
+name = "LC_MESSAGES"
+value = "5"
+
+[[macros]]
+name = "LC_ALL"
+value = "6"
+
+[[types]]
+text = """
+/** @brief Locale-specific numeric formatting information. */
+struct lconv {
+    char *decimal_point;     /**< Decimal point character.            */
+    char *thousands_sep;     /**< Thousands separator.                */
+    char *grouping;          /**< Digit grouping.                     */
+    char *int_curr_symbol;   /**< International currency symbol.      */
+    char *currency_symbol;   /**< Local currency symbol.              */
+    char *mon_decimal_point; /**< Monetary decimal point.             */
+    char *mon_thousands_sep; /**< Monetary thousands separator.       */
+    char *mon_grouping;      /**< Monetary digit grouping.            */
+    char *positive_sign;     /**< Positive sign string.               */
+    char *negative_sign;     /**< Negative sign string.               */
+    char int_frac_digits;    /**< International fractional digits.    */
+    char frac_digits;        /**< Local fractional digits.            */
+    char p_cs_precedes;      /**< Currency symbol precedes positive.  */
+    char p_sep_by_space;     /**< Space separates symbol and positive.*/
+    char n_cs_precedes;      /**< Currency symbol precedes negative.  */
+    char n_sep_by_space;     /**< Space separates symbol and negative.*/
+    char p_sign_posn;        /**< Positive sign position.             */
+    char n_sign_posn;        /**< Negative sign position.             */
+};
+"""
+
+[[sections]]
+title = "Functions"
+functions = ["setlocale", "localeconv"]

--- a/src/libs/libc_locale/src/lib.rs
+++ b/src/libs/libc_locale/src/lib.rs
@@ -1,0 +1,34 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod localeconv;
+pub mod setlocale;

--- a/src/libs/libc_locale/src/localeconv.rs
+++ b/src/libs/libc_locale/src/localeconv.rs
@@ -1,0 +1,166 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Locale-specific numeric formatting information, as defined by POSIX.
+#[repr(C)]
+pub struct lconv {
+    /// Decimal-point character for non-monetary values.
+    pub decimal_point: *mut c_char,
+    /// Thousands separator for non-monetary values.
+    pub thousands_sep: *mut c_char,
+    /// Grouping sizes for non-monetary values (empty string means no grouping).
+    pub grouping: *mut c_char,
+    /// International currency symbol.
+    pub int_curr_symbol: *mut c_char,
+    /// Local currency symbol.
+    pub currency_symbol: *mut c_char,
+    /// Decimal-point character for monetary values.
+    pub mon_decimal_point: *mut c_char,
+    /// Thousands separator for monetary values.
+    pub mon_thousands_sep: *mut c_char,
+    /// Grouping sizes for monetary values.
+    pub mon_grouping: *mut c_char,
+    /// Positive sign for monetary values.
+    pub positive_sign: *mut c_char,
+    /// Negative sign for monetary values.
+    pub negative_sign: *mut c_char,
+    /// Number of fractional digits for international monetary values.
+    pub int_frac_digits: c_char,
+    /// Number of fractional digits for local monetary values.
+    pub frac_digits: c_char,
+    /// 1 if `currency_symbol` precedes a positive monetary value.
+    pub p_cs_precedes: c_char,
+    /// 1 if a space separates `currency_symbol` from a positive monetary value.
+    pub p_sep_by_space: c_char,
+    /// 1 if `currency_symbol` precedes a negative monetary value.
+    pub n_cs_precedes: c_char,
+    /// 1 if a space separates `currency_symbol` from a negative monetary value.
+    pub n_sep_by_space: c_char,
+    /// Positioning of positive sign for monetary values.
+    pub p_sign_posn: c_char,
+    /// Positioning of negative sign for monetary values.
+    pub n_sign_posn: c_char,
+}
+
+//==================================================================================================
+// Static Data
+//==================================================================================================
+
+/// Decimal-point string for the "C" locale.
+static DECIMAL_POINT: [u8; 2] = [b'.', 0];
+
+/// Empty string used for locale fields that have no value in the "C" locale.
+static EMPTY: [u8; 1] = [0];
+
+/// `CHAR_MAX` sentinel indicating "not available" for numeric locale fields.
+const CHAR_MAX: c_char = i8::MAX;
+
+/// Wrapper that makes the immutable `lconv` static shareable across threads.
+///
+/// `lconv` holds raw pointers and is therefore `!Sync`, but every pointer refers to read-only
+/// static data, so sharing the structure across threads is sound.
+struct SyncLconv(lconv);
+
+// SAFETY: every pointer in the wrapped `lconv` refers to immutable, read-only static data, so the
+// structure is safe to share across threads.
+unsafe impl Sync for SyncLconv {}
+
+/// Static `lconv` structure for the "C" locale with POSIX-defined defaults.
+static C_LCONV: SyncLconv = SyncLconv(lconv {
+    decimal_point: DECIMAL_POINT.as_ptr() as *mut c_char,
+    thousands_sep: EMPTY.as_ptr() as *mut c_char,
+    grouping: EMPTY.as_ptr() as *mut c_char,
+    int_curr_symbol: EMPTY.as_ptr() as *mut c_char,
+    currency_symbol: EMPTY.as_ptr() as *mut c_char,
+    mon_decimal_point: EMPTY.as_ptr() as *mut c_char,
+    mon_thousands_sep: EMPTY.as_ptr() as *mut c_char,
+    mon_grouping: EMPTY.as_ptr() as *mut c_char,
+    positive_sign: EMPTY.as_ptr() as *mut c_char,
+    negative_sign: EMPTY.as_ptr() as *mut c_char,
+    int_frac_digits: CHAR_MAX,
+    frac_digits: CHAR_MAX,
+    p_cs_precedes: CHAR_MAX,
+    p_sep_by_space: CHAR_MAX,
+    n_cs_precedes: CHAR_MAX,
+    n_sep_by_space: CHAR_MAX,
+    p_sign_posn: CHAR_MAX,
+    n_sign_posn: CHAR_MAX,
+});
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns a pointer to a `lconv` structure containing numeric and monetary formatting
+/// information for the current locale.
+///
+/// # Returns
+///
+/// A pointer to the static `lconv` structure describing the "C" locale. The structure is immutable
+/// and remains valid for the lifetime of the program.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn localeconv() -> *mut lconv {
+    core::ptr::addr_of!(C_LCONV.0).cast_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        lconv,
+        localeconv,
+    };
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn test_localeconv_returns_non_null() {
+        let ret: *mut lconv = localeconv();
+        assert!(!ret.is_null());
+    }
+
+    #[test]
+    fn test_localeconv_decimal_point() {
+        let lc: &lconv = unsafe { &*localeconv() };
+        assert!(!lc.decimal_point.is_null());
+        assert_eq!(
+            unsafe { *lc.decimal_point },
+            c_char::try_from(b'.').expect("should fit in c_char")
+        );
+    }
+
+    #[test]
+    fn test_localeconv_thousands_sep_empty() {
+        let lc: &lconv = unsafe { &*localeconv() };
+        assert!(!lc.thousands_sep.is_null());
+        assert_eq!(unsafe { *lc.thousands_sep }, 0);
+    }
+
+    #[test]
+    fn test_localeconv_frac_digits() {
+        let lc: &lconv = unsafe { &*localeconv() };
+        assert_eq!(lc.frac_digits, i8::MAX);
+    }
+}

--- a/src/libs/libc_locale/src/setlocale.rs
+++ b/src/libs/libc_locale/src/setlocale.rs
@@ -1,0 +1,208 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::sync::atomic::{
+    AtomicPtr,
+    Ordering,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Static string for the "C" locale name.
+static C_LOCALE: [u8; 2] = [b'C', 0];
+
+/// Static string for the "POSIX" locale name.
+static POSIX_LOCALE: [u8; 6] = [b'P', b'O', b'S', b'I', b'X', 0];
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Pointer to the name of the currently selected locale.
+///
+/// A null pointer denotes the default `"C"` locale, which is also the initial state.
+static CURRENT_LOCALE: AtomicPtr<c_char> = AtomicPtr::new(::core::ptr::null_mut());
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Compares a C string pointer against a byte slice (excluding the null terminator of the slice).
+///
+/// Returns `true` if the strings match.
+unsafe fn c_str_eq(s: *const c_char, expected: &[u8]) -> bool {
+    for (i, &byte) in expected.iter().enumerate() {
+        let current: c_char = *s.add(i);
+        // A NUL here means the C string is shorter than `expected`, so stop before reading past it.
+        if current == 0 || current != byte.cast_signed() {
+            return false;
+        }
+    }
+    // All expected bytes matched, so reading the terminator is in bounds: the C string ends here.
+    *s.add(expected.len()) == 0
+}
+
+/// Returns a pointer to the name of the currently selected locale.
+///
+/// Falls back to the `"C"` locale when no locale has been selected yet.
+fn current_locale() -> *mut c_char {
+    let current: *mut c_char = CURRENT_LOCALE.load(Ordering::Relaxed);
+    if current.is_null() {
+        C_LOCALE.as_ptr() as *mut c_char
+    } else {
+        current
+    }
+}
+
+///
+/// # Description
+///
+/// Sets the program's current locale. Only the `"C"`, `"POSIX"`, and `""` (empty string,
+/// meaning the default "C" locale) locales are supported.
+///
+/// # Parameters
+///
+/// - `_category`: The locale category to set (ignored; all categories use "C").
+/// - `locale`: Pointer to a null-terminated string naming the desired locale, or a null pointer
+///   to query the current locale.
+///
+/// # Returns
+///
+/// A pointer to a string identifying the current locale for the given category. Returns a null
+/// pointer if the requested locale is not supported.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `locale`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn setlocale(_category: c_int, locale: *const c_char) -> *mut c_char {
+    // Query: return the currently selected locale.
+    if locale.is_null() {
+        return current_locale();
+    }
+
+    // Empty string means use the default ("C") locale.
+    if *locale == 0 {
+        let name: *mut c_char = C_LOCALE.as_ptr() as *mut c_char;
+        CURRENT_LOCALE.store(name, Ordering::Relaxed);
+        return name;
+    }
+
+    // Accept "C".
+    if c_str_eq(locale, b"C") {
+        let name: *mut c_char = C_LOCALE.as_ptr() as *mut c_char;
+        CURRENT_LOCALE.store(name, Ordering::Relaxed);
+        return name;
+    }
+
+    // Accept "POSIX".
+    if c_str_eq(locale, b"POSIX") {
+        let name: *mut c_char = POSIX_LOCALE.as_ptr() as *mut c_char;
+        CURRENT_LOCALE.store(name, Ordering::Relaxed);
+        return name;
+    }
+
+    // Unsupported locale: leave the current locale unchanged.
+    core::ptr::null_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::setlocale;
+    use ::std::sync::{
+        Mutex,
+        MutexGuard,
+    };
+    use ::sysapi::ffi::c_char;
+
+    /// Serializes tests that observe the process-global current locale. They mutate and query the
+    /// shared `CURRENT_LOCALE`, so they must not run concurrently with one another.
+    static SETLOCALE_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Acquires the serialization guard, recovering from poisoning so that a failing test does not
+    /// cascade into unrelated ones.
+    fn guard() -> MutexGuard<'static, ()> {
+        SETLOCALE_GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn test_setlocale_null_query() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        // After selecting "C", a NULL query must report "C".
+        let c_str: [u8; 2] = [b'C', 0];
+        unsafe { setlocale(0, c_str.as_ptr().cast::<c_char>()) };
+        let ret: *mut c_char = unsafe { setlocale(0, core::ptr::null()) };
+        assert!(!ret.is_null());
+        // Should point to "C".
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'C').expect("should fit in c_char"));
+        assert_eq!(unsafe { *ret.add(1) }, 0);
+    }
+
+    #[test]
+    fn test_setlocale_empty_string() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        let empty: [u8; 1] = [0];
+        let ret: *mut c_char = unsafe { setlocale(0, empty.as_ptr().cast::<c_char>()) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'C').expect("should fit in c_char"));
+    }
+
+    #[test]
+    fn test_setlocale_c_locale() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        let c_str: [u8; 2] = [b'C', 0];
+        let ret: *mut c_char = unsafe { setlocale(0, c_str.as_ptr().cast::<c_char>()) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'C').expect("should fit in c_char"));
+    }
+
+    #[test]
+    fn test_setlocale_posix_locale() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        let posix: [u8; 6] = [b'P', b'O', b'S', b'I', b'X', 0];
+        let ret: *mut c_char = unsafe { setlocale(0, posix.as_ptr().cast::<c_char>()) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'P').expect("should fit in c_char"));
+    }
+
+    #[test]
+    fn test_setlocale_query_reflects_selection() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        // Selecting "POSIX" must be observable through a subsequent NULL query.
+        let posix: [u8; 6] = [b'P', b'O', b'S', b'I', b'X', 0];
+        unsafe { setlocale(0, posix.as_ptr().cast::<c_char>()) };
+        let ret: *mut c_char = unsafe { setlocale(0, core::ptr::null()) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'P').expect("should fit in c_char"));
+
+        // Switching back to "C" must likewise be observable.
+        let c_str: [u8; 2] = [b'C', 0];
+        unsafe { setlocale(0, c_str.as_ptr().cast::<c_char>()) };
+        let ret: *mut c_char = unsafe { setlocale(0, core::ptr::null()) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { *ret }, c_char::try_from(b'C').expect("should fit in c_char"));
+    }
+
+    #[test]
+    fn test_setlocale_unsupported() {
+        let _guard: MutexGuard<'static, ()> = guard();
+        let utf8: [u8; 6] = [b'e', b'n', b'_', b'U', b'S', 0];
+        let ret: *mut c_char = unsafe { setlocale(0, utf8.as_ptr().cast::<c_char>()) };
+        assert!(ret.is_null());
+    }
+}


### PR DESCRIPTION
Introduce two new no_std guest libc crates that provide POSIX
locale support limited to the C/POSIX locale:

- libc_locale: implements setlocale() and localeconv(), plus the
  lconv structure and LC_* category macros. setlocale() accepts
  "C", "POSIX", and "" (default), and localeconv() returns a static
  lconv populated with POSIX "C" locale defaults.

- libc_langinfo: implements nl_langinfo() and the nl_item constants,
  reporting UTF-8 as the codeset and providing C-locale date/time
  formats, day and month names, radix character, and yes/no
  expressions.

Each crate ships a header.toml consumed by gen-headers to emit
include/locale.h and include/langinfo.h, and includes unit tests
gated behind the std feature.

Register both crates in the workspace (Cargo.toml, Cargo.lock) and
add them to ALL_GUEST_RUST_LIBS and ALL_GUEST_RUST_LIBS_TEST_LIST
in the Makefile.
