### PR TITLE
[sysapi] Fix cross-arch IPC wire compatibility

### DIFF
--- a/src/daemons/linuxd/src/linux/fcntl.rs
+++ b/src/daemons/linuxd/src/linux/fcntl.rs
@@ -368,6 +368,7 @@ pub fn do_renameat<T>(
 // do_fstatat
 //==================================================================================================
 
+#[cfg_attr(target_arch = "x86_64", allow(clippy::useless_conversion))]
 pub fn do_fstat_at<T>(
     syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
@@ -575,6 +576,7 @@ pub fn do_posix_fadvise<T>(
 // do_fstat()
 //==================================================================================================
 
+#[cfg_attr(target_arch = "x86_64", allow(clippy::useless_conversion))]
 pub fn do_fstat<T>(
     syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,

--- a/src/daemons/linuxd/src/linux/sys_select.rs
+++ b/src/daemons/linuxd/src/linux/sys_select.rs
@@ -31,6 +31,7 @@ use ::sys::{
 };
 use ::sysapi::sys_select::{
     fd_set,
+    timeval,
     FdSetError,
     FD_SETSIZE,
 };
@@ -67,7 +68,14 @@ pub fn do_select<T>(
         tv_sec: 0,
         tv_usec: 0,
     };
-    let timeout_ptr: *mut libc::timeval = if let Some(tv) = request.timeout {
+    let timeout_ptr: *mut libc::timeval = if let Some(bytes) = request.timeout {
+        let tv: timeval = match timeval::try_from_bytes(&bytes) {
+            Ok(tv) => tv,
+            Err(e) => {
+                error!("select(): invalid timeout payload (error={e:?})");
+                return Ok(crate::build_error(tid, ErrorCode::InvalidMessage));
+            },
+        };
         timeout_storage.tv_sec = tv.tv_sec as libc::time_t;
         timeout_storage.tv_usec = tv.tv_usec as libc::suseconds_t;
         &mut timeout_storage

--- a/src/daemons/linuxd/src/time.rs
+++ b/src/daemons/linuxd/src/time.rs
@@ -33,6 +33,7 @@ impl From<LibcTimeSpec> for libc::timespec {
     }
 }
 
+#[cfg_attr(target_arch = "x86_64", allow(clippy::useless_conversion))]
 impl TryFrom<LibcTimeSpec> for timespec {
     type Error = Error;
 
@@ -47,6 +48,7 @@ impl TryFrom<LibcTimeSpec> for timespec {
     }
 }
 
+#[cfg_attr(target_arch = "x86_64", allow(clippy::useless_conversion))]
 impl From<timespec> for LibcTimeSpec {
     fn from(tp: timespec) -> Self {
         LibcTimeSpec(libc::timespec {

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -890,7 +890,7 @@ impl WorkerThreadHandle {
                 unistd::do_lseek(&syscall_table, source, request)
             },
             SystemCallMessageHeader::SelectRequest => {
-                let request: SelectRequest = SelectRequest::from_bytes(message.payload);
+                let request: SelectRequest = SelectRequest::from_bytes(message.payload)?;
                 sys_select::do_select(&syscall_table, source, request)
             },
             SystemCallMessageHeader::SendSocketRequest => {
@@ -908,7 +908,7 @@ impl WorkerThreadHandle {
             },
             SystemCallMessageHeader::UpdateFileAccessTimeRequest => {
                 let request: UpdateFileAccessTimeRequest =
-                    UpdateFileAccessTimeRequest::from_bytes(message.payload);
+                    UpdateFileAccessTimeRequest::from_bytes(message.payload)?;
                 fcntl::do_futimens(&syscall_table, source, request)
             },
             SystemCallMessageHeader::PipeRequest => {

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -168,7 +168,11 @@ pub(crate) fn handle_fchown(source: ThreadIdentifier, msg: SystemCallMessage) ->
 }
 
 pub(crate) fn handle_futimens(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
-    let req: UpdateFileAccessTimeRequest = UpdateFileAccessTimeRequest::from_bytes(msg.payload);
+    let req: UpdateFileAccessTimeRequest =
+        match UpdateFileAccessTimeRequest::from_bytes(msg.payload) {
+            Ok(req) => req,
+            Err(e) => return build_error(source, e.code),
+        };
     let fd: i32 = req.fd;
     // futimens is a no-op in our VFS.
     ::syslog::trace!("handle_futimens(): stubbed (fd={})", fd);

--- a/src/libs/sysapi/src/dirent.rs
+++ b/src/libs/sysapi/src/dirent.rs
@@ -65,14 +65,13 @@ pub mod dirent_file_type {
 ///
 /// Directory entry.
 ///
-#[repr(C, packed)]
+#[repr(C)]
 pub struct dirent {
     /// File serial number.
     pub d_ino: ino_t,
     /// File name (including null terminator character).
     pub d_name: [c_uchar; NAME_MAX + 1],
 }
-::static_assert::assert_eq_size!(dirent, dirent::_SIZE_OF_DIRENT);
 
 impl dirent {
     /// Size of `d_ino` field, used for static assertions.
@@ -112,7 +111,7 @@ impl Default for dirent {
 ///
 /// A type representing a POSIX directory entry.
 ///
-#[repr(C, packed)]
+#[repr(C)]
 pub struct posix_dent {
     /// File serial number.
     pub d_ino: ino_t,
@@ -125,7 +124,7 @@ pub struct posix_dent {
     /// Padding.
     pub _padding: [c_char; 1],
 }
-::static_assert::assert_eq_size!(posix_dent, posix_dent::_SIZE_OF_POSIX_DIRENT);
+// Serialized size may differ from sizeof on 64-bit targets due to trailing alignment padding.
 
 impl posix_dent {
     /// Size of `d_ino` field, used for static assertions.

--- a/src/libs/sysapi/src/ffi.rs
+++ b/src/libs/sysapi/src/ffi.rs
@@ -12,31 +12,61 @@
 //==================================================================================================
 
 /// 32-Bit Foreign Function Interface
-mod bits32 {
-    // Equivalent to C’s signed char type.
+#[cfg(target_pointer_width = "32")]
+mod bits {
+    // Equivalent to C's signed char type.
     pub type c_schar = i8;
-    // Equivalent to C’s char type.
+    // Equivalent to C's char type.
     pub type c_char = i8;
-    // Equivalent to C’s short type.
+    // Equivalent to C's short type.
     pub type c_short = i16;
-    // Equivalent to C’s signed int type.
+    // Equivalent to C's signed int type.
     pub type c_int = i32;
-    // Equivalent to C’s signed long type.
+    // Equivalent to C's signed long type.
     pub type c_long = i32;
-    // Equivalent to C’s signed long long type.
+    // Equivalent to C's signed long long type.
     pub type c_longlong = i64;
-    // Equivalent to C’s unsigned char type.
+    // Equivalent to C's unsigned char type.
     pub type c_uchar = u8;
-    // Equivalent to C’s unsigned short type.
+    // Equivalent to C's unsigned short type.
     pub type c_ushort = u16;
-    // Equivalent to C’s unsigned int type.
+    // Equivalent to C's unsigned int type.
     pub type c_uint = u32;
-    // Equivalent to C’s unsigned long type.
+    // Equivalent to C's unsigned long type.
     pub type c_ulong = u32;
-    // Equivalent to C’s unsigned long long type.
+    // Equivalent to C's unsigned long long type.
     pub type c_ulonglong = u64;
-    // Equivalent to C’s void pointer type.
+    // Equivalent to C's void pointer type.
     pub type c_void = core::ffi::c_void;
 }
 
-pub use bits32::*;
+/// 64-Bit Foreign Function Interface (LP64)
+#[cfg(target_pointer_width = "64")]
+mod bits {
+    // Equivalent to C's signed char type.
+    pub type c_schar = i8;
+    // Equivalent to C's char type.
+    pub type c_char = i8;
+    // Equivalent to C's short type.
+    pub type c_short = i16;
+    // Equivalent to C's signed int type.
+    pub type c_int = i32;
+    // Equivalent to C's signed long type (LP64: long = 64-bit).
+    pub type c_long = i64;
+    // Equivalent to C's signed long long type.
+    pub type c_longlong = i64;
+    // Equivalent to C's unsigned char type.
+    pub type c_uchar = u8;
+    // Equivalent to C's unsigned short type.
+    pub type c_ushort = u16;
+    // Equivalent to C's unsigned int type.
+    pub type c_uint = u32;
+    // Equivalent to C's unsigned long type (LP64: unsigned long = 64-bit).
+    pub type c_ulong = u64;
+    // Equivalent to C's unsigned long long type.
+    pub type c_ulonglong = u64;
+    // Equivalent to C's void pointer type.
+    pub type c_void = core::ffi::c_void;
+}
+
+pub use bits::*;

--- a/src/libs/sysapi/src/sys_select.rs
+++ b/src/libs/sysapi/src/sys_select.rs
@@ -25,10 +25,10 @@ use ::core::mem::size_of;
 //==================================================================================================
 
 /// Microseconds in a second.
-const MICROSECONDS_PER_SECOND: i32 = 1_000_000;
+const MICROSECONDS_PER_SECOND: suseconds_t = 1_000_000;
 
 /// Nanoseconds in a second.
-const NANOSECONDS_PER_SECOND: i32 = 1_000_000_000;
+const NANOSECONDS_PER_SECOND: suseconds_t = 1_000_000_000;
 
 /// Maximum number of file descriptors tracked by [`fd_set`].
 pub const FD_SETSIZE: usize = 64;
@@ -278,6 +278,59 @@ impl fd_set {
             (*fd_set).zero();
         }
     }
+
+    /// Fixed-width size of the wire encoding produced by [`fd_set::to_bytes()`].
+    ///
+    /// This is independent of the width of [`c_ulong`] (4 bytes on x86 ILP32 guests, 8 bytes on
+    /// x86_64 LP64 hosts), so the on-the-wire representation is identical across targets.
+    pub const WIRE_SIZE: usize = FD_SET_WORD_COUNT * size_of::<c_ulong>();
+
+    ///
+    /// # Description
+    ///
+    /// Serializes the file descriptor set into its fixed-width wire representation.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a byte array holding the wire encoding of the file descriptor set.
+    ///
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
+        let mut bytes: [u8; Self::WIRE_SIZE] = [0; Self::WIRE_SIZE];
+        // Operate through a raw pointer to avoid creating an unaligned reference to a packed field.
+        let base: *const c_ulong = ::core::ptr::addr_of!(self.fds_bits) as *const c_ulong;
+        for index in 0..FD_SET_WORD_COUNT {
+            // SAFETY: `index` is within the bounds of `fds_bits`.
+            let word: c_ulong = unsafe { base.add(index).read_unaligned() };
+            let offset: usize = index * size_of::<c_ulong>();
+            bytes[offset..offset + size_of::<c_ulong>()].copy_from_slice(&word.to_ne_bytes());
+        }
+        bytes
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Deserializes a file descriptor set from the fixed-width wire representation produced by
+    /// [`fd_set::to_bytes()`].
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Wire encoding of the file descriptor set.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the reconstructed file descriptor set.
+    ///
+    pub fn from_bytes(bytes: [u8; Self::WIRE_SIZE]) -> Self {
+        let mut fds_bits: [c_ulong; FD_SET_WORD_COUNT] = [0; FD_SET_WORD_COUNT];
+        for (index, word) in fds_bits.iter_mut().enumerate() {
+            let offset: usize = index * size_of::<c_ulong>();
+            let mut buffer: [u8; size_of::<c_ulong>()] = [0; size_of::<c_ulong>()];
+            buffer.copy_from_slice(&bytes[offset..offset + size_of::<c_ulong>()]);
+            *word = c_ulong::from_ne_bytes(buffer);
+        }
+        Self { fds_bits }
+    }
 }
 
 impl Default for fd_set {
@@ -295,6 +348,82 @@ pub struct timeval {
     pub tv_sec: time_t,
     /// Nano-seconds.
     pub tv_usec: suseconds_t,
+}
+
+/// Errors that can occur when serializing or deserializing a [`timeval`] wire payload.
+#[derive(Debug, Clone, Copy)]
+pub enum TimevalError {
+    /// Error code indicating an invalid array size.
+    InvalidArraySize,
+    /// Error code indicating failure to parse `tv_sec` field.
+    FailedToParseTvSec,
+    /// Error code indicating failure to parse `tv_usec` field.
+    FailedToParseTvUsec,
+}
+
+impl timeval {
+    /// Size of the seconds field.
+    const SIZE_OF_TV_SEC: usize = size_of::<time_t>();
+    /// Offset of the seconds field.
+    const OFFSET_OF_TV_SEC: usize = 0;
+    /// Offset of the micro-seconds field.
+    const OFFSET_OF_TV_USEC: usize = Self::OFFSET_OF_TV_SEC + Self::SIZE_OF_TV_SEC;
+
+    /// Wire format always uses i64 (8 bytes) for `tv_usec`, ensuring IPC compatibility
+    /// between x86 guests (`c_long=i32`) and x86_64 hosts (`c_long=i64`).
+    const WIRE_SIZE_OF_TV_USEC: usize = size_of::<i64>();
+    /// Wire format size for IPC serialization (always 16 bytes).
+    pub const WIRE_SIZE: usize = Self::SIZE_OF_TV_SEC + Self::WIRE_SIZE_OF_TV_USEC;
+
+    /// Converts a `timeval` structure to a wire-format byte array.
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
+        let mut bytes: [u8; Self::WIRE_SIZE] = [0; Self::WIRE_SIZE];
+
+        // Convert seconds field.
+        bytes[Self::OFFSET_OF_TV_SEC..Self::OFFSET_OF_TV_SEC + Self::SIZE_OF_TV_SEC]
+            .copy_from_slice(&self.tv_sec.to_ne_bytes());
+
+        // Convert micro-seconds field (always as i64 for IPC compatibility).
+        // Cast is needed on x86 (c_long=i32→i64) but is a no-op on x86_64 (c_long=i64).
+        #[cfg_attr(target_arch = "x86_64", allow(clippy::unnecessary_cast))]
+        let usec_bytes = (self.tv_usec as i64).to_ne_bytes();
+        bytes[Self::OFFSET_OF_TV_USEC..Self::OFFSET_OF_TV_USEC + Self::WIRE_SIZE_OF_TV_USEC]
+            .copy_from_slice(&usec_bytes);
+
+        bytes
+    }
+
+    /// Tries to convert a `timeval` structure from a wire-format byte array.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, TimevalError> {
+        // Check if the array has the correct wire size.
+        if bytes.len() != Self::WIRE_SIZE {
+            return Err(TimevalError::InvalidArraySize);
+        }
+
+        // Parse seconds field.
+        let tv_sec: time_t = time_t::from_ne_bytes(
+            bytes[Self::OFFSET_OF_TV_SEC..Self::OFFSET_OF_TV_SEC + Self::SIZE_OF_TV_SEC]
+                .try_into()
+                .map_err(|_| TimevalError::FailedToParseTvSec)?,
+        );
+
+        // Parse micro-seconds field (always read as i64, then convert to suseconds_t).
+        // The checked conversion rejects out-of-range values instead of silently wrapping on
+        // 32-bit targets where suseconds_t (c_long) is narrower than the i64 wire value.
+        let raw_tv_usec: i64 = i64::from_ne_bytes(
+            bytes[Self::OFFSET_OF_TV_USEC..Self::OFFSET_OF_TV_USEC + Self::WIRE_SIZE_OF_TV_USEC]
+                .try_into()
+                .map_err(|_| TimevalError::FailedToParseTvUsec)?,
+        );
+        #[cfg_attr(
+            target_arch = "x86_64",
+            allow(clippy::unnecessary_fallible_conversions)
+        )]
+        let tv_usec: suseconds_t =
+            suseconds_t::try_from(raw_tv_usec).map_err(|_| TimevalError::FailedToParseTvUsec)?;
+
+        Ok(Self { tv_sec, tv_usec })
+    }
 }
 
 /// Errors that can occur when converting a `timeval` to a `timespec`.

--- a/src/libs/sysapi/src/sys_stat.rs
+++ b/src/libs/sysapi/src/sys_stat.rs
@@ -168,7 +168,7 @@ pub enum StatError {
 
 /// File status structure.
 #[derive(Default, Debug, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct stat {
     /// Device ID.
     pub st_dev: dev_t,
@@ -197,7 +197,8 @@ pub struct stat {
     /// Number of blocks allocated.
     pub st_blocks: blkcnt_t,
 }
-::static_assert::assert_eq_size!(stat, stat::SIZE);
+// The serialized size (stat::SIZE) is the packed wire format without padding.
+// The in-memory size (sizeof stat) may differ due to alignment padding on 64-bit targets.
 
 impl stat {
     /// Size of the device ID field.
@@ -216,16 +217,16 @@ impl stat {
     const SIZE_OF_ST_RDEV: usize = size_of::<dev_t>();
     /// Size of the file size field.
     const SIZE_OF_ST_SIZE: usize = size_of::<off_t>();
-    /// Size of the last access time field.
-    const SIZE_OF_ST_ATIM: usize = size_of::<timespec>();
-    /// Size of the last modification time field.
-    const SIZE_OF_ST_MTIM: usize = size_of::<timespec>();
-    /// Size of the last status change time field.
-    const SIZE_OF_ST_CTIM: usize = size_of::<timespec>();
-    /// Size of the block size field.
-    const SIZE_OF_ST_BLKSIZE: usize = size_of::<blksize_t>();
-    /// Size of the number of blocks allocated field.
-    const SIZE_OF_ST_BLOCKS: usize = size_of::<blkcnt_t>();
+    /// Wire size of the last access time field (always 16 bytes for IPC).
+    const SIZE_OF_ST_ATIM: usize = timespec::WIRE_SIZE;
+    /// Wire size of the last modification time field (always 16 bytes for IPC).
+    const SIZE_OF_ST_MTIM: usize = timespec::WIRE_SIZE;
+    /// Wire size of the last status change time field (always 16 bytes for IPC).
+    const SIZE_OF_ST_CTIM: usize = timespec::WIRE_SIZE;
+    /// Wire size of the block size field (always 8 bytes for IPC; blksize_t = c_longlong).
+    const SIZE_OF_ST_BLKSIZE: usize = size_of::<i64>();
+    /// Wire size of the blocks-allocated field (always 8 bytes for IPC; blkcnt_t = c_longlong).
+    const SIZE_OF_ST_BLOCKS: usize = size_of::<i64>();
     /// Offset of the device ID field.
     const OFFSET_OF_ST_DEV: usize = 0;
     /// Offset of the file serial number field.
@@ -253,7 +254,8 @@ impl stat {
     /// Offset of the number of blocks allocated field.
     const OFFSET_OF_ST_BLOCKS: usize = Self::OFFSET_OF_ST_BLKSIZE + Self::SIZE_OF_ST_BLKSIZE;
 
-    /// Size of the structure.
+    /// Serialized (wire-format) size of the structure. Always 104 bytes regardless of target,
+    /// ensuring IPC compatibility between x86 guests and x86_64 hosts.
     pub const SIZE: usize = Self::SIZE_OF_ST_DEV
         + Self::SIZE_OF_ST_INO
         + Self::SIZE_OF_ST_MODE
@@ -316,13 +318,15 @@ impl stat {
         bytes[Self::OFFSET_OF_ST_CTIM..Self::OFFSET_OF_ST_CTIM + Self::SIZE_OF_ST_CTIM]
             .copy_from_slice(&self.st_ctim.to_bytes());
 
-        // Convert block size field.
+        // Convert block size field (already 64-bit: blksize_t = c_longlong).
+        let blksize_bytes = self.st_blksize.to_ne_bytes();
         bytes[Self::OFFSET_OF_ST_BLKSIZE..Self::OFFSET_OF_ST_BLKSIZE + Self::SIZE_OF_ST_BLKSIZE]
-            .copy_from_slice(&self.st_blksize.to_ne_bytes());
+            .copy_from_slice(&blksize_bytes);
 
-        // Convert number of blocks allocated field.
+        // Convert number of blocks allocated field (already 64-bit: blkcnt_t = c_longlong).
+        let blocks_bytes = self.st_blocks.to_ne_bytes();
         bytes[Self::OFFSET_OF_ST_BLOCKS..Self::OFFSET_OF_ST_BLOCKS + Self::SIZE_OF_ST_BLOCKS]
-            .copy_from_slice(&self.st_blocks.to_ne_bytes());
+            .copy_from_slice(&blocks_bytes);
 
         bytes
     }
@@ -408,7 +412,7 @@ impl stat {
         )
         .map_err(|_| StatError::FailedToParseCtim)?;
 
-        // Parse block size field.
+        // Parse block size field (blksize_t = c_longlong = i64 on all targets).
         let st_blksize: blksize_t = blksize_t::from_ne_bytes(
             bytes
                 [Self::OFFSET_OF_ST_BLKSIZE..Self::OFFSET_OF_ST_BLKSIZE + Self::SIZE_OF_ST_BLKSIZE]
@@ -416,7 +420,7 @@ impl stat {
                 .map_err(|_| StatError::FailedToParseBlksize)?,
         );
 
-        // Parse number of blocks allocated field.
+        // Parse number of blocks allocated field (blkcnt_t = c_longlong = i64 on all targets).
         let st_blocks: blkcnt_t = blkcnt_t::from_ne_bytes(
             bytes[Self::OFFSET_OF_ST_BLOCKS..Self::OFFSET_OF_ST_BLOCKS + Self::SIZE_OF_ST_BLOCKS]
                 .try_into()

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -34,7 +34,6 @@ use ::config::memory_layout::{
 };
 use ::core::mem::size_of;
 
-#[cfg(target_pointer_width = "32")]
 use crate::sys_uio::iovec;
 
 //==================================================================================================
@@ -119,7 +118,7 @@ pub type uid_t = c_uint;
 
 /// Thread attributes.
 #[derive(Debug, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct pthread_attr_t {
     pub is_initialized: c_int,
     pub stackaddr: *mut c_void,
@@ -131,7 +130,8 @@ pub struct pthread_attr_t {
     pub cputime_clock_allowed: c_int,
     pub detachstate: c_int,
 }
-::static_assert::assert_eq_size!(pthread_attr_t, pthread_attr_t::_SIZE);
+// No `assert_eq_size!`: the serialized size may differ from `sizeof` on 64-bit targets due to
+// alignment padding.
 
 impl pthread_attr_t {
     /// Size of the `is_initialized` field.
@@ -188,14 +188,15 @@ impl Default for pthread_attr_t {
 /// Condition variable attributes.
 ///
 #[derive(Debug, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct pthread_condattr_t {
     /// Whether the condition variable attributes are initialized.
     is_initialized: c_int,
     /// Clock used for timeouts.
     clock: clock_t,
 }
-::static_assert::assert_eq_size!(pthread_condattr_t, pthread_condattr_t::SIZE);
+// No `assert_eq_size!`: the serialized size may differ from `sizeof` on 64-bit targets due to
+// alignment padding.
 
 impl pthread_condattr_t {
     // Size of the `is_initialized` field.
@@ -433,6 +434,26 @@ impl msghdr {
         + Self::SIZE_OF_MSG_CONTROL
         + Self::SIZE_OF_MSG_CONTROLLEN
         + Self::SIZE_OF_MSG_FLAGS;
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+#[cfg(target_pointer_width = "64")]
+pub struct msghdr {
+    /// Optional address.
+    pub msg_name: *mut c_void,
+    // Size of the address.
+    pub msg_namelen: socklen_t,
+    // Scatter/gather array of message blocks.
+    pub msg_iov: *mut iovec,
+    /// Number of member in `msg_iov`.
+    pub msg_iovlen: size_t,
+    /// Ancillary data.
+    pub msg_control: *mut c_void,
+    /// Ancillary data buffer length.
+    pub msg_controllen: size_t,
+    /// Flags.
+    pub msg_flags: c_int,
 }
 
 /// Header for ancililary data data objects in msg_control buffer in `msghdr`.

--- a/src/libs/sysapi/src/sys_uio.rs
+++ b/src/libs/sysapi/src/sys_uio.rs
@@ -11,14 +11,12 @@
 // Imports
 //==================================================================================================
 
-#[cfg(target_pointer_width = "32")]
 use crate::sys_types::size_t;
 
 //==================================================================================================
 
 /// An I/O vector.
-#[cfg(target_pointer_width = "32")]
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct iovec {
     /// Base address of a memory region for input or output.

--- a/src/libs/sysapi/src/time.rs
+++ b/src/libs/sysapi/src/time.rs
@@ -49,6 +49,7 @@ pub mod clock_ids {
 // TODO: define tms structure here.
 
 /// Errors for the `timespec` structure.
+#[derive(Debug)]
 pub enum TimespecError {
     /// Error code indicating an invalid array size.
     InvalidArraySize,
@@ -79,27 +80,37 @@ impl timespec {
     /// Offset of the nano-seconds field.
     const OFFSET_OF_TV_NSEC: usize = Self::OFFSET_OF_TV_SEC + Self::SIZE_OF_TV_SEC;
 
+    /// In-memory size (matches `repr(C, packed)` layout, varies by target).
     const SIZE: usize = Self::SIZE_OF_TV_SEC + Self::SIZE_OF_TV_NSEC;
 
-    /// Converts a time spec structure to a byte array.
-    pub fn to_bytes(&self) -> [u8; Self::SIZE] {
-        let mut bytes: [u8; Self::SIZE] = [0; Self::SIZE];
+    /// Wire format always uses i64 (8 bytes) for tv_nsec, ensuring IPC compatibility
+    /// between x86 guests (c_long=i32) and x86_64 hosts (c_long=i64).
+    const WIRE_SIZE_OF_TV_NSEC: usize = size_of::<i64>();
+    /// Wire format size for IPC serialization (always 16 bytes).
+    pub const WIRE_SIZE: usize = Self::SIZE_OF_TV_SEC + Self::WIRE_SIZE_OF_TV_NSEC;
+
+    /// Converts a time spec structure to a wire-format byte array.
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_SIZE] {
+        let mut bytes: [u8; Self::WIRE_SIZE] = [0; Self::WIRE_SIZE];
 
         // Convert seconds field.
         bytes[Self::OFFSET_OF_TV_SEC..Self::OFFSET_OF_TV_SEC + Self::SIZE_OF_TV_SEC]
             .copy_from_slice(&self.tv_sec.to_ne_bytes());
 
-        // Convert nano-seconds field.
-        bytes[Self::OFFSET_OF_TV_NSEC..Self::OFFSET_OF_TV_NSEC + Self::SIZE_OF_TV_NSEC]
-            .copy_from_slice(&self.tv_nsec.to_ne_bytes());
+        // Convert nano-seconds field (always as i64 for IPC compatibility).
+        // Cast is needed on x86 (c_long=i32→i64) but is a no-op on x86_64 (c_long=i64).
+        #[cfg_attr(target_arch = "x86_64", allow(clippy::unnecessary_cast))]
+        let nsec_bytes = (self.tv_nsec as i64).to_ne_bytes();
+        bytes[Self::OFFSET_OF_TV_NSEC..Self::OFFSET_OF_TV_NSEC + Self::WIRE_SIZE_OF_TV_NSEC]
+            .copy_from_slice(&nsec_bytes);
 
         bytes
     }
 
-    /// Tries to convert a time spec structure from a byte array.
+    /// Tries to convert a time spec structure from a wire-format byte array.
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, TimespecError> {
-        // Check if the array has the correct size.
-        if bytes.len() != Self::SIZE {
+        // Check if the array has the correct wire size.
+        if bytes.len() != Self::WIRE_SIZE {
             return Err(TimespecError::InvalidArraySize);
         }
 
@@ -110,12 +121,20 @@ impl timespec {
                 .map_err(|_| TimespecError::FailedToParseTvSec)?,
         );
 
-        // Parse nano-seconds field.
-        let tv_nsec: c_long = c_long::from_ne_bytes(
-            bytes[Self::OFFSET_OF_TV_NSEC..Self::OFFSET_OF_TV_NSEC + Self::SIZE_OF_TV_NSEC]
+        // Parse nano-seconds field (always read as i64, then convert to c_long).
+        // The checked conversion rejects out-of-range values instead of silently wrapping on
+        // 32-bit targets where c_long is narrower than the i64 wire value.
+        let raw_tv_nsec: i64 = i64::from_ne_bytes(
+            bytes[Self::OFFSET_OF_TV_NSEC..Self::OFFSET_OF_TV_NSEC + Self::WIRE_SIZE_OF_TV_NSEC]
                 .try_into()
                 .map_err(|_| TimespecError::FailedToParseTvNsec)?,
         );
+        #[cfg_attr(
+            target_arch = "x86_64",
+            allow(clippy::unnecessary_fallible_conversions)
+        )]
+        let tv_nsec: c_long =
+            c_long::try_from(raw_tv_nsec).map_err(|_| TimespecError::FailedToParseTvNsec)?;
 
         Ok(Self { tv_sec, tv_nsec })
     }

--- a/src/libs/syscall/src/safe/time.rs
+++ b/src/libs/syscall/src/safe/time.rs
@@ -168,7 +168,7 @@ impl From<Time> for timespec {
     fn from(time: Time) -> Self {
         timespec {
             tv_sec: time.0.seconds() as i64,
-            tv_nsec: time.0.nanoseconds() as i32,
+            tv_nsec: time.0.nanoseconds() as sysapi::ffi::c_long,
         }
     }
 }

--- a/src/libs/syscall/src/sys/mount/bindings/mount.rs
+++ b/src/libs/syscall/src/sys/mount/bindings/mount.rs
@@ -52,6 +52,8 @@ use ::syslog::trace_syscall;
 ///
 #[trace_syscall]
 #[unsafe(no_mangle)]
+// `flags as u64` widens `c_ulong` (u32) on x86 but is an identity cast on x86_64 (c_ulong = u64).
+#[cfg_attr(target_arch = "x86_64", allow(clippy::unnecessary_cast))]
 pub unsafe extern "C" fn mount(
     source: *const c_char,
     target: *const c_char,

--- a/src/libs/syscall/src/sys/select/message/mod.rs
+++ b/src/libs/syscall/src/sys/select/message/mod.rs
@@ -33,11 +33,50 @@ use ::sysapi::sys_select::{
 };
 
 //==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Encodes an optional [`fd_set`] at `offset` as a one-byte presence flag (`0` = absent,
+/// `1` = present) followed by the set's fixed-width wire payload. A `None` value leaves the
+/// zero-initialized flag and payload untouched.
+fn encode_optional_fd_set(bytes: &mut [u8], offset: usize, value: Option<fd_set>) {
+    if let Some(set) = value {
+        bytes[offset] = 1;
+        bytes[offset + 1..offset + 1 + fd_set::WIRE_SIZE].copy_from_slice(&set.to_bytes());
+    }
+}
+
+/// Decodes an optional [`fd_set`] encoded by [`encode_optional_fd_set()`].
+fn decode_optional_fd_set(bytes: &[u8], offset: usize) -> Result<Option<fd_set>, Error> {
+    match bytes[offset] {
+        0 => Ok(None),
+        1 => {
+            let mut payload: [u8; fd_set::WIRE_SIZE] = [0; fd_set::WIRE_SIZE];
+            payload.copy_from_slice(&bytes[offset + 1..offset + 1 + fd_set::WIRE_SIZE]);
+            Ok(Some(fd_set::from_bytes(payload)))
+        },
+        _ => Err(Error::new(
+            ErrorCode::InvalidMessage,
+            "invalid fd_set presence flag in select message",
+        )),
+    }
+}
+
+//==================================================================================================
 // SelectRequest
 //==================================================================================================
 
 /// Request message for the `select()` system call.
-#[repr(C, packed)]
+///
+/// The payload is serialized with an explicit, offset-based wire layout (rather than relying on
+/// the in-memory representation of `Option<...>` fields) so that a 32-bit guest and a 64-bit host
+/// interoperate byte-for-byte:
+///
+/// `nfds (1) | readfds (1 + fd_set::WIRE_SIZE) | writefds (1 + fd_set::WIRE_SIZE) |
+///  errorfds (1 + fd_set::WIRE_SIZE) | timeout (1 + timeval::WIRE_SIZE)` followed by padding.
+///
+/// Each optional field is prefixed by a one-byte presence flag (`0` = absent, `1` = present).
+#[derive(Debug)]
 pub struct SelectRequest {
     /// Number of file descriptors in each set (must be <= FD_SETSIZE).
     pub nfds: u8,
@@ -47,24 +86,35 @@ pub struct SelectRequest {
     pub writefds: Option<fd_set>,
     /// Error/exception file descriptors of interest.
     pub errorfds: Option<fd_set>,
-    /// Timeout.
-    pub timeout: Option<timeval>,
-    /// Required padding.
-    _padding: [u8; Self::PADDING_SIZE],
+    /// Timeout, encoded in `timeval`'s fixed-width wire format for cross-architecture IPC.
+    pub timeout: Option<[u8; timeval::WIRE_SIZE]>,
 }
-::static_assert::assert_eq_size!(SelectRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+// Ensure the fixed-width wire layout fits within the payload, so the manual offsets/slices in
+// `from_bytes()`/`into_bytes()` cannot overflow `PAYLOAD_SIZE` and panic at runtime.
+::static_assert::assert_eq!(SelectRequest::WIRE_SIZE <= SystemCallMessage::PAYLOAD_SIZE);
 
 // Ensure that the maximum number of file descriptors can be encoded in a `u8`.
 ::static_assert::assert_eq!(FD_SETSIZE < u8::MAX as usize);
 
 impl SelectRequest {
-    /// Size of the padding field.
-    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
-        - mem::size_of::<u8>()
-        - mem::size_of::<Option<fd_set>>()
-        - mem::size_of::<Option<fd_set>>()
-        - mem::size_of::<Option<fd_set>>()
-        - mem::size_of::<Option<timeval>>();
+    /// Wire size of an optional `fd_set` field (presence flag + set payload).
+    const OPTIONAL_FD_SET_WIRE_SIZE: usize = mem::size_of::<u8>() + fd_set::WIRE_SIZE;
+    /// Wire size of the optional timeout field (presence flag + timeval payload).
+    const OPTIONAL_TIMEOUT_WIRE_SIZE: usize = mem::size_of::<u8>() + timeval::WIRE_SIZE;
+
+    /// Offset of the `nfds` field.
+    const OFFSET_NFDS: usize = 0;
+    /// Offset of the read file descriptor set.
+    const OFFSET_READFDS: usize = Self::OFFSET_NFDS + mem::size_of::<u8>();
+    /// Offset of the write file descriptor set.
+    const OFFSET_WRITEFDS: usize = Self::OFFSET_READFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
+    /// Offset of the error file descriptor set.
+    const OFFSET_ERRORFDS: usize = Self::OFFSET_WRITEFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
+    /// Offset of the timeout field.
+    const OFFSET_TIMEOUT: usize = Self::OFFSET_ERRORFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
+    /// Total number of meaningful wire bytes.
+    const WIRE_SIZE: usize = Self::OFFSET_TIMEOUT + Self::OPTIONAL_TIMEOUT_WIRE_SIZE;
 
     /// Creates a new `SelectRequest`.
     fn new(
@@ -79,19 +129,61 @@ impl SelectRequest {
             readfds: readfds.as_ref().map(|fd_set| **fd_set),
             writefds: writefds.as_ref().map(|fd_set| **fd_set),
             errorfds: errorfds.as_ref().map(|fd_set| **fd_set),
-            timeout: *timeout,
-            _padding: [0; Self::PADDING_SIZE],
+            timeout: timeout.as_ref().map(|tv| tv.to_bytes()),
         }
     }
 
-    /// Deserializes a request from raw bytes.
-    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
-        unsafe { mem::transmute(bytes) }
+    /// Deserializes a request from its fixed-width wire representation.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Result<Self, Error> {
+        let nfds: u8 = bytes[Self::OFFSET_NFDS];
+        // Reject messages whose number of file descriptors exceeds the wire contract bound.
+        if nfds as usize > FD_SETSIZE {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "number of file descriptors exceeds maximum supported in select message",
+            ));
+        }
+        let readfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_READFDS)?;
+        let writefds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_WRITEFDS)?;
+        let errorfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_ERRORFDS)?;
+        let timeout: Option<[u8; timeval::WIRE_SIZE]> = match bytes[Self::OFFSET_TIMEOUT] {
+            0 => None,
+            1 => {
+                let mut payload: [u8; timeval::WIRE_SIZE] = [0; timeval::WIRE_SIZE];
+                payload.copy_from_slice(
+                    &bytes[Self::OFFSET_TIMEOUT + 1..Self::OFFSET_TIMEOUT + 1 + timeval::WIRE_SIZE],
+                );
+                Some(payload)
+            },
+            _ => {
+                return Err(Error::new(
+                    ErrorCode::InvalidMessage,
+                    "invalid timeout presence flag in select message",
+                ));
+            },
+        };
+        Ok(Self {
+            nfds,
+            readfds,
+            writefds,
+            errorfds,
+            timeout,
+        })
     }
 
-    /// Serializes the request into raw bytes.
+    /// Serializes the request into its fixed-width wire representation.
     fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
-        unsafe { mem::transmute(self) }
+        let mut bytes: [u8; SystemCallMessage::PAYLOAD_SIZE] = [0; SystemCallMessage::PAYLOAD_SIZE];
+        bytes[Self::OFFSET_NFDS] = self.nfds;
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_READFDS, self.readfds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_WRITEFDS, self.writefds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_ERRORFDS, self.errorfds);
+        if let Some(payload) = self.timeout {
+            bytes[Self::OFFSET_TIMEOUT] = 1;
+            bytes[Self::OFFSET_TIMEOUT + 1..Self::OFFSET_TIMEOUT + 1 + timeval::WIRE_SIZE]
+                .copy_from_slice(&payload);
+        }
+        bytes
     }
 
     /// Builds a kernel IPC message for a `select()` system call request.
@@ -140,24 +232,20 @@ impl SelectRequest {
     }
 }
 
-impl core::fmt::Debug for SelectRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectRequest")
-            .field("nfds", &self.nfds)
-            .field("readfds", &self.readfds)
-            .field("writefds", &self.writefds)
-            .field("errorfds", &self.errorfds)
-            .field("timeout", &self.timeout)
-            .finish()
-    }
-}
-
 //==================================================================================================
 // SelectResponse
 //==================================================================================================
 
 /// Response message for the `select()` system call.
-#[repr(C, packed)]
+///
+/// Uses the same explicit, offset-based wire layout as [`SelectRequest`] for cross-architecture
+/// IPC compatibility:
+///
+/// `ready_fds (1) | readfds (1 + fd_set::WIRE_SIZE) | writefds (1 + fd_set::WIRE_SIZE) |
+///  errorfds (1 + fd_set::WIRE_SIZE)` followed by padding.
+///
+/// Each optional field is prefixed by a one-byte presence flag (`0` = absent, `1` = present).
+#[derive(Debug)]
 pub struct SelectResponse {
     /// Number of file descriptors ready.
     pub ready_fds: u8,
@@ -167,18 +255,26 @@ pub struct SelectResponse {
     pub writefds: Option<fd_set>,
     /// Error/exception file descriptors ready.
     pub errorfds: Option<fd_set>,
-    /// Required padding.
-    _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(SelectResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+// Ensure the fixed-width wire layout fits within the payload, so the manual offsets/slices in
+// `from_bytes()`/`into_bytes()` cannot overflow `PAYLOAD_SIZE` and panic at runtime.
+::static_assert::assert_eq!(SelectResponse::WIRE_SIZE <= SystemCallMessage::PAYLOAD_SIZE);
 
 impl SelectResponse {
-    /// Size of the padding field.
-    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
-        - mem::size_of::<u8>()
-        - mem::size_of::<Option<fd_set>>()
-        - mem::size_of::<Option<fd_set>>()
-        - mem::size_of::<Option<fd_set>>();
+    /// Wire size of an optional `fd_set` field (presence flag + set payload).
+    const OPTIONAL_FD_SET_WIRE_SIZE: usize = mem::size_of::<u8>() + fd_set::WIRE_SIZE;
+
+    /// Offset of the `ready_fds` field.
+    const OFFSET_READY_FDS: usize = 0;
+    /// Offset of the read file descriptor set.
+    const OFFSET_READFDS: usize = Self::OFFSET_READY_FDS + mem::size_of::<u8>();
+    /// Offset of the write file descriptor set.
+    const OFFSET_WRITEFDS: usize = Self::OFFSET_READFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
+    /// Offset of the error file descriptor set.
+    const OFFSET_ERRORFDS: usize = Self::OFFSET_WRITEFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
+    /// Total number of meaningful wire bytes.
+    const WIRE_SIZE: usize = Self::OFFSET_ERRORFDS + Self::OPTIONAL_FD_SET_WIRE_SIZE;
 
     /// Creates a new `SelectResponse`.
     fn new(
@@ -192,18 +288,38 @@ impl SelectResponse {
             readfds: *readfds,
             writefds: *writefds,
             errorfds: *errorfds,
-            _padding: [0; Self::PADDING_SIZE],
         }
     }
 
-    /// Deserializes a response from raw bytes.
-    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
-        unsafe { mem::transmute(bytes) }
+    /// Deserializes a response from its fixed-width wire representation.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Result<Self, Error> {
+        let ready_fds: u8 = bytes[Self::OFFSET_READY_FDS];
+        // Reject messages whose number of ready file descriptors exceeds the wire contract bound.
+        if ready_fds as usize > FD_SETSIZE {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "number of ready file descriptors exceeds maximum supported in select message",
+            ));
+        }
+        let readfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_READFDS)?;
+        let writefds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_WRITEFDS)?;
+        let errorfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_ERRORFDS)?;
+        Ok(Self {
+            ready_fds,
+            readfds,
+            writefds,
+            errorfds,
+        })
     }
 
-    /// Serializes the response into raw bytes.
+    /// Serializes the response into its fixed-width wire representation.
     fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
-        unsafe { mem::transmute(self) }
+        let mut bytes: [u8; SystemCallMessage::PAYLOAD_SIZE] = [0; SystemCallMessage::PAYLOAD_SIZE];
+        bytes[Self::OFFSET_READY_FDS] = self.ready_fds;
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_READFDS, self.readfds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_WRITEFDS, self.writefds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_ERRORFDS, self.errorfds);
+        bytes
     }
 
     /// Builds a kernel IPC message for a `select()` system call response.
@@ -227,16 +343,5 @@ impl SelectResponse {
             message.into_bytes(),
         );
         message
-    }
-}
-
-impl core::fmt::Debug for SelectResponse {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectResponse")
-            .field("ready_fds", &self.ready_fds)
-            .field("readfds", &self.readfds)
-            .field("writefds", &self.writefds)
-            .field("errorfds", &self.errorfds)
-            .finish()
     }
 }

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -132,7 +132,7 @@ pub fn select(
         match message.header {
             // Response was successfully parsed.
             SystemCallMessageHeader::SelectResponse => {
-                let response: SelectResponse = SelectResponse::from_bytes(message.payload);
+                let response: SelectResponse = SelectResponse::from_bytes(message.payload)?;
 
                 for (fd_set, dest) in [
                     (response.readfds.as_ref(), readfds),

--- a/src/libs/syscall/src/sys/stat/message/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstatat.rs
@@ -243,8 +243,8 @@ pub struct FileStatAtResponse {
 }
 
 impl FileStatAtResponse {
-    /// Size of file status field.
-    const SIZE_OF_STAT: usize = mem::size_of::<stat>();
+    /// Size of file status field (serialized wire format, not in-memory layout).
+    const SIZE_OF_STAT: usize = stat::SIZE;
 
     ///
     /// # Description

--- a/src/libs/syscall/src/sys/stat/message/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/message/futimens.rs
@@ -11,6 +11,10 @@ use crate::{
 };
 use ::core::mem;
 use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
     ipc::{
         Message,
         MessageReceiver,
@@ -28,25 +32,56 @@ use sysapi::time::timespec;
 // UpdateFileAccessTimeRequest
 //==================================================================================================
 
+/// Wire layout: fd (4 bytes) + times[0] (WIRE_SIZE) + times[1] (WIRE_SIZE) + padding.
 #[derive(Debug)]
-#[repr(C, packed)]
 pub struct UpdateFileAccessTimeRequest {
     pub fd: i32,
     pub times: [timespec; 2],
-    _padding: [u8; Self::PADDING_SIZE],
 }
-::static_assert::assert_eq_size!(UpdateFileAccessTimeRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+// Ensure the fixed-width wire layout fits within the payload, so the manual offsets/slices in
+// `from_bytes()`/`into_bytes()` cannot overflow `PAYLOAD_SIZE` and panic at runtime.
+::static_assert::assert_eq!(
+    UpdateFileAccessTimeRequest::OFFSET_TIMES_1 + timespec::WIRE_SIZE
+        <= SystemCallMessage::PAYLOAD_SIZE
+);
 
 impl UpdateFileAccessTimeRequest {
-    pub const PADDING_SIZE: usize =
-        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - 2 * mem::size_of::<timespec>();
+    const OFFSET_FD: usize = 0;
+    const OFFSET_TIMES_0: usize = mem::size_of::<i32>();
+    const OFFSET_TIMES_1: usize = Self::OFFSET_TIMES_0 + timespec::WIRE_SIZE;
 
-    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
-        unsafe { mem::transmute(bytes) }
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Result<Self, Error> {
+        let fd = i32::from_ne_bytes(
+            bytes[Self::OFFSET_FD..Self::OFFSET_FD + mem::size_of::<i32>()]
+                .try_into()
+                .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid fd field"))?,
+        );
+        let t0 = timespec::try_from_bytes(
+            &bytes[Self::OFFSET_TIMES_0..Self::OFFSET_TIMES_0 + timespec::WIRE_SIZE],
+        )
+        .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid times[0] field"))?;
+        let t1 = timespec::try_from_bytes(
+            &bytes[Self::OFFSET_TIMES_1..Self::OFFSET_TIMES_1 + timespec::WIRE_SIZE],
+        )
+        .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid times[1] field"))?;
+        Ok(Self {
+            fd,
+            times: [t0, t1],
+        })
     }
 
     fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
-        unsafe { mem::transmute(self) }
+        let mut bytes = [0u8; SystemCallMessage::PAYLOAD_SIZE];
+        bytes[Self::OFFSET_FD..Self::OFFSET_FD + mem::size_of::<i32>()]
+            .copy_from_slice(&self.fd.to_ne_bytes());
+        let t0 = self.times[0].to_bytes();
+        bytes[Self::OFFSET_TIMES_0..Self::OFFSET_TIMES_0 + timespec::WIRE_SIZE]
+            .copy_from_slice(&t0);
+        let t1 = self.times[1].to_bytes();
+        bytes[Self::OFFSET_TIMES_1..Self::OFFSET_TIMES_1 + timespec::WIRE_SIZE]
+            .copy_from_slice(&t1);
+        bytes
     }
 
     pub fn build(
@@ -56,14 +91,10 @@ impl UpdateFileAccessTimeRequest {
         destination: ProcessIdentifier,
         message_type: MessageType,
     ) -> Message {
-        let message: UpdateFileAccessTimeRequest = UpdateFileAccessTimeRequest {
-            fd,
-            times: *times,
-            _padding: [0; Self::PADDING_SIZE],
-        };
+        let request = UpdateFileAccessTimeRequest { fd, times: *times };
         let message: SystemCallMessage = SystemCallMessage::new(
             SystemCallMessageHeader::UpdateFileAccessTimeRequest,
-            message.into_bytes(),
+            request.into_bytes(),
         );
         let message: Message = Message::new(
             MessageSender::from(tid),

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -72,8 +72,8 @@ impl UpdateFileAccessTimeAtRequest {
     const SIZE_OF_FLAG: usize = mem::size_of::<i32>();
     /// Sizes of 'path length' field.
     const SIZE_OF_PATH_LENGTH: usize = mem::size_of::<u32>();
-    /// Sizes of 'access time' field.
-    const SIZE_OF_TIMES: usize = 2 * mem::size_of::<timespec>();
+    /// Sizes of 'access time' field (wire format: always 2 * 16 = 32 bytes).
+    const SIZE_OF_TIMES: usize = 2 * timespec::WIRE_SIZE;
     /// Offsets to 'directory file descriptor' field.
     const OFFSET_TO_DIRFD: usize = 0;
     /// Offsets to 'flags' field.
@@ -206,11 +206,11 @@ impl MessageDeserializer for UpdateFileAccessTimeAtRequest {
                 .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid path length"))?,
         ) as usize;
 
-        // Deserialize access time.
+        // Deserialize access time (using wire format size).
         let mut times: [timespec; 2] = [timespec::default(); 2];
         for (i, time) in times.iter_mut().enumerate() {
-            let offset: usize = Self::OFFSET_TO_TIMES + i * mem::size_of::<timespec>();
-            *time = timespec::try_from_bytes(&bytes[offset..(offset + mem::size_of::<timespec>())])
+            let offset: usize = Self::OFFSET_TO_TIMES + i * timespec::WIRE_SIZE;
+            *time = timespec::try_from_bytes(&bytes[offset..(offset + timespec::WIRE_SIZE)])
                 .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid time"))?;
         }
 

--- a/src/libs/syscall/src/time/syscall/nanosleep.rs
+++ b/src/libs/syscall/src/time/syscall/nanosleep.rs
@@ -13,6 +13,7 @@ use ::sys::{
     },
     time::SystemTime,
 };
+use ::sysapi::ffi::c_long;
 use sysapi::time::timespec;
 
 //==================================================================================================
@@ -98,7 +99,7 @@ pub fn nanosleep(req: &timespec, rem: &mut Option<&mut timespec>) -> Result<(), 
             rem.tv_nsec = 0;
         } else {
             rem.tv_sec = (later.seconds() - now.seconds()) as i64;
-            rem.tv_nsec = (later.nanoseconds() - now.nanoseconds()) as i32;
+            rem.tv_nsec = (later.nanoseconds() - now.nanoseconds()) as c_long;
         }
     }
 


### PR DESCRIPTION
## Summary

The x86_64 port makes the FFI primitives follow **LP64** (`c_long`/`c_ulong` become 64-bit) on the host while the guest may be **ILP32** (32-bit). Any `sysapi` structure that embeds a variable-width field and crosses the guest↔host IPC boundary therefore had a mismatched on-the-wire layout between a 32-bit guest and the 64-bit host daemons.

This change decouples the IPC wire format from in-memory struct layout so a 32-bit guest and a 64-bit host interoperate byte-for-byte, regardless of target.

## Changes

**FFI**
- `ffi.rs`: gate primitive C types on `target_pointer_width` (LP64 on x86_64).

**Fixed-width wire serializers (target-independent)**
- `time.rs`: `timespec` gains `WIRE_SIZE` (`tv_nsec` always `i64`) + `to_bytes`/`try_from_bytes`.
- `sys_select.rs`: `timeval` gains the same (`tv_usec` always `i64`).
- `sys_stat.rs`: `stat` serializes to a fixed wire `SIZE`; already-64-bit fields (`blksize_t`/`blkcnt_t = c_longlong`) are written directly.

**IPC messages — explicit, offset-based serialization (replacing raw `mem::transmute`)**
- `sys/select/message`: `SelectRequest` timeout uses `timeval`'s wire encoding.
- `sys/stat/message/futimens`: explicit per-field layout; `from_bytes` is now fallible (`Result`).
- `sys/stat/message/utimensat`, `fstatat`: sizes from `WIRE_SIZE` / `stat::SIZE` instead of `size_of::<T>()`.

**Consumers updated for fallible deserialization**
- `linuxd` `worker_thread`, `vfsd` `handler/short`: propagate `UpdateFileAccessTime` `from_bytes` errors.
- `linuxd` `linux/sys_select`: decode the `timeval` wire payload.

**Struct/layout cleanups required by the above**
- `dirent`, `sys_types` (pthread/msghdr), `sys_uio` (iovec): `repr(C, packed)` → `repr(C)`; drop now-invalid size asserts; add LP64 `msghdr` variant.
- `safe/time`, `nanosleep`: `tv_nsec` cast `i32` → `c_long` (target-correct).
- `linuxd` time/fcntl, mount bindings: gate clippy allows to x86_64, where `c_long`/`c_ulong` widening makes the conversions/casts no-ops.

## Testing

Unit tests, `lint-check`, and integration tests pass on both `TARGET=x86` and `TARGET=x86_64` across standalone, single-process, and multi-process deployments.

| Target | standalone | single-process | multi-process |
|--------|-----------|----------------|---------------|
| x86 | ✅ | ✅ | ✅ |
| x86_64 | ✅ 18/18 | ✅ 16/16 | ✅ 16/16 |
