### PR TITLE
[libc_time] Add time.h implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_time"
+version = "0.16.100"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "linux-app"
 version = "0.16.100"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
         "src/libs/libc_stdlib",
         "src/libs/libc_math",
         "src/libs/libc_string",
+        "src/libs/libc_time",
         "src/libs/cache",
         "src/libs/cmdline",
         "src/libs/koptions",
@@ -230,6 +231,7 @@ libc_signal = { path = "src/libs/libc_signal", default-features = false }
 libc_stdio = { path = "src/libs/libc_stdio", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
+libc_time = { path = "src/libs/libc_time", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_time/Cargo.toml
+++ b/src/libs/libc_time/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_time"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_time/header.toml
+++ b/src/libs/libc_time/header.toml
@@ -1,0 +1,93 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for time.h.
+
+file = "time.h"
+brief = "Date and time."
+description = '''
+Declares functions for calendar time manipulation and conversion.
+Implemented by the libc_time Rust crate.'''
+includes = ["stddef.h"]
+guard = "_NANVIX_TIME_H"
+content_order = ["types", "section:0", "section:1", "raw:0", "raw:1"]
+
+[[types]]
+text = '''
+#ifndef _TIME_T_DEFINED
+#define _TIME_T_DEFINED
+typedef long long time_t;
+#endif
+
+#ifndef _CLOCK_T_DEFINED
+#define _CLOCK_T_DEFINED
+typedef long long clock_t;
+#endif
+
+#ifndef _CLOCKID_T_DEFINED
+#define _CLOCKID_T_DEFINED
+typedef int clockid_t;
+#endif
+
+#ifndef CLOCKS_PER_SEC
+#define CLOCKS_PER_SEC 1000000
+#endif
+
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME 1
+#endif
+
+#ifndef CLOCK_PROCESS_CPUTIME_ID
+#define CLOCK_PROCESS_CPUTIME_ID 2
+#endif
+
+#ifndef CLOCK_THREAD_CPUTIME_ID
+#define CLOCK_THREAD_CPUTIME_ID 3
+#endif
+
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 4
+#endif
+
+/** @brief Broken-down time representation. */
+struct tm {
+    int tm_sec;   /**< Seconds [0, 60].            */
+    int tm_min;   /**< Minutes [0, 59].             */
+    int tm_hour;  /**< Hours [0, 23].               */
+    int tm_mday;  /**< Day of month [1, 31].        */
+    int tm_mon;   /**< Months since January [0, 11].*/
+    int tm_year;  /**< Years since 1900.            */
+    int tm_wday;  /**< Days since Sunday [0, 6].    */
+    int tm_yday;  /**< Days since Jan 1 [0, 365].   */
+    int tm_isdst; /**< Daylight Saving Time flag.   */
+};
+
+/** @brief Time specification for clock_gettime(). */
+struct timespec {
+    time_t tv_sec; /**< Seconds.     */
+    long tv_nsec;  /**< Nanoseconds. */
+};'''
+
+[[raw_sections]]
+title = "Time Formatting"
+text = '''
+extern char *asctime(const struct tm *timeptr);
+extern char *asctime_r(const struct tm *timeptr, char *buf);
+extern char *ctime(const time_t *timep);
+extern char *ctime_r(const time_t *timep, char *buf);'''
+
+# Implemented by the syscall crate; declared here so callers of time.h can use them.
+[[raw_sections]]
+title = "Clocks"
+text = '''
+extern int clock_gettime(clockid_t clock_id, struct timespec *tp);
+extern int clock_getres(clockid_t clock_id, struct timespec *res);
+extern int nanosleep(const struct timespec *req, struct timespec *rem);'''
+
+[[sections]]
+title = "Calendar Time"
+functions = ["time", "clock", "difftime", "mktime"]
+
+[[sections]]
+title = "Time Conversion"
+functions = ["gmtime", "gmtime_r", "localtime", "localtime_r"]

--- a/src/libs/libc_time/src/asctime.rs
+++ b/src/libs/libc_time/src/asctime.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the broken-down time to a string representation using an internal static buffer.
+///
+/// # Parameters
+///
+/// - `timeptr`: Pointer to the broken-down time structure.
+///
+/// # Returns
+///
+/// On success, returns a pointer to the internal static buffer containing the formatted string.
+/// The returned pointer is only valid until the next call to `asctime`. Returns a null pointer if
+/// `timeptr` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `timeptr` and accesses a shared
+/// static buffer. The caller must ensure single-threaded access.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn asctime(timeptr: *const tm) -> *mut c_char {
+    static mut BUF: [c_char; 26] = [0; 26];
+    crate::asctime_r::asctime_r(timeptr, core::ptr::addr_of_mut!(BUF).cast::<c_char>())
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::asctime;
+    use crate::tm_struct::tm;
+
+    #[test]
+    fn test_asctime_returns_non_null() {
+        let t: tm = tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 1,
+            tm_mon: 0,
+            tm_year: 70,
+            tm_wday: 4,
+            tm_yday: 0,
+            tm_isdst: 0,
+        };
+        let ret: *mut i8 = unsafe { asctime(&t) };
+        assert!(!ret.is_null());
+    }
+
+    #[test]
+    fn test_asctime_null_input() {
+        let ret: *mut i8 = unsafe { asctime(core::ptr::null()) };
+        assert!(ret.is_null());
+    }
+}

--- a/src/libs/libc_time/src/asctime_r.rs
+++ b/src/libs/libc_time/src/asctime_r.rs
@@ -1,0 +1,287 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::{
+    tm,
+    DAY_NAMES,
+    MONTH_NAMES,
+    TM_YEAR_BASE,
+};
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Writes a byte to the buffer at the given offset and returns the next offset.
+unsafe fn write_byte(buf: *mut c_char, offset: usize, byte: u8) -> usize {
+    *buf.add(offset) = byte as c_char;
+    offset + 1
+}
+
+/// Writes a 3-byte name (day or month) to the buffer at the given offset.
+unsafe fn write_name(buf: *mut c_char, offset: usize, name: &[u8; 3]) -> usize {
+    let mut pos: usize = offset;
+    pos = write_byte(buf, pos, name[0]);
+    pos = write_byte(buf, pos, name[1]);
+    pos = write_byte(buf, pos, name[2]);
+    pos
+}
+
+/// Writes a 2-digit zero-padded number to the buffer.
+unsafe fn write_2digit(buf: *mut c_char, offset: usize, value: i32) -> usize {
+    let tens: u8 = ((value / 10) % 10) as u8;
+    let ones: u8 = (value % 10) as u8;
+    let mut pos: usize = offset;
+    pos = write_byte(buf, pos, b'0' + tens);
+    pos = write_byte(buf, pos, b'0' + ones);
+    pos
+}
+
+/// Writes the year (space-padded or sign-prefixed) to the buffer.
+unsafe fn write_year(buf: *mut c_char, offset: usize, year: i32) -> usize {
+    let mut pos: usize = offset;
+    let mut y: i32 = year;
+
+    if y < 0 {
+        pos = write_byte(buf, pos, b'-');
+        y = -y;
+    }
+
+    // Write up to 4 digits.
+    let d3: u8 = (y / 1000 % 10) as u8;
+    let d2: u8 = (y / 100 % 10) as u8;
+    let d1: u8 = (y / 10 % 10) as u8;
+    let d0: u8 = (y % 10) as u8;
+
+    pos = write_byte(buf, pos, b'0' + d3);
+    pos = write_byte(buf, pos, b'0' + d2);
+    pos = write_byte(buf, pos, b'0' + d1);
+    pos = write_byte(buf, pos, b'0' + d0);
+
+    pos
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the broken-down time in the `tm` structure to a string of the form:
+/// `"Wed Jun 30 21:49:08 1993\n"`.
+///
+/// # Parameters
+///
+/// - `timeptr`: Pointer to the broken-down time structure.
+/// - `buf`: Pointer to a character buffer of at least 26 bytes.
+///
+/// # Returns
+///
+/// On success, returns `buf`. Returns a null pointer if `timeptr` or `buf` is null, or if fields
+/// are out of range.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers `timeptr` and `buf`. The caller
+/// must ensure `buf` has room for at least 26 bytes.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn asctime_r(timeptr: *const tm, buf: *mut c_char) -> *mut c_char {
+    if timeptr.is_null() || buf.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let t: &tm = &*timeptr;
+
+    // Validate ranges to avoid out-of-bounds access.
+    let wday: usize = if t.tm_wday >= 0 && t.tm_wday <= 6 {
+        t.tm_wday as usize
+    } else {
+        return core::ptr::null_mut();
+    };
+    let mon: usize = if t.tm_mon >= 0 && t.tm_mon <= 11 {
+        t.tm_mon as usize
+    } else {
+        return core::ptr::null_mut();
+    };
+
+    // Validate the remaining numeric fields so out-of-range input fails instead of producing
+    // malformed output or overflowing the digit arithmetic below.
+    if !(1..=31).contains(&t.tm_mday)
+        || !(0..=23).contains(&t.tm_hour)
+        || !(0..=59).contains(&t.tm_min)
+        || !(0..=60).contains(&t.tm_sec)
+    {
+        return core::ptr::null_mut();
+    }
+
+    // The 26-byte output buffer has a fixed 4-digit year field, so reject years that do not fit it
+    // (in particular negative years, which would otherwise write past the end of the buffer).
+    let year: i64 = i64::from(t.tm_year) + TM_YEAR_BASE;
+    if !(0..=9999).contains(&year) {
+        return core::ptr::null_mut();
+    }
+
+    let mut pos: usize = 0;
+
+    // Day name.
+    pos = write_name(buf, pos, DAY_NAMES[wday]);
+    pos = write_byte(buf, pos, b' ');
+
+    // Month name.
+    pos = write_name(buf, pos, MONTH_NAMES[mon]);
+    pos = write_byte(buf, pos, b' ');
+
+    // Day of month (space-padded).
+    if t.tm_mday < 10 {
+        pos = write_byte(buf, pos, b' ');
+        pos = write_byte(buf, pos, b'0' + t.tm_mday as u8);
+    } else {
+        pos = write_2digit(buf, pos, t.tm_mday);
+    }
+    pos = write_byte(buf, pos, b' ');
+
+    // Hour:minute:second.
+    pos = write_2digit(buf, pos, t.tm_hour);
+    pos = write_byte(buf, pos, b':');
+    pos = write_2digit(buf, pos, t.tm_min);
+    pos = write_byte(buf, pos, b':');
+    pos = write_2digit(buf, pos, t.tm_sec);
+    pos = write_byte(buf, pos, b' ');
+
+    // Year.
+    pos = write_year(buf, pos, year as i32);
+    pos = write_byte(buf, pos, b'\n');
+    write_byte(buf, pos, 0);
+
+    buf
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::asctime_r;
+    use crate::tm_struct::tm;
+    use ::sysapi::ffi::c_char;
+
+    fn buf_to_string(buf: &[c_char; 26]) -> ::std::string::String {
+        let bytes: ::std::vec::Vec<u8> = buf
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect();
+        ::std::string::String::from_utf8(bytes).expect("valid UTF-8")
+    }
+
+    #[test]
+    fn test_asctime_r_known_date() {
+        // Wednesday, June 30, 1993 21:49:08.
+        let t: tm = tm {
+            tm_sec: 8,
+            tm_min: 49,
+            tm_hour: 21,
+            tm_mday: 30,
+            tm_mon: 5,
+            tm_year: 93,
+            tm_wday: 3,
+            tm_yday: 180,
+            tm_isdst: 0,
+        };
+        let mut buf: [c_char; 26] = [0; 26];
+        let ret: *mut c_char = unsafe { asctime_r(&t, buf.as_mut_ptr()) };
+        assert!(!ret.is_null());
+        assert_eq!(buf_to_string(&buf), "Wed Jun 30 21:49:08 1993\n");
+    }
+
+    #[test]
+    fn test_asctime_r_epoch() {
+        let t: tm = tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 1,
+            tm_mon: 0,
+            tm_year: 70,
+            tm_wday: 4,
+            tm_yday: 0,
+            tm_isdst: 0,
+        };
+        let mut buf: [c_char; 26] = [0; 26];
+        let ret: *mut c_char = unsafe { asctime_r(&t, buf.as_mut_ptr()) };
+        assert!(!ret.is_null());
+        assert_eq!(buf_to_string(&buf), "Thu Jan  1 00:00:00 1970\n");
+    }
+
+    #[test]
+    fn test_asctime_r_null_pointers() {
+        let t: tm = tm::new();
+        let mut buf: [c_char; 26] = [0; 26];
+        assert!(unsafe { asctime_r(core::ptr::null(), buf.as_mut_ptr()) }.is_null());
+        assert!(unsafe { asctime_r(&t, core::ptr::null_mut()) }.is_null());
+    }
+
+    #[test]
+    fn test_asctime_r_year_out_of_range() {
+        // Years that do not fit the fixed 4-digit field must be rejected rather than overflowing
+        // the 26-byte buffer.
+        let mut t: tm = tm::new();
+        t.tm_mday = 1;
+        t.tm_wday = 4;
+
+        t.tm_year = -2000; // Year -100 (before year 0).
+        let mut buf: [c_char; 26] = [0; 26];
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+
+        t.tm_year = 9000; // Year 10900 (more than 4 digits).
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+    }
+
+    #[test]
+    fn test_asctime_r_invalid_fields() {
+        // Out-of-range numeric fields must be rejected rather than producing malformed output.
+        let base: tm = tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 1,
+            tm_mon: 0,
+            tm_year: 70,
+            tm_wday: 4,
+            tm_yday: 0,
+            tm_isdst: 0,
+        };
+        let mut buf: [c_char; 26] = [0; 26];
+
+        let mut t: tm = base;
+        t.tm_mday = 0;
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+
+        let mut t: tm = base;
+        t.tm_hour = 24;
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+
+        let mut t: tm = base;
+        t.tm_min = -1;
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+
+        let mut t: tm = base;
+        t.tm_sec = 61;
+        assert!(unsafe { asctime_r(&t, buf.as_mut_ptr()) }.is_null());
+    }
+}

--- a/src/libs/libc_time/src/clock.rs
+++ b/src/libs/libc_time/src/clock.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_long,
+    },
+    sys_types::{
+        clock_t,
+        clockid_t,
+    },
+    time::{
+        clock_ids::CLOCK_MONOTONIC,
+        timespec,
+    },
+};
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+extern "C" {
+    fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -> c_int;
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Converts a monotonic-clock `timespec` into clock ticks of `CLOCKS_PER_SEC` (microseconds).
+///
+/// Sub-microsecond nanosecond resolution is truncated, matching the microsecond tick rate that
+/// `CLOCKS_PER_SEC` advertises. Returns `None` if the conversion overflows `clock_t`.
+fn ticks_from_timespec(sec: clock_t, nsec: c_long) -> Option<clock_t> {
+    let nsec: clock_t = clock_t::from(nsec);
+    sec.checked_mul(1_000_000)?.checked_add(nsec / 1_000)
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns an approximation of processor time used by the program, expressed in clock ticks of
+/// `CLOCKS_PER_SEC` (one microsecond). Nanvix approximates this with the monotonic clock.
+///
+/// # Returns
+///
+/// The elapsed time in microseconds, or `(clock_t)-1` if it is unavailable.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn clock() -> clock_t {
+    let mut ts: timespec = timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts is a valid, writable timespec.
+    let rc: c_int = unsafe { clock_gettime(CLOCK_MONOTONIC, &mut ts) };
+    if rc != 0 {
+        return -1;
+    }
+    ticks_from_timespec(ts.tv_sec, ts.tv_nsec).unwrap_or(-1)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ticks_from_timespec;
+    use ::sysapi::sys_types::clock_t;
+
+    #[test]
+    fn test_ticks_whole_seconds() {
+        // 2 seconds expressed in microsecond ticks.
+        assert_eq!(ticks_from_timespec(2 as clock_t, 0), Some(2_000_000));
+    }
+
+    #[test]
+    fn test_ticks_nanoseconds_to_micros() {
+        // 1_500_000 ns is 1_500 microseconds.
+        assert_eq!(ticks_from_timespec(0 as clock_t, 1_500_000), Some(1_500));
+    }
+
+    #[test]
+    fn test_ticks_combined() {
+        // 1 s plus 1_000 ns (1 microsecond).
+        assert_eq!(ticks_from_timespec(1 as clock_t, 1_000), Some(1_000_001));
+    }
+
+    #[test]
+    fn test_ticks_sub_microsecond_truncated() {
+        // Sub-microsecond resolution is discarded.
+        assert_eq!(ticks_from_timespec(0 as clock_t, 999), Some(0));
+    }
+
+    #[test]
+    fn test_ticks_overflow_returns_none() {
+        // A tick count that overflows `clock_t` is reported as an error.
+        assert_eq!(ticks_from_timespec(clock_t::MAX, 0), None);
+    }
+}

--- a/src/libs/libc_time/src/ctime.rs
+++ b/src/libs/libc_time/src/ctime.rs
@@ -1,0 +1,78 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::time_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time to a string representation using an internal static buffer.
+///
+/// Equivalent to `asctime(localtime(timep))`.
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+///
+/// # Returns
+///
+/// On success, returns a pointer to an internal static buffer containing the formatted string.
+/// The returned pointer is only valid until the next call to `ctime`. Returns a null pointer on
+/// error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `timep` and accesses shared
+/// static buffers. The caller must ensure single-threaded access.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ctime(timep: *const time_t) -> *mut c_char {
+    if timep.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    static mut BUF: [c_char; 26] = [0; 26];
+
+    let mut tmp: tm = tm::new();
+    let ret: *mut tm = crate::localtime_r::localtime_r(timep, &mut tmp);
+    if ret.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    crate::asctime_r::asctime_r(&tmp, core::ptr::addr_of_mut!(BUF).cast::<c_char>())
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ctime;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_ctime_returns_non_null() {
+        let t: time_t = 0;
+        let ret: *mut i8 = unsafe { ctime(&t) };
+        assert!(!ret.is_null());
+    }
+
+    #[test]
+    fn test_ctime_null_input() {
+        let ret: *mut i8 = unsafe { ctime(core::ptr::null()) };
+        assert!(ret.is_null());
+    }
+}

--- a/src/libs/libc_time/src/ctime_r.rs
+++ b/src/libs/libc_time/src/ctime_r.rs
@@ -1,0 +1,102 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::time_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time to a string representation of the form
+/// `"Wed Jun 30 21:49:08 1993\n"` using a caller-provided buffer.
+///
+/// Equivalent to `asctime_r(localtime_r(timep, &tmp), buf)`.
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+/// - `buf`: Pointer to a character buffer of at least 26 bytes.
+///
+/// # Returns
+///
+/// On success, returns `buf`. Returns a null pointer on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `timep` and `buf`. The caller
+/// must ensure `buf` has room for at least 26 bytes.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ctime_r(timep: *const time_t, buf: *mut c_char) -> *mut c_char {
+    if timep.is_null() || buf.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let mut tmp: tm = tm::new();
+    let ret: *mut tm = crate::localtime_r::localtime_r(timep, &mut tmp);
+    if ret.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    crate::asctime_r::asctime_r(&tmp, buf)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ctime_r;
+    use ::sysapi::{
+        ffi::c_char,
+        sys_types::time_t,
+    };
+
+    fn buf_to_string(buf: &[c_char; 26]) -> ::std::string::String {
+        let bytes: ::std::vec::Vec<u8> = buf
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8)
+            .collect();
+        ::std::string::String::from_utf8(bytes).expect("valid UTF-8")
+    }
+
+    #[test]
+    fn test_ctime_r_epoch() {
+        let t: time_t = 0;
+        let mut buf: [c_char; 26] = [0; 26];
+        let ret: *mut c_char = unsafe { ctime_r(&t, buf.as_mut_ptr()) };
+        assert!(!ret.is_null());
+        assert_eq!(buf_to_string(&buf), "Thu Jan  1 00:00:00 1970\n");
+    }
+
+    #[test]
+    fn test_ctime_r_known_date() {
+        // 1993-06-30 21:49:08 UTC.
+        let t: time_t = 741_476_948;
+        let mut buf: [c_char; 26] = [0; 26];
+        let ret: *mut c_char = unsafe { ctime_r(&t, buf.as_mut_ptr()) };
+        assert!(!ret.is_null());
+        assert_eq!(buf_to_string(&buf), "Wed Jun 30 21:49:08 1993\n");
+    }
+
+    #[test]
+    fn test_ctime_r_null_pointers() {
+        let t: time_t = 0;
+        let mut buf: [c_char; 26] = [0; 26];
+        assert!(unsafe { ctime_r(core::ptr::null(), buf.as_mut_ptr()) }.is_null());
+        assert!(unsafe { ctime_r(&t, core::ptr::null_mut()) }.is_null());
+    }
+}

--- a/src/libs/libc_time/src/difftime.rs
+++ b/src/libs/libc_time/src/difftime.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the difference between two calendar times as a floating-point number of seconds.
+///
+/// # Parameters
+///
+/// - `time1`: The later time value.
+/// - `time0`: The earlier time value.
+///
+/// # Returns
+///
+/// The number of seconds elapsed from `time0` to `time1`, as a `f64`.
+///
+/// # Safety
+///
+/// This function is safe for all input values.
+///
+#[allow(clippy::cast_precision_loss)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn difftime(time1: time_t, time0: time_t) -> f64 {
+    // Compute the difference in floating point to avoid overflowing `time_t` for extreme inputs.
+    (time1 as f64) - (time0 as f64)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::difftime;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_difftime_positive() {
+        let result: f64 = difftime(100 as time_t, 50 as time_t);
+        assert!((result - 50.0).abs() < f64::EPSILON, "Expected 50.0, got {result}");
+    }
+
+    #[test]
+    fn test_difftime_negative() {
+        let result: f64 = difftime(50 as time_t, 100 as time_t);
+        assert!((result - (-50.0)).abs() < f64::EPSILON, "Expected -50.0, got {result}");
+    }
+
+    #[test]
+    fn test_difftime_zero() {
+        let result: f64 = difftime(100 as time_t, 100 as time_t);
+        assert!((result - 0.0).abs() < f64::EPSILON, "Expected 0.0, got {result}");
+    }
+
+    #[test]
+    fn test_difftime_large_values() {
+        let t1: time_t = 1_000_000_000;
+        let t0: time_t = 0;
+        let result: f64 = difftime(t1, t0);
+        assert!((result - 1_000_000_000.0).abs() < f64::EPSILON, "Expected 1e9, got {result}");
+    }
+}

--- a/src/libs/libc_time/src/gmtime.rs
+++ b/src/libs/libc_time/src/gmtime.rs
@@ -1,0 +1,64 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time (`time_t`) to a broken-down UTC time representation using an internal
+/// static buffer.
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+///
+/// # Returns
+///
+/// On success, returns a pointer to an internal static `tm` structure. Returns a null pointer if
+/// `timep` is null. The returned pointer is only valid until the next call to `gmtime`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `timep` and accesses a shared
+/// static buffer. The caller must ensure single-threaded access.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn gmtime(timep: *const time_t) -> *mut tm {
+    static mut GM_BUF: tm = tm::new();
+    crate::gmtime_r::gmtime_r(timep, core::ptr::addr_of_mut!(GM_BUF))
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::gmtime;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_gmtime_returns_non_null() {
+        let t: time_t = 0;
+        let ret: *mut tm = unsafe { gmtime(&t) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { (*ret).tm_year }, 70);
+    }
+
+    #[test]
+    fn test_gmtime_null_input() {
+        let ret: *mut tm = unsafe { gmtime(core::ptr::null()) };
+        assert!(ret.is_null());
+    }
+}

--- a/src/libs/libc_time/src/gmtime_r.rs
+++ b/src/libs/libc_time/src/gmtime_r.rs
@@ -1,0 +1,217 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::{
+    self,
+    tm,
+    DAYS_PER_100_YEARS,
+    DAYS_PER_4_YEARS,
+    DAYS_PER_5_MONTHS,
+    DAYS_PER_COMMON_YEAR,
+    DAYS_PER_ERA,
+    EPOCH_DAYS_OFFSET,
+    SECS_PER_DAY,
+    SECS_PER_HOUR,
+    SECS_PER_MIN,
+    TM_YEAR_BASE,
+    YEARS_PER_ERA,
+};
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::time_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time (`time_t`) to a broken-down UTC time representation and stores the
+/// result in the caller-provided `tm` structure.
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+/// - `result`: Pointer to a `tm` structure where the broken-down time will be stored.
+///
+/// # Returns
+///
+/// On success, returns `result`. Returns a null pointer if `timep` or `result` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `timep` and `result`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn gmtime_r(timep: *const time_t, result: *mut tm) -> *mut tm {
+    if timep.is_null() || result.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let total_secs: time_t = *timep;
+
+    // Extract time-of-day components using Euclidean division for correct negative handling.
+    let day_secs: i64 = total_secs.rem_euclid(SECS_PER_DAY);
+    let days: i64 = total_secs.div_euclid(SECS_PER_DAY);
+
+    let hours: c_int = (day_secs / SECS_PER_HOUR) as c_int;
+    let minutes: c_int = ((day_secs % SECS_PER_HOUR) / SECS_PER_MIN) as c_int;
+    let seconds: c_int = (day_secs % SECS_PER_MIN) as c_int;
+
+    // Weekday: January 1, 1970 was a Thursday (wday = 4).
+    let wday: c_int = ((days + 4).rem_euclid(7)) as c_int;
+
+    // Convert days-since-epoch to a civil (year, month, day) date in O(1) using the algorithm by
+    // Howard Hinnant. `month` is in [1, 12] and `mday` in [1, 31].
+    let z: i64 = days + EPOCH_DAYS_OFFSET;
+    let era: i64 = if z >= 0 { z } else { z - (DAYS_PER_ERA - 1) } / DAYS_PER_ERA;
+    let doe: i64 = z - era * DAYS_PER_ERA; // Day of era, in [0, DAYS_PER_ERA - 1].
+    let yoe: i64 = (doe - doe / DAYS_PER_4_YEARS + doe / DAYS_PER_100_YEARS
+        - doe / (DAYS_PER_ERA - 1))
+        / DAYS_PER_COMMON_YEAR; // Year of era, in [0, 399].
+    let civil_year: i64 = yoe + era * YEARS_PER_ERA;
+    let doy: i64 = doe - (DAYS_PER_COMMON_YEAR * yoe + yoe / 4 - yoe / 100); // Day of year, [0, 365].
+    let mp: i64 = (5 * doy + 2) / DAYS_PER_5_MONTHS; // Internal month index, in [0, 11].
+    let mday: i64 = doy - (DAYS_PER_5_MONTHS * mp + 2) / 5 + 1; // Day of month, in [1, 31].
+    let month: i64 = if mp < 10 { mp + 3 } else { mp - 9 }; // Calendar month, in [1, 12].
+    let year: i64 = if month <= 2 {
+        civil_year + 1
+    } else {
+        civil_year
+    };
+
+    // The `tm_year` field stores `year - TM_YEAR_BASE` as a `c_int`; reject dates that do not fit it
+    // instead of silently wrapping.
+    let tm_year: i64 = year - TM_YEAR_BASE;
+    if tm_year < i64::from(c_int::MIN) || tm_year > i64::from(c_int::MAX) {
+        return core::ptr::null_mut();
+    }
+
+    // Day of the year, in [0, 365].
+    let yday: i64 = days - tm_struct::days_from_civil(year, 1, 1);
+
+    (*result).tm_sec = seconds;
+    (*result).tm_min = minutes;
+    (*result).tm_hour = hours;
+    (*result).tm_mday = mday as c_int;
+    (*result).tm_mon = (month - 1) as c_int;
+    (*result).tm_year = tm_year as c_int;
+    (*result).tm_wday = wday;
+    (*result).tm_yday = yday as c_int;
+    (*result).tm_isdst = 0;
+
+    result
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::gmtime_r;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_gmtime_r_epoch() {
+        // 1970-01-01 00:00:00 UTC.
+        let t: time_t = 0;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { gmtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_sec, 0);
+        assert_eq!(result.tm_min, 0);
+        assert_eq!(result.tm_hour, 0);
+        assert_eq!(result.tm_mday, 1);
+        assert_eq!(result.tm_mon, 0);
+        assert_eq!(result.tm_year, 70);
+        assert_eq!(result.tm_wday, 4); // Thursday.
+        assert_eq!(result.tm_yday, 0);
+    }
+
+    #[test]
+    fn test_gmtime_r_known_date() {
+        // 2000-01-01 00:00:00 UTC = 946684800 seconds since epoch.
+        let t: time_t = 946_684_800;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { gmtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_sec, 0);
+        assert_eq!(result.tm_min, 0);
+        assert_eq!(result.tm_hour, 0);
+        assert_eq!(result.tm_mday, 1);
+        assert_eq!(result.tm_mon, 0); // January.
+        assert_eq!(result.tm_year, 100); // 2000 - 1900.
+        assert_eq!(result.tm_wday, 6); // Saturday.
+        assert_eq!(result.tm_yday, 0);
+    }
+
+    #[test]
+    fn test_gmtime_r_leap_year() {
+        // 2000-02-29 12:00:00 UTC = 951825600 seconds since epoch.
+        let t: time_t = 951_825_600;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { gmtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_sec, 0);
+        assert_eq!(result.tm_min, 0);
+        assert_eq!(result.tm_hour, 12);
+        assert_eq!(result.tm_mday, 29);
+        assert_eq!(result.tm_mon, 1); // February.
+        assert_eq!(result.tm_year, 100); // 2000 - 1900.
+        assert_eq!(result.tm_yday, 59); // Day 60, zero-indexed = 59.
+    }
+
+    #[test]
+    fn test_gmtime_r_null_timep() {
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { gmtime_r(core::ptr::null(), &mut result) };
+        assert!(ret.is_null());
+    }
+
+    #[test]
+    fn test_gmtime_r_null_result() {
+        let t: time_t = 0;
+        let ret: *mut tm = unsafe { gmtime_r(&t, core::ptr::null_mut()) };
+        assert!(ret.is_null());
+    }
+
+    #[test]
+    fn test_gmtime_r_year_out_of_range() {
+        // Extreme calendar times yield a year that does not fit `tm_year` (a `c_int`); these must
+        // be rejected in O(1) rather than looping or silently wrapping the year.
+        let mut result: tm = tm::new();
+        assert!(unsafe { gmtime_r(&time_t::MAX, &mut result) }.is_null());
+        assert!(unsafe { gmtime_r(&time_t::MIN, &mut result) }.is_null());
+    }
+
+    #[test]
+    fn test_gmtime_r_specific_time() {
+        // 1993-06-30 21:49:08 UTC = 741476948 seconds since epoch.
+        let t: time_t = 741_476_948;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { gmtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_sec, 8);
+        assert_eq!(result.tm_min, 49);
+        assert_eq!(result.tm_hour, 21);
+        assert_eq!(result.tm_mday, 30);
+        assert_eq!(result.tm_mon, 5); // June (0-indexed).
+        assert_eq!(result.tm_year, 93); // 1993 - 1900.
+        assert_eq!(result.tm_wday, 3); // Wednesday.
+    }
+}

--- a/src/libs/libc_time/src/lib.rs
+++ b/src/libs/libc_time/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+// Time arithmetic requires width conversions (i64 → i32) for struct tm fields.
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+// difftime() returns f64 from i64 subtraction, as required by the C standard.
+#![deny(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod asctime;
+pub mod asctime_r;
+pub mod clock;
+pub mod ctime;
+pub mod ctime_r;
+pub mod difftime;
+pub mod gmtime;
+pub mod gmtime_r;
+pub mod localtime;
+pub mod localtime_r;
+pub mod mktime;
+pub mod time;
+pub mod tm_struct;

--- a/src/libs/libc_time/src/localtime.rs
+++ b/src/libs/libc_time/src/localtime.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time (`time_t`) to a broken-down local time representation using an
+/// internal static buffer.
+///
+/// In Nanvix (no timezone support), this function is equivalent to [`gmtime`].
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+///
+/// # Returns
+///
+/// On success, returns a pointer to an internal static `tm` structure. Returns a null pointer if
+/// `timep` is null. The returned pointer is only valid until the next call to `localtime`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `timep` and accesses a shared
+/// static buffer. The caller must ensure single-threaded access.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn localtime(timep: *const time_t) -> *mut tm {
+    static mut LT_BUF: tm = tm::new();
+    crate::localtime_r::localtime_r(timep, core::ptr::addr_of_mut!(LT_BUF))
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::localtime;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_localtime_returns_non_null() {
+        let t: time_t = 0;
+        let ret: *mut tm = unsafe { localtime(&t) };
+        assert!(!ret.is_null());
+        assert_eq!(unsafe { (*ret).tm_year }, 70);
+    }
+
+    #[test]
+    fn test_localtime_null_input() {
+        let ret: *mut tm = unsafe { localtime(core::ptr::null()) };
+        assert!(ret.is_null());
+    }
+}

--- a/src/libs/libc_time/src/localtime_r.rs
+++ b/src/libs/libc_time/src/localtime_r.rs
@@ -1,0 +1,80 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::tm;
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a calendar time (`time_t`) to a broken-down local time representation.
+///
+/// In Nanvix (no timezone support), this function is equivalent to [`gmtime_r`].
+///
+/// # Parameters
+///
+/// - `timep`: Pointer to the calendar time to convert.
+/// - `result`: Pointer to a `tm` structure where the broken-down time will be stored.
+///
+/// # Returns
+///
+/// On success, returns `result`. Returns a null pointer if `timep` or `result` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `timep` and `result`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn localtime_r(timep: *const time_t, result: *mut tm) -> *mut tm {
+    crate::gmtime_r::gmtime_r(timep, result)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::localtime_r;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_localtime_r_epoch() {
+        let t: time_t = 0;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { localtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_year, 70);
+        assert_eq!(result.tm_mon, 0);
+        assert_eq!(result.tm_mday, 1);
+    }
+
+    #[test]
+    fn test_localtime_r_known_date() {
+        // 2000-01-01 00:00:00 UTC.
+        let t: time_t = 946_684_800;
+        let mut result: tm = tm::new();
+        let ret: *mut tm = unsafe { localtime_r(&t, &mut result) };
+        assert!(!ret.is_null());
+        assert_eq!(result.tm_year, 100);
+        assert_eq!(result.tm_mon, 0);
+        assert_eq!(result.tm_mday, 1);
+    }
+
+    #[test]
+    fn test_localtime_r_null_pointers() {
+        let t: time_t = 0;
+        let mut result: tm = tm::new();
+        assert!(unsafe { localtime_r(core::ptr::null(), &mut result) }.is_null());
+        assert!(unsafe { localtime_r(&t, core::ptr::null_mut()) }.is_null());
+    }
+}

--- a/src/libs/libc_time/src/mktime.rs
+++ b/src/libs/libc_time/src/mktime.rs
@@ -1,0 +1,171 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::{
+    self,
+    tm,
+    SECS_PER_DAY,
+    SECS_PER_HOUR,
+    SECS_PER_MIN,
+    TM_YEAR_BASE,
+};
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a broken-down time structure (expressed as UTC) to a calendar time (`time_t`).
+/// The `tm` structure is normalized so that its fields are within their proper ranges.
+///
+/// # Parameters
+///
+/// - `timeptr`: Pointer to the broken-down time to convert.
+///
+/// # Returns
+///
+/// On success, the calendar time in seconds since the epoch. On error, `(time_t)(-1)`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences and writes to the raw pointer `timeptr`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mktime(timeptr: *mut tm) -> time_t {
+    if timeptr.is_null() {
+        return -1;
+    }
+
+    let t: &mut tm = &mut *timeptr;
+
+    // Normalize seconds → minutes.
+    let mut total_min: i64 = i64::from(t.tm_min) + i64::from(t.tm_sec) / SECS_PER_MIN;
+    let mut sec: i64 = i64::from(t.tm_sec) % SECS_PER_MIN;
+    if sec < 0 {
+        sec += SECS_PER_MIN;
+        total_min -= 1;
+    }
+
+    // Normalize minutes → hours.
+    let mut total_hour: i64 = i64::from(t.tm_hour) + total_min / 60;
+    let mut min: i64 = total_min % 60;
+    if min < 0 {
+        min += 60;
+        total_hour -= 1;
+    }
+
+    // Normalize hours → days.
+    let mut extra_days: i64 = total_hour / 24;
+    let mut hour: i64 = total_hour % 24;
+    if hour < 0 {
+        hour += 24;
+        extra_days -= 1;
+    }
+
+    // Normalize months → years.
+    let total_mon: i64 = i64::from(t.tm_mon);
+    let mut year: i64 = i64::from(t.tm_year) + TM_YEAR_BASE + total_mon / 12;
+    let mut mon: i64 = total_mon % 12;
+    if mon < 0 {
+        mon += 12;
+        year -= 1;
+    }
+
+    // Compute total days since the epoch in O(1) from the normalized civil date.
+    let days: i64 = tm_struct::days_from_civil(year, mon + 1, i64::from(t.tm_mday)) + extra_days;
+
+    // The intra-day term is bounded, but `days * SECS_PER_DAY` can overflow for far-future or
+    // far-past dates. Use checked arithmetic and report an error instead of wrapping.
+    let secs_of_day: i64 = hour * SECS_PER_HOUR + min * SECS_PER_MIN + sec;
+    let result: time_t = match days
+        .checked_mul(SECS_PER_DAY)
+        .and_then(|day_secs| day_secs.checked_add(secs_of_day))
+    {
+        Some(result) => result,
+        None => return -1,
+    };
+
+    // Normalize the tm struct by converting back. If the back-conversion fails (e.g., the computed
+    // year does not fit in `tm_year`), the value cannot be round-tripped through `struct tm`, so
+    // report an error and leave the result unspecified per the C standard.
+    if crate::gmtime_r::gmtime_r(&result, timeptr).is_null() {
+        return -1;
+    }
+
+    result
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::mktime;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_mktime_epoch() {
+        let mut t: tm = tm::new();
+        t.tm_year = 70;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        let result: time_t = unsafe { mktime(&mut t) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_mktime_known_date() {
+        // 2000-01-01 00:00:00 UTC.
+        let mut t: tm = tm::new();
+        t.tm_year = 100;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        let result: time_t = unsafe { mktime(&mut t) };
+        assert_eq!(result, 946_684_800);
+    }
+
+    #[test]
+    fn test_mktime_round_trip() {
+        let original: time_t = 741_476_948;
+        let mut broken: tm = tm::new();
+        unsafe { crate::gmtime_r::gmtime_r(&original, &mut broken) };
+        let result: time_t = unsafe { mktime(&mut broken) };
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_mktime_normalizes() {
+        // 1970-01-01 00:00:90 (90 seconds should normalize to 00:01:30).
+        let mut t: tm = tm::new();
+        t.tm_year = 70;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        t.tm_sec = 90;
+        let result: time_t = unsafe { mktime(&mut t) };
+        assert_eq!(result, 90);
+        assert_eq!(t.tm_min, 1);
+        assert_eq!(t.tm_sec, 30);
+    }
+
+    #[test]
+    fn test_mktime_null() {
+        let result: time_t = unsafe { mktime(core::ptr::null_mut()) };
+        assert_eq!(result, -1);
+    }
+}

--- a/src/libs/libc_time/src/time.rs
+++ b/src/libs/libc_time/src/time.rs
@@ -1,0 +1,102 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::{
+        clockid_t,
+        time_t,
+    },
+    time::{
+        clock_ids::CLOCK_REALTIME,
+        timespec,
+    },
+};
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+extern "C" {
+    fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -> c_int;
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Stores `result` into `tloc` when it is non-null and returns `result`.
+///
+/// # Safety
+///
+/// `tloc` must be null or point to a valid, writable `time_t`.
+unsafe fn store_time(result: time_t, tloc: *mut time_t) -> time_t {
+    if !tloc.is_null() {
+        *tloc = result;
+    }
+    result
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the current calendar time in seconds since the epoch (1970-01-01 00:00:00 UTC).
+///
+/// # Parameters
+///
+/// - `tloc`: If non-null, the return value is also stored in the location pointed to by `tloc`.
+///
+/// # Returns
+///
+/// On success, the current time in seconds since the epoch. On error, `(time_t)(-1)`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `tloc` when non-null and calls
+/// an external C function.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn time(tloc: *mut time_t) -> time_t {
+    let mut ts: timespec = timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    if clock_gettime(CLOCK_REALTIME, &mut ts) != 0 {
+        return -1;
+    }
+    store_time(ts.tv_sec, tloc)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::store_time;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_store_time_writes_when_non_null() {
+        // A non-null `tloc` receives a copy of the returned value.
+        let mut out: time_t = 0;
+        let ret: time_t = unsafe { store_time(12_345 as time_t, &mut out) };
+        assert_eq!(ret, 12_345);
+        assert_eq!(out, 12_345);
+    }
+
+    #[test]
+    fn test_store_time_ignores_null() {
+        // A null `tloc` is tolerated and the value is still returned.
+        let ret: time_t = unsafe { store_time(67_890 as time_t, core::ptr::null_mut()) };
+        assert_eq!(ret, 67_890);
+    }
+}

--- a/src/libs/libc_time/src/tm_struct.rs
+++ b/src/libs/libc_time/src/tm_struct.rs
@@ -1,0 +1,162 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Seconds per minute.
+pub const SECS_PER_MIN: i64 = 60;
+
+/// Seconds per hour.
+pub const SECS_PER_HOUR: i64 = 3600;
+
+/// Seconds per day.
+pub const SECS_PER_DAY: i64 = 86400;
+
+/// Year that the `tm_year` field is offset from.
+pub const TM_YEAR_BASE: i64 = 1900;
+
+/// Number of years in a full Gregorian era (one complete leap-year cycle).
+pub const YEARS_PER_ERA: i64 = 400;
+
+/// Number of days in a full Gregorian era of 400 years.
+pub const DAYS_PER_ERA: i64 = 146_097;
+
+/// Number of days in a common (non-leap) year.
+pub const DAYS_PER_COMMON_YEAR: i64 = 365;
+
+/// Number of days in a 4-year cycle, used for leap-year correction.
+pub const DAYS_PER_4_YEARS: i64 = 1_460;
+
+/// Number of days in a 100-year cycle, used for leap-year correction.
+pub const DAYS_PER_100_YEARS: i64 = 36_524;
+
+/// Number of days in a 5-month block (March-July or August-December), used to convert between the
+/// day of the year and the month.
+pub const DAYS_PER_5_MONTHS: i64 = 153;
+
+/// Number of days from 0000-03-01 to the Unix epoch (1970-01-01), used to align the era-based
+/// civil-date algorithm with the epoch.
+pub const EPOCH_DAYS_OFFSET: i64 = 719_468;
+
+/// Days in each month (non-leap year).
+pub const DAYS_IN_MONTH: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/// Abbreviated day names.
+pub const DAY_NAMES: [&[u8; 3]; 7] = [b"Sun", b"Mon", b"Tue", b"Wed", b"Thu", b"Fri", b"Sat"];
+
+/// Abbreviated month names.
+pub const MONTH_NAMES: [&[u8; 3]; 12] = [
+    b"Jan", b"Feb", b"Mar", b"Apr", b"May", b"Jun", b"Jul", b"Aug", b"Sep", b"Oct", b"Nov", b"Dec",
+];
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Broken-down time structure, as defined by POSIX.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct tm {
+    /// Seconds after the minute `[0, 60]`.
+    pub tm_sec: c_int,
+    /// Minutes after the hour `[0, 59]`.
+    pub tm_min: c_int,
+    /// Hours since midnight `[0, 23]`.
+    pub tm_hour: c_int,
+    /// Day of the month `[1, 31]`.
+    pub tm_mday: c_int,
+    /// Months since January `[0, 11]`.
+    pub tm_mon: c_int,
+    /// Years since 1900.
+    pub tm_year: c_int,
+    /// Days since Sunday `[0, 6]`.
+    pub tm_wday: c_int,
+    /// Days since January 1 `[0, 365]`.
+    pub tm_yday: c_int,
+    /// Daylight Saving Time flag.
+    pub tm_isdst: c_int,
+}
+
+impl tm {
+    /// Creates a zeroed broken-down time structure.
+    pub const fn new() -> Self {
+        Self {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 0,
+            tm_mon: 0,
+            tm_year: 0,
+            tm_wday: 0,
+            tm_yday: 0,
+            tm_isdst: 0,
+        }
+    }
+}
+
+impl Default for tm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns `true` if the given year is a leap year.
+pub fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+/// Returns the number of days in the given month of the given year.
+///
+/// `month` is expressed in `[0, 11]`. Returns `None` if `month` is out of range.
+pub fn days_in_month(month: usize, year: i64) -> Option<i64> {
+    if month == 1 && is_leap_year(year) {
+        Some(29)
+    } else if month < 12 {
+        Some(DAYS_IN_MONTH[month])
+    } else {
+        None
+    }
+}
+
+/// Returns the number of days in the given year.
+pub fn days_in_year(year: i64) -> i64 {
+    if is_leap_year(year) {
+        366
+    } else {
+        365
+    }
+}
+
+/// Returns the number of days from the Unix epoch (1970-01-01) to the given civil date.
+///
+/// `month` is expressed in `[1, 12]` and `day` in `[1, 31]`. The computation is `O(1)` and uses
+/// the algorithm by Howard Hinnant, so it stays bounded regardless of how far the date is from the
+/// epoch.
+pub fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    // Shift so that the leap day falls at the end of the (internal) year.
+    let y: i64 = if month <= 2 { year - 1 } else { year };
+    let era: i64 = if y >= 0 { y } else { y - (YEARS_PER_ERA - 1) } / YEARS_PER_ERA;
+    let yoe: i64 = y - era * YEARS_PER_ERA; // Year of era, in [0, 399].
+    let mp: i64 = if month > 2 { month - 3 } else { month + 9 }; // Month index, in [0, 11].
+    let doy: i64 = (DAYS_PER_5_MONTHS * mp + 2) / 5 + day - 1; // Day of internal year, in [0, 365].
+    let doe: i64 = yoe * DAYS_PER_COMMON_YEAR + yoe / 4 - yoe / 100 + doy; // Day of era.
+    era * DAYS_PER_ERA + doe - EPOCH_DAYS_OFFSET
+}


### PR DESCRIPTION
Adds a 	ime.h implementation for the Nanvix C library.

## Summary
- Add time.h implementation

_Draft PR opened from branch `feature-nanvix-libc_time`._