### PR TITLE
[vfs] Add pipe buffer and FD layer for POSIX unnamed pipes

### DIFF
--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -132,7 +132,8 @@ pub(crate) fn handle_fcntl(source: ThreadIdentifier, msg: SystemCallMessage) -> 
     let req: FileControlRequest = FileControlRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
     let cmd: i32 = req.cmd;
-    match ::vfs::fd::vfs_fcntl(fd, cmd) {
+    let arg: i32 = req.arg;
+    match ::vfs::fd::vfs_fcntl(fd, cmd, arg) {
         Ok(ret) => {
             FileControlResponse::build(source, ret, ProcessIdentifier::VFSD, MessageType::Ipc)
         },

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -42,6 +42,7 @@ use ::sysapi::{
     fcntl::{
         file_control_request,
         file_creation_flags,
+        file_status_flags,
     },
     ffi::c_int,
     sys_stat::{
@@ -193,6 +194,8 @@ pub enum VfsFileHandle {
     /// Remote file opened through the host filesystem daemon (hostfsd).
     /// Operations on this handle must be forwarded via IKC by the caller (vfsd).
     HostFs(HostFsHandle),
+    /// One end of a POSIX unnamed pipe.
+    Pipe(crate::pipe::PipeEnd),
 }
 
 /// Handle for a file opened on the host filesystem via hostfsd.
@@ -312,6 +315,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => Ok(handle.read(buf)),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // Pipes are served by vfsd through the dedicated non-blocking primitives.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -322,6 +327,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // Pipes are served by vfsd through the dedicated non-blocking primitives.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -335,6 +342,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => handle.seek(offset, whence),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // A pipe is not seekable (`ESPIPE`); the daemon rejects seeks before reaching here.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -345,6 +354,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => Ok(handle.size() as u64),
             VfsFileHandle::Directory(_) => Ok(0),
             VfsFileHandle::HostFs(_) => Ok(0),
+            VfsFileHandle::Pipe(_) => Ok(0),
         }
     }
 
@@ -369,6 +379,14 @@ impl VfsFileHandle {
             _ => None,
         }
     }
+
+    /// Returns the pipe end if this handle is one end of a pipe.
+    pub fn pipe_end(&self) -> Option<&crate::pipe::PipeEnd> {
+        match self {
+            VfsFileHandle::Pipe(end) => Some(end),
+            _ => None,
+        }
+    }
 }
 
 //==================================================================================================
@@ -390,6 +408,11 @@ struct VfsEntry {
     handle: VfsFileHandle,
     /// POSIX-compliant virtual file position (may exceed file size).
     virtual_pos: off_t,
+    /// Open file status flags (the mutable subset settable via `fcntl(F_SETFL)`).
+    ///
+    /// Only `O_NONBLOCK` is honored today; it is consulted by vfsd's pipe read/write handlers to
+    /// choose `EAGAIN` over blocking. Non-pipe descriptors are unaffected because they never block.
+    status_flags: c_int,
 }
 
 // SAFETY: VfsEntry contains FAT filesystem types that use `Cell` internally
@@ -530,6 +553,7 @@ fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
             state.slots[i] = Some(Arc::new(Mutex::new(VfsEntry {
                 handle,
                 virtual_pos: 0,
+                status_flags: 0,
             })));
             return Ok(VFS_FD_BASE + i as c_int);
         }
@@ -612,6 +636,28 @@ pub fn vfs_fork_clone(
     Ok(())
 }
 
+/// Pipe count-to-zero transitions surfaced by [`vfs_process_exit`].
+///
+/// Each entry records that the exiting process held the final reference to one end of a pipe, so
+/// that end's reference count dropped to zero when its open file description was released. vfsd
+/// uses these to run the corresponding wakeup (EOF for readers when a write end vanishes, `EPIPE`
+/// for writers when a read end vanishes).
+pub struct PipeClosure {
+    /// Stable identity of the affected pipe.
+    pub pipe_id: u64,
+    /// Whether the released end was the write end (`true`) or the read end (`false`).
+    pub was_write: bool,
+}
+
+/// Resources surfaced by [`vfs_process_exit`] that the daemon must act on after a process exits.
+pub struct ProcessExitReclaim {
+    /// Remote file descriptors of host-backed descriptions for which the process held the final
+    /// reference. Each must be closed on hostfsd or the remote handle leaks.
+    pub orphaned_hostfs_fds: Vec<i32>,
+    /// Pipe ends whose reference count reached zero because the process held the final reference.
+    pub pipe_closures: Vec<PipeClosure>,
+}
+
 /// Reclaims the per-process filesystem state of a terminated process.
 ///
 /// Drops `pid`'s recorded state, releasing its references to the open file descriptions it held.
@@ -619,12 +665,13 @@ pub fn vfs_fork_clone(
 /// descriptions, and prevents the per-process table from growing without bound. Reclaiming an
 /// unknown `pid` is a no-op.
 ///
-/// Returns the remote file descriptors of any host-backed open file descriptions for which `pid`
-/// held the final reference. The caller (vfsd) must forward a close for each of these to hostfsd:
-/// because the process is gone it can no longer close them itself, and the VFS has no other way to
-/// release a remote handle. Descriptions still shared with a surviving process are not returned.
-#[must_use = "the returned remote fds must be closed on hostfsd or they leak"]
-pub fn vfs_process_exit(pid: ProcessIdentifier) -> Vec<i32> {
+/// Returns the resources the daemon must act on: the remote file descriptors of any host-backed
+/// open file descriptions for which `pid` held the final reference (which it must close on hostfsd,
+/// because the process is gone and can no longer close them itself), and the pipe ends whose
+/// reference count reached zero (so the daemon can fire EOF/`EPIPE` wakeups for any suspended
+/// counterparts). Descriptions still shared with a surviving process are not returned.
+#[must_use = "the returned hostfs fds must be closed and pipe closures must trigger wakeups"]
+pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // Detach the process's state while holding the registry lock, but defer dropping it until the
     // lock is released. Dropping an open file description may run backend teardown; deferring keeps
     // the registry lock from ever nesting with backend locks, matching `vfs_close`.
@@ -634,23 +681,37 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> Vec<i32> {
         procs.remove(&pid)
     };
     let Some(state) = removed else {
-        return Vec::new();
+        return ProcessExitReclaim {
+            orphaned_hostfs_fds: Vec::new(),
+            pipe_closures: Vec::new(),
+        };
     };
     // The process has been removed from the registry, so an `Arc` strong count of one means no
     // surviving descriptor — in this or any other process — still shares the open file description.
-    // Its remote handle must therefore be closed on hostfsd. As the sole owner, the lock below is
+    // A host-backed handle must therefore be closed on hostfsd, and a pipe end's count drops to
+    // zero (which the dropped end's `Drop` applies just below). As the sole owner, the lock is
     // uncontended.
     let mut orphaned: Vec<i32> = Vec::new();
+    let mut pipe_closures: Vec<PipeClosure> = Vec::new();
     for open_file in state.slots.into_iter().flatten() {
         if Arc::strong_count(&open_file) != 1 {
             continue;
         }
-        if let VfsFileHandle::HostFs(h) = &open_file.lock().handle {
-            orphaned.push(h.remote_fd());
+        match &open_file.lock().handle {
+            VfsFileHandle::HostFs(h) => orphaned.push(h.remote_fd()),
+            VfsFileHandle::Pipe(end) => pipe_closures.push(PipeClosure {
+                pipe_id: end.pipe_id(),
+                was_write: end.is_write(),
+            }),
+            _ => {},
         }
-        // `open_file` is dropped here, after the registry lock has been released.
+        // `open_file` is dropped here, after the registry lock has been released; the pipe end's
+        // `Drop` decrements its reader/writer count as part of that.
     }
-    orphaned
+    ProcessExitReclaim {
+        orphaned_hostfs_fds: orphaned,
+        pipe_closures,
+    }
 }
 
 /// Reports whether `fd` is the last descriptor referencing its open file description.
@@ -671,6 +732,30 @@ pub fn vfs_hostfs_is_last_ref(fd: c_int) -> bool {
         // The table holds exactly one reference, so a strong count of one means no other descriptor
         // shares this open file description.
         Some(entry) => Arc::strong_count(entry) == 1,
+        None => false,
+    }
+}
+
+/// Reports whether closing `fd` would drop the final reference to a pipe end.
+///
+/// Returns `true` when `fd` refers to a pipe end and the current process holds the only descriptor
+/// for that end's open file description, so closing it (or the owning process exiting) decrements
+/// the pipe's reader/writer count to zero. Returns `false` when other descriptors still share the
+/// end (for example in a forked child), when `fd` is not a pipe, or when `fd` is invalid. This does
+/// not modify the descriptor table.
+pub fn vfs_pipe_is_last_ref(fd: c_int) -> bool {
+    let Ok(idx) = fd_index(fd) else {
+        return false;
+    };
+    let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
+    let Some(state) = procs.get(&current_pid()) else {
+        return false;
+    };
+    match state.slots.get(idx).and_then(|slot| slot.as_ref()) {
+        Some(entry) => {
+            // Must be a pipe and the sole reference for closing to drive the count to zero.
+            Arc::strong_count(entry) == 1 && matches!(&entry.lock().handle, VfsFileHandle::Pipe(_))
+        },
         None => false,
     }
 }
@@ -734,6 +819,97 @@ pub fn vfs_hostfs_set_readdir_offset(fd: c_int, offset: u32) -> bool {
             true
         },
         _ => false,
+    }
+}
+
+//==================================================================================================
+// Pipe FD Helpers
+//==================================================================================================
+
+/// Re-exported pipe outcome types so the daemon can match on them without importing
+/// [`crate::pipe`] directly.
+pub use crate::pipe::{
+    PipeReadOutcome,
+    PipeWriteOutcome,
+};
+
+/// Creates a pipe and allocates its read and write file descriptors in the current process.
+///
+/// Returns `(read_fd, write_fd)`. The two descriptors share a single pipe buffer with the reader
+/// and writer counts both initialized to one.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::TooManyOpenFiles`] when the descriptor table cannot accommodate both ends.
+/// If only the read end could be allocated, it is released before returning so that no half-open
+/// pipe is left behind.
+pub fn vfs_pipe() -> Result<(c_int, c_int), Fat32Error> {
+    let (read_end, write_end): (crate::pipe::PipeEnd, crate::pipe::PipeEnd) =
+        crate::pipe::PipeEnd::new_pair();
+    let read_fd: c_int = alloc_fd(VfsFileHandle::Pipe(read_end))?;
+    match alloc_fd(VfsFileHandle::Pipe(write_end)) {
+        Ok(write_fd) => Ok((read_fd, write_fd)),
+        Err(e) => {
+            // Releasing the read end drops its `PipeEnd`, decrementing the reader count; the write
+            // end was already dropped when `alloc_fd` consumed and failed on it. No half-open pipe
+            // survives.
+            let _ = vfs_close(read_fd);
+            Err(e)
+        },
+    }
+}
+
+/// Returns a pipe descriptor's identity and direction, or `None` if `fd` is not a pipe.
+///
+/// The returned tuple is `(pipe_id, is_write)`. vfsd uses `pipe_id` to key its blocked-request
+/// queues and `is_write` to enforce I/O direction.
+pub fn vfs_pipe_id(fd: c_int) -> Option<(u64, bool)> {
+    let file: OpenFile = entry_arc(fd).ok()?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end()?;
+    Some((end.pipe_id(), end.is_write()))
+}
+
+/// Attempts a non-blocking read from a pipe read end.
+///
+/// On [`PipeReadOutcome::Read(n)`](PipeReadOutcome::Read), `n` bytes of space were freed, so vfsd
+/// must try to revive a suspended writer.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the write end (reading the
+/// write end is rejected, mirroring `EBADF`).
+pub fn vfs_pipe_read(fd: c_int, buf: &mut [u8]) -> Result<PipeReadOutcome, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.read(buf).map_err(|_| Fat32Error::InvalidFd)
+}
+
+/// Attempts a non-blocking write to a pipe write end, honoring `PIPE_BUF` atomicity.
+///
+/// On [`PipeWriteOutcome::Wrote(n)`](PipeWriteOutcome::Wrote), `n` bytes became available, so vfsd
+/// must try to revive a suspended reader.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the read end (writing the
+/// read end is rejected, mirroring `EBADF`).
+pub fn vfs_pipe_write(fd: c_int, buf: &[u8]) -> Result<PipeWriteOutcome, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.write(buf).map_err(|_| Fat32Error::InvalidFd)
+}
+
+/// Returns the open file status flags for `fd` (as reported by `fcntl(F_GETFL)`).
+///
+/// Returns `0` if `fd` is invalid, which is harmless: callers consult this only to decide whether
+/// `O_NONBLOCK` is set, and a missing descriptor will fail the surrounding operation anyway.
+pub fn vfs_get_status_flags(fd: c_int) -> c_int {
+    match entry_arc(fd) {
+        Ok(file) => file.lock().status_flags,
+        Err(_) => 0,
     }
 }
 
@@ -967,11 +1143,44 @@ fn populate_stat_fields(buf: &mut ::sysapi::sys_stat::stat, size: u64, is_dir: b
     };
 }
 
+/// Populates stat fields for a pipe (FIFO) descriptor.
+///
+/// A pipe has no name, size, or on-disk blocks: `st_mode` carries `S_IFIFO` with owner read/write
+/// permissions and `st_size` is `0`, matching POSIX expectations for an unnamed pipe. `st_ino`
+/// carries the pipe's unique identity, and `st_dev` a synthetic pipefs device distinct from the
+/// VFS file device, so distinct pipes report distinct `(st_dev, st_ino)` pairs that never collide
+/// with regular files — mirroring how a real pipefs assigns one inode per pipe.
+fn populate_pipe_stat_fields(buf: &mut ::sysapi::sys_stat::stat, pipe_id: u64) {
+    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
+    const FIXED_EPOCH: i64 = 1_704_067_200;
+
+    buf.st_size = 0;
+    buf.st_nlink = 1;
+    buf.st_dev = 2; // Synthetic pipefs device ID, distinct from the VFS file device (1).
+    buf.st_ino = pipe_id;
+    buf.st_mode = file_type::S_IFIFO | file_mode::S_IRUSR | file_mode::S_IWUSR;
+    buf.st_blksize = STAT_BLOCK_SIZE;
+    buf.st_blocks = 0;
+    buf.st_atim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_mtim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_ctim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+}
+
 /// Gets file status for a VFS file descriptor.
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+    let pipe_id: Option<u64> = entry.handle.pipe_end().map(|end| end.pipe_id());
     let is_dir: bool = matches!(&entry.handle, VfsFileHandle::Directory(_));
     let size: u64 = entry.handle.size()?;
 
@@ -980,7 +1189,11 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
 
-    populate_stat_fields(buf, size, is_dir);
+    if let Some(pipe_id) = pipe_id {
+        populate_pipe_stat_fields(buf, pipe_id);
+    } else {
+        populate_stat_fields(buf, size, is_dir);
+    }
 
     Ok(())
 }
@@ -1155,7 +1368,9 @@ pub fn vfs_ftruncate(fd: c_int, length: off_t) -> Result<(), Fat32Error> {
             }
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
-        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) | VfsFileHandle::Pipe(_) => {
+            Err(Fat32Error::NotSupported)
+        },
     }
 }
 
@@ -1197,7 +1412,9 @@ pub fn vfs_fallocate(fd: c_int, offset: off_t, len: off_t) -> Result<(), Fat32Er
             Ok(())
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
-        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) | VfsFileHandle::Pipe(_) => {
+            Err(Fat32Error::NotSupported)
+        },
     }
 }
 
@@ -1210,9 +1427,10 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
     let entry: &mut VfsEntry = &mut guard;
     match &mut entry.handle {
         VfsFileHandle::Fat32(file) => file.flush(),
-        VfsFileHandle::DirectRead(_) | VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => {
-            Ok(())
-        },
+        VfsFileHandle::DirectRead(_)
+        | VfsFileHandle::Directory(_)
+        | VfsFileHandle::HostFs(_)
+        | VfsFileHandle::Pipe(_) => Ok(()),
     }
 }
 
@@ -1318,18 +1536,24 @@ pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
 
 /// File control operation on a VFS file descriptor.
 ///
-/// Only `F_GETFL` and `F_SETFL` are supported (as no-ops for FAT32).
-/// Other commands return `NotSupported`.
-pub fn vfs_fcntl(fd: c_int, cmd: c_int) -> Result<c_int, Fat32Error> {
-    // Verify the fd is valid.
-    let _file: OpenFile = entry_arc(fd)?;
+/// Supports the file-descriptor flag commands (`F_GETFD`/`F_SETFD`, which have no effect because
+/// the VFS implements no close-on-exec) and the file-status-flag commands (`F_GETFL`/`F_SETFL`).
+/// `F_SETFL` stores the mutable status-flag subset (currently only `O_NONBLOCK`) on the open file
+/// description; `F_GETFL` returns it. Other commands return [`Fat32Error::NotSupported`].
+pub fn vfs_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> Result<c_int, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
 
     match cmd {
         file_control_request::F_GETFD => Ok(0), // No FD flags (no close-on-exec for VFS).
         file_control_request::F_SETFD => Ok(0), // Accept but ignore (no close-on-exec).
-        file_control_request::F_GETFL => Ok(0), // No meaningful flags for FAT32.
-        file_control_request::F_SETFL => Ok(0), // Accept but ignore (no O_NONBLOCK etc.).
-        _ => Err(Fat32Error::NotSupported),     // Other commands not supported.
+        file_control_request::F_GETFL => Ok(file.lock().status_flags),
+        file_control_request::F_SETFL => {
+            // Persist only the mutable status-flag subset (currently `O_NONBLOCK`). The remaining
+            // bits (access mode, creation flags) are not changeable via `F_SETFL` per POSIX.
+            file.lock().status_flags = arg & file_status_flags::O_NONBLOCK;
+            Ok(0)
+        },
+        _ => Err(Fat32Error::NotSupported), // Other commands not supported.
     }
 }
 
@@ -2127,5 +2351,156 @@ mod tests {
         );
 
         forget_processes(&[parent, child]);
+    }
+
+    // -- pipe descriptor tests ---------------------------------------------------
+
+    /// Tests that `vfs_pipe` allocates two descriptors with correct directions and shared identity.
+    #[test]
+    fn pipe_allocates_read_and_write_ends() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7101);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        let (rid, r_is_write): (u64, bool) =
+            vfs_pipe_id(read_fd).expect("read fd should be a pipe");
+        let (wid, w_is_write): (u64, bool) =
+            vfs_pipe_id(write_fd).expect("write fd should be a pipe");
+        assert_eq!(rid, wid, "both ends share one pipe identity");
+        assert!(!r_is_write, "read_fd must be the read end");
+        assert!(w_is_write, "write_fd must be the write end");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests the non-blocking read/write outcome matrix and direction enforcement on a pipe.
+    #[test]
+    fn pipe_read_write_outcomes() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7111);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+
+        // Empty pipe with an open writer: a read would block.
+        let mut buf: [u8; 8] = [0u8; 8];
+        assert!(
+            matches!(vfs_pipe_read(read_fd, &mut buf), Ok(PipeReadOutcome::WouldBlock)),
+            "an empty pipe with a writer should block reads"
+        );
+
+        // Write then read back.
+        assert!(
+            matches!(vfs_pipe_write(write_fd, &[1, 2, 3]), Ok(PipeWriteOutcome::Wrote(3))),
+            "a write into a pipe with space should succeed"
+        );
+        match vfs_pipe_read(read_fd, &mut buf) {
+            Ok(PipeReadOutcome::Read(n)) => {
+                assert_eq!(n, 3, "should read the 3 written bytes");
+                assert_eq!(&buf[..3], &[1, 2, 3], "read bytes should match");
+            },
+            _ => panic!("expected a successful read"),
+        }
+
+        // Direction enforcement.
+        assert!(vfs_pipe_read(write_fd, &mut buf).is_err(), "reading the write end is rejected");
+        assert!(vfs_pipe_write(read_fd, &[0]).is_err(), "writing the read end is rejected");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests EOF after the write end closes and a broken pipe after the read end closes.
+    #[test]
+    fn pipe_eof_and_broken_pipe() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7121);
+        set_current_process(pid);
+
+        // EOF: close the write end, the read end then reports EOF.
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        assert!(vfs_pipe_is_last_ref(write_fd), "the sole write descriptor is the last reference");
+        vfs_close(write_fd).expect("closing the write end should succeed");
+        let mut buf: [u8; 4] = [0u8; 4];
+        assert!(
+            matches!(vfs_pipe_read(read_fd, &mut buf), Ok(PipeReadOutcome::Eof)),
+            "after the writer closes, the empty pipe reports EOF"
+        );
+        vfs_close(read_fd).expect("closing the read end should succeed");
+
+        // Broken pipe: close the read end, a write then reports a broken pipe.
+        let (read_fd2, write_fd2): (c_int, c_int) =
+            vfs_pipe().expect("pipe creation should succeed");
+        vfs_close(read_fd2).expect("closing the read end should succeed");
+        assert!(
+            matches!(vfs_pipe_write(write_fd2, &[9]), Ok(PipeWriteOutcome::BrokenPipe)),
+            "writing with no readers reports a broken pipe"
+        );
+        vfs_close(write_fd2).expect("closing the write end should succeed");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that `F_SETFL` stores `O_NONBLOCK` and `F_GETFL`/`vfs_get_status_flags` read it back.
+    #[test]
+    fn pipe_nonblock_status_flags_round_trip() {
+        use ::sysapi::fcntl::{
+            file_control_request,
+            file_status_flags,
+        };
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7131);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        assert_eq!(vfs_get_status_flags(read_fd), 0, "flags default to zero");
+
+        vfs_fcntl(read_fd, file_control_request::F_SETFL, file_status_flags::O_NONBLOCK)
+            .expect("F_SETFL should succeed");
+        assert_eq!(
+            vfs_get_status_flags(read_fd),
+            file_status_flags::O_NONBLOCK,
+            "O_NONBLOCK should be stored"
+        );
+        assert_eq!(
+            vfs_fcntl(read_fd, file_control_request::F_GETFL, 0).expect("F_GETFL should succeed"),
+            file_status_flags::O_NONBLOCK,
+            "F_GETFL returns the stored flags"
+        );
+        // Status flags are per open file description: the write end is unaffected.
+        assert_eq!(vfs_get_status_flags(write_fd), 0, "the write end is unaffected");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that process exit surfaces pipe count-to-zero transitions for the process's own ends.
+    #[test]
+    fn pipe_process_exit_reports_closures() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7141);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        let (pipe_id, _): (u64, bool) = vfs_pipe_id(read_fd).expect("read fd should be a pipe");
+        // Both ends stay open in this single process, so it holds the only reference to each.
+        let _ = write_fd;
+
+        let reclaim: ProcessExitReclaim = vfs_process_exit(pid);
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "no hostfs fds were opened");
+        assert_eq!(reclaim.pipe_closures.len(), 2, "both ends are last references at exit");
+        assert!(
+            reclaim.pipe_closures.iter().all(|c| c.pipe_id == pipe_id),
+            "closures must target our pipe"
+        );
+        assert!(
+            reclaim.pipe_closures.iter().any(|c| c.was_write),
+            "the write end closure is reported"
+        );
+        assert!(
+            reclaim.pipe_closures.iter().any(|c| !c.was_write),
+            "the read end closure is reported"
+        );
+
+        forget_processes(&[pid]);
     }
 }

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -74,6 +74,9 @@ pub mod mount;
 /// Path-resolution cache used by the mount table.
 mod path_cache;
 
+/// In-memory pipe buffers for POSIX unnamed pipes.
+pub mod pipe;
+
 /// Global VFS state management.
 pub mod state;
 

--- a/src/libs/vfs/src/pipe.rs
+++ b/src/libs/vfs/src/pipe.rs
@@ -1,0 +1,459 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! In-memory pipe buffers for POSIX unnamed pipes.
+//!
+//! A pipe is a fixed-capacity byte ring buffer plus reader/writer reference counts. The buffer is
+//! owned by the VFS library (`no_std`) so that it lives next to the existing FD machinery; the
+//! daemon (vfsd) holds no buffer bytes and drives all blocking from its side via the non-blocking
+//! primitives exposed here.
+//!
+//! # Model
+//!
+//! [`PipeEnd::new_pair`] allocates one [`PipeInner`] (shared by both ends) and returns the read end
+//! and write end. Each end is stored inside a `VfsFileHandle::Pipe` in its own open file
+//! description (`Arc<Mutex<VfsEntry>>`). `fork()` clones the descriptor slots, sharing the same
+//! end, so the reader/writer counts are unaffected — matching POSIX, where `fork()` shares the open
+//! file description rather than creating a new one.
+//!
+//! [`PipeEnd`] implements [`Drop`]: when the last descriptor referring to a given end's open file
+//! description is closed (or its owning process exits), the description drops, [`PipeEnd::drop`]
+//! runs, and decrements `readers` or `writers` on the shared [`PipeInner`]. The corresponding
+//! *wakeup* of suspended callers is the daemon's responsibility (the VFS only adjusts the count).
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::{
+    collections::VecDeque,
+    sync::Arc,
+};
+use ::core::sync::atomic::{
+    AtomicU64,
+    Ordering,
+};
+use ::spin::Mutex;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Capacity of a pipe's kernel buffer, in bytes.
+///
+/// Matches the Linux default and is guaranteed to be at least [`PIPE_BUF`].
+pub const PIPE_CAPACITY: usize = 64 * 1024;
+
+/// Maximum size of an atomic pipe write (POSIX `PIPE_BUF`).
+///
+/// A write of at most this many bytes is performed all-or-nothing and never interleaves with the
+/// data of another writer. POSIX requires this to be at least 512.
+pub const PIPE_BUF: usize = 4096;
+
+//==================================================================================================
+// Pipe Identity Allocator
+//==================================================================================================
+
+/// Source of process-global, monotonically increasing pipe identifiers.
+///
+/// Identifiers are never recycled for the lifetime of the daemon, so a stale wakeup can never
+/// target the wrong pipe. Starts at `1` so that `0` can be reserved as an always-invalid sentinel
+/// by callers that need one.
+static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Allocates the next unique pipe identifier.
+fn alloc_pipe_id() -> u64 {
+    // `fetch_add` returns the previous value, so on wraparound it can yield `0`. Skip it to keep
+    // `0` reserved as an always-invalid sentinel.
+    loop {
+        let id: u64 = NEXT_PIPE_ID.fetch_add(1, Ordering::Relaxed);
+        if id != 0 {
+            return id;
+        }
+    }
+}
+
+//==================================================================================================
+// Pipe Buffer
+//==================================================================================================
+
+/// Shared state of a pipe: the byte ring buffer plus reader/writer reference counts.
+struct PipeInner {
+    /// Byte ring buffer, capped at [`PIPE_CAPACITY`].
+    buf: VecDeque<u8>,
+    /// Number of open read-end descriptions (`0` or `1` under `pipe()`/`dup`/`fork` sharing).
+    readers: u32,
+    /// Number of open write-end descriptions.
+    writers: u32,
+}
+
+impl PipeInner {
+    /// Non-blocking read from the buffer.
+    ///
+    /// Copies as many bytes as are available into `buf` (up to `buf.len()`). Returns
+    /// [`PipeReadOutcome::WouldBlock`] when the buffer is empty but at least one writer is still
+    /// open, and [`PipeReadOutcome::Eof`] when the buffer is empty and no writers remain. A
+    /// zero-length read transfers no data and never blocks — POSIX `read(2)` with `count == 0`
+    /// returns `0` immediately.
+    fn read(&mut self, buf: &mut [u8]) -> PipeReadOutcome {
+        // A zero-length read must succeed immediately and never block, even on an empty pipe.
+        if buf.is_empty() {
+            return PipeReadOutcome::Read(0);
+        }
+        let available: usize = self.buf.len();
+        if available == 0 {
+            if self.writers == 0 {
+                return PipeReadOutcome::Eof;
+            }
+            return PipeReadOutcome::WouldBlock;
+        }
+        let n: usize = available.min(buf.len());
+        // `n <= self.buf.len()`, so the drain yields exactly `n` bytes in front-to-back order.
+        for (dst, src) in buf.iter_mut().zip(self.buf.drain(..n)) {
+            *dst = src;
+        }
+        PipeReadOutcome::Read(n)
+    }
+
+    /// Non-blocking write into the buffer, honoring [`PIPE_BUF`] atomicity.
+    ///
+    /// If `buf.len() <= PIPE_BUF` the write is all-or-nothing: it either appends every byte or,
+    /// when there is insufficient free space, appends nothing and returns
+    /// [`PipeWriteOutcome::WouldBlock`]. For larger writes, as much as fits is appended. Returns
+    /// [`PipeWriteOutcome::BrokenPipe`] when no readers remain.
+    fn write(&mut self, buf: &[u8]) -> PipeWriteOutcome {
+        // A zero-length write transfers no data and has no other effect, so it succeeds even with
+        // no readers — matching Linux, which never reports `EPIPE`/`SIGPIPE` for an empty write.
+        if buf.is_empty() {
+            return PipeWriteOutcome::Wrote(0);
+        }
+        if self.readers == 0 {
+            return PipeWriteOutcome::BrokenPipe;
+        }
+        let free: usize = PIPE_CAPACITY.saturating_sub(self.buf.len());
+        let to_write: usize = if buf.len() <= PIPE_BUF {
+            // Atomic write: all-or-nothing.
+            if free < buf.len() {
+                return PipeWriteOutcome::WouldBlock;
+            }
+            buf.len()
+        } else {
+            // Large write: append as much as fits.
+            if free == 0 {
+                return PipeWriteOutcome::WouldBlock;
+            }
+            free.min(buf.len())
+        };
+        self.buf.extend(buf[..to_write].iter().copied());
+        PipeWriteOutcome::Wrote(to_write)
+    }
+}
+
+//==================================================================================================
+// Pipe End
+//==================================================================================================
+
+/// One end of a pipe, stored inside a `VfsFileHandle::Pipe`.
+///
+/// Both ends share the same [`PipeInner`] through an [`Arc`]; the `is_write` flag distinguishes the
+/// write end from the read end and is used to enforce I/O direction.
+pub struct PipeEnd {
+    inner: Arc<Mutex<PipeInner>>,
+    is_write: bool,
+    /// Stable identity used by vfsd to key blocked-request queues.
+    ///
+    /// Copied onto each end at construction so that identity lookups (and the `Drop`/exit paths
+    /// that report it) never need to take the shared [`PipeInner`] lock.
+    pipe_id: u64,
+}
+
+impl PipeEnd {
+    /// Allocates a new pipe and returns its `(read_end, write_end)` pair.
+    ///
+    /// The shared [`PipeInner`] starts with `readers == 1` and `writers == 1`.
+    pub fn new_pair() -> (PipeEnd, PipeEnd) {
+        let pipe_id: u64 = alloc_pipe_id();
+        let inner: Arc<Mutex<PipeInner>> = Arc::new(Mutex::new(PipeInner {
+            buf: VecDeque::new(),
+            readers: 1,
+            writers: 1,
+        }));
+        let read_end: PipeEnd = PipeEnd {
+            inner: inner.clone(),
+            is_write: false,
+            pipe_id,
+        };
+        let write_end: PipeEnd = PipeEnd {
+            inner,
+            is_write: true,
+            pipe_id,
+        };
+        (read_end, write_end)
+    }
+
+    /// Returns the stable identity of the pipe this end belongs to.
+    pub fn pipe_id(&self) -> u64 {
+        self.pipe_id
+    }
+
+    /// Returns `true` if this is the write end, `false` if it is the read end.
+    pub fn is_write(&self) -> bool {
+        self.is_write
+    }
+
+    /// Attempts a non-blocking read from the pipe.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the write end.
+    pub fn read(&self, buf: &mut [u8]) -> Result<PipeReadOutcome, PipeEndError> {
+        if self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().read(buf))
+    }
+
+    /// Attempts a non-blocking write to the pipe.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the read end.
+    pub fn write(&self, buf: &[u8]) -> Result<PipeWriteOutcome, PipeEndError> {
+        if !self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().write(buf))
+    }
+}
+
+impl Drop for PipeEnd {
+    /// Decrements the reader or writer count of the shared [`PipeInner`].
+    ///
+    /// Only the count is adjusted here; waking suspended callers is the daemon's responsibility,
+    /// because it owns the blocked-request queues.
+    fn drop(&mut self) {
+        let mut inner: spin::MutexGuard<'_, PipeInner> = self.inner.lock();
+        if self.is_write {
+            inner.writers = inner.writers.saturating_sub(1);
+        } else {
+            inner.readers = inner.readers.saturating_sub(1);
+        }
+    }
+}
+
+//==================================================================================================
+// Outcomes
+//==================================================================================================
+
+/// Outcome of a non-blocking pipe read attempt.
+#[derive(Debug)]
+pub enum PipeReadOutcome {
+    /// Copied `N` bytes out of the buffer; freed `N` bytes of space. `N` is `0` only for a
+    /// zero-length read.
+    Read(usize),
+    /// Buffer empty with writers still open — the caller must block (or receive `EAGAIN`).
+    WouldBlock,
+    /// Buffer empty and no writers remain — the caller must receive end-of-file (`0`).
+    Eof,
+}
+
+/// Outcome of a non-blocking pipe write attempt.
+#[derive(Debug)]
+pub enum PipeWriteOutcome {
+    /// Appended `N` bytes (`N > 0`, or `0` only for a zero-length write).
+    Wrote(usize),
+    /// Insufficient space to make progress — the caller must block (or receive `EAGAIN`).
+    WouldBlock,
+    /// No readers remain — the caller must receive `EPIPE`.
+    BrokenPipe,
+}
+
+/// Error returned by [`PipeEnd::read`]/[`PipeEnd::write`] when used in the wrong direction.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeEndError {
+    /// Read attempted on the write end, or write attempted on the read end.
+    WrongDirection,
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Drains all available bytes from a read end into a freshly allocated vector.
+    fn read_all(end: &PipeEnd, max: usize) -> alloc::vec::Vec<u8> {
+        let mut buf: alloc::vec::Vec<u8> = alloc::vec![0u8; max];
+        match end.read(&mut buf).expect("read end") {
+            PipeReadOutcome::Read(n) => {
+                buf.truncate(n);
+                buf
+            },
+            _ => alloc::vec::Vec::new(),
+        }
+    }
+
+    /// Tests a basic write-then-read round-trip preserving byte order.
+    #[test]
+    fn round_trip_preserves_bytes() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let data: [u8; 5] = [1, 2, 3, 4, 5];
+        match w.write(&data).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => assert_eq!(n, 5, "should write all 5 bytes"),
+            _ => panic!("write should succeed"),
+        }
+        assert_eq!(read_all(&r, 16), data, "read bytes should match written bytes");
+    }
+
+    /// Tests that the two ends report the same, unique pipe identity.
+    #[test]
+    fn ends_share_identity_unique_across_pipes() {
+        let (r1, w1): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let (r2, _w2): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(r1.pipe_id(), w1.pipe_id(), "both ends share one identity");
+        assert_ne!(r1.pipe_id(), r2.pipe_id(), "distinct pipes have distinct identities");
+        assert!(!r1.is_write(), "read end must not be the write end");
+        assert!(w1.is_write(), "write end must be the write end");
+    }
+
+    /// Tests that a read on an empty pipe with an open writer would block.
+    #[test]
+    fn empty_with_writer_would_block() {
+        let (r, _w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::WouldBlock),
+            "empty pipe with a writer should block"
+        );
+    }
+
+    /// Tests that a read on an empty pipe with no writers returns EOF.
+    #[test]
+    fn empty_without_writer_is_eof() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        drop(w);
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::Eof),
+            "empty pipe with no writers should report EOF"
+        );
+    }
+
+    /// Tests that buffered data is still readable after all writers close (drain-then-EOF).
+    #[test]
+    fn buffered_data_readable_after_writer_close() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        w.write(&[9, 8, 7]).expect("write end");
+        drop(w);
+        assert_eq!(
+            read_all(&r, 8),
+            alloc::vec![9, 8, 7],
+            "buffered bytes must survive writer close"
+        );
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::Eof),
+            "after draining, an empty pipe with no writers reports EOF"
+        );
+    }
+
+    /// Tests that a write to a pipe whose readers have all closed is a broken pipe.
+    #[test]
+    fn write_without_reader_is_broken_pipe() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        drop(r);
+        assert!(
+            matches!(w.write(&[1, 2, 3]).expect("write end"), PipeWriteOutcome::BrokenPipe),
+            "writing with no readers should report a broken pipe"
+        );
+    }
+
+    /// Tests `PIPE_BUF`-sized atomic writes: a write that does not fit entirely appends nothing.
+    #[test]
+    fn atomic_write_is_all_or_nothing() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        // Fill the buffer to within less than PIPE_BUF of capacity.
+        let bulk: alloc::vec::Vec<u8> = alloc::vec![0u8; PIPE_CAPACITY - 16];
+        match w.write(&bulk).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => assert_eq!(n, PIPE_CAPACITY - 16, "bulk fill should fit"),
+            _ => panic!("bulk fill should succeed"),
+        }
+        // A PIPE_BUF-sized write cannot fit in the remaining 16 bytes, so nothing is written.
+        let atomic: [u8; PIPE_BUF] = [7u8; PIPE_BUF];
+        assert!(
+            matches!(w.write(&atomic).expect("write end"), PipeWriteOutcome::WouldBlock),
+            "an atomic write that does not fit must append nothing"
+        );
+        // Free space, then the same write succeeds atomically.
+        let _ = r.read(&mut [0u8; 4096]).expect("read end");
+        assert!(
+            matches!(w.write(&atomic).expect("write end"), PipeWriteOutcome::Wrote(PIPE_BUF)),
+            "the atomic write should succeed once space is available"
+        );
+    }
+
+    /// Tests that a write larger than `PIPE_BUF` may be partially accepted up to capacity.
+    #[test]
+    fn large_write_is_partial() {
+        let (_r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let big: alloc::vec::Vec<u8> = alloc::vec![5u8; PIPE_CAPACITY + 4096];
+        match w.write(&big).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => {
+                assert_eq!(n, PIPE_CAPACITY, "a large write fills exactly to capacity")
+            },
+            _ => panic!("a large write into an empty pipe should make progress"),
+        }
+        // The pipe is now full: a further large write would block.
+        assert!(
+            matches!(w.write(&big).expect("write end"), PipeWriteOutcome::WouldBlock),
+            "a full pipe should block further writes"
+        );
+    }
+
+    /// Tests that using an end in the wrong direction is rejected.
+    #[test]
+    fn wrong_direction_is_rejected() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(
+            w.read(&mut [0u8; 4]).expect_err("read on write end"),
+            PipeEndError::WrongDirection,
+            "reading the write end must be rejected"
+        );
+        assert_eq!(
+            r.write(&[0u8; 4]).expect_err("write on read end"),
+            PipeEndError::WrongDirection,
+            "writing the read end must be rejected"
+        );
+    }
+
+    /// Tests ring-buffer wrap-around across many interleaved write/read cycles.
+    #[test]
+    fn ring_buffer_wraps_around() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let chunk: [u8; 1000] = [3u8; 1000];
+        // Many cycles push total bytes well past PIPE_CAPACITY, exercising wrap-around.
+        for _ in 0..200 {
+            assert!(
+                matches!(w.write(&chunk).expect("write end"), PipeWriteOutcome::Wrote(1000)),
+                "each 1000-byte chunk should fit after draining"
+            );
+            assert_eq!(read_all(&r, 1000).len(), 1000, "each cycle should read back 1000 bytes");
+        }
+    }
+
+    /// Tests that a zero-length read returns `Read(0)` immediately and never blocks.
+    #[test]
+    fn zero_length_read_does_not_block() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        // Empty pipe with an open writer would normally block, but a zero-length read must not.
+        assert!(
+            matches!(r.read(&mut []).expect("read end"), PipeReadOutcome::Read(0)),
+            "a zero-length read on an empty pipe with a writer must return Read(0)"
+        );
+        // The same holds once all writers have closed: still `Read(0)`, never `Eof`.
+        drop(w);
+        assert!(
+            matches!(r.read(&mut []).expect("read end"), PipeReadOutcome::Read(0)),
+            "a zero-length read on an empty pipe with no writers must return Read(0)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the VFS-library foundation for `pipe(2)`. All pipe buffer state lives in the `no_std` `vfs` crate next to the existing FD machinery; the daemon (vfsd) owns no buffer bytes and drives blocking from its side via the non-blocking primitives added here.

This PR is the **library layer only**. The vfsd daemon, syscall, and test consumers will follow in subsequent commits/PRs.

## Changes

**New module — `src/libs/vfs/src/pipe.rs`**
- `PipeInner`: a fixed-capacity (64 KiB) byte ring buffer plus reader/writer reference counts.
- `PipeEnd`: one end of a pipe over a shared `Arc<Mutex<PipeInner>>`, with an `is_write` direction flag and a copied-in `pipe_id` for lockless identity lookups. `Drop` decrements the reader/writer count; waking suspended callers is left to the daemon, which owns the blocked-request queues.
- Non-blocking outcomes (`PipeReadOutcome`/`PipeWriteOutcome`) modelling `Read`/`WouldBlock`/`Eof` and `Wrote`/`WouldBlock`/`BrokenPipe`, with `PIPE_BUF` (4 KiB) write atomicity and direction enforcement.
- Process-global monotonic pipe-id allocator so stale wakeups can never target the wrong pipe.

**FD integration — `src/libs/vfs/src/fd.rs`**
- Add `VfsFileHandle::Pipe` and route the read/write/seek/size/ftruncate/fallocate/fsync handlers to the appropriate not-supported results.
- Add pipe FD helpers: `vfs_pipe`, `vfs_pipe_read`, `vfs_pipe_write`, `vfs_pipe_id`, `vfs_pipe_is_last_ref`, `vfs_get_status_flags`.
- Track per-description open file status flags; implement `fcntl` `F_GETFL`/`F_SETFL` for the mutable subset (`O_NONBLOCK`) and accept `F_GETFD`/`F_SETFD` as no-ops. `vfs_fcntl` now takes the `F_SETFL` argument.
- Report pipe (`S_IFIFO`) metadata from `fstat` with a synthetic pipefs device id distinct from regular VFS files.
- Extend `vfs_process_exit` to return `ProcessExitReclaim`, surfacing both orphaned hostfs fds and pipe count-to-zero closures so the daemon can fire EOF/`EPIPE` wakeups for suspended counterparts on process exit.

## Behavioral notes
- Zero-length writes succeed with `Wrote(0)` even when no readers remain, matching Linux (no `EPIPE`/`SIGPIPE` for empty writes).

## Testing
15 new unit tests for the buffer (round-trip, ring wrap-around, EOF, broken pipe, `PIPE_BUF` atomicity, partial large writes, direction, identity) and the FD layer (allocation, outcome matrix, EOF/broken pipe, `O_NONBLOCK` round-trip, exit closures).

## Issues

https://github.com/nanvix/nanvix/issues/343
