### PR TITLE
[libc_stdio] Add stdio.h implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_stdio"
+version = "0.16.96"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_stdlib"
 version = "0.16.97"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
         "src/libs/libc_locale",
         "src/libs/libc_setjmp",
         "src/libs/libc_signal",
+        "src/libs/libc_stdio",
         "src/libs/libc_stdlib",
         "src/libs/libc_math",
         "src/libs/libc_string",
@@ -226,6 +227,7 @@ libc_locale = { path = "src/libs/libc_locale", default-features = false }
 libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }
 libc_signal = { path = "src/libs/libc_signal", default-features = false }
+libc_stdio = { path = "src/libs/libc_stdio", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_stdio/Cargo.toml
+++ b/src/libs/libc_stdio/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_stdio"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_stdio/header.toml
+++ b/src/libs/libc_stdio/header.toml
@@ -1,0 +1,161 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for stdio.h.
+
+file = "stdio.h"
+brief = "Standard input/output."
+description = '''
+Declares functions for formatted and unformatted I/O, stream management,
+and error reporting. Implemented by the libc_stdio Rust crate.'''
+includes = ["stdarg.h", "stddef.h"]
+guard = "_NANVIX_STDIO_H"
+content_order = [
+    "raw:0",
+    "types",
+    "section:0",
+    "raw:1",
+    "raw:2",
+    "section:1",
+    "section:2",
+    "raw:3",
+    "section:3",
+    "section:4",
+    "section:5",
+    "section:6",
+]
+
+[[types]]
+text = '''
+/**
+ * @brief Opaque file stream type.
+ *
+ * The internal layout matches the Rust FILE struct in libc_stdio::streams.
+ * Fields should not be accessed directly; use the accessor functions below.
+ */
+typedef struct {
+    int fd;         /**< Underlying file descriptor. */
+    int eof;        /**< End-of-file indicator.      */
+    int error;      /**< Error indicator.             */
+    int ungetc_buf; /**< Push-back character buffer.  */
+} FILE;'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#ifndef EOF
+#define EOF (-1)
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET 0
+#endif
+
+#ifndef SEEK_CUR
+#define SEEK_CUR 1
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END 2
+#endif
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+#ifndef BUFSIZ
+#define BUFSIZ 8192
+#endif
+
+#ifndef FOPEN_MAX
+#define FOPEN_MAX 256
+#endif
+
+#ifndef FILENAME_MAX
+#define FILENAME_MAX 4096
+#endif
+
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
+
+#ifndef TMP_MAX
+#define TMP_MAX 10000
+#endif'''
+
+[[raw_sections]]
+title = ""
+text = '''
+/* Convenience macros matching common usage. */
+#define stdin (stdin())
+#define stdout (stdout())
+#define stderr (stderr())'''
+
+[[raw_sections]]
+title = "Stream Operations"
+text = '''
+extern FILE *fopen(const char *pathname, const char *mode);
+extern FILE *fdopen(int fd, const char *mode);
+extern int fclose(FILE *stream);
+extern int fflush(FILE *stream);
+extern void clearerr(FILE *stream);
+extern int ferror(FILE *stream);
+extern int feof(FILE *stream);
+extern int fileno(FILE *stream);
+extern int remove(const char *pathname);
+extern int rename(const char *old, const char *new);
+extern FILE *tmpfile(void);
+extern int sscanf(const char *s, const char *format, ...);
+extern int vsscanf(const char *s, const char *format, __builtin_va_list ap);
+
+/* Stream buffering modes (Nanvix streams are unbuffered). */
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+extern void setbuf(FILE *stream, char *buf);
+extern int setvbuf(FILE *stream, char *buf, int mode, size_t size);'''
+
+[[raw_sections]]
+title = ""
+text = '''
+/* putc is equivalent to fputc. */
+#ifndef putc
+#define putc(c, stream) fputc((c), (stream))
+#endif'''
+
+[[sections]]
+title = "Standard Streams"
+functions = ["stdin", "stdout", "stderr"]
+
+[[sections]]
+title = "Positioning"
+functions = ["fseek", "ftell", "rewind"]
+
+[[sections]]
+title = "Character I/O"
+functions = ["fgetc", "getc", "getchar", "fputc", "putchar", "ungetc"]
+
+[[sections]]
+title = "String I/O"
+functions = ["fgets", "fputs", "puts"]
+
+[[sections]]
+title = "Block I/O"
+functions = ["fread", "fwrite"]
+
+[[sections]]
+title = "Formatted I/O"
+functions = [
+    "printf",
+    "fprintf",
+    "sprintf",
+    "snprintf",
+    "vprintf",
+    "vfprintf",
+    "vsprintf",
+    "vsnprintf",
+]
+
+[[sections]]
+title = "Error Reporting"
+functions = ["perror"]

--- a/src/libs/libc_stdio/src/clearerr.rs
+++ b/src/libs/libc_stdio/src/clearerr.rs
@@ -1,0 +1,40 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Clears the end-of-file and error indicators for the stream pointed to by `stream`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/clearerr.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn clearerr(stream: *mut FILE) {
+    if stream.is_null() {
+        return;
+    }
+
+    (*stream).eof = 0;
+    (*stream).error = 0;
+}

--- a/src/libs/libc_stdio/src/fclose.rs
+++ b/src/libs/libc_stdio/src/fclose.rs
@@ -1,0 +1,84 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::{
+    stderr,
+    stdin,
+    stdout,
+    FILE,
+};
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Flushes and closes the stream associated with `stream`. The underlying file descriptor is
+/// closed and the [`FILE`] memory is freed. Standard streams (stdin, stdout, stderr) are not
+/// closed or freed.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the [`FILE`] stream to close.
+///
+/// # Returns
+///
+/// Zero on success, or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure previously returned by
+/// [`crate::fopen::fopen`].
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fclose.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fclose(stream: *mut FILE) -> c_int {
+    extern "C" {
+        fn close(fd: c_int) -> c_int;
+        fn free(ptr: *mut c_void);
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    // Do not close or free the standard streams. Identify them by pointer identity rather
+    // than by descriptor value, because a regular stream may legitimately own descriptor 0,
+    // 1, or 2 if a standard descriptor was previously closed.
+    // SAFETY: the accessors return valid pointers to the static standard streams.
+    let is_standard: bool = unsafe {
+        core::ptr::eq(stream, stdin())
+            || core::ptr::eq(stream, stdout())
+            || core::ptr::eq(stream, stderr())
+    };
+    if is_standard {
+        return 0;
+    }
+
+    let fd: c_int = (*stream).fd;
+    let mut result: c_int = 0;
+
+    // SAFETY: fd is a valid open file descriptor.
+    if unsafe { close(fd) } != 0 {
+        result = -1;
+    }
+
+    // SAFETY: stream was allocated by malloc in fopen.
+    unsafe { free(stream.cast::<c_void>()) };
+
+    result
+}

--- a/src/libs/libc_stdio/src/fdopen.rs
+++ b/src/libs/libc_stdio/src/fdopen.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Associates a stream with the already-open file descriptor `fd`. The `mode` string must be
+/// compatible with the mode the descriptor was opened with; it is validated for a recognized
+/// first character but otherwise advisory, since a [`FILE`] in this library is a thin wrapper
+/// around the descriptor.
+///
+/// # Parameters
+///
+/// - `fd`: An open file descriptor to wrap.
+/// - `mode`: Pointer to a null-terminated file access mode string (`"r"`, `"w"`, `"a"`, optionally
+///   followed by `"+"` and/or `"b"`).
+///
+/// # Returns
+///
+/// A pointer to a [`FILE`] object on success, or a null pointer on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `fd` is a valid, open file descriptor.
+/// - `mode` points to a valid, null-terminated mode string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fdopen.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fdopen(fd: c_int, mode: *const c_char) -> *mut FILE {
+    extern "C" {
+        fn malloc(size: c_size_t) -> *mut c_void;
+    }
+
+    if fd < 0 || mode.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Validate the access mode's first character.
+    match *mode as u8 {
+        b'r' | b'w' | b'a' => {},
+        _ => return core::ptr::null_mut(),
+    }
+
+    // SAFETY: allocating memory for a FILE struct.
+    let ptr: *mut c_void = unsafe { malloc(core::mem::size_of::<FILE>() as c_size_t) };
+    if ptr.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let file: *mut FILE = ptr.cast::<FILE>();
+    (*file).fd = fd;
+    (*file).eof = 0;
+    (*file).error = 0;
+    (*file).ungetc_buf = -1;
+
+    file
+}

--- a/src/libs/libc_stdio/src/feof.rs
+++ b/src/libs/libc_stdio/src/feof.rs
@@ -1,0 +1,44 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests the end-of-file indicator for the stream pointed to by `stream`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// Non-zero if the end-of-file indicator is set for `stream`, zero otherwise.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/feof.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn feof(stream: *mut FILE) -> c_int {
+    if stream.is_null() {
+        return 0;
+    }
+
+    (*stream).eof
+}

--- a/src/libs/libc_stdio/src/ferror.rs
+++ b/src/libs/libc_stdio/src/ferror.rs
@@ -1,0 +1,44 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests the error indicator for the stream pointed to by `stream`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// Non-zero if the error indicator is set for `stream`, zero otherwise.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ferror.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ferror(stream: *mut FILE) -> c_int {
+    if stream.is_null() {
+        return 0;
+    }
+
+    (*stream).error
+}

--- a/src/libs/libc_stdio/src/fflush.rs
+++ b/src/libs/libc_stdio/src/fflush.rs
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Flushes any buffered output for the stream pointed to by `stream`. Since this implementation
+/// uses unbuffered I/O, this function is a no-op.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream, or null to flush all open streams.
+///
+/// # Returns
+///
+/// Zero on success.
+///
+/// # Safety
+///
+/// This function is unsafe for API compatibility. When `stream` is non-null the caller must
+/// ensure that it points to a valid [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fflush.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fflush(_stream: *mut FILE) -> c_int {
+    // No-op: this implementation uses unbuffered I/O.
+    0
+}

--- a/src/libs/libc_stdio/src/fgetc.rs
+++ b/src/libs/libc_stdio/src/fgetc.rs
@@ -1,0 +1,108 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads the next character from the given file stream and returns it as an `unsigned char` cast
+/// to [`c_int`], or `EOF` (`-1`) on end-of-file or error. If a character was pushed back via
+/// [`crate::ungetc::ungetc`], it is returned first.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// The next character as an `unsigned char` promoted to [`c_int`], or `EOF` (`-1`) on end-of-file
+/// or error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fgetc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fgetc(stream: *mut FILE) -> c_int {
+    extern "C" {
+        fn read(fd: c_int, buf: *mut c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    // Return the pushed-back character if present.
+    if (*stream).ungetc_buf != -1 {
+        let c: c_int = (*stream).ungetc_buf;
+        (*stream).ungetc_buf = -1;
+        return c;
+    }
+
+    let fd: c_int = (*stream).fd;
+    let mut byte: u8 = 0;
+    // SAFETY: byte is a valid 1-byte buffer on the stack, fd comes from a valid FILE.
+    let ret: c_ssize_t = unsafe { read(fd, (&raw mut byte).cast::<c_void>(), 1 as c_size_t) };
+
+    if ret < 0 {
+        (*stream).error = 1;
+        -1
+    } else if ret == 0 {
+        (*stream).eof = 1;
+        -1
+    } else {
+        byte as c_int
+    }
+}
+
+///
+/// # Description
+///
+/// Equivalent to [`fgetc`]. Reads the next character from the given file stream.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// The next character as an `unsigned char` promoted to [`c_int`], or `EOF` (`-1`) on end-of-file
+/// or error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getc(stream: *mut FILE) -> c_int {
+    fgetc(stream)
+}

--- a/src/libs/libc_stdio/src/fgets.rs
+++ b/src/libs/libc_stdio/src/fgets.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads at most `size - 1` characters from the given file stream into the buffer pointed to by
+/// `s`. Reading stops after a newline character (which is stored) or at end-of-file. A null
+/// terminator is written after the last character in the buffer.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the buffer where the read string will be stored.
+/// - `size`: Maximum number of characters to store (including the null terminator).
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// `s` on success, or a null pointer if end-of-file is reached before any characters are read
+/// or if an error occurs.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `s` points to a buffer of at least `size` bytes.
+/// - `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fgets.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fgets(s: *mut c_char, size: c_int, stream: *mut FILE) -> *mut c_char {
+    if s.is_null() || stream.is_null() || size <= 0 {
+        return core::ptr::null_mut();
+    }
+
+    let max: usize = (size - 1) as usize;
+    let mut i: usize = 0;
+
+    while i < max {
+        let c: c_int = crate::fgetc::fgetc(stream);
+        if c == -1 {
+            break;
+        }
+        *s.add(i) = c as c_char;
+        i += 1;
+        if c == b'\n' as c_int {
+            break;
+        }
+    }
+
+    if i == 0 {
+        return core::ptr::null_mut();
+    }
+
+    *s.add(i) = 0;
+    s
+}

--- a/src/libs/libc_stdio/src/fileno.rs
+++ b/src/libs/libc_stdio/src/fileno.rs
@@ -1,0 +1,44 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the integer file descriptor associated with the stream pointed to by `stream`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// The file descriptor on success, or `-1` if `stream` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fileno.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fileno(stream: *mut FILE) -> c_int {
+    if stream.is_null() {
+        return -1;
+    }
+
+    (*stream).fd
+}

--- a/src/libs/libc_stdio/src/fopen.rs
+++ b/src/libs/libc_stdio/src/fopen.rs
@@ -1,0 +1,113 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    fcntl::{
+        file_access_mode::{
+            O_RDONLY,
+            O_RDWR,
+            O_WRONLY,
+        },
+        file_creation_flags::{
+            O_CREAT,
+            O_TRUNC,
+        },
+        file_status_flags::O_APPEND,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        mode_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Opens the file whose pathname is the string pointed to by `pathname` and associates a stream
+/// with it.
+///
+/// # Parameters
+///
+/// - `pathname`: Pointer to a null-terminated string containing the path of the file to open.
+/// - `mode`: Pointer to a null-terminated string specifying the file access mode (`"r"`, `"w"`,
+///   `"a"`, `"r+"`, `"w+"`, or `"a+"`).
+///
+/// # Returns
+///
+/// A pointer to a [`FILE`] object on success, or a null pointer on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `pathname` points to a valid, null-terminated string.
+/// - `mode` points to a valid, null-terminated mode string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fopen.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fopen(pathname: *const c_char, mode: *const c_char) -> *mut FILE {
+    extern "C" {
+        fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int;
+        fn malloc(size: c_size_t) -> *mut c_void;
+        fn close(fd: c_int) -> c_int;
+    }
+
+    if pathname.is_null() || mode.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Parse the mode string.
+    let first: u8 = *mode as u8;
+    let second: u8 = *mode.add(1) as u8;
+    let has_plus: bool = second == b'+' || (second != 0 && *mode.add(2) as u8 == b'+');
+
+    let flags: c_int = match (first, has_plus) {
+        (b'r', false) => O_RDONLY,
+        (b'r', true) => O_RDWR,
+        (b'w', false) => O_WRONLY | O_CREAT | O_TRUNC,
+        (b'w', true) => O_RDWR | O_CREAT | O_TRUNC,
+        (b'a', false) => O_WRONLY | O_CREAT | O_APPEND,
+        (b'a', true) => O_RDWR | O_CREAT | O_APPEND,
+        _ => return core::ptr::null_mut(),
+    };
+
+    let perm: mode_t = 0o666;
+
+    // SAFETY: pathname is non-null, flags and permissions are valid.
+    let fd: c_int = unsafe { open(pathname, flags, perm) };
+    if fd < 0 {
+        return core::ptr::null_mut();
+    }
+
+    // SAFETY: allocating memory for a FILE struct.
+    let ptr: *mut c_void = unsafe { malloc(core::mem::size_of::<FILE>() as c_size_t) };
+    if ptr.is_null() {
+        // SAFETY: fd is a valid open file descriptor.
+        unsafe { close(fd) };
+        return core::ptr::null_mut();
+    }
+
+    let file: *mut FILE = ptr.cast::<FILE>();
+    (*file).fd = fd;
+    (*file).eof = 0;
+    (*file).error = 0;
+    (*file).ungetc_buf = -1;
+
+    file
+}

--- a/src/libs/libc_stdio/src/format_engine.rs
+++ b/src/libs/libc_stdio/src/format_engine.rs
@@ -1,0 +1,1162 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+// C-interop formatting requires reinterpret casts between signed and unsigned integer types
+// (e.g., c_char (i8) to u8, negative values to their unsigned bit-pattern).
+#![allow(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Flags parsed from a printf format specifier.
+struct FormatFlags {
+    /// Left-align the output within the field width (`-`).
+    left_align: bool,
+    /// Always print a sign character (`+`).
+    force_sign: bool,
+    /// Print a space before positive numbers (` `).
+    space_sign: bool,
+    /// Pad with zeros instead of spaces (`0`).
+    zero_pad: bool,
+    /// Use alternate form (`#`).
+    alternate: bool,
+}
+
+/// Length modifier for printf format specifiers.
+#[derive(Clone, Copy)]
+enum LengthMod {
+    /// No length modifier.
+    None,
+    /// `l` — long.
+    Long,
+    /// `ll` — long long.
+    LongLong,
+    /// `z` — size_t.
+    SizeT,
+}
+
+//==================================================================================================
+// Traits
+//==================================================================================================
+
+/// A write target for formatted output.
+pub(crate) trait WriteTarget {
+    /// Writes a single byte to the target. Returns `Ok(())` on success.
+    fn write_byte(&mut self, b: u8) -> Result<(), ()>;
+
+    /// Writes a slice of bytes to the target.
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ()> {
+        for &b in bytes {
+            self.write_byte(b)?;
+        }
+        Ok(())
+    }
+
+    /// Returns the total number of characters written (or that would have been written,
+    /// ignoring any buffer bounds).
+    fn total(&self) -> usize;
+}
+
+/// An argument source that provides typed values for format specifiers.
+pub(crate) trait ArgSource {
+    /// Fetches the next `c_int` argument.
+    fn next_int(&mut self) -> c_int;
+    /// Fetches the next `u32` argument.
+    fn next_uint(&mut self) -> u32;
+    /// Fetches the next `i32` (long) argument.
+    fn next_long(&mut self) -> i32;
+    /// Fetches the next `u32` (unsigned long) argument.
+    fn next_ulong(&mut self) -> u32;
+    /// Fetches the next `i64` (long long) argument.
+    fn next_longlong(&mut self) -> i64;
+    /// Fetches the next `u64` (unsigned long long) argument.
+    fn next_ulonglong(&mut self) -> u64;
+    /// Fetches the next `usize` (size_t) argument.
+    fn next_size(&mut self) -> usize;
+    /// Fetches the next pointer argument as `usize`.
+    fn next_ptr(&mut self) -> usize;
+    /// Fetches the next `*const c_char` string argument.
+    fn next_str(&mut self) -> *const c_char;
+}
+
+//==================================================================================================
+// Write Targets
+//==================================================================================================
+
+/// Writes formatted output into a bounded buffer (for snprintf/vsnprintf).
+pub(crate) struct BufWriter {
+    buf: *mut u8,
+    /// Maximum buffer size (including space for null terminator).
+    size: usize,
+    /// Current write position in the buffer.
+    pos: usize,
+    /// Total characters that would be written (ignoring buffer bounds).
+    total: usize,
+}
+
+impl BufWriter {
+    /// Creates a new [`BufWriter`] targeting the given buffer.
+    pub(crate) fn new(buf: *mut u8, size: usize) -> Self {
+        Self {
+            buf,
+            size,
+            pos: 0,
+            total: 0,
+        }
+    }
+
+    /// Writes a null terminator at the current position (or at end of buffer).
+    pub(crate) fn null_terminate(&mut self) {
+        if self.size > 0 {
+            let idx: usize = if self.pos < self.size {
+                self.pos
+            } else {
+                self.size - 1
+            };
+            // SAFETY: idx < self.size, so the write is within buffer bounds.
+            unsafe {
+                *self.buf.add(idx) = 0;
+            }
+        }
+    }
+}
+
+impl WriteTarget for BufWriter {
+    fn write_byte(&mut self, b: u8) -> Result<(), ()> {
+        if self.pos < self.size.saturating_sub(1) {
+            // SAFETY: pos < size - 1, so the write is within buffer bounds.
+            unsafe {
+                *self.buf.add(self.pos) = b;
+            }
+            self.pos += 1;
+        }
+        self.total += 1;
+        Ok(())
+    }
+
+    fn total(&self) -> usize {
+        self.total
+    }
+}
+
+/// Writes formatted output to a file descriptor (for fprintf/vfprintf).
+pub(crate) struct FdWriter {
+    fd: c_int,
+    written: usize,
+    error: bool,
+}
+
+impl FdWriter {
+    /// Creates a new [`FdWriter`] for the given file descriptor.
+    pub(crate) fn new(fd: c_int) -> Self {
+        Self {
+            fd,
+            written: 0,
+            error: false,
+        }
+    }
+
+    /// Returns the total number of bytes successfully written, or `-1` on error.
+    pub(crate) fn result(&self) -> c_int {
+        if self.error {
+            -1
+        } else {
+            self.written as c_int
+        }
+    }
+}
+
+impl WriteTarget for FdWriter {
+    fn write_byte(&mut self, b: u8) -> Result<(), ()> {
+        if self.error {
+            return Err(());
+        }
+        let buf: [u8; 1] = [b];
+        // SAFETY: buf is a valid 1-byte buffer on the stack.
+        let ret: isize = unsafe { write_fd(self.fd, buf.as_ptr(), 1) };
+        // write() may legally return 0 (no progress) or a negative value (error); only a
+        // return of exactly 1 means the byte was written.
+        if ret != 1 {
+            self.error = true;
+            return Err(());
+        }
+        self.written += 1;
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ()> {
+        if self.error {
+            return Err(());
+        }
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        // write() may perform a short write, so loop until the whole buffer is flushed. A
+        // return of 0 (no progress) or a negative value (error) stops the loop and marks
+        // the stream as failed.
+        let mut off: usize = 0;
+        while off < bytes.len() {
+            // SAFETY: bytes[off..] is a valid, non-empty slice.
+            let ret: isize =
+                unsafe { write_fd(self.fd, bytes.as_ptr().add(off), bytes.len() - off) };
+            if ret <= 0 {
+                self.error = true;
+                return Err(());
+            }
+            off += ret as usize;
+            self.written += ret as usize;
+        }
+        Ok(())
+    }
+
+    fn total(&self) -> usize {
+        self.written
+    }
+}
+
+/// Writes formatted output to an unbounded buffer (for sprintf/vsprintf).
+pub(crate) struct UnboundedBufWriter {
+    buf: *mut u8,
+    /// Current write position in the buffer.
+    pos: usize,
+}
+
+impl UnboundedBufWriter {
+    /// Creates a new [`UnboundedBufWriter`] targeting the given buffer.
+    pub(crate) fn new(buf: *mut u8) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    /// Writes a null terminator at the current position.
+    pub(crate) fn null_terminate(&mut self) {
+        // SAFETY: caller guarantees the buffer is large enough.
+        unsafe {
+            *self.buf.add(self.pos) = 0;
+        }
+    }
+}
+
+impl WriteTarget for UnboundedBufWriter {
+    fn write_byte(&mut self, b: u8) -> Result<(), ()> {
+        // SAFETY: caller guarantees the buffer is large enough.
+        unsafe {
+            *self.buf.add(self.pos) = b;
+        }
+        self.pos += 1;
+        Ok(())
+    }
+
+    fn total(&self) -> usize {
+        self.pos
+    }
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Platform write wrapper.
+///
+/// # Safety
+///
+/// `buf` must point to at least `len` valid bytes.
+unsafe fn write_fd(fd: c_int, buf: *const u8, len: usize) -> isize {
+    extern "C" {
+        fn write(
+            fd: c_int,
+            buf: *const ::sysapi::ffi::c_void,
+            count: ::sysapi::sys_types::c_size_t,
+        ) -> ::sysapi::sys_types::c_ssize_t;
+    }
+    // SAFETY: caller guarantees buf/len validity.
+    unsafe {
+        write(fd, buf.cast::<::sysapi::ffi::c_void>(), len as ::sysapi::sys_types::c_size_t)
+            as isize
+    }
+}
+
+/// Reads a byte from a `*const c_char` pointer at the given offset.
+///
+/// # Safety
+///
+/// The caller must ensure that `fmt.add(pos)` points to a valid, readable byte.
+unsafe fn read_byte(fmt: *const c_char, pos: usize) -> u8 {
+    // SAFETY: caller guarantees pointer validity.
+    unsafe { *fmt.add(pos) as u8 }
+}
+
+/// Parses format flags from the format string starting at `pos`.
+/// Returns the parsed flags and the updated position.
+fn parse_flags(fmt: *const c_char, start: usize) -> (FormatFlags, usize) {
+    let mut flags: FormatFlags = FormatFlags {
+        left_align: false,
+        force_sign: false,
+        space_sign: false,
+        zero_pad: false,
+        alternate: false,
+    };
+    let mut pos: usize = start;
+    loop {
+        // SAFETY: pos is within the format string (we stop at null terminator).
+        let b: u8 = unsafe { read_byte(fmt, pos) };
+        match b {
+            b'-' => flags.left_align = true,
+            b'+' => flags.force_sign = true,
+            b' ' => flags.space_sign = true,
+            b'0' => flags.zero_pad = true,
+            b'#' => flags.alternate = true,
+            _ => break,
+        }
+        pos += 1;
+    }
+    (flags, pos)
+}
+
+/// Parses a decimal integer from the format string starting at `pos`.
+/// Returns the parsed value and the updated position.
+fn parse_decimal(fmt: *const c_char, start: usize) -> (usize, usize) {
+    let mut val: usize = 0;
+    let mut pos: usize = start;
+    loop {
+        // SAFETY: pos is within the format string.
+        let b: u8 = unsafe { read_byte(fmt, pos) };
+        if b.is_ascii_digit() {
+            val = val.wrapping_mul(10).wrapping_add((b - b'0') as usize);
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+    (val, pos)
+}
+
+/// Parses the width field from the format string. Supports `*` (from args).
+fn parse_width<A: ArgSource>(
+    fmt: *const c_char,
+    start: usize,
+    args: &mut A,
+) -> (usize, bool, usize) {
+    // SAFETY: start is within the format string.
+    let b: u8 = unsafe { read_byte(fmt, start) };
+    if b == b'*' {
+        let w: c_int = args.next_int();
+        if w < 0 {
+            // Negative width means left-align with absolute width.
+            ((-w) as usize, true, start + 1)
+        } else {
+            (w as usize, false, start + 1)
+        }
+    } else if b.is_ascii_digit() {
+        let (val, pos) = parse_decimal(fmt, start);
+        (val, false, pos)
+    } else {
+        (0, false, start)
+    }
+}
+
+/// Parses the precision field from the format string. Supports `*` (from args).
+/// Returns (has_precision, precision_value, new_position).
+fn parse_precision<A: ArgSource>(
+    fmt: *const c_char,
+    start: usize,
+    args: &mut A,
+) -> (bool, usize, usize) {
+    // SAFETY: start is within the format string.
+    let b: u8 = unsafe { read_byte(fmt, start) };
+    if b != b'.' {
+        return (false, 0, start);
+    }
+    let pos: usize = start + 1;
+    // SAFETY: pos is within the format string.
+    let b2: u8 = unsafe { read_byte(fmt, pos) };
+    if b2 == b'*' {
+        let p: c_int = args.next_int();
+        if p < 0 {
+            (false, 0, pos + 1)
+        } else {
+            (true, p as usize, pos + 1)
+        }
+    } else {
+        let (val, new_pos) = parse_decimal(fmt, pos);
+        (true, val, new_pos)
+    }
+}
+
+/// Parses the length modifier from the format string.
+fn parse_length(fmt: *const c_char, start: usize) -> (LengthMod, usize) {
+    // SAFETY: start is within the format string.
+    let b: u8 = unsafe { read_byte(fmt, start) };
+    match b {
+        b'l' => {
+            // SAFETY: start + 1 is within the format string.
+            let b2: u8 = unsafe { read_byte(fmt, start + 1) };
+            if b2 == b'l' {
+                (LengthMod::LongLong, start + 2)
+            } else {
+                (LengthMod::Long, start + 1)
+            }
+        },
+        b'z' => (LengthMod::SizeT, start + 1),
+        b'h' => {
+            // Skip 'h' or 'hh' — treat as default (promoted to int).
+            // SAFETY: start + 1 is within the format string.
+            let b2: u8 = unsafe { read_byte(fmt, start + 1) };
+            if b2 == b'h' {
+                (LengthMod::None, start + 2)
+            } else {
+                (LengthMod::None, start + 1)
+            }
+        },
+        _ => (LengthMod::None, start),
+    }
+}
+
+/// Writes padding characters to the writer.
+fn write_padding<W: WriteTarget>(writer: &mut W, ch: u8, count: usize) -> Result<(), ()> {
+    // Emit padding in fixed-size chunks so that file-descriptor-backed writers do not incur
+    // one syscall per padding byte for large widths/precisions.
+    const CHUNK: usize = 64;
+    let chunk: [u8; CHUNK] = [ch; CHUNK];
+    let mut remaining: usize = count;
+    while remaining > 0 {
+        let n: usize = if remaining < CHUNK { remaining } else { CHUNK };
+        writer.write_bytes(&chunk[..n])?;
+        remaining -= n;
+    }
+    Ok(())
+}
+
+/// Formats an unsigned 64-bit integer into a stack buffer.
+/// Returns the starting index and the number of digits in `buf`.
+fn format_unsigned(value: u64, base: u64, uppercase: bool, buf: &mut [u8; 32]) -> (usize, usize) {
+    let digits: &[u8; 16] = if uppercase {
+        b"0123456789ABCDEF"
+    } else {
+        b"0123456789abcdef"
+    };
+    if value == 0 {
+        buf[31] = b'0';
+        return (31, 1);
+    }
+    let mut pos: usize = 32;
+    let mut v: u64 = value;
+    while v > 0 {
+        pos -= 1;
+        buf[pos] = digits[(v % base) as usize];
+        v /= base;
+    }
+    (pos, 32 - pos)
+}
+
+/// Formats a signed integer specifier (%d / %i) and writes to the target.
+fn format_signed<W: WriteTarget>(
+    writer: &mut W,
+    value: i64,
+    flags: &FormatFlags,
+    width: usize,
+    has_precision: bool,
+    precision: usize,
+) -> Result<(), ()> {
+    let negative: bool = value < 0;
+    let abs_val: u64 = if negative {
+        // Handle i64::MIN correctly: -(i64::MIN) overflows, use wrapping.
+        (value.wrapping_neg()) as u64
+    } else {
+        value as u64
+    };
+
+    let mut buf: [u8; 32] = [0u8; 32];
+    let (digit_start, digit_len) = format_unsigned(abs_val, 10, false, &mut buf);
+
+    // Determine sign character.
+    let sign: Option<u8> = if negative {
+        Some(b'-')
+    } else if flags.force_sign {
+        Some(b'+')
+    } else if flags.space_sign {
+        Some(b' ')
+    } else {
+        Option::None
+    };
+    let sign_len: usize = if sign.is_some() { 1 } else { 0 };
+
+    // Apply precision: minimum number of digits.
+    let effective_digits: usize = if has_precision && precision > digit_len {
+        precision
+    } else {
+        digit_len
+    };
+    let zero_prefix: usize = effective_digits - digit_len;
+
+    let content_len: usize = sign_len + effective_digits;
+
+    // Determine padding.
+    let pad_len: usize = width.saturating_sub(content_len);
+
+    // Zero-pad only when no precision is given and not left-aligned.
+    let use_zero_pad: bool = flags.zero_pad && !flags.left_align && !has_precision;
+
+    if flags.left_align {
+        // Sign, zero-prefix, digits, then space padding.
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        write_padding(writer, b'0', zero_prefix)?;
+        writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+        write_padding(writer, b' ', pad_len)?;
+    } else if use_zero_pad {
+        // Sign, then zero padding, then digits.
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        write_padding(writer, b'0', pad_len + zero_prefix)?;
+        writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+    } else {
+        // Space padding, sign, zero-prefix, digits.
+        write_padding(writer, b' ', pad_len)?;
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        write_padding(writer, b'0', zero_prefix)?;
+        writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+    }
+
+    Ok(())
+}
+
+/// Parameters for formatting an unsigned integer specifier.
+struct UnsignedFmtParams<'a> {
+    base: u64,
+    uppercase: bool,
+    flags: &'a FormatFlags,
+    width: usize,
+    has_precision: bool,
+    precision: usize,
+}
+
+/// Formats an unsigned integer specifier (%u / %x / %X / %o) and writes to the target.
+fn format_unsigned_spec<W: WriteTarget>(
+    writer: &mut W,
+    value: u64,
+    params: &UnsignedFmtParams<'_>,
+) -> Result<(), ()> {
+    let mut buf: [u8; 32] = [0u8; 32];
+    let (digit_start, digit_len) = format_unsigned(value, params.base, params.uppercase, &mut buf);
+
+    // Alternate form prefix.
+    let prefix: &[u8] = if params.flags.alternate && value != 0 {
+        match params.base {
+            16 => {
+                if params.uppercase {
+                    b"0X"
+                } else {
+                    b"0x"
+                }
+            },
+            8 => b"0",
+            _ => b"",
+        }
+    } else {
+        b""
+    };
+
+    // Apply precision.
+    let effective_digits: usize = if params.has_precision && params.precision > digit_len {
+        params.precision
+    } else if params.has_precision && params.precision == 0 && value == 0 {
+        0
+    } else {
+        digit_len
+    };
+    let zero_prefix: usize = effective_digits.saturating_sub(digit_len);
+
+    let content_len: usize = prefix.len() + effective_digits;
+    let pad_len: usize = params.width.saturating_sub(content_len);
+
+    let use_zero_pad: bool =
+        params.flags.zero_pad && !params.flags.left_align && !params.has_precision;
+
+    if params.flags.left_align {
+        writer.write_bytes(prefix)?;
+        write_padding(writer, b'0', zero_prefix)?;
+        if effective_digits > 0 {
+            writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+        }
+        write_padding(writer, b' ', pad_len)?;
+    } else if use_zero_pad {
+        writer.write_bytes(prefix)?;
+        write_padding(writer, b'0', pad_len + zero_prefix)?;
+        if effective_digits > 0 {
+            writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+        }
+    } else {
+        write_padding(writer, b' ', pad_len)?;
+        writer.write_bytes(prefix)?;
+        write_padding(writer, b'0', zero_prefix)?;
+        if effective_digits > 0 {
+            writer.write_bytes(&buf[digit_start..digit_start + digit_len])?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Formats a string specifier (%s) and writes to the target.
+fn format_string<W: WriteTarget>(
+    writer: &mut W,
+    s: *const c_char,
+    flags: &FormatFlags,
+    width: usize,
+    has_precision: bool,
+    precision: usize,
+) -> Result<(), ()> {
+    let null_str: &[u8; 6] = b"(null)";
+
+    // Compute string length.
+    let (ptr, slen): (*const u8, usize) = if s.is_null() {
+        (null_str.as_ptr(), null_str.len())
+    } else {
+        let mut len: usize = 0;
+        // SAFETY: s is non-null; we walk until the null terminator.
+        unsafe {
+            while *s.add(len) != 0 {
+                len += 1;
+            }
+        }
+        (s.cast::<u8>(), len)
+    };
+
+    // Apply precision as maximum length.
+    let print_len: usize = if has_precision && precision < slen {
+        precision
+    } else {
+        slen
+    };
+
+    let pad_len: usize = width.saturating_sub(print_len);
+
+    if flags.left_align {
+        // SAFETY: ptr is valid for print_len bytes.
+        let slice: &[u8] = unsafe { core::slice::from_raw_parts(ptr, print_len) };
+        writer.write_bytes(slice)?;
+        write_padding(writer, b' ', pad_len)?;
+    } else {
+        write_padding(writer, b' ', pad_len)?;
+        // SAFETY: ptr is valid for print_len bytes.
+        let slice: &[u8] = unsafe { core::slice::from_raw_parts(ptr, print_len) };
+        writer.write_bytes(slice)?;
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Core formatting engine for printf-family functions. Parses the format string `fmt`, fetches
+/// arguments from `args`, and writes formatted output to `writer`.
+///
+/// # Parameters
+///
+/// - `writer`: The output target implementing [`WriteTarget`].
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `args`: An argument source implementing [`ArgSource`].
+///
+/// # Returns
+///
+/// The total number of characters written (or that would have been written) as a [`c_int`].
+/// Returns `-1` if `fmt` is null.
+///
+/// # Safety
+///
+/// The caller must ensure that `fmt` points to a valid, null-terminated format string and that
+/// `args` provides arguments matching the format specifiers in `fmt`.
+///
+pub(crate) fn format_core<W: WriteTarget, A: ArgSource>(
+    writer: &mut W,
+    fmt: *const c_char,
+    args: &mut A,
+) -> c_int {
+    if fmt.is_null() {
+        return -1;
+    }
+
+    let mut pos: usize = 0;
+
+    loop {
+        // SAFETY: pos is within the format string.
+        let b: u8 = unsafe { read_byte(fmt, pos) };
+
+        if b == 0 {
+            break;
+        }
+
+        if b != b'%' {
+            let _ = writer.write_byte(b);
+            pos += 1;
+            continue;
+        }
+
+        // Skip the '%'.
+        pos += 1;
+
+        // Parse flags.
+        let (mut flags, new_pos) = parse_flags(fmt, pos);
+        pos = new_pos;
+
+        // Parse width.
+        let (width, width_neg, new_pos) = parse_width(fmt, pos, args);
+        pos = new_pos;
+        if width_neg {
+            flags.left_align = true;
+        }
+
+        // Parse precision.
+        let (has_precision, precision, new_pos) = parse_precision(fmt, pos, args);
+        pos = new_pos;
+
+        // Parse length modifier.
+        let (length, new_pos) = parse_length(fmt, pos);
+        pos = new_pos;
+
+        // Parse conversion specifier.
+        // SAFETY: pos is within the format string.
+        let spec: u8 = unsafe { read_byte(fmt, pos) };
+        if spec == 0 {
+            break;
+        }
+        pos += 1;
+
+        match spec {
+            b'd' | b'i' => {
+                let val: i64 = match length {
+                    LengthMod::None => args.next_int() as i64,
+                    LengthMod::Long => args.next_long() as i64,
+                    LengthMod::LongLong => args.next_longlong(),
+                    LengthMod::SizeT => args.next_size() as i64,
+                };
+                let _ = format_signed(writer, val, &flags, width, has_precision, precision);
+            },
+            b'u' => {
+                let val: u64 = match length {
+                    LengthMod::None => args.next_uint() as u64,
+                    LengthMod::Long => args.next_ulong() as u64,
+                    LengthMod::LongLong => args.next_ulonglong(),
+                    LengthMod::SizeT => args.next_size() as u64,
+                };
+                let params: UnsignedFmtParams<'_> = UnsignedFmtParams {
+                    base: 10,
+                    uppercase: false,
+                    flags: &flags,
+                    width,
+                    has_precision,
+                    precision,
+                };
+                let _ = format_unsigned_spec(writer, val, &params);
+            },
+            b'x' | b'X' => {
+                let upper: bool = spec == b'X';
+                let val: u64 = match length {
+                    LengthMod::None => args.next_uint() as u64,
+                    LengthMod::Long => args.next_ulong() as u64,
+                    LengthMod::LongLong => args.next_ulonglong(),
+                    LengthMod::SizeT => args.next_size() as u64,
+                };
+                let params: UnsignedFmtParams<'_> = UnsignedFmtParams {
+                    base: 16,
+                    uppercase: upper,
+                    flags: &flags,
+                    width,
+                    has_precision,
+                    precision,
+                };
+                let _ = format_unsigned_spec(writer, val, &params);
+            },
+            b'o' => {
+                let val: u64 = match length {
+                    LengthMod::None => args.next_uint() as u64,
+                    LengthMod::Long => args.next_ulong() as u64,
+                    LengthMod::LongLong => args.next_ulonglong(),
+                    LengthMod::SizeT => args.next_size() as u64,
+                };
+                let params: UnsignedFmtParams<'_> = UnsignedFmtParams {
+                    base: 8,
+                    uppercase: false,
+                    flags: &flags,
+                    width,
+                    has_precision,
+                    precision,
+                };
+                let _ = format_unsigned_spec(writer, val, &params);
+            },
+            b's' => {
+                let s: *const c_char = args.next_str();
+                let _ = format_string(writer, s, &flags, width, has_precision, precision);
+            },
+            b'c' => {
+                let c: u8 = args.next_int() as u8;
+                if width > 1 && !flags.left_align {
+                    let _ = write_padding(writer, b' ', width - 1);
+                }
+                let _ = writer.write_byte(c);
+                if width > 1 && flags.left_align {
+                    let _ = write_padding(writer, b' ', width - 1);
+                }
+            },
+            b'p' => {
+                let ptr: usize = args.next_ptr();
+                let _ = writer.write_bytes(b"0x");
+                let mut buf: [u8; 32] = [0u8; 32];
+                let (start, len) = format_unsigned(ptr as u64, 16, false, &mut buf);
+                let _ = writer.write_bytes(&buf[start..start + len]);
+            },
+            b'%' => {
+                let _ = writer.write_byte(b'%');
+            },
+            b'n' => {
+                // %n is intentionally not supported (security risk).
+            },
+            _ => {
+                // Unknown specifier — write it literally.
+                let _ = writer.write_byte(b'%');
+                let _ = writer.write_byte(spec);
+            },
+        }
+    }
+
+    // Return the total number of characters written (or that would have been written).
+    writer.total() as c_int
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use ::std::vec::Vec;
+
+    /// Test write target that collects output into a Vec.
+    struct VecWriter {
+        data: Vec<u8>,
+    }
+
+    impl VecWriter {
+        fn new() -> Self {
+            Self { data: Vec::new() }
+        }
+
+        fn as_str(&self) -> &str {
+            core::str::from_utf8(&self.data).expect("valid utf8")
+        }
+    }
+
+    impl WriteTarget for VecWriter {
+        fn write_byte(&mut self, b: u8) -> Result<(), ()> {
+            self.data.push(b);
+            Ok(())
+        }
+
+        fn total(&self) -> usize {
+            self.data.len()
+        }
+    }
+
+    /// Test argument source backed by slices.
+    struct TestArgs {
+        ints: Vec<c_int>,
+        uints: Vec<u32>,
+        longs: Vec<i32>,
+        ulongs: Vec<u32>,
+        longlongs: Vec<i64>,
+        ulonglongs: Vec<u64>,
+        sizes: Vec<usize>,
+        ptrs: Vec<usize>,
+        strs: Vec<*const c_char>,
+        int_idx: usize,
+        uint_idx: usize,
+        long_idx: usize,
+        ulong_idx: usize,
+        longlong_idx: usize,
+        ulonglong_idx: usize,
+        size_idx: usize,
+        ptr_idx: usize,
+        str_idx: usize,
+    }
+
+    impl TestArgs {
+        fn new() -> Self {
+            Self {
+                ints: Vec::new(),
+                uints: Vec::new(),
+                longs: Vec::new(),
+                ulongs: Vec::new(),
+                longlongs: Vec::new(),
+                ulonglongs: Vec::new(),
+                sizes: Vec::new(),
+                ptrs: Vec::new(),
+                strs: Vec::new(),
+                int_idx: 0,
+                uint_idx: 0,
+                long_idx: 0,
+                ulong_idx: 0,
+                longlong_idx: 0,
+                ulonglong_idx: 0,
+                size_idx: 0,
+                ptr_idx: 0,
+                str_idx: 0,
+            }
+        }
+    }
+
+    impl ArgSource for TestArgs {
+        fn next_int(&mut self) -> c_int {
+            let v: c_int = self.ints[self.int_idx];
+            self.int_idx += 1;
+            v
+        }
+        fn next_uint(&mut self) -> u32 {
+            let v: u32 = self.uints[self.uint_idx];
+            self.uint_idx += 1;
+            v
+        }
+        fn next_long(&mut self) -> i32 {
+            let v: i32 = self.longs[self.long_idx];
+            self.long_idx += 1;
+            v
+        }
+        fn next_ulong(&mut self) -> u32 {
+            let v: u32 = self.ulongs[self.ulong_idx];
+            self.ulong_idx += 1;
+            v
+        }
+        fn next_longlong(&mut self) -> i64 {
+            let v: i64 = self.longlongs[self.longlong_idx];
+            self.longlong_idx += 1;
+            v
+        }
+        fn next_ulonglong(&mut self) -> u64 {
+            let v: u64 = self.ulonglongs[self.ulonglong_idx];
+            self.ulonglong_idx += 1;
+            v
+        }
+        fn next_size(&mut self) -> usize {
+            let v: usize = self.sizes[self.size_idx];
+            self.size_idx += 1;
+            v
+        }
+        fn next_ptr(&mut self) -> usize {
+            let v: usize = self.ptrs[self.ptr_idx];
+            self.ptr_idx += 1;
+            v
+        }
+        fn next_str(&mut self) -> *const c_char {
+            let v: *const c_char = self.strs[self.str_idx];
+            self.str_idx += 1;
+            v
+        }
+    }
+
+    /// Helper: format with test args and return the output string.
+    fn fmt(format: &[u8], args: &mut TestArgs) -> String {
+        let mut writer: VecWriter = VecWriter::new();
+        format_core(&mut writer, format.as_ptr().cast::<c_char>(), args);
+        writer.as_str().to_string()
+    }
+
+    #[test]
+    fn test_plain_string() {
+        let mut args: TestArgs = TestArgs::new();
+        assert_eq!(fmt(b"hello\0", &mut args), "hello");
+    }
+
+    #[test]
+    fn test_percent_d() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"%d\0", &mut args), "42");
+    }
+
+    #[test]
+    fn test_percent_d_negative() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(-7);
+        assert_eq!(fmt(b"%d\0", &mut args), "-7");
+    }
+
+    #[test]
+    fn test_percent_u() {
+        let mut args: TestArgs = TestArgs::new();
+        args.uints.push(123);
+        assert_eq!(fmt(b"%u\0", &mut args), "123");
+    }
+
+    #[test]
+    fn test_percent_x() {
+        let mut args: TestArgs = TestArgs::new();
+        args.uints.push(255);
+        assert_eq!(fmt(b"%x\0", &mut args), "ff");
+    }
+
+    #[test]
+    fn test_percent_upper_x() {
+        let mut args: TestArgs = TestArgs::new();
+        args.uints.push(255);
+        assert_eq!(fmt(b"%X\0", &mut args), "FF");
+    }
+
+    #[test]
+    fn test_percent_o() {
+        let mut args: TestArgs = TestArgs::new();
+        args.uints.push(8);
+        assert_eq!(fmt(b"%o\0", &mut args), "10");
+    }
+
+    #[test]
+    fn test_percent_s() {
+        let mut args: TestArgs = TestArgs::new();
+        let s: &[u8] = b"world\0";
+        args.strs.push(s.as_ptr().cast::<c_char>());
+        assert_eq!(fmt(b"hello %s\0", &mut args), "hello world");
+    }
+
+    #[test]
+    fn test_percent_s_null() {
+        let mut args: TestArgs = TestArgs::new();
+        args.strs.push(core::ptr::null());
+        assert_eq!(fmt(b"%s\0", &mut args), "(null)");
+    }
+
+    #[test]
+    fn test_percent_c() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(b'A' as c_int);
+        assert_eq!(fmt(b"%c\0", &mut args), "A");
+    }
+
+    #[test]
+    fn test_percent_percent() {
+        let mut args: TestArgs = TestArgs::new();
+        assert_eq!(fmt(b"100%%\0", &mut args), "100%");
+    }
+
+    #[test]
+    fn test_width_right_align() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"%10d\0", &mut args), "        42");
+    }
+
+    #[test]
+    fn test_width_left_align() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"%-10d\0", &mut args), "42        ");
+    }
+
+    #[test]
+    fn test_zero_pad() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"%05d\0", &mut args), "00042");
+    }
+
+    #[test]
+    fn test_plus_flag() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"%+d\0", &mut args), "+42");
+    }
+
+    #[test]
+    fn test_space_flag() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(42);
+        assert_eq!(fmt(b"% d\0", &mut args), " 42");
+    }
+
+    #[test]
+    fn test_alternate_hex() {
+        let mut args: TestArgs = TestArgs::new();
+        args.uints.push(255);
+        assert_eq!(fmt(b"%#x\0", &mut args), "0xff");
+    }
+
+    #[test]
+    fn test_string_precision() {
+        let mut args: TestArgs = TestArgs::new();
+        let s: &[u8] = b"hello world\0";
+        args.strs.push(s.as_ptr().cast::<c_char>());
+        assert_eq!(fmt(b"%.5s\0", &mut args), "hello");
+    }
+
+    #[test]
+    fn test_string_width_right() {
+        let mut args: TestArgs = TestArgs::new();
+        let s: &[u8] = b"hi\0";
+        args.strs.push(s.as_ptr().cast::<c_char>());
+        assert_eq!(fmt(b"%10s\0", &mut args), "        hi");
+    }
+
+    #[test]
+    fn test_long_long_d() {
+        let mut args: TestArgs = TestArgs::new();
+        args.longlongs.push(1234567890123_i64);
+        assert_eq!(fmt(b"%lld\0", &mut args), "1234567890123");
+    }
+
+    #[test]
+    fn test_pointer() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ptrs.push(0xDEAD);
+        assert_eq!(fmt(b"%p\0", &mut args), "0xdead");
+    }
+
+    #[test]
+    fn test_zero_value_d() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(0);
+        assert_eq!(fmt(b"%d\0", &mut args), "0");
+    }
+
+    #[test]
+    fn test_null_format() {
+        let mut args: TestArgs = TestArgs::new();
+        let mut writer: VecWriter = VecWriter::new();
+        let ret: c_int = format_core(&mut writer, core::ptr::null(), &mut args);
+        assert_eq!(ret, -1);
+    }
+
+    #[test]
+    fn test_buf_writer_truncation() {
+        let mut buf: [u8; 6] = [0xFF; 6];
+        let mut writer: BufWriter = BufWriter::new(buf.as_mut_ptr(), 6);
+        // Write "hello world" — should truncate to "hello".
+        let data: &[u8] = b"hello world";
+        for &b in data {
+            let _ = writer.write_byte(b);
+        }
+        writer.null_terminate();
+        assert_eq!(writer.total(), 11);
+        assert_eq!(&buf, b"hello\0");
+    }
+}

--- a/src/libs/libc_stdio/src/fprintf.rs
+++ b/src/libs/libc_stdio/src/fprintf.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to the given file stream. This is a variadic wrapper around
+/// [`crate::vfprintf::vfprintf`].
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `stream` points to a valid, open [`FILE`] structure.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fprintf(stream: *mut FILE, fmt: *const c_char, args: ...) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vfprintf.
+    unsafe { crate::vfprintf::vfprintf(stream, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/fputc.rs
+++ b/src/libs/libc_stdio/src/fputc.rs
@@ -1,0 +1,68 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the character `c` (converted to `unsigned char`) to the given file stream.
+///
+/// # Parameters
+///
+/// - `c`: The character to write, passed as a [`c_int`].
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// The character written as an `unsigned char` cast to [`c_int`], or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fputc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fputc(c: c_int, stream: *mut FILE) -> c_int {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    let fd: c_int = (*stream).fd;
+    let byte: u8 = c as u8;
+    // SAFETY: byte is a valid 1-byte value on the stack, fd comes from a valid FILE.
+    let ret: c_ssize_t = unsafe { write(fd, (&raw const byte).cast::<c_void>(), 1 as c_size_t) };
+    if ret < 0 {
+        // POSIX: on a write error the error indicator for the stream shall be set.
+        (*stream).error = 1;
+        -1
+    } else {
+        byte as c_int
+    }
+}

--- a/src/libs/libc_stdio/src/fputs.rs
+++ b/src/libs/libc_stdio/src/fputs.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the string `s` to the given file stream. Unlike [`crate::puts::puts`], no trailing
+/// newline is appended.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated string to be written.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// A non-negative value on success, or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `s` points to a valid, null-terminated string.
+/// - `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fputs.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fputs(s: *const c_char, stream: *mut FILE) -> c_int {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if s.is_null() || stream.is_null() {
+        return -1;
+    }
+
+    let fd: c_int = (*stream).fd;
+
+    // Compute string length.
+    let mut len: usize = 0;
+    // SAFETY: s is non-null; we walk until the null terminator.
+    unsafe {
+        while *s.add(len) != 0 {
+            len += 1;
+        }
+    }
+
+    if len == 0 {
+        return 0;
+    }
+
+    // Loop until every byte is written: a single `write` may transfer fewer bytes than requested
+    // without an error, and `fputs` must not stop short in that case.
+    let mut offset: usize = 0;
+    while offset < len {
+        // SAFETY: s is valid for len bytes, fd comes from a valid FILE.
+        let ret: c_ssize_t = unsafe {
+            write(fd, s.cast::<u8>().add(offset).cast::<c_void>(), (len - offset) as c_size_t)
+        };
+        // A negative return is an error; a zero return makes no forward progress. In either case
+        // POSIX requires the stream's error indicator to be set and EOF returned.
+        if ret <= 0 {
+            (*stream).error = 1;
+            return -1;
+        }
+        offset += ret as usize;
+    }
+
+    0
+}

--- a/src/libs/libc_stdio/src/fread.rs
+++ b/src/libs/libc_stdio/src/fread.rs
@@ -1,0 +1,108 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads `nmemb` elements, each `size` bytes long, from the stream pointed to by `stream` into
+/// the buffer pointed to by `ptr`.
+///
+/// # Parameters
+///
+/// - `ptr`: Pointer to the buffer where data will be stored.
+/// - `size`: Size of each element in bytes.
+/// - `nmemb`: Number of elements to read.
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// The number of elements successfully read. If an error occurs or end-of-file is reached, the
+/// return value may be less than `nmemb`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `ptr` points to at least `size * nmemb` writable bytes.
+/// - `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fread.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fread(
+    ptr: *mut c_void,
+    size: c_size_t,
+    nmemb: c_size_t,
+    stream: *mut FILE,
+) -> c_size_t {
+    extern "C" {
+        fn read(fd: c_int, buf: *mut c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if ptr.is_null() || stream.is_null() || size == 0 || nmemb == 0 {
+        return 0;
+    }
+
+    // Compute the request size with overflow checking: a wrapping multiply could yield a
+    // small (or zero) byte count and cause a short or out-of-bounds transfer.
+    let total: usize = match (size as usize).checked_mul(nmemb as usize) {
+        Some(total) => total,
+        None => {
+            (*stream).error = 1;
+            return 0;
+        },
+    };
+    let buf: *mut u8 = ptr.cast::<u8>();
+    let mut offset: usize = 0;
+
+    // Drain the push-back buffer first.
+    if (*stream).ungetc_buf != -1 {
+        *buf = (*stream).ungetc_buf as u8;
+        (*stream).ungetc_buf = -1;
+        offset = 1;
+    }
+
+    if offset < total {
+        let fd: c_int = (*stream).fd;
+        // Loop until the request is satisfied: a single `read` may return fewer
+        // bytes than requested without being at end-of-file, and `fread` must
+        // only report a short count on a genuine EOF or error.
+        while offset < total {
+            let remaining: c_size_t = (total - offset) as c_size_t;
+            // SAFETY: buf + offset is valid for remaining bytes, fd comes from a valid FILE.
+            let ret: c_ssize_t = unsafe { read(fd, buf.add(offset).cast::<c_void>(), remaining) };
+            if ret < 0 {
+                (*stream).error = 1;
+                break;
+            } else if ret == 0 {
+                (*stream).eof = 1;
+                break;
+            }
+            offset += ret as usize;
+        }
+    }
+
+    let size_usize: usize = size as usize;
+    (offset / size_usize) as c_size_t
+}

--- a/src/libs/libc_stdio/src/fseek.rs
+++ b/src/libs/libc_stdio/src/fseek.rs
@@ -1,0 +1,69 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_long,
+    },
+    sys_types::off_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the file position indicator for the stream pointed to by `stream`. The new position,
+/// measured in bytes, is obtained by adding `offset` bytes to the position specified by `whence`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `offset`: Number of bytes to offset from `whence`.
+/// - `whence`: Position from which `offset` is applied (`SEEK_SET`, `SEEK_CUR`, or `SEEK_END`).
+///
+/// # Returns
+///
+/// Zero on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fseek.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fseek(stream: *mut FILE, offset: c_long, whence: c_int) -> c_int {
+    extern "C" {
+        fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    let fd: c_int = (*stream).fd;
+    // SAFETY: fd comes from a valid FILE, offset and whence are caller-provided.
+    let ret: off_t = unsafe { lseek(fd, offset as off_t, whence) };
+    if ret < 0 {
+        (*stream).error = 1;
+        return -1;
+    }
+
+    // A successful seek clears the end-of-file indicator and the push-back buffer.
+    (*stream).eof = 0;
+    (*stream).ungetc_buf = -1;
+
+    0
+}

--- a/src/libs/libc_stdio/src/ftell.rs
+++ b/src/libs/libc_stdio/src/ftell.rs
@@ -1,0 +1,70 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_long,
+    },
+    sys_types::off_t,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Seek relative to current position.
+const SEEK_CUR: c_int = ::sysapi::unistd::file_seek::SEEK_CUR;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the current value of the file position indicator for the stream pointed to by
+/// `stream`.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// The current file position on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ftell.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ftell(stream: *mut FILE) -> c_long {
+    extern "C" {
+        fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    let fd: c_int = (*stream).fd;
+    // SAFETY: fd comes from a valid FILE.
+    let pos: off_t = unsafe { lseek(fd, 0, SEEK_CUR) };
+    if pos < 0 {
+        // Reflect the seek failure in the stream's error indicator so ferror() reports it.
+        (*stream).error = 1;
+        return -1;
+    }
+    pos as c_long
+}

--- a/src/libs/libc_stdio/src/fwrite.rs
+++ b/src/libs/libc_stdio/src/fwrite.rs
@@ -1,0 +1,103 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes `nmemb` elements, each `size` bytes long, from the buffer pointed to by `ptr` to the
+/// given file stream.
+///
+/// # Parameters
+///
+/// - `ptr`: Pointer to the data to be written.
+/// - `size`: Size of each element in bytes.
+/// - `nmemb`: Number of elements to write.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// The number of elements successfully written. If an error occurs or `size`/`nmemb` is zero,
+/// zero is returned.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `ptr` points to at least `size * nmemb` readable bytes.
+/// - `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fwrite.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fwrite(
+    ptr: *const c_void,
+    size: c_size_t,
+    nmemb: c_size_t,
+    stream: *mut FILE,
+) -> c_size_t {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if ptr.is_null() || stream.is_null() || size == 0 || nmemb == 0 {
+        return 0;
+    }
+
+    let fd: c_int = (*stream).fd;
+    // Compute the request size with overflow checking: a wrapping multiply could silently
+    // change the number of bytes written.
+    let total_bytes: usize = match (size as usize).checked_mul(nmemb as usize) {
+        Some(total_bytes) => total_bytes,
+        None => {
+            (*stream).error = 1;
+            return 0;
+        },
+    };
+
+    // Loop until every byte is written: a single `write` may transfer fewer
+    // bytes than requested (a short write) without an error, and `fwrite` must
+    // not report a short count in that case.
+    let mut written: usize = 0;
+    while written < total_bytes {
+        // SAFETY: ptr is valid for total_bytes, fd comes from a valid FILE.
+        let ret: c_ssize_t = unsafe {
+            write(
+                fd,
+                ptr.cast::<u8>().add(written).cast::<c_void>(),
+                (total_bytes - written) as c_size_t,
+            )
+        };
+        if ret <= 0 {
+            // A negative result is a write error; a zero result means no progress can be
+            // made. Either way, flag the stream's error indicator and stop to keep the
+            // stream state consistent and avoid an infinite loop.
+            (*stream).error = 1;
+            break;
+        }
+        written += ret as usize;
+    }
+
+    let size_usize: usize = size as usize;
+    (written / size_usize) as c_size_t
+}

--- a/src/libs/libc_stdio/src/getchar.rs
+++ b/src/libs/libc_stdio/src/getchar.rs
@@ -1,0 +1,37 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads the next character from standard input. Equivalent to
+/// [`fgetc`](`crate::fgetc::fgetc`) called with [`crate::stdin`].
+///
+/// # Returns
+///
+/// The next character as an `unsigned char` promoted to [`c_int`], or `EOF` (`-1`) on end-of-file
+/// or error.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses the global standard input stream.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getchar.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getchar() -> c_int {
+    // SAFETY: stdin() returns a valid pointer to the standard input FILE.
+    unsafe { crate::fgetc::fgetc(crate::stdin()) }
+}

--- a/src/libs/libc_stdio/src/lib.rs
+++ b/src/libs/libc_stdio/src/lib.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+// Use no_std except during tests so the Rust test harness (which requires std) can run.
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Features
+#![feature(c_variadic)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints need to be handled case-by-case depending on the target pointer width.
+// C-interop casts between Rust native types and fixed-width C ABI types are inherent to printf
+// formatting. On the 32-bit Nanvix target, these casts are no-ops.
+#![cfg_attr(target_pointer_width = "32", expect(clippy::cast_possible_truncation))]
+#![cfg_attr(
+    not(target_pointer_width = "32"),
+    expect(clippy::cast_possible_truncation)
+)]
+#![cfg_attr(target_pointer_width = "32", expect(clippy::cast_possible_wrap))]
+#![cfg_attr(not(target_pointer_width = "32"), expect(clippy::cast_possible_wrap))]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod format_engine;
+mod streams;
+
+pub mod clearerr;
+pub mod fclose;
+pub mod fdopen;
+pub mod feof;
+pub mod ferror;
+pub mod fflush;
+pub mod fgetc;
+pub mod fgets;
+pub mod fileno;
+pub mod fopen;
+pub mod fprintf;
+pub mod fputc;
+pub mod fputs;
+pub mod fread;
+pub mod fseek;
+pub mod ftell;
+pub mod fwrite;
+pub mod getchar;
+pub mod perror;
+pub mod printf;
+pub mod putchar;
+pub mod puts;
+pub mod remove;
+pub mod rename;
+pub mod rewind;
+pub mod setbuf;
+pub mod snprintf;
+pub mod sprintf;
+pub mod sscanf;
+pub mod swprintf;
+pub mod tmpfile;
+pub mod ungetc;
+pub mod vfprintf;
+pub mod vprintf;
+pub mod vsnprintf;
+pub mod vsprintf;
+pub mod vsscanf;
+
+//==================================================================================================
+// Exports
+//==================================================================================================
+
+pub use streams::{
+    stderr,
+    stdin,
+    stdout,
+    FILE,
+};

--- a/src/libs/libc_stdio/src/perror.rs
+++ b/src/libs/libc_stdio/src/perror.rs
@@ -1,0 +1,80 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// File descriptor for standard error.
+const STDERR_FD: c_int = 2;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Prints an error message to standard error. If `s` is not null and does not point to a null
+/// byte, the string `s` is printed followed by a colon and a space. A generic error message is
+/// then printed, followed by a newline.
+///
+/// # Note
+///
+/// A per-`errno` message string is not emitted because `errno`-to-string mapping is not available
+/// in this `no_std` environment; a fixed generic message is used instead.
+///
+/// # Parameters
+///
+/// - `s`: Optional pointer to a null-terminated prefix string. May be null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that,
+/// if `s` is non-null, it points to a valid, null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/perror.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn perror(s: *const c_char) {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    // Write prefix string if provided.
+    if !s.is_null() {
+        let first_byte: c_char = *s;
+        if first_byte != 0 {
+            // Compute string length.
+            let mut len: usize = 0;
+            while *s.add(len) != 0 {
+                len += 1;
+            }
+            let _ = write(STDERR_FD, s.cast::<c_void>(), len as c_size_t);
+            let sep: &[u8] = b": ";
+            let _ = write(STDERR_FD, sep.as_ptr().cast::<c_void>(), sep.len() as c_size_t);
+        }
+    }
+
+    // Write a generic error message (errno-to-string mapping is not available in no_std).
+    let msg: &[u8] = b"error\n";
+    let _ = write(STDERR_FD, msg.as_ptr().cast::<c_void>(), msg.len() as c_size_t);
+}

--- a/src/libs/libc_stdio/src/printf.rs
+++ b/src/libs/libc_stdio/src/printf.rs
@@ -1,0 +1,104 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::format_engine::{
+    format_core,
+    ArgSource,
+    FdWriter,
+};
+use ::core::ffi::VaList;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// File descriptor for standard output.
+const STDOUT_FD: c_int = 1;
+
+//==================================================================================================
+// VaList Adapter
+//==================================================================================================
+
+/// Wraps a [`VaList`] to implement [`ArgSource`].
+struct VaListArgs<'a> {
+    va: VaList<'a>,
+}
+
+impl<'a> ArgSource for VaListArgs<'a> {
+    fn next_int(&mut self) -> c_int {
+        unsafe { self.va.next_arg::<c_int>() }
+    }
+    fn next_uint(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_long(&mut self) -> i32 {
+        unsafe { self.va.next_arg::<i32>() }
+    }
+    fn next_ulong(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_longlong(&mut self) -> i64 {
+        unsafe { self.va.next_arg::<i64>() }
+    }
+    fn next_ulonglong(&mut self) -> u64 {
+        unsafe { self.va.next_arg::<u64>() }
+    }
+    fn next_size(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_ptr(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_str(&mut self) -> *const c_char {
+        unsafe { self.va.next_arg::<*const c_char>() }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to standard output. This is a variadic wrapper that creates a
+/// [`VaList`] and delegates to the formatting engine.
+///
+/// # Parameters
+///
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that:
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/printf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn printf(fmt: *const c_char, args: ...) -> c_int {
+    let mut writer: FdWriter = FdWriter::new(STDOUT_FD);
+    let ap: VaList<'_> = args;
+    let mut va_args: VaListArgs<'_> = VaListArgs { va: ap };
+    let ret: c_int = format_core(&mut writer, fmt, &mut va_args);
+    if ret < 0 {
+        return ret;
+    }
+    writer.result()
+}

--- a/src/libs/libc_stdio/src/putchar.rs
+++ b/src/libs/libc_stdio/src/putchar.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// File descriptor for standard output.
+const STDOUT_FD: c_int = 1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the character `c` (converted to `unsigned char`) to standard output.
+///
+/// # Parameters
+///
+/// - `c`: The character to write, passed as a [`c_int`].
+///
+/// # Returns
+///
+/// The character written as an `unsigned char` cast to [`c_int`], or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls an external write function.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/putchar.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn putchar(c: c_int) -> c_int {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    let byte: u8 = c as u8;
+    // SAFETY: byte is a valid 1-byte value on the stack.
+    let ret: c_ssize_t =
+        unsafe { write(STDOUT_FD, (&raw const byte).cast::<c_void>(), 1 as c_size_t) };
+    if ret < 0 {
+        -1
+    } else {
+        byte as c_int
+    }
+}

--- a/src/libs/libc_stdio/src/puts.rs
+++ b/src/libs/libc_stdio/src/puts.rs
@@ -1,0 +1,91 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// File descriptor for standard output.
+const STDOUT_FD: c_int = 1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the string `s` followed by a newline character to standard output.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated string to be written.
+///
+/// # Returns
+///
+/// A non-negative value on success, or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that
+/// `s` points to a valid, null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/puts.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn puts(s: *const c_char) -> c_int {
+    extern "C" {
+        fn write(fd: c_int, buf: *const c_void, count: c_size_t) -> c_ssize_t;
+    }
+
+    if s.is_null() {
+        return -1;
+    }
+
+    // Compute string length.
+    let mut len: usize = 0;
+    // SAFETY: s is non-null; we walk until the null terminator.
+    unsafe {
+        while *s.add(len) != 0 {
+            len += 1;
+        }
+    }
+
+    // Write string.
+    if len > 0 {
+        // SAFETY: s is valid for len bytes.
+        let ret: c_ssize_t = unsafe { write(STDOUT_FD, s.cast::<c_void>(), len as c_size_t) };
+        if ret < 0 {
+            return -1;
+        }
+    }
+
+    // Write trailing newline.
+    let nl: u8 = b'\n';
+    // SAFETY: nl is a valid 1-byte value on the stack.
+    let ret: c_ssize_t =
+        unsafe { write(STDOUT_FD, (&raw const nl).cast::<c_void>(), 1 as c_size_t) };
+    if ret < 0 {
+        return -1;
+    }
+
+    0
+}

--- a/src/libs/libc_stdio/src/remove.rs
+++ b/src/libs/libc_stdio/src/remove.rs
@@ -1,0 +1,71 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EISDIR,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Removes a file or directory. Regular files (and other non-directory entries) are removed with
+/// `unlink`; if the path refers to a directory, it is removed with `rmdir`.
+///
+/// # Parameters
+///
+/// - `pathname`: Pointer to a null-terminated string naming the file to remove.
+///
+/// # Returns
+///
+/// Zero on success, or -1 on failure with `errno` set.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `pathname` points to a valid, null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/remove.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn remove(pathname: *const c_char) -> c_int {
+    extern "C" {
+        fn unlink(path: *const c_char) -> c_int;
+        fn rmdir(path: *const c_char) -> c_int;
+    }
+
+    if pathname.is_null() {
+        return -1;
+    }
+
+    // SAFETY: pathname is a valid, null-terminated string.
+    let rc: c_int = unsafe { unlink(pathname) };
+    if rc == 0 {
+        return 0;
+    }
+
+    // A directory cannot be unlinked; retry with rmdir.
+    // SAFETY: __errno_location returns a valid pointer to the errno storage.
+    if unsafe { *__errno_location() } == EISDIR {
+        // SAFETY: pathname is a valid, null-terminated string.
+        return unsafe { rmdir(pathname) };
+    }
+
+    rc
+}

--- a/src/libs/libc_stdio/src/rename.rs
+++ b/src/libs/libc_stdio/src/rename.rs
@@ -1,0 +1,57 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    fcntl::atflags::AT_FDCWD,
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Renames the file `old` to `new`, delegating to `renameat` relative to the current working
+/// directory.
+///
+/// # Parameters
+///
+/// - `old`: Path of the existing file.
+/// - `new`: New path for the file.
+///
+/// # Returns
+///
+/// Zero on success, or -1 on failure with `errno` set.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. Both `old` and `new` must point to
+/// valid, null-terminated strings.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn rename(old: *const c_char, new: *const c_char) -> c_int {
+    extern "C" {
+        fn renameat(
+            olddirfd: c_int,
+            oldpath: *const c_char,
+            newdirfd: c_int,
+            newpath: *const c_char,
+        ) -> c_int;
+    }
+
+    // SAFETY: old and new are valid, null-terminated strings.
+    unsafe { renameat(AT_FDCWD, old, AT_FDCWD, new) }
+}

--- a/src/libs/libc_stdio/src/rewind.rs
+++ b/src/libs/libc_stdio/src/rewind.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Seek relative to start-of-file.
+const SEEK_SET: c_int = ::sysapi::unistd::file_seek::SEEK_SET;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the file position indicator for the stream pointed to by `stream` to the beginning of
+/// the file. It is equivalent to `fseek(stream, 0, SEEK_SET)` except that the error indicator
+/// for the stream is also cleared.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/rewind.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn rewind(stream: *mut FILE) {
+    if stream.is_null() {
+        return;
+    }
+
+    crate::fseek::fseek(stream, 0, SEEK_SET);
+    (*stream).error = 0;
+}

--- a/src/libs/libc_stdio/src/setbuf.rs
+++ b/src/libs/libc_stdio/src/setbuf.rs
@@ -1,0 +1,64 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the buffering of `stream`. Nanvix streams are unbuffered (each operation issues a direct
+/// system call), so this is a no-op.
+///
+/// # Safety
+///
+/// `stream` must be null or a valid [`FILE`]; it is not dereferenced.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/setbuf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn setbuf(_stream: *mut FILE, _buf: *mut c_char) {}
+
+///
+/// # Description
+///
+/// Sets the buffering mode of `stream`. Nanvix streams are unbuffered, so this is a no-op that
+/// reports success.
+///
+/// # Returns
+///
+/// Zero.
+///
+/// # Safety
+///
+/// `stream` must be null or a valid [`FILE`]; it is not dereferenced.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/setvbuf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn setvbuf(
+    _stream: *mut FILE,
+    _buf: *mut c_char,
+    _mode: c_int,
+    _size: c_size_t,
+) -> c_int {
+    0
+}

--- a/src/libs/libc_stdio/src/snprintf.rs
+++ b/src/libs/libc_stdio/src/snprintf.rs
@@ -1,0 +1,58 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes at most `size - 1` characters of formatted output to `buf`, followed by a null
+/// terminator. This is a variadic wrapper around [`crate::vsnprintf::vsnprintf`].
+///
+/// # Parameters
+///
+/// - `buf`: Pointer to the destination buffer.
+/// - `size`: Size of the destination buffer in bytes.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters that would have been written (excluding the null terminator) had the
+/// buffer been large enough. A return value of `size` or more indicates truncation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `buf` points to a writable buffer of at least `size` bytes (when `size > 0`).
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/snprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn snprintf(
+    buf: *mut c_char,
+    size: c_size_t,
+    fmt: *const c_char,
+    args: ...
+) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vsnprintf.
+    unsafe { crate::vsnprintf::vsnprintf(buf, size, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/sprintf.rs
+++ b/src/libs/libc_stdio/src/sprintf.rs
@@ -1,0 +1,48 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to `buf` with no bounds checking. This is a variadic wrapper around
+/// [`crate::vsprintf::vsprintf`].
+///
+/// # Parameters
+///
+/// - `buf`: Pointer to the destination buffer. Must be large enough to hold the result.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written (excluding the null terminator).
+///
+/// # Safety
+///
+/// This function is unsafe because it performs no bounds checking. The caller must ensure that:
+/// - `buf` points to a writable buffer large enough to hold the formatted output.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sprintf(buf: *mut c_char, fmt: *const c_char, args: ...) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vsprintf.
+    unsafe { crate::vsprintf::vsprintf(buf, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/sscanf.rs
+++ b/src/libs/libc_stdio/src/sscanf.rs
@@ -1,0 +1,46 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads formatted input from the string `s` according to the format string `fmt`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated input string.
+/// - `fmt`: Pointer to a null-terminated scanf format string.
+/// - `args`: Pointers to the storage locations matching the conversions in `fmt`.
+///
+/// # Returns
+///
+/// The number of input items successfully matched and assigned, or `EOF` if input ends before the
+/// first conversion.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. `s` and `fmt` must be valid,
+/// null-terminated strings and the variadic arguments must be pointers matching the conversions.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sscanf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sscanf(s: *const c_char, fmt: *const c_char, args: ...) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vsscanf.
+    unsafe { crate::vsscanf::vsscanf(s, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/streams.rs
+++ b/src/libs/libc_stdio/src/streams.rs
@@ -1,0 +1,153 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Minimal FILE structure wrapping a file descriptor.
+#[repr(C)]
+pub struct FILE {
+    /// File descriptor.
+    pub fd: c_int,
+    /// End-of-file indicator (0 = not EOF).
+    pub eof: c_int,
+    /// Error indicator (0 = no error).
+    pub error: c_int,
+    /// One-character push-back buffer for [`ungetc`](`crate::ungetc::ungetc`) (-1 = empty).
+    pub ungetc_buf: c_int,
+}
+
+//==================================================================================================
+// Static Data
+//==================================================================================================
+
+/// Standard input stream.
+static mut STDIN_FILE: FILE = FILE {
+    fd: 0,
+    eof: 0,
+    error: 0,
+    ungetc_buf: -1,
+};
+/// Standard output stream.
+static mut STDOUT_FILE: FILE = FILE {
+    fd: 1,
+    eof: 0,
+    error: 0,
+    ungetc_buf: -1,
+};
+/// Standard error stream.
+static mut STDERR_FILE: FILE = FILE {
+    fd: 2,
+    eof: 0,
+    error: 0,
+    ungetc_buf: -1,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns a pointer to the standard input stream.
+///
+/// # Returns
+///
+/// A mutable pointer to the standard input [`FILE`].
+///
+/// # Safety
+///
+/// The caller must ensure that no data races occur when accessing the returned pointer.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn stdin() -> *mut FILE {
+    &raw mut STDIN_FILE
+}
+
+///
+/// # Description
+///
+/// Returns a pointer to the standard output stream.
+///
+/// # Returns
+///
+/// A mutable pointer to the standard output [`FILE`].
+///
+/// # Safety
+///
+/// The caller must ensure that no data races occur when accessing the returned pointer.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn stdout() -> *mut FILE {
+    &raw mut STDOUT_FILE
+}
+
+///
+/// # Description
+///
+/// Returns a pointer to the standard error stream.
+///
+/// # Returns
+///
+/// A mutable pointer to the standard error [`FILE`].
+///
+/// # Safety
+///
+/// The caller must ensure that no data races occur when accessing the returned pointer.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn stderr() -> *mut FILE {
+    &raw mut STDERR_FILE
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        stderr,
+        stdin,
+        stdout,
+    };
+
+    #[test]
+    fn standard_streams_have_expected_descriptors() {
+        // SAFETY: the accessors return valid pointers to the static standard streams.
+        unsafe {
+            assert_eq!((*stdin()).fd, 0);
+            assert_eq!((*stdout()).fd, 1);
+            assert_eq!((*stderr()).fd, 2);
+        }
+    }
+
+    #[test]
+    fn standard_streams_start_without_errors_or_pushback() {
+        // SAFETY: the accessors return valid pointers to the static standard streams.
+        unsafe {
+            let s: *mut super::FILE = stdin();
+            assert_eq!((*s).eof, 0);
+            assert_eq!((*s).error, 0);
+            assert_eq!((*s).ungetc_buf, -1);
+        }
+    }
+
+    #[test]
+    fn standard_streams_are_distinct_and_stable() {
+        // SAFETY: the accessors return stable pointers to distinct static streams.
+        unsafe {
+            assert!(!core::ptr::eq(stdin(), stdout()));
+            assert!(!core::ptr::eq(stdout(), stderr()));
+            assert!(core::ptr::eq(stdin(), stdin()));
+        }
+    }
+}

--- a/src/libs/libc_stdio/src/swprintf.rs
+++ b/src/libs/libc_stdio/src/swprintf.rs
@@ -1,0 +1,126 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::ffi::VaList;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Types and Constants
+//==================================================================================================
+
+type wchar_t = i32;
+
+/// Value returned by the multibyte conversion functions on an encoding error (`(size_t)-1`).
+const SIZE_ERR: c_size_t = c_size_t::MAX;
+
+//==================================================================================================
+// External Symbols
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+    fn wcslen(s: *const wchar_t) -> c_size_t;
+    fn wcstombs(dst: *mut c_char, src: *const wchar_t, n: c_size_t) -> c_size_t;
+    fn mbstowcs(dst: *mut wchar_t, src: *const c_char, n: c_size_t) -> c_size_t;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Writes formatted output to the wide-character buffer `ws` (at most `n` wide characters including
+/// the terminator), taking arguments from `ap`.
+///
+/// # Description
+///
+/// The wide format string is converted to UTF-8 and rendered with the narrow `vsnprintf()` engine;
+/// the resulting bytes are converted back to wide characters. This reuses the single, well-tested
+/// formatting implementation for both the narrow and wide entry points.
+///
+/// # Safety
+///
+/// `ws` must have room for `n` wide characters and `format` must be a valid wide format string
+/// matching the variadic arguments in `ap`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vswprintf(
+    ws: *mut wchar_t,
+    n: c_size_t,
+    format: *const wchar_t,
+    ap: VaList<'_>,
+) -> c_int {
+    if n == 0 {
+        return -1;
+    }
+
+    // Reject null buffers before dereferencing them.
+    if ws.is_null() || format.is_null() {
+        return -1;
+    }
+
+    // Convert the wide format string to narrow UTF-8.
+    let flen: c_size_t = unsafe { wcslen(format) };
+    let nfmt_size: c_size_t = flen.saturating_mul(4).saturating_add(1);
+    let nfmt: *mut c_char = unsafe { malloc(nfmt_size) }.cast::<c_char>();
+    if nfmt.is_null() {
+        return -1;
+    }
+    // On an encoding error wcstombs() returns (size_t)-1; fail and free the buffer.
+    if unsafe { wcstombs(nfmt, format, nfmt_size) } == SIZE_ERR {
+        unsafe { free(nfmt.cast::<c_void>()) };
+        return -1;
+    }
+
+    // Render into a narrow buffer large enough to back `n` wide characters.
+    let nout_size: c_size_t = n.saturating_mul(4).saturating_add(4);
+    let nout: *mut c_char = unsafe { malloc(nout_size) }.cast::<c_char>();
+    if nout.is_null() {
+        unsafe { free(nfmt.cast::<c_void>()) };
+        return -1;
+    }
+    unsafe { crate::vsnprintf::vsnprintf(nout, nout_size, nfmt, ap) };
+
+    // Convert the formatted narrow output back to wide characters.
+    let max_chars: c_size_t = n - 1;
+    let res: c_size_t = unsafe { mbstowcs(ws, nout, max_chars) };
+    unsafe {
+        free(nfmt.cast::<c_void>());
+        free(nout.cast::<c_void>());
+    }
+    if res == SIZE_ERR {
+        return -1;
+    }
+
+    let written: c_size_t = if res > max_chars { max_chars } else { res };
+    unsafe { *ws.add(written as usize) = 0 };
+    written as c_int
+}
+
+/// Writes formatted output to the wide-character buffer `ws` (at most `n` wide characters including
+/// the terminator).
+///
+/// # Safety
+///
+/// See [`vswprintf`].
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn swprintf(
+    ws: *mut wchar_t,
+    n: c_size_t,
+    format: *const wchar_t,
+    args: ...
+) -> c_int {
+    unsafe { vswprintf(ws, n, format, args) }
+}

--- a/src/libs/libc_stdio/src/tmpfile.rs
+++ b/src/libs/libc_stdio/src/tmpfile.rs
@@ -1,0 +1,111 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::core::sync::atomic::{
+    AtomicU32,
+    Ordering,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EEXIST,
+    },
+    fcntl::{
+        file_access_mode::O_RDWR,
+        file_creation_flags::{
+            O_CREAT,
+            O_EXCL,
+        },
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::mode_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Creates a temporary file opened for update (`"w+b"`) under `/tmp`. The file is given a unique
+/// name; unlike a full implementation it is not automatically removed on close, because the
+/// standalone file system does not support unlinking an open file.
+///
+/// # Returns
+///
+/// A pointer to a [`FILE`] on success, or a null pointer on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls into the C runtime and dereferences raw pointers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tmpfile.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn tmpfile() -> *mut FILE {
+    extern "C" {
+        fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int;
+        fn fdopen(fd: c_int, mode: *const c_char) -> *mut FILE;
+        fn close(fd: c_int) -> c_int;
+    }
+
+    /// Process-wide counter used to build unique temporary file names.
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    // Template: "/tmp/tmpfXXXXXXXX\0" (8 hex digits).
+    let mut name: [u8; 18] = *b"/tmp/tmpf00000000\0";
+
+    for _ in 0..64 {
+        // Atomically reserve a unique id so concurrent callers neither race nor collide.
+        let id: u32 = COUNTER.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+        let mut v: u32 = id;
+        let mut idx: usize = 16;
+        while idx >= 9 {
+            let digit: u8 = (v & 0xf) as u8;
+            name[idx] = if digit < 10 {
+                b'0' + digit
+            } else {
+                b'a' + (digit - 10)
+            };
+            v >>= 4;
+            idx -= 1;
+        }
+
+        // SAFETY: name is a valid, null-terminated path; mode is valid.
+        let fd: c_int =
+            unsafe { open(name.as_ptr().cast::<c_char>(), O_RDWR | O_CREAT | O_EXCL, 0o600) };
+        if fd >= 0 {
+            // SAFETY: fd is a freshly opened, valid file descriptor.
+            let stream: *mut FILE = unsafe { fdopen(fd, c"w+b".as_ptr()) };
+            if stream.is_null() {
+                // fdopen() failed after the file was created: close the descriptor so it is
+                // not leaked, then give up (a retry cannot recover an allocation failure).
+                // SAFETY: fd is a valid open descriptor.
+                unsafe { close(fd) };
+                return core::ptr::null_mut();
+            }
+            return stream;
+        }
+
+        // Only a name collision (EEXIST) is worth retrying with a fresh name. Any other error
+        // (e.g. missing /tmp, permission denied) is non-transient and will never succeed, so
+        // bail out immediately and let errno describe the failure.
+        // SAFETY: __errno_location returns a valid pointer to the errno storage.
+        if unsafe { *__errno_location() } != EEXIST {
+            return core::ptr::null_mut();
+        }
+    }
+
+    core::ptr::null_mut()
+}

--- a/src/libs/libc_stdio/src/ungetc.rs
+++ b/src/libs/libc_stdio/src/ungetc.rs
@@ -1,0 +1,134 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// End-of-file return value.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Pushes the character `c` (converted to `unsigned char`) back onto the input stream pointed to
+/// by `stream`, where it will be available for subsequent read operations. Only one character of
+/// push-back is guaranteed.
+///
+/// # Parameters
+///
+/// - `c`: The character to push back, passed as a [`c_int`].
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Returns
+///
+/// The character pushed back as an `unsigned char` cast to [`c_int`], or `EOF` (`-1`) on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ungetc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ungetc(c: c_int, stream: *mut FILE) -> c_int {
+    if stream.is_null() || c == EOF {
+        return EOF;
+    }
+
+    // Only one character of push-back is supported.
+    if (*stream).ungetc_buf != -1 {
+        return EOF;
+    }
+
+    // POSIX: the pushed-back character is the value of `c` converted to `unsigned char`.
+    let byte: c_int = c_int::from(c as u8);
+    (*stream).ungetc_buf = byte;
+    // A successful ungetc clears the end-of-file indicator.
+    (*stream).eof = 0;
+
+    byte
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ungetc;
+    use crate::streams::FILE;
+
+    /// Builds a stream with the end-of-file indicator set and an empty push-back slot.
+    fn make_file() -> FILE {
+        FILE {
+            fd: 0,
+            eof: 1,
+            error: 0,
+            ungetc_buf: -1,
+        }
+    }
+
+    #[test]
+    fn stores_character_and_clears_eof() {
+        let mut f: FILE = make_file();
+        // SAFETY: `f` is a valid FILE on the stack.
+        let r: i32 = unsafe { ungetc(i32::from(b'A'), &raw mut f) };
+        assert_eq!(r, i32::from(b'A'));
+        assert_eq!(f.ungetc_buf, i32::from(b'A'));
+        assert_eq!(f.eof, 0);
+    }
+
+    #[test]
+    fn converts_value_to_unsigned_char() {
+        let mut f: FILE = make_file();
+        // 0x1FF is truncated to 0xFF when converted to unsigned char.
+        // SAFETY: `f` is a valid FILE on the stack.
+        let r: i32 = unsafe { ungetc(0x1FF, &raw mut f) };
+        assert_eq!(r, 0xFF);
+        assert_eq!(f.ungetc_buf, 0xFF);
+    }
+
+    #[test]
+    fn rejects_eof() {
+        let mut f: FILE = make_file();
+        // SAFETY: `f` is a valid FILE on the stack.
+        let r: i32 = unsafe { ungetc(-1, &raw mut f) };
+        assert_eq!(r, -1);
+        assert_eq!(f.ungetc_buf, -1);
+        // The end-of-file indicator must remain untouched on failure.
+        assert_eq!(f.eof, 1);
+    }
+
+    #[test]
+    fn rejects_second_pushback() {
+        let mut f: FILE = make_file();
+        // SAFETY: `f` is a valid FILE on the stack.
+        unsafe {
+            assert_eq!(ungetc(i32::from(b'x'), &raw mut f), i32::from(b'x'));
+            assert_eq!(ungetc(i32::from(b'y'), &raw mut f), -1);
+        }
+        assert_eq!(f.ungetc_buf, i32::from(b'x'));
+    }
+
+    #[test]
+    fn rejects_null_stream() {
+        // SAFETY: a null stream is explicitly handled and returns EOF.
+        let r: i32 = unsafe { ungetc(i32::from(b'A'), ::core::ptr::null_mut()) };
+        assert_eq!(r, -1);
+    }
+}

--- a/src/libs/libc_stdio/src/vfprintf.rs
+++ b/src/libs/libc_stdio/src/vfprintf.rs
@@ -1,0 +1,111 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    format_engine::{
+        format_core,
+        ArgSource,
+        FdWriter,
+    },
+    streams::FILE,
+};
+use ::core::ffi::VaList;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// VaList Adapter
+//==================================================================================================
+
+/// Wraps a [`VaList`] to implement [`ArgSource`].
+struct VaListArgs<'a> {
+    va: VaList<'a>,
+}
+
+impl<'a> ArgSource for VaListArgs<'a> {
+    fn next_int(&mut self) -> c_int {
+        unsafe { self.va.next_arg::<c_int>() }
+    }
+    fn next_uint(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_long(&mut self) -> i32 {
+        unsafe { self.va.next_arg::<i32>() }
+    }
+    fn next_ulong(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_longlong(&mut self) -> i64 {
+        unsafe { self.va.next_arg::<i64>() }
+    }
+    fn next_ulonglong(&mut self) -> u64 {
+        unsafe { self.va.next_arg::<u64>() }
+    }
+    fn next_size(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_ptr(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_str(&mut self) -> *const c_char {
+        unsafe { self.va.next_arg::<*const c_char>() }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to the given file stream.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `ap`: Variable argument list matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `stream` points to a valid, open [`FILE`] structure.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - `ap` provides arguments matching the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vfprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vfprintf(stream: *mut FILE, fmt: *const c_char, ap: VaList<'_>) -> c_int {
+    if stream.is_null() {
+        return -1;
+    }
+    let fd: c_int = (*stream).fd;
+    let mut writer: FdWriter = FdWriter::new(fd);
+    let mut args: VaListArgs<'_> = VaListArgs { va: ap };
+    let fmt_ret: c_int = format_core(&mut writer, fmt, &mut args);
+    let ret: c_int = if fmt_ret < 0 {
+        fmt_ret
+    } else {
+        writer.result()
+    };
+    if ret < 0 {
+        // Reflect the failure (write error or invalid format) in the stream's error indicator
+        // so ferror() reports it.
+        (*stream).error = 1;
+    }
+    ret
+}

--- a/src/libs/libc_stdio/src/vprintf.rs
+++ b/src/libs/libc_stdio/src/vprintf.rs
@@ -1,0 +1,102 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::format_engine::{
+    format_core,
+    ArgSource,
+    FdWriter,
+};
+use ::core::ffi::VaList;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// File descriptor for standard output.
+const STDOUT_FD: c_int = 1;
+
+//==================================================================================================
+// VaList Adapter
+//==================================================================================================
+
+/// Wraps a [`VaList`] to implement [`ArgSource`].
+struct VaListArgs<'a> {
+    va: VaList<'a>,
+}
+
+impl<'a> ArgSource for VaListArgs<'a> {
+    fn next_int(&mut self) -> c_int {
+        unsafe { self.va.next_arg::<c_int>() }
+    }
+    fn next_uint(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_long(&mut self) -> i32 {
+        unsafe { self.va.next_arg::<i32>() }
+    }
+    fn next_ulong(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_longlong(&mut self) -> i64 {
+        unsafe { self.va.next_arg::<i64>() }
+    }
+    fn next_ulonglong(&mut self) -> u64 {
+        unsafe { self.va.next_arg::<u64>() }
+    }
+    fn next_size(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_ptr(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_str(&mut self) -> *const c_char {
+        unsafe { self.va.next_arg::<*const c_char>() }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to standard output.
+///
+/// # Parameters
+///
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `ap`: Variable argument list matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that:
+/// - `fmt` points to a valid, null-terminated format string.
+/// - `ap` provides arguments matching the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vprintf(fmt: *const c_char, ap: VaList<'_>) -> c_int {
+    let mut writer: FdWriter = FdWriter::new(STDOUT_FD);
+    let mut args: VaListArgs<'_> = VaListArgs { va: ap };
+    let ret: c_int = format_core(&mut writer, fmt, &mut args);
+    if ret < 0 {
+        return ret;
+    }
+    writer.result()
+}

--- a/src/libs/libc_stdio/src/vsnprintf.rs
+++ b/src/libs/libc_stdio/src/vsnprintf.rs
@@ -1,0 +1,121 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::format_engine::{
+    format_core,
+    ArgSource,
+    BufWriter,
+    WriteTarget,
+};
+use ::core::ffi::VaList;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// VaList Adapter
+//==================================================================================================
+
+/// Wraps a [`VaList`] to implement [`ArgSource`].
+struct VaListArgs<'a> {
+    va: VaList<'a>,
+}
+
+impl<'a> ArgSource for VaListArgs<'a> {
+    fn next_int(&mut self) -> c_int {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<c_int>() }
+    }
+    fn next_uint(&mut self) -> u32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_long(&mut self) -> i32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<i32>() }
+    }
+    fn next_ulong(&mut self) -> u32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_longlong(&mut self) -> i64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<i64>() }
+    }
+    fn next_ulonglong(&mut self) -> u64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<u64>() }
+    }
+    fn next_size(&mut self) -> usize {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_ptr(&mut self) -> usize {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_str(&mut self) -> *const c_char {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<*const c_char>() }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes at most `size - 1` characters of formatted output to `buf`, followed by a null
+/// terminator. If `size` is zero, nothing is written but the return value still reflects the
+/// number of characters that would have been written.
+///
+/// # Parameters
+///
+/// - `buf`: Pointer to the destination buffer.
+/// - `size`: Size of the destination buffer in bytes.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `ap`: Variable argument list matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters that would have been written (excluding the null terminator) had the
+/// buffer been large enough. A return value of `size` or more indicates truncation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `buf` points to a writable buffer of at least `size` bytes (when `size > 0`).
+/// - `fmt` points to a valid, null-terminated format string.
+/// - `ap` provides arguments matching the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vsnprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vsnprintf(
+    buf: *mut c_char,
+    size: c_size_t,
+    fmt: *const c_char,
+    ap: VaList<'_>,
+) -> c_int {
+    let buf_size: usize = size as usize;
+    let mut writer: BufWriter = BufWriter::new(buf.cast::<u8>(), buf_size);
+    let mut args: VaListArgs<'_> = VaListArgs { va: ap };
+    let ret: c_int = format_core(&mut writer, fmt, &mut args);
+    if ret < 0 {
+        return ret;
+    }
+    writer.null_terminate();
+    writer.total() as c_int
+}

--- a/src/libs/libc_stdio/src/vsprintf.rs
+++ b/src/libs/libc_stdio/src/vsprintf.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::format_engine::{
+    format_core,
+    ArgSource,
+    UnboundedBufWriter,
+    WriteTarget,
+};
+use ::core::ffi::VaList;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// VaList Adapter
+//==================================================================================================
+
+/// Wraps a [`VaList`] to implement [`ArgSource`].
+struct VaListArgs<'a> {
+    va: VaList<'a>,
+}
+
+impl<'a> ArgSource for VaListArgs<'a> {
+    fn next_int(&mut self) -> c_int {
+        unsafe { self.va.next_arg::<c_int>() }
+    }
+    fn next_uint(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_long(&mut self) -> i32 {
+        unsafe { self.va.next_arg::<i32>() }
+    }
+    fn next_ulong(&mut self) -> u32 {
+        unsafe { self.va.next_arg::<u32>() }
+    }
+    fn next_longlong(&mut self) -> i64 {
+        unsafe { self.va.next_arg::<i64>() }
+    }
+    fn next_ulonglong(&mut self) -> u64 {
+        unsafe { self.va.next_arg::<u64>() }
+    }
+    fn next_size(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_ptr(&mut self) -> usize {
+        unsafe { self.va.next_arg::<usize>() }
+    }
+    fn next_str(&mut self) -> *const c_char {
+        unsafe { self.va.next_arg::<*const c_char>() }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted output to `buf` with no bounds checking. The output is null-terminated.
+///
+/// # Parameters
+///
+/// - `buf`: Pointer to the destination buffer. Must be large enough to hold the result.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `ap`: Variable argument list matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written (excluding the null terminator).
+///
+/// # Safety
+///
+/// This function is unsafe because it performs no bounds checking. The caller must ensure that:
+/// - `buf` points to a writable buffer large enough to hold the formatted output.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - `ap` provides arguments matching the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vsprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vsprintf(buf: *mut c_char, fmt: *const c_char, ap: VaList<'_>) -> c_int {
+    let mut writer: UnboundedBufWriter = UnboundedBufWriter::new(buf.cast::<u8>());
+    let mut args: VaListArgs<'_> = VaListArgs { va: ap };
+    let ret: c_int = format_core(&mut writer, fmt, &mut args);
+    if ret < 0 {
+        return ret;
+    }
+    writer.null_terminate();
+    writer.total() as c_int
+}

--- a/src/libs/libc_stdio/src/vsscanf.rs
+++ b/src/libs/libc_stdio/src/vsscanf.rs
@@ -1,0 +1,633 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::ffi::VaList;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Return value indicating end-of-input before any conversion.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Input cursor
+//==================================================================================================
+
+/// A read cursor over a null-terminated input string.
+struct Cursor {
+    p: *const u8,
+    consumed: usize,
+}
+
+impl Cursor {
+    /// Returns the current byte without advancing (0 at end of input).
+    unsafe fn peek(&self) -> u8 {
+        unsafe { *self.p }
+    }
+
+    /// Returns the current byte and advances the cursor.
+    unsafe fn bump(&mut self) -> u8 {
+        let c: u8 = unsafe { *self.p };
+        if c != 0 {
+            self.p = unsafe { self.p.add(1) };
+            self.consumed += 1;
+        }
+        c
+    }
+
+    /// Skips ASCII whitespace.
+    unsafe fn skip_ws(&mut self) {
+        while is_space(unsafe { self.peek() }) {
+            unsafe { self.bump() };
+        }
+    }
+}
+
+/// Returns true for ASCII whitespace.
+fn is_space(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
+}
+
+/// Returns the numeric value of `b` as a digit in `base`, or `None`.
+fn digit_value(b: u8, base: u32) -> Option<u32> {
+    let v: u32 = match b {
+        b'0'..=b'9' => u32::from(b - b'0'),
+        b'a'..=b'z' => u32::from(b - b'a') + 10,
+        b'A'..=b'Z' => u32::from(b - b'A') + 10,
+        _ => return None,
+    };
+    if v < base {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Length modifiers
+//==================================================================================================
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Length {
+    Char,
+    Short,
+    Int,
+    Long,
+    LongLong,
+    Size,
+    /// Pointer storage for `%p`, writing through a `void **` argument.
+    Pointer,
+}
+
+//==================================================================================================
+// Integer storage
+//==================================================================================================
+
+/// Stores `value` into the variadic integer pointer of the given `length`.
+unsafe fn store_int(ap: &mut VaList<'_>, length: Length, value: u64) {
+    // SAFETY: caller guarantees a matching pointer argument.
+    let ptr: *mut c_void = unsafe { ap.next_arg::<*mut c_void>() };
+    if ptr.is_null() {
+        return;
+    }
+    unsafe {
+        match length {
+            Length::Char => *ptr.cast::<i8>() = value as i8,
+            Length::Short => *ptr.cast::<i16>() = value as i16,
+            Length::Int => *ptr.cast::<i32>() = value as i32,
+            Length::Long => *ptr.cast::<i32>() = value as i32,
+            Length::LongLong => *ptr.cast::<i64>() = value as i64,
+            Length::Size => *ptr.cast::<usize>() = value as usize,
+            // `%p` writes through a `void **`, storing a real pointer value.
+            Length::Pointer => *ptr.cast::<*mut c_void>() = (value as usize) as *mut c_void,
+        }
+    }
+}
+
+//==================================================================================================
+// Core
+//==================================================================================================
+
+/// Parses one integer conversion from `cur` and optionally stores it.
+///
+/// Returns true on a successful match.
+#[allow(clippy::too_many_arguments)]
+unsafe fn convert_int(
+    cur: &mut Cursor,
+    ap: &mut VaList<'_>,
+    base: u32,
+    auto_base: bool,
+    width: usize,
+    length: Length,
+    suppress: bool,
+) -> bool {
+    unsafe { cur.skip_ws() };
+    let mut remaining: usize = if width == 0 { usize::MAX } else { width };
+
+    let mut negative: bool = false;
+    let c: u8 = unsafe { cur.peek() };
+    if (c == b'+' || c == b'-') && remaining > 0 {
+        negative = c == b'-';
+        unsafe { cur.bump() };
+        remaining -= 1;
+    }
+
+    let mut base: u32 = base;
+    if auto_base {
+        base = 10;
+        if unsafe { cur.peek() } == b'0' && remaining > 0 {
+            unsafe { cur.bump() };
+            remaining -= 1;
+            // A leading 0 selects octal; a "0x"/"0X" prefix selects hexadecimal, but only
+            // when at least one hexadecimal digit follows it (matching strtol with base 0).
+            base = 8;
+            if (unsafe { cur.peek() } == b'x' || unsafe { cur.peek() } == b'X') && remaining > 0 {
+                let save: *const u8 = cur.p;
+                let save_consumed: usize = cur.consumed;
+                unsafe { cur.bump() };
+                if digit_value(unsafe { cur.peek() }, 16).is_some() {
+                    remaining -= 1;
+                    base = 16;
+                } else {
+                    // No hex digit after the prefix: keep the leading 0 as an octal value.
+                    cur.p = save;
+                    cur.consumed = save_consumed;
+                }
+            }
+            // A leading 0 already counts as a digit; fall through to read more.
+            return finish_int(cur, ap, base, negative, remaining, length, suppress, true);
+        }
+    } else if base == 16 && unsafe { cur.peek() } == b'0' && remaining >= 2 {
+        // Optional 0x/0X prefix for hex, consumed only when a hex digit follows it.
+        let save: *const u8 = cur.p;
+        let save_consumed: usize = cur.consumed;
+        unsafe { cur.bump() };
+        if unsafe { cur.peek() } == b'x' || unsafe { cur.peek() } == b'X' {
+            unsafe { cur.bump() };
+            if digit_value(unsafe { cur.peek() }, 16).is_some() {
+                remaining -= 2;
+            } else {
+                // No hex digit after the prefix: rewind so the leading 0 is read as a digit.
+                cur.p = save;
+                cur.consumed = save_consumed;
+            }
+        } else {
+            cur.p = save;
+            cur.consumed = save_consumed;
+        }
+    }
+
+    unsafe { finish_int(cur, ap, base, negative, remaining, length, suppress, false) }
+}
+
+/// Reads digits and stores the resulting integer.
+#[allow(clippy::too_many_arguments)]
+unsafe fn finish_int(
+    cur: &mut Cursor,
+    ap: &mut VaList<'_>,
+    base: u32,
+    negative: bool,
+    mut remaining: usize,
+    length: Length,
+    suppress: bool,
+    seeded_zero: bool,
+) -> bool {
+    let mut value: u64 = 0;
+    let mut any: bool = seeded_zero;
+    while remaining > 0 {
+        match digit_value(unsafe { cur.peek() }, base) {
+            Some(d) => {
+                value = value
+                    .wrapping_mul(u64::from(base))
+                    .wrapping_add(u64::from(d));
+                any = true;
+                unsafe { cur.bump() };
+                remaining -= 1;
+            },
+            None => break,
+        }
+    }
+    if !any {
+        return false;
+    }
+    // Apply the sign for both signed and unsigned conversions: scanf accepts an optional
+    // leading sign even for %u/%o/%x/%p, and a negative value wraps (matching strtoul).
+    let stored: u64 = if negative {
+        (value as i64).wrapping_neg() as u64
+    } else {
+        value
+    };
+    if !suppress {
+        unsafe { store_int(ap, length, stored) };
+    }
+    true
+}
+
+/// Implementation of `vsscanf`.
+unsafe fn scan(s: *const c_char, fmt: *const c_char, mut ap: VaList<'_>) -> c_int {
+    if s.is_null() || fmt.is_null() {
+        return EOF;
+    }
+
+    let mut cur: Cursor = Cursor {
+        p: s.cast::<u8>(),
+        consumed: 0,
+    };
+    let mut f: *const u8 = fmt.cast::<u8>();
+    let mut count: c_int = 0;
+    let mut matched_any: bool = false;
+
+    loop {
+        let fc: u8 = unsafe { *f };
+        if fc == 0 {
+            break;
+        }
+
+        if is_space(fc) {
+            unsafe { cur.skip_ws() };
+            f = unsafe { f.add(1) };
+            continue;
+        }
+
+        if fc != b'%' {
+            // Literal character must match.
+            if unsafe { cur.peek() } != fc {
+                // End-of-input before any conversion is an input failure (EOF); a
+                // differing byte is a matching failure that simply stops scanning.
+                if unsafe { cur.peek() } == 0 && !matched_any {
+                    return EOF;
+                }
+                break;
+            }
+            unsafe { cur.bump() };
+            f = unsafe { f.add(1) };
+            continue;
+        }
+
+        // Parse a conversion specification.
+        f = unsafe { f.add(1) };
+        if unsafe { *f } == b'%' {
+            // A literal `%%` matches a single '%' in the input without skipping leading
+            // whitespace (it behaves like an ordinary character, not a conversion).
+            if unsafe { cur.peek() } != b'%' {
+                // End-of-input before any conversion is an input failure (EOF).
+                if unsafe { cur.peek() } == 0 && !matched_any {
+                    return EOF;
+                }
+                break;
+            }
+            unsafe { cur.bump() };
+            f = unsafe { f.add(1) };
+            continue;
+        }
+
+        let mut suppress: bool = false;
+        if unsafe { *f } == b'*' {
+            suppress = true;
+            f = unsafe { f.add(1) };
+        }
+
+        // Field width.
+        let mut width: usize = 0;
+        while let Some(d) = digit_value(unsafe { *f }, 10) {
+            width = width.wrapping_mul(10).wrapping_add(d as usize);
+            f = unsafe { f.add(1) };
+        }
+
+        // Length modifier.
+        let mut length: Length = Length::Int;
+        match unsafe { *f } {
+            b'h' => {
+                f = unsafe { f.add(1) };
+                if unsafe { *f } == b'h' {
+                    length = Length::Char;
+                    f = unsafe { f.add(1) };
+                } else {
+                    length = Length::Short;
+                }
+            },
+            b'l' => {
+                f = unsafe { f.add(1) };
+                if unsafe { *f } == b'l' {
+                    length = Length::LongLong;
+                    f = unsafe { f.add(1) };
+                } else {
+                    length = Length::Long;
+                }
+            },
+            b'L' | b'q' | b'j' => {
+                length = Length::LongLong;
+                f = unsafe { f.add(1) };
+            },
+            b'z' | b't' => {
+                length = Length::Size;
+                f = unsafe { f.add(1) };
+            },
+            _ => {},
+        }
+
+        let spec: u8 = unsafe { *f };
+        if spec == 0 {
+            break;
+        }
+        f = unsafe { f.add(1) };
+
+        let ok: bool = match spec {
+            b'd' => unsafe { convert_int(&mut cur, &mut ap, 10, false, width, length, suppress) },
+            b'u' => unsafe { convert_int(&mut cur, &mut ap, 10, false, width, length, suppress) },
+            b'i' => unsafe { convert_int(&mut cur, &mut ap, 10, true, width, length, suppress) },
+            b'o' => unsafe { convert_int(&mut cur, &mut ap, 8, false, width, length, suppress) },
+            b'x' | b'X' => unsafe {
+                convert_int(&mut cur, &mut ap, 16, false, width, length, suppress)
+            },
+            b'p' => unsafe {
+                convert_int(&mut cur, &mut ap, 16, false, width, Length::Pointer, suppress)
+            },
+            b'c' => unsafe { convert_char(&mut cur, &mut ap, width, suppress) },
+            b's' => unsafe { convert_str(&mut cur, &mut ap, width, suppress) },
+            b'n' => {
+                if !suppress {
+                    // %n stores the number of characters consumed so far, honoring the
+                    // active length modifier (e.g. %hhn, %hn, %ln, %lln, %zn).
+                    // SAFETY: caller supplied a pointer matching the length modifier.
+                    unsafe { store_int(&mut ap, length, cur.consumed as u64) };
+                }
+                // %n consumes no input and never fails, so it always completes as a
+                // conversion. Record that to prevent a later end-of-input from being
+                // reported as EOF, but do not count it as an assignment.
+                matched_any = true;
+                continue;
+            },
+            _ => break,
+        };
+
+        if !ok {
+            // On a matching failure, stop. If input is exhausted with no match
+            // at all, report EOF.
+            if unsafe { cur.peek() } == 0 && !matched_any {
+                return EOF;
+            }
+            break;
+        }
+        matched_any = true;
+        if !suppress {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+/// Parses a `%c` conversion.
+unsafe fn convert_char(
+    cur: &mut Cursor,
+    ap: &mut VaList<'_>,
+    width: usize,
+    suppress: bool,
+) -> bool {
+    let n: usize = if width == 0 { 1 } else { width };
+    if unsafe { cur.peek() } == 0 {
+        return false;
+    }
+    let dst: *mut c_char = if suppress {
+        core::ptr::null_mut()
+    } else {
+        // SAFETY: caller supplied a matching char pointer.
+        unsafe { ap.next_arg::<*mut c_void>() }.cast::<c_char>()
+    };
+    let mut i: usize = 0;
+    while i < n {
+        let c: u8 = unsafe { cur.peek() };
+        if c == 0 {
+            break;
+        }
+        unsafe { cur.bump() };
+        if !dst.is_null() {
+            unsafe { *dst.add(i) = c as c_char };
+        }
+        i += 1;
+    }
+    // A field width requires reading exactly that many characters; a short read because
+    // the input ended early is a failure for the conversion.
+    i == n
+}
+
+/// Parses a `%s` conversion.
+unsafe fn convert_str(cur: &mut Cursor, ap: &mut VaList<'_>, width: usize, suppress: bool) -> bool {
+    unsafe { cur.skip_ws() };
+    if unsafe { cur.peek() } == 0 || is_space(unsafe { cur.peek() }) {
+        return false;
+    }
+    let limit: usize = if width == 0 { usize::MAX } else { width };
+    let dst: *mut c_char = if suppress {
+        core::ptr::null_mut()
+    } else {
+        // SAFETY: caller supplied a matching char pointer.
+        unsafe { ap.next_arg::<*mut c_void>() }.cast::<c_char>()
+    };
+    let mut i: usize = 0;
+    while i < limit {
+        let c: u8 = unsafe { cur.peek() };
+        if c == 0 || is_space(c) {
+            break;
+        }
+        unsafe { cur.bump() };
+        if !dst.is_null() {
+            unsafe { *dst.add(i) = c as c_char };
+        }
+        i += 1;
+    }
+    if !dst.is_null() {
+        unsafe { *dst.add(i) = 0 };
+    }
+    i > 0
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads formatted input from the string `s` according to `fmt`, using the variadic argument list
+/// `ap` for the storage locations.
+///
+/// # Returns
+///
+/// The number of input items successfully matched and assigned, or `EOF` if input ends before the
+/// first conversion.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. `s` and `fmt` must be valid,
+/// null-terminated strings and `ap` must provide pointers matching the conversions in `fmt`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vsscanf(s: *const c_char, fmt: *const c_char, ap: VaList<'_>) -> c_int {
+    unsafe { scan(s, fmt, ap) }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        digit_value,
+        is_space,
+        vsscanf,
+        Cursor,
+    };
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    /// Variadic helper that forwards to [`vsscanf`], used to construct a real `VaList`.
+    ///
+    /// # Safety
+    ///
+    /// `s` and `fmt` must be valid null-terminated strings and the variadic pointers must match
+    /// the conversions in `fmt`.
+    unsafe extern "C" fn run(s: *const c_char, fmt: *const c_char, args: ...) -> c_int {
+        unsafe { vsscanf(s, fmt, args) }
+    }
+
+    /// Collects the bytes of a null-terminated `c_char` buffer into a `Vec<u8>`.
+    fn cstr_bytes(buf: &[c_char]) -> Vec<u8> {
+        buf.iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect()
+    }
+
+    #[test]
+    fn is_space_matches_ascii_whitespace() {
+        for b in [b' ', b'\t', b'\n', b'\r', 0x0b, 0x0c] {
+            assert!(is_space(b));
+        }
+        for b in [b'a', b'0', b'.', 0] {
+            assert!(!is_space(b));
+        }
+    }
+
+    #[test]
+    fn digit_value_respects_base() {
+        assert_eq!(digit_value(b'9', 10), Some(9));
+        assert_eq!(digit_value(b'a', 16), Some(10));
+        assert_eq!(digit_value(b'F', 16), Some(15));
+        assert_eq!(digit_value(b'7', 8), Some(7));
+        assert_eq!(digit_value(b'8', 8), None);
+        assert_eq!(digit_value(b'g', 16), None);
+    }
+
+    #[test]
+    fn cursor_skips_whitespace_and_bumps() {
+        let data = c"  ab";
+        let mut cur = Cursor {
+            p: data.as_ptr().cast::<u8>(),
+            consumed: 0,
+        };
+        // SAFETY: `cur` points at a valid null-terminated buffer.
+        unsafe {
+            cur.skip_ws();
+            assert_eq!(cur.peek(), b'a');
+            assert_eq!(cur.bump(), b'a');
+            assert_eq!(cur.bump(), b'b');
+            assert_eq!(cur.peek(), 0);
+            // A bump at end-of-input does not advance past the terminator.
+            assert_eq!(cur.bump(), 0);
+        }
+        // `consumed` counts every byte consumed, including the two skipped spaces.
+        assert_eq!(cur.consumed, 4);
+    }
+
+    #[test]
+    fn scan_two_decimals() {
+        let mut a: c_int = 0;
+        let mut b: c_int = 0;
+        // SAFETY: both pointers are valid and match the `%d` conversions.
+        let n = unsafe { run(c"12 34".as_ptr(), c"%d %d".as_ptr(), &raw mut a, &raw mut b) };
+        assert_eq!(n, 2);
+        assert_eq!(a, 12);
+        assert_eq!(b, 34);
+    }
+
+    #[test]
+    fn scan_negative_decimal() {
+        let mut a: c_int = 0;
+        // SAFETY: the pointer is valid and matches the `%d` conversion.
+        let n = unsafe { run(c"-42".as_ptr(), c"%d".as_ptr(), &raw mut a) };
+        assert_eq!(n, 1);
+        assert_eq!(a, -42);
+    }
+
+    #[test]
+    fn scan_hex_with_prefix() {
+        let mut a: c_int = 0;
+        // SAFETY: the pointer is valid and matches the `%x` conversion.
+        let n = unsafe { run(c"0xff".as_ptr(), c"%x".as_ptr(), &raw mut a) };
+        assert_eq!(n, 1);
+        assert_eq!(a, 255);
+    }
+
+    #[test]
+    fn scan_string() {
+        let mut buf = [0 as c_char; 8];
+        // SAFETY: the buffer is large enough for "hello" plus a null terminator.
+        let n = unsafe { run(c"hello world".as_ptr(), c"%s".as_ptr(), buf.as_mut_ptr()) };
+        assert_eq!(n, 1);
+        assert_eq!(cstr_bytes(&buf), b"hello");
+    }
+
+    #[test]
+    fn scan_respects_field_width() {
+        let mut a: c_int = 0;
+        let mut b: c_int = 0;
+        // SAFETY: both pointers are valid and match the width-limited `%d` conversions.
+        let n = unsafe { run(c"1234".as_ptr(), c"%2d%2d".as_ptr(), &raw mut a, &raw mut b) };
+        assert_eq!(n, 2);
+        assert_eq!(a, 12);
+        assert_eq!(b, 34);
+    }
+
+    #[test]
+    fn scan_suppresses_assignment() {
+        let mut a: c_int = 0;
+        // SAFETY: the single pointer matches the non-suppressed `%d` conversion.
+        let n = unsafe { run(c"7 8".as_ptr(), c"%*d %d".as_ptr(), &raw mut a) };
+        assert_eq!(n, 1);
+        assert_eq!(a, 8);
+    }
+
+    #[test]
+    fn scan_reports_eof_on_empty_input() {
+        let mut a: c_int = 0;
+        // SAFETY: the pointer is valid; no conversion will be performed.
+        let n = unsafe { run(c"".as_ptr(), c"%d".as_ptr(), &raw mut a) };
+        assert_eq!(n, -1);
+    }
+
+    #[test]
+    fn scan_stops_at_matching_failure() {
+        let mut a: c_int = 0;
+        let mut b: c_int = 0;
+        // SAFETY: both pointers are valid; the second conversion fails to match.
+        let n = unsafe { run(c"12 xy".as_ptr(), c"%d %d".as_ptr(), &raw mut a, &raw mut b) };
+        assert_eq!(n, 1);
+        assert_eq!(a, 12);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an initial stdio.h implementation as a new `libc_stdio` library under `src/libs`.

## Changes

- New `src/libs/libc_stdio` crate wiring (`Cargo.toml`, `header.toml`) and workspace/Makefile integration.
- File stream APIs: `fopen`, `fdopen`, `fclose`, `fflush`, `fread`, `fwrite`, `fseek`, `ftell`, `rewind`, `setbuf`, `tmpfile`, `fileno`.
- Character/string I/O: `fgetc`, `getchar`, `fputc`, `putchar`, `fgets`, `fputs`, `puts`, `ungetc`.
- Formatted I/O: `printf`/`fprintf`/`sprintf`/`snprintf` family plus `v*` variants, `swprintf`, and `sscanf`/`vsscanf` with a shared `format_engine`.
- Status/error helpers: `feof`, `ferror`, `clearerr`, `perror`.
- File ops: `remove`, `rename`.

## Status

Draft — work in progress.