### PR TITLE
[libc_signal] Add signal.h implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_signal"
+version = "0.16.90"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.90"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
         "src/libs/libc_langinfo",
         "src/libs/libc_locale",
         "src/libs/libc_setjmp",
+        "src/libs/libc_signal",
         "src/libs/libc_stdlib",
         "src/libs/libc_math",
         "src/libs/libc_string",
@@ -224,6 +225,7 @@ libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
 libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }
+libc_signal = { path = "src/libs/libc_signal", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_signal/Cargo.toml
+++ b/src/libs/libc_signal/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_signal"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_signal/header.toml
+++ b/src/libs/libc_signal/header.toml
@@ -1,0 +1,144 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for signal.h.
+
+file = "signal.h"
+brief = "Signal handling."
+description = '''
+Declares functions and types for signal delivery and management.
+Implemented by the libc_signal Rust crate.'''
+includes = ["stdint.h", "sys/types.h"]
+guard = "_NANVIX_SIGNAL_H"
+content_order = ["types", "raw:0", "raw:1", "section:0", "section:1"]
+
+[[types]]
+text = '''
+/** @brief Signal handler function pointer. */
+typedef void (*sighandler_t)(int);
+
+/** @brief Signal set type. */
+typedef uint64_t sigset_t;
+
+/** @brief Type that can be accessed atomically with respect to signals. */
+typedef int sig_atomic_t;
+
+/** @brief Value that accompanies a signal (used by SA_SIGINFO handlers). */
+union sigval {
+    int sival_int;   /**< Integer signal value. */
+    void *sival_ptr; /**< Pointer signal value. */
+};
+
+/**
+ * @brief Information passed to an SA_SIGINFO signal handler.
+ *
+ * Minimal POSIX subset: only the members common to every signal are provided.
+ * The guest does not yet populate this structure because asynchronous signal
+ * delivery is not implemented.
+ */
+typedef struct {
+    int si_signo;          /**< Signal number.                        */
+    int si_code;           /**< Signal code (one of the SI_* values). */
+    int si_errno;          /**< errno value associated with signal.   */
+    union sigval si_value; /**< Signal value.                         */
+} siginfo_t;
+
+/** @brief Structure for sigaction(). */
+struct sigaction {
+    sighandler_t sa_handler; /**< Signal handler.              */
+    sigset_t sa_mask;        /**< Signals to block in handler. */
+    int sa_flags;            /**< Action flags.                */
+    void (*sa_sigaction)(int, siginfo_t *, void *); /**< Handler used with SA_SIGINFO. */
+};'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define SIG_DFL ((sighandler_t)0)
+#define SIG_IGN ((sighandler_t)1)
+#define SIG_ERR ((sighandler_t) - 1)
+
+/* `how` argument values for sigprocmask(). */
+#define SIG_BLOCK 0
+#define SIG_UNBLOCK 1
+#define SIG_SETMASK 2
+
+/* Flags for sigaction(). */
+#define SA_NOCLDSTOP 0x00000001
+#define SA_NOCLDWAIT 0x00000002
+#define SA_SIGINFO 0x00000004
+#define SA_ONSTACK 0x08000000
+#define SA_RESTART 0x10000000
+#define SA_NODEFER 0x40000000
+#define SA_RESETHAND 0x80000000
+
+/* `si_code` values carried by siginfo_t. */
+#define SI_USER 0
+#define SI_QUEUE (-1)
+#define SI_TIMER (-2)
+#define SI_MESGQ (-3)
+#define SI_ASYNCIO (-4)'''
+
+[[raw_sections]]
+title = "Signal Numbers"
+text = '''
+/* Standard signal numbers. */
+#ifndef SIGHUP
+#define SIGHUP 1
+#define SIGINT 2
+#define SIGQUIT 3
+#define SIGILL 4
+#define SIGTRAP 5
+#define SIGABRT 6
+#define SIGBUS 7
+#define SIGFPE 8
+#define SIGKILL 9
+#define SIGUSR1 10
+#define SIGSEGV 11
+#define SIGUSR2 12
+#define SIGPIPE 13
+#define SIGALRM 14
+#define SIGTERM 15
+#define SIGCHLD 17
+#define SIGCONT 18
+#define SIGSTOP 19
+#define SIGTSTP 20
+#define SIGTTIN 21
+#define SIGTTOU 22
+#define SIGURG 23
+#define SIGXCPU 24
+#define SIGXFSZ 25
+#define SIGVTALRM 26
+#define SIGPROF 27
+#define SIGWINCH 28
+#define SIGIO 29
+#define SIGSYS 31
+#define _NSIG 65
+#endif'''
+
+[[sections]]
+title = "Signal Functions"
+functions = ["signal", "raise", "kill"]
+
+[[sections]]
+title = "Signal Set Functions"
+functions = [
+    "sigemptyset",
+    "sigfillset",
+    "sigaddset",
+    "sigdelset",
+    "sigismember",
+    "sigprocmask",
+    "sigaction",
+    "pthread_sigmask",
+]
+
+[overrides]
+signal = '''
+extern sighandler_t signal(int signum, sighandler_t handler);'''
+kill = '''
+extern int kill(pid_t pid, int sig);'''
+sigaction = '''
+extern int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);'''
+pthread_sigmask = '''
+extern int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset);'''

--- a/src/libs/libc_signal/src/lib.rs
+++ b/src/libs/libc_signal/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod raise;
+pub mod signal;
+pub mod sigprocmask;
+pub mod sigset;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#[cfg(not(feature = "std"))]
+use ::sysapi::errno::__errno_location;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes `code` to `errno`.
+///
+/// # Parameters
+///
+/// - `code`: Error code to be written to `errno`.
+///
+#[cfg(not(feature = "std"))]
+#[inline(always)]
+fn set_errno(code: c_int) {
+    // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
+    unsafe {
+        *__errno_location() = code;
+    }
+}
+
+/// Host-only stand-in for [`set_errno`] used by unit tests.
+///
+/// The C `errno` location is not linkable into the host test binary, so this is a no-op. The guest
+/// never compiles this variant; only the unit tests exercise it, and they assert on return values
+/// rather than on `errno`.
+#[cfg(feature = "std")]
+#[inline(always)]
+fn set_errno(_code: c_int) {}

--- a/src/libs/libc_signal/src/raise.rs
+++ b/src/libs/libc_signal/src/raise.rs
@@ -1,0 +1,87 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+#[cfg(not(feature = "std"))]
+use ::sysapi::sys_types::pid_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sends a signal to the calling process (equivalent to `kill(getpid(), sig)`).
+///
+/// # Parameters
+///
+/// - `sig`: The signal number to send.
+///
+/// # Returns
+///
+/// Zero on success, or a non-zero value on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls external system calls (`getpid` and `kill`) that
+/// modify process state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn raise(sig: c_int) -> c_int {
+    // SAFETY: delegates to the platform-specific implementation, which upholds this function's
+    // contract.
+    unsafe { raise_impl(sig) }
+}
+
+/// Guest implementation of [`raise`]: delivers `sig` to the calling process through
+/// `kill(getpid(), sig)`.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls the external `getpid` and `kill` system calls that
+/// modify process state.
+#[cfg(not(feature = "std"))]
+unsafe fn raise_impl(sig: c_int) -> c_int {
+    extern "C" {
+        fn getpid() -> pid_t;
+        fn kill(pid: pid_t, sig: c_int) -> c_int;
+    }
+
+    // SAFETY: both calls are FFI to the guest C runtime and have no preconditions here.
+    unsafe { kill(getpid(), sig) }
+}
+
+/// Host-only stand-in for [`raise_impl`] used by unit tests.
+///
+/// Signal delivery is unavailable on the host, so this reports failure without referencing any
+/// guest-only symbol. The guest never compiles this variant.
+///
+/// # Safety
+///
+/// Matches the signature of the guest variant; it has no additional preconditions.
+#[cfg(feature = "std")]
+unsafe fn raise_impl(_sig: c_int) -> c_int {
+    -1
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn raise_reports_failure_on_host() {
+        // The host build cannot deliver signals, so raise() must fail rather than reference any
+        // guest-only symbol. This guards against reintroducing an unconditional FFI call that
+        // would break the host build.
+        assert_eq!(unsafe { raise(2) }, -1);
+    }
+}

--- a/src/libs/libc_signal/src/signal.rs
+++ b/src/libs/libc_signal/src/signal.rs
@@ -1,0 +1,225 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::EINVAL,
+    ffi::{
+        c_int,
+        c_void,
+    },
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Signal handler representation.
+///
+/// Modeled as a pointer-sized integer (equivalent to C `intptr_t`) rather than a Rust function
+/// pointer. `<signal.h>` uses non-function-pointer sentinels (`SIG_DFL` = 0, `SIG_IGN` = 1,
+/// `SIG_ERR` = -1); forming those as `fn` pointers would be undefined behavior across the C ABI.
+/// Real handler addresses cross this boundary as opaque pointer-sized values and are only ever
+/// reinterpreted as callable functions by the kernel, never by this layer.
+pub type SignalHandler = usize;
+
+/// Signal set type (bitmask supporting up to 64 signals).
+pub type sigset_t = u64;
+
+/// Extended signal handler function pointer type, used when `SA_SIGINFO` is set in `sa_flags`.
+///
+/// The pointee types of the second and third arguments (`siginfo_t *` and `void *` in C) are
+/// represented as opaque pointers here; only their pointer ABI is relevant to this layer.
+pub type SignalAction = Option<unsafe extern "C" fn(c_int, *mut c_void, *mut c_void)>;
+
+/// Signal action structure for use with the `sigaction` system call.
+///
+/// The field layout mirrors `struct sigaction` as declared in the generated `signal.h` and in the
+/// `sigaction` binding this crate links against, so the structure is safe to pass across the C ABI.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct sigaction_t {
+    /// Signal handler.
+    pub sa_handler: SignalHandler,
+    /// Signal mask to apply during handler execution.
+    pub sa_mask: sigset_t,
+    /// Signal action flags.
+    pub sa_flags: c_int,
+    /// Extended signal handler invoked when `SA_SIGINFO` is set in `sa_flags`.
+    pub sa_sigaction: SignalAction,
+}
+
+impl sigaction_t {
+    /// Creates a zeroed signal action structure.
+    pub const fn new() -> Self {
+        Self {
+            sa_handler: SIG_DFL,
+            sa_mask: 0,
+            sa_flags: 0,
+            sa_sigaction: None,
+        }
+    }
+}
+
+impl Default for sigaction_t {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default signal handling disposition.
+pub const SIG_DFL: SignalHandler = 0;
+
+/// Ignore signal disposition.
+pub const SIG_IGN: SignalHandler = 1;
+
+/// Error return value from [`signal`], mirroring the C `SIG_ERR` sentinel `((void (*)(int)) -1)`.
+pub const SIG_ERR: SignalHandler = usize::MAX;
+
+/// Maximum signal number supported.
+pub const SIG_MAX: c_int = 64;
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Returns `true` if `signum` is a signal number that `signal()` accepts.
+///
+/// Valid signal numbers are `1..=SIG_MAX`; the null signal `0` and out-of-range values are
+/// rejected.
+fn is_valid_signum(signum: c_int) -> bool {
+    signum > 0 && signum <= SIG_MAX
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Establishes a simplified signal handler for the given signal number.
+///
+/// This wraps the `sigaction` system call to provide the traditional `signal()` interface.
+///
+/// # Parameters
+///
+/// - `signum`: The signal number to handle.
+/// - `handler`: The new signal handler, or `SIG_DFL`/`SIG_IGN`.
+///
+/// # Returns
+///
+/// The previous signal handler on success, or `SIG_ERR` on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls the external `sigaction` system call and modifies
+/// process-wide signal handling state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn signal(signum: c_int, handler: SignalHandler) -> SignalHandler {
+    if !is_valid_signum(signum) {
+        // POSIX: signal() shall fail with EINVAL when `signum` is not a valid signal number.
+        set_errno(EINVAL);
+        return SIG_ERR;
+    }
+
+    // SAFETY: `signum` has been validated above; `install_handler` upholds the same contract as
+    // this function.
+    unsafe { install_handler(signum, handler) }
+}
+
+/// Installs `handler` for the already-validated signal `signum` via the `sigaction` kernel call.
+///
+/// Returns the previous handler, or [`SIG_ERR`] if the underlying call fails.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls the external `sigaction` system call and modifies
+/// process-wide signal handling state.
+#[cfg(not(feature = "std"))]
+unsafe fn install_handler(signum: c_int, handler: SignalHandler) -> SignalHandler {
+    extern "C" {
+        fn sigaction(sig: c_int, act: *const sigaction_t, oact: *mut sigaction_t) -> c_int;
+    }
+
+    let act: sigaction_t = sigaction_t {
+        sa_handler: handler,
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: None,
+    };
+    let mut old_act: sigaction_t = sigaction_t::new();
+
+    // SAFETY: `act` and `old_act` are valid, properly aligned `sigaction_t` values.
+    if unsafe { sigaction(signum, &act, &mut old_act) } != 0 {
+        return SIG_ERR;
+    }
+
+    old_act.sa_handler
+}
+
+/// Host-only stand-in for [`install_handler`] used by unit tests.
+///
+/// The guest `sigaction` kernel call is unavailable on the host, so this reports failure via
+/// [`SIG_ERR`] without referencing any guest-only symbol. The guest never compiles this variant.
+///
+/// # Safety
+///
+/// Matches the signature of the guest variant; it has no additional preconditions.
+#[cfg(feature = "std")]
+unsafe fn install_handler(_signum: c_int, _handler: SignalHandler) -> SignalHandler {
+    SIG_ERR
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sig_err_is_non_null_sentinel() {
+        // SIG_ERR must be a non-null value so that C callers can distinguish it from a real
+        // handler or from SIG_DFL (null).
+        assert_ne!(SIG_ERR, SIG_DFL, "SIG_ERR must be a non-null sentinel");
+    }
+
+    #[test]
+    fn is_valid_signum_accepts_in_range_signals() {
+        assert!(is_valid_signum(1));
+        assert!(is_valid_signum(SIG_MAX));
+    }
+
+    #[test]
+    fn is_valid_signum_rejects_out_of_range_signals() {
+        assert!(!is_valid_signum(0));
+        assert!(!is_valid_signum(-1));
+        assert!(!is_valid_signum(SIG_MAX + 1));
+    }
+
+    #[test]
+    fn signal_rejects_invalid_signum() {
+        // Invalid signal numbers must fail with SIG_ERR (a non-null sentinel) rather than touch
+        // kernel state.
+        assert_eq!(unsafe { signal(0, SIG_DFL) }, SIG_ERR);
+        assert_eq!(unsafe { signal(-1, SIG_DFL) }, SIG_ERR);
+        assert_eq!(unsafe { signal(SIG_MAX + 1, SIG_DFL) }, SIG_ERR);
+    }
+}

--- a/src/libs/libc_signal/src/sigprocmask.rs
+++ b/src/libs/libc_signal/src/sigprocmask.rs
@@ -1,0 +1,193 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    set_errno,
+    signal::sigset_t,
+};
+use ::sysapi::{
+    errno::EINVAL,
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// `how` argument to [`sigprocmask`]: add the signals in `set` to the mask.
+pub const SIG_BLOCK: c_int = 0;
+/// `how` argument to [`sigprocmask`]: remove the signals in `set` from the mask.
+pub const SIG_UNBLOCK: c_int = 1;
+/// `how` argument to [`sigprocmask`]: replace the mask with `set`.
+pub const SIG_SETMASK: c_int = 2;
+
+/// Signals that can never be blocked: `SIGKILL` (9) and `SIGSTOP` (19).
+///
+/// POSIX requires that any attempt to block these signals be silently ignored rather than
+/// reported as an error, so they are masked out of every computed blocked-signal set.
+const UNBLOCKABLE: sigset_t = (1u64 << (9 - 1)) | (1u64 << (19 - 1));
+
+//==================================================================================================
+// Static Data
+//==================================================================================================
+
+/// Process-wide blocked-signal mask.
+///
+/// Nanvix does not yet deliver asynchronous signals, so the mask is pure
+/// bookkeeping: it is faithfully maintained so that callers which save and
+/// restore the mask (e.g. xz's single-threaded `mythread_sigmask`) observe
+/// consistent values, but it has no effect on signal delivery.
+static mut SIGNAL_MASK: sigset_t = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Examines and/or changes the calling process's blocked-signal mask.
+///
+/// # Parameters
+///
+/// - `how`: One of [`SIG_BLOCK`], [`SIG_UNBLOCK`], or [`SIG_SETMASK`].
+/// - `set`: New signals to apply per `how`, or null to leave the mask unchanged.
+/// - `oldset`: Receives the previous mask, or null if not wanted.
+///
+/// # Returns
+///
+/// Zero on success, or -1 on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `set` and `oldset`.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigprocmask.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigprocmask(
+    how: c_int,
+    set: *const sigset_t,
+    oldset: *mut sigset_t,
+) -> c_int {
+    // SAFETY: SIGNAL_MASK is only accessed from this single-threaded library.
+    let current: sigset_t = unsafe { SIGNAL_MASK };
+
+    if !oldset.is_null() {
+        *oldset = current;
+    }
+
+    if !set.is_null() {
+        let value: sigset_t = *set;
+        let next: sigset_t = match apply_how(how, current, value) {
+            // SIGKILL and SIGSTOP can never be blocked; drop them silently (not an error).
+            Some(next) => next & !UNBLOCKABLE,
+            None => {
+                // POSIX: sigprocmask() shall fail with EINVAL when `how` is invalid.
+                set_errno(EINVAL);
+                return -1;
+            },
+        };
+        // SAFETY: single-threaded access to the process mask.
+        unsafe { SIGNAL_MASK = next };
+    }
+
+    0
+}
+
+/// Computes the updated blocked-signal mask.
+///
+/// Combines the `current` mask with `value` according to `how`. Returns [`None`] when `how` is not
+/// one of [`SIG_BLOCK`], [`SIG_UNBLOCK`], or [`SIG_SETMASK`].
+fn apply_how(how: c_int, current: sigset_t, value: sigset_t) -> Option<sigset_t> {
+    match how {
+        SIG_BLOCK => Some(current | value),
+        SIG_UNBLOCK => Some(current & !value),
+        SIG_SETMASK => Some(value),
+        _ => None,
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn apply_how_block_computes_union() {
+        assert_eq!(apply_how(SIG_BLOCK, 0b0001, 0b0100), Some(0b0101));
+    }
+
+    #[test]
+    fn apply_how_unblock_clears_requested_bits() {
+        assert_eq!(apply_how(SIG_UNBLOCK, 0b0111, 0b0010), Some(0b0101));
+    }
+
+    #[test]
+    fn apply_how_setmask_replaces_mask() {
+        assert_eq!(apply_how(SIG_SETMASK, 0b1111, 0b0010), Some(0b0010));
+    }
+
+    #[test]
+    fn apply_how_rejects_invalid_how() {
+        assert_eq!(apply_how(42, 0, 0), None);
+        assert_eq!(apply_how(-1, 0, 0), None);
+    }
+
+    #[test]
+    fn sigprocmask_round_trips_through_the_process_mask() {
+        // This is the only test that touches the process-wide SIGNAL_MASK; keeping the whole
+        // sequence in a single test keeps it deterministic regardless of test execution order.
+        unsafe {
+            // Start from a known, empty mask.
+            let empty: sigset_t = 0;
+            assert_eq!(sigprocmask(SIG_SETMASK, &empty, core::ptr::null_mut()), 0);
+
+            // Blocking reports the previous (empty) mask through `oldset`.
+            let to_block: sigset_t = 0b1010;
+            let mut old: sigset_t = u64::MAX;
+            assert_eq!(sigprocmask(SIG_BLOCK, &to_block, &mut old), 0);
+            assert_eq!(old, 0);
+
+            // A null `set` leaves the mask unchanged and returns it through `oldset`.
+            let mut current: sigset_t = 0;
+            assert_eq!(sigprocmask(SIG_BLOCK, core::ptr::null(), &mut current), 0);
+            assert_eq!(current, 0b1010);
+
+            // Unblocking clears only the requested bits.
+            let to_unblock: sigset_t = 0b0010;
+            assert_eq!(sigprocmask(SIG_UNBLOCK, &to_unblock, core::ptr::null_mut()), 0);
+            let mut after: sigset_t = u64::MAX;
+            assert_eq!(sigprocmask(SIG_BLOCK, &empty, &mut after), 0);
+            assert_eq!(after, 0b1000);
+
+            // An invalid `how` combined with a non-null `set` is rejected.
+            let mut ignored: sigset_t = 0;
+            assert_eq!(sigprocmask(999, &to_block, &mut ignored), -1);
+
+            // SIGKILL and SIGSTOP can never be blocked (POSIX); attempts are silently ignored,
+            // whether requested through SIG_SETMASK or SIG_BLOCK.
+            let kill_stop: sigset_t = (1 << (9 - 1)) | (1 << (19 - 1));
+            assert_eq!(sigprocmask(SIG_SETMASK, &kill_stop, core::ptr::null_mut()), 0);
+            let mut after_setmask: sigset_t = u64::MAX;
+            assert_eq!(sigprocmask(SIG_BLOCK, &empty, &mut after_setmask), 0);
+            assert_eq!(after_setmask & kill_stop, 0);
+            assert_eq!(sigprocmask(SIG_BLOCK, &kill_stop, core::ptr::null_mut()), 0);
+            let mut after_block: sigset_t = u64::MAX;
+            assert_eq!(sigprocmask(SIG_BLOCK, &empty, &mut after_block), 0);
+            assert_eq!(after_block & kill_stop, 0);
+
+            // Leave the global mask clean for any other consumers.
+            assert_eq!(sigprocmask(SIG_SETMASK, &empty, core::ptr::null_mut()), 0);
+        }
+    }
+}

--- a/src/libs/libc_signal/src/sigset.rs
+++ b/src/libs/libc_signal/src/sigset.rs
@@ -1,0 +1,241 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::signal::{
+    sigset_t,
+    SIG_MAX,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes a signal set to be empty (all signals excluded).
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set to initialize.
+///
+/// # Returns
+///
+/// Zero on success, or -1 if `set` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigemptyset(set: *mut sigset_t) -> c_int {
+    if set.is_null() {
+        return -1;
+    }
+    *set = 0;
+    0
+}
+
+///
+/// # Description
+///
+/// Initializes a signal set to be full (all signals included).
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set to initialize.
+///
+/// # Returns
+///
+/// Zero on success, or -1 if `set` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigfillset(set: *mut sigset_t) -> c_int {
+    if set.is_null() {
+        return -1;
+    }
+    *set = u64::MAX;
+    0
+}
+
+///
+/// # Description
+///
+/// Adds the specified signal to the signal set.
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set.
+/// - `signum`: The signal number to add (1-based).
+///
+/// # Returns
+///
+/// Zero on success, or -1 if `set` is null or `signum` is out of range.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigaddset(set: *mut sigset_t, signum: c_int) -> c_int {
+    if set.is_null() || signum <= 0 || signum > SIG_MAX {
+        return -1;
+    }
+    // `signum` is validated to be in `1..=SIG_MAX`, so `(signum - 1)` is a non-negative shift
+    // amount that fits in `u32`.
+    *set |= 1u64 << ((signum - 1) as u32);
+    0
+}
+
+///
+/// # Description
+///
+/// Removes the specified signal from the signal set.
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set.
+/// - `signum`: The signal number to remove (1-based).
+///
+/// # Returns
+///
+/// Zero on success, or -1 if `set` is null or `signum` is out of range.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigdelset(set: *mut sigset_t, signum: c_int) -> c_int {
+    if set.is_null() || signum <= 0 || signum > SIG_MAX {
+        return -1;
+    }
+    // `signum` is validated to be in `1..=SIG_MAX`, so `(signum - 1)` is a non-negative shift
+    // amount that fits in `u32`.
+    *set &= !(1u64 << ((signum - 1) as u32));
+    0
+}
+
+///
+/// # Description
+///
+/// Tests whether the specified signal is a member of the signal set.
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set.
+/// - `signum`: The signal number to test (1-based).
+///
+/// # Returns
+///
+/// 1 if `signum` is a member of the set, 0 if it is not, or -1 on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigismember(set: *const sigset_t, signum: c_int) -> c_int {
+    if set.is_null() || signum <= 0 || signum > SIG_MAX {
+        return -1;
+    }
+    // `signum` is validated to be in `1..=SIG_MAX`, so `(signum - 1)` is a non-negative shift
+    // amount that fits in `u32`.
+    if *set & (1u64 << ((signum - 1) as u32)) != 0 {
+        1
+    } else {
+        0
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use crate::signal::sigset_t;
+
+    #[test]
+    fn test_sigemptyset() {
+        let mut set: sigset_t = u64::MAX;
+        assert_eq!(unsafe { sigemptyset(&mut set) }, 0);
+        assert_eq!(set, 0);
+    }
+
+    #[test]
+    fn test_sigfillset() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigfillset(&mut set) }, 0);
+        assert_eq!(set, u64::MAX);
+    }
+
+    #[test]
+    fn test_sigaddset_and_sigismember() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigemptyset(&mut set) }, 0);
+
+        // Add signal 1.
+        assert_eq!(unsafe { sigaddset(&mut set, 1) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 1) }, 1);
+        assert_eq!(unsafe { sigismember(&set, 2) }, 0);
+
+        // Add signal 15.
+        assert_eq!(unsafe { sigaddset(&mut set, 15) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 15) }, 1);
+        assert_eq!(unsafe { sigismember(&set, 1) }, 1);
+    }
+
+    #[test]
+    fn test_sigdelset() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigfillset(&mut set) }, 0);
+
+        // Remove signal 9.
+        assert_eq!(unsafe { sigdelset(&mut set, 9) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 9) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 10) }, 1);
+    }
+
+    #[test]
+    fn test_sigset_invalid_signum() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigaddset(&mut set, 0) }, -1);
+        assert_eq!(unsafe { sigaddset(&mut set, 65) }, -1);
+        assert_eq!(unsafe { sigdelset(&mut set, -1) }, -1);
+        assert_eq!(unsafe { sigismember(&set, 0) }, -1);
+    }
+
+    #[test]
+    fn test_sigset_null_pointer() {
+        assert_eq!(unsafe { sigemptyset(core::ptr::null_mut()) }, -1);
+        assert_eq!(unsafe { sigfillset(core::ptr::null_mut()) }, -1);
+        assert_eq!(unsafe { sigaddset(core::ptr::null_mut(), 1) }, -1);
+        assert_eq!(unsafe { sigdelset(core::ptr::null_mut(), 1) }, -1);
+        assert_eq!(unsafe { sigismember(core::ptr::null(), 1) }, -1);
+    }
+
+    #[test]
+    fn test_sigset_boundary_signals() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigemptyset(&mut set) }, 0);
+
+        // Signal 1 (minimum valid).
+        assert_eq!(unsafe { sigaddset(&mut set, 1) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 1) }, 1);
+
+        // Signal 64 (maximum valid).
+        assert_eq!(unsafe { sigaddset(&mut set, 64) }, 0);
+        assert_eq!(unsafe { sigismember(&set, 64) }, 1);
+    }
+}

--- a/src/libs/syscall/src/signal/mod.rs
+++ b/src/libs/syscall/src/signal/mod.rs
@@ -15,17 +15,29 @@
 pub mod bindings;
 
 //==================================================================================================
+// Imports
+//==================================================================================================
+
+use core::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
-#[repr(C)]
-pub struct sigset_t {
-    pub bits: [u64; 16],
-}
+/// Signal set type: a 64-bit blocked-signal bitmask, matching the `<signal.h>` ABI.
+pub type sigset_t = u64;
 
+/// Signal action structure, matching the `struct sigaction` ABI declared in `<signal.h>` and used
+/// by the `libc_signal` crate that calls this `sigaction` binding.
 #[repr(C)]
 pub struct sigaction_t {
-    pub sa_handler: extern "C" fn(usize),
+    /// Signal handler, represented as a pointer-sized value so the `<signal.h>` sentinels
+    /// (`SIG_DFL`/`SIG_IGN`/`SIG_ERR`) are representable without forming invalid function pointers.
+    pub sa_handler: usize,
     pub sa_mask: sigset_t,
-    pub sa_flags: usize,
+    pub sa_flags: c_int,
+    pub sa_sigaction: Option<unsafe extern "C" fn(c_int, *mut c_void, *mut c_void)>,
 }


### PR DESCRIPTION
## Summary

Introduces a new `no_std` guest libc crate, `libc_signal`, providing a
POSIX-conformant implementation of `<signal.h>`, and reconciles the
corresponding ABI in the `syscall` crate.

## What's included

**New crate (`src/libs/libc_signal`)**
- `signal()` — dispositions with `SIG_DFL`/`SIG_IGN`/`SIG_ERR` sentinels.
- `raise()` — self-directed signal delivery.
- `sigprocmask()` — `SIG_BLOCK`/`SIG_UNBLOCK`/`SIG_SETMASK` mask manipulation.
- `sigemptyset()`, `sigfillset()`, `sigaddset()`, `sigdelset()`, `sigismember()` — signal-set primitives.
- `sigaction_t` with `sa_handler`, `sa_mask`, `sa_flags`, and the `SA_SIGINFO` `sa_sigaction` handler member.
- `header.toml` — C header spec for the generated `signal.h`, including `union sigval`, a minimal `siginfo_t`, the `sa_sigaction` member, and the `SI_*` code constants.

**POSIX conformance**
- `signal()` sets `errno` to `EINVAL` on an invalid signal number.
- `sigprocmask()` silently drops `SIGKILL`/`SIGSTOP` from the new mask and rejects an invalid `how` with `EINVAL`.
- `errno` writes route through a cfg-split `set_errno` helper: the guest writes the C `errno` location, while the host (`feature = "std"`) test build uses a no-op stand-in since `__errno_location` is not host-linkable on MSVC.

**ABI reconciliation (`src/libs/syscall/src/signal/mod.rs`)**
- `sigset_t` is now a 64-bit bitmask (`type sigset_t = u64`), matching the `<signal.h>` ABI.
- `sigaction_t` mirrors the `libc_signal`/header layout (Option-wrapped handler pointers, `c_int` flags, `sa_sigaction` member).

**Build wiring**
- Register `libc_signal` as a workspace member and dependency (`Cargo.toml`).
- Add `libc_signal` to `ALL_GUEST_RUST_LIBS` and the guest test list (`Makefile`).

## Validation
- Guest `no_std` checks for `syscall` and `libc_signal`.
- 17 host unit tests for `libc_signal` pass.
- Clippy (lib + tests) and `rustfmt` clean for both crates.

## Out of scope
- Realtime signals (`SIGRTMIN/MAX`), `sigevent`/`SIGEV_*`, `sigqueue`/`sigwait`/`sigtimedwait`/`sigsuspend`/`sigpending`, `sig2str`/`str2sig`/`psiginfo`/`psignal`, `ucontext_t`/`stack_t` — no kernel support yet.
- `pthread_sigmask` oldset (TODO #717) and `pthread_kill` (TODO #716) remain stubs.
