### PR TITLE
[sys] Add fork-aware getpid() cache

### DIFF
--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -90,7 +90,7 @@ fn handle_ipc_request(message: Message) -> Result<bool, Error> {
 
 #[unsafe(no_mangle)]
 pub fn main() {
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
         Ok(pid) => pid,
         Err(e) => panic!("failed to get pid (error={:?})", e),
     };

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -56,7 +56,7 @@ use alloc::collections::{
 
 #[unsafe(no_mangle)]
 pub fn main() {
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
         Ok(pid) => pid,
         Err(e) => panic!("failed to get pid (error={:?})", e),
     };

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -176,7 +176,7 @@ impl ProcessDaemon {
     /// Initializes the process manager daemon.
     pub fn init() -> Result<Self, Error> {
         ::syslog::info!("running process manager daemon...");
-        let mypid: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
+        let mypid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
         assert_eq!(mypid, ProcessIdentifier::PROCD, "process daemon has unexpected pid");
 
         // Acquire process management capabilities.

--- a/src/libs/proc/src/syscall/lookup.rs
+++ b/src/libs/proc/src/syscall/lookup.rs
@@ -45,7 +45,7 @@ use ::sys::{
 ///
 pub fn lookup(name: &str) -> Result<ProcessIdentifier, Error> {
     // FIXME: this should not be required.
-    let mypid: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
+    let mypid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
 
     // Build lookup message and send it.
     let message: Message = message::lookup_request(name, mypid)?;

--- a/src/libs/proc/src/syscall/wait.rs
+++ b/src/libs/proc/src/syscall/wait.rs
@@ -69,7 +69,7 @@ pub enum WaitOutcome {
 ///
 pub fn wait(target: WaitTarget, options: i32) -> Result<WaitOutcome, Error> {
     // Retrieve process identifier of the calling process.
-    let caller: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
+    let caller: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
 
     // Build wait message and send it.
     let message: Message = message::wait_request(caller, target, options)?;

--- a/src/libs/sys/src/sys/kcall/fork.rs
+++ b/src/libs/sys/src/sys/kcall/fork.rs
@@ -113,6 +113,12 @@ pub fn __kcall_fork() -> Result<ProcessIdentifier, Error> {
         // Child path. The fork stack was never touched (the child runs on its private copy of the
         // parent's stack), and the shared static storage requires no cleanup, so simply report a
         // process identifier of zero to the caller.
+        //
+        // Invalidate the cached process identifier first: the child inherited the parent's cached
+        // pid through the duplicated address space, so it must be dropped here — the single,
+        // lowest-level choke point common to every fork caller — before any code resolves the
+        // identity of the freshly created child.
+        crate::kcall::pm::invalidate_cached_pid();
         return Ok(ProcessIdentifier::from(0));
     }
 

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -30,6 +30,10 @@ use crate::{
 };
 use ::core::{
     hint::unlikely,
+    sync::atomic::{
+        AtomicI32,
+        Ordering,
+    },
     time::Duration,
 };
 
@@ -37,18 +41,34 @@ use ::core::{
 // Get Process Identifier
 //==================================================================================================
 
+/// Sentinel stored in [`CACHED_PID`] meaning "not yet cached". Every valid process identifier is
+/// non-negative, so a negative value can never be mistaken for a real pid.
+const PID_UNCACHED: i32 = -1;
+
+/// Process-global cache of the calling process's identifier.
+///
+/// `getpid()` is invariant for the lifetime of a process and identical across all of its threads
+/// (the kernel resolves it per process, not per thread), so it can be memoized to avoid a kernel
+/// transition on every query. The cache lives in the process address space and is therefore
+/// duplicated into a child by `fork()`; the child half of `__kcall_fork()` invalidates it (see
+/// [`invalidate_cached_pid`]) so the child re-queries its own identity rather than reusing the
+/// parent's.
+static CACHED_PID: AtomicI32 = AtomicI32::new(PID_UNCACHED);
+
 ///
 /// # Description
 ///
-/// Gets the process identifier of the calling process.
+/// Issues the raw `getpid()` kernel call, bypassing the cache.
+///
+/// This is the private primitive shared by the public [`getpid`] (cached) and [`getpid_uncached`]
+/// (uncached) wrappers. It always incurs a kernel transition.
 ///
 /// # Returns
 ///
 /// Upon successful completion, the process identifier of the calling process is returned. Upon
 /// failure, an error is returned instead.
 ///
-#[unsafe(no_mangle)]
-pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
+fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetPid.into());
 
     // NOTE: errors are unlikely because getpid() always succeeds for a valid calling process.
@@ -57,6 +77,74 @@ pub fn __kcall_getpid() -> Result<ProcessIdentifier, Error> {
     } else {
         ProcessIdentifier::try_from(result)
     }
+}
+
+///
+/// # Description
+///
+/// Gets the process identifier of the calling process, serving a memoized value when available.
+///
+/// The kernel is queried only on the first call per process image; subsequent calls return the
+/// cached value without a kernel transition. The cache is invalidated by the child half of
+/// `fork()`, so the returned identifier always reflects the *current* process even after a fork.
+/// This is the preferred way to obtain the calling process's identifier.
+///
+/// # Returns
+///
+/// Upon successful completion, the process identifier of the calling process is returned. Upon
+/// failure, an error is returned instead.
+///
+pub fn getpid() -> Result<ProcessIdentifier, Error> {
+    // Fast path: return the memoized identifier without a kernel transition.
+    let cached: i32 = CACHED_PID.load(Ordering::Relaxed);
+    if cached != PID_UNCACHED {
+        return Ok(ProcessIdentifier::from(cached));
+    }
+
+    // Cold path: query the kernel once and memoize the result. Concurrent threads of the same
+    // process all resolve to the same identifier, so a benign race that stores it twice is
+    // harmless.
+    let pid: ProcessIdentifier = __kcall_getpid()?;
+    CACHED_PID.store(pid.into(), Ordering::Relaxed);
+    Ok(pid)
+}
+
+///
+/// # Description
+///
+/// Gets the process identifier of the calling process by always querying the kernel, bypassing the
+/// cache.
+///
+/// Prefer [`getpid`] in production code. This uncached variant exists for low-level callers that
+/// must observe the kernel's current identity directly — most notably code that creates children
+/// through the raw `__kcall_duplicate()` primitive, which does not pass through the cache
+/// invalidation performed by the child half of `__kcall_fork()` and therefore cannot rely on the
+/// cached value being fresh in the child.
+///
+/// # Returns
+///
+/// Upon successful completion, the process identifier of the calling process is returned. Upon
+/// failure, an error is returned instead.
+///
+pub fn getpid_uncached() -> Result<ProcessIdentifier, Error> {
+    __kcall_getpid()
+}
+
+///
+/// # Description
+///
+/// Invalidates the cached process identifier so that the next [`getpid`] call re-queries the
+/// kernel.
+///
+/// The child half of `__kcall_fork()` invokes this automatically. Callers that create a child
+/// through the raw `__kcall_duplicate()` primitive instead — which has no in-child choke point —
+/// must invoke it themselves as the child's first action; otherwise the child inherits the parent's
+/// cached identifier through the duplicated address space and would issue kernel calls under the
+/// parent's identity. A process's identifier is otherwise stable for its whole lifetime, so no
+/// other caller needs this.
+///
+pub fn invalidate_cached_pid() {
+    CACHED_PID.store(PID_UNCACHED, Ordering::Relaxed);
 }
 
 //==================================================================================================

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -28,13 +28,11 @@ use ::sys::{
         Error,
         ErrorCode,
     },
-    kcall,
     mm::{
         self,
         Address,
         VirtualAddress,
     },
-    pm::ProcessIdentifier,
 };
 use ::talc::*;
 
@@ -61,13 +59,8 @@ struct NanvixOomHandler {
 }
 
 impl NanvixOomHandler {
-    fn new(
-        pid: ProcessIdentifier,
-        base: VirtualAddress,
-        size: usize,
-        capacity: usize,
-    ) -> Result<Talc<Self>, Error> {
-        let heap: Heap = Heap::new(pid, base, size, capacity)?;
+    fn new(base: VirtualAddress, size: usize, capacity: usize) -> Result<Talc<Self>, Error> {
+        let heap: Heap = Heap::new(base, size, capacity)?;
 
         let oom_handler: NanvixOomHandler = Self { heap, span: None };
 
@@ -215,8 +208,6 @@ impl OomHandler for NanvixOomHandler {
 ///
 #[allow(static_mut_refs)]
 pub fn init(base: VirtualAddress, capacity: usize) -> Result<(), Error> {
-    let pid: ProcessIdentifier = kcall::pm::__kcall_getpid()?;
-
     let size: usize = PAGE_SIZE;
 
     let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
@@ -225,7 +216,7 @@ pub fn init(base: VirtualAddress, capacity: usize) -> Result<(), Error> {
         return Err(Error::new(ErrorCode::ResourceBusy, "heap already initialized"));
     }
 
-    *locked_heap = Some(NanvixOomHandler::new(pid, base, size, capacity)?);
+    *locked_heap = Some(NanvixOomHandler::new(base, size, capacity)?);
 
     Ok(())
 }

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -29,19 +29,13 @@ use ::sys::{
 //==================================================================================================
 
 pub struct Heap {
-    pid: ProcessIdentifier,
     base: VirtualAddress,
     size: usize,
     capacity: usize,
 }
 
 impl Heap {
-    pub fn new(
-        pid: ProcessIdentifier,
-        base: VirtualAddress,
-        size: usize,
-        capacity: usize,
-    ) -> Result<Self, Error> {
+    pub fn new(base: VirtualAddress, size: usize, capacity: usize) -> Result<Self, Error> {
         ::syslog::trace!("new(): base={:X?}, size={:X?}, capacity={:X?}", base, size, capacity);
 
         // Check if base address is page-aligned.
@@ -69,12 +63,16 @@ impl Heap {
         }
 
         // Map initial pages.
+        //
+        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
+        // transition and is invalidated in the child after fork(), so mapping always targets the
+        // current process rather than the parent this heap may have been inherited from.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
         let start: VirtualAddress = base;
         let end: VirtualAddress = VirtualAddress::from_raw_value(base.into_raw_value() + size);
         map_range(pid, start, end)?;
 
         Ok(Self {
-            pid,
             base,
             size,
             capacity,
@@ -120,9 +118,14 @@ impl Heap {
         }
 
         // Map pages.
+        //
+        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
+        // transition and is invalidated in the child after fork(), so mapping always targets the
+        // current process rather than the parent this heap may have been inherited from.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
         let end: VirtualAddress = self.base + self.size;
         let new_end: VirtualAddress = end + increment;
-        map_range(self.pid, end, new_end)?;
+        map_range(pid, end, new_end)?;
 
         // Update metadata.
         self.size += increment;
@@ -158,6 +161,11 @@ impl Heap {
             return Ok(());
         }
 
+        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
+        // transition and is invalidated in the child after fork(), so unmapping always targets the
+        // current process rather than the parent this heap may have been inherited from.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+
         // Unmap tail pages from the end backwards, stopping at the first failure so that
         // self.size always reflects the actual contiguous mapped extent.
         let base_raw: usize = self.base.into_raw_value();
@@ -166,7 +174,7 @@ impl Heap {
 
         for page in (new_end..old_end).step_by(mem::PAGE_SIZE).rev() {
             let page_addr: VirtualAddress = VirtualAddress::from_raw_value(page);
-            if let Err(error) = kcall::mm::__kcall_munmap(self.pid, page_addr) {
+            if let Err(error) = kcall::mm::__kcall_munmap(pid, page_addr) {
                 ::syslog::warn!(
                     "shrink(): failed to unmap page at {:X?}, stopping (error={:?})",
                     page_addr,
@@ -274,9 +282,19 @@ impl Drop for Heap {
             self.capacity
         );
 
+        // Resolve the owning pid through the fork-aware cache; see grow() for rationale. Drop
+        // cannot propagate errors, so skip unmapping if the pid cannot be determined.
+        let pid: ProcessIdentifier = match kcall::pm::getpid() {
+            Ok(pid) => pid,
+            Err(_error) => {
+                ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);
+                return;
+            },
+        };
+
         // Unmap pages.
         if let Err(_error) = unmap_range(
-            self.pid,
+            pid,
             self.base,
             VirtualAddress::from_raw_value(self.base.into_raw_value() + self.size),
         ) {

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -42,8 +42,6 @@ use ::sys::{
 ///
 #[derive(Debug)]
 pub struct MemorySegment {
-    /// Identifier of the process that owns the segment.
-    pid: ProcessIdentifier,
     /// Base address.
     base: VirtualAddress,
     /// Capacity of the segment.
@@ -100,7 +98,11 @@ impl MemorySegment {
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
-        let pid: ProcessIdentifier = kcall::pm::__kcall_getpid()?;
+        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
+        // transition and is invalidated in the child after fork(). Segments live in a
+        // process-global map that a child inherits across fork(), so mapping must always target
+        // the current process; a kcall with a foreign pid trips the kernel's capability check.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
 
         map_range(
             pid,
@@ -109,11 +111,7 @@ impl MemorySegment {
             access,
         )?;
 
-        Ok(MemorySegment {
-            pid,
-            base,
-            capacity,
-        })
+        Ok(MemorySegment { base, capacity })
     }
 
     ///
@@ -211,8 +209,14 @@ impl MemorySegment {
             prot
         );
 
+        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
+        // transition and is invalidated in the child after fork(). Segments live in a
+        // process-global map that a child inherits across fork(), so this must always target the
+        // current process; a kcall with a foreign pid trips the kernel's capability check.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+
         protect_range(
-            self.pid,
+            pid,
             self.base,
             VirtualAddress::from_raw_value(self.base.into_raw_value() + self.capacity),
             prot,
@@ -224,9 +228,20 @@ impl Drop for MemorySegment {
     fn drop(&mut self) {
         ::syslog::trace!("drop(): base={:X?}, capacity={:X?}", self.base, self.capacity);
 
+        // Resolve the owning pid through the fork-aware cache; see set_protection() for
+        // rationale. Drop cannot propagate errors, so skip unmapping if the pid cannot be
+        // determined.
+        let pid: ProcessIdentifier = match kcall::pm::getpid() {
+            Ok(pid) => pid,
+            Err(_error) => {
+                ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);
+                return;
+            },
+        };
+
         // Unmap pages.
         if let Err(_error) = unmap_range(
-            self.pid,
+            pid,
             self.base,
             VirtualAddress::from_raw_value(self.base.into_raw_value() + self.capacity),
         ) {

--- a/src/libs/syscall/src/unistd/fork/mod.rs
+++ b/src/libs/syscall/src/unistd/fork/mod.rs
@@ -80,7 +80,7 @@ fn map_duplicate_error(code: ErrorCode) -> ErrorCode {
 fn sync_parent_after_fork(child: ProcessIdentifier) -> Result<(), Error> {
     // The request must carry the parent's own identity as its source so that the daemon knows which
     // process to release alongside the child.
-    let parent: ProcessIdentifier = ::sys::kcall::pm::__kcall_getpid()?;
+    let parent: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
     let request: Message = fork_sync_request(parent, child)?;
     if let Err(error) = ::sys::kcall::ipc::__kcall_send(&request) {
         ::syslog::error!("sync_parent_after_fork(): failed to send fork-sync request: {error:?}");

--- a/src/libs/syscall/src/unistd/syscall/getpid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getpid.rs
@@ -20,5 +20,5 @@ use ::sys::{
 /// `getpid()` returns the process ID (PID) of the calling process.
 ///
 pub fn getpid() -> Result<ProcessIdentifier, Error> {
-    ::sys::kcall::pm::__kcall_getpid()
+    ::sys::kcall::pm::getpid()
 }

--- a/src/tests/setenv-rust/src/tests/fork.rs
+++ b/src/tests/setenv-rust/src/tests/fork.rs
@@ -206,7 +206,7 @@ fn test_child_mutations_isolated() -> Result<(), Error> {
 
 /// Verifies that a parent's mutations after `fork()` are not visible to the child.
 fn test_parent_mutations_isolated() -> Result<(), Error> {
-    let parent: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent: ProcessIdentifier = pm::getpid_uncached()?;
     assert!(
         do_setenv(b"FORK_PMOD\0", b"original\0", OVERWRITE) == 0,
         "setenv() failed before fork()"

--- a/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
+++ b/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
@@ -23,7 +23,7 @@ use ::sys::{
             __kcall_mprotect,
             __kcall_munmap,
         },
-        pm::__kcall_getpid,
+        pm::getpid_uncached,
     },
     mm::{
         AccessPermission,
@@ -59,7 +59,7 @@ const MMAP_STRESS_STRIDE_BYTES: usize = 4 * KILOBYTE;
 pub fn run() -> Result<(), StressError> {
     let mut cap_guard: CapabilityGuard = CapabilityGuard::enable(Capability::MemoryManagement)?;
 
-    let pid: ProcessIdentifier = __kcall_getpid()?;
+    let pid: ProcessIdentifier = getpid_uncached()?;
 
     // Reserve address space from the unified bump allocator so we don't conflict with the heap
     // region.

--- a/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
@@ -36,8 +36,8 @@ use ::sys::{
         },
         pm::{
             __kcall_create_thread,
-            __kcall_getpid,
             __kcall_join_thread,
+            getpid_uncached,
         },
         sched::__kcall_sched_yield,
     },
@@ -196,7 +196,7 @@ extern "C" fn scoreboard_pressure_worker(worker_id: usize) -> usize {
 /// Propagates failures from kernel calls or address calculations.
 ///
 fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
-    let pid: ProcessIdentifier = __kcall_getpid()?;
+    let pid: ProcessIdentifier = getpid_uncached()?;
     let region_base: usize = worker_region_base(worker_id)?;
 
     for iteration in 0..SCOREBOARD_PRESSURE_ITERATIONS {

--- a/src/tests/stress-rust/src/tests/thread_identity.rs
+++ b/src/tests/stress-rust/src/tests/thread_identity.rs
@@ -26,9 +26,9 @@ use ::sys::{
     },
     kcall::pm::{
         __kcall_create_thread,
-        __kcall_getpid,
         __kcall_gettid,
         __kcall_join_thread,
+        getpid_uncached,
     },
     pm::{
         ProcessIdentifier,
@@ -70,7 +70,7 @@ pub fn run() -> Result<(), StressError> {
     THREAD_IDENTITY_PID.store(0, Ordering::Relaxed);
     THREAD_IDENTITY_TID.store(0, Ordering::Relaxed);
 
-    let main_pid: ProcessIdentifier = __kcall_getpid()?;
+    let main_pid: ProcessIdentifier = getpid_uncached()?;
     let main_tid: ThreadIdentifier = __kcall_gettid()?;
 
     let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
@@ -146,7 +146,7 @@ extern "C" fn thread_identity_worker(_: usize) -> usize {
 ///
 /// `Ok(tag)` on success where `tag` encodes the identity completion marker.
 fn thread_identity_worker_impl() -> Result<usize, Error> {
-    let pid: ProcessIdentifier = __kcall_getpid()?;
+    let pid: ProcessIdentifier = getpid_uncached()?;
     let tid: ThreadIdentifier = __kcall_gettid()?;
 
     THREAD_IDENTITY_PID.store(usize::try_from(pid)?, Ordering::Release);

--- a/src/tests/test-fork-guestfs/src/tests/fork_fds.rs
+++ b/src/tests/test-fork-guestfs/src/tests/fork_fds.rs
@@ -217,7 +217,7 @@ fn run_child(parent_pid: ProcessIdentifier, my_pid: ProcessIdentifier) -> Result
 
 /// Runs the descriptor-inheritance and shared-offset scenario.
 fn test_fork_descriptor_inheritance() -> Result<(), Error> {
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Open the fixture read-only. The descriptor is allocated in the parent's table inside vfsd.
     let fd: c_int = fcntl::open(FIXTURE_PATH, RegularFileOpenFlags::read_only().into(), 0)?;
@@ -239,7 +239,7 @@ fn test_fork_descriptor_inheritance() -> Result<(), Error> {
 
     // Child: perform its checks and terminate without returning to the shared flow.
     if child_pid == ProcessIdentifier::from(0) {
-        let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
             Ok(pid) => pid,
             Err(_) => pm::__kcall_exit(CHILD_EXIT_FAIL)?,
         };

--- a/src/tests/test-fork-hostfs/src/tests/fork_hostfs.rs
+++ b/src/tests/test-fork-hostfs/src/tests/fork_hostfs.rs
@@ -225,7 +225,7 @@ fn run_child(parent_pid: ProcessIdentifier, my_pid: ProcessIdentifier) -> Result
 
 /// Runs the descriptor-inheritance and shared-offset scenario over the host filesystem.
 fn test_fork_hostfs_descriptor_inheritance() -> Result<(), Error> {
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Attach the host filesystem at /mnt so the fixture is reachable from the guest. The mount is
     // VFS-global, so the child forked below observes it without remounting.
@@ -252,7 +252,7 @@ fn test_fork_hostfs_descriptor_inheritance() -> Result<(), Error> {
 
     // Child: perform its checks and terminate without returning to the shared flow.
     if child_pid == ProcessIdentifier::from(0) {
-        let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+        let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
             Ok(pid) => pid,
             Err(_) => pm::__kcall_exit(CHILD_EXIT_FAIL)?,
         };

--- a/src/tests/test-fork-kcall/src/tests/fork.rs
+++ b/src/tests/test-fork-kcall/src/tests/fork.rs
@@ -93,7 +93,7 @@ static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
 /// 3. Writes [`PATTERN_CHILD`] to [`SHARED_BYTE`], taking a private copy of the page.
 /// 4. Queries `getppid()` and reports both the observed byte and the parent PID to the parent.
 fn run_child(parent_pid: ProcessIdentifier) -> Result<(), Error> {
-    let my_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Barrier: block until the parent signals that its post-fork write has completed.
     ipc::__kcall_recv()?;
@@ -130,7 +130,7 @@ fn run_child(parent_pid: ProcessIdentifier) -> Result<(), Error> {
 
 /// Runs the fork copy-on-write and lineage scenario.
 fn test_fork_cow_and_lineage() -> Result<(), Error> {
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
     PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
 
     // Prime the shared byte with the pre-fork pattern.
@@ -218,6 +218,99 @@ fn test_fork_cow_and_lineage() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Process-Identifier Cache Invalidation
+//==================================================================================================
+
+/// Reports the child's cached process identifier to the parent over IPC.
+///
+/// The child resolves its identifier through [`pm::getpid`] — which, if the cache were not
+/// invalidated after `fork()`, would still hold the parent's identifier inherited through the
+/// duplicated address space. The message is sent under the child's *real* identifier (so the
+/// kernel's source-spoofing check accepts it), carrying the cached value in the payload so the
+/// parent can compare it against the child's actual pid.
+fn report_cached_pid(parent: ProcessIdentifier) -> Result<(), Error> {
+    let real_pid: ProcessIdentifier = pm::getpid_uncached()?;
+    let cached_pid: ProcessIdentifier = pm::getpid()?;
+
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    payload[0..4].copy_from_slice(&i32::from(cached_pid).to_le_bytes());
+    let reply: Message = Message::new(
+        MessageSender::from(real_pid),
+        MessageReceiver::from(parent),
+        MessageType::Ipc,
+        None,
+        payload,
+    );
+    ipc::__kcall_send(&reply)?;
+
+    Ok(())
+}
+
+/// Verifies that the cached process identifier is invalidated in the child after `fork()`.
+///
+/// The parent primes the cache with its own identifier before forking. With the cache correctly
+/// invalidated in the child half of `fork()`, the child's [`pm::getpid`] must resolve to the
+/// child's own identifier — the very value the parent observed as the `fork()` return — rather than
+/// the parent's stale identifier. A regression that drops the invalidation makes the child report
+/// the parent's pid, turning this into a deterministic failure.
+fn test_fork_pid_cache_invalidation() -> Result<(), Error> {
+    // Prime the cache with the parent's identifier so a missing invalidation surfaces as the child
+    // reporting the parent's value.
+    let parent_pid: ProcessIdentifier = pm::getpid()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Fork the calling process. Both processes resume execution at this point.
+    let child_pid: ProcessIdentifier = fork::__kcall_fork()?;
+
+    if child_pid == ProcessIdentifier::from(0) {
+        let parent: ProcessIdentifier =
+            match ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER)) {
+                Ok(pid) => pid,
+                // The freshly forked child is at a safe point to terminate; it holds no locks or
+                // resources that require explicit cleanup.
+                Err(_) => pm::__kcall_exit(CHILD_EXIT_FAIL)?,
+            };
+        let status: i32 = match report_cached_pid(parent) {
+            Ok(()) => CHILD_EXIT_OK,
+            Err(_) => CHILD_EXIT_FAIL,
+        };
+        // The child terminates here and never returns.
+        pm::__kcall_exit(status)?;
+    }
+
+    // Parent: a process identifier of zero would indicate the child path; reaching here means this
+    // is the parent.
+    assert!(child_pid != parent_pid, "child PID must differ from parent PID");
+
+    // Receive the child's report and recover the identifier it resolved through the cache.
+    let reply: Message = ipc::__kcall_recv()?;
+    assert!(reply.message_type == MessageType::Ipc, "expected IPC reply from child");
+    let child_cached_raw: i32 = i32::from_le_bytes([
+        reply.payload[0],
+        reply.payload[1],
+        reply.payload[2],
+        reply.payload[3],
+    ]);
+
+    // The child's cached identifier must equal its own pid (the fork() return observed here), which
+    // is only possible if the cache was invalidated and re-queried in the child.
+    assert!(
+        child_cached_raw == i32::from(child_pid),
+        "child getpid() returned {}; expected child pid {} (cache not invalidated after fork)",
+        child_cached_raw,
+        i32::from(child_pid)
+    );
+    // And it must not be the parent's stale identifier.
+    assert!(
+        child_cached_raw != i32::from(parent_pid),
+        "child getpid() returned the parent's pid {} (stale cache inherited across fork)",
+        i32::from(parent_pid)
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
 // Public Entry Point
 //==================================================================================================
 
@@ -226,5 +319,7 @@ pub fn run() -> Result<(), Error> {
     ::syslog::info!("test-fork-kcall: starting fork() regression tests");
     test_fork_cow_and_lineage()?;
     ::syslog::info!("test-fork-kcall: PASS - fork_cow_and_lineage");
+    test_fork_pid_cache_invalidation()?;
+    ::syslog::info!("test-fork-kcall: PASS - fork_pid_cache_invalidation");
     Ok(())
 }

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -99,8 +99,12 @@ static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
 /// 4. Reports both observed values to the parent via IPC.
 /// 5. Spins until the parent terminates it.
 extern "C" fn child_entry(_arg: usize) -> usize {
+    // Drop the parent's cached pid inherited through the duplicated address space. Unlike fork(),
+    // the raw duplicate() primitive has no in-child choke point, so the child invalidates here.
+    pm::invalidate_cached_pid();
+
     // Recover identifiers.
-    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+    let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
         Ok(p) => p,
         Err(_) => return 1,
     };
@@ -152,7 +156,7 @@ extern "C" fn child_entry(_arg: usize) -> usize {
 /// Runs the duplicate/CoW correctness scenario described in the module docstring.
 fn test_duplicate_cow() -> Result<(), Error> {
     // Record the parent's PID where the child can find it via CoW-shared memory.
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
     PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
 
     // Prime the shared byte with the pre-duplicate pattern.
@@ -287,7 +291,7 @@ fn test_duplicate_cow() -> Result<(), Error> {
 /// replies, so the parent's `recv()` never returns and the test fails by timing out.
 fn test_duplicate_cow_refork() -> Result<(), Error> {
     // Record the parent's PID where the children can find it via CoW-shared memory.
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
     PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
 
     // Prime the shared byte with the pre-duplicate pattern while the page is still private.

--- a/src/tests/test-kernel/src/getppid.rs
+++ b/src/tests/test-kernel/src/getppid.rs
@@ -95,8 +95,12 @@ static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
 /// 3. Calls `getppid()` and reports the raw result back to the parent via IPC.
 /// 4. Spins until the parent terminates it.
 extern "C" fn child_entry(_arg: usize) -> usize {
+    // Drop the parent's cached pid inherited through the duplicated address space. Unlike fork(),
+    // the raw duplicate() primitive has no in-child choke point, so the child invalidates here.
+    pm::invalidate_cached_pid();
+
     // Recover identifiers.
-    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+    let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
         Ok(p) => p,
         Err(_) => return CHILD_ERR_GETPID,
     };
@@ -149,7 +153,7 @@ extern "C" fn child_entry(_arg: usize) -> usize {
 /// through the `getppid()` kernel call.
 fn test_getppid_reports_parent() -> Result<(), Error> {
     // Record the parent's PID where the child can find it via CoW-shared memory.
-    let parent_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
     PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
 
     // Allocate a page-aligned stack for the child's main thread.

--- a/src/tests/test-kernel/src/rendezvous.rs
+++ b/src/tests/test-kernel/src/rendezvous.rs
@@ -168,7 +168,7 @@ fn join_child_thread(tid: ThreadIdentifier) -> Result<(), Error> {
 /// A tuple of (pid, main_tid).
 ///
 fn store_caller_ids() -> Result<(ProcessIdentifier, ThreadIdentifier), Error> {
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
 
@@ -766,7 +766,7 @@ fn test_multi_round() -> Result<(), Error> {
 fn test_self_push_rejected() -> Result<(), Error> {
     ::syslog::info!("test_self_push_rejected: starting");
 
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
     let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
     let payload: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
@@ -804,7 +804,7 @@ fn test_self_push_rejected() -> Result<(), Error> {
 fn test_self_pull_rejected() -> Result<(), Error> {
     ::syslog::info!("test_self_pull_rejected: starting");
 
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
     let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
     let mut recv_buf: [u8; 4] = [0u8; 4];
@@ -877,7 +877,7 @@ fn test_reverse_direction() -> Result<(), Error> {
     let child_tid: ThreadIdentifier = spawn_child_thread(puller_thread_reverse, stack_base)?;
 
     // Retrieve our own PID for the push call.
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Push data to the child thread.
     ipc::__kcall_push(pid, child_tid, &TEST_PAYLOAD_16)?;
@@ -1443,7 +1443,7 @@ fn test_independent_pairs() -> Result<(), Error> {
 
     ::syslog::info!("test_independent_pairs: starting (pairs={})", NUM_PAIRS);
 
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
     TRANSFER_SIZE.store(TRANSFER as u32, ORDER);
@@ -1824,7 +1824,7 @@ fn test_reverse_asymmetric() -> Result<(), Error> {
     let child_tid: ThreadIdentifier =
         spawn_child_thread(puller_thread_reverse_asymmetric, stack_base)?;
 
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Push only 4 bytes to the child that expects up to 16.
     let payload: [u8; 4] = [0xA1, 0xB2, 0xC3, 0xD4];
@@ -2194,7 +2194,7 @@ fn test_stress_concurrent_pairs() -> Result<(), Error> {
         TRANSFER
     );
 
-    let pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let pid: ProcessIdentifier = pm::getpid_uncached()?;
     let pid_raw: u32 = u32::try_from(pid)?;
     SELF_PID.store(pid_raw, ORDER);
     TRANSFER_SIZE.store(TRANSFER as u32, ORDER);

--- a/src/tests/test-kernel/src/source_spoofing.rs
+++ b/src/tests/test-kernel/src/source_spoofing.rs
@@ -54,7 +54,7 @@ use ::sys::{
 /// (negative) TID-encoded identity, so the kernel must reject the send with
 /// [`ErrorCode::OperationNotPermitted`] instead of delivering the forged message.
 fn test_reject_spoofed_source() -> Result<(), Error> {
-    let my_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Impersonate a privileged daemon other than ourselves. In the test-kernel environment this
     // process runs as PROCD, so forge VFSD; if it ever runs as VFSD, forge PROCD instead. Either
@@ -96,7 +96,7 @@ fn test_reject_spoofed_source() -> Result<(), Error> {
 /// Verifies that a send carrying the caller's legitimate PID-encoded source still succeeds and is
 /// delivered intact, ensuring the spoof rejection does not reject well-formed messages.
 fn test_allow_legitimate_source() -> Result<(), Error> {
-    let my_pid: ProcessIdentifier = pm::__kcall_getpid()?;
+    let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // A message from ourselves to ourselves carries a legitimate source and must be accepted.
     const PAYLOAD_MARKER: u8 = 0xA5;

--- a/src/tests/testd/src/main.rs
+++ b/src/tests/testd/src/main.rs
@@ -60,7 +60,7 @@ pub fn main() {
     event::test();
     mm::test();
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(e) => panic!("failed to get process identifier (error={:?})", e),
     };

--- a/src/tests/testd/src/mm/mod.rs
+++ b/src/tests/testd/src/mm/mod.rs
@@ -54,7 +54,7 @@ fn test_mmap_munmap() -> bool {
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -98,7 +98,7 @@ fn test_mmap_write_munmap() -> bool {
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -158,7 +158,7 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -204,7 +204,7 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
         _ => return false,
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -252,7 +252,7 @@ fn test_mmap_munmap_return_zeros() -> bool {
         return false;
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };
@@ -325,7 +325,7 @@ fn test_mmap_multi_page() -> bool {
         return false;
     }
 
-    let mypid: ProcessIdentifier = match ::sys::kcall::pm::__kcall_getpid() {
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };

--- a/src/tests/testd/src/pm/duplicate_burst.rs
+++ b/src/tests/testd/src/pm/duplicate_burst.rs
@@ -107,6 +107,9 @@ fn spin() -> ! {
 /// whole burst (`duplicate()` refuses a caller that owns special resources such as a non-empty
 /// mailbox). It simply spins, yielding the processor, until the parent terminates it.
 extern "C" fn burst_child_entry(_arg: usize) -> usize {
+    // Drop the parent's cached pid inherited through the duplicated address space. Unlike fork(),
+    // the raw duplicate() primitive has no in-child choke point, so the child invalidates here.
+    pm::invalidate_cached_pid();
     spin()
 }
 
@@ -125,7 +128,7 @@ extern "C" fn burst_child_entry(_arg: usize) -> usize {
 /// If the test passed, `true` is returned. Otherwise, `false` is returned instead.
 ///
 fn test_duplicate_burst() -> bool {
-    let parent_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+    let parent_pid: ProcessIdentifier = match pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };

--- a/src/tests/testd/src/pm/terminate.rs
+++ b/src/tests/testd/src/pm/terminate.rs
@@ -99,7 +99,11 @@ fn spin() -> ! {
 /// the parent to prove that it was created and actually executed, then spins until the parent
 /// terminates it.
 extern "C" fn terminate_child_entry(_arg: usize) -> usize {
-    let my_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+    // Drop the parent's cached pid inherited through the duplicated address space. Unlike fork(),
+    // the raw duplicate() primitive has no in-child choke point, so the child invalidates here.
+    pm::invalidate_cached_pid();
+
+    let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => spin(),
     };
@@ -138,7 +142,7 @@ extern "C" fn terminate_child_entry(_arg: usize) -> usize {
 /// If the test passed, `true` is returned. Otherwise, `false` is returned instead.
 ///
 fn test_terminate_requires_process_management_capability() -> bool {
-    let parent_pid: ProcessIdentifier = match pm::__kcall_getpid() {
+    let parent_pid: ProcessIdentifier = match pm::getpid_uncached() {
         Ok(pid) => pid,
         Err(_) => return false,
     };

--- a/src/tests/thread-rust/src/tests/threads.rs
+++ b/src/tests/thread-rust/src/tests/threads.rs
@@ -16,9 +16,9 @@ use ::sys::{
     error::Error,
     kcall::pm::{
         __kcall_create_thread,
-        __kcall_getpid,
         __kcall_gettid,
         __kcall_join_thread,
+        getpid_uncached,
     },
     pm::ThreadCreateArgs,
 };
@@ -50,7 +50,7 @@ pub fn run() -> Result<(), Error> {
 }
 
 fn test_identifiers() -> Result<(), Error> {
-    let pid = __kcall_getpid()?;
+    let pid = getpid_uncached()?;
     assert!(i32::from(pid) > 0, "process identifier must be positive");
 
     let tid = __kcall_gettid()?;

--- a/src/tests/waitpid-rust/src/tests/waitpid.rs
+++ b/src/tests/waitpid-rust/src/tests/waitpid.rs
@@ -140,7 +140,7 @@ fn release_child(parent: ProcessIdentifier, child: ProcessIdentifier) -> Result<
 /// so init can later release and reap the adopted orphan. The kernel validates the sender field, so
 /// the message is sent from the caller's own PID.
 fn report_pid(to: ProcessIdentifier, pid: ProcessIdentifier) -> Result<(), Error> {
-    let from: ProcessIdentifier = pm::__kcall_getpid()?;
+    let from: ProcessIdentifier = pm::getpid_uncached()?;
     let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     payload[0..4].copy_from_slice(&i32::from(pid).to_le_bytes());
     let report: Message = Message::new(
@@ -201,7 +201,7 @@ fn test_einval_rejects_bad_options() -> Result<(), Error> {
 
 /// Verifies the non-blocking poll, blocking reap, exit-status decoding and post-reap `ECHILD`.
 fn test_wnohang_then_reap() -> Result<(), Error> {
-    let parent: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent: ProcessIdentifier = pm::getpid_uncached()?;
     let child: ProcessIdentifier = spawn_blocked_child(CHILD_STATUS_A)?;
 
     // The child is alive (blocked on its barrier): a non-blocking poll must report nothing ready.
@@ -245,7 +245,7 @@ fn test_wnohang_then_reap() -> Result<(), Error> {
 
 /// Verifies that `wait()` reaps any child and that draining all children ends with `ECHILD`.
 fn test_wait_any_drains_children() -> Result<(), Error> {
-    let parent: ProcessIdentifier = pm::__kcall_getpid()?;
+    let parent: ProcessIdentifier = pm::getpid_uncached()?;
     let child_a: ProcessIdentifier = spawn_blocked_child(CHILD_STATUS_B)?;
     let child_b: ProcessIdentifier = spawn_blocked_child(CHILD_STATUS_C)?;
 
@@ -312,7 +312,7 @@ fn test_wait_any_drains_children() -> Result<(), Error> {
 /// intervening `fork()` returns (the fork-sync handshake), so it is always present in the
 /// intermediate child's child list when that child terminates.
 fn test_orphan_adopted_by_init() -> Result<(), Error> {
-    let init: ProcessIdentifier = pm::__kcall_getpid()?;
+    let init: ProcessIdentifier = pm::getpid_uncached()?;
 
     let ret: pid_t = bindings::fork::fork();
     if ret == 0 {


### PR DESCRIPTION
## Summary

`getpid()` is invariant for a process's lifetime and identical across all of its threads, yet every call trapped into the kernel. This memoizes it in user space and serves subsequent queries without a kernel transition, while staying correct across `fork()`.

## Mechanism

- Adds a process-global `CACHED_PID: AtomicI32` (sentinel `-1` = uncached) in `sys::kcall::pm`. The fill is a benign race under `Relaxed` ordering since every thread of a process resolves the same value.
- Makes the raw `__kcall_getpid()` private (drops its `no_mangle`) and exposes two wrappers:
  - `getpid()` — cached; preferred for production code.
  - `getpid_uncached()` — always traps; escape hatch for callers that must observe the kernel's identity directly.
- Adds `invalidate_cached_pid()` to reset the cache.

## Fork awareness

The cache lives in the address space and is duplicated into a child, so it must be dropped when a process's identity changes.

- The child half of `__kcall_fork()` calls `invalidate_cached_pid()` before returning the child sentinel — the single low-level choke point shared by the POSIX `do_fork()` and the C `fork()` binding.
- `__kcall_duplicate()` has no in-child resume site (the child starts at a caller-supplied entry point), so its child entries invalidate the inherited cache themselves as their first action (test-kernel `duplicate`/`getppid`, testd `duplicate_burst`/`terminate`). `getpid_uncached()` alone is insufficient there because it never refreshes the cache; a later *implicit* cached `getpid()` (heap/segment mapping) would otherwise resolve the parent's pid and be rejected by the kernel capability check.

## Call-site migration

- Production callers use cached `getpid()`: memd/vfsd, proc daemon (lookup/wait/init), POSIX `getpid` binding, fork-sync parent.
- sysalloc `Heap` and `MemorySegment` no longer store a `pid` field; mapping/unmapping resolves the owner via cached `getpid()`, which stays correct across `fork()` via the invalidation above.
- Low-level and test callers that create children through the raw `__kcall_duplicate()` primitive use `getpid_uncached()`.

## Testing

- Adds `test_fork_pid_cache_invalidation` to `test-fork-kcall`: the parent primes the cache, forks via `__kcall_fork`, and the child reports its cached pid over IPC (sent under its real pid to pass the source-spoofing check); the parent asserts the child's cached value equals the child pid and differs from the parent's.
- `./z build` and `./z build -- format-check` pass.
