### PR TITLE
[syscall] Fix stale cached PID in forked child

### DIFF
--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -62,6 +62,12 @@ impl Heap {
             return Err(Error::new(ErrorCode::BadAddress, "capacity is too small"));
         }
 
+        // Check if size is page-aligned.
+        if !mm::is_aligned(size, PAGE_ALIGNMENT) {
+            ::syslog::warn!("new(): unaligned size");
+            return Err(Error::new(ErrorCode::BadAddress, "unaligned size"));
+        }
+
         // Map initial pages.
         //
         // Resolve the owning pid with an UNCACHED kernel query. The kernel rejects an mmap whose

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -64,10 +64,20 @@ impl Heap {
 
         // Map initial pages.
         //
-        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
-        // transition and is invalidated in the child after fork(), so mapping always targets the
-        // current process rather than the parent this heap may have been inherited from.
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        // Resolve the owning pid with an UNCACHED kernel query. The kernel rejects an mmap whose
+        // target pid differs from the calling process (its memory-management capability check), so a
+        // mapping must always name the current process. The cached getpid() offers no guarantee
+        // here: the pid cache is a per-link-unit `static`, and a C-linked image ends up with several
+        // independent copies of it (cpython, for example, links libposix.a and libnvx_crt0.a, each
+        // compiled with its own `sys` crate and therefore its own cache). fork() can invalidate only
+        // the copy in its own link unit, so it cannot guarantee that the copy this mapping consults
+        // was refreshed; that copy may still hold the parent's pid inherited through copy-on-write
+        // memory. Querying the kernel directly is independent of every cached copy.
+        //
+        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a process image is
+        // guaranteed to carry a single, unified pid cache that fork() invalidates, restore the
+        // cached getpid() here.
+        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
         let start: VirtualAddress = base;
         let end: VirtualAddress = VirtualAddress::from_raw_value(base.into_raw_value() + size);
         map_range(pid, start, end)?;
@@ -119,10 +129,9 @@ impl Heap {
 
         // Map pages.
         //
-        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
-        // transition and is invalidated in the child after fork(), so mapping always targets the
-        // current process rather than the parent this heap may have been inherited from.
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
+        // getpid() cannot be trusted for a capability-sensitive mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
         let end: VirtualAddress = self.base + self.size;
         let new_end: VirtualAddress = end + increment;
         map_range(pid, end, new_end)?;
@@ -161,10 +170,9 @@ impl Heap {
             return Ok(());
         }
 
-        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
-        // transition and is invalidated in the child after fork(), so unmapping always targets the
-        // current process rather than the parent this heap may have been inherited from.
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
+        // getpid() cannot be trusted for a capability-sensitive unmapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
 
         // Unmap tail pages from the end backwards, stopping at the first failure so that
         // self.size always reflects the actual contiguous mapped extent.
@@ -282,9 +290,9 @@ impl Drop for Heap {
             self.capacity
         );
 
-        // Resolve the owning pid through the fork-aware cache; see grow() for rationale. Drop
+        // Resolve the owning pid with an UNCACHED kernel query; see new() for the rationale. Drop
         // cannot propagate errors, so skip unmapping if the pid cannot be determined.
-        let pid: ProcessIdentifier = match kcall::pm::getpid() {
+        let pid: ProcessIdentifier = match kcall::pm::getpid_uncached() {
             Ok(pid) => pid,
             Err(_error) => {
                 ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -98,11 +98,20 @@ impl MemorySegment {
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
-        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
-        // transition and is invalidated in the child after fork(). Segments live in a
-        // process-global map that a child inherits across fork(), so mapping must always target
-        // the current process; a kcall with a foreign pid trips the kernel's capability check.
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        // Resolve the owning pid with an UNCACHED kernel query. The kernel rejects an mmap whose
+        // target pid differs from the calling process (its memory-management capability check), so a
+        // mapping must always name the current process. The cached getpid() offers no guarantee
+        // here: the pid cache is a per-link-unit `static`, and a C-linked image ends up with several
+        // independent copies of it (cpython, for example, links libposix.a and libnvx_crt0.a, each
+        // compiled with its own `sys` crate and therefore its own cache). fork() can invalidate only
+        // the copy in its own link unit, so it cannot guarantee that the copy this mapping consults
+        // was refreshed; that copy may still hold the parent's pid inherited through copy-on-write
+        // memory. Querying the kernel directly is independent of every cached copy.
+        //
+        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a process image is
+        // guaranteed to carry a single, unified pid cache that fork() invalidates, restore the
+        // cached getpid() here.
+        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
 
         map_range(
             pid,
@@ -209,11 +218,9 @@ impl MemorySegment {
             prot
         );
 
-        // Resolve the owning pid through the fork-aware cache: it is memoized to avoid a kernel
-        // transition and is invalidated in the child after fork(). Segments live in a
-        // process-global map that a child inherits across fork(), so this must always target the
-        // current process; a kcall with a foreign pid trips the kernel's capability check.
-        let pid: ProcessIdentifier = kcall::pm::getpid()?;
+        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
+        // getpid() cannot be trusted for a capability-sensitive mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
 
         protect_range(
             pid,
@@ -228,10 +235,9 @@ impl Drop for MemorySegment {
     fn drop(&mut self) {
         ::syslog::trace!("drop(): base={:X?}, capacity={:X?}", self.base, self.capacity);
 
-        // Resolve the owning pid through the fork-aware cache; see set_protection() for
-        // rationale. Drop cannot propagate errors, so skip unmapping if the pid cannot be
-        // determined.
-        let pid: ProcessIdentifier = match kcall::pm::getpid() {
+        // Resolve the owning pid with an UNCACHED kernel query; see new() for the rationale. Drop
+        // cannot propagate errors, so skip unmapping if the pid cannot be determined.
+        let pid: ProcessIdentifier = match kcall::pm::getpid_uncached() {
             Ok(pid) => pid,
             Err(_error) => {
                 ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);

--- a/src/libs/syscall/src/unistd/fork/mod.rs
+++ b/src/libs/syscall/src/unistd/fork/mod.rs
@@ -241,6 +241,27 @@ pub fn do_fork() -> Result<pid_t, ErrorCode> {
             // the parent's best-effort terminate is a further backstop.
             panic!("do_fork(): child exit kcall returned (error={exit_error:?})");
         }
+
+        // Defensively refresh the child's cached process identifier.
+        //
+        // The child inherits `CACHED_PID` (holding the *parent's* pid) through copy-on-write
+        // memory. `__kcall_fork()` already clears this crate instance's copy at the start of the
+        // child path, and the kernel always reports the child's own identity — there is no window
+        // in which `getpid()` returns the parent's pid — so the next cached query re-resolves to
+        // the child regardless. This post-handshake clear is a low-cost safety net for the
+        // libc-side identity cache; it adds at most one kernel transition per fork.
+        //
+        // It is NOT the capability fix. `CACHED_PID` is a per-link-unit static, so a process image
+        // that links several independently-compiled copies of this crate (e.g. a C program linking
+        // `libposix.a` and `libnvx_crt0.a`) carries multiple instances that no single invalidation
+        // can reach. The capability-sensitive callers — `mmap`/`mprotect`/`munmap` in
+        // `MemorySegment` and the heap allocator — therefore resolve the owning pid with
+        // `getpid_uncached()` and never trust this cache for the kernel's `pid != caller_pid` check.
+        //
+        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a single unified pid cache
+        // is guaranteed per image, this defensive re-invalidation can be dropped.
+        ::sys::kcall::pm::invalidate_cached_pid();
+
         Ok(0)
     } else {
         // Parent: ask the daemon to duplicate our descriptors onto the child, and block until it


### PR DESCRIPTION
## Problem

After `fork()`, a child could fail to `mmap` into its own address space: the exec/loader path's `mmap` was rejected by the kernel with a memory-management capability error:

```
mmap(): process does not have memory management capabilities
```

`os.fork()` + `os.execv()` under CPython reproduced this; a single-binary Rust `fork()` did not. Plain `fork()`/`waitpid()`, and `exec()` from a freshly spawned process, both worked.

## Root cause

`getpid()` is memoized in a process-global cache, `CACHED_PID`, which is a **private, per-link-unit `static`**. The kernel's `mmap` handler enforces `Capability::MemoryManagement` only when the target pid differs from the caller, so a child mapping into itself with a stale **parent** pid looks like a foreign-process mapping and is denied.

The stale value originates from the child inheriting the cache through copy-on-write memory. What lets it *survive* is that a C-linked image carries **several independent copies** of the cache: e.g. CPython's `python.elf` links `libposix.a` and `libnvx_crt0.a`, each compiled with its own `sys` crate and therefore its own `CACHED_PID`. `fork()` / `__kcall_fork()` can only invalidate the copy in their own link unit, so the copy a given `mmap` consults is not guaranteed to be the one that was refreshed. A single-compilation Rust binary unifies `sys` into one cache, which is why it never reproduced there.

The kernel always reports the child's own pid — there is no "settling window".

## Fix

Resolve the owning pid with `getpid_uncached()` at every capability-sensitive memory kcall, so the decision never rides on a cache that may be stale in some link unit:

- `MemorySegment::new` / `set_protection` / `drop` (`syscall`)
- `Heap::new` / `grow` / `shrink` / `drop` (`sysalloc`)

Additionally, re-invalidate the child's cached pid once more after the fork handshake in `do_fork()` as a low-cost safety net for the libc-side identity `getpid()`. This is **not** the capability fix and can be dropped once the cache is unified.

## Follow-up

The cache duplication is the real underlying problem and is tracked in #2622. Once a process image is guaranteed to carry a single, unified pid cache that `fork()` invalidates, the cached `getpid()` can be restored at these sites and the `do_fork()` re-invalidation removed.

## Testing

- `os.fork()` + `os.execv()` of a real program now succeeds end-to-end on the standalone deployment (CPython): the child replaces its image, runs to completion, and the parent reaps it with the expected status.
- In a forked child, `getpid()`/`getppid()` report the child's own and its parent's identifiers.
- Guest clippy (`-D warnings`) and host unit tests pass for the touched crates.
