### PR TITLE
[libc_math] Add C math.h functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_math"
+version = "0.16.87"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.87"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
         "src/libs/libc_langinfo",
         "src/libs/libc_locale",
         "src/libs/libc_stdlib",
+        "src/libs/libc_math",
         "src/libs/libc_string",
         "src/libs/cache",
         "src/libs/cmdline",
@@ -220,6 +221,7 @@ libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
 libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
 libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
+libc_math = { path = "src/libs/libc_math", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_math/Cargo.toml
+++ b/src/libs/libc_math/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_math"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_math/header.toml
+++ b/src/libs/libc_math/header.toml
@@ -1,0 +1,227 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for math.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/math.h.
+
+file = "math.h"
+brief = "Mathematical functions."
+description = """
+Declares software floating-point math functions covering trigonometric,
+exponential, logarithmic, rounding, and classification operations.
+Implemented by the libc_math Rust crate."""
+includes = []
+guard = "_NANVIX_MATH_H"
+content_order = [
+    "raw:2",      # Real-floating types (float_t, double_t).
+    "macros",
+    "raw:0",
+    "raw:4",      # Error-handling macros (MATH_ERRNO, MATH_ERREXCEPT, math_errhandling).
+    "section:0",
+    "raw:1",
+    "raw:3",      # Comparison macros (isgreater, isless, ...).
+    "section:1",
+    "section:9",
+    "section:2",
+    "section:3",
+    "section:4",
+    "section:5",
+    "section:6",
+    "section:7",
+    "section:8",
+    "section:10",
+]
+
+[[macros]]
+name = "HUGE_VAL"
+value = "(__builtin_huge_val())"
+guard = "HUGE_VAL"
+
+[[macros]]
+name = "HUGE_VALF"
+value = "(__builtin_huge_valf())"
+guard = "HUGE_VALF"
+
+[[macros]]
+name = "HUGE_VALL"
+value = "(__builtin_huge_vall())"
+guard = "HUGE_VALL"
+
+[[macros]]
+name = "INFINITY"
+value = "(__builtin_inff())"
+guard = "INFINITY"
+
+[[macros]]
+name = "NAN"
+value = "(__builtin_nanf(\"\"))"
+guard = "NAN"
+
+[[raw_sections]]
+title = "Floating-Point Classification Constants"
+text = """
+#define FP_NAN 0
+#define FP_INFINITE 1
+#define FP_ZERO 2
+#define FP_SUBNORMAL 3
+#define FP_NORMAL 4
+
+/* Values returned by ilogb() for a zero or NaN argument. */
+#define FP_ILOGB0 (-2147483647 - 1)
+#define FP_ILOGBNAN 2147483647
+"""
+
+[[sections]]
+title = "Classification Functions (internal)"
+functions = [
+    "__fpclassifyf",
+    "__fpclassifyd",
+    "__isnanf",
+    "__isnand",
+    "__isinff",
+    "__isinfd",
+    "__signbitf",
+    "__signbitd",
+]
+
+# Classification macros are inserted as a raw section.
+[[raw_sections]]
+title = "Classification Macros"
+text = """
+#define fpclassify(x) (sizeof(x) == sizeof(float) ? __fpclassifyf(x) : __fpclassifyd(x))
+
+#define isnan(x) (sizeof(x) == sizeof(float) ? __isnanf(x) : __isnand(x))
+
+#define isinf(x) (sizeof(x) == sizeof(float) ? __isinff(x) : __isinfd(x))
+
+#define signbit(x) (sizeof(x) == sizeof(float) ? __signbitf(x) : __signbitd(x))
+
+#define isfinite(x) __builtin_isfinite(x)
+#define isnormal(x) __builtin_isnormal(x)
+"""
+
+[[sections]]
+title = "Trigonometric Functions"
+functions = ["sin", "cos", "tan", "sinf", "cosf", "tanf"]
+
+[[sections]]
+title = "Inverse Trigonometric Functions"
+functions = [
+    "asin",
+    "acos",
+    "atan",
+    "atan2",
+    "asinf",
+    "acosf",
+    "atanf",
+    "atan2f",
+]
+
+[[sections]]
+title = "Exponential and Logarithmic Functions"
+functions = [
+    "exp",
+    "exp2",
+    "log",
+    "log2",
+    "log10",
+    "pow",
+    "expm1",
+    "log1p",
+    "lrint",
+    "erf",
+    "erfc",
+    "lgamma",
+    "tgamma",
+    "gamma",
+    "nextafter",
+    "remainder",
+    "expf",
+    "exp2f",
+    "logf",
+    "log2f",
+    "log10f",
+    "powf",
+]
+
+[[sections]]
+title = "Square Root and Cube Root"
+functions = ["sqrt", "cbrt", "hypot", "sqrtf", "cbrtf", "hypotf"]
+
+[[sections]]
+title = "Rounding and Truncation"
+functions = [
+    "ceil",
+    "floor",
+    "round",
+    "trunc",
+    "ceilf",
+    "floorf",
+    "roundf",
+    "truncf",
+]
+
+[[sections]]
+title = "Absolute Value and Remainder"
+functions = ["fabs", "fmod", "fabsf", "fmodf"]
+
+[[sections]]
+title = "Floating-Point Manipulation"
+functions = [
+    "copysign",
+    "ldexp",
+    "scalbn",
+    "frexp",
+    "modf",
+    "copysignf",
+    "ldexpf",
+    "scalbnf",
+    "frexpf",
+    "modff",
+]
+
+[[sections]]
+title = "Min / Max"
+functions = ["fmin", "fmax", "fminf", "fmaxf"]
+
+[[sections]]
+title = "Hyperbolic Functions"
+functions = ["sinh", "cosh", "tanh", "asinh", "acosh", "atanh"]
+
+[[sections]]
+title = "Fused Multiply-Add"
+functions = ["fma", "fmaf"]
+
+# POSIX <math.h> shall define the real-floating types float_t and double_t.
+# On x86-64 (FLT_EVAL_METHOD == 0) these are float and double, respectively.
+[[raw_sections]]
+title = "Real-Floating Types"
+text = """
+typedef float float_t;
+typedef double double_t;
+"""
+
+# POSIX <math.h> relational macros. They compare their operands without raising
+# the invalid floating-point exception when an operand is NaN.
+[[raw_sections]]
+title = "Comparison Macros"
+text = """
+#define isgreater(x, y) __builtin_isgreater(x, y)
+#define isgreaterequal(x, y) __builtin_isgreaterequal(x, y)
+#define isless(x, y) __builtin_isless(x, y)
+#define islessequal(x, y) __builtin_islessequal(x, y)
+#define islessgreater(x, y) __builtin_islessgreater(x, y)
+#define isunordered(x, y) __builtin_isunordered(x, y)
+"""
+
+# POSIX <math.h> error-handling macros. The MATH_ERRNO and MATH_ERREXCEPT macros
+# must be defined, but this implementation reports neither errno-based domain and
+# range errors nor floating-point exceptions, so math_errhandling evaluates to 0.
+[[raw_sections]]
+title = "Error Handling"
+text = """
+#define MATH_ERRNO 1
+#define MATH_ERREXCEPT 2
+#define math_errhandling 0
+"""

--- a/src/libs/libc_math/src/acos.rs
+++ b/src/libs/libc_math/src/acos.rs
@@ -1,0 +1,75 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const PI: f64 = core::f64::consts::PI;
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arccosine of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value in `[-1, 1]`.
+///
+/// # Returns
+///
+/// The arccosine of `x` in radians in `[0, PI]`. NaN if `|x| > 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn acos(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    let abs_x: f64 = f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+    if abs_x > 1.0 {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+    if x == 1.0 {
+        return 0.0;
+    }
+    if x == -1.0 {
+        return PI;
+    }
+    FRAC_PI_2 - crate::asin::asin(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((acos(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert!((acos(0.0) - FRAC_PI_2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_one() {
+        assert!((acos(-1.0) - PI).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_half() {
+        let pi_over_3: f64 = PI / 3.0;
+        assert!((acos(0.5) - pi_over_3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        assert!(acos(1.5).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/acosf.rs
+++ b/src/libs/libc_math/src/acosf.rs
@@ -1,0 +1,64 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const PI: f32 = core::f32::consts::PI;
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arccosine of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value in `[-1, 1]`.
+///
+/// # Returns
+///
+/// The arccosine of `x` in radians. NaN if `|x| > 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn acosf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    let abs_x: f32 = f32::from_bits(x.to_bits() & 0x7FFF_FFFF);
+    if abs_x > 1.0 {
+        return f32::from_bits(0x7FC0_0000);
+    }
+    if x == 1.0 {
+        return 0.0;
+    }
+    if x == -1.0 {
+        return PI;
+    }
+    FRAC_PI_2 - crate::asinf::asinf(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((acosf(1.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert!((acosf(0.0) - FRAC_PI_2).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        assert!(acosf(1.5).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/acosh.rs
+++ b/src/libs/libc_math/src/acosh.rs
@@ -1,0 +1,51 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the inverse hyperbolic cosine of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be `>= 1`).
+///
+/// # Returns
+///
+/// The value `acosh(x) = ln(x + sqrt(x^2 - 1))`, or NaN for `x < 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn acosh(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x < 1.0 {
+        return f64::NAN;
+    }
+    crate::log::log(x + crate::sqrt::sqrt(x * x - 1.0))
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((acosh(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_two() {
+        assert!((acosh(2.0) - 1.316_957_896_924_816_6).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_below_one() {
+        assert!(acosh(0.5).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(acosh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/asin.rs
+++ b/src/libs/libc_math/src/asin.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arcsine of `x`.
+///
+/// # Description
+///
+/// Returns the angle in radians whose sine is `x`. Uses identity
+/// `asin(x) = atan(x / sqrt(1 - x^2))` for `|x| <= 0.5` and
+/// `asin(x) = PI/2 - 2*asin(sqrt((1-|x|)/2))` for `|x| > 0.5`.
+///
+/// # Parameters
+///
+/// - `x`: Input value in `[-1, 1]`.
+///
+/// # Returns
+///
+/// The arcsine of `x` in radians in `[-PI/2, PI/2]`. NaN if `|x| > 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn asin(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    let abs_x: f64 = f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+    if abs_x > 1.0 {
+        return f64::from_bits(0x7FF8_0000_0000_0000); // NaN
+    }
+    if abs_x == 1.0 {
+        return if x > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+    }
+
+    if abs_x <= 0.5 {
+        let denom: f64 = crate::sqrt::sqrt(1.0 - x * x);
+        if denom == 0.0 {
+            return if x > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+        }
+        crate::atan::atan(x / denom)
+    } else {
+        // For |x| > 0.5, use identity for better accuracy.
+        let half: f64 = (1.0 - abs_x) * 0.5;
+        let s: f64 = crate::sqrt::sqrt(half);
+        let result: f64 = FRAC_PI_2 - 2.0 * crate::atan::atan(s / crate::sqrt::sqrt(1.0 - half));
+        if x < 0.0 {
+            -result
+        } else {
+            result
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((asin(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_half() {
+        let pi_over_6: f64 = 3.141_592_653_589_793 / 6.0;
+        assert!((asin(0.5) - pi_over_6).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((asin(1.0) - FRAC_PI_2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_one() {
+        assert!((asin(-1.0) - (-FRAC_PI_2)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        assert!(asin(1.5).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(asin(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/asinf.rs
+++ b/src/libs/libc_math/src/asinf.rs
@@ -1,0 +1,77 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arcsine of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value in `[-1, 1]`.
+///
+/// # Returns
+///
+/// The arcsine of `x` in radians. NaN if `|x| > 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn asinf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    let abs_x: f32 = f32::from_bits(x.to_bits() & 0x7FFF_FFFF);
+    if abs_x > 1.0 {
+        return f32::from_bits(0x7FC0_0000);
+    }
+    if abs_x == 1.0 {
+        return if x > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+    }
+
+    if abs_x <= 0.5 {
+        let denom: f32 = crate::sqrtf::sqrtf(1.0 - x * x);
+        if denom == 0.0 {
+            return if x > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+        }
+        crate::atanf::atanf(x / denom)
+    } else {
+        let half: f32 = (1.0 - abs_x) * 0.5;
+        let s: f32 = crate::sqrtf::sqrtf(half);
+        let result: f32 =
+            FRAC_PI_2 - 2.0 * crate::atanf::atanf(s / crate::sqrtf::sqrtf(1.0 - half));
+        if x < 0.0 {
+            -result
+        } else {
+            result
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((asinf(0.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((asinf(1.0) - FRAC_PI_2).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        assert!(asinf(1.5).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/asinh.rs
+++ b/src/libs/libc_math/src/asinh.rs
@@ -1,0 +1,60 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the inverse hyperbolic sine of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `asinh(x) = sign(x) * ln(|x| + sqrt(x^2 + 1))`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn asinh(x: f64) -> f64 {
+    if x.is_nan() || x.is_infinite() || x == 0.0 {
+        return x;
+    }
+    let a: f64 = x.abs();
+    let r: f64 = crate::log::log(a + crate::sqrt::sqrt(a * a + 1.0));
+    if x < 0.0 {
+        -r
+    } else {
+        r
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(asinh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_positive() {
+        assert!((asinh(1.0) - 0.881_373_587_019_543).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_odd_symmetry() {
+        assert!((asinh(-1.0) + 0.881_373_587_019_543).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(asinh(f64::INFINITY), f64::INFINITY);
+        assert_eq!(asinh(f64::NEG_INFINITY), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(asinh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/atan.rs
+++ b/src/libs/libc_math/src/atan.rs
@@ -1,0 +1,110 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+const FRAC_PI_4: f64 = core::f64::consts::FRAC_PI_4;
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+/// Polynomial approximation of atan(x) for |x| <= 1.
+fn atan_poly(x: f64) -> f64 {
+    let x2: f64 = x * x;
+    // Polynomial: x - x^3/3 + x^5/5 - x^7/7 + x^9/9 - x^11/11 + x^13/13
+    x * (1.0
+        + x2 * (-1.0 / 3.0
+            + x2 * (1.0 / 5.0
+                + x2 * (-1.0 / 7.0
+                    + x2 * (1.0 / 9.0
+                        + x2 * (-1.0 / 11.0
+                            + x2 * (1.0 / 13.0 + x2 * (-1.0 / 15.0 + x2 * (1.0 / 17.0)))))))))
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arctangent of `x`.
+///
+/// # Description
+///
+/// Uses argument reduction and polynomial approximation.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The arctangent of `x` in radians, in the range `[-PI/2, PI/2]`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn atan(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() == 0x7FF0_0000_0000_0000 {
+        return FRAC_PI_2;
+    }
+    if x.to_bits() == 0xFFF0_0000_0000_0000 {
+        return -FRAC_PI_2;
+    }
+
+    let abs_x: f64 = f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+    let sign: f64 = if x < 0.0 { -1.0 } else { 1.0 };
+
+    if abs_x > 1.0 {
+        // Use identity: atan(x) = PI/2 - atan(1/x) for |x| > 1.
+        sign * (FRAC_PI_2 - atan_poly(1.0 / abs_x))
+    } else if abs_x > 0.414_213_562_373_095 {
+        // Use identity: atan(x) = PI/4 + atan((x-1)/(x+1)) for x near 1.
+        let t: f64 = (abs_x - 1.0) / (abs_x + 1.0);
+        sign * (FRAC_PI_4 + atan_poly(t))
+    } else {
+        atan_poly(x)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((atan(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((atan(1.0) - FRAC_PI_4).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_one() {
+        assert!((atan(-1.0) - (-FRAC_PI_4)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_large() {
+        assert!((atan(1000.0) - FRAC_PI_2).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert!((atan(f64::INFINITY) - FRAC_PI_2).abs() < 1e-10);
+        assert!((atan(f64::NEG_INFINITY) - (-FRAC_PI_2)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(atan(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/atan2.rs
+++ b/src/libs/libc_math/src/atan2.rs
@@ -1,0 +1,120 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const PI: f64 = core::f64::consts::PI;
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the four-quadrant arctangent of `y / x`.
+///
+/// # Description
+///
+/// Returns the angle in radians between the positive x-axis and the point `(x, y)`.
+///
+/// # Parameters
+///
+/// - `y`: Y-coordinate.
+/// - `x`: X-coordinate.
+///
+/// # Returns
+///
+/// The angle in radians in the range `[-PI, PI]`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn atan2(y: f64, x: f64) -> f64 {
+    // Handle NaN.
+    if x.is_nan() || y.is_nan() {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+
+    // Handle y == 0.
+    if y == 0.0 {
+        if x > 0.0 || (x.to_bits() == 0x0000_0000_0000_0000) {
+            return y; // ±0
+        }
+        // x is negative or -0.0
+        if y.to_bits() & 0x8000_0000_0000_0000 != 0 {
+            return -PI;
+        }
+        return PI;
+    }
+
+    // Handle x == 0.
+    if x == 0.0 {
+        return if y > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+    }
+
+    // Handle infinities.
+    let x_inf: bool = x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF == 0x7FF0_0000_0000_0000;
+    let y_inf: bool = y.to_bits() & 0x7FFF_FFFF_FFFF_FFFF == 0x7FF0_0000_0000_0000;
+
+    if y_inf && x_inf {
+        let qtr: f64 = PI / 4.0;
+        if x > 0.0 {
+            return if y > 0.0 { qtr } else { -qtr };
+        }
+        let three_qtr: f64 = 3.0 * PI / 4.0;
+        return if y > 0.0 { three_qtr } else { -three_qtr };
+    }
+    if y_inf {
+        return if y > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+    }
+    if x_inf {
+        if x > 0.0 {
+            return if y > 0.0 { 0.0 } else { -0.0 };
+        }
+        return if y > 0.0 { PI } else { -PI };
+    }
+
+    // General case.
+    let a: f64 = crate::atan::atan(y / x);
+    if x > 0.0 {
+        a
+    } else if y >= 0.0 {
+        a + PI
+    } else {
+        a - PI
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_quadrant() {
+        assert!((atan2(1.0, 1.0) - PI / 4.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_second_quadrant() {
+        assert!((atan2(1.0, -1.0) - 3.0 * PI / 4.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_third_quadrant() {
+        assert!((atan2(-1.0, -1.0) - (-3.0 * PI / 4.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_axes() {
+        assert!((atan2(1.0, 0.0) - FRAC_PI_2).abs() < 1e-10);
+        assert!((atan2(-1.0, 0.0) - (-FRAC_PI_2)).abs() < 1e-10);
+        assert!((atan2(0.0, 1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(atan2(f64::NAN, 1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/atan2f.rs
+++ b/src/libs/libc_math/src/atan2f.rs
@@ -1,0 +1,77 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const PI: f32 = core::f32::consts::PI;
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the four-quadrant arctangent of `y / x` (single-precision).
+///
+/// # Parameters
+///
+/// - `y`: Y-coordinate.
+/// - `x`: X-coordinate.
+///
+/// # Returns
+///
+/// The angle in radians in the range `[-PI, PI]`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn atan2f(y: f32, x: f32) -> f32 {
+    if x.is_nan() || y.is_nan() {
+        return f32::from_bits(0x7FC0_0000);
+    }
+
+    if y == 0.0 {
+        if x > 0.0 || x.to_bits() == 0x0000_0000 {
+            return y;
+        }
+        if y.to_bits() & 0x8000_0000 != 0 {
+            return -PI;
+        }
+        return PI;
+    }
+
+    if x == 0.0 {
+        return if y > 0.0 { FRAC_PI_2 } else { -FRAC_PI_2 };
+    }
+
+    let a: f32 = crate::atanf::atanf(y / x);
+    if x > 0.0 {
+        a
+    } else if y >= 0.0 {
+        a + PI
+    } else {
+        a - PI
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_quadrant() {
+        assert!((atan2f(1.0, 1.0) - PI / 4.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_axes() {
+        assert!((atan2f(1.0, 0.0) - FRAC_PI_2).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(atan2f(f32::NAN, 1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/atanf.rs
+++ b/src/libs/libc_math/src/atanf.rs
@@ -1,0 +1,80 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+const FRAC_PI_4: f32 = core::f32::consts::FRAC_PI_4;
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+fn atan_poly(x: f32) -> f32 {
+    let x2: f32 = x * x;
+    x * (1.0 + x2 * (-1.0 / 3.0 + x2 * (1.0 / 5.0 + x2 * (-1.0 / 7.0 + x2 * (1.0 / 9.0)))))
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the arctangent of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The arctangent of `x` in radians.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn atanf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() == 0x7F80_0000 {
+        return FRAC_PI_2;
+    }
+    if x.to_bits() == 0xFF80_0000 {
+        return -FRAC_PI_2;
+    }
+
+    let abs_x: f32 = f32::from_bits(x.to_bits() & 0x7FFF_FFFF);
+    let sign: f32 = if x < 0.0 { -1.0 } else { 1.0 };
+
+    if abs_x > 1.0 {
+        sign * (FRAC_PI_2 - atan_poly(1.0 / abs_x))
+    } else if abs_x > 0.414_213_6 {
+        let t: f32 = (abs_x - 1.0) / (abs_x + 1.0);
+        sign * (FRAC_PI_4 + atan_poly(t))
+    } else {
+        atan_poly(x)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((atanf(0.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((atanf(1.0) - FRAC_PI_4).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(atanf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/atanh.rs
+++ b/src/libs/libc_math/src/atanh.rs
@@ -1,0 +1,69 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the inverse hyperbolic tangent of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must satisfy `|x| <= 1`).
+///
+/// # Returns
+///
+/// The value `atanh(x) = 0.5 * ln((1 + x) / (1 - x))`, or NaN for `|x| > 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn atanh(x: f64) -> f64 {
+    if x.is_nan() || x == 0.0 {
+        return x;
+    }
+    if x == 1.0 {
+        return f64::INFINITY;
+    }
+    if x == -1.0 {
+        return f64::NEG_INFINITY;
+    }
+    if x.abs() > 1.0 {
+        return f64::NAN;
+    }
+    0.5 * crate::log::log((1.0 + x) / (1.0 - x))
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(atanh(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_half() {
+        assert!((atanh(0.5) - 0.549_306_144_334_054_9).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_odd_symmetry() {
+        assert!((atanh(-0.5) + 0.549_306_144_334_054_9).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_unit_poles() {
+        assert_eq!(atanh(1.0), f64::INFINITY);
+        assert_eq!(atanh(-1.0), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_out_of_domain() {
+        assert!(atanh(2.0).is_nan());
+        assert!(atanh(-2.0).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(atanh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/cbrt.rs
+++ b/src/libs/libc_math/src/cbrt.rs
@@ -1,0 +1,81 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the cube root of `x`.
+///
+/// # Description
+///
+/// Uses Halley's method with an initial guess from IEEE 754 bit manipulation.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The cube root of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cbrt(x: f64) -> f64 {
+    if x.is_nan() || x == 0.0 {
+        return x;
+    }
+    if x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF == 0x7FF0_0000_0000_0000 {
+        return x;
+    }
+
+    let abs_x: f64 = f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+    let sign: f64 = if x < 0.0 { -1.0 } else { 1.0 };
+
+    // Initial guess via bit manipulation: cbrt(x) ≈ 2^(e/3) * m^(1/3).
+    let bits: u64 = abs_x.to_bits();
+    let guess_bits: u64 = bits / 3 + 0x2AA0_0000_0000_0000;
+    let mut guess: f64 = f64::from_bits(guess_bits);
+
+    // Newton's method: g_{n+1} = (2*g + x/g^2) / 3.
+    let mut i: u32 = 0;
+    while i < 8 {
+        guess = (2.0 * guess + abs_x / (guess * guess)) / 3.0;
+        i += 1;
+    }
+
+    sign * guess
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perfect_cubes() {
+        assert!((cbrt(8.0) - 2.0).abs() < 1e-10);
+        assert!((cbrt(27.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((cbrt(-8.0) - (-2.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((cbrt(1.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(cbrt(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(cbrt(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/cbrtf.rs
+++ b/src/libs/libc_math/src/cbrtf.rs
@@ -1,0 +1,64 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the cube root of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The cube root of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cbrtf(x: f32) -> f32 {
+    if x.is_nan() || x == 0.0 {
+        return x;
+    }
+    if x.to_bits() & 0x7FFF_FFFF == 0x7F80_0000 {
+        return x;
+    }
+
+    let abs_x: f32 = f32::from_bits(x.to_bits() & 0x7FFF_FFFF);
+    let sign: f32 = if x < 0.0 { -1.0 } else { 1.0 };
+
+    let bits: u32 = abs_x.to_bits();
+    let guess_bits: u32 = bits / 3 + 0x2A50_0000;
+    let mut guess: f32 = f32::from_bits(guess_bits);
+
+    let mut i: u32 = 0;
+    while i < 8 {
+        guess = (2.0 * guess + abs_x / (guess * guess)) / 3.0;
+        i += 1;
+    }
+
+    sign * guess
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perfect_cube() {
+        assert!((cbrtf(8.0) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((cbrtf(-8.0) - (-2.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(cbrtf(0.0), 0.0);
+    }
+}

--- a/src/libs/libc_math/src/ceil.rs
+++ b/src/libs/libc_math/src/ceil.rs
@@ -1,0 +1,69 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the smallest integer value not less than `x`.
+///
+/// # Description
+///
+/// Returns the ceiling of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The smallest integer not less than `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ceil(x: f64) -> f64 {
+    let t: f64 = crate::trunc::trunc(x);
+    if x > t {
+        t + 1.0
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((ceil(2.3) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((ceil(-2.3) - (-2.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_integer() {
+        assert!((ceil(5.0) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(ceil(0.0).to_bits(), 0.0_f64.to_bits());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(ceil(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(ceil(f64::INFINITY), f64::INFINITY);
+        assert_eq!(ceil(f64::NEG_INFINITY), f64::NEG_INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/ceilf.rs
+++ b/src/libs/libc_math/src/ceilf.rs
@@ -1,0 +1,54 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the smallest integer value not less than `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The smallest integer not less than `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    let t: f32 = crate::truncf::truncf(x);
+    if x > t {
+        t + 1.0
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((ceilf(2.3) - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((ceilf(-2.3) - (-2.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(ceilf(f32::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(ceilf(f32::INFINITY), f32::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/copysign.rs
+++ b/src/libs/libc_math/src/copysign.rs
@@ -1,0 +1,52 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns a value with the magnitude of `x` and the sign of `y`.
+///
+/// # Parameters
+///
+/// - `x`: Value providing magnitude.
+/// - `y`: Value providing sign.
+///
+/// # Returns
+///
+/// A value with `|x|` and the sign of `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn copysign(x: f64, y: f64) -> f64 {
+    let mag: u64 = x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF;
+    let sign: u64 = y.to_bits() & 0x8000_0000_0000_0000;
+    f64::from_bits(mag | sign)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_to_negative() {
+        assert!((copysign(3.0, -1.0) - (-3.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_to_positive() {
+        assert!((copysign(-3.0, 1.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_same_sign() {
+        assert!((copysign(3.0, 1.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(copysign(0.0, -1.0).to_bits(), (-0.0_f64).to_bits());
+    }
+}

--- a/src/libs/libc_math/src/copysignf.rs
+++ b/src/libs/libc_math/src/copysignf.rs
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns a value with the magnitude of `x` and the sign of `y` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Value providing magnitude.
+/// - `y`: Value providing sign.
+///
+/// # Returns
+///
+/// A value with `|x|` and the sign of `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn copysignf(x: f32, y: f32) -> f32 {
+    let mag: u32 = x.to_bits() & 0x7FFF_FFFF;
+    let sign: u32 = y.to_bits() & 0x8000_0000;
+    f32::from_bits(mag | sign)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_to_negative() {
+        assert!((copysignf(3.0, -1.0) - (-3.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative_to_positive() {
+        assert!((copysignf(-3.0, 1.0) - 3.0).abs() < 1e-5);
+    }
+}

--- a/src/libs/libc_math/src/cos.rs
+++ b/src/libs/libc_math/src/cos.rs
@@ -1,0 +1,137 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#[cfg(test)]
+const PI: f64 = core::f64::consts::PI;
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+const FRAC_2_PI: f64 = core::f64::consts::FRAC_2_PI;
+
+const SIN_COEFFS: [f64; 7] = [
+    1.605_904_383_682_161_5e-10,
+    -2.505_210_838_544_172e-8,
+    2.755_731_922_398_589_3e-6,
+    -1.984_126_984_126_984e-4,
+    8.333_333_333_333_332e-3,
+    -1.666_666_666_666_666_4e-1,
+    1.0,
+];
+
+const COS_COEFFS: [f64; 7] = [
+    2.087_675_698_786_81e-9,
+    -2.755_731_922_398_589_3e-7,
+    2.480_158_730_158_73e-5,
+    -1.388_888_888_888_889e-3,
+    4.166_666_666_666_666e-2,
+    -0.5,
+    1.0,
+];
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+fn sin_kernel(x: f64) -> f64 {
+    let x2: f64 = x * x;
+    let mut p: f64 = SIN_COEFFS[0];
+    let mut i: usize = 1;
+    while i < SIN_COEFFS.len() {
+        p = p * x2 + SIN_COEFFS[i];
+        i += 1;
+    }
+    x * p
+}
+
+fn cos_kernel(x: f64) -> f64 {
+    let x2: f64 = x * x;
+    let mut p: f64 = COS_COEFFS[0];
+    let mut i: usize = 1;
+    while i < COS_COEFFS.len() {
+        p = p * x2 + COS_COEFFS[i];
+        i += 1;
+    }
+    p
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the cosine of `x` (in radians).
+///
+/// # Description
+///
+/// Uses quadrant-based range reduction followed by polynomial approximation.
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The cosine of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cos(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+
+    let k_f: f64 = crate::round::round(x * FRAC_2_PI);
+    #[allow(clippy::cast_possible_truncation)]
+    let k: i64 = k_f as i64;
+    let r: f64 = x - k_f * FRAC_PI_2;
+    let quadrant: u64 = (k as u64) & 3;
+
+    match quadrant {
+        0 => cos_kernel(r),
+        1 => -sin_kernel(r),
+        2 => -cos_kernel(r),
+        3 => sin_kernel(r),
+        _ => cos_kernel(r),
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((cos(0.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi_over_2() {
+        assert!((cos(FRAC_PI_2)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi() {
+        assert!((cos(PI) - (-1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi_over_3() {
+        assert!((cos(PI / 3.0) - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(cos(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert!(cos(f64::INFINITY).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/cosf.rs
+++ b/src/libs/libc_math/src/cosf.rs
@@ -1,0 +1,87 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+const FRAC_2_PI: f32 = core::f32::consts::FRAC_2_PI;
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+fn sin_kernel(x: f32) -> f32 {
+    let x2: f32 = x * x;
+    x * (1.0
+        + x2 * (-1.666_666_7e-1 + x2 * (8.333_334e-3 + x2 * (-1.984_127e-4 + x2 * 2.755_732e-6))))
+}
+
+fn cos_kernel(x: f32) -> f32 {
+    let x2: f32 = x * x;
+    1.0 + x2 * (-0.5 + x2 * (4.166_666_7e-2 + x2 * (-1.388_888_9e-3 + x2 * 2.480_158_8e-5)))
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the cosine of `x` in radians (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The cosine of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cosf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        return f32::from_bits(0x7FC0_0000);
+    }
+
+    let k_f: f32 = crate::roundf::roundf(x * FRAC_2_PI);
+
+    #[allow(clippy::cast_possible_truncation)]
+    let k: i64 = k_f as i64;
+
+    let r: f32 = x - k_f * FRAC_PI_2;
+    let quadrant: u64 = (k as u64) & 3;
+
+    match quadrant {
+        0 => cos_kernel(r),
+        1 => -sin_kernel(r),
+        2 => -cos_kernel(r),
+        3 => sin_kernel(r),
+        _ => cos_kernel(r),
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((cosf(0.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_pi_over_2() {
+        assert!((cosf(FRAC_PI_2)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(cosf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/cosh.rs
+++ b/src/libs/libc_math/src/cosh.rs
@@ -1,0 +1,58 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the hyperbolic cosine of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `cosh(x) = (e^x + e^-x) / 2`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cosh(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.is_infinite() {
+        return f64::INFINITY;
+    }
+    let e: f64 = crate::exp::exp(x.abs());
+    (e + 1.0 / e) * 0.5
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((cosh(0.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((cosh(1.0) - 1.543_080_634_815_243_7).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_even_symmetry() {
+        assert!((cosh(-1.0) - cosh(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(cosh(f64::INFINITY), f64::INFINITY);
+        assert_eq!(cosh(f64::NEG_INFINITY), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(cosh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/erf.rs
+++ b/src/libs/libc_math/src/erf.rs
@@ -1,0 +1,65 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the error function of `x`.
+///
+/// Uses the Abramowitz & Stegun 7.1.26 rational approximation.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `erf(x)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn erf(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    let sign: f64 = if x < 0.0 { -1.0 } else { 1.0 };
+    let ax: f64 = x.abs();
+    let t: f64 = 1.0 / (1.0 + 0.3275911 * ax);
+    let poly: f64 =
+        ((((1.061_405_429 * t - 1.453_152_027) * t + 1.421_413_741) * t - 0.284_496_736) * t
+            + 0.254_829_592)
+            * t;
+    let y: f64 = 1.0 - poly * crate::exp::exp(-ax * ax);
+    sign * y
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((erf(0.0)).abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_one() {
+        // The Abramowitz & Stegun approximation is accurate to about 1.5e-7.
+        assert!((erf(1.0) - 0.842_700_792_949_714_9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_odd_symmetry() {
+        assert!((erf(-1.0) + erf(1.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_large() {
+        assert!((erf(5.0) - 1.0).abs() < 1e-6);
+        assert!((erf(-5.0) + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(erf(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/erfc.rs
+++ b/src/libs/libc_math/src/erfc.rs
@@ -1,0 +1,48 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the complementary error function of `x`, `erfc(x) = 1 - erf(x)`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `erfc(x)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn erfc(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    1.0 - crate::erf::erf(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((erfc(0.0) - 1.0).abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((erfc(1.0) - 0.157_299_207_050_285_1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_large() {
+        assert!((erfc(5.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(erfc(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/exp.rs
+++ b/src/libs/libc_math/src/exp.rs
@@ -1,0 +1,151 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LN2: f64 = core::f64::consts::LN_2;
+const LN2_INV: f64 = core::f64::consts::LOG2_E;
+
+/// Taylor series coefficients for e^r: 1/n! from n=12 down to n=0.
+const EXP_COEFFS: [f64; 13] = [
+    1.0 / 479_001_600.0,
+    1.0 / 39_916_800.0,
+    1.0 / 3_628_800.0,
+    1.0 / 362_880.0,
+    1.0 / 40_320.0,
+    1.0 / 5_040.0,
+    1.0 / 720.0,
+    1.0 / 120.0,
+    1.0 / 24.0,
+    1.0 / 6.0,
+    0.5,
+    1.0,
+    1.0,
+];
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `e^x`.
+///
+/// # Description
+///
+/// Uses range reduction: `e^x = 2^k * e^r` where `r = x - k*ln(2)` and `|r| <= ln(2)/2`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `e^x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn exp(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+
+    // Range reduction: x = k*ln(2) + r.
+    let k_f: f64 = crate::round::round(x * LN2_INV);
+    let r: f64 = x - k_f * LN2;
+
+    // Horner evaluation of degree-12 Taylor polynomial.
+    let mut poly: f64 = EXP_COEFFS[0];
+    let mut i: usize = 1;
+    while i < EXP_COEFFS.len() {
+        poly = poly * r + EXP_COEFFS[i];
+        i += 1;
+    }
+
+    // Multiply by 2^k.
+    #[allow(clippy::cast_possible_truncation)]
+    let k_i64: i64 = k_f as i64;
+
+    // The result is `poly * 2^k`. Inputs just below the overflow boundary
+    // (`ln(f64::MAX) ~= 709.7827`) reduce to `k == 1024`, whose result is still
+    // finite even though `2^1024` is not a representable exponent. Scale as
+    // `2^1023 * 2` so those values round correctly while true overflows saturate
+    // to `+inf`.
+    if k_i64 > 1024 {
+        return f64::from_bits(0x7FF0_0000_0000_0000);
+    }
+    if k_i64 == 1024 {
+        return poly * f64::from_bits(0x7FE0_0000_0000_0000) * 2.0;
+    }
+    if k_i64 < -1022 {
+        let scale: f64 = f64::from_bits(0x0010_0000_0000_0000);
+        let adj: i64 = k_i64 + 1022;
+        if adj < -1022 {
+            return 0.0;
+        }
+        let biased: u64 = (adj + 1023) as u64;
+        return poly * scale * f64::from_bits(biased << 52);
+    }
+
+    let biased: u64 = (k_i64 + 1023) as u64;
+    poly * f64::from_bits(biased << 52)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((exp(0.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((exp(1.0) - 2.718_281_828_459_045).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((exp(-1.0) - 0.367_879_441_171_442_3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_ln2() {
+        assert!((exp(LN2) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_overflow() {
+        assert_eq!(exp(710.0), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_underflow() {
+        assert_eq!(exp(-746.0), 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(exp(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_overflow_boundary_is_finite() {
+        // Inputs below `ln(f64::MAX)` (~= 709.7827) must not overflow prematurely.
+        let v: f64 = exp(709.5);
+        let expected: f64 = 709.5f64.exp();
+        assert!(v.is_finite() && v > 0.0);
+        assert!((v - expected).abs() <= expected * 1e-10);
+    }
+
+    #[test]
+    fn test_underflow_boundary_is_subnormal() {
+        // Inputs above `ln(2^-1075)` (~= -745.133) must not underflow to zero.
+        let v: f64 = exp(-745.1);
+        assert!(v > 0.0);
+        assert!(v < f64::MIN_POSITIVE);
+    }
+}

--- a/src/libs/libc_math/src/exp2.rs
+++ b/src/libs/libc_math/src/exp2.rs
@@ -1,0 +1,88 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LN2: f64 = core::f64::consts::LN_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `2` raised to the power `x`.
+///
+/// # Description
+///
+/// Decomposes `x` into an integer part `k` and a fractional part `f` with `|f| <= 0.5`, computing
+/// `2^f` via `exp(f * ln 2)` and scaling by `2^k`. Integer inputs therefore yield exact results.
+///
+/// # Parameters
+///
+/// - `x`: Exponent.
+///
+/// # Returns
+///
+/// The value of `2^x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn exp2(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x >= 1024.0 {
+        return f64::INFINITY;
+    }
+    if x <= -1075.0 {
+        return 0.0;
+    }
+
+    let k: f64 = crate::round::round(x);
+    let f: f64 = x - k;
+    let two_f: f64 = if f == 0.0 {
+        1.0
+    } else {
+        crate::exp::exp(f * LN2)
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    let ki: i32 = k as i32;
+    crate::ldexp::ldexp(two_f, ki)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_powers() {
+        assert_eq!(exp2(0.0), 1.0);
+        assert_eq!(exp2(3.0), 8.0);
+        assert_eq!(exp2(10.0), 1024.0);
+        assert_eq!(exp2(-1.0), 0.5);
+    }
+
+    #[test]
+    fn test_half() {
+        assert!((exp2(0.5) - core::f64::consts::SQRT_2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_overflow() {
+        assert_eq!(exp2(1024.0), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_underflow() {
+        assert_eq!(exp2(-1075.0), 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(exp2(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/exp2f.rs
+++ b/src/libs/libc_math/src/exp2f.rs
@@ -1,0 +1,48 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `2` raised to the power `x` in single precision.
+///
+/// # Parameters
+///
+/// - `x`: Exponent.
+///
+/// # Returns
+///
+/// The value of `2^x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn exp2f(x: f32) -> f32 {
+    #[allow(clippy::cast_possible_truncation)]
+    let result: f32 = crate::exp2::exp2(f64::from(x)) as f32;
+    result
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_powers() {
+        assert_eq!(exp2f(0.0), 1.0);
+        assert_eq!(exp2f(3.0), 8.0);
+        assert_eq!(exp2f(-1.0), 0.5);
+    }
+
+    #[test]
+    fn test_half() {
+        assert!((exp2f(0.5) - core::f32::consts::SQRT_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(exp2f(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/expf.rs
+++ b/src/libs/libc_math/src/expf.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LN2: f32 = core::f32::consts::LN_2;
+const LN2_INV: f32 = core::f32::consts::LOG2_E;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `e^x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `e^x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn expf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+
+    let k_f: f32 = crate::roundf::roundf(x * LN2_INV);
+    let r: f32 = x - k_f * LN2;
+
+    let poly: f32 = 1.0
+        + r * (1.0
+            + r * (0.5
+                + r * (1.0 / 6.0 + r * (1.0 / 24.0 + r * (1.0 / 120.0 + r * (1.0 / 720.0))))));
+
+    #[allow(clippy::cast_possible_truncation)]
+    let k_i64: i64 = k_f as i64;
+
+    // The result is `poly * 2^k`. Inputs just below the overflow boundary
+    // (`ln(f32::MAX) ~= 88.7228`) reduce to `k == 128`, whose result is still
+    // finite even though `2^128` is not a representable exponent. Scale as
+    // `2^127 * 2` so those values round correctly while true overflows saturate
+    // to `+inf`.
+    if k_i64 > 128 {
+        return f32::from_bits(0x7F80_0000);
+    }
+    if k_i64 == 128 {
+        return poly * f32::from_bits(0x7F00_0000) * 2.0;
+    }
+    if k_i64 < -126 {
+        let scale: f32 = f32::from_bits(0x0080_0000);
+        let adj: i64 = k_i64 + 126;
+        if adj < -126 {
+            return 0.0;
+        }
+        let biased: u64 = (adj + 127) as u64;
+        #[allow(clippy::cast_possible_truncation)]
+        let biased_u32: u32 = biased as u32;
+        return poly * scale * f32::from_bits(biased_u32 << 23);
+    }
+
+    let biased: u64 = (k_i64 + 127) as u64;
+    #[allow(clippy::cast_possible_truncation)]
+    let biased_u32: u32 = biased as u32;
+    poly * f32::from_bits(biased_u32 << 23)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((expf(0.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((expf(1.0) - 2.718_28).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_overflow() {
+        assert_eq!(expf(89.0), f32::INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(expf(f32::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_overflow_boundary_is_finite() {
+        // Inputs below `ln(f32::MAX)` (~= 88.7228) must not overflow prematurely.
+        let v: f32 = expf(88.5);
+        let expected: f32 = 88.5f32.exp();
+        assert!(v.is_finite() && v > 0.0);
+        assert!((v - expected).abs() <= expected * 1e-4);
+    }
+
+    #[test]
+    fn test_underflow_boundary_is_subnormal() {
+        // Inputs above `ln(2^-150)` (~= -103.972) must not underflow to zero.
+        let v: f32 = expf(-103.5);
+        assert!(v > 0.0);
+        assert!(v < f32::MIN_POSITIVE);
+    }
+}

--- a/src/libs/libc_math/src/expm1.rs
+++ b/src/libs/libc_math/src/expm1.rs
@@ -1,0 +1,48 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes `e^x - 1`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `expm1(x) = e^x - 1`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn expm1(x: f64) -> f64 {
+    if x.is_nan() || x == 0.0 {
+        return x;
+    }
+    crate::exp::exp(x) - 1.0
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(expm1(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((expm1(1.0) - 1.718_281_828_459_045).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((expm1(-1.0) + 0.632_120_558_828_557_7).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(expm1(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/fabs.rs
+++ b/src/libs/libc_math/src/fabs.rs
@@ -1,0 +1,62 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the absolute value of a floating-point number.
+///
+/// # Description
+///
+/// Returns the absolute value of `x` by clearing the sign bit.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The absolute value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fabs(x: f64) -> f64 {
+    f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive() {
+        let result: f64 = fabs(3.14);
+        assert!((result - 3.14).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        let result: f64 = fabs(-2.72);
+        assert!((result - 2.72).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(fabs(0.0).to_bits(), 0u64);
+        assert_eq!(fabs(-0.0).to_bits(), 0u64);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(fabs(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(fabs(f64::INFINITY), f64::INFINITY);
+        assert_eq!(fabs(f64::NEG_INFINITY), f64::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/fabsf.rs
+++ b/src/libs/libc_math/src/fabsf.rs
@@ -1,0 +1,62 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the absolute value of a single-precision floating-point number.
+///
+/// # Description
+///
+/// Returns the absolute value of `x` by clearing the sign bit.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The absolute value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fabsf(x: f32) -> f32 {
+    f32::from_bits(x.to_bits() & 0x7FFF_FFFF)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive() {
+        let result: f32 = fabsf(3.14);
+        assert!((result - 3.14).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative() {
+        let result: f32 = fabsf(-2.72);
+        assert!((result - 2.72).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(fabsf(0.0).to_bits(), 0u32);
+        assert_eq!(fabsf(-0.0).to_bits(), 0u32);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(fabsf(f32::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(fabsf(f32::INFINITY), f32::INFINITY);
+        assert_eq!(fabsf(f32::NEG_INFINITY), f32::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/fenv.rs
+++ b/src/libs/libc_math/src/fenv.rs
@@ -1,0 +1,217 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Round to nearest (default).
+pub const FE_TONEAREST: c_int = 0x0000;
+/// Round toward negative infinity.
+pub const FE_DOWNWARD: c_int = 0x0400;
+/// Round toward positive infinity.
+pub const FE_UPWARD: c_int = 0x0800;
+/// Round toward zero.
+pub const FE_TOWARDZERO: c_int = 0x0c00;
+
+/// Mask covering all rounding-mode bits.
+const FE_ROUND_MASK: c_int = 0x0c00;
+
+//==================================================================================================
+// Rounding-Mode Storage
+//==================================================================================================
+
+// Tracks the current rounding mode for `fegetround`/`fesetround` consistency.
+//
+// POSIX specifies the floating-point environment as per-thread state, so hosted
+// (`std`) builds keep the mode in thread-local storage. The freestanding
+// (`no_std`) build uses an atomic, which provides race-free shared access
+// without relying on a thread-local runtime. Floating-point code generated for
+// this target uses SSE, whose default round-to-nearest matches `FE_TONEAREST`.
+
+#[cfg(feature = "std")]
+mod round {
+    use ::core::cell::Cell;
+    use ::sysapi::ffi::c_int;
+
+    std::thread_local! {
+        static FE_ROUND: Cell<c_int> = const { Cell::new(super::FE_TONEAREST) };
+    }
+
+    /// Returns the calling thread's rounding mode.
+    pub fn get() -> c_int {
+        FE_ROUND.with(Cell::get)
+    }
+
+    /// Sets the calling thread's rounding mode.
+    pub fn set(mode: c_int) {
+        FE_ROUND.with(|cell| cell.set(mode));
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod round {
+    use ::core::sync::atomic::{
+        AtomicI32,
+        Ordering,
+    };
+    use ::sysapi::ffi::c_int;
+
+    static FE_ROUND: AtomicI32 = AtomicI32::new(super::FE_TONEAREST);
+
+    /// Returns the current rounding mode.
+    pub fn get() -> c_int {
+        FE_ROUND.load(Ordering::Relaxed)
+    }
+
+    /// Sets the current rounding mode.
+    pub fn set(mode: c_int) {
+        FE_ROUND.store(mode, Ordering::Relaxed);
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns the current rounding mode.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fegetround.html>
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fegetround() -> c_int {
+    round::get()
+}
+
+/// Sets the rounding mode to `mode`.
+///
+/// # Returns
+///
+/// Zero on success, or non-zero if `mode` is not a valid rounding mode.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fesetround.html>
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fesetround(mode: c_int) -> c_int {
+    match mode {
+        FE_TONEAREST | FE_DOWNWARD | FE_UPWARD | FE_TOWARDZERO => {
+            round::set(mode & FE_ROUND_MASK);
+            0
+        },
+        _ => -1,
+    }
+}
+
+/// Clears the specified floating-point exceptions. No-op: exceptions are not tracked.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn feclearexcept(_excepts: c_int) -> c_int {
+    0
+}
+
+/// Raises the specified floating-point exceptions. No-op: exceptions are not tracked.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn feraiseexcept(_excepts: c_int) -> c_int {
+    0
+}
+
+/// Tests the specified floating-point exceptions. Always reports none set.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fetestexcept(_excepts: c_int) -> c_int {
+    0
+}
+
+/// Stores the current floating-point environment in `*envp`.
+///
+/// # Safety
+///
+/// `envp` must point to a writable `fenv_t` (a `c_int`).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fegetenv(envp: *mut c_int) -> c_int {
+    if !envp.is_null() {
+        unsafe {
+            *envp = fegetround();
+        }
+    }
+    0
+}
+
+/// Restores the floating-point environment from `*envp`.
+///
+/// # Safety
+///
+/// `envp` must point to a readable `fenv_t` (a `c_int`).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fesetenv(envp: *const c_int) -> c_int {
+    // FE_DFL_ENV is the sentinel (const fenv_t *)-1: reset to the default
+    // environment (round to nearest) rather than dereferencing it.
+    if envp == (-1isize as *const c_int) {
+        fesetround(FE_TONEAREST);
+    } else if !envp.is_null() {
+        fesetround(unsafe { *envp });
+    }
+    0
+}
+
+/// Saves the current environment in `*envp` and clears exceptions.
+///
+/// # Safety
+///
+/// `envp` must point to a writable `fenv_t` (a `c_int`).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn feholdexcept(envp: *mut c_int) -> c_int {
+    fegetenv(envp)
+}
+
+/// Restores the environment saved in `*envp`.
+///
+/// # Safety
+///
+/// `envp` must point to a readable `fenv_t` (a `c_int`).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn feupdateenv(envp: *const c_int) -> c_int {
+    fesetenv(envp)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rounding_mode_roundtrip() {
+        // The default rounding mode is round-to-nearest.
+        assert_eq!(fegetround(), FE_TONEAREST);
+
+        for &mode in &[FE_DOWNWARD, FE_UPWARD, FE_TOWARDZERO, FE_TONEAREST] {
+            assert_eq!(fesetround(mode), 0);
+            assert_eq!(fegetround(), mode);
+        }
+
+        // Restore the default so other tests observe a clean environment.
+        assert_eq!(fesetround(FE_TONEAREST), 0);
+    }
+
+    #[test]
+    fn test_invalid_rounding_mode() {
+        // An unrecognized mode is rejected and does not change the environment.
+        assert_ne!(fesetround(0x1234), 0);
+    }
+
+    #[test]
+    fn test_exceptions_are_noops() {
+        assert_eq!(feclearexcept(0x3f), 0);
+        assert_eq!(feraiseexcept(0x3f), 0);
+        assert_eq!(fetestexcept(0x3f), 0);
+    }
+}

--- a/src/libs/libc_math/src/floor.rs
+++ b/src/libs/libc_math/src/floor.rs
@@ -1,0 +1,65 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the largest integer value not greater than `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The largest integer not greater than `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn floor(x: f64) -> f64 {
+    let t: f64 = crate::trunc::trunc(x);
+    if x < t {
+        t - 1.0
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((floor(2.7) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((floor(-2.3) - (-3.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_integer() {
+        assert!((floor(5.0) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(floor(0.0).to_bits(), 0.0_f64.to_bits());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(floor(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(floor(f64::INFINITY), f64::INFINITY);
+        assert_eq!(floor(f64::NEG_INFINITY), f64::NEG_INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/floorf.rs
+++ b/src/libs/libc_math/src/floorf.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the largest integer value not greater than `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The largest integer not greater than `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn floorf(x: f32) -> f32 {
+    let t: f32 = crate::truncf::truncf(x);
+    if x < t {
+        t - 1.0
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((floorf(2.7) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((floorf(-2.3) - (-3.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(floorf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/fma.rs
+++ b/src/libs/libc_math/src/fma.rs
@@ -1,0 +1,103 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Splits `x` into high and low parts using Veltkamp's algorithm, such that `hi + lo == x` and
+/// each part holds at most 26 significand bits.
+fn split(x: f64) -> (f64, f64) {
+    // 2^27 + 1.
+    const FACTOR: f64 = 134_217_729.0;
+    let t: f64 = FACTOR * x;
+    let hi: f64 = t - (t - x);
+    let lo: f64 = x - hi;
+    (hi, lo)
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `x * y + z` as a single ternary operation, rounded once.
+///
+/// # Description
+///
+/// Uses Dekker's two-product algorithm to obtain the exact product `x * y = p + e`, then a two-sum
+/// to add `z` with a single final rounding. This avoids the double rounding of the naive
+/// expression on targets without a hardware fused-multiply-add instruction.
+///
+/// # Parameters
+///
+/// - `x`: First factor.
+/// - `y`: Second factor.
+/// - `z`: Addend.
+///
+/// # Returns
+///
+/// The value of `x * y + z`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fma(x: f64, y: f64, z: f64) -> f64 {
+    // Non-finite or zero factors: the naive expression already yields IEEE-correct propagation.
+    if !x.is_finite() || !y.is_finite() || !z.is_finite() || x == 0.0 || y == 0.0 {
+        return x * y + z;
+    }
+
+    // TwoProduct: x * y = p + e exactly.
+    let p: f64 = x * y;
+    if !p.is_finite() {
+        return p + z;
+    }
+    let (xh, xl): (f64, f64) = split(x);
+    let (yh, yl): (f64, f64) = split(y);
+    let e: f64 = ((xh * yh - p) + xh * yl + xl * yh) + xl * yl;
+
+    // TwoSum: p + z = s + t exactly.
+    let s: f64 = p + z;
+    let bb: f64 = s - p;
+    let t: f64 = (p - (s - bb)) + (z - bb);
+
+    s + (t + e)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(fma(2.0, 3.0, 4.0), 10.0);
+        assert_eq!(fma(3.0, 4.0, 5.0), 17.0);
+    }
+
+    #[test]
+    fn test_zero_factor() {
+        assert_eq!(fma(0.0, 5.0, 7.0), 7.0);
+        assert_eq!(fma(5.0, 0.0, 7.0), 7.0);
+    }
+
+    #[test]
+    fn test_single_rounding() {
+        // (1 + eps) * (1 - eps) = 1 - eps^2 exactly; adding -1 leaves -eps^2, which a single
+        // rounding preserves but a naive multiply-then-add would round away to 0.
+        let hi: f64 = 1.0 + f64::EPSILON;
+        let lo: f64 = 1.0 - f64::EPSILON;
+        assert_eq!(fma(hi, lo, -1.0), -(f64::EPSILON * f64::EPSILON));
+        assert_eq!(hi * lo - 1.0, 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(fma(f64::NAN, 1.0, 1.0).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(fma(1.0, 1.0, f64::INFINITY), f64::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/fmaf.rs
+++ b/src/libs/libc_math/src/fmaf.rs
@@ -1,0 +1,53 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `x * y + z` as a single ternary operation in single precision.
+///
+/// # Description
+///
+/// Performs a fused multiply-add: the product `x * y` and the sum with `z` are computed with a
+/// single rounding step, yielding a correctly-rounded `f32` result without the intermediate
+/// rounding (and possible cancellation) of a separate multiply and add.
+///
+/// # Parameters
+///
+/// - `x`: First factor.
+/// - `y`: Second factor.
+/// - `z`: Addend.
+///
+/// # Returns
+///
+/// The value of `x * y + z`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmaf(x: f32, y: f32, z: f32) -> f32 {
+    core::intrinsics::fmaf32(x, y, z)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(fmaf(2.0, 3.0, 4.0), 10.0);
+        assert_eq!(fmaf(3.0, 4.0, 5.0), 17.0);
+    }
+
+    #[test]
+    fn test_zero_factor() {
+        assert_eq!(fmaf(0.0, 5.0, 7.0), 7.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(fmaf(f32::NAN, 1.0, 1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/fmax.rs
+++ b/src/libs/libc_math/src/fmax.rs
@@ -1,0 +1,71 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns the maximum of two floating-point values (NaN-aware).
+///
+/// # Description
+///
+/// If one argument is NaN, the other is returned. If both are NaN, NaN is returned.
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The maximum of `x` and `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmax(x: f64, y: f64) -> f64 {
+    if x.is_nan() {
+        return y;
+    }
+    if y.is_nan() {
+        return x;
+    }
+    // Handle signed zeros (and any mixed signs): +0.0 compares greater than
+    // -0.0, so return the positively-signed operand when the signs differ (C
+    // Annex F.10.9.2).
+    if x.is_sign_negative() != y.is_sign_negative() {
+        return if x.is_sign_negative() { y } else { x };
+    }
+    if x > y {
+        x
+    } else {
+        y
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fmax(2.0, 3.0) - 3.0).abs() < 1e-10);
+        assert!((fmax(3.0, 2.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!((fmax(f64::NAN, 2.0) - 2.0).abs() < 1e-10);
+        assert!((fmax(2.0, f64::NAN) - 2.0).abs() < 1e-10);
+        assert!(fmax(f64::NAN, f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // +0.0 is treated as larger than -0.0, regardless of argument order.
+        assert!(!fmax(-0.0, 0.0).is_sign_negative());
+        assert!(!fmax(0.0, -0.0).is_sign_negative());
+        assert_eq!(fmax(-0.0, 0.0), 0.0);
+    }
+}

--- a/src/libs/libc_math/src/fmaxf.rs
+++ b/src/libs/libc_math/src/fmaxf.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns the maximum of two single-precision values (NaN-aware).
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The maximum of `x` and `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmaxf(x: f32, y: f32) -> f32 {
+    if x.is_nan() {
+        return y;
+    }
+    if y.is_nan() {
+        return x;
+    }
+    // Handle signed zeros (and any mixed signs): +0.0 compares greater than
+    // -0.0, so return the positively-signed operand when the signs differ (C
+    // Annex F.10.9.2).
+    if x.is_sign_negative() != y.is_sign_negative() {
+        return if x.is_sign_negative() { y } else { x };
+    }
+    if x > y {
+        x
+    } else {
+        y
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fmaxf(2.0, 3.0) - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!((fmaxf(f32::NAN, 2.0) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // +0.0 is treated as larger than -0.0, regardless of argument order.
+        assert!(!fmaxf(-0.0, 0.0).is_sign_negative());
+        assert!(!fmaxf(0.0, -0.0).is_sign_negative());
+    }
+}

--- a/src/libs/libc_math/src/fmin.rs
+++ b/src/libs/libc_math/src/fmin.rs
@@ -1,0 +1,76 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns the minimum of two floating-point values (NaN-aware).
+///
+/// # Description
+///
+/// If one argument is NaN, the other is returned. If both are NaN, NaN is returned.
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The minimum of `x` and `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmin(x: f64, y: f64) -> f64 {
+    if x.is_nan() {
+        return y;
+    }
+    if y.is_nan() {
+        return x;
+    }
+    // Handle signed zeros (and any mixed signs): -0.0 compares less than +0.0,
+    // so return the negatively-signed operand when the signs differ (C Annex
+    // F.10.9.2).
+    if x.is_sign_negative() != y.is_sign_negative() {
+        return if x.is_sign_negative() { x } else { y };
+    }
+    if x < y {
+        x
+    } else {
+        y
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fmin(2.0, 3.0) - 2.0).abs() < 1e-10);
+        assert!((fmin(3.0, 2.0) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!((fmin(f64::NAN, 2.0) - 2.0).abs() < 1e-10);
+        assert!((fmin(2.0, f64::NAN) - 2.0).abs() < 1e-10);
+        assert!(fmin(f64::NAN, f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((fmin(-1.0, -2.0) - (-2.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // -0.0 is treated as smaller than +0.0, regardless of argument order.
+        assert!(fmin(-0.0, 0.0).is_sign_negative());
+        assert!(fmin(0.0, -0.0).is_sign_negative());
+        assert_eq!(fmin(-0.0, 0.0), 0.0);
+    }
+}

--- a/src/libs/libc_math/src/fminf.rs
+++ b/src/libs/libc_math/src/fminf.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Returns the minimum of two single-precision values (NaN-aware).
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The minimum of `x` and `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fminf(x: f32, y: f32) -> f32 {
+    if x.is_nan() {
+        return y;
+    }
+    if y.is_nan() {
+        return x;
+    }
+    // Handle signed zeros (and any mixed signs): -0.0 compares less than +0.0,
+    // so return the negatively-signed operand when the signs differ (C Annex
+    // F.10.9.2).
+    if x.is_sign_negative() != y.is_sign_negative() {
+        return if x.is_sign_negative() { x } else { y };
+    }
+    if x < y {
+        x
+    } else {
+        y
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fminf(2.0, 3.0) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!((fminf(f32::NAN, 2.0) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // -0.0 is treated as smaller than +0.0, regardless of argument order.
+        assert!(fminf(-0.0, 0.0).is_sign_negative());
+        assert!(fminf(0.0, -0.0).is_sign_negative());
+    }
+}

--- a/src/libs/libc_math/src/fmod.rs
+++ b/src/libs/libc_math/src/fmod.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the floating-point remainder of `x / y`.
+///
+/// # Description
+///
+/// The result has the same sign as `x` and magnitude less than that of `y`.
+///
+/// # Parameters
+///
+/// - `x`: Dividend.
+/// - `y`: Divisor.
+///
+/// # Returns
+///
+/// The floating-point remainder `x - n*y` where `n = trunc(x/y)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmod(x: f64, y: f64) -> f64 {
+    if y == 0.0 || x.is_nan() || y.is_nan() {
+        return f64::from_bits(0x7FF8_0000_0000_0000); // NaN
+    }
+    if x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        return f64::from_bits(0x7FF8_0000_0000_0000); // NaN for inf
+    }
+    let n: f64 = crate::trunc::trunc(x / y);
+    x - n * y
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fmod(5.3, 2.0) - 1.3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((fmod(-5.3, 2.0) - (-1.3)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_exact() {
+        assert!((fmod(6.0, 3.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero_divisor() {
+        assert!(fmod(5.0, 0.0).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(fmod(f64::NAN, 2.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/fmodf.rs
+++ b/src/libs/libc_math/src/fmodf.rs
@@ -1,0 +1,52 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the floating-point remainder of `x / y` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Dividend.
+/// - `y`: Divisor.
+///
+/// # Returns
+///
+/// The floating-point remainder.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn fmodf(x: f32, y: f32) -> f32 {
+    if y == 0.0 || x.is_nan() || y.is_nan() {
+        return f32::from_bits(0x7FC0_0000); // NaN
+    }
+    if x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        return f32::from_bits(0x7FC0_0000); // NaN for inf
+    }
+    let n: f32 = crate::truncf::truncf(x / y);
+    x - n * y
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((fmodf(5.3, 2.0) - 1.3).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((fmodf(-5.3, 2.0) - (-1.3)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero_divisor() {
+        assert!(fmodf(5.0, 0.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/fpclassify.rs
+++ b/src/libs/libc_math/src/fpclassify.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// IEEE 754 classification: Not a Number.
+const FP_NAN: c_int = 0;
+/// IEEE 754 classification: Infinity.
+const FP_INFINITE: c_int = 1;
+/// IEEE 754 classification: Zero.
+const FP_ZERO: c_int = 2;
+/// IEEE 754 classification: Subnormal.
+const FP_SUBNORMAL: c_int = 3;
+/// IEEE 754 classification: Normal.
+const FP_NORMAL: c_int = 4;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Classifies a single-precision floating-point value.
+///
+/// # Parameters
+///
+/// - `x`: Value to classify.
+///
+/// # Returns
+///
+/// `FP_NAN` (0), `FP_INFINITE` (1), `FP_ZERO` (2), `FP_SUBNORMAL` (3), or `FP_NORMAL` (4).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __fpclassifyf(x: f32) -> c_int {
+    let bits: u32 = x.to_bits();
+    let exp: u32 = bits & 0x7F80_0000;
+    let mantissa: u32 = bits & 0x007F_FFFF;
+
+    if exp == 0x7F80_0000 {
+        if mantissa != 0 {
+            FP_NAN
+        } else {
+            FP_INFINITE
+        }
+    } else if exp == 0 {
+        if mantissa == 0 {
+            FP_ZERO
+        } else {
+            FP_SUBNORMAL
+        }
+    } else {
+        FP_NORMAL
+    }
+}
+
+/// Classifies a double-precision floating-point value.
+///
+/// # Parameters
+///
+/// - `x`: Value to classify.
+///
+/// # Returns
+///
+/// `FP_NAN` (0), `FP_INFINITE` (1), `FP_ZERO` (2), `FP_SUBNORMAL` (3), or `FP_NORMAL` (4).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __fpclassifyd(x: f64) -> c_int {
+    let bits: u64 = x.to_bits();
+    let exp: u64 = bits & 0x7FF0_0000_0000_0000;
+    let mantissa: u64 = bits & 0x000F_FFFF_FFFF_FFFF;
+
+    if exp == 0x7FF0_0000_0000_0000 {
+        if mantissa != 0 {
+            FP_NAN
+        } else {
+            FP_INFINITE
+        }
+    } else if exp == 0 {
+        if mantissa == 0 {
+            FP_ZERO
+        } else {
+            FP_SUBNORMAL
+        }
+    } else {
+        FP_NORMAL
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fpclassifyf() {
+        assert_eq!(__fpclassifyf(1.0), FP_NORMAL);
+        assert_eq!(__fpclassifyf(0.0), FP_ZERO);
+        assert_eq!(__fpclassifyf(f32::INFINITY), FP_INFINITE);
+        assert_eq!(__fpclassifyf(f32::NAN), FP_NAN);
+        assert_eq!(__fpclassifyf(1.0e-40), FP_SUBNORMAL);
+    }
+
+    #[test]
+    fn test_fpclassifyd() {
+        assert_eq!(__fpclassifyd(1.0), FP_NORMAL);
+        assert_eq!(__fpclassifyd(0.0), FP_ZERO);
+        assert_eq!(__fpclassifyd(f64::INFINITY), FP_INFINITE);
+        assert_eq!(__fpclassifyd(f64::NAN), FP_NAN);
+        assert_eq!(__fpclassifyd(5.0e-324), FP_SUBNORMAL);
+    }
+}

--- a/src/libs/libc_math/src/frexp.rs
+++ b/src/libs/libc_math/src/frexp.rs
@@ -1,0 +1,118 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Extracts the normalized fraction and exponent from `x`.
+///
+/// # Description
+///
+/// Decomposes `x` into a fraction `f` in `[0.5, 1)` and an integer exponent `e`
+/// such that `x = f * 2^e`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+/// - `exp`: Pointer to store the exponent.
+///
+/// # Returns
+///
+/// The normalized fraction. The exponent is stored in `*exp`.
+///
+/// # Safety
+///
+/// The caller must ensure `exp` points to a valid, writable `c_int` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn frexp(x: f64, exp: *mut c_int) -> f64 {
+    // Handle special cases.
+    if x == 0.0 {
+        if !exp.is_null() {
+            unsafe { *exp = 0 };
+        }
+        return x;
+    }
+    if x.is_nan() || x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        if !exp.is_null() {
+            unsafe { *exp = 0 };
+        }
+        return x;
+    }
+
+    let mut bits: u64 = x.to_bits();
+    let mut exp_raw: u64 = (bits >> 52) & 0x7FF;
+
+    // Handle subnormals.
+    let mut adj: i64 = 0;
+    if exp_raw == 0 {
+        let scaled: f64 = x * 4_503_599_627_370_496.0; // 2^52
+        bits = scaled.to_bits();
+        exp_raw = (bits >> 52) & 0x7FF;
+        adj = -52;
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    let e: i64 = (exp_raw as i64) - 1022 + adj;
+
+    if !exp.is_null() {
+        #[allow(clippy::cast_possible_truncation)]
+        let e_int: c_int = e as c_int;
+        unsafe { *exp = e_int };
+    }
+
+    // Construct fraction with exponent -1 (biased: 1022), in [0.5, 1).
+    let frac_bits: u64 = (bits & 0x800F_FFFF_FFFF_FFFF) | 0x3FE0_0000_0000_0000;
+    f64::from_bits(frac_bits)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut e: c_int = 0;
+        let f: f64 = unsafe { frexp(8.0, &mut e) };
+        assert!((f - 0.5).abs() < 1e-10);
+        assert_eq!(e, 4);
+    }
+
+    #[test]
+    fn test_fraction() {
+        let mut e: c_int = 0;
+        let f: f64 = unsafe { frexp(0.75, &mut e) };
+        assert!((f - 0.75).abs() < 1e-10);
+        assert_eq!(e, 0);
+    }
+
+    #[test]
+    fn test_one() {
+        let mut e: c_int = 0;
+        let f: f64 = unsafe { frexp(1.0, &mut e) };
+        assert!((f - 0.5).abs() < 1e-10);
+        assert_eq!(e, 1);
+    }
+
+    #[test]
+    fn test_zero() {
+        let mut e: c_int = 0;
+        let f: f64 = unsafe { frexp(0.0, &mut e) };
+        assert_eq!(f, 0.0);
+        assert_eq!(e, 0);
+    }
+
+    #[test]
+    fn test_negative() {
+        let mut e: c_int = 0;
+        let f: f64 = unsafe { frexp(-4.0, &mut e) };
+        assert!((f - (-0.5)).abs() < 1e-10);
+        assert_eq!(e, 3);
+    }
+}

--- a/src/libs/libc_math/src/frexpf.rs
+++ b/src/libs/libc_math/src/frexpf.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Extracts the normalized fraction and exponent from `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+/// - `exp`: Pointer to store the exponent.
+///
+/// # Returns
+///
+/// The normalized fraction. The exponent is stored in `*exp`.
+///
+/// # Safety
+///
+/// The caller must ensure `exp` points to a valid, writable `c_int` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn frexpf(x: f32, exp: *mut c_int) -> f32 {
+    if x == 0.0 {
+        if !exp.is_null() {
+            unsafe { *exp = 0 };
+        }
+        return x;
+    }
+    if x.is_nan() || x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        if !exp.is_null() {
+            unsafe { *exp = 0 };
+        }
+        return x;
+    }
+
+    let mut bits: u32 = x.to_bits();
+    let mut exp_raw: u32 = (bits >> 23) & 0xFF;
+
+    let mut adj: i64 = 0;
+    if exp_raw == 0 {
+        let scaled: f32 = x * 8_388_608.0; // 2^23
+        bits = scaled.to_bits();
+        exp_raw = (bits >> 23) & 0xFF;
+        adj = -23;
+    }
+
+    let e: i64 = i64::from(exp_raw) - 126 + adj;
+
+    if !exp.is_null() {
+        #[allow(clippy::cast_possible_truncation)]
+        let e_int: c_int = e as c_int;
+        unsafe { *exp = e_int };
+    }
+
+    let frac_bits: u32 = (bits & 0x807F_FFFF) | 0x3F00_0000;
+    f32::from_bits(frac_bits)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut e: c_int = 0;
+        let f: f32 = unsafe { frexpf(8.0, &mut e) };
+        assert!((f - 0.5).abs() < 1e-5);
+        assert_eq!(e, 4);
+    }
+
+    #[test]
+    fn test_zero() {
+        let mut e: c_int = 0;
+        let f: f32 = unsafe { frexpf(0.0, &mut e) };
+        assert_eq!(f, 0.0);
+        assert_eq!(e, 0);
+    }
+
+    #[test]
+    fn test_one() {
+        let mut e: c_int = 0;
+        let f: f32 = unsafe { frexpf(1.0, &mut e) };
+        assert!((f - 0.5).abs() < 1e-5);
+        assert_eq!(e, 1);
+    }
+}

--- a/src/libs/libc_math/src/gamma.rs
+++ b/src/libs/libc_math/src/gamma.rs
@@ -1,0 +1,38 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the natural logarithm of the absolute value of the gamma function (legacy `gamma`,
+/// equivalent to [`lgamma`](crate::lgamma::lgamma)).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `ln(|Γ(x)|)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn gamma(x: f64) -> f64 {
+    crate::lgamma::lgamma(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alias_of_lgamma() {
+        // gamma() is the legacy alias for lgamma().
+        assert_eq!(gamma(3.0), crate::lgamma::lgamma(3.0));
+        assert_eq!(gamma(5.0), crate::lgamma::lgamma(5.0));
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(gamma(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/hypot.rs
+++ b/src/libs/libc_math/src/hypot.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the hypotenuse: `sqrt(x^2 + y^2)` without undue overflow.
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The Euclidean distance `sqrt(x^2 + y^2)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn hypot(x: f64, y: f64) -> f64 {
+    // Handle special cases.
+    let ax: f64 = f64::from_bits(x.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+    let ay: f64 = f64::from_bits(y.to_bits() & 0x7FFF_FFFF_FFFF_FFFF);
+
+    // If either is inf, result is inf (even if the other is NaN).
+    if ax.to_bits() == 0x7FF0_0000_0000_0000 || ay.to_bits() == 0x7FF0_0000_0000_0000 {
+        return f64::from_bits(0x7FF0_0000_0000_0000);
+    }
+    if x.is_nan() || y.is_nan() {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+
+    // Use the larger magnitude to avoid overflow.
+    let (big, small) = if ax >= ay { (ax, ay) } else { (ay, ax) };
+
+    if big == 0.0 {
+        return 0.0;
+    }
+
+    let ratio: f64 = small / big;
+    big * crate::sqrt::sqrt(1.0 + ratio * ratio)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_345() {
+        assert!((hypot(3.0, 4.0) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert!((hypot(0.0, 5.0) - 5.0).abs() < 1e-10);
+        assert!((hypot(3.0, 0.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_inf() {
+        assert_eq!(hypot(f64::INFINITY, 1.0), f64::INFINITY);
+        assert_eq!(hypot(1.0, f64::INFINITY), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(hypot(f64::NAN, 1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/hypotf.rs
+++ b/src/libs/libc_math/src/hypotf.rs
@@ -1,0 +1,56 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the hypotenuse: `sqrt(x^2 + y^2)` without undue overflow (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: First value.
+/// - `y`: Second value.
+///
+/// # Returns
+///
+/// The Euclidean distance.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn hypotf(x: f32, y: f32) -> f32 {
+    let ax: f32 = f32::from_bits(x.to_bits() & 0x7FFF_FFFF);
+    let ay: f32 = f32::from_bits(y.to_bits() & 0x7FFF_FFFF);
+
+    if ax.to_bits() == 0x7F80_0000 || ay.to_bits() == 0x7F80_0000 {
+        return f32::from_bits(0x7F80_0000);
+    }
+    if x.is_nan() || y.is_nan() {
+        return f32::from_bits(0x7FC0_0000);
+    }
+
+    let (big, small) = if ax >= ay { (ax, ay) } else { (ay, ax) };
+    if big == 0.0 {
+        return 0.0;
+    }
+
+    let ratio: f32 = small / big;
+    big * crate::sqrtf::sqrtf(1.0 + ratio * ratio)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_345() {
+        assert!((hypotf(3.0, 4.0) - 5.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_inf() {
+        assert_eq!(hypotf(f32::INFINITY, 1.0), f32::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/isinf.rs
+++ b/src/libs/libc_math/src/isinf.rs
@@ -1,0 +1,71 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Tests whether a single-precision value is infinite.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if `x` is infinite, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __isinff(x: f32) -> c_int {
+    let bits: u32 = x.to_bits();
+    if bits & 0x7FFF_FFFF == 0x7F80_0000 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Tests whether a double-precision value is infinite.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if `x` is infinite, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __isinfd(x: f64) -> c_int {
+    let bits: u64 = x.to_bits();
+    if bits & 0x7FFF_FFFF_FFFF_FFFF == 0x7FF0_0000_0000_0000 {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_isinff() {
+        assert_eq!(__isinff(f32::INFINITY), 1);
+        assert_eq!(__isinff(f32::NEG_INFINITY), 1);
+        assert_eq!(__isinff(1.0), 0);
+        assert_eq!(__isinff(f32::NAN), 0);
+    }
+
+    #[test]
+    fn test_isinfd() {
+        assert_eq!(__isinfd(f64::INFINITY), 1);
+        assert_eq!(__isinfd(f64::NEG_INFINITY), 1);
+        assert_eq!(__isinfd(1.0), 0);
+        assert_eq!(__isinfd(f64::NAN), 0);
+    }
+}

--- a/src/libs/libc_math/src/isnan.rs
+++ b/src/libs/libc_math/src/isnan.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Tests whether a single-precision value is NaN.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if `x` is NaN, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __isnanf(x: f32) -> c_int {
+    if x.is_nan() {
+        1
+    } else {
+        0
+    }
+}
+
+/// Tests whether a double-precision value is NaN.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if `x` is NaN, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __isnand(x: f64) -> c_int {
+    if x.is_nan() {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_isnanf() {
+        assert_eq!(__isnanf(f32::NAN), 1);
+        assert_eq!(__isnanf(1.0), 0);
+        assert_eq!(__isnanf(f32::INFINITY), 0);
+    }
+
+    #[test]
+    fn test_isnand() {
+        assert_eq!(__isnand(f64::NAN), 1);
+        assert_eq!(__isnand(1.0), 0);
+        assert_eq!(__isnand(f64::INFINITY), 0);
+    }
+}

--- a/src/libs/libc_math/src/ldexp.rs
+++ b/src/libs/libc_math/src/ldexp.rs
@@ -1,0 +1,97 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Multiplies a floating-point number by a power of two.
+///
+/// # Description
+///
+/// Computes `x * 2^exp`.
+///
+/// # Parameters
+///
+/// - `x`: Base value.
+/// - `exp`: Exponent.
+///
+/// # Returns
+///
+/// The value `x * 2^exp`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ldexp(x: f64, exp: c_int) -> f64 {
+    // Handle special cases.
+    if x == 0.0 || x.is_nan() || x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        return x;
+    }
+
+    let mut n: i64 = i64::from(exp);
+
+    // Apply scaling in steps to handle large exponents.
+    const SCALE_UP: f64 = f64::from_bits(0x7FE0_0000_0000_0000u64); // 2^1023
+    const SCALE_DN: f64 = f64::from_bits(0x0010_0000_0000_0000u64); // 2^-1022
+
+    let mut result: f64 = x;
+
+    if n > 1023 {
+        result *= SCALE_UP;
+        n -= 1023;
+        if n > 1023 {
+            result *= SCALE_UP;
+            n -= 1023;
+            if n > 1023 {
+                n = 1023;
+            }
+        }
+    } else if n < -1022 {
+        result *= SCALE_DN;
+        n += 1022;
+        if n < -1022 {
+            result *= SCALE_DN;
+            n += 1022;
+            if n < -1022 {
+                n = -1022;
+            }
+        }
+    }
+
+    let biased: u64 = (n + 1023) as u64;
+    result * f64::from_bits(biased << 52)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((ldexp(1.0, 3) - 8.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_fraction() {
+        assert!((ldexp(1.5, 2) - 6.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_exp() {
+        assert!((ldexp(8.0, -3) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(ldexp(0.0, 10), 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(ldexp(f64::NAN, 5).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/ldexpf.rs
+++ b/src/libs/libc_math/src/ldexpf.rs
@@ -1,0 +1,82 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Multiplies a single-precision floating-point number by a power of two.
+///
+/// # Parameters
+///
+/// - `x`: Base value.
+/// - `exp`: Exponent.
+///
+/// # Returns
+///
+/// The value `x * 2^exp`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ldexpf(x: f32, exp: c_int) -> f32 {
+    if x == 0.0 || x.is_nan() || x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        return x;
+    }
+
+    let mut n: i64 = i64::from(exp);
+    let mut result: f32 = x;
+
+    const SCALE_UP: f32 = f32::from_bits(0x7F00_0000u32); // 2^127
+    const SCALE_DN: f32 = f32::from_bits(0x0080_0000u32); // 2^-126
+
+    if n > 127 {
+        result *= SCALE_UP;
+        n -= 127;
+        if n > 127 {
+            result *= SCALE_UP;
+            n -= 127;
+            if n > 127 {
+                n = 127;
+            }
+        }
+    } else if n < -126 {
+        result *= SCALE_DN;
+        n += 126;
+        if n < -126 {
+            result *= SCALE_DN;
+            n += 126;
+            if n < -126 {
+                n = -126;
+            }
+        }
+    }
+
+    let biased: u64 = (n + 127) as u64;
+    #[allow(clippy::cast_possible_truncation)]
+    let biased_u32: u32 = biased as u32;
+    result * f32::from_bits(biased_u32 << 23)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((ldexpf(1.0, 3) - 8.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative_exp() {
+        assert!((ldexpf(8.0, -3) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(ldexpf(0.0, 10), 0.0);
+    }
+}

--- a/src/libs/libc_math/src/lgamma.rs
+++ b/src/libs/libc_math/src/lgamma.rs
@@ -1,0 +1,98 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Lanczos approximation parameter `g`.
+const G: f64 = 7.0;
+
+/// Lanczos coefficients (g = 7, n = 9).
+const C: [f64; 9] = [
+    0.999_999_999_999_809_9,
+    676.520_368_121_885_1,
+    -1_259.139_216_722_402_8,
+    771.323_428_777_653_1,
+    -176.615_029_162_140_6,
+    12.507_343_278_686_905,
+    -0.138_571_095_265_720_12,
+    9.984_369_578_019_572e-6,
+    1.505_632_735_149_311_6e-7,
+];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Computes the natural logarithm of the absolute value of the gamma function of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `ln(|Γ(x)|)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn lgamma(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x < 0.5 {
+        // Reflection: ln Γ(x) = ln(π / |sin(πx)|) - ln Γ(1 - x).
+        let s: f64 = crate::sin::sin(core::f64::consts::PI * x).abs();
+        if s == 0.0 {
+            return f64::INFINITY;
+        }
+        crate::log::log(core::f64::consts::PI / s) - lgamma(1.0 - x)
+    } else {
+        let y: f64 = x - 1.0;
+        let mut a: f64 = C[0];
+        let mut denom: f64 = y + 1.0;
+        let mut i: usize = 1;
+        while i < 9 {
+            a += C[i] / denom;
+            denom += 1.0;
+            i += 1;
+        }
+        let t: f64 = y + G + 0.5;
+        const HALF_LN_2PI: f64 = 0.918_938_533_204_672_8;
+        HALF_LN_2PI + (y + 0.5) * crate::log::log(t) - t + crate::log::log(a)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_factorials() {
+        // lgamma(n) == ln((n - 1)!).
+        assert!((lgamma(1.0)).abs() < 1e-9);
+        assert!((lgamma(2.0)).abs() < 1e-9);
+        assert!((lgamma(3.0) - core::f64::consts::LN_2).abs() < 1e-9);
+        assert!((lgamma(5.0) - 3.178_053_830_347_945).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_half() {
+        // lgamma(0.5) == ln(sqrt(pi)).
+        assert!((lgamma(0.5) - 0.572_364_942_924_700_4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_reflection() {
+        // lgamma is finite for negative non-integer arguments.
+        assert!(lgamma(-0.5).is_finite());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(lgamma(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/lib.rs
+++ b/src/libs/libc_math/src/lib.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(core_intrinsics)]
+#![allow(internal_features)]
+// Lints
+#![allow(clippy::approx_constant)]
+#![forbid(clippy::unwrap_used)]
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod acos;
+pub mod acosf;
+pub mod acosh;
+pub mod asin;
+pub mod asinf;
+pub mod asinh;
+pub mod atan;
+pub mod atan2;
+pub mod atan2f;
+pub mod atanf;
+pub mod atanh;
+pub mod cbrt;
+pub mod cbrtf;
+pub mod ceil;
+pub mod ceilf;
+pub mod copysign;
+pub mod copysignf;
+pub mod cos;
+pub mod cosf;
+pub mod cosh;
+pub mod erf;
+pub mod erfc;
+pub mod exp;
+pub mod exp2;
+pub mod exp2f;
+pub mod expf;
+pub mod expm1;
+pub mod fabs;
+pub mod fabsf;
+pub mod fenv;
+pub mod floor;
+pub mod floorf;
+pub mod fma;
+pub mod fmaf;
+pub mod fmax;
+pub mod fmaxf;
+pub mod fmin;
+pub mod fminf;
+pub mod fmod;
+pub mod fmodf;
+pub mod fpclassify;
+pub mod frexp;
+pub mod frexpf;
+pub mod gamma;
+pub mod hypot;
+pub mod hypotf;
+pub mod isinf;
+pub mod isnan;
+pub mod ldexp;
+pub mod ldexpf;
+pub mod lgamma;
+pub mod log;
+pub mod log10;
+pub mod log10f;
+pub mod log1p;
+pub mod log2;
+pub mod log2f;
+pub mod logf;
+pub mod lrint;
+pub mod modf;
+pub mod modff;
+pub mod nextafter;
+pub mod pow;
+pub mod powf;
+pub mod remainder;
+pub mod round;
+pub mod roundf;
+pub mod scalbn;
+pub mod scalbnf;
+pub mod signbit;
+pub mod sin;
+pub mod sinf;
+pub mod sinh;
+pub mod sqrt;
+pub mod sqrtf;
+pub mod tan;
+pub mod tanf;
+pub mod tanh;
+pub mod tgamma;
+pub mod trunc;
+pub mod truncf;

--- a/src/libs/libc_math/src/log.rs
+++ b/src/libs/libc_math/src/log.rs
@@ -1,0 +1,132 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LN2: f64 = core::f64::consts::LN_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the natural logarithm of `x`.
+///
+/// # Description
+///
+/// Decomposes `x` into mantissa `m` and exponent `e`, then computes
+/// `log(x) = e * ln(2) + log(m)` using the substitution `s = (m-1)/(m+1)` for fast convergence.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The natural logarithm of `x`. Returns NaN for negative inputs, -inf for zero.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x < 0.0 {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+    if x == 0.0 {
+        return f64::from_bits(0xFFF0_0000_0000_0000);
+    }
+    if x.to_bits() == 0x7FF0_0000_0000_0000 {
+        return x;
+    }
+
+    let bits: u64 = x.to_bits();
+    let exp_raw: u64 = (bits >> 52) & 0x7FF;
+
+    // Handle subnormals by scaling up.
+    let (adj_bits, exp_adj): (u64, i64) = if exp_raw == 0 {
+        let scaled: f64 = x * 4_503_599_627_370_496.0; // 2^52
+        (scaled.to_bits(), -52)
+    } else {
+        (bits, 0)
+    };
+
+    let exp_biased: u64 = (adj_bits >> 52) & 0x7FF;
+    #[allow(clippy::cast_possible_wrap)]
+    let mut e: i64 = (exp_biased as i64) - 1023 + exp_adj;
+
+    // Extract mantissa in [1, 2).
+    let m_bits: u64 = (adj_bits & 0x000F_FFFF_FFFF_FFFF) | 0x3FF0_0000_0000_0000;
+    let mut m: f64 = f64::from_bits(m_bits);
+
+    // Reduce m to [sqrt(2)/2, sqrt(2)] for better convergence.
+    if m > core::f64::consts::SQRT_2 {
+        m *= 0.5;
+        e += 1;
+    }
+
+    // Use substitution s = (m-1)/(m+1), then log(m) = 2*(s + s^3/3 + s^5/5 + ...).
+    let s: f64 = (m - 1.0) / (m + 1.0);
+    let s2: f64 = s * s;
+
+    let log_m: f64 = 2.0
+        * s
+        * (1.0
+            + s2 * (1.0 / 3.0
+                + s2 * (0.2
+                    + s2 * (1.0 / 7.0
+                        + s2 * (1.0 / 9.0
+                            + s2 * (1.0 / 11.0 + s2 * (1.0 / 13.0 + s2 * (1.0 / 15.0))))))));
+
+    let e_f64: f64 = e as f64;
+    e_f64 * LN2 + log_m
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((log(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_e() {
+        assert!((log(2.718_281_828_459_045) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_two() {
+        assert!((log(2.0) - LN2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_ten() {
+        assert!((log(10.0) - 2.302_585_092_994_046).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(log(0.0), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(log(-1.0).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(log(f64::INFINITY), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(log(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/log10.rs
+++ b/src/libs/libc_math/src/log10.rs
@@ -1,0 +1,55 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LOG10_E: f64 = core::f64::consts::LOG10_E;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the base-10 logarithm of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The base-10 logarithm of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log10(x: f64) -> f64 {
+    crate::log::log(x) * LOG10_E
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((log10(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_ten() {
+        assert!((log10(10.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_hundred() {
+        assert!((log10(100.0) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(log10(0.0), f64::NEG_INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/log10f.rs
+++ b/src/libs/libc_math/src/log10f.rs
@@ -1,0 +1,45 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LOG10_E: f32 = core::f32::consts::LOG10_E;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the base-10 logarithm of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The base-10 logarithm of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log10f(x: f32) -> f32 {
+    crate::logf::logf(x) * LOG10_E
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ten() {
+        assert!((log10f(10.0) - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((log10f(1.0)).abs() < 1e-4);
+    }
+}

--- a/src/libs/libc_math/src/log1p.rs
+++ b/src/libs/libc_math/src/log1p.rs
@@ -1,0 +1,59 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes `ln(1 + x)`.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must satisfy `x >= -1`).
+///
+/// # Returns
+///
+/// The value `log1p(x) = ln(1 + x)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log1p(x: f64) -> f64 {
+    if x.is_nan() || x == 0.0 {
+        return x;
+    }
+    if x == -1.0 {
+        return f64::NEG_INFINITY;
+    }
+    if x < -1.0 {
+        return f64::NAN;
+    }
+    crate::log::log(1.0 + x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(log1p(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((log1p(1.0) - core::f64::consts::LN_2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_one() {
+        assert_eq!(log1p(-1.0), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_below_minus_one() {
+        assert!(log1p(-2.0).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(log1p(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/log2.rs
+++ b/src/libs/libc_math/src/log2.rs
@@ -1,0 +1,60 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LOG2_E: f64 = core::f64::consts::LOG2_E;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the base-2 logarithm of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The base-2 logarithm of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log2(x: f64) -> f64 {
+    crate::log::log(x) * LOG2_E
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((log2(1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_two() {
+        assert!((log2(2.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_eight() {
+        assert!((log2(8.0) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(log2(0.0), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(log2(-1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/log2f.rs
+++ b/src/libs/libc_math/src/log2f.rs
@@ -1,0 +1,45 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LOG2_E: f32 = core::f32::consts::LOG2_E;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the base-2 logarithm of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The base-2 logarithm of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn log2f(x: f32) -> f32 {
+    crate::logf::logf(x) * LOG2_E
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_two() {
+        assert!((log2f(2.0) - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((log2f(1.0)).abs() < 1e-4);
+    }
+}

--- a/src/libs/libc_math/src/logf.rs
+++ b/src/libs/libc_math/src/logf.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const LN2: f32 = core::f32::consts::LN_2;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the natural logarithm of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be positive).
+///
+/// # Returns
+///
+/// The natural logarithm of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn logf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    if x < 0.0 {
+        return f32::from_bits(0x7FC0_0000);
+    }
+    if x == 0.0 {
+        return f32::from_bits(0xFF80_0000);
+    }
+    if x.to_bits() == 0x7F80_0000 {
+        return x;
+    }
+
+    let bits: u32 = x.to_bits();
+    let exp_raw: u32 = (bits >> 23) & 0xFF;
+
+    let (adj_bits, exp_adj): (u32, i64) = if exp_raw == 0 {
+        let scaled: f32 = x * 8_388_608.0;
+        (scaled.to_bits(), -23)
+    } else {
+        (bits, 0)
+    };
+
+    let exp_biased: u32 = (adj_bits >> 23) & 0xFF;
+    let mut e: i64 = i64::from(exp_biased) - 127 + exp_adj;
+
+    let m_bits: u32 = (adj_bits & 0x007F_FFFF) | 0x3F80_0000;
+    let mut m: f32 = f32::from_bits(m_bits);
+
+    if m > core::f32::consts::SQRT_2 {
+        m *= 0.5;
+        e += 1;
+    }
+
+    let s: f32 = (m - 1.0) / (m + 1.0);
+    let s2: f32 = s * s;
+
+    let log_m: f32 =
+        2.0 * s * (1.0 + s2 * (1.0 / 3.0 + s2 * (0.2 + s2 * (1.0 / 7.0 + s2 * (1.0 / 9.0)))));
+
+    let e_f32: f32 = e as f32;
+    e_f32 * LN2 + log_m
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_one() {
+        assert!((logf(1.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_e() {
+        assert!((logf(2.718_282) - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(logf(0.0), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(logf(-1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/lrint.rs
+++ b/src/libs/libc_math/src/lrint.rs
@@ -1,0 +1,116 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use ::sysapi::ffi::c_long;
+
+/// Rounds `x` to the nearest integer (per the current rounding mode) as a `long`.
+///
+/// `lrint` rounds according to the current rounding mode (see `fesetround`),
+/// whose default is round-to-nearest, ties-to-even (IEEE-754 `roundTiesToEven`).
+/// In the default mode this differs from C `round()` (ties away from zero): e.g.
+/// `lrint(0.5) == 0`, `lrint(2.5) == 2`, while `round(0.5) == 1`. Code that
+/// depends on the default mode (for example ECMAScript `Uint8ClampedArray`
+/// element conversion, which is specified as round-half-to-even) relies on this.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The rounded integer value of `x`, as a `long`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation)]
+pub extern "C" fn lrint(x: f64) -> c_long {
+    let f: f64 = crate::floor::floor(x);
+    let diff: f64 = x - f;
+    let rounded: f64 = match crate::fenv::fegetround() {
+        // Round toward negative infinity.
+        crate::fenv::FE_DOWNWARD => f,
+        // Round toward positive infinity.
+        crate::fenv::FE_UPWARD => {
+            if diff > 0.0 {
+                f + 1.0
+            } else {
+                f
+            }
+        },
+        // Round toward zero (truncate).
+        crate::fenv::FE_TOWARDZERO => crate::trunc::trunc(x),
+        // Round to nearest, ties to even (`FE_TONEAREST`, the default).
+        _ => {
+            if diff < 0.5 {
+                f
+            } else if diff > 0.5 {
+                f + 1.0
+            } else {
+                // Exact tie: round to the even neighbor. `f` is integral, so it
+                // is even iff `f / 2` is also integral (`floor(f / 2) == f / 2`).
+                // This holds for every representable magnitude, unlike an
+                // integer-cast parity check.
+                let half: f64 = f * 0.5;
+                if crate::floor::floor(half) == half {
+                    f
+                } else {
+                    f + 1.0
+                }
+            }
+        },
+    };
+    rounded as c_long
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ties_to_even() {
+        // Halfway cases round to the nearest even integer.
+        assert_eq!(lrint(0.5), 0);
+        assert_eq!(lrint(1.5), 2);
+        assert_eq!(lrint(2.5), 2);
+        assert_eq!(lrint(3.5), 4);
+        assert_eq!(lrint(-0.5), 0);
+        assert_eq!(lrint(-1.5), -2);
+        assert_eq!(lrint(-2.5), -2);
+    }
+
+    #[test]
+    fn test_non_ties() {
+        assert_eq!(lrint(2.3), 2);
+        assert_eq!(lrint(2.7), 3);
+        assert_eq!(lrint(-2.3), -2);
+        assert_eq!(lrint(-2.7), -3);
+        assert_eq!(lrint(0.0), 0);
+        assert_eq!(lrint(7.0), 7);
+    }
+
+    #[test]
+    fn test_rounding_modes() {
+        use crate::fenv;
+
+        // Round toward negative infinity.
+        assert_eq!(fenv::fesetround(fenv::FE_DOWNWARD), 0);
+        assert_eq!(lrint(2.7), 2);
+        assert_eq!(lrint(-2.3), -3);
+
+        // Round toward positive infinity.
+        assert_eq!(fenv::fesetround(fenv::FE_UPWARD), 0);
+        assert_eq!(lrint(2.3), 3);
+        assert_eq!(lrint(-2.7), -2);
+
+        // Round toward zero.
+        assert_eq!(fenv::fesetround(fenv::FE_TOWARDZERO), 0);
+        assert_eq!(lrint(2.7), 2);
+        assert_eq!(lrint(-2.7), -2);
+
+        // Restore the default mode and confirm ties-to-even.
+        assert_eq!(fenv::fesetround(fenv::FE_TONEAREST), 0);
+        assert_eq!(lrint(2.5), 2);
+    }
+}

--- a/src/libs/libc_math/src/modf.rs
+++ b/src/libs/libc_math/src/modf.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Splits `x` into integer and fractional parts.
+///
+/// # Description
+///
+/// Stores the integer part in `*iptr` and returns the fractional part. Both parts
+/// have the same sign as `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+/// - `iptr`: Pointer to store the integer part.
+///
+/// # Returns
+///
+/// The fractional part of `x`.
+///
+/// # Safety
+///
+/// The caller must ensure `iptr` points to a valid, writable `f64` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn modf(x: f64, iptr: *mut f64) -> f64 {
+    let t: f64 = crate::trunc::trunc(x);
+    if !iptr.is_null() {
+        unsafe { *iptr = t };
+    }
+    // Handle NaN and inf.
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        // For infinity, fractional part is ±0.
+        return f64::from_bits(x.to_bits() & 0x8000_0000_0000_0000);
+    }
+    x - t
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive() {
+        let mut i: f64 = 0.0;
+        let f: f64 = unsafe { modf(3.75, &mut i) };
+        assert!((i - 3.0).abs() < 1e-10);
+        assert!((f - 0.75).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        let mut i: f64 = 0.0;
+        let f: f64 = unsafe { modf(-3.75, &mut i) };
+        assert!((i - (-3.0)).abs() < 1e-10);
+        assert!((f - (-0.75)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_integer() {
+        let mut i: f64 = 0.0;
+        let f: f64 = unsafe { modf(5.0, &mut i) };
+        assert!((i - 5.0).abs() < 1e-10);
+        assert!(f.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        let mut i: f64 = 0.0;
+        let f: f64 = unsafe { modf(0.0, &mut i) };
+        assert_eq!(i, 0.0);
+        assert_eq!(f, 0.0);
+    }
+}

--- a/src/libs/libc_math/src/modff.rs
+++ b/src/libs/libc_math/src/modff.rs
@@ -1,0 +1,68 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Splits `x` into integer and fractional parts (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+/// - `iptr`: Pointer to store the integer part.
+///
+/// # Returns
+///
+/// The fractional part of `x`.
+///
+/// # Safety
+///
+/// The caller must ensure `iptr` points to a valid, writable `f32` location.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn modff(x: f32, iptr: *mut f32) -> f32 {
+    let t: f32 = crate::truncf::truncf(x);
+    if !iptr.is_null() {
+        unsafe { *iptr = t };
+    }
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        return f32::from_bits(x.to_bits() & 0x8000_0000);
+    }
+    x - t
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive() {
+        let mut i: f32 = 0.0;
+        let f: f32 = unsafe { modff(3.75, &mut i) };
+        assert!((i - 3.0).abs() < 1e-5);
+        assert!((f - 0.75).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative() {
+        let mut i: f32 = 0.0;
+        let f: f32 = unsafe { modff(-3.75, &mut i) };
+        assert!((i - (-3.0)).abs() < 1e-5);
+        assert!((f - (-0.75)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_zero() {
+        let mut i: f32 = 0.0;
+        let f: f32 = unsafe { modff(0.0, &mut i) };
+        assert_eq!(i, 0.0);
+        assert_eq!(f, 0.0);
+    }
+}

--- a/src/libs/libc_math/src/nextafter.rs
+++ b/src/libs/libc_math/src/nextafter.rs
@@ -1,0 +1,70 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the next representable value after `x` in the direction of `y`.
+///
+/// # Parameters
+///
+/// - `x`: Starting value.
+/// - `y`: Direction value.
+///
+/// # Returns
+///
+/// The next representable double after `x` toward `y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn nextafter(x: f64, y: f64) -> f64 {
+    if x.is_nan() || y.is_nan() {
+        return f64::NAN;
+    }
+    if x == y {
+        return y;
+    }
+    if x == 0.0 {
+        // Smallest subnormal in the direction of y.
+        let tiny: f64 = f64::from_bits(1);
+        return if y > 0.0 { tiny } else { -tiny };
+    }
+
+    let bits: u64 = x.to_bits();
+    // Moving away from zero increases the magnitude bits; toward zero decreases.
+    let away_from_zero: bool = (y > x) == (x > 0.0);
+    let next: u64 = if away_from_zero { bits + 1 } else { bits - 1 };
+    f64::from_bits(next)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toward_larger() {
+        assert_eq!(nextafter(1.0, 2.0), 1.0 + f64::EPSILON);
+    }
+
+    #[test]
+    fn test_toward_smaller() {
+        assert!(nextafter(1.0, 0.0) < 1.0);
+        assert_eq!(nextafter(1.0, 0.0), 1.0 - f64::EPSILON / 2.0);
+    }
+
+    #[test]
+    fn test_equal() {
+        assert_eq!(nextafter(3.5, 3.5), 3.5);
+    }
+
+    #[test]
+    fn test_from_zero() {
+        assert_eq!(nextafter(0.0, 1.0), f64::from_bits(1));
+        assert_eq!(nextafter(0.0, -1.0), -f64::from_bits(1));
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(nextafter(f64::NAN, 1.0).is_nan());
+        assert!(nextafter(1.0, f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/pow.rs
+++ b/src/libs/libc_math/src/pow.rs
@@ -1,0 +1,186 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `x` raised to the power `y`.
+///
+/// # Description
+///
+/// Integer exponents are evaluated by exact binary exponentiation (so results such as
+/// `pow(2, -1022)` reproduce the exact IEEE-754 value), and fractional exponents fall back to
+/// `exp(y * log(x))` with special-case handling per IEEE 754.
+///
+/// # Parameters
+///
+/// - `x`: Base.
+/// - `y`: Exponent.
+///
+/// # Returns
+///
+/// The value `x^y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn pow(x: f64, y: f64) -> f64 {
+    // x^0 = 1 for any x, including NaN (C Annex F.10.4.4).
+    if y == 0.0 {
+        return 1.0;
+    }
+
+    // 1^y = 1 for any y, including NaN (C Annex F.10.4.4).
+    if x == 1.0 {
+        return 1.0;
+    }
+
+    // Any other NaN operand propagates NaN.
+    if x.is_nan() || y.is_nan() {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+
+    // x^1 = x.
+    if y == 1.0 {
+        return x;
+    }
+
+    // pow(-1, ±inf) == 1 (C Annex F.10.4.4 / IEEE-754).
+    if x == -1.0 && y.is_infinite() {
+        return 1.0;
+    }
+
+    // Handle x == 0, preserving the sign of zero per IEEE 754 / C Annex F.10.4.4.
+    // The result is negative only when the base is -0 and the exponent is an odd
+    // integer.
+    if x == 0.0 {
+        let y_trunc: f64 = crate::trunc::trunc(y);
+        let y_is_odd_integer: bool =
+            y == y_trunc && crate::trunc::trunc(y_trunc * 0.5) != y_trunc * 0.5;
+        let negative: bool = x.is_sign_negative() && y_is_odd_integer;
+        if y > 0.0 {
+            return if negative { -0.0 } else { 0.0 };
+        }
+        // y < 0 here (y == 0 handled above): pole at zero yields infinity.
+        return if negative {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+    }
+
+    // Integer exponent: evaluate by exact binary exponentiation. This reproduces the exact
+    // IEEE-754 result for exactly-representable values (e.g. powers of two and integer bases),
+    // which the `exp(y * log(x))` approximation cannot guarantee.
+    let y_trunc: f64 = crate::trunc::trunc(y);
+    let y_is_integer: bool = y == y_trunc;
+    if y_is_integer && crate::fabs::fabs(y) < 9_007_199_254_740_992.0 {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let mut n: u64 = crate::fabs::fabs(y) as u64;
+        let mut base: f64 = x;
+        let mut acc: f64 = 1.0;
+        while n > 0 {
+            if n & 1 == 1 {
+                acc *= base;
+            }
+            n >>= 1;
+            if n > 0 {
+                base *= base;
+            }
+        }
+        return if y < 0.0 { 1.0 / acc } else { acc };
+    }
+
+    // Negative base.
+    if x < 0.0 {
+        // A real result exists only for integer exponents.
+        if !y_is_integer {
+            return f64::from_bits(0x7FF8_0000_0000_0000); // NaN
+        }
+        // Integer exponents with magnitude below 2^53 were handled above. Every
+        // f64 whose magnitude is >= 2^53 is an exact even integer, so the result
+        // is the positive magnitude |x|^y.
+        return crate::exp::exp(y * crate::log::log(-x));
+    }
+
+    // General case: positive base, fractional exponent.
+    crate::exp::exp(y * crate::log::log(x))
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_squares() {
+        assert!((pow(2.0, 2.0) - 4.0).abs() < 1e-10);
+        assert!((pow(3.0, 3.0) - 27.0).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_zero_exponent() {
+        assert!((pow(5.0, 0.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one_exponent() {
+        assert!((pow(5.0, 1.0) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        assert!((pow(4.0, 0.5) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_base() {
+        assert!((pow(-2.0, 3.0) - (-8.0)).abs() < 1e-8);
+        assert!((pow(-2.0, 2.0) - 4.0).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_negative_base_non_integer() {
+        assert!(pow(-2.0, 1.5).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(pow(f64::NAN, 2.0).is_nan());
+    }
+
+    #[test]
+    fn test_nan_special_cases() {
+        // pow(x, +-0) == 1 for any x, including NaN.
+        assert_eq!(pow(f64::NAN, 0.0), 1.0);
+        assert_eq!(pow(f64::NAN, -0.0), 1.0);
+        // pow(1, y) == 1 for any y, including NaN.
+        assert_eq!(pow(1.0, f64::NAN), 1.0);
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // Odd integer exponents preserve the sign of zero.
+        assert!(pow(-0.0, 3.0).is_sign_negative());
+        assert_eq!(pow(-0.0, 3.0), 0.0);
+        assert_eq!(pow(-0.0, -3.0), f64::NEG_INFINITY);
+        // Non-odd exponents yield positive results.
+        assert!(!pow(-0.0, 2.0).is_sign_negative());
+        assert_eq!(pow(-0.0, -2.0), f64::INFINITY);
+        assert!(!pow(0.0, 3.0).is_sign_negative());
+        assert_eq!(pow(0.0, -3.0), f64::INFINITY);
+    }
+
+    #[test]
+    fn test_negative_base_large_even_integer() {
+        // 2^53 + 2 is an exact even integer in f64, so the result must be real
+        // (positive), not NaN. |-2|^(2^53+2) overflows to +inf.
+        let y: f64 = 9_007_199_254_740_994.0;
+        assert_eq!(pow(-2.0, y), f64::INFINITY);
+        // A base with magnitude < 1 underflows to +0 (still positive, not NaN).
+        let v: f64 = pow(-0.5, y);
+        assert_eq!(v, 0.0);
+        assert!(v.is_sign_positive());
+    }
+}

--- a/src/libs/libc_math/src/powf.rs
+++ b/src/libs/libc_math/src/powf.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes `x` raised to the power `y` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Base.
+/// - `y`: Exponent.
+///
+/// # Returns
+///
+/// The value `x^y`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn powf(x: f32, y: f32) -> f32 {
+    // Evaluate in double precision (reusing the exact integer-exponent path in `pow`) and round
+    // once back to single precision. This is at least as accurate as a native single-precision
+    // `expf(y * logf(x))` and yields exact results for integer exponents.
+    #[allow(clippy::cast_possible_truncation)]
+    let result: f32 = crate::pow::pow(f64::from(x), f64::from(y)) as f32;
+    result
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_square() {
+        assert!((powf(2.0, 2.0) - 4.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_zero_exp() {
+        assert!((powf(5.0, 0.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(powf(f32::NAN, 2.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/remainder.rs
+++ b/src/libs/libc_math/src/remainder.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the IEEE-754 remainder of `x / y`.
+///
+/// The result is `x - n*y`, where `n` is the integer nearest the exact value of `x/y`; when
+/// `|x/y - n| == 1/2`, `n` is chosen to be even.
+///
+/// # Parameters
+///
+/// - `x`: Dividend.
+/// - `y`: Divisor.
+///
+/// # Returns
+///
+/// The value `remainder(x, y)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn remainder(x: f64, y: f64) -> f64 {
+    if x.is_nan() || y.is_nan() || x.is_infinite() || y == 0.0 {
+        return f64::NAN;
+    }
+    if y.is_infinite() {
+        return x;
+    }
+    let q: f64 = x / y;
+    let n: f64 = round_ties_even(q);
+    x - n * y
+}
+
+/// Rounds `v` to the nearest integer, rounding halves to the nearest even integer.
+fn round_ties_even(v: f64) -> f64 {
+    let floor: f64 = crate::floor::floor(v);
+    let diff: f64 = v - floor;
+    if diff < 0.5 {
+        floor
+    } else if diff > 0.5 {
+        floor + 1.0
+    } else {
+        // Halfway: pick the even neighbor.
+        let half: f64 = floor * 0.5;
+        if half == crate::floor::floor(half) {
+            floor
+        } else {
+            floor + 1.0
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(remainder(5.0, 3.0), -1.0);
+        assert_eq!(remainder(7.0, 4.0), -1.0);
+    }
+
+    #[test]
+    fn test_ties_to_even() {
+        assert_eq!(remainder(5.0, 2.0), 1.0);
+    }
+
+    #[test]
+    fn test_infinite_divisor() {
+        assert_eq!(remainder(1.0, f64::INFINITY), 1.0);
+    }
+
+    #[test]
+    fn test_domain_errors() {
+        assert!(remainder(1.0, 0.0).is_nan());
+        assert!(remainder(f64::INFINITY, 1.0).is_nan());
+        assert!(remainder(f64::NAN, 1.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/round.rs
+++ b/src/libs/libc_math/src/round.rs
@@ -1,0 +1,65 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Rounds a floating-point number to the nearest integer, away from zero.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The rounded value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn round(x: f64) -> f64 {
+    let t: f64 = crate::trunc::trunc(x);
+    let d: f64 = crate::fabs::fabs(x - t);
+    if d >= 0.5 {
+        if x > 0.0 {
+            t + 1.0
+        } else {
+            t - 1.0
+        }
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_up() {
+        assert!((round(2.5) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_round_down() {
+        assert!((round(2.3) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_round() {
+        assert!((round(-2.5) - (-3.0)).abs() < 1e-10);
+        assert!((round(-2.3) - (-2.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(round(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(round(f64::INFINITY), f64::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/roundf.rs
+++ b/src/libs/libc_math/src/roundf.rs
@@ -1,0 +1,59 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Rounds a single-precision floating-point number to the nearest integer, away from zero.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The rounded value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn roundf(x: f32) -> f32 {
+    let t: f32 = crate::truncf::truncf(x);
+    let d: f32 = crate::fabsf::fabsf(x - t);
+    if d >= 0.5 {
+        if x > 0.0 {
+            t + 1.0
+        } else {
+            t - 1.0
+        }
+    } else {
+        t
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_up() {
+        assert!((roundf(2.5) - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_round_down() {
+        assert!((roundf(2.3) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((roundf(-2.5) - (-3.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(roundf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/scalbn.rs
+++ b/src/libs/libc_math/src/scalbn.rs
@@ -1,0 +1,46 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Multiplies a floating-point number by a power of two.
+///
+/// # Description
+///
+/// Equivalent to [`ldexp`](crate::ldexp::ldexp). Computes `x * 2^n`.
+///
+/// # Parameters
+///
+/// - `x`: Base value.
+/// - `n`: Exponent.
+///
+/// # Returns
+///
+/// The value `x * 2^n`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn scalbn(x: f64, n: c_int) -> f64 {
+    crate::ldexp::ldexp(x, n)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((scalbn(1.0, 4) - 16.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((scalbn(16.0, -4) - 1.0).abs() < 1e-10);
+    }
+}

--- a/src/libs/libc_math/src/scalbnf.rs
+++ b/src/libs/libc_math/src/scalbnf.rs
@@ -1,0 +1,37 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Multiplies a single-precision floating-point number by a power of two.
+///
+/// # Parameters
+///
+/// - `x`: Base value.
+/// - `n`: Exponent.
+///
+/// # Returns
+///
+/// The value `x * 2^n`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn scalbnf(x: f32, n: c_int) -> f32 {
+    crate::ldexpf::ldexpf(x, n)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert!((scalbnf(1.0, 4) - 16.0).abs() < 1e-5);
+    }
+}

--- a/src/libs/libc_math/src/signbit.rs
+++ b/src/libs/libc_math/src/signbit.rs
@@ -1,0 +1,69 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use sysapi::ffi::c_int;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Tests whether the sign bit of a single-precision value is set.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if the sign bit is set, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __signbitf(x: f32) -> c_int {
+    if x.to_bits() & 0x8000_0000 != 0 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Tests whether the sign bit of a double-precision value is set.
+///
+/// # Parameters
+///
+/// - `x`: Value to test.
+///
+/// # Returns
+///
+/// Non-zero if the sign bit is set, zero otherwise.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __signbitd(x: f64) -> c_int {
+    if x.to_bits() & 0x8000_0000_0000_0000 != 0 {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signbitf() {
+        assert_eq!(__signbitf(1.0), 0);
+        assert_eq!(__signbitf(-1.0), 1);
+        assert_eq!(__signbitf(-0.0), 1);
+        assert_eq!(__signbitf(0.0), 0);
+    }
+
+    #[test]
+    fn test_signbitd() {
+        assert_eq!(__signbitd(1.0), 0);
+        assert_eq!(__signbitd(-1.0), 1);
+        assert_eq!(__signbitd(-0.0), 1);
+        assert_eq!(__signbitd(0.0), 0);
+    }
+}

--- a/src/libs/libc_math/src/sin.rs
+++ b/src/libs/libc_math/src/sin.rs
@@ -1,0 +1,153 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#[cfg(test)]
+const PI: f64 = core::f64::consts::PI;
+const FRAC_PI_2: f64 = core::f64::consts::FRAC_PI_2;
+const FRAC_2_PI: f64 = core::f64::consts::FRAC_2_PI;
+
+/// Sin polynomial coefficients for Horner evaluation: c6, c5, ..., c0.
+/// sin(x) = x * (c0 + c1*x^2 + c2*x^4 + ... + c6*x^12).
+const SIN_COEFFS: [f64; 7] = [
+    1.605_904_383_682_161_5e-10,
+    -2.505_210_838_544_172e-8,
+    2.755_731_922_398_589_3e-6,
+    -1.984_126_984_126_984e-4,
+    8.333_333_333_333_332e-3,
+    -1.666_666_666_666_666_4e-1,
+    1.0,
+];
+
+/// Cos polynomial coefficients: c6, c5, ..., c0.
+/// cos(x) = c0 + c1*x^2 + c2*x^4 + ... + c6*x^12.
+const COS_COEFFS: [f64; 7] = [
+    2.087_675_698_786_81e-9,
+    -2.755_731_922_398_589_3e-7,
+    2.480_158_730_158_73e-5,
+    -1.388_888_888_888_889e-3,
+    4.166_666_666_666_666e-2,
+    -0.5,
+    1.0,
+];
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+/// Polynomial approximation of sin(x) for |x| <= PI/4.
+fn sin_kernel(x: f64) -> f64 {
+    let x2: f64 = x * x;
+    let mut p: f64 = SIN_COEFFS[0];
+    let mut i: usize = 1;
+    while i < SIN_COEFFS.len() {
+        p = p * x2 + SIN_COEFFS[i];
+        i += 1;
+    }
+    x * p
+}
+
+/// Polynomial approximation of cos(x) for |x| <= PI/4.
+fn cos_kernel(x: f64) -> f64 {
+    let x2: f64 = x * x;
+    let mut p: f64 = COS_COEFFS[0];
+    let mut i: usize = 1;
+    while i < COS_COEFFS.len() {
+        p = p * x2 + COS_COEFFS[i];
+        i += 1;
+    }
+    p
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the sine of `x` (in radians).
+///
+/// # Description
+///
+/// Uses quadrant-based range reduction to `[-PI/4, PI/4]` followed by polynomial approximation.
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The sine of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn sin(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
+        return f64::from_bits(0x7FF8_0000_0000_0000);
+    }
+
+    let k_f: f64 = crate::round::round(x * FRAC_2_PI);
+    #[allow(clippy::cast_possible_truncation)]
+    let k: i64 = k_f as i64;
+    let r: f64 = x - k_f * FRAC_PI_2;
+    let quadrant: u64 = (k as u64) & 3;
+
+    match quadrant {
+        0 => sin_kernel(r),
+        1 => cos_kernel(r),
+        2 => -sin_kernel(r),
+        3 => -cos_kernel(r),
+        _ => sin_kernel(r),
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((sin(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi_over_2() {
+        assert!((sin(FRAC_PI_2) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi() {
+        assert!((sin(PI)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_pi_over_2() {
+        assert!((sin(-FRAC_PI_2) - (-1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi_over_6() {
+        assert!((sin(PI / 6.0) - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_large_value() {
+        assert!((sin(100.0 * PI)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(sin(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert!(sin(f64::INFINITY).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/sinf.rs
+++ b/src/libs/libc_math/src/sinf.rs
@@ -1,0 +1,92 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+const FRAC_2_PI: f32 = core::f32::consts::FRAC_2_PI;
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+fn sin_kernel(x: f32) -> f32 {
+    let x2: f32 = x * x;
+    x * (1.0
+        + x2 * (-1.666_666_7e-1 + x2 * (8.333_334e-3 + x2 * (-1.984_127e-4 + x2 * 2.755_732e-6))))
+}
+
+fn cos_kernel(x: f32) -> f32 {
+    let x2: f32 = x * x;
+    1.0 + x2 * (-0.5 + x2 * (4.166_666_7e-2 + x2 * (-1.388_888_9e-3 + x2 * 2.480_158_8e-5)))
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the sine of `x` in radians (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The sine of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn sinf(x: f32) -> f32 {
+    if x.is_nan() {
+        return x;
+    }
+    if x.to_bits() & 0x7F80_0000 == 0x7F80_0000 {
+        return f32::from_bits(0x7FC0_0000);
+    }
+
+    let k_f: f32 = crate::roundf::roundf(x * FRAC_2_PI);
+
+    #[allow(clippy::cast_possible_truncation)]
+    let k: i64 = k_f as i64;
+
+    let r: f32 = x - k_f * FRAC_PI_2;
+    let quadrant: u64 = (k as u64) & 3;
+
+    match quadrant {
+        0 => sin_kernel(r),
+        1 => cos_kernel(r),
+        2 => -sin_kernel(r),
+        3 => -cos_kernel(r),
+        _ => sin_kernel(r),
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((sinf(0.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_pi_over_2() {
+        assert!((sinf(FRAC_PI_2) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_pi_over_6() {
+        assert!((sinf(core::f32::consts::PI / 6.0) - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(sinf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/sinh.rs
+++ b/src/libs/libc_math/src/sinh.rs
@@ -1,0 +1,55 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the hyperbolic sine of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `sinh(x) = (e^x - e^-x) / 2`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn sinh(x: f64) -> f64 {
+    if x.is_nan() || x.is_infinite() {
+        return x;
+    }
+    let e: f64 = crate::exp::exp(x);
+    (e - 1.0 / e) * 0.5
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((sinh(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((sinh(1.0) - 1.175_201_193_643_801_4).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_odd_symmetry() {
+        assert!((sinh(-1.0) + 1.175_201_193_643_801_4).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(sinh(f64::INFINITY), f64::INFINITY);
+        assert_eq!(sinh(f64::NEG_INFINITY), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(sinh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/sqrt.rs
+++ b/src/libs/libc_math/src/sqrt.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the square root of `x`.
+///
+/// # Description
+///
+/// Lowers to the target's hardware square-root instruction (`fsqrt` / `sqrtsd`) via the
+/// `sqrtf64` intrinsic, which is fully IEEE-754 correct (including NaN, infinity, and signed
+/// zero) and matches the newlib implementation's performance.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The square root of `x`. Returns NaN for negative inputs.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn sqrt(x: f64) -> f64 {
+    core::intrinsics::sqrtf64(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perfect_squares() {
+        assert!((sqrt(4.0) - 2.0).abs() < 1e-10);
+        assert!((sqrt(9.0) - 3.0).abs() < 1e-10);
+        assert!((sqrt(16.0) - 4.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_non_perfect() {
+        assert!((sqrt(2.0) - 1.41421356237).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(sqrt(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((sqrt(1.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(sqrt(-1.0).is_nan());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(sqrt(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(sqrt(f64::INFINITY), f64::INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/sqrtf.rs
+++ b/src/libs/libc_math/src/sqrtf.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the square root of `x` (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input value (must be non-negative).
+///
+/// # Returns
+///
+/// The square root of `x`. Returns NaN for negative inputs.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn sqrtf(x: f32) -> f32 {
+    core::intrinsics::sqrtf32(x)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perfect_squares() {
+        assert!((sqrtf(4.0) - 2.0).abs() < 1e-5);
+        assert!((sqrtf(9.0) - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_non_perfect() {
+        assert!((sqrtf(2.0) - 1.41421).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(sqrtf(-1.0).is_nan());
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(sqrtf(0.0), 0.0);
+    }
+}

--- a/src/libs/libc_math/src/tan.rs
+++ b/src/libs/libc_math/src/tan.rs
@@ -1,0 +1,64 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the tangent of `x` (in radians).
+///
+/// # Description
+///
+/// Computed as `sin(x) / cos(x)`.
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The tangent of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tan(x: f64) -> f64 {
+    let s: f64 = crate::sin::sin(x);
+    let c: f64 = crate::cos::cos(x);
+    // Divide directly so IEEE-754 signed-zero semantics select the correct signed infinity at the
+    // poles, where cos(x) underflows to +0.0 or -0.0.
+    s / c
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    const PI: f64 = core::f64::consts::PI;
+
+    #[test]
+    fn test_zero() {
+        assert!((tan(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pi_over_4() {
+        assert!((tan(PI / 4.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!((tan(-PI / 4.0) - (-1.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(tan(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert!(tan(f64::INFINITY).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/tanf.rs
+++ b/src/libs/libc_math/src/tanf.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Computes the tangent of `x` in radians (single-precision).
+///
+/// # Parameters
+///
+/// - `x`: Input angle in radians.
+///
+/// # Returns
+///
+/// The tangent of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tanf(x: f32) -> f32 {
+    let s: f32 = crate::sinf::sinf(x);
+    let c: f32 = crate::cosf::cosf(x);
+    // Divide directly so IEEE-754 signed-zero semantics select the correct signed infinity at the
+    // poles, where cosf(x) underflows to +0.0 or -0.0.
+    s / c
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    const PI: f32 = core::f32::consts::PI;
+
+    #[test]
+    fn test_zero() {
+        assert!((tanf(0.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_pi_over_4() {
+        assert!((tanf(PI / 4.0) - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(tanf(f32::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/tanh.rs
+++ b/src/libs/libc_math/src/tanh.rs
@@ -1,0 +1,61 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Computes the hyperbolic tangent of `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `tanh(x)`, saturating to `+/-1` for large magnitudes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tanh(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x > 20.0 {
+        return 1.0;
+    }
+    if x < -20.0 {
+        return -1.0;
+    }
+    let e2: f64 = crate::exp::exp(2.0 * x);
+    (e2 - 1.0) / (e2 + 1.0)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert!((tanh(0.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_one() {
+        assert!((tanh(1.0) - 0.761_594_155_955_764_9).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_odd_symmetry() {
+        assert!((tanh(-1.0) + 0.761_594_155_955_764_9).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_saturation() {
+        assert_eq!(tanh(30.0), 1.0);
+        assert_eq!(tanh(-30.0), -1.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(tanh(f64::NAN).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/tgamma.rs
+++ b/src/libs/libc_math/src/tgamma.rs
@@ -1,0 +1,118 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Lanczos approximation parameter `g`.
+const G: f64 = 7.0;
+
+/// Lanczos coefficients (g = 7, n = 9).
+const C: [f64; 9] = [
+    0.999_999_999_999_809_9,
+    676.520_368_121_885_1,
+    -1_259.139_216_722_402_8,
+    771.323_428_777_653_1,
+    -176.615_029_162_140_6,
+    12.507_343_278_686_905,
+    -0.138_571_095_265_720_12,
+    9.984_369_578_019_572e-6,
+    1.505_632_735_149_311_6e-7,
+];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Computes the gamma function of `x` using the Lanczos approximation.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The value `tgamma(x)`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tgamma(x: f64) -> f64 {
+    if x.is_nan() {
+        return x;
+    }
+    if x < 0.5 {
+        // The gamma function has poles at zero and the negative integers.
+        //
+        // At zero the one-sided limits are signed infinities: Γ(+0) = +∞ and Γ(-0) = -∞, so the sign
+        // of the zero is preserved. At a negative integer the two-sided limit does not exist (the
+        // function diverges to +∞ on one side and -∞ on the other); this is a domain error and yields
+        // NaN per the C standard (Annex F).
+        if x == 0.0 {
+            return if x.is_sign_negative() {
+                f64::from_bits(0xFFF0_0000_0000_0000) // -inf
+            } else {
+                f64::from_bits(0x7FF0_0000_0000_0000) // +inf
+            };
+        }
+        // Reflection formula: Γ(x) = π / (sin(πx) · Γ(1 - x)).
+        let s: f64 = crate::sin::sin(core::f64::consts::PI * x);
+        if s == 0.0 {
+            // Negative-integer pole: domain error.
+            return f64::NAN;
+        }
+        core::f64::consts::PI / (s * tgamma(1.0 - x))
+    } else {
+        let y: f64 = x - 1.0;
+        let mut a: f64 = C[0];
+        let mut denom: f64 = y + 1.0;
+        let mut i: usize = 1;
+        while i < 9 {
+            a += C[i] / denom;
+            denom += 1.0;
+            i += 1;
+        }
+        let t: f64 = y + G + 0.5;
+        const SQRT_2PI: f64 = 2.506_628_274_631_000_5;
+        SQRT_2PI * crate::pow::pow(t, y + 0.5) * crate::exp::exp(-t) * a
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_factorials() {
+        assert!((tgamma(1.0) - 1.0).abs() < 1e-9);
+        assert!((tgamma(2.0) - 1.0).abs() < 1e-9);
+        assert!((tgamma(3.0) - 2.0).abs() < 1e-9);
+        assert!((tgamma(4.0) - 6.0).abs() < 1e-9);
+        assert!((tgamma(5.0) - 24.0).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_half() {
+        // tgamma(0.5) == sqrt(pi).
+        assert!((tgamma(0.5) - 1.772_453_850_905_515_9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(tgamma(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_poles() {
+        // Γ(+0) = +∞ and Γ(-0) = -∞: the sign of the zero is preserved.
+        assert!(tgamma(0.0).is_infinite() && tgamma(0.0).is_sign_positive());
+        assert!(tgamma(-0.0).is_infinite() && tgamma(-0.0).is_sign_negative());
+
+        // Negative integers are domain errors and yield NaN.
+        assert!(tgamma(-1.0).is_nan());
+        assert!(tgamma(-2.0).is_nan());
+        assert!(tgamma(-3.0).is_nan());
+    }
+}

--- a/src/libs/libc_math/src/trunc.rs
+++ b/src/libs/libc_math/src/trunc.rs
@@ -1,0 +1,87 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Truncates a floating-point number toward zero.
+///
+/// # Description
+///
+/// Returns the nearest integer not greater in magnitude than `x`, effectively rounding toward zero.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The truncated value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn trunc(x: f64) -> f64 {
+    let bits: u64 = x.to_bits();
+    let exp_raw: u64 = (bits >> 52) & 0x7FF;
+
+    // If exponent indicates value is already integer (or NaN/inf), return as-is.
+    if exp_raw >= 1023 + 52 {
+        return x;
+    }
+
+    // If exponent indicates |x| < 1, return ±0.0.
+    if exp_raw < 1023 {
+        return f64::from_bits(bits & 0x8000_0000_0000_0000);
+    }
+
+    // Mask out fractional mantissa bits.
+    let shift: u64 = exp_raw - 1023;
+    let mask: u64 = 0x000F_FFFF_FFFF_FFFF >> shift;
+    f64::from_bits(bits & !mask)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((trunc(3.7) - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((trunc(-3.7) - (-3.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_integer() {
+        assert!((trunc(5.0) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_small() {
+        assert_eq!(trunc(0.9).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(trunc(-0.9).to_bits(), (-0.0_f64).to_bits());
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(trunc(0.0).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(trunc(-0.0).to_bits(), (-0.0_f64).to_bits());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(trunc(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(trunc(f64::INFINITY), f64::INFINITY);
+        assert_eq!(trunc(f64::NEG_INFINITY), f64::NEG_INFINITY);
+    }
+}

--- a/src/libs/libc_math/src/truncf.rs
+++ b/src/libs/libc_math/src/truncf.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Truncates a single-precision floating-point number toward zero.
+///
+/// # Description
+///
+/// Returns the nearest integer not greater in magnitude than `x`.
+///
+/// # Parameters
+///
+/// - `x`: Input value.
+///
+/// # Returns
+///
+/// The truncated value of `x`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn truncf(x: f32) -> f32 {
+    let bits: u32 = x.to_bits();
+    let exp_raw: u32 = (bits >> 23) & 0xFF;
+
+    if exp_raw >= 127 + 23 {
+        return x;
+    }
+    if exp_raw < 127 {
+        return f32::from_bits(bits & 0x8000_0000);
+    }
+
+    let shift: u32 = exp_raw - 127;
+    let mask: u32 = 0x007F_FFFF >> shift;
+    f32::from_bits(bits & !mask)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positive_fraction() {
+        assert!((truncf(3.7) - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_negative_fraction() {
+        assert!((truncf(-3.7) - (-3.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_small() {
+        assert_eq!(truncf(0.9).to_bits(), 0.0_f32.to_bits());
+        assert_eq!(truncf(-0.9).to_bits(), (-0.0_f32).to_bits());
+    }
+
+    #[test]
+    fn test_nan() {
+        assert!(truncf(f32::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinity() {
+        assert_eq!(truncf(f32::INFINITY), f32::INFINITY);
+        assert_eq!(truncf(f32::NEG_INFINITY), f32::NEG_INFINITY);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `libc_math` guest crate implementing the software floating-point functions of the C `<math.h>` API, plus the rounding-mode subset of `<fenv.h>`. Implementations are `no_std` and depend only on `sysapi`, targeting POSIX.1-2024 conformance.

## Functions

Double and float variants where applicable:

- Trigonometric: `sin`, `cos`, `tan` and inverses `asin`, `acos`, `atan`, `atan2`.
- Hyperbolic: `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`.
- Exponential / logarithmic: `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`.
- Power / root: `sqrt`, `cbrt`, `hypot`.
- Rounding: `ceil`, `floor`, `round`, `trunc`, `lrint`.
- Remainder / abs: `fabs`, `fmod`, `remainder`.
- FP manipulation: `copysign`, `ldexp`, `scalbn`, `frexp`, `modf`, `nextafter`.
- Min / max and fused multiply-add: `fmin`, `fmax`, `fma`.
- Special functions: `erf`, `erfc`, `lgamma`, `tgamma`, and the legacy `gamma` alias.
- Classification helpers backing the macros: `__fpclassify*`, `__isnan*`, `__isinf*`, `__signbit*`.

## Header specification

`header.toml` describes `math.h` for the header generator: `float_t`/`double_t` types; `HUGE_VAL`/`HUGE_VALF`/`HUGE_VALL`, `INFINITY`, `NAN`; `FP_*` classification constants and `FP_ILOGB0`/`FP_ILOGBNAN`; classification macros (`fpclassify`, `isnan`, `isinf`, `signbit`, `isfinite`, `isnormal`); relational macros (`isgreater`, `isgreaterequal`, `isless`, `islessequal`, `islessgreater`, `isunordered`); and error-handling macros (`MATH_ERRNO`, `MATH_ERREXCEPT`, `math_errhandling`). `isfinite`/`isnormal` expand to compiler builtins so the argument is evaluated exactly once.

## ABI

`#[no_mangle]` is gated behind `not(feature = "std")` so the C-ABI symbols do not clash with the host C library during host test builds, matching the `libc_stdlib`/`libc_assert` convention.

## Tests

Per-function host unit tests (`feature = "std"`) cover known values, even/odd symmetry, special values (NaN, +/-Inf), domain errors, IEEE `remainder` ties-to-even, FMA single-rounding, `frexp`/`modf` decomposition, and `fenv` rounding-mode round-trip.
