### PR TITLE
[syscall] Add POSIX unnamed pipes support

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -30,6 +30,7 @@ use crate::{
         PendingOpKind,
         PendingQueue,
     },
+    pipe_wait::PipeWaitTable,
 };
 use ::sys::{
     error::ErrorCode,
@@ -59,9 +60,25 @@ pub(crate) fn handle_close_with_hostfs(
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
+    pipe_wait: &mut PipeWaitTable,
 ) -> Option<Message> {
     let req: CloseRequest = CloseRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+
+    // Pipe close: if this drops the last reference to an end, fire the matching wakeup so any
+    // suspended counterparts observe EOF (write end gone) or `EPIPE` (read end gone).
+    if let Some((pipe_id, is_write)) = ::vfs::fd::vfs_pipe_id(fd) {
+        let last_ref: bool = ::vfs::fd::vfs_pipe_is_last_ref(fd);
+        let response: Message = super::short::handle_close(source, msg);
+        if last_ref {
+            if is_write {
+                super::pipe::wake_all_readers_eof(pipe_id, pipe_wait);
+            } else {
+                super::pipe::fail_all_writers_epipe(pipe_id, pipe_wait);
+            }
+        }
+        return Some(response);
+    }
 
     if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
         // A forked child may share this open file description with its parent. Only forward the
@@ -113,6 +130,11 @@ pub(crate) fn handle_seek_with_hostfs(
 ) -> Option<Message> {
     let req: SeekRequest = SeekRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+
+    // A pipe is not seekable: report `ESPIPE` without touching the buffer.
+    if ::vfs::fd::vfs_pipe_id(fd).is_some() {
+        return Some(build_error(source, ErrorCode::IllegalSeek));
+    }
 
     if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
         if !pending.has_capacity() {
@@ -310,9 +332,23 @@ pub(crate) fn handle_read_with_hostfs(
     source_tid: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
+    pipe_wait: &mut PipeWaitTable,
 ) -> Option<Message> {
     let req: ReadRequest = ReadRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+
+    // Pipe read end: served by the pipe handler (which may park the caller).
+    if let Some((pipe_id, is_write)) = ::vfs::fd::vfs_pipe_id(fd) {
+        return super::pipe::handle_pipe_read(
+            source_pid,
+            source_tid,
+            fd,
+            req.count as usize,
+            is_write,
+            pipe_id,
+            pipe_wait,
+        );
+    }
 
     if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
         if !pending.has_capacity() {
@@ -351,9 +387,23 @@ pub(crate) fn handle_write_with_hostfs(
     source_tid: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
+    pipe_wait: &mut PipeWaitTable,
 ) -> Option<Message> {
     let req: WriteRequest = WriteRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+
+    // Pipe write end: served by the pipe handler (which may park the caller).
+    if let Some((pipe_id, is_write)) = ::vfs::fd::vfs_pipe_id(fd) {
+        return super::pipe::handle_pipe_write(
+            source_pid,
+            source_tid,
+            fd,
+            req.count as usize,
+            is_write,
+            pipe_id,
+            pipe_wait,
+        );
+    }
 
     if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(fd) {
         if !pending.has_capacity() {

--- a/src/daemons/vfsd/src/handler/mod.rs
+++ b/src/daemons/vfsd/src/handler/mod.rs
@@ -8,6 +8,7 @@
 mod hostfs_handlers;
 mod long;
 mod mount_handler;
+pub(crate) mod pipe;
 mod readwrite;
 mod short;
 

--- a/src/daemons/vfsd/src/handler/pipe.rs
+++ b/src/daemons/vfsd/src/handler/pipe.rs
@@ -1,0 +1,476 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Pipe operation handlers.
+//!
+//! These functions create pipes and service `read`/`write`/`close` on pipe descriptors, parking
+//! callers that would block and reviving them from the complementary operation. They mirror the
+//! MINIX VFS `suspend`/`revive` model on vfsd's single-threaded event loop: a parked reader stays
+//! blocked inside its `__kcall_pull`, and a parked writer inside its `__kcall_recv`, until the
+//! counterpart makes progress (or the pipe transitions to EOF/broken).
+
+extern crate alloc;
+
+use crate::{
+    error::{
+        build_error,
+        fat32_to_error_code,
+        send_response,
+    },
+    pipe_wait::{
+        BlockedReader,
+        BlockedWriter,
+        PipeWaitTable,
+    },
+};
+use ::arch::mem::PAGE_SIZE;
+use ::sys::{
+    error::ErrorCode,
+    ipc::{
+        Message,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::syscall::unistd::message::{
+    PipeResponse,
+    ReadResponse,
+    WriteResponse,
+};
+use ::vfs::fd::{
+    set_current_process,
+    vfs_get_status_flags,
+    vfs_pipe,
+    vfs_pipe_read,
+    vfs_pipe_write,
+    PipeReadOutcome,
+    PipeWriteOutcome,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of bytes transferred in a single pipe read/write request.
+///
+/// Matches the page-aligned chunk size the syscall layer uses, so a single request never exceeds
+/// this. It must stay within `PIPE_BUF` so that each request is performed atomically.
+const PIPE_BULK_SIZE: usize = PAGE_SIZE;
+
+/// Compile-time guarantee that a single pipe request is always atomic.
+///
+/// Keeping `PIPE_BULK_SIZE` within `PIPE_BUF` ensures a write never splits across a `PIPE_BUF`
+/// boundary and so never interleaves with another writer's data (POSIX pipe-write atomicity), and
+/// keeps the partial-write path in [`handle_pipe_write`] unreachable. If a platform's `PAGE_SIZE`
+/// ever exceeds `PIPE_BUF`, raise `PIPE_BUF` rather than relaxing this bound.
+const _: () = assert!(PIPE_BULK_SIZE <= ::vfs::pipe::PIPE_BUF);
+
+/// Static buffer used for pipe data transfers.
+///
+/// Safety: vfsd is single-threaded (one message at a time), so there is never concurrent access.
+/// Each access below is a momentary borrow that is released before any callee that also touches the
+/// buffer runs.
+static mut PIPE_BULK_BUFFER: [u8; PIPE_BULK_SIZE] = [0u8; PIPE_BULK_SIZE];
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Returns `true` if the open file description for `fd` has `O_NONBLOCK` set.
+fn is_nonblocking(fd: i32) -> bool {
+    vfs_get_status_flags(fd) & ::sysapi::fcntl::file_status_flags::O_NONBLOCK != 0
+}
+
+/// Pushes an empty buffer to `(pid, tid)` to release a caller blocked in `__kcall_pull`.
+fn push_empty(pid: ProcessIdentifier, tid: ThreadIdentifier) {
+    if let Err(e) = ::sys::kcall::ipc::__kcall_push(pid, tid, &[]) {
+        ::syslog::error!("pipe: unblock push failed (error={:?})", e);
+    }
+}
+
+/// Builds a `ReadResponse` carrying `n` (the bytes already pushed to the caller).
+fn read_response(tid: ThreadIdentifier, n: usize) -> Message {
+    ReadResponse::build(
+        tid,
+        n as i32,
+        [0u8; ReadResponse::BUFFER_SIZE],
+        ProcessIdentifier::VFSD,
+        MessageType::Ipc,
+    )
+}
+
+/// Builds a `WriteResponse` carrying `n` (the bytes accepted into the pipe).
+fn write_response(tid: ThreadIdentifier, n: usize) -> Message {
+    WriteResponse::build(tid, n as i32, ProcessIdentifier::VFSD, MessageType::Ipc)
+}
+
+/// Outcome of attempting to serve a reader from the pipe buffer.
+///
+/// The data push to the caller (for [`Served`](ServeOutcome::Served), [`Eof`](ServeOutcome::Eof),
+/// and [`Error`](ServeOutcome::Error)) is performed inside [`try_serve_reader`]; only
+/// [`WouldBlock`](ServeOutcome::WouldBlock) leaves the caller blocked in `__kcall_pull`.
+enum ServeOutcome {
+    /// Pushed `N` bytes to the caller (`N > 0`).
+    Served(usize),
+    /// Pushed an empty buffer; the caller must receive end-of-file.
+    Eof,
+    /// No data available; the caller is still blocked in `__kcall_pull`.
+    WouldBlock,
+    /// The descriptor was not a readable pipe end; pushed an empty buffer.
+    Error,
+}
+
+/// Attempts a non-blocking read of `fd` into the shared buffer and, on success, pushes the bytes to
+/// the caller. The current process must already be set to the caller's process.
+fn try_serve_reader(
+    pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
+    fd: i32,
+    count: usize,
+) -> ServeOutcome {
+    let cap: usize = count.min(PIPE_BULK_SIZE);
+    // SAFETY: single-threaded; the borrow is released when this function returns, and the only
+    // callee touched while it is held (`__kcall_push`) does not access the buffer itself.
+    let buf: &mut [u8] = unsafe { &mut PIPE_BULK_BUFFER[..cap] };
+    match vfs_pipe_read(fd, buf) {
+        Ok(PipeReadOutcome::Read(n)) => {
+            if let Err(e) = ::sys::kcall::ipc::__kcall_push(pid, tid, &buf[..n]) {
+                ::syslog::error!("pipe read: push failed (error={:?})", e);
+                return ServeOutcome::Error;
+            }
+            ServeOutcome::Served(n)
+        },
+        Ok(PipeReadOutcome::Eof) => {
+            push_empty(pid, tid);
+            ServeOutcome::Eof
+        },
+        Ok(PipeReadOutcome::WouldBlock) => ServeOutcome::WouldBlock,
+        Err(_) => {
+            push_empty(pid, tid);
+            ServeOutcome::Error
+        },
+    }
+}
+
+//==================================================================================================
+// Create
+//==================================================================================================
+
+/// Handles a `pipe()` request: allocates a pipe and its two descriptors in the caller's process.
+///
+/// The current process is bound by the dispatcher before this runs, so the descriptors land in the
+/// caller's table.
+pub(crate) fn handle_pipe_create(source: ThreadIdentifier) -> Message {
+    match vfs_pipe() {
+        Ok((read_fd, write_fd)) => {
+            ::syslog::trace!("pipe(): read_fd={}, write_fd={}", read_fd, write_fd);
+            PipeResponse::build(
+                source,
+                read_fd,
+                write_fd,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
+        },
+        Err(e) => build_error(source, fat32_to_error_code(&e)),
+    }
+}
+
+//==================================================================================================
+// Read
+//==================================================================================================
+
+/// Handles a `read()` on a pipe read end.
+///
+/// Returns `Some(response)` when the request completes immediately (data available, EOF, `EAGAIN`,
+/// or error) and `None` when the caller is parked (it stays blocked in `__kcall_pull` until a
+/// writer or a close revives it).
+pub(crate) fn handle_pipe_read(
+    source_pid: ProcessIdentifier,
+    source_tid: ThreadIdentifier,
+    fd: i32,
+    count: usize,
+    is_write: bool,
+    pipe_id: u64,
+    pipe_wait: &mut PipeWaitTable,
+) -> Option<Message> {
+    // Reading the write end is rejected with `EBADF`, regardless of `count`. The caller is blocked
+    // in `__kcall_pull`, so release it before sending the error response.
+    if is_write {
+        push_empty(source_pid, source_tid);
+        return Some(build_error(source_tid, ErrorCode::BadFile));
+    }
+
+    // A zero-length read returns immediately without blocking.
+    if count == 0 {
+        push_empty(source_pid, source_tid);
+        return Some(read_response(source_tid, 0));
+    }
+
+    match try_serve_reader(source_pid, source_tid, fd, count) {
+        ServeOutcome::Served(n) => {
+            // Freed buffer space: a suspended writer may now make progress.
+            rebalance(pipe_id, pipe_wait);
+            Some(read_response(source_tid, n))
+        },
+        ServeOutcome::Eof => Some(read_response(source_tid, 0)),
+        ServeOutcome::WouldBlock => {
+            if is_nonblocking(fd) {
+                // The caller is blocked in `__kcall_pull`; release it before the error response.
+                push_empty(source_pid, source_tid);
+                Some(build_error(source_tid, ErrorCode::TryAgain))
+            } else {
+                pipe_wait.park_reader(
+                    pipe_id,
+                    BlockedReader {
+                        source_tid,
+                        source_pid,
+                        fd,
+                        count,
+                    },
+                );
+                None
+            }
+        },
+        ServeOutcome::Error => Some(build_error(source_tid, ErrorCode::BadFile)),
+    }
+}
+
+//==================================================================================================
+// Write
+//==================================================================================================
+
+/// Handles a `write()` on a pipe write end.
+///
+/// Pulls the caller's bytes immediately (releasing its `__kcall_push`), buffers what it can, and
+/// either answers now or parks the caller (which stays blocked in `__kcall_recv`) until a reader
+/// drains space or all readers close.
+pub(crate) fn handle_pipe_write(
+    source_pid: ProcessIdentifier,
+    source_tid: ThreadIdentifier,
+    fd: i32,
+    count: usize,
+    is_write: bool,
+    pipe_id: u64,
+    pipe_wait: &mut PipeWaitTable,
+) -> Option<Message> {
+    let cap: usize = count.min(PIPE_BULK_SIZE);
+
+    // Pull the caller's data first; this releases the client's blocking `__kcall_push`.
+    let pulled: usize = {
+        // SAFETY: single-threaded; the borrow is released at the end of this block.
+        let buf: &mut [u8] = unsafe { &mut PIPE_BULK_BUFFER[..cap] };
+        match ::sys::kcall::ipc::__kcall_pull(source_pid, source_tid, buf) {
+            Ok(p) => p.min(cap),
+            Err(e) => {
+                ::syslog::error!("pipe write: pull failed (error={:?})", e);
+                return Some(build_error(source_tid, ErrorCode::IoErr));
+            },
+        }
+    };
+
+    // Writing the read end is rejected with `EBADF`. The pull above already drained the client's
+    // `__kcall_push`, so no data transfer is left dangling.
+    if !is_write {
+        return Some(build_error(source_tid, ErrorCode::BadFile));
+    }
+
+    // A zero-length write returns 0 without testing for a broken pipe (POSIX-permitted leniency).
+    if pulled == 0 {
+        return Some(write_response(source_tid, 0));
+    }
+
+    // SAFETY: single-threaded; this momentary borrow is not held across any buffer-touching call.
+    let outcome: Result<PipeWriteOutcome, ::vfs::Fat32Error> =
+        vfs_pipe_write(fd, unsafe { &PIPE_BULK_BUFFER[..pulled] });
+
+    match outcome {
+        Ok(PipeWriteOutcome::Wrote(n)) if n >= pulled => {
+            // Everything fit: data is available, so revive any suspended readers.
+            rebalance(pipe_id, pipe_wait);
+            Some(write_response(source_tid, pulled))
+        },
+        Ok(PipeWriteOutcome::Wrote(n)) => {
+            // Partial write (only reachable for requests larger than PIPE_BUF, which the atomicity
+            // bound above rules out today). The `n` bytes that fit are already buffered, so revive
+            // readers for them either way.
+            if is_nonblocking(fd) {
+                // POSIX: a non-blocking write transfers what fits and returns immediately.
+                rebalance(pipe_id, pipe_wait);
+                Some(write_response(source_tid, n))
+            } else {
+                // Park the remainder and let reviving readers drain space until it completes.
+                // SAFETY: single-threaded; momentary borrow copied into an owned vector.
+                let data: alloc::vec::Vec<u8> = unsafe { PIPE_BULK_BUFFER[..pulled].to_vec() };
+                pipe_wait.park_writer(
+                    pipe_id,
+                    BlockedWriter {
+                        source_tid,
+                        source_pid,
+                        fd,
+                        data,
+                        written: n,
+                        total: pulled,
+                    },
+                );
+                rebalance(pipe_id, pipe_wait);
+                None
+            }
+        },
+        Ok(PipeWriteOutcome::WouldBlock) => {
+            if is_nonblocking(fd) {
+                Some(build_error(source_tid, ErrorCode::TryAgain))
+            } else {
+                // SAFETY: single-threaded; momentary borrow copied into an owned vector.
+                let data: alloc::vec::Vec<u8> = unsafe { PIPE_BULK_BUFFER[..pulled].to_vec() };
+                pipe_wait.park_writer(
+                    pipe_id,
+                    BlockedWriter {
+                        source_tid,
+                        source_pid,
+                        fd,
+                        data,
+                        written: 0,
+                        total: pulled,
+                    },
+                );
+                None
+            }
+        },
+        Ok(PipeWriteOutcome::BrokenPipe) => Some(build_error(source_tid, ErrorCode::BrokenPipe)),
+        Err(_) => Some(build_error(source_tid, ErrorCode::BadFile)),
+    }
+}
+
+//==================================================================================================
+// Revive / Wakeups
+//==================================================================================================
+
+/// Drains as many suspended readers as the buffer allows, pushing data and answering each.
+///
+/// Returns `true` if any reader was answered (used to drive [`rebalance`] to a fixpoint).
+fn wake_readers(pipe_id: u64, pipe_wait: &mut PipeWaitTable) -> bool {
+    let mut progress: bool = false;
+    while let Some((pid, tid, fd, count)) = pipe_wait.front_reader(pipe_id) {
+        set_current_process(pid);
+        match try_serve_reader(pid, tid, fd, count) {
+            ServeOutcome::Served(n) => {
+                pipe_wait.pop_reader(pipe_id);
+                send_response(&read_response(tid, n));
+                progress = true;
+            },
+            ServeOutcome::Eof => {
+                pipe_wait.pop_reader(pipe_id);
+                send_response(&read_response(tid, 0));
+                progress = true;
+            },
+            ServeOutcome::WouldBlock => break,
+            ServeOutcome::Error => {
+                pipe_wait.pop_reader(pipe_id);
+                send_response(&build_error(tid, ErrorCode::BadFile));
+                progress = true;
+            },
+        }
+    }
+    progress
+}
+
+/// Advances as many suspended writers as the buffer allows, completing or re-parking each.
+///
+/// Returns `true` if any writer completed or made progress.
+fn wake_writers(pipe_id: u64, pipe_wait: &mut PipeWaitTable) -> bool {
+    let mut progress: bool = false;
+    while let Some((pid, fd)) = pipe_wait.front_writer_meta(pipe_id) {
+        set_current_process(pid);
+
+        // Attempt to buffer the writer's remaining bytes.
+        let outcome: Result<PipeWriteOutcome, ::vfs::Fat32Error> = {
+            let w: &crate::pipe_wait::BlockedWriter = match pipe_wait.front_writer(pipe_id) {
+                Some(w) => w,
+                None => break,
+            };
+            vfs_pipe_write(fd, &w.data[w.written..])
+        };
+
+        match outcome {
+            Ok(PipeWriteOutcome::Wrote(n)) => {
+                let (done, tid, total): (bool, ThreadIdentifier, usize) = {
+                    let w: &mut crate::pipe_wait::BlockedWriter =
+                        match pipe_wait.front_writer_mut(pipe_id) {
+                            Some(w) => w,
+                            None => break,
+                        };
+                    w.written += n;
+                    (w.written >= w.data.len(), w.source_tid, w.total)
+                };
+                if done {
+                    pipe_wait.pop_writer(pipe_id);
+                    send_response(&write_response(tid, total));
+                    progress = true;
+                } else {
+                    progress |= n > 0;
+                    // Buffer is full again; the writer remains parked with its remainder.
+                    break;
+                }
+            },
+            Ok(PipeWriteOutcome::WouldBlock) => break,
+            Ok(PipeWriteOutcome::BrokenPipe) => {
+                let tid: ThreadIdentifier = match pipe_wait.front_writer(pipe_id) {
+                    Some(w) => w.source_tid,
+                    None => break,
+                };
+                pipe_wait.pop_writer(pipe_id);
+                send_response(&build_error(tid, ErrorCode::BrokenPipe));
+                progress = true;
+            },
+            Err(_) => {
+                let tid: ThreadIdentifier = match pipe_wait.front_writer(pipe_id) {
+                    Some(w) => w.source_tid,
+                    None => break,
+                };
+                pipe_wait.pop_writer(pipe_id);
+                send_response(&build_error(tid, ErrorCode::BadFile));
+                progress = true;
+            },
+        }
+    }
+    progress
+}
+
+/// Drives the complementary wakeups to a fixpoint after a pipe buffer mutation.
+///
+/// Reviving writers adds data (which may free a reader to run) and reviving readers frees space
+/// (which may let a writer run); the loop terminates once neither side can make further progress.
+fn rebalance(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
+    loop {
+        let writers_progressed: bool = wake_writers(pipe_id, pipe_wait);
+        let readers_progressed: bool = wake_readers(pipe_id, pipe_wait);
+        if !writers_progressed && !readers_progressed {
+            break;
+        }
+    }
+}
+
+/// Wakes all readers suspended on `pipe_id` with end-of-file.
+///
+/// Invoked when the last write end closes (or its owner exits): every parked reader is answered
+/// with a zero-length read.
+pub(crate) fn wake_all_readers_eof(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
+    for reader in pipe_wait.drain_readers(pipe_id) {
+        push_empty(reader.source_pid, reader.source_tid);
+        send_response(&read_response(reader.source_tid, 0));
+    }
+}
+
+/// Fails all writers suspended on `pipe_id` with `EPIPE`.
+///
+/// Invoked when the last read end closes (or its owner exits): every parked writer is answered with
+/// a broken-pipe error.
+pub(crate) fn fail_all_writers_epipe(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
+    for writer in pipe_wait.drain_writers(pipe_id) {
+        send_response(&build_error(writer.source_tid, ErrorCode::BrokenPipe));
+    }
+}

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -132,7 +132,8 @@ pub(crate) fn handle_fcntl(source: ThreadIdentifier, msg: SystemCallMessage) -> 
     let req: FileControlRequest = FileControlRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
     let cmd: i32 = req.cmd;
-    match ::vfs::fd::vfs_fcntl(fd, cmd) {
+    let arg: i32 = req.arg;
+    match ::vfs::fd::vfs_fcntl(fd, cmd, arg) {
         Ok(ret) => {
             FileControlResponse::build(source, ret, ProcessIdentifier::VFSD, MessageType::Ipc)
         },

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -17,6 +17,7 @@ use crate::{
     handler,
     hostfs,
     pending::PendingQueue,
+    pipe_wait::PipeWaitTable,
 };
 use ::proc::{
     ForkCloneMessage,
@@ -96,7 +97,7 @@ fn caller_pid(message: &Message) -> ProcessIdentifier {
 // SystemMessage Handler (procd shutdown)
 //==================================================================================================
 
-fn handle_system_message(message: Message) -> Result<bool, Error> {
+fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Result<bool, Error> {
     // State-mutating process-management messages are privileged: only procd may direct them. The
     // caller (handle_ipc_message) routes here only when the message source is procd, which is the
     // runtime gate. Note that this trusts `message.source`: the kernel currently only *logs* an
@@ -150,12 +151,24 @@ fn handle_system_message(message: Message) -> Result<bool, Error> {
                     let exit: ProcessExitMessage = ProcessExitMessage::from_bytes(pm_msg.payload);
                     let pid: ProcessIdentifier = exit.pid;
                     // Reclaim the terminated process's per-process filesystem state, dropping its
-                    // open file descriptors so that surviving siblings retain correct last-reference
+                    // open file descriptors so that surviving siblings keep correct last-reference
                     // accounting. Any host-backed descriptors for which the process held the final
                     // reference can no longer be closed by the process itself, so close them on
-                    // hostfsd here to avoid leaking remote handles.
-                    let orphaned: Vec<i32> = ::vfs::fd::vfs_process_exit(pid);
-                    for remote_fd in orphaned {
+                    // hostfsd here to avoid leaking remote handles. Pipe ends for which it held the
+                    // final reference have their counts drop to zero, which must fire EOF/`EPIPE`
+                    // wakeups for any suspended counterparts.
+                    let reclaim: ::vfs::fd::ProcessExitReclaim = ::vfs::fd::vfs_process_exit(pid);
+                    // First discard any requests this process had parked: there is no longer a
+                    // client to answer, so they must not be revived by the wakeups below.
+                    pipe_wait.purge_pid(pid);
+                    for closure in reclaim.pipe_closures {
+                        if closure.was_write {
+                            handler::pipe::wake_all_readers_eof(closure.pipe_id, pipe_wait);
+                        } else {
+                            handler::pipe::fail_all_writers_epipe(closure.pipe_id, pipe_wait);
+                        }
+                    }
+                    for remote_fd in reclaim.orphaned_hostfs_fds {
                         // Fire-and-forget close: the requesting process is gone, so there is no
                         // caller to acknowledge. As in the leak-avoidance path in `complete_open`,
                         // the request is tagged with the `FIRE_AND_FORGET` sentinel op_id and no
@@ -202,13 +215,14 @@ pub(crate) fn handle_ipc_message(
     message: Message,
     assemblers: &mut BTreeMap<(i32, u16), AssemblerEntry>,
     pending: &mut PendingQueue,
+    pipe_wait: &mut PipeWaitTable,
 ) -> Result<bool, Error> {
     let source_tid: ThreadIdentifier = caller_tid(&message);
     let source_pid: ProcessIdentifier = caller_pid(&message);
 
     // Route messages from the process manager daemon (PROCD).
     if source_pid == ProcessIdentifier::PROCD {
-        return handle_system_message(message);
+        return handle_system_message(message, pipe_wait);
     }
 
     // Bind the VFS to the requesting process so that descriptor and working-directory operations
@@ -236,7 +250,7 @@ pub(crate) fn handle_ipc_message(
         //==========================================================================================
         SystemCallMessageHeader::CloseRequest => {
             if let Some(response) =
-                handler::handle_close_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_close_with_hostfs(source_tid, syscall_msg, pending, pipe_wait)
             {
                 send_response(&response);
             }
@@ -296,19 +310,35 @@ pub(crate) fn handle_ipc_message(
         },
 
         //==========================================================================================
+        // Pipe creation: single message request, single message response.
+        //==========================================================================================
+        SystemCallMessageHeader::PipeRequest => {
+            let response: Message = handler::pipe::handle_pipe_create(source_tid);
+            send_response(&response);
+        },
+
+        //==========================================================================================
         // Read/Write: single message request + bulk data via push/pull.
         //==========================================================================================
         SystemCallMessageHeader::ReadRequest => {
-            if let Some(response) =
-                handler::handle_read_with_hostfs(source_pid, source_tid, syscall_msg, pending)
-            {
+            if let Some(response) = handler::handle_read_with_hostfs(
+                source_pid,
+                source_tid,
+                syscall_msg,
+                pending,
+                pipe_wait,
+            ) {
                 send_response(&response);
             }
         },
         SystemCallMessageHeader::WriteRequest => {
-            if let Some(response) =
-                handler::handle_write_with_hostfs(source_pid, source_tid, syscall_msg, pending)
-            {
+            if let Some(response) = handler::handle_write_with_hostfs(
+                source_pid,
+                source_tid,
+                syscall_msg,
+                pending,
+                pipe_wait,
+            ) {
                 send_response(&response);
             }
         },

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -19,6 +19,7 @@ mod hostfs;
 mod init;
 mod ipc;
 mod pending;
+mod pipe_wait;
 
 //==================================================================================================
 // Imports
@@ -121,6 +122,9 @@ pub fn main() {
     // Pending hostfs operations awaiting IKC responses.
     let mut pending: pending::PendingQueue = pending::PendingQueue::new();
 
+    // Suspended pipe readers/writers awaiting their complementary operation.
+    let mut pipe_wait: pipe_wait::PipeWaitTable = pipe_wait::PipeWaitTable::new();
+
     // In-flight multi-part hostfs *response* assembler, paired with the op_id
     // extracted eagerly from part 0 so a discarded stream can be cancelled (the
     // pending op would otherwise sit until the eviction timer fires).
@@ -152,7 +156,7 @@ pub fn main() {
 
     // Process any messages that were buffered during the signup phase.
     while let Some(message) = buffered_messages.pop_front() {
-        match ipc::handle_ipc_message(message, &mut assemblers, &mut pending) {
+        match ipc::handle_ipc_message(message, &mut assemblers, &mut pending, &mut pipe_wait) {
             Ok(true) => {
                 let e = ::sys::kcall::pm::__kcall_exit(0);
                 ::syslog::error!("failed to shutdown vfsd (error={:?})", e);
@@ -171,7 +175,12 @@ pub fn main() {
         match ::sys::kcall::ipc::__kcall_recv() {
             Ok(message) => match message.message_type {
                 MessageType::Ipc => {
-                    match ipc::handle_ipc_message(message, &mut assemblers, &mut pending) {
+                    match ipc::handle_ipc_message(
+                        message,
+                        &mut assemblers,
+                        &mut pending,
+                        &mut pipe_wait,
+                    ) {
                         Ok(true) => break,
                         Ok(false) => {},
                         Err(e) => {

--- a/src/daemons/vfsd/src/pipe_wait.rs
+++ b/src/daemons/vfsd/src/pipe_wait.rs
@@ -1,0 +1,176 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Suspended pipe-request queues (the vfsd side of MINIX-style `suspend`/`revive`).
+//!
+//! vfsd must never block its own event loop. When a `read` finds an empty pipe (with writers still
+//! open) or a `write` finds a full pipe, the caller is *parked* here instead of being answered, and
+//! the client stays blocked inside its `__kcall_pull`/`__kcall_recv`. The complementary operation —
+//! a later `write` for a parked reader, or a `read` for a parked writer — *revives* the parked
+//! caller from [`super::handler::pipe`].
+//!
+//! State is keyed by the pipe's stable identity (`pipe_id`), which never recycles, so a stale
+//! wakeup can never target the wrong pipe. Only IPC identity lives here; the buffer bytes live in
+//! the VFS library next to the FD table.
+
+extern crate alloc;
+
+use ::alloc::{
+    collections::{
+        BTreeMap,
+        VecDeque,
+    },
+    vec::Vec,
+};
+use ::sys::pm::{
+    ProcessIdentifier,
+    ThreadIdentifier,
+};
+
+//==================================================================================================
+// Blocked Requests
+//==================================================================================================
+
+/// A `read` request suspended on an empty pipe.
+pub(crate) struct BlockedReader {
+    /// Thread that issued the read (used to route the eventual `ReadResponse`).
+    pub source_tid: ThreadIdentifier,
+    /// Process that issued the read (needed to `__kcall_push` the data back to the caller).
+    pub source_pid: ProcessIdentifier,
+    /// Read-end file descriptor in the caller's process.
+    pub fd: i32,
+    /// Number of bytes the caller requested.
+    pub count: usize,
+}
+
+/// A `write` request suspended on a full pipe.
+pub(crate) struct BlockedWriter {
+    /// Thread that issued the write (used to route the eventual `WriteResponse`).
+    pub source_tid: ThreadIdentifier,
+    /// Process that issued the write (needed to resolve the write-end FD on revive).
+    pub source_pid: ProcessIdentifier,
+    /// Write-end file descriptor in the caller's process.
+    pub fd: i32,
+    /// Bytes already pulled from the caller but not yet fully buffered.
+    pub data: Vec<u8>,
+    /// Bytes of `data` accepted into the pipe buffer so far (for writes larger than `PIPE_BUF`).
+    pub written: usize,
+    /// Original request length, reported in the final `WriteResponse`.
+    pub total: usize,
+}
+
+//==================================================================================================
+// Wait Table
+//==================================================================================================
+
+/// Per-pipe FIFO queues of suspended readers and writers, keyed by `pipe_id`.
+pub(crate) struct PipeWaitTable {
+    readers: BTreeMap<u64, VecDeque<BlockedReader>>,
+    writers: BTreeMap<u64, VecDeque<BlockedWriter>>,
+}
+
+impl PipeWaitTable {
+    /// Creates an empty wait table.
+    pub fn new() -> Self {
+        Self {
+            readers: BTreeMap::new(),
+            writers: BTreeMap::new(),
+        }
+    }
+
+    /// Suspends a reader at the back of `pipe_id`'s reader queue.
+    pub fn park_reader(&mut self, pipe_id: u64, reader: BlockedReader) {
+        self.readers.entry(pipe_id).or_default().push_back(reader);
+    }
+
+    /// Suspends a writer at the back of `pipe_id`'s writer queue.
+    pub fn park_writer(&mut self, pipe_id: u64, writer: BlockedWriter) {
+        self.writers.entry(pipe_id).or_default().push_back(writer);
+    }
+
+    /// Returns the identity of the reader at the front of `pipe_id`'s queue, if any.
+    ///
+    /// The fields are copied out so the caller can drop the borrow before touching the VFS or the
+    /// table again (e.g. to `pop_reader` after serving it).
+    pub fn front_reader(
+        &self,
+        pipe_id: u64,
+    ) -> Option<(ProcessIdentifier, ThreadIdentifier, i32, usize)> {
+        let r: &BlockedReader = self.readers.get(&pipe_id)?.front()?;
+        Some((r.source_pid, r.source_tid, r.fd, r.count))
+    }
+
+    /// Removes the reader at the front of `pipe_id`'s queue.
+    pub fn pop_reader(&mut self, pipe_id: u64) -> Option<BlockedReader> {
+        let queue: &mut VecDeque<BlockedReader> = self.readers.get_mut(&pipe_id)?;
+        let reader: Option<BlockedReader> = queue.pop_front();
+        if queue.is_empty() {
+            self.readers.remove(&pipe_id);
+        }
+        reader
+    }
+
+    /// Returns a shared reference to the writer at the front of `pipe_id`'s queue, if any.
+    pub fn front_writer(&self, pipe_id: u64) -> Option<&BlockedWriter> {
+        self.writers.get(&pipe_id)?.front()
+    }
+
+    /// Returns the routing identity `(source_pid, fd)` of the front writer of `pipe_id`, if any.
+    ///
+    /// The values are copied out so the caller can use them as a `while let` loop condition without
+    /// holding a borrow on the table across the body.
+    pub fn front_writer_meta(&self, pipe_id: u64) -> Option<(ProcessIdentifier, i32)> {
+        let w: &BlockedWriter = self.writers.get(&pipe_id)?.front()?;
+        Some((w.source_pid, w.fd))
+    }
+
+    /// Returns a mutable reference to the writer at the front of `pipe_id`'s queue, if any.
+    pub fn front_writer_mut(&mut self, pipe_id: u64) -> Option<&mut BlockedWriter> {
+        self.writers.get_mut(&pipe_id)?.front_mut()
+    }
+
+    /// Removes the writer at the front of `pipe_id`'s queue.
+    pub fn pop_writer(&mut self, pipe_id: u64) -> Option<BlockedWriter> {
+        let queue: &mut VecDeque<BlockedWriter> = self.writers.get_mut(&pipe_id)?;
+        let writer: Option<BlockedWriter> = queue.pop_front();
+        if queue.is_empty() {
+            self.writers.remove(&pipe_id);
+        }
+        writer
+    }
+
+    /// Removes and returns all readers suspended on `pipe_id` (used for EOF wakeups).
+    pub fn drain_readers(&mut self, pipe_id: u64) -> VecDeque<BlockedReader> {
+        self.readers.remove(&pipe_id).unwrap_or_default()
+    }
+
+    /// Removes and returns all writers suspended on `pipe_id` (used for `EPIPE` wakeups).
+    pub fn drain_writers(&mut self, pipe_id: u64) -> VecDeque<BlockedWriter> {
+        self.writers.remove(&pipe_id).unwrap_or_default()
+    }
+
+    /// Drops every suspended request issued by `pid`.
+    ///
+    /// Called when a process exits: it can no longer be answered, so its parked readers and writers
+    /// are discarded before the exit-driven EOF/`EPIPE` wakeups run for its peers.
+    pub fn purge_pid(&mut self, pid: ProcessIdentifier) {
+        Self::purge_readers(&mut self.readers, pid);
+        Self::purge_writers(&mut self.writers, pid);
+    }
+
+    /// Removes all readers belonging to `pid`, dropping now-empty per-pipe queues.
+    fn purge_readers(map: &mut BTreeMap<u64, VecDeque<BlockedReader>>, pid: ProcessIdentifier) {
+        map.retain(|_, queue| {
+            queue.retain(|r| r.source_pid != pid);
+            !queue.is_empty()
+        });
+    }
+
+    /// Removes all writers belonging to `pid`, dropping now-empty per-pipe queues.
+    fn purge_writers(map: &mut BTreeMap<u64, VecDeque<BlockedWriter>>, pid: ProcessIdentifier) {
+        map.retain(|_, queue| {
+            queue.retain(|w| w.source_pid != pid);
+            !queue.is_empty()
+        });
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -5,24 +5,21 @@
 // Imports
 //==================================================================================================
 
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use crate::{
+    unistd::message::{
+        PipeRequest,
+        PipeResponse,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
 };
-#[cfg(not(feature = "standalone"))]
-use {
-    crate::{
-        unistd::message::{
-            PipeRequest,
-            PipeResponse,
-        },
-        SystemCallMessage,
-        SystemCallMessageHeader,
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
     },
-    ::sys::{
-        ipc::Message,
-        pm::ThreadIdentifier,
-    },
+    ipc::Message,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -32,15 +29,32 @@ use {
 pub fn pipe() -> Result<[i32; 2], Error> {
     ::syslog::trace!("pipe()");
 
-    // In standalone mode, pipe is not available (no linuxd).
+    // In standalone mode, route the request to the guest-side vfsd daemon.
     #[cfg(feature = "standalone")]
     {
-        Err(Error::new(ErrorCode::OperationNotSupported, "pipe not available in standalone mode"))
+        pipe_vfsd()
     }
 
-    // Forward to linuxd via IPC.
+    // Otherwise, forward to linuxd via IKC.
     #[cfg(not(feature = "standalone"))]
     pipe_linuxd()
+}
+
+/// Sends a `pipe` request to vfsd via IPC and parses the response.
+///
+/// Mirrors the short-syscall convention used by `close`: send the request, then receive the reply.
+/// vfsd allocates the shared pipe buffer and the two descriptors and returns them.
+#[cfg(feature = "standalone")]
+fn pipe_vfsd() -> Result<[i32; 2], Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+
+    // Build request and send it to vfsd over local IPC.
+    let request: Message = PipeRequest::build(tid, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    parse_pipe_response(response)
 }
 
 /// Forwards a `pipe` request to linuxd via IPC.
@@ -54,7 +68,12 @@ fn pipe_linuxd() -> Result<[i32; 2], Error> {
 
     // Receive response.
     let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    parse_pipe_response(response)
+}
 
+/// Parses a `pipe` response, mapping a non-zero status onto an error code and otherwise extracting
+/// the read/write descriptors from the [`PipeResponse`].
+fn parse_pipe_response(response: Message) -> Result<[i32; 2], Error> {
     // Check whether system call succeeded or not.
     if response.status != 0 {
         // System call failed, parse error code and return it.

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -42,6 +42,7 @@ use ::sysapi::{
     fcntl::{
         file_control_request,
         file_creation_flags,
+        file_status_flags,
     },
     ffi::c_int,
     sys_stat::{
@@ -193,6 +194,8 @@ pub enum VfsFileHandle {
     /// Remote file opened through the host filesystem daemon (hostfsd).
     /// Operations on this handle must be forwarded via IKC by the caller (vfsd).
     HostFs(HostFsHandle),
+    /// One end of a POSIX unnamed pipe.
+    Pipe(crate::pipe::PipeEnd),
 }
 
 /// Handle for a file opened on the host filesystem via hostfsd.
@@ -312,6 +315,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => Ok(handle.read(buf)),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // Pipes are served by vfsd through the dedicated non-blocking primitives.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -322,6 +327,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // Pipes are served by vfsd through the dedicated non-blocking primitives.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -335,6 +342,8 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => handle.seek(offset, whence),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            // A pipe is not seekable (`ESPIPE`); the daemon rejects seeks before reaching here.
+            VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
         }
     }
 
@@ -345,6 +354,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => Ok(handle.size() as u64),
             VfsFileHandle::Directory(_) => Ok(0),
             VfsFileHandle::HostFs(_) => Ok(0),
+            VfsFileHandle::Pipe(_) => Ok(0),
         }
     }
 
@@ -369,6 +379,14 @@ impl VfsFileHandle {
             _ => None,
         }
     }
+
+    /// Returns the pipe end if this handle is one end of a pipe.
+    pub fn pipe_end(&self) -> Option<&crate::pipe::PipeEnd> {
+        match self {
+            VfsFileHandle::Pipe(end) => Some(end),
+            _ => None,
+        }
+    }
 }
 
 //==================================================================================================
@@ -390,6 +408,11 @@ struct VfsEntry {
     handle: VfsFileHandle,
     /// POSIX-compliant virtual file position (may exceed file size).
     virtual_pos: off_t,
+    /// Open file status flags (the mutable subset settable via `fcntl(F_SETFL)`).
+    ///
+    /// Only `O_NONBLOCK` is honored today; it is consulted by vfsd's pipe read/write handlers to
+    /// choose `EAGAIN` over blocking. Non-pipe descriptors are unaffected because they never block.
+    status_flags: c_int,
 }
 
 // SAFETY: VfsEntry contains FAT filesystem types that use `Cell` internally
@@ -530,6 +553,7 @@ fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
             state.slots[i] = Some(Arc::new(Mutex::new(VfsEntry {
                 handle,
                 virtual_pos: 0,
+                status_flags: 0,
             })));
             return Ok(VFS_FD_BASE + i as c_int);
         }
@@ -612,6 +636,28 @@ pub fn vfs_fork_clone(
     Ok(())
 }
 
+/// Pipe count-to-zero transitions surfaced by [`vfs_process_exit`].
+///
+/// Each entry records that the exiting process held the final reference to one end of a pipe, so
+/// that end's reference count dropped to zero when its open file description was released. vfsd
+/// uses these to run the corresponding wakeup (EOF for readers when a write end vanishes, `EPIPE`
+/// for writers when a read end vanishes).
+pub struct PipeClosure {
+    /// Stable identity of the affected pipe.
+    pub pipe_id: u64,
+    /// Whether the released end was the write end (`true`) or the read end (`false`).
+    pub was_write: bool,
+}
+
+/// Resources surfaced by [`vfs_process_exit`] that the daemon must act on after a process exits.
+pub struct ProcessExitReclaim {
+    /// Remote file descriptors of host-backed descriptions for which the process held the final
+    /// reference. Each must be closed on hostfsd or the remote handle leaks.
+    pub orphaned_hostfs_fds: Vec<i32>,
+    /// Pipe ends whose reference count reached zero because the process held the final reference.
+    pub pipe_closures: Vec<PipeClosure>,
+}
+
 /// Reclaims the per-process filesystem state of a terminated process.
 ///
 /// Drops `pid`'s recorded state, releasing its references to the open file descriptions it held.
@@ -619,12 +665,13 @@ pub fn vfs_fork_clone(
 /// descriptions, and prevents the per-process table from growing without bound. Reclaiming an
 /// unknown `pid` is a no-op.
 ///
-/// Returns the remote file descriptors of any host-backed open file descriptions for which `pid`
-/// held the final reference. The caller (vfsd) must forward a close for each of these to hostfsd:
-/// because the process is gone it can no longer close them itself, and the VFS has no other way to
-/// release a remote handle. Descriptions still shared with a surviving process are not returned.
-#[must_use = "the returned remote fds must be closed on hostfsd or they leak"]
-pub fn vfs_process_exit(pid: ProcessIdentifier) -> Vec<i32> {
+/// Returns the resources the daemon must act on: the remote file descriptors of any host-backed
+/// open file descriptions for which `pid` held the final reference (which it must close on hostfsd,
+/// because the process is gone and can no longer close them itself), and the pipe ends whose
+/// reference count reached zero (so the daemon can fire EOF/`EPIPE` wakeups for any suspended
+/// counterparts). Descriptions still shared with a surviving process are not returned.
+#[must_use = "the returned hostfs fds must be closed and pipe closures must trigger wakeups"]
+pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // Detach the process's state while holding the registry lock, but defer dropping it until the
     // lock is released. Dropping an open file description may run backend teardown; deferring keeps
     // the registry lock from ever nesting with backend locks, matching `vfs_close`.
@@ -634,23 +681,37 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> Vec<i32> {
         procs.remove(&pid)
     };
     let Some(state) = removed else {
-        return Vec::new();
+        return ProcessExitReclaim {
+            orphaned_hostfs_fds: Vec::new(),
+            pipe_closures: Vec::new(),
+        };
     };
     // The process has been removed from the registry, so an `Arc` strong count of one means no
     // surviving descriptor — in this or any other process — still shares the open file description.
-    // Its remote handle must therefore be closed on hostfsd. As the sole owner, the lock below is
+    // A host-backed handle must therefore be closed on hostfsd, and a pipe end's count drops to
+    // zero (which the dropped end's `Drop` applies just below). As the sole owner, the lock is
     // uncontended.
     let mut orphaned: Vec<i32> = Vec::new();
+    let mut pipe_closures: Vec<PipeClosure> = Vec::new();
     for open_file in state.slots.into_iter().flatten() {
         if Arc::strong_count(&open_file) != 1 {
             continue;
         }
-        if let VfsFileHandle::HostFs(h) = &open_file.lock().handle {
-            orphaned.push(h.remote_fd());
+        match &open_file.lock().handle {
+            VfsFileHandle::HostFs(h) => orphaned.push(h.remote_fd()),
+            VfsFileHandle::Pipe(end) => pipe_closures.push(PipeClosure {
+                pipe_id: end.pipe_id(),
+                was_write: end.is_write(),
+            }),
+            _ => {},
         }
-        // `open_file` is dropped here, after the registry lock has been released.
+        // `open_file` is dropped here, after the registry lock has been released; the pipe end's
+        // `Drop` decrements its reader/writer count as part of that.
     }
-    orphaned
+    ProcessExitReclaim {
+        orphaned_hostfs_fds: orphaned,
+        pipe_closures,
+    }
 }
 
 /// Reports whether `fd` is the last descriptor referencing its open file description.
@@ -671,6 +732,30 @@ pub fn vfs_hostfs_is_last_ref(fd: c_int) -> bool {
         // The table holds exactly one reference, so a strong count of one means no other descriptor
         // shares this open file description.
         Some(entry) => Arc::strong_count(entry) == 1,
+        None => false,
+    }
+}
+
+/// Reports whether closing `fd` would drop the final reference to a pipe end.
+///
+/// Returns `true` when `fd` refers to a pipe end and the current process holds the only descriptor
+/// for that end's open file description, so closing it (or the owning process exiting) decrements
+/// the pipe's reader/writer count to zero. Returns `false` when other descriptors still share the
+/// end (for example in a forked child), when `fd` is not a pipe, or when `fd` is invalid. This does
+/// not modify the descriptor table.
+pub fn vfs_pipe_is_last_ref(fd: c_int) -> bool {
+    let Ok(idx) = fd_index(fd) else {
+        return false;
+    };
+    let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
+    let Some(state) = procs.get(&current_pid()) else {
+        return false;
+    };
+    match state.slots.get(idx).and_then(|slot| slot.as_ref()) {
+        Some(entry) => {
+            // Must be a pipe and the sole reference for closing to drive the count to zero.
+            Arc::strong_count(entry) == 1 && matches!(&entry.lock().handle, VfsFileHandle::Pipe(_))
+        },
         None => false,
     }
 }
@@ -734,6 +819,97 @@ pub fn vfs_hostfs_set_readdir_offset(fd: c_int, offset: u32) -> bool {
             true
         },
         _ => false,
+    }
+}
+
+//==================================================================================================
+// Pipe FD Helpers
+//==================================================================================================
+
+/// Re-exported pipe outcome types so the daemon can match on them without importing
+/// [`crate::pipe`] directly.
+pub use crate::pipe::{
+    PipeReadOutcome,
+    PipeWriteOutcome,
+};
+
+/// Creates a pipe and allocates its read and write file descriptors in the current process.
+///
+/// Returns `(read_fd, write_fd)`. The two descriptors share a single pipe buffer with the reader
+/// and writer counts both initialized to one.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::TooManyOpenFiles`] when the descriptor table cannot accommodate both ends.
+/// If only the read end could be allocated, it is released before returning so that no half-open
+/// pipe is left behind.
+pub fn vfs_pipe() -> Result<(c_int, c_int), Fat32Error> {
+    let (read_end, write_end): (crate::pipe::PipeEnd, crate::pipe::PipeEnd) =
+        crate::pipe::PipeEnd::new_pair();
+    let read_fd: c_int = alloc_fd(VfsFileHandle::Pipe(read_end))?;
+    match alloc_fd(VfsFileHandle::Pipe(write_end)) {
+        Ok(write_fd) => Ok((read_fd, write_fd)),
+        Err(e) => {
+            // Releasing the read end drops its `PipeEnd`, decrementing the reader count; the write
+            // end was already dropped when `alloc_fd` consumed and failed on it. No half-open pipe
+            // survives.
+            let _ = vfs_close(read_fd);
+            Err(e)
+        },
+    }
+}
+
+/// Returns a pipe descriptor's identity and direction, or `None` if `fd` is not a pipe.
+///
+/// The returned tuple is `(pipe_id, is_write)`. vfsd uses `pipe_id` to key its blocked-request
+/// queues and `is_write` to enforce I/O direction.
+pub fn vfs_pipe_id(fd: c_int) -> Option<(u64, bool)> {
+    let file: OpenFile = entry_arc(fd).ok()?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end()?;
+    Some((end.pipe_id(), end.is_write()))
+}
+
+/// Attempts a non-blocking read from a pipe read end.
+///
+/// On [`PipeReadOutcome::Read(n)`](PipeReadOutcome::Read), `n` bytes of space were freed, so vfsd
+/// must try to revive a suspended writer.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the write end (reading the
+/// write end is rejected, mirroring `EBADF`).
+pub fn vfs_pipe_read(fd: c_int, buf: &mut [u8]) -> Result<PipeReadOutcome, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.read(buf).map_err(|_| Fat32Error::InvalidFd)
+}
+
+/// Attempts a non-blocking write to a pipe write end, honoring `PIPE_BUF` atomicity.
+///
+/// On [`PipeWriteOutcome::Wrote(n)`](PipeWriteOutcome::Wrote), `n` bytes became available, so vfsd
+/// must try to revive a suspended reader.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the read end (writing the
+/// read end is rejected, mirroring `EBADF`).
+pub fn vfs_pipe_write(fd: c_int, buf: &[u8]) -> Result<PipeWriteOutcome, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.write(buf).map_err(|_| Fat32Error::InvalidFd)
+}
+
+/// Returns the open file status flags for `fd` (as reported by `fcntl(F_GETFL)`).
+///
+/// Returns `0` if `fd` is invalid, which is harmless: callers consult this only to decide whether
+/// `O_NONBLOCK` is set, and a missing descriptor will fail the surrounding operation anyway.
+pub fn vfs_get_status_flags(fd: c_int) -> c_int {
+    match entry_arc(fd) {
+        Ok(file) => file.lock().status_flags,
+        Err(_) => 0,
     }
 }
 
@@ -967,11 +1143,44 @@ fn populate_stat_fields(buf: &mut ::sysapi::sys_stat::stat, size: u64, is_dir: b
     };
 }
 
+/// Populates stat fields for a pipe (FIFO) descriptor.
+///
+/// A pipe has no name, size, or on-disk blocks: `st_mode` carries `S_IFIFO` with owner read/write
+/// permissions and `st_size` is `0`, matching POSIX expectations for an unnamed pipe. `st_ino`
+/// carries the pipe's unique identity, and `st_dev` a synthetic pipefs device distinct from the
+/// VFS file device, so distinct pipes report distinct `(st_dev, st_ino)` pairs that never collide
+/// with regular files — mirroring how a real pipefs assigns one inode per pipe.
+fn populate_pipe_stat_fields(buf: &mut ::sysapi::sys_stat::stat, pipe_id: u64) {
+    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
+    const FIXED_EPOCH: i64 = 1_704_067_200;
+
+    buf.st_size = 0;
+    buf.st_nlink = 1;
+    buf.st_dev = 2; // Synthetic pipefs device ID, distinct from the VFS file device (1).
+    buf.st_ino = pipe_id;
+    buf.st_mode = file_type::S_IFIFO | file_mode::S_IRUSR | file_mode::S_IWUSR;
+    buf.st_blksize = STAT_BLOCK_SIZE;
+    buf.st_blocks = 0;
+    buf.st_atim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_mtim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_ctim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+}
+
 /// Gets file status for a VFS file descriptor.
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+    let pipe_id: Option<u64> = entry.handle.pipe_end().map(|end| end.pipe_id());
     let is_dir: bool = matches!(&entry.handle, VfsFileHandle::Directory(_));
     let size: u64 = entry.handle.size()?;
 
@@ -980,7 +1189,11 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
 
-    populate_stat_fields(buf, size, is_dir);
+    if let Some(pipe_id) = pipe_id {
+        populate_pipe_stat_fields(buf, pipe_id);
+    } else {
+        populate_stat_fields(buf, size, is_dir);
+    }
 
     Ok(())
 }
@@ -1155,7 +1368,9 @@ pub fn vfs_ftruncate(fd: c_int, length: off_t) -> Result<(), Fat32Error> {
             }
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
-        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) | VfsFileHandle::Pipe(_) => {
+            Err(Fat32Error::NotSupported)
+        },
     }
 }
 
@@ -1197,7 +1412,9 @@ pub fn vfs_fallocate(fd: c_int, offset: off_t, len: off_t) -> Result<(), Fat32Er
             Ok(())
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
-        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+        VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) | VfsFileHandle::Pipe(_) => {
+            Err(Fat32Error::NotSupported)
+        },
     }
 }
 
@@ -1210,9 +1427,10 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
     let entry: &mut VfsEntry = &mut guard;
     match &mut entry.handle {
         VfsFileHandle::Fat32(file) => file.flush(),
-        VfsFileHandle::DirectRead(_) | VfsFileHandle::Directory(_) | VfsFileHandle::HostFs(_) => {
-            Ok(())
-        },
+        VfsFileHandle::DirectRead(_)
+        | VfsFileHandle::Directory(_)
+        | VfsFileHandle::HostFs(_)
+        | VfsFileHandle::Pipe(_) => Ok(()),
     }
 }
 
@@ -1318,18 +1536,24 @@ pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
 
 /// File control operation on a VFS file descriptor.
 ///
-/// Only `F_GETFL` and `F_SETFL` are supported (as no-ops for FAT32).
-/// Other commands return `NotSupported`.
-pub fn vfs_fcntl(fd: c_int, cmd: c_int) -> Result<c_int, Fat32Error> {
-    // Verify the fd is valid.
-    let _file: OpenFile = entry_arc(fd)?;
+/// Supports the file-descriptor flag commands (`F_GETFD`/`F_SETFD`, which have no effect because
+/// the VFS implements no close-on-exec) and the file-status-flag commands (`F_GETFL`/`F_SETFL`).
+/// `F_SETFL` stores the mutable status-flag subset (currently only `O_NONBLOCK`) on the open file
+/// description; `F_GETFL` returns it. Other commands return [`Fat32Error::NotSupported`].
+pub fn vfs_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> Result<c_int, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
 
     match cmd {
         file_control_request::F_GETFD => Ok(0), // No FD flags (no close-on-exec for VFS).
         file_control_request::F_SETFD => Ok(0), // Accept but ignore (no close-on-exec).
-        file_control_request::F_GETFL => Ok(0), // No meaningful flags for FAT32.
-        file_control_request::F_SETFL => Ok(0), // Accept but ignore (no O_NONBLOCK etc.).
-        _ => Err(Fat32Error::NotSupported),     // Other commands not supported.
+        file_control_request::F_GETFL => Ok(file.lock().status_flags),
+        file_control_request::F_SETFL => {
+            // Persist only the mutable status-flag subset (currently `O_NONBLOCK`). The remaining
+            // bits (access mode, creation flags) are not changeable via `F_SETFL` per POSIX.
+            file.lock().status_flags = arg & file_status_flags::O_NONBLOCK;
+            Ok(0)
+        },
+        _ => Err(Fat32Error::NotSupported), // Other commands not supported.
     }
 }
 
@@ -2127,5 +2351,156 @@ mod tests {
         );
 
         forget_processes(&[parent, child]);
+    }
+
+    // -- pipe descriptor tests ---------------------------------------------------
+
+    /// Tests that `vfs_pipe` allocates two descriptors with correct directions and shared identity.
+    #[test]
+    fn pipe_allocates_read_and_write_ends() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7101);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        let (rid, r_is_write): (u64, bool) =
+            vfs_pipe_id(read_fd).expect("read fd should be a pipe");
+        let (wid, w_is_write): (u64, bool) =
+            vfs_pipe_id(write_fd).expect("write fd should be a pipe");
+        assert_eq!(rid, wid, "both ends share one pipe identity");
+        assert!(!r_is_write, "read_fd must be the read end");
+        assert!(w_is_write, "write_fd must be the write end");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests the non-blocking read/write outcome matrix and direction enforcement on a pipe.
+    #[test]
+    fn pipe_read_write_outcomes() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7111);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+
+        // Empty pipe with an open writer: a read would block.
+        let mut buf: [u8; 8] = [0u8; 8];
+        assert!(
+            matches!(vfs_pipe_read(read_fd, &mut buf), Ok(PipeReadOutcome::WouldBlock)),
+            "an empty pipe with a writer should block reads"
+        );
+
+        // Write then read back.
+        assert!(
+            matches!(vfs_pipe_write(write_fd, &[1, 2, 3]), Ok(PipeWriteOutcome::Wrote(3))),
+            "a write into a pipe with space should succeed"
+        );
+        match vfs_pipe_read(read_fd, &mut buf) {
+            Ok(PipeReadOutcome::Read(n)) => {
+                assert_eq!(n, 3, "should read the 3 written bytes");
+                assert_eq!(&buf[..3], &[1, 2, 3], "read bytes should match");
+            },
+            _ => panic!("expected a successful read"),
+        }
+
+        // Direction enforcement.
+        assert!(vfs_pipe_read(write_fd, &mut buf).is_err(), "reading the write end is rejected");
+        assert!(vfs_pipe_write(read_fd, &[0]).is_err(), "writing the read end is rejected");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests EOF after the write end closes and a broken pipe after the read end closes.
+    #[test]
+    fn pipe_eof_and_broken_pipe() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7121);
+        set_current_process(pid);
+
+        // EOF: close the write end, the read end then reports EOF.
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        assert!(vfs_pipe_is_last_ref(write_fd), "the sole write descriptor is the last reference");
+        vfs_close(write_fd).expect("closing the write end should succeed");
+        let mut buf: [u8; 4] = [0u8; 4];
+        assert!(
+            matches!(vfs_pipe_read(read_fd, &mut buf), Ok(PipeReadOutcome::Eof)),
+            "after the writer closes, the empty pipe reports EOF"
+        );
+        vfs_close(read_fd).expect("closing the read end should succeed");
+
+        // Broken pipe: close the read end, a write then reports a broken pipe.
+        let (read_fd2, write_fd2): (c_int, c_int) =
+            vfs_pipe().expect("pipe creation should succeed");
+        vfs_close(read_fd2).expect("closing the read end should succeed");
+        assert!(
+            matches!(vfs_pipe_write(write_fd2, &[9]), Ok(PipeWriteOutcome::BrokenPipe)),
+            "writing with no readers reports a broken pipe"
+        );
+        vfs_close(write_fd2).expect("closing the write end should succeed");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that `F_SETFL` stores `O_NONBLOCK` and `F_GETFL`/`vfs_get_status_flags` read it back.
+    #[test]
+    fn pipe_nonblock_status_flags_round_trip() {
+        use ::sysapi::fcntl::{
+            file_control_request,
+            file_status_flags,
+        };
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7131);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        assert_eq!(vfs_get_status_flags(read_fd), 0, "flags default to zero");
+
+        vfs_fcntl(read_fd, file_control_request::F_SETFL, file_status_flags::O_NONBLOCK)
+            .expect("F_SETFL should succeed");
+        assert_eq!(
+            vfs_get_status_flags(read_fd),
+            file_status_flags::O_NONBLOCK,
+            "O_NONBLOCK should be stored"
+        );
+        assert_eq!(
+            vfs_fcntl(read_fd, file_control_request::F_GETFL, 0).expect("F_GETFL should succeed"),
+            file_status_flags::O_NONBLOCK,
+            "F_GETFL returns the stored flags"
+        );
+        // Status flags are per open file description: the write end is unaffected.
+        assert_eq!(vfs_get_status_flags(write_fd), 0, "the write end is unaffected");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that process exit surfaces pipe count-to-zero transitions for the process's own ends.
+    #[test]
+    fn pipe_process_exit_reports_closures() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7141);
+        set_current_process(pid);
+
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        let (pipe_id, _): (u64, bool) = vfs_pipe_id(read_fd).expect("read fd should be a pipe");
+        // Both ends stay open in this single process, so it holds the only reference to each.
+        let _ = write_fd;
+
+        let reclaim: ProcessExitReclaim = vfs_process_exit(pid);
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "no hostfs fds were opened");
+        assert_eq!(reclaim.pipe_closures.len(), 2, "both ends are last references at exit");
+        assert!(
+            reclaim.pipe_closures.iter().all(|c| c.pipe_id == pipe_id),
+            "closures must target our pipe"
+        );
+        assert!(
+            reclaim.pipe_closures.iter().any(|c| c.was_write),
+            "the write end closure is reported"
+        );
+        assert!(
+            reclaim.pipe_closures.iter().any(|c| !c.was_write),
+            "the read end closure is reported"
+        );
+
+        forget_processes(&[pid]);
     }
 }

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -74,6 +74,9 @@ pub mod mount;
 /// Path-resolution cache used by the mount table.
 mod path_cache;
 
+/// In-memory pipe buffers for POSIX unnamed pipes.
+pub mod pipe;
+
 /// Global VFS state management.
 pub mod state;
 

--- a/src/libs/vfs/src/pipe.rs
+++ b/src/libs/vfs/src/pipe.rs
@@ -1,0 +1,459 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! In-memory pipe buffers for POSIX unnamed pipes.
+//!
+//! A pipe is a fixed-capacity byte ring buffer plus reader/writer reference counts. The buffer is
+//! owned by the VFS library (`no_std`) so that it lives next to the existing FD machinery; the
+//! daemon (vfsd) holds no buffer bytes and drives all blocking from its side via the non-blocking
+//! primitives exposed here.
+//!
+//! # Model
+//!
+//! [`PipeEnd::new_pair`] allocates one [`PipeInner`] (shared by both ends) and returns the read end
+//! and write end. Each end is stored inside a `VfsFileHandle::Pipe` in its own open file
+//! description (`Arc<Mutex<VfsEntry>>`). `fork()` clones the descriptor slots, sharing the same
+//! end, so the reader/writer counts are unaffected — matching POSIX, where `fork()` shares the open
+//! file description rather than creating a new one.
+//!
+//! [`PipeEnd`] implements [`Drop`]: when the last descriptor referring to a given end's open file
+//! description is closed (or its owning process exits), the description drops, [`PipeEnd::drop`]
+//! runs, and decrements `readers` or `writers` on the shared [`PipeInner`]. The corresponding
+//! *wakeup* of suspended callers is the daemon's responsibility (the VFS only adjusts the count).
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::{
+    collections::VecDeque,
+    sync::Arc,
+};
+use ::core::sync::atomic::{
+    AtomicU64,
+    Ordering,
+};
+use ::spin::Mutex;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Capacity of a pipe's kernel buffer, in bytes.
+///
+/// Matches the Linux default and is guaranteed to be at least [`PIPE_BUF`].
+pub const PIPE_CAPACITY: usize = 64 * 1024;
+
+/// Maximum size of an atomic pipe write (POSIX `PIPE_BUF`).
+///
+/// A write of at most this many bytes is performed all-or-nothing and never interleaves with the
+/// data of another writer. POSIX requires this to be at least 512.
+pub const PIPE_BUF: usize = 4096;
+
+//==================================================================================================
+// Pipe Identity Allocator
+//==================================================================================================
+
+/// Source of process-global, monotonically increasing pipe identifiers.
+///
+/// Identifiers are never recycled for the lifetime of the daemon, so a stale wakeup can never
+/// target the wrong pipe. Starts at `1` so that `0` can be reserved as an always-invalid sentinel
+/// by callers that need one.
+static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Allocates the next unique pipe identifier.
+fn alloc_pipe_id() -> u64 {
+    // `fetch_add` returns the previous value, so on wraparound it can yield `0`. Skip it to keep
+    // `0` reserved as an always-invalid sentinel.
+    loop {
+        let id: u64 = NEXT_PIPE_ID.fetch_add(1, Ordering::Relaxed);
+        if id != 0 {
+            return id;
+        }
+    }
+}
+
+//==================================================================================================
+// Pipe Buffer
+//==================================================================================================
+
+/// Shared state of a pipe: the byte ring buffer plus reader/writer reference counts.
+struct PipeInner {
+    /// Byte ring buffer, capped at [`PIPE_CAPACITY`].
+    buf: VecDeque<u8>,
+    /// Number of open read-end descriptions (`0` or `1` under `pipe()`/`dup`/`fork` sharing).
+    readers: u32,
+    /// Number of open write-end descriptions.
+    writers: u32,
+}
+
+impl PipeInner {
+    /// Non-blocking read from the buffer.
+    ///
+    /// Copies as many bytes as are available into `buf` (up to `buf.len()`). Returns
+    /// [`PipeReadOutcome::WouldBlock`] when the buffer is empty but at least one writer is still
+    /// open, and [`PipeReadOutcome::Eof`] when the buffer is empty and no writers remain. A
+    /// zero-length read transfers no data and never blocks — POSIX `read(2)` with `count == 0`
+    /// returns `0` immediately.
+    fn read(&mut self, buf: &mut [u8]) -> PipeReadOutcome {
+        // A zero-length read must succeed immediately and never block, even on an empty pipe.
+        if buf.is_empty() {
+            return PipeReadOutcome::Read(0);
+        }
+        let available: usize = self.buf.len();
+        if available == 0 {
+            if self.writers == 0 {
+                return PipeReadOutcome::Eof;
+            }
+            return PipeReadOutcome::WouldBlock;
+        }
+        let n: usize = available.min(buf.len());
+        // `n <= self.buf.len()`, so the drain yields exactly `n` bytes in front-to-back order.
+        for (dst, src) in buf.iter_mut().zip(self.buf.drain(..n)) {
+            *dst = src;
+        }
+        PipeReadOutcome::Read(n)
+    }
+
+    /// Non-blocking write into the buffer, honoring [`PIPE_BUF`] atomicity.
+    ///
+    /// If `buf.len() <= PIPE_BUF` the write is all-or-nothing: it either appends every byte or,
+    /// when there is insufficient free space, appends nothing and returns
+    /// [`PipeWriteOutcome::WouldBlock`]. For larger writes, as much as fits is appended. Returns
+    /// [`PipeWriteOutcome::BrokenPipe`] when no readers remain.
+    fn write(&mut self, buf: &[u8]) -> PipeWriteOutcome {
+        // A zero-length write transfers no data and has no other effect, so it succeeds even with
+        // no readers — matching Linux, which never reports `EPIPE`/`SIGPIPE` for an empty write.
+        if buf.is_empty() {
+            return PipeWriteOutcome::Wrote(0);
+        }
+        if self.readers == 0 {
+            return PipeWriteOutcome::BrokenPipe;
+        }
+        let free: usize = PIPE_CAPACITY.saturating_sub(self.buf.len());
+        let to_write: usize = if buf.len() <= PIPE_BUF {
+            // Atomic write: all-or-nothing.
+            if free < buf.len() {
+                return PipeWriteOutcome::WouldBlock;
+            }
+            buf.len()
+        } else {
+            // Large write: append as much as fits.
+            if free == 0 {
+                return PipeWriteOutcome::WouldBlock;
+            }
+            free.min(buf.len())
+        };
+        self.buf.extend(buf[..to_write].iter().copied());
+        PipeWriteOutcome::Wrote(to_write)
+    }
+}
+
+//==================================================================================================
+// Pipe End
+//==================================================================================================
+
+/// One end of a pipe, stored inside a `VfsFileHandle::Pipe`.
+///
+/// Both ends share the same [`PipeInner`] through an [`Arc`]; the `is_write` flag distinguishes the
+/// write end from the read end and is used to enforce I/O direction.
+pub struct PipeEnd {
+    inner: Arc<Mutex<PipeInner>>,
+    is_write: bool,
+    /// Stable identity used by vfsd to key blocked-request queues.
+    ///
+    /// Copied onto each end at construction so that identity lookups (and the `Drop`/exit paths
+    /// that report it) never need to take the shared [`PipeInner`] lock.
+    pipe_id: u64,
+}
+
+impl PipeEnd {
+    /// Allocates a new pipe and returns its `(read_end, write_end)` pair.
+    ///
+    /// The shared [`PipeInner`] starts with `readers == 1` and `writers == 1`.
+    pub fn new_pair() -> (PipeEnd, PipeEnd) {
+        let pipe_id: u64 = alloc_pipe_id();
+        let inner: Arc<Mutex<PipeInner>> = Arc::new(Mutex::new(PipeInner {
+            buf: VecDeque::new(),
+            readers: 1,
+            writers: 1,
+        }));
+        let read_end: PipeEnd = PipeEnd {
+            inner: inner.clone(),
+            is_write: false,
+            pipe_id,
+        };
+        let write_end: PipeEnd = PipeEnd {
+            inner,
+            is_write: true,
+            pipe_id,
+        };
+        (read_end, write_end)
+    }
+
+    /// Returns the stable identity of the pipe this end belongs to.
+    pub fn pipe_id(&self) -> u64 {
+        self.pipe_id
+    }
+
+    /// Returns `true` if this is the write end, `false` if it is the read end.
+    pub fn is_write(&self) -> bool {
+        self.is_write
+    }
+
+    /// Attempts a non-blocking read from the pipe.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the write end.
+    pub fn read(&self, buf: &mut [u8]) -> Result<PipeReadOutcome, PipeEndError> {
+        if self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().read(buf))
+    }
+
+    /// Attempts a non-blocking write to the pipe.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the read end.
+    pub fn write(&self, buf: &[u8]) -> Result<PipeWriteOutcome, PipeEndError> {
+        if !self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().write(buf))
+    }
+}
+
+impl Drop for PipeEnd {
+    /// Decrements the reader or writer count of the shared [`PipeInner`].
+    ///
+    /// Only the count is adjusted here; waking suspended callers is the daemon's responsibility,
+    /// because it owns the blocked-request queues.
+    fn drop(&mut self) {
+        let mut inner: spin::MutexGuard<'_, PipeInner> = self.inner.lock();
+        if self.is_write {
+            inner.writers = inner.writers.saturating_sub(1);
+        } else {
+            inner.readers = inner.readers.saturating_sub(1);
+        }
+    }
+}
+
+//==================================================================================================
+// Outcomes
+//==================================================================================================
+
+/// Outcome of a non-blocking pipe read attempt.
+#[derive(Debug)]
+pub enum PipeReadOutcome {
+    /// Copied `N` bytes out of the buffer; freed `N` bytes of space. `N` is `0` only for a
+    /// zero-length read.
+    Read(usize),
+    /// Buffer empty with writers still open — the caller must block (or receive `EAGAIN`).
+    WouldBlock,
+    /// Buffer empty and no writers remain — the caller must receive end-of-file (`0`).
+    Eof,
+}
+
+/// Outcome of a non-blocking pipe write attempt.
+#[derive(Debug)]
+pub enum PipeWriteOutcome {
+    /// Appended `N` bytes (`N > 0`, or `0` only for a zero-length write).
+    Wrote(usize),
+    /// Insufficient space to make progress — the caller must block (or receive `EAGAIN`).
+    WouldBlock,
+    /// No readers remain — the caller must receive `EPIPE`.
+    BrokenPipe,
+}
+
+/// Error returned by [`PipeEnd::read`]/[`PipeEnd::write`] when used in the wrong direction.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeEndError {
+    /// Read attempted on the write end, or write attempted on the read end.
+    WrongDirection,
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Drains all available bytes from a read end into a freshly allocated vector.
+    fn read_all(end: &PipeEnd, max: usize) -> alloc::vec::Vec<u8> {
+        let mut buf: alloc::vec::Vec<u8> = alloc::vec![0u8; max];
+        match end.read(&mut buf).expect("read end") {
+            PipeReadOutcome::Read(n) => {
+                buf.truncate(n);
+                buf
+            },
+            _ => alloc::vec::Vec::new(),
+        }
+    }
+
+    /// Tests a basic write-then-read round-trip preserving byte order.
+    #[test]
+    fn round_trip_preserves_bytes() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let data: [u8; 5] = [1, 2, 3, 4, 5];
+        match w.write(&data).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => assert_eq!(n, 5, "should write all 5 bytes"),
+            _ => panic!("write should succeed"),
+        }
+        assert_eq!(read_all(&r, 16), data, "read bytes should match written bytes");
+    }
+
+    /// Tests that the two ends report the same, unique pipe identity.
+    #[test]
+    fn ends_share_identity_unique_across_pipes() {
+        let (r1, w1): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let (r2, _w2): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(r1.pipe_id(), w1.pipe_id(), "both ends share one identity");
+        assert_ne!(r1.pipe_id(), r2.pipe_id(), "distinct pipes have distinct identities");
+        assert!(!r1.is_write(), "read end must not be the write end");
+        assert!(w1.is_write(), "write end must be the write end");
+    }
+
+    /// Tests that a read on an empty pipe with an open writer would block.
+    #[test]
+    fn empty_with_writer_would_block() {
+        let (r, _w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::WouldBlock),
+            "empty pipe with a writer should block"
+        );
+    }
+
+    /// Tests that a read on an empty pipe with no writers returns EOF.
+    #[test]
+    fn empty_without_writer_is_eof() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        drop(w);
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::Eof),
+            "empty pipe with no writers should report EOF"
+        );
+    }
+
+    /// Tests that buffered data is still readable after all writers close (drain-then-EOF).
+    #[test]
+    fn buffered_data_readable_after_writer_close() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        w.write(&[9, 8, 7]).expect("write end");
+        drop(w);
+        assert_eq!(
+            read_all(&r, 8),
+            alloc::vec![9, 8, 7],
+            "buffered bytes must survive writer close"
+        );
+        let mut buf: [u8; 4] = [0; 4];
+        assert!(
+            matches!(r.read(&mut buf).expect("read end"), PipeReadOutcome::Eof),
+            "after draining, an empty pipe with no writers reports EOF"
+        );
+    }
+
+    /// Tests that a write to a pipe whose readers have all closed is a broken pipe.
+    #[test]
+    fn write_without_reader_is_broken_pipe() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        drop(r);
+        assert!(
+            matches!(w.write(&[1, 2, 3]).expect("write end"), PipeWriteOutcome::BrokenPipe),
+            "writing with no readers should report a broken pipe"
+        );
+    }
+
+    /// Tests `PIPE_BUF`-sized atomic writes: a write that does not fit entirely appends nothing.
+    #[test]
+    fn atomic_write_is_all_or_nothing() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        // Fill the buffer to within less than PIPE_BUF of capacity.
+        let bulk: alloc::vec::Vec<u8> = alloc::vec![0u8; PIPE_CAPACITY - 16];
+        match w.write(&bulk).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => assert_eq!(n, PIPE_CAPACITY - 16, "bulk fill should fit"),
+            _ => panic!("bulk fill should succeed"),
+        }
+        // A PIPE_BUF-sized write cannot fit in the remaining 16 bytes, so nothing is written.
+        let atomic: [u8; PIPE_BUF] = [7u8; PIPE_BUF];
+        assert!(
+            matches!(w.write(&atomic).expect("write end"), PipeWriteOutcome::WouldBlock),
+            "an atomic write that does not fit must append nothing"
+        );
+        // Free space, then the same write succeeds atomically.
+        let _ = r.read(&mut [0u8; 4096]).expect("read end");
+        assert!(
+            matches!(w.write(&atomic).expect("write end"), PipeWriteOutcome::Wrote(PIPE_BUF)),
+            "the atomic write should succeed once space is available"
+        );
+    }
+
+    /// Tests that a write larger than `PIPE_BUF` may be partially accepted up to capacity.
+    #[test]
+    fn large_write_is_partial() {
+        let (_r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let big: alloc::vec::Vec<u8> = alloc::vec![5u8; PIPE_CAPACITY + 4096];
+        match w.write(&big).expect("write end") {
+            PipeWriteOutcome::Wrote(n) => {
+                assert_eq!(n, PIPE_CAPACITY, "a large write fills exactly to capacity")
+            },
+            _ => panic!("a large write into an empty pipe should make progress"),
+        }
+        // The pipe is now full: a further large write would block.
+        assert!(
+            matches!(w.write(&big).expect("write end"), PipeWriteOutcome::WouldBlock),
+            "a full pipe should block further writes"
+        );
+    }
+
+    /// Tests that using an end in the wrong direction is rejected.
+    #[test]
+    fn wrong_direction_is_rejected() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(
+            w.read(&mut [0u8; 4]).expect_err("read on write end"),
+            PipeEndError::WrongDirection,
+            "reading the write end must be rejected"
+        );
+        assert_eq!(
+            r.write(&[0u8; 4]).expect_err("write on read end"),
+            PipeEndError::WrongDirection,
+            "writing the read end must be rejected"
+        );
+    }
+
+    /// Tests ring-buffer wrap-around across many interleaved write/read cycles.
+    #[test]
+    fn ring_buffer_wraps_around() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        let chunk: [u8; 1000] = [3u8; 1000];
+        // Many cycles push total bytes well past PIPE_CAPACITY, exercising wrap-around.
+        for _ in 0..200 {
+            assert!(
+                matches!(w.write(&chunk).expect("write end"), PipeWriteOutcome::Wrote(1000)),
+                "each 1000-byte chunk should fit after draining"
+            );
+            assert_eq!(read_all(&r, 1000).len(), 1000, "each cycle should read back 1000 bytes");
+        }
+    }
+
+    /// Tests that a zero-length read returns `Read(0)` immediately and never blocks.
+    #[test]
+    fn zero_length_read_does_not_block() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        // Empty pipe with an open writer would normally block, but a zero-length read must not.
+        assert!(
+            matches!(r.read(&mut []).expect("read end"), PipeReadOutcome::Read(0)),
+            "a zero-length read on an empty pipe with a writer must return Read(0)"
+        );
+        // The same holds once all writers have closed: still `Read(0)`, never `Eof`.
+        drop(w);
+        assert!(
+            matches!(r.read(&mut []).expect("read end"), PipeReadOutcome::Read(0)),
+            "a zero-length read on an empty pipe with no writers must return Read(0)"
+        );
+    }
+}

--- a/src/tests/linux-app/src/file_system.rs
+++ b/src/tests/linux-app/src/file_system.rs
@@ -294,6 +294,9 @@ pub fn test() {
 
     #[cfg(not(feature = "standalone"))]
     test_pipe();
+
+    #[cfg(feature = "standalone")]
+    test_pipe_standalone();
 }
 
 #[cfg(not(feature = "standalone"))]
@@ -451,5 +454,608 @@ fn test_pipe() {
         Err(error) => {
             panic!("failed to close directory: {:?}", error);
         },
+    }
+}
+
+/// Exercises unnamed pipes in standalone mode (routed through vfsd).
+///
+/// Covers the single-process paths that do not require a peer: creation, `fstat` reporting
+/// `S_IFIFO`, `lseek` returning `ESPIPE`, `fcntl` round-tripping `O_NONBLOCK`, non-blocking
+/// `EAGAIN` on an empty read and on a full write, a byte-exact round trip, end-of-file after the
+/// write end closes, and `EPIPE` after the read end closes. Cross-process blocking is covered by
+/// the dedicated `pipe-test` binary.
+#[cfg(feature = "standalone")]
+fn test_pipe_standalone() {
+    use ::sys::error::ErrorCode;
+    use ::sysapi::{
+        fcntl::{
+            file_control_request::{
+                F_GETFL,
+                F_SETFL,
+            },
+            file_status_flags::O_NONBLOCK,
+        },
+        sys_stat::{
+            self,
+            file_type::S_ISFIFO,
+        },
+        unistd::file_seek::SEEK_SET,
+    };
+
+    /// Pipe buffer capacity in vfsd; filling this many bytes makes the pipe full.
+    const PIPE_CAPACITY: usize = 64 * 1024;
+
+    ::syslog::info!("testing unnamed pipes in standalone mode");
+
+    let [read_fd, write_fd]: [i32; 2] = match unistd::pipe() {
+        Ok(fds) => {
+            ::syslog::info!("created pipe with fds ({}, {})", fds[0], fds[1]);
+            fds
+        },
+        Err(e) => panic!("pipe() failed: {:?}", e),
+    };
+
+    // fstat() reports a FIFO with zero size.
+    let mut st: sys_stat::stat = sys_stat::stat::default();
+    match sys::stat::fstat(read_fd, &mut st) {
+        Ok(()) => {
+            if !S_ISFIFO(st.st_mode) {
+                panic!("pipe fstat st_mode is not S_IFIFO (mode={:#o})", { st.st_mode });
+            }
+            if st.st_size != 0 {
+                panic!("pipe fstat st_size should be 0 (size={})", { st.st_size });
+            }
+        },
+        Err(e) => panic!("fstat on pipe failed: {:?}", e),
+    }
+
+    // lseek() on a pipe fails with ESPIPE.
+    match unistd::lseek(read_fd, 0, SEEK_SET) {
+        Ok(_) => panic!("lseek on a pipe should fail with ESPIPE"),
+        Err(e) if e.code == ErrorCode::IllegalSeek => {},
+        Err(e) => panic!("lseek on a pipe returned unexpected error: {:?}", e),
+    }
+
+    // fcntl(F_GETFL/F_SETFL) round-trips O_NONBLOCK.
+    match fcntl::fcntl(read_fd, F_GETFL, None) {
+        Ok(0) => {},
+        Ok(fl) => panic!("initial F_GETFL should be 0 (got {})", fl),
+        Err(e) => panic!("F_GETFL failed: {:?}", e),
+    }
+    if let Err(e) = fcntl::fcntl(read_fd, F_SETFL, Some(O_NONBLOCK)) {
+        panic!("F_SETFL O_NONBLOCK failed: {:?}", e);
+    }
+    match fcntl::fcntl(read_fd, F_GETFL, None) {
+        Ok(fl) if fl & O_NONBLOCK != 0 => {},
+        Ok(fl) => panic!("F_GETFL should report O_NONBLOCK (got {:#x})", fl),
+        Err(e) => panic!("F_GETFL failed: {:?}", e),
+    }
+
+    // A non-blocking read on an empty pipe returns EAGAIN.
+    let mut one: [u8; 1] = [0u8; 1];
+    match unistd::read(read_fd, &mut one) {
+        Err(e) if e.code == ErrorCode::TryAgain => {},
+        Ok(n) => panic!("nonblocking read on empty pipe should fail, got {} bytes", n),
+        Err(e) => panic!("nonblocking read returned unexpected error: {:?}", e),
+    }
+
+    // Restore blocking mode for the round trip.
+    if let Err(e) = fcntl::fcntl(read_fd, F_SETFL, Some(0)) {
+        panic!("F_SETFL clear failed: {:?}", e);
+    }
+
+    // A write-then-read round trip preserves bytes in order.
+    let mut write_buf: [u8; 128] = [0u8; 128];
+    for (i, b) in write_buf.iter_mut().enumerate() {
+        *b = i as u8;
+    }
+    match unistd::write(write_fd, &write_buf) {
+        Ok(128) => {},
+        Ok(n) => panic!("short pipe write (n={})", n),
+        Err(e) => panic!("pipe write failed: {:?}", e),
+    }
+    let mut read_buf: [u8; 128] = [0u8; 128];
+    match unistd::read(read_fd, &mut read_buf) {
+        Ok(128) => {},
+        Ok(n) => panic!("short pipe read (n={})", n),
+        Err(e) => panic!("pipe read failed: {:?}", e),
+    }
+    if read_buf != write_buf {
+        panic!("pipe round-trip data mismatch");
+    }
+    ::syslog::info!("pipe round trip preserved 128 bytes");
+
+    // A non-blocking write to a full pipe returns EAGAIN. Fill the buffer with page-sized writes,
+    // then expect the next write to fail.
+    if let Err(e) = fcntl::fcntl(write_fd, F_SETFL, Some(O_NONBLOCK)) {
+        panic!("F_SETFL O_NONBLOCK on write end failed: {:?}", e);
+    }
+    let page: [u8; 4096] = [0xABu8; 4096];
+    let mut filled: usize = 0;
+    while filled < PIPE_CAPACITY {
+        match unistd::write(write_fd, &page) {
+            Ok(0) => break,
+            Ok(n) => filled += n as usize,
+            Err(e) if e.code == ErrorCode::TryAgain => break,
+            Err(e) => panic!("fill write failed: {:?}", e),
+        }
+    }
+    match unistd::write(write_fd, &page[..1]) {
+        Err(e) if e.code == ErrorCode::TryAgain => {},
+        Ok(n) => panic!("nonblocking write to full pipe should fail, wrote {}", n),
+        Err(e) => panic!("nonblocking full-pipe write returned unexpected error: {:?}", e),
+    }
+    ::syslog::info!("nonblocking write to a full pipe returned EAGAIN (filled {} bytes)", filled);
+
+    // Drain everything so the EOF check below sees an empty pipe.
+    let mut sink: [u8; 4096] = [0u8; 4096];
+    let mut drained: usize = 0;
+    while drained < filled {
+        match unistd::read(read_fd, &mut sink) {
+            Ok(0) => break,
+            Ok(n) => drained += n as usize,
+            Err(e) => panic!("drain read failed: {:?}", e),
+        }
+    }
+    if let Err(e) = fcntl::fcntl(write_fd, F_SETFL, Some(0)) {
+        panic!("F_SETFL clear on write end failed: {:?}", e);
+    }
+
+    // Closing the write end makes a blocking read return end-of-file.
+    if let Err(e) = unistd::close(write_fd) {
+        panic!("close write end failed: {:?}", e);
+    }
+    match unistd::read(read_fd, &mut one) {
+        Ok(0) => {},
+        Ok(n) => panic!("read after writer close should be EOF, got {} bytes", n),
+        Err(e) => panic!("EOF read failed: {:?}", e),
+    }
+    if let Err(e) = unistd::close(read_fd) {
+        panic!("close read end failed: {:?}", e);
+    }
+    ::syslog::info!("read returned EOF after the write end closed");
+
+    // Writing to a pipe whose read end is closed fails with EPIPE.
+    let [read_fd2, write_fd2]: [i32; 2] = match unistd::pipe() {
+        Ok(fds) => fds,
+        Err(e) => panic!("second pipe() failed: {:?}", e),
+    };
+    if let Err(e) = unistd::close(read_fd2) {
+        panic!("close read end (2) failed: {:?}", e);
+    }
+    match unistd::write(write_fd2, &write_buf[..1]) {
+        Err(e) if e.code == ErrorCode::BrokenPipe => {},
+        Ok(n) => panic!("write with no readers should fail with EPIPE, wrote {}", n),
+        Err(e) => panic!("EPIPE write returned unexpected error: {:?}", e),
+    }
+    if let Err(e) = unistd::close(write_fd2) {
+        panic!("close write end (2) failed: {:?}", e);
+    }
+    ::syslog::info!("write returned EPIPE after the read end closed");
+
+    // Cross-process blocking transfer (suspend/revive) via fork().
+    test_pipe_blocking_fork();
+
+    // Peer-exit wakeups: a parked reader observes EOF when the last writer process exits, and a
+    // parked writer observes EPIPE when the last reader process exits.
+    test_pipe_eof_on_writer_exit();
+    test_pipe_epipe_on_reader_exit();
+
+    ::syslog::info!("pipe standalone test passed");
+}
+
+/// Streams more than one pipe buffer's worth of data from a parent to a forked child, forcing the
+/// writer to block until the reader drains and exercising vfsd's suspend/revive path end-to-end.
+///
+/// The parent writes a deterministic ramp larger than the pipe capacity; the child drains and
+/// verifies it, then reports a pass/fail verdict over IPC. The child exits without returning to the
+/// shared flow, so only the parent continues.
+#[cfg(feature = "standalone")]
+fn test_pipe_blocking_fork() {
+    use ::sys::{
+        ipc::{
+            Message,
+            MessageReceiver,
+            MessageSender,
+            MessageType,
+        },
+        kcall::{
+            fork,
+            ipc,
+            pm,
+        },
+        pm::ProcessIdentifier,
+    };
+
+    /// Total bytes streamed; exceeds the 64 KiB pipe capacity to force the writer to block.
+    const TOTAL: usize = 96 * 1024;
+    /// Bytes transferred per read/write iteration.
+    const CHUNK: usize = 4096;
+    /// Bound on first-read retries absorbing the asynchronous fork-clone descriptor duplication.
+    const MAX_FIRST_READ_ATTEMPTS: u32 = 4096;
+    /// Child exit status when the transfer verifies successfully.
+    const CHILD_EXIT_OK: i32 = 0;
+    /// Child exit status when the transfer fails.
+    const CHILD_EXIT_FAIL: i32 = 1;
+
+    ::syslog::info!("testing cross-process blocking pipe transfer via fork()");
+
+    let parent_pid: ProcessIdentifier = match pm::getpid_uncached() {
+        Ok(pid) => pid,
+        Err(e) => panic!("getpid failed: {:?}", e),
+    };
+
+    let [read_fd, write_fd]: [i32; 2] = match unistd::pipe() {
+        Ok(fds) => fds,
+        Err(e) => panic!("pipe() for fork test failed: {:?}", e),
+    };
+
+    let child_pid: ProcessIdentifier = match fork::__kcall_fork() {
+        Ok(pid) => pid,
+        Err(e) => panic!("fork() failed: {:?}", e),
+    };
+
+    // Child path: drain and verify the stream, report the verdict, and exit.
+    if child_pid == ProcessIdentifier::from(0) {
+        let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
+            Ok(pid) => pid,
+            Err(_) => {
+                let _ = pm::__kcall_exit(CHILD_EXIT_FAIL);
+                loop {
+                    ::core::hint::spin_loop();
+                }
+            },
+        };
+        let passed: bool = pipe_child_drain(read_fd, TOTAL, CHUNK, MAX_FIRST_READ_ATTEMPTS);
+
+        // Report the verdict to the parent.
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        payload[0] = u8::from(passed);
+        let reply: Message = Message::new(
+            MessageSender::from(my_pid),
+            MessageReceiver::from(parent_pid),
+            MessageType::Ipc,
+            None,
+            payload,
+        );
+        let _ = ipc::__kcall_send(&reply);
+
+        let status: i32 = if passed {
+            CHILD_EXIT_OK
+        } else {
+            CHILD_EXIT_FAIL
+        };
+        let _ = pm::__kcall_exit(status);
+        loop {
+            ::core::hint::spin_loop();
+        }
+    }
+
+    // Parent path: write the ramp, blocking whenever the pipe fills, then collect the verdict.
+    let mut page: [u8; CHUNK] = [0u8; CHUNK];
+    let mut offset: usize = 0;
+    while offset < TOTAL {
+        let len: usize = core::cmp::min(CHUNK, TOTAL - offset);
+        for (i, b) in page[..len].iter_mut().enumerate() {
+            *b = ((offset + i) & 0xFF) as u8;
+        }
+        match unistd::write(write_fd, &page[..len]) {
+            Ok(0) => panic!("parent pipe write made no progress at offset {}", offset),
+            Ok(n) => offset += n as usize,
+            Err(e) => panic!("parent pipe write failed at offset {}: {:?}", offset, e),
+        }
+    }
+
+    // Receive the child's verdict (happens-after the child has drained the whole stream).
+    let reply: Message = match ipc::__kcall_recv() {
+        Ok(m) => m,
+        Err(e) => panic!("parent failed to receive child verdict: {:?}", e),
+    };
+    if reply.payload[0] != 1 {
+        panic!("child reported a blocking pipe transfer failure");
+    }
+
+    let _ = unistd::close(read_fd);
+    let _ = unistd::close(write_fd);
+    ::syslog::info!("cross-process blocking pipe transfer of {} bytes succeeded", TOTAL);
+}
+
+/// Drains exactly `total` bytes from `read_fd` and verifies they form the expected ramp.
+///
+/// The first read is retried up to `max_first_attempts` times to absorb the window in which a
+/// freshly forked child's descriptors have not yet been duplicated into vfsd. Returns whether the
+/// full stream was received and validated.
+#[cfg(feature = "standalone")]
+fn pipe_child_drain(read_fd: i32, total: usize, chunk: usize, max_first_attempts: u32) -> bool {
+    let mut buf: [u8; 4096] = [0u8; 4096];
+    let mut offset: usize = 0;
+    let mut first_read_done: bool = false;
+    let mut attempts: u32 = 0;
+
+    while offset < total {
+        let len: usize = core::cmp::min(chunk, total - offset);
+        match unistd::read(read_fd, &mut buf[..len]) {
+            // Premature EOF while the writer is still open: a failure.
+            Ok(0) => return false,
+            Ok(n) => {
+                first_read_done = true;
+                let n: usize = n as usize;
+                for (i, b) in buf[..n].iter().enumerate() {
+                    if *b != ((offset + i) & 0xFF) as u8 {
+                        return false;
+                    }
+                }
+                offset += n;
+            },
+            // Absorb the fork-clone duplication window on the very first read only.
+            Err(_) if !first_read_done && attempts < max_first_attempts => {
+                attempts += 1;
+            },
+            Err(_) => return false,
+        }
+    }
+
+    offset == total
+}
+
+/// Verifies that a reader parked on an empty pipe observes EOF when the last writer *process*
+/// exits, exercising vfsd's process-exit reclamation path (`wake_all_readers_eof`).
+///
+/// The parent keeps the read end and survives; the forked child keeps the write end and exits
+/// without writing. The parent closes its own write end first, so the child holds the sole
+/// remaining writer reference at exit. Whether the parent parks before the child exits or reads
+/// afterward, the observable result is the same: a clean EOF.
+#[cfg(feature = "standalone")]
+fn test_pipe_eof_on_writer_exit() {
+    use ::sys::{
+        ipc::{
+            Message,
+            MessageReceiver,
+            MessageSender,
+            MessageType,
+        },
+        kcall::{
+            fork,
+            ipc,
+            pm,
+        },
+        pm::ProcessIdentifier,
+    };
+
+    /// Bound on close retries absorbing the asynchronous fork-clone descriptor duplication.
+    const MAX_SETUP_ATTEMPTS: u32 = 4096;
+    /// Payload byte signalling that the child has finished setting up its descriptors.
+    const READY: u8 = 1;
+    /// Child exit status when setup succeeds.
+    const CHILD_EXIT_OK: i32 = 0;
+    /// Child exit status when setup fails.
+    const CHILD_EXIT_FAIL: i32 = 1;
+
+    ::syslog::info!("testing pipe EOF wakeup when the last writer process exits");
+
+    let parent_pid: ProcessIdentifier = match pm::getpid_uncached() {
+        Ok(pid) => pid,
+        Err(e) => panic!("getpid failed: {:?}", e),
+    };
+
+    let [read_fd, write_fd]: [i32; 2] = match unistd::pipe() {
+        Ok(fds) => fds,
+        Err(e) => panic!("pipe() for EOF-on-exit test failed: {:?}", e),
+    };
+
+    let child_pid: ProcessIdentifier = match fork::__kcall_fork() {
+        Ok(pid) => pid,
+        Err(e) => panic!("fork() failed: {:?}", e),
+    };
+
+    // Child path: drop the unused read end, signal readiness, and exit holding the write end.
+    if child_pid == ProcessIdentifier::from(0) {
+        let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
+            Ok(pid) => pid,
+            Err(_) => {
+                let _ = pm::__kcall_exit(CHILD_EXIT_FAIL);
+                loop {
+                    ::core::hint::spin_loop();
+                }
+            },
+        };
+
+        // A successful close proves the fork-clone landed and drops the child's reader reference.
+        let status: i32 = if pipe_close_after_fork_clone(read_fd, MAX_SETUP_ATTEMPTS) {
+            let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+            payload[0] = READY;
+            let reply: Message = Message::new(
+                MessageSender::from(my_pid),
+                MessageReceiver::from(parent_pid),
+                MessageType::Ipc,
+                None,
+                payload,
+            );
+            let _ = ipc::__kcall_send(&reply);
+            CHILD_EXIT_OK
+        } else {
+            CHILD_EXIT_FAIL
+        };
+
+        // Exit while holding the write end: this drops the final writer reference.
+        let _ = pm::__kcall_exit(status);
+        loop {
+            ::core::hint::spin_loop();
+        }
+    }
+
+    // Parent path: wait for the child to be ready, then become the sole reader and read EOF.
+    let ready: Message = match ipc::__kcall_recv() {
+        Ok(m) => m,
+        Err(e) => panic!("parent failed to receive child readiness: {:?}", e),
+    };
+    if ready.payload[0] != READY {
+        panic!("child failed to set up the writer end for the EOF test");
+    }
+
+    // Drop the parent's own write reference so the child holds the only remaining writer.
+    if let Err(e) = unistd::close(write_fd) {
+        panic!("parent failed to close its write end: {:?}", e);
+    }
+
+    // The child exits holding the last writer reference, so this read must observe a clean EOF,
+    // whether it parks first and is revived or runs after the child has already exited.
+    let mut buf: [u8; 64] = [0u8; 64];
+    match unistd::read(read_fd, &mut buf) {
+        Ok(0) => {},
+        Ok(n) => panic!("reader expected EOF but received {} bytes", n),
+        Err(e) => panic!("reader expected EOF but read failed: {:?}", e),
+    }
+
+    let _ = unistd::close(read_fd);
+    ::syslog::info!("reader observed EOF after the last writer process exited");
+}
+
+/// Verifies that a writer parked on a full pipe observes EPIPE when the last reader *process*
+/// exits, exercising vfsd's process-exit reclamation path (`fail_all_writers_epipe`).
+///
+/// The parent keeps the write end and survives; the forked child keeps the read end and exits
+/// without draining. The parent closes its own read end first, so the child holds the sole
+/// remaining reader reference at exit. The parent fills the pipe until it blocks; the child's
+/// exit then fails the parked writer with EPIPE.
+#[cfg(feature = "standalone")]
+fn test_pipe_epipe_on_reader_exit() {
+    use ::sys::{
+        error::ErrorCode,
+        ipc::{
+            Message,
+            MessageReceiver,
+            MessageSender,
+            MessageType,
+        },
+        kcall::{
+            fork,
+            ipc,
+            pm,
+        },
+        pm::ProcessIdentifier,
+    };
+
+    /// Bound on close retries absorbing the asynchronous fork-clone descriptor duplication.
+    const MAX_SETUP_ATTEMPTS: u32 = 4096;
+    /// Payload byte signalling that the child has finished setting up its descriptors.
+    const READY: u8 = 1;
+    /// Bytes written per iteration while filling the pipe.
+    const CHUNK: usize = 4096;
+    /// Upper bound on bytes written before the writer is expected to have failed; comfortably
+    /// exceeds the 64 KiB pipe capacity so a healthy pipe parks well before this limit.
+    const MAX_WRITE: usize = 256 * 1024;
+    /// Child exit status when setup succeeds.
+    const CHILD_EXIT_OK: i32 = 0;
+    /// Child exit status when setup fails.
+    const CHILD_EXIT_FAIL: i32 = 1;
+
+    ::syslog::info!("testing pipe EPIPE wakeup when the last reader process exits");
+
+    let parent_pid: ProcessIdentifier = match pm::getpid_uncached() {
+        Ok(pid) => pid,
+        Err(e) => panic!("getpid failed: {:?}", e),
+    };
+
+    let [read_fd, write_fd]: [i32; 2] = match unistd::pipe() {
+        Ok(fds) => fds,
+        Err(e) => panic!("pipe() for EPIPE-on-exit test failed: {:?}", e),
+    };
+
+    let child_pid: ProcessIdentifier = match fork::__kcall_fork() {
+        Ok(pid) => pid,
+        Err(e) => panic!("fork() failed: {:?}", e),
+    };
+
+    // Child path: drop the unused write end, signal readiness, and exit holding the read end.
+    if child_pid == ProcessIdentifier::from(0) {
+        let my_pid: ProcessIdentifier = match pm::getpid_uncached() {
+            Ok(pid) => pid,
+            Err(_) => {
+                let _ = pm::__kcall_exit(CHILD_EXIT_FAIL);
+                loop {
+                    ::core::hint::spin_loop();
+                }
+            },
+        };
+
+        // A successful close proves the fork-clone landed and drops the child's writer reference.
+        let status: i32 = if pipe_close_after_fork_clone(write_fd, MAX_SETUP_ATTEMPTS) {
+            let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+            payload[0] = READY;
+            let reply: Message = Message::new(
+                MessageSender::from(my_pid),
+                MessageReceiver::from(parent_pid),
+                MessageType::Ipc,
+                None,
+                payload,
+            );
+            let _ = ipc::__kcall_send(&reply);
+            CHILD_EXIT_OK
+        } else {
+            CHILD_EXIT_FAIL
+        };
+
+        // Exit while holding the read end without draining: drops the final reader reference.
+        let _ = pm::__kcall_exit(status);
+        loop {
+            ::core::hint::spin_loop();
+        }
+    }
+
+    // Parent path: wait for the child to be ready, then become the sole writer and fill the pipe.
+    let ready: Message = match ipc::__kcall_recv() {
+        Ok(m) => m,
+        Err(e) => panic!("parent failed to receive child readiness: {:?}", e),
+    };
+    if ready.payload[0] != READY {
+        panic!("child failed to set up the reader end for the EPIPE test");
+    }
+
+    // Drop the parent's own read reference so the child holds the only remaining reader.
+    if let Err(e) = unistd::close(read_fd) {
+        panic!("parent failed to close its read end: {:?}", e);
+    }
+
+    // Fill the pipe until the writer blocks; the child's exit then fails the parked writer with
+    // EPIPE. If the child exits before the pipe fills, the write fails with EPIPE immediately.
+    let page: [u8; CHUNK] = [0xABu8; CHUNK];
+    let mut written: usize = 0;
+    let broken: bool = loop {
+        match unistd::write(write_fd, &page) {
+            Ok(0) => panic!("writer made no progress after writing {} bytes", written),
+            Ok(n) => {
+                written += n as usize;
+                if written >= MAX_WRITE {
+                    break false;
+                }
+            },
+            Err(e) if e.code == ErrorCode::BrokenPipe => break true,
+            Err(e) => panic!("writer failed with an unexpected error: {:?}", e),
+        }
+    };
+
+    if !broken {
+        panic!("writer wrote {} bytes without observing EPIPE after the reader exited", written);
+    }
+
+    let _ = unistd::close(write_fd);
+    ::syslog::info!("writer observed EPIPE after the last reader process exited");
+}
+
+/// Closes `fd` from a freshly forked child, retrying to absorb the window during which the child's
+/// descriptors have not yet been duplicated into vfsd.
+///
+/// A successful close proves the fork-clone has landed (the descriptor now resolves) and drops the
+/// child's reference to the unused pipe end. Returns whether the close eventually succeeded.
+#[cfg(feature = "standalone")]
+fn pipe_close_after_fork_clone(fd: i32, max_attempts: u32) -> bool {
+    let mut attempts: u32 = 0;
+    loop {
+        match unistd::close(fd) {
+            Ok(()) => return true,
+            Err(_) if attempts < max_attempts => attempts += 1,
+            Err(_) => return false,
+        }
     }
 }

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -766,28 +766,28 @@ fn test_fcntl_fd_flags() -> Result<(), Error> {
     let fd: i32 = vfs::fd::vfs_open("/fcn/fc.txt", 0).map_err(|e| fat_err(e, "open fc.txt fd"))?;
 
     // F_GETFD should succeed and return 0.
-    let flags: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFD)
+    let flags: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFD, 0)
         .map_err(|e| fat_err(e, "fcntl F_GETFD"))?;
     if flags != 0 {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_GETFD should return 0"));
     }
 
     // F_SETFD should succeed and return 0.
-    let result: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_SETFD)
+    let result: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_SETFD, 0)
         .map_err(|e| fat_err(e, "fcntl F_SETFD"))?;
     if result != 0 {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_SETFD should return 0"));
     }
 
     // F_GETFL and F_SETFL should still work.
-    let fl: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFL)
+    let fl: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFL, 0)
         .map_err(|e| fat_err(e, "fcntl F_GETFL"))?;
     if fl != 0 {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_GETFL should return 0"));
     }
 
     // An unsupported command (e.g. F_DUPFD) should fail.
-    if vfs::fd::vfs_fcntl(fd, file_control_request::F_DUPFD).is_ok() {
+    if vfs::fd::vfs_fcntl(fd, file_control_request::F_DUPFD, 0).is_ok() {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_DUPFD should fail on VFS"));
     }
 


### PR DESCRIPTION
## Summary

Implements POSIX unnamed pipes end-to-end, from the `pipe()` syscall down through the VFS layer and the `vfsd` daemon.

## Changes

- **vfs library**: Add pipe abstraction (`src/libs/vfs/src/pipe.rs`) and extend file descriptor handling (`src/libs/vfs/src/fd.rs`) to support pipe read/write ends.
- **syscall**: Route the `pipe()` syscall to `vfsd` (`src/libs/syscall/src/unistd/syscall/pipe.rs`).
- **vfsd daemon**: Add pipe request handlers (`src/daemons/vfsd/src/handler/pipe.rs`), blocking/wait support (`src/daemons/vfsd/src/pipe_wait.rs`), hostfs handlers, and IPC plumbing.
- **tests**: Add standalone pipe tests in the Linux app file-system suite and extend `vfs-test`.

## Notes

- Untracked working-tree files (`doc/pipe.md`, `build/tier-harness/`) are not included in this PR.

## Issues

Closes #343 
