### PR TITLE
[libc_setjmp] Add C setjmp.h functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,6 +1689,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_setjmp"
+version = "0.16.88"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.88"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
         "src/libs/libc_inttypes",
         "src/libs/libc_langinfo",
         "src/libs/libc_locale",
+        "src/libs/libc_setjmp",
         "src/libs/libc_stdlib",
         "src/libs/libc_math",
         "src/libs/libc_string",
@@ -221,6 +222,7 @@ libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
 libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
 libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
+libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_setjmp/Cargo.toml
+++ b/src/libs/libc_setjmp/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_setjmp"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_setjmp/header.toml
+++ b/src/libs/libc_setjmp/header.toml
@@ -1,0 +1,53 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for setjmp.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/setjmp.h.
+
+file = "setjmp.h"
+brief = "Non-local jumps."
+description = """
+Declares setjmp()/longjmp() and the POSIX sigsetjmp()/siglongjmp() functions
+for non-local control flow. jmp_buf and sigjmp_buf store the x86-32 callee-saved
+registers (EBX, ESI, EDI, EBP, ESP, EIP); sigjmp_buf additionally records a
+savemask flag. The guest does not yet maintain a signal mask, so the saved mask
+is currently empty. Implemented by the libc_setjmp Rust crate using global_asm."""
+includes = []
+guard = "_NANVIX_SETJMP_H"
+
+[[types]]
+text = """
+/** @brief Buffer type for saving and restoring execution context. */
+typedef struct {
+    int regs[6]; /**< Saved registers: EBX, ESI, EDI, EBP, ESP, EIP. */
+} jmp_buf[1];
+"""
+
+[[types]]
+text = """
+/** @brief Buffer type for sigsetjmp()/siglongjmp() execution context. */
+typedef struct {
+    int regs[6];  /**< Saved registers: EBX, ESI, EDI, EBP, ESP, EIP.    */
+    int savemask; /**< Nonzero if sigsetjmp() was asked to save the mask. */
+} sigjmp_buf[1];
+"""
+
+[[sections]]
+title = "Functions"
+functions = ["setjmp", "longjmp"]
+
+[[sections]]
+title = "Signal Jumps (POSIX)"
+functions = ["sigsetjmp", "siglongjmp"]
+
+# Override auto-extracted signatures for setjmp/longjmp (assembly uses different
+# parameter types than what the C API exposes).
+[overrides]
+setjmp = "extern int setjmp(jmp_buf env);"
+# longjmp never returns (POSIX.1-2024 marks it _Noreturn). Use the NewLib-compatible
+# __attribute__((__noreturn__)) form so the declaration is valid in C99 and C11.
+longjmp = "extern void longjmp(jmp_buf env, int val) __attribute__((__noreturn__));"
+sigsetjmp = "extern int sigsetjmp(sigjmp_buf env, int savemask);"
+# siglongjmp never returns (POSIX.1-2024 marks it _Noreturn), mirroring longjmp.
+siglongjmp = "extern void siglongjmp(sigjmp_buf env, int val) __attribute__((__noreturn__));"

--- a/src/libs/libc_setjmp/src/jmp_buf.rs
+++ b/src/libs/libc_setjmp/src/jmp_buf.rs
@@ -1,0 +1,69 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// C library types intentionally follow C naming conventions.
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// The `jmp_buf` type stores registers for `setjmp`/`longjmp`.
+///
+/// On x86-32, the following registers are saved: EBX, ESI, EDI, EBP, ESP, and the return address
+/// (EIP).
+///
+#[repr(C)]
+pub struct jmp_buf {
+    /// Saved registers: EBX, ESI, EDI, EBP, ESP, EIP.
+    pub regs: [c_int; 6],
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::jmp_buf;
+    use ::core::mem::{
+        align_of,
+        size_of,
+    };
+    use ::sysapi::ffi::c_int;
+
+    // The setjmp/longjmp assembly reads and writes six register slots at byte offsets 0, 4, 8, 12,
+    // 16, and 20. These tests lock the jmp_buf layout to that contract so the Rust type and the
+    // assembly cannot silently diverge.
+
+    #[test]
+    fn jmp_buf_has_six_register_slots() {
+        let buf: jmp_buf = jmp_buf { regs: [0; 6] };
+        assert_eq!(buf.regs.len(), 6);
+    }
+
+    #[test]
+    fn jmp_buf_size_matches_register_count() {
+        assert_eq!(size_of::<jmp_buf>(), 6 * size_of::<c_int>());
+    }
+
+    #[test]
+    fn jmp_buf_alignment_matches_register() {
+        assert_eq!(align_of::<jmp_buf>(), align_of::<c_int>());
+    }
+
+    #[test]
+    fn jmp_buf_zero_initialized() {
+        let buf: jmp_buf = jmp_buf { regs: [0; 6] };
+        assert!(buf.regs.iter().all(|&slot| slot == 0));
+    }
+}

--- a/src/libs/libc_setjmp/src/lib.rs
+++ b/src/libs/libc_setjmp/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod jmp_buf;
+pub mod longjmp;
+pub mod setjmp;
+pub mod sigjmp_buf;
+pub mod siglongjmp;
+pub mod sigsetjmp;

--- a/src/libs/libc_setjmp/src/longjmp.rs
+++ b/src/libs/libc_setjmp/src/longjmp.rs
@@ -1,0 +1,58 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Restores the environment saved by `setjmp` and causes `setjmp` to return `val`.
+///
+/// # Parameters
+///
+/// - `env`: Pointer to a `jmp_buf` previously filled by `setjmp`.
+/// - `val`: Value that `setjmp` will appear to return. If `val` is 0, `setjmp` returns 1 instead.
+///
+/// # Return Value
+///
+/// This function does not return.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer and performs a non-local jump.
+///
+// Host/std/test builds: provide a non-exported stub. Mirroring the libc_assert convention, the
+// C-ABI symbol is exported only in guest (no_std) builds, so `no_mangle` is deliberately omitted
+// here to avoid colliding with the host C library's `longjmp` when this crate is built on the host.
+#[cfg(any(feature = "std", test))]
+pub unsafe extern "C" fn longjmp(
+    _env: *mut crate::jmp_buf::jmp_buf,
+    _val: ::sysapi::ffi::c_int,
+) -> ! {
+    ::std::process::abort()
+}
+
+// Guest (no_std) build: the real implementation is x86-32 assembly. The assembler's `.global
+// longjmp` directive exports the C symbol directly and is the equivalent of `no_mangle`, applied
+// only in non-std builds (see libc_assert).
+#[cfg(all(target_arch = "x86", not(any(feature = "std", test))))]
+core::arch::global_asm!(
+    ".global longjmp",
+    ".type longjmp, @function",
+    "longjmp:",
+    "    mov 4(%esp), %edx", // edx = pointer to jmp_buf
+    "    mov 8(%esp), %eax", // eax = return value
+    "    test %eax, %eax",
+    "    jnz 1f",
+    "    inc %eax", // if val == 0, set to 1
+    "1:",
+    "    mov 0(%edx), %ebx",  // restore EBX
+    "    mov 4(%edx), %esi",  // restore ESI
+    "    mov 8(%edx), %edi",  // restore EDI
+    "    mov 12(%edx), %ebp", // restore EBP
+    "    mov 16(%edx), %esp", // restore ESP
+    "    jmp *20(%edx)",      // jump to saved EIP
+    options(att_syntax),
+);

--- a/src/libs/libc_setjmp/src/setjmp.rs
+++ b/src/libs/libc_setjmp/src/setjmp.rs
@@ -1,0 +1,76 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Saves the calling environment in `env` for later use by `longjmp`.
+///
+/// # Parameters
+///
+/// - `env`: Pointer to a `jmp_buf` in which the environment is saved.
+///
+/// # Return Value
+///
+/// Returns zero when called directly. When returning from a `longjmp` call, returns the value
+/// passed to `longjmp` (or 1 if that value was 0).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer.
+///
+// Host/std/test builds: provide a non-exported stub. Mirroring the libc_assert convention, the
+// C-ABI symbol is exported only in guest (no_std) builds, so `no_mangle` is deliberately omitted
+// here to avoid colliding with the host C library's `setjmp` when this crate is unit-tested on the
+// host.
+#[cfg(any(feature = "std", test))]
+pub unsafe extern "C" fn setjmp(_env: *mut crate::jmp_buf::jmp_buf) -> ::sysapi::ffi::c_int {
+    0
+}
+
+// Guest (no_std) build: the real implementation is x86-32 assembly. The assembler's `.global
+// setjmp` directive exports the C symbol directly and is the equivalent of `no_mangle`, applied
+// only in non-std builds (see libc_assert).
+#[cfg(all(target_arch = "x86", not(any(feature = "std", test))))]
+core::arch::global_asm!(
+    ".global setjmp",
+    ".type setjmp, @function",
+    "setjmp:",
+    "    mov 4(%esp), %eax",  // eax = pointer to jmp_buf
+    "    mov %ebx, 0(%eax)",  // save EBX
+    "    mov %esi, 4(%eax)",  // save ESI
+    "    mov %edi, 8(%eax)",  // save EDI
+    "    mov %ebp, 12(%eax)", // save EBP
+    "    lea 4(%esp), %ecx",  // compute original ESP (before call pushed return addr)
+    "    mov %ecx, 16(%eax)", // save ESP
+    "    mov (%esp), %ecx",   // get return address
+    "    mov %ecx, 20(%eax)", // save EIP (return addr)
+    "    xor %eax, %eax",     // return 0
+    "    ret",
+    options(att_syntax),
+);
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::setjmp;
+    use crate::jmp_buf::jmp_buf;
+    use ::sysapi::ffi::c_int;
+
+    // On the host, setjmp is a non-functional stub that always reports a direct (zero) return. The
+    // real non-local control flow only exists in the guest assembly build, which cannot run under
+    // the host test harness.
+    #[test]
+    fn setjmp_stub_reports_direct_return() {
+        let mut buf: jmp_buf = jmp_buf { regs: [0; 6] };
+        let result: c_int = unsafe { setjmp(&mut buf) };
+        assert_eq!(result, 0);
+    }
+}

--- a/src/libs/libc_setjmp/src/sigjmp_buf.rs
+++ b/src/libs/libc_setjmp/src/sigjmp_buf.rs
@@ -1,0 +1,78 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// C library types intentionally follow C naming conventions.
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// The `sigjmp_buf` type stores the execution context for `sigsetjmp`/`siglongjmp`.
+///
+/// On x86-32, the following registers are saved: EBX, ESI, EDI, EBP, ESP, and the return address
+/// (EIP). The `savemask` field records whether `sigsetjmp` was asked to save the signal mask.
+///
+#[repr(C)]
+pub struct sigjmp_buf {
+    /// Saved registers: EBX, ESI, EDI, EBP, ESP, EIP.
+    pub regs: [c_int; 6],
+    /// Nonzero if `sigsetjmp` was called with a nonzero `savemask` argument.
+    pub savemask: c_int,
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::sigjmp_buf;
+    use ::core::mem::{
+        align_of,
+        size_of,
+    };
+    use ::sysapi::ffi::c_int;
+
+    // The sigsetjmp/siglongjmp assembly reuses the setjmp/longjmp register slots at byte offsets 0,
+    // 4, 8, 12, 16, and 20, and stores the savemask flag at offset 24. These tests lock the
+    // sigjmp_buf layout to that contract so the Rust type and the assembly cannot silently diverge.
+
+    #[test]
+    fn sigjmp_buf_has_six_register_slots() {
+        let buf: sigjmp_buf = sigjmp_buf {
+            regs: [0; 6],
+            savemask: 0,
+        };
+        assert_eq!(buf.regs.len(), 6);
+    }
+
+    #[test]
+    fn sigjmp_buf_size_matches_register_count_plus_savemask() {
+        assert_eq!(size_of::<sigjmp_buf>(), 7 * size_of::<c_int>());
+    }
+
+    #[test]
+    fn sigjmp_buf_alignment_matches_register() {
+        assert_eq!(align_of::<sigjmp_buf>(), align_of::<c_int>());
+    }
+
+    #[test]
+    fn sigjmp_buf_zero_initialized() {
+        let buf: sigjmp_buf = sigjmp_buf {
+            regs: [0; 6],
+            savemask: 0,
+        };
+        assert!(buf.regs.iter().all(|&slot| slot == 0));
+        assert_eq!(buf.savemask, 0);
+    }
+}

--- a/src/libs/libc_setjmp/src/siglongjmp.rs
+++ b/src/libs/libc_setjmp/src/siglongjmp.rs
@@ -1,0 +1,54 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Restores the environment saved by `sigsetjmp` and causes `sigsetjmp` to return `val`.
+///
+/// This is equivalent to `longjmp`, except that the saved signal mask is restored if and only if
+/// `env` was initialized by a `sigsetjmp` call with a nonzero `savemask` argument.
+///
+/// # Parameters
+///
+/// - `env`: Pointer to a `sigjmp_buf` previously filled by `sigsetjmp`.
+/// - `val`: Value that `sigsetjmp` will appear to return. If `val` is 0, `sigsetjmp` returns 1
+///   instead.
+///
+/// # Return Value
+///
+/// This function does not return.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer and performs a non-local jump.
+///
+// Host/std/test builds: provide a non-exported stub. Mirroring the libc_assert convention, the
+// C-ABI symbol is exported only in guest (no_std) builds, so `no_mangle` is deliberately omitted
+// here to avoid colliding with the host C library's `siglongjmp` when this crate is built on the
+// host.
+#[cfg(any(feature = "std", test))]
+pub unsafe extern "C" fn siglongjmp(
+    _env: *mut crate::sigjmp_buf::sigjmp_buf,
+    _val: ::sysapi::ffi::c_int,
+) -> ! {
+    ::std::process::abort()
+}
+
+// Guest (no_std) build: the real implementation is x86-32 assembly. POSIX defines siglongjmp to be
+// equivalent to longjmp (except for the signal mask), so it tail-calls longjmp to restore the
+// register context and resume. Reusing longjmp guarantees the two cannot diverge. A saved signal
+// mask would be restored here when env->savemask is nonzero, but the guest does not yet maintain a
+// signal mask (pthread_sigmask is a no-op), so there is nothing to restore.
+#[cfg(all(target_arch = "x86", not(any(feature = "std", test))))]
+core::arch::global_asm!(
+    ".global siglongjmp",
+    ".type siglongjmp, @function",
+    "siglongjmp:",
+    "    jmp longjmp", // tail-call longjmp: restores the register context and resumes
+    options(att_syntax),
+);

--- a/src/libs/libc_setjmp/src/sigsetjmp.rs
+++ b/src/libs/libc_setjmp/src/sigsetjmp.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Saves the calling environment in `env` for later use by `siglongjmp`.
+///
+/// This is equivalent to `setjmp`, except that when `savemask` is nonzero `sigsetjmp` also records
+/// that the signal mask should be saved as part of the calling environment.
+///
+/// # Parameters
+///
+/// - `env`: Pointer to a `sigjmp_buf` in which the environment is saved.
+/// - `savemask`: If nonzero, the current signal mask is saved in `env` and restored by a matching
+///   `siglongjmp`.
+///
+/// # Return Value
+///
+/// Returns zero when called directly. When returning from a `siglongjmp` call, returns the value
+/// passed to `siglongjmp` (or 1 if that value was 0).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer.
+///
+// Host/std/test builds: provide a non-exported stub. Mirroring the libc_assert convention, the
+// C-ABI symbol is exported only in guest (no_std) builds, so `no_mangle` is deliberately omitted
+// here to avoid colliding with the host C library's `sigsetjmp` when this crate is unit-tested on
+// the host.
+#[cfg(any(feature = "std", test))]
+pub unsafe extern "C" fn sigsetjmp(
+    _env: *mut crate::sigjmp_buf::sigjmp_buf,
+    _savemask: ::sysapi::ffi::c_int,
+) -> ::sysapi::ffi::c_int {
+    0
+}
+
+// Guest (no_std) build: the real implementation is x86-32 assembly. POSIX defines sigsetjmp to be
+// equivalent to setjmp (except for the signal mask), so it records the savemask flag and then
+// tail-calls setjmp to capture the register context. Reusing setjmp guarantees the two cannot
+// diverge. The guest does not yet maintain a signal mask (pthread_sigmask is a no-op), so there is
+// nothing to save when savemask is nonzero; the flag is recorded so the behavior becomes correct
+// automatically once a signal mask is implemented.
+#[cfg(all(target_arch = "x86", not(any(feature = "std", test))))]
+core::arch::global_asm!(
+    ".global sigsetjmp",
+    ".type sigsetjmp, @function",
+    "sigsetjmp:",
+    "    mov 4(%esp), %eax",  // eax = pointer to sigjmp_buf
+    "    mov 8(%esp), %ecx",  // ecx = savemask
+    "    mov %ecx, 24(%eax)", // save savemask flag
+    "    jmp setjmp",         // tail-call setjmp: saves the register context and returns 0
+    options(att_syntax),
+);
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::sigsetjmp;
+    use crate::sigjmp_buf::sigjmp_buf;
+    use ::sysapi::ffi::c_int;
+
+    // On the host, sigsetjmp is a non-functional stub that always reports a direct (zero) return.
+    // The real non-local control flow only exists in the guest assembly build, which cannot run
+    // under the host test harness.
+    #[test]
+    fn sigsetjmp_stub_reports_direct_return() {
+        let mut buf: sigjmp_buf = sigjmp_buf {
+            regs: [0; 6],
+            savemask: 0,
+        };
+        let result: c_int = unsafe { sigsetjmp(&mut buf, 1) };
+        assert_eq!(result, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `libc_setjmp` crate, a `no_std` guest library that implements the
POSIX `<setjmp.h>` non-local jump interface and feeds the generated header via
`header.toml`.

## Types

- `jmp_buf`: array type holding the x86-32 callee-saved registers
  (EBX, ESI, EDI, EBP, ESP, EIP).
- `sigjmp_buf`: `jmp_buf` extended with a `savemask` flag for the POSIX
  `sigsetjmp()`/`siglongjmp()` pair.

## Functions

- `setjmp()` / `longjmp()`: saved and restored entirely in x86-32 assembly via
  `global_asm`; `longjmp()` forces a nonzero return value (1 when `val` is 0) as
  required by POSIX.
- `sigsetjmp()` / `siglongjmp()`: implemented as exact equivalents of
  `setjmp()`/`longjmp()` by tail-calling them, so the register logic cannot
  diverge. `sigsetjmp()` records the `savemask` flag. The guest does not yet
  maintain a signal mask (`pthread_sigmask` is a no-op), so the mask save and
  restore are currently empty; the recorded flag makes the behavior correct
  automatically once a signal mask is implemented.

## Build / packaging

- Adds the crate to the workspace (`Cargo.toml`, `Cargo.lock`) and to the guest
  Rust library and test lists in the `Makefile`.
- `header.toml` declares `jmp_buf` and `sigjmp_buf` and overrides the
  `setjmp`/`longjmp` and `sigsetjmp`/`siglongjmp` signatures, marking the
  `longjmp` variants `_Noreturn` via `__attribute__((__noreturn__))` for
  C99/C11 validity.

The C-ABI symbols are exported only in guest (`no_std`) builds; host/test builds
provide non-exported stubs so the crate can be unit-tested without colliding
with the host C library. Host unit tests lock the `jmp_buf`/`sigjmp_buf` layout
to the byte offsets used by the assembly.

## Validation

- `test-guest-rlib-libc_setjmp` (host unit tests)
- `check-guest-rlib-libc_setjmp` (guest `no_std` x86 build)
- `format-check-guest-rlib-libc_setjmp`
- `rust-lint-check-guest-rlib-libc_setjmp` and
  `rust-lint-check-guest-rlib-tests-libc_setjmp` (clippy `-D warnings`)
- `codespell`

## Conformance

Implementation follows the POSIX.1-2024 `<setjmp.h>` specification:
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/setjmp.h.html
