### PR TITLE
[syscall] Idempotent pthread mutex/cond init

### DIFF
--- a/src/libs/syscall/src/pthread/syscall/cond.rs
+++ b/src/libs/syscall/src/pthread/syscall/cond.rs
@@ -81,20 +81,16 @@ pub fn pthread_cond_init(
     cond: &mut pthread_cond_t,
     attr: &pthread_condattr_t,
 ) -> Result<(), Error> {
-    // Check if condition variable is not initialized.
-    if let Entry::Vacant(entry) = CONDITIONS
+    // Register (or re-register) the condition variable's attributes.
+    //
+    // Initialization is idempotent for the same reasons as `pthread_mutex_init`: it matches the
+    // kernel's lazy, per-process recreation model and keeps the userspace registry consistent
+    // across `fork()`, where the child inherits this map through copy-on-write memory while the
+    // kernel deliberately drops and lazily recreates the underlying objects.
+    CONDITIONS
         .lock()
-        .entry(cond as *const pthread_cond_t as usize)
-    {
-        // Condition variable is not initialized.
-        entry.insert(*attr);
-        Ok(())
-    } else {
-        // Condition variable is already initialized.
-        let reason: &str = "condition variable is already initialized";
-        ::syslog::warn!("pthread_cond_init(): {}", reason);
-        Err(Error::new(ErrorCode::ResourceBusy, reason))
-    }
+        .insert(cond as *const pthread_cond_t as usize, *attr);
+    Ok(())
 }
 
 pub fn pthread_cond_destroy(cond: &mut pthread_cond_t) -> Result<(), Error> {

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -50,19 +50,21 @@ pub fn pthread_mutex_init(
     mutex: &mut pthread_mutex_t,
     attr: &pthread_mutexattr_t,
 ) -> Result<(), Error> {
-    // Check if mutex is not initialized.
-    if let Entry::Vacant(entry) = MUTEXES
+    // Register (or re-register) the mutex's attributes.
+    //
+    // Initialization is idempotent: an existing entry for this address is overwritten rather than
+    // rejected. This mirrors the kernel, which keeps mutexes in a per-process table and lazily
+    // (re)creates them on access (`Process::get_mutex` uses `or_insert_with`). It is also what
+    // makes `fork()` work: the kernel intentionally drops the child's inherited mutexes and
+    // recreates them lazily, but this userspace registry is inherited through copy-on-write
+    // memory, so a child that re-initializes a mutex (e.g. CPython rebuilding its GIL in
+    // `PyOS_AfterFork_Child`) would otherwise observe a stale, already-registered entry and fail.
+    // POSIX leaves re-initialization of an initialized mutex undefined and glibc/musl tolerate it;
+    // Nanvix defines it as "reset", consistent with its lazy, kernel-backed model.
+    MUTEXES
         .lock()
-        .entry(mutex as *const pthread_mutex_t as usize)
-    {
-        // Mutex was is not initialized.
-        entry.insert(*attr);
-        Ok(())
-    } else {
-        let reason: &str = "mutex is not initialized";
-        ::syslog::warn!("pthread_mutex_init(): {}", reason);
-        Err(Error::new(ErrorCode::InvalidArgument, reason))
-    }
+        .insert(mutex as *const pthread_mutex_t as usize, *attr);
+    Ok(())
 }
 
 pub fn pthread_mutex_destroy(mutex: &mut pthread_mutex_t) -> Result<(), Error> {


### PR DESCRIPTION
## Problem

A program that calls `fork()` and runs a threaded runtime in the child can die
immediately in the child with a fatal error. The concrete trigger we hit was
CPython: after `fork()`, CPython re-initializes its global interpreter lock in
`PyOS_AfterFork_Child` by calling `pthread_mutex_init`/`pthread_cond_init` on
the *same* lock objects in place. On Nanvix the child aborted with:

```
Fatal Python error: create_gil: PyMUTEX_INIT(gil->mutex) failed
```

## Root cause

The userspace pthread layer tracks each mutex and condition variable in a
process-global registry keyed by the object's address. `pthread_mutex_init`
and `pthread_cond_init` treated an address that was *already present* as an
error (`pthread_mutex_init` → `EINVAL`, `pthread_cond_init` → `EBUSY`).

This collides with `fork()`:

- The kernel keeps each process's mutexes/conditions in a per-process table and
  **intentionally drops** them in a forked child, recreating them lazily on
  first access (`Process::get_mutex` uses `or_insert_with`).
- The userspace registry, by contrast, lives in ordinary process memory and is
  inherited by the child through copy-on-write. The child therefore sees the
  parent's stale registrations.

So when the child re-initializes an inherited lock, userspace says "already
registered" and fails, even though the kernel has already discarded the
underlying object. The two layers disagree.

## Fix

Make `pthread_mutex_init` and `pthread_cond_init` **idempotent**: registering an
address that is already present now overwrites the entry instead of returning an
error. This mirrors the kernel's lazy, per-process model and keeps the userspace
registry consistent across `fork()`.

## Semantics and prior art

POSIX leaves re-initialization of an already-initialized mutex/condition
variable undefined. In glibc and musl, `pthread_mutex_t` is fully
self-contained — all state lives inside the object's own memory and there is no
side registry — so `fork()` simply copies the object and re-initialization just
rewrites it; both libraries tolerate it in practice. Nanvix uses an
address-keyed registry instead, so it must explicitly define re-initialization
as a reset to obtain the same effect. This change does exactly that.

## Testing

With this change, a forked child that re-initializes inherited synchronization
objects no longer aborts:

- `fork()` + `waitpid()`: child runs and the parent observes its real exit code.
- `fork()` + `pipe()`: the child writes and the parent reads the bytes back.

These were verified end to end with CPython's `os.fork()` on the standalone
deployment.
