### PR TITLE
[libc_wchar] Add libc_wchar crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_wchar"
+version = "0.16.105"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "linux-app"
 version = "0.16.105"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
         "src/libs/libc_math",
         "src/libs/libc_string",
         "src/libs/libc_time",
+        "src/libs/libc_wchar",
         "src/libs/cache",
         "src/libs/cmdline",
         "src/libs/koptions",
@@ -232,6 +233,7 @@ libc_stdio = { path = "src/libs/libc_stdio", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }
 libc_string = { path = "src/libs/libc_string", default-features = false }
 libc_time = { path = "src/libs/libc_time", default-features = false }
+libc_wchar = { path = "src/libs/libc_wchar", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -329,8 +329,8 @@ export VERUS_KERNEL_FEATURES := microvm trace
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time libc_wchar syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/libc_langinfo/src/nl_langinfo.rs
+++ b/src/libs/libc_langinfo/src/nl_langinfo.rs
@@ -99,7 +99,8 @@ static ABMONTHS: [&[u8]; 12] = [
 /// # Returns
 ///
 /// A pointer to a null-terminated string describing `item`. Unrecognized items yield an empty
-/// string. The codeset is reported as UTF-8 to match the libc multibyte conversions.
+/// string. The codeset is reported as ISO-8859-1 to match the byte-oriented C/POSIX locale
+/// multibyte conversions.
 ///
 /// # Safety
 ///
@@ -109,7 +110,7 @@ static ABMONTHS: [&[u8]; 12] = [
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub extern "C" fn nl_langinfo(item: nl_item) -> *mut c_char {
     let s: &'static [u8] = match item {
-        CODESET => b"UTF-8\0",
+        CODESET => b"ISO-8859-1\0",
         D_T_FMT => b"%a %b %e %H:%M:%S %Y\0",
         D_FMT => b"%m/%d/%y\0",
         T_FMT => b"%H:%M:%S\0",
@@ -179,8 +180,8 @@ mod test {
     }
 
     #[test]
-    fn test_codeset_is_utf8() {
-        assert!(c_str_eq(nl_langinfo(CODESET), b"UTF-8"));
+    fn test_codeset_is_iso_8859_1() {
+        assert!(c_str_eq(nl_langinfo(CODESET), b"ISO-8859-1"));
     }
 
     #[test]

--- a/src/libs/libc_locale/header.toml
+++ b/src/libs/libc_locale/header.toml
@@ -43,6 +43,11 @@ value = "6"
 
 [[types]]
 text = """
+#ifndef _LOCALE_T_DEFINED
+#define _LOCALE_T_DEFINED
+typedef void *locale_t;
+#endif
+
 /** @brief Locale-specific numeric formatting information. */
 struct lconv {
     char *decimal_point;     /**< Decimal point character.            */

--- a/src/libs/libc_stdio/src/lib.rs
+++ b/src/libs/libc_stdio/src/lib.rs
@@ -91,3 +91,29 @@ pub use streams::{
     stdout,
     FILE,
 };
+
+//==================================================================================================
+// Test Support
+//==================================================================================================
+
+// The MSVC C runtime used for Windows host unit tests does not export the glibc/musl
+// `__errno_location` symbol used by the guest libc build, so provide a thread-local test shim.
+#[cfg(all(test, feature = "std", target_os = "windows"))]
+mod windows_errno_shim {
+    use ::core::cell::Cell;
+    use ::sysapi::ffi::c_int;
+
+    std::thread_local! {
+        static ERRNO: Cell<c_int> = const { Cell::new(0) };
+    }
+
+    /// Host-only definition of `__errno_location` for Windows `std` unit tests.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid for the lifetime of the calling thread.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn __errno_location() -> *mut c_int {
+        ERRNO.with(Cell::as_ptr)
+    }
+}

--- a/src/libs/libc_stdio/src/swprintf.rs
+++ b/src/libs/libc_stdio/src/swprintf.rs
@@ -9,6 +9,10 @@
 
 use ::core::ffi::VaList;
 use ::sysapi::{
+    errno::{
+        __errno_location,
+        EOVERFLOW,
+    },
     ffi::{
         c_char,
         c_int,
@@ -25,6 +29,15 @@ type wchar_t = i32;
 
 /// Value returned by the multibyte conversion functions on an encoding error (`(size_t)-1`).
 const SIZE_ERR: c_size_t = c_size_t::MAX;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Sets `errno` to `code`.
+fn set_errno(code: c_int) {
+    unsafe { *__errno_location() = code };
+}
 
 //==================================================================================================
 // External Symbols
@@ -91,7 +104,23 @@ pub unsafe extern "C" fn vswprintf(
         unsafe { free(nfmt.cast::<c_void>()) };
         return -1;
     }
-    unsafe { crate::vsnprintf::vsnprintf(nout, nout_size, nfmt, ap) };
+    let needed: c_int = unsafe { crate::vsnprintf::vsnprintf(nout, nout_size, nfmt, ap) };
+    if needed < 0 {
+        unsafe {
+            free(nfmt.cast::<c_void>());
+            free(nout.cast::<c_void>());
+        }
+        return -1;
+    }
+    let needed: c_size_t = c_size_t::try_from(needed).unwrap_or(c_size_t::MAX);
+    if needed >= n {
+        unsafe {
+            free(nfmt.cast::<c_void>());
+            free(nout.cast::<c_void>());
+        }
+        set_errno(EOVERFLOW);
+        return -1;
+    }
 
     // Convert the formatted narrow output back to wide characters.
     let max_chars: c_size_t = n - 1;
@@ -123,4 +152,81 @@ pub unsafe extern "C" fn swprintf(
     args: ...
 ) -> c_int {
     unsafe { vswprintf(ws, n, format, args) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn wcslen(s: *const wchar_t) -> c_size_t {
+        let mut len: c_size_t = 0;
+        while unsafe { *s.add(len as usize) } != 0 {
+            len += 1;
+        }
+        len
+    }
+
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn wcstombs(dst: *mut c_char, src: *const wchar_t, n: c_size_t) -> c_size_t {
+        let mut i: c_size_t = 0;
+        loop {
+            let wc: wchar_t = unsafe { *src.add(i as usize) };
+            if wc == 0 {
+                if !dst.is_null() && i < n {
+                    unsafe { *dst.add(i as usize) = 0 };
+                }
+                return i;
+            }
+            if !dst.is_null() {
+                if i >= n {
+                    return i;
+                }
+                unsafe { *dst.add(i as usize) = c_char::from_ne_bytes([(wc & 0xff) as u8]) };
+            }
+            i += 1;
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn mbstowcs(dst: *mut wchar_t, src: *const c_char, n: c_size_t) -> c_size_t {
+        let mut i: c_size_t = 0;
+        loop {
+            let c: c_char = unsafe { *src.add(i as usize) };
+            if c == 0 {
+                if !dst.is_null() && i < n {
+                    unsafe { *dst.add(i as usize) = 0 };
+                }
+                return i;
+            }
+            if !dst.is_null() {
+                if i >= n {
+                    return i;
+                }
+                unsafe { *dst.add(i as usize) = wchar_t::from(c.to_ne_bytes()[0]) };
+            }
+            i += 1;
+        }
+    }
+
+    #[test]
+    fn test_swprintf_fails_when_output_would_not_fit() {
+        let mut out: [wchar_t; 2] = [-1; 2];
+        let fmt: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let ret: c_int = unsafe { swprintf(out.as_mut_ptr(), out.len() as c_size_t, fmt.as_ptr()) };
+        assert_eq!(ret, -1);
+    }
+
+    #[test]
+    fn test_swprintf_writes_when_output_fits() {
+        let mut out: [wchar_t; 4] = [-1; 4];
+        let fmt: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let ret: c_int = unsafe { swprintf(out.as_mut_ptr(), out.len() as c_size_t, fmt.as_ptr()) };
+        assert_eq!(ret, 3);
+        assert_eq!(out, fmt);
+    }
 }

--- a/src/libs/libc_wchar/Cargo.toml
+++ b/src/libs/libc_wchar/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_wchar"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -1,0 +1,130 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for wchar.h.
+
+file = "wchar.h"
+brief = "Wide character strings."
+description = '''
+Declares functions for wide character string manipulation and memory
+operations. Implemented by the libc_wchar Rust crate.'''
+includes = ["stdarg.h", "stddef.h", "stdio.h", "locale.h", "time.h"]
+guard = "_NANVIX_WCHAR_H"
+scan_crates = ["libc_wchar", "libc_stdio"]
+content_order = [
+    "types",
+    "raw:0",
+    "section:0",
+    "section:1",
+    "section:2",
+    "section:3",
+    "section:4",
+    "section:5",
+    "section:6",
+    "section:7",
+]
+
+[[types]]
+text = '''
+#ifndef _WCHAR_T_DEFINED
+#define _WCHAR_T_DEFINED
+#ifndef __cplusplus
+typedef int wchar_t;
+#endif
+#endif
+
+#ifndef _WINT_T_DEFINED
+#define _WINT_T_DEFINED
+typedef int wint_t;
+#endif
+
+#ifndef _MBSTATE_T_DEFINED
+#define _MBSTATE_T_DEFINED
+/** @brief Conversion state for the restartable multibyte functions. */
+typedef struct {
+    int __count;       /**< Number of pending bytes.            */
+    unsigned char __buf[4]; /**< Buffered bytes of an incomplete seq. */
+} mbstate_t;
+#endif'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#ifndef WEOF
+#define WEOF ((wint_t)(-1))
+#endif
+
+#ifndef WCHAR_MAX
+#define WCHAR_MAX 0x7fffffff
+#endif
+
+#ifndef WCHAR_MIN
+#define WCHAR_MIN (-WCHAR_MAX - 1)
+#endif
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif'''
+
+[[sections]]
+title = "String Operations"
+functions = ["wcslen", "wcscpy", "wcsncpy", "wcscat"]
+
+[[sections]]
+title = "Comparison"
+functions = ["wcscmp", "wcsncmp", "wcscoll", "wcsxfrm"]
+
+[[sections]]
+title = "Search"
+functions = ["wcschr", "wcsrchr", "wcsstr", "wcstok"]
+
+[[sections]]
+title = "Numeric Conversions"
+functions = ["wcstol", "wcstoul", "wcstoll", "wcstoull", "wcstod"]
+
+[[sections]]
+title = "Wide Memory Operations"
+functions = ["wmemcpy", "wmemmove", "wmemset", "wmemcmp", "wmemchr"]
+
+[[sections]]
+title = "Byte / Wide Conversion"
+functions = ["btowc", "wctob"]
+
+[[sections]]
+title = "Wide Character Formatted Output"
+functions = ["swprintf", "vswprintf"]
+
+[[sections]]
+title = "Restartable Multibyte / Wide Conversion"
+functions = [
+    "mbrtowc",
+    "wcrtomb",
+    "mbrlen",
+    "mbsinit",
+    "mbsrtowcs",
+    "wcsrtombs",
+]
+
+[overrides]
+wcscoll = '''
+extern int wcscoll(const wchar_t *s1, const wchar_t *s2);'''
+wcsxfrm = '''
+extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);'''
+wcstok = '''
+extern wchar_t *wcstok(wchar_t *ws, const wchar_t *delim, wchar_t **ptr);'''
+wmemchr = '''
+extern wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);'''
+vswprintf = '''
+extern int vswprintf(wchar_t *ws, size_t n, const wchar_t *format, va_list ap);'''
+mbrtowc = '''
+extern size_t mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps);'''
+wcrtomb = '''
+extern size_t wcrtomb(char *s, wchar_t wc, mbstate_t *ps);'''
+mbrlen = '''
+extern size_t mbrlen(const char *s, size_t n, mbstate_t *ps);'''
+mbsinit = '''
+extern int mbsinit(const mbstate_t *ps);'''
+mbsrtowcs = '''
+extern size_t mbsrtowcs(wchar_t *dest, const char **src, size_t n, mbstate_t *ps);'''
+wcsrtombs = '''
+extern size_t wcsrtombs(char *dest, const wchar_t **src, size_t n, mbstate_t *ps);'''

--- a/src/libs/libc_wchar/src/btowc.rs
+++ b/src/libs/libc_wchar/src/btowc.rs
@@ -1,0 +1,78 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::{
+    wint_t,
+    WEOF,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a single-byte character to a wide character. In the POSIX locale, every byte value in
+/// the range 0..=255 is a valid single-byte character.
+///
+/// # Parameters
+///
+/// - `c`: Character to convert, as an `int`.
+///
+/// # Return Value
+///
+/// The wide character representation of `c`, or `WEOF` if `c` is `EOF` or outside the byte range.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn btowc(c: c_int) -> wint_t {
+    if (0..=255).contains(&c) {
+        c as wint_t
+    } else {
+        WEOF
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_btowc_ascii() {
+        assert_eq!(btowc(0x41), 0x41); // 'A'
+        assert_eq!(btowc(0), 0); // null
+        assert_eq!(btowc(127), 127); // DEL
+    }
+
+    #[test]
+    fn test_btowc_posix_locale_accepts_all_bytes() {
+        assert_eq!(btowc(128), 128);
+        assert_eq!(btowc(255), 255);
+    }
+
+    #[test]
+    fn test_btowc_eof() {
+        assert_eq!(btowc(-1), WEOF);
+    }
+
+    #[test]
+    fn test_btowc_out_of_range() {
+        assert_eq!(btowc(-2), WEOF);
+        assert_eq!(btowc(256), WEOF);
+    }
+}

--- a/src/libs/libc_wchar/src/lib.rs
+++ b/src/libs/libc_wchar/src/lib.rs
@@ -1,0 +1,89 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod btowc;
+pub mod mbstate;
+pub mod multibyte;
+pub mod utf8;
+pub mod wchar_t;
+pub mod wcs_narrow;
+pub mod wcscat;
+pub mod wcschr;
+pub mod wcscmp;
+pub mod wcscoll;
+pub mod wcscpy;
+pub mod wcslen;
+pub mod wcsncmp;
+pub mod wcsncpy;
+pub mod wcsrchr;
+pub mod wcsstr;
+pub mod wcstod;
+pub mod wcstok;
+pub mod wcstol;
+pub mod wcstoll;
+pub mod wcstoul;
+pub mod wcstoull;
+pub mod wcsxfrm;
+pub mod wctob;
+pub mod wmemchr;
+pub mod wmemcmp;
+pub mod wmemcpy;
+pub mod wmemmove;
+pub mod wmemset;
+
+//==================================================================================================
+// Test Support
+//==================================================================================================
+
+// The conversion routines reference `__errno_location` to report `EILSEQ`. That symbol is provided
+// by the C library in the guest build, but the MSVC C runtime used for host `std` unit tests on
+// Windows does not export this glibc/musl symbol, so supply a thread-local definition here to let
+// the errno-setting paths link and run. On Linux hosts the system C library already provides the
+// symbol, so the shim is not compiled there.
+#[cfg(all(test, feature = "std", target_os = "windows"))]
+mod windows_errno_shim {
+    use ::core::cell::Cell;
+    use ::sysapi::ffi::c_int;
+
+    std::thread_local! {
+        static ERRNO: Cell<c_int> = const { Cell::new(0) };
+    }
+
+    /// Host-only definition of `__errno_location` for Windows `std` unit tests.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid for the lifetime of the calling thread.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn __errno_location() -> *mut c_int {
+        ERRNO.with(Cell::as_ptr)
+    }
+}

--- a/src/libs/libc_wchar/src/mbstate.rs
+++ b/src/libs/libc_wchar/src/mbstate.rs
@@ -1,0 +1,20 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Conversion state for the restartable multibyte functions.
+///
+/// The layout mirrors the conventional `glibc` definition: a pending-byte counter followed by a
+/// four-byte holding buffer. For the stateless UTF-8 encoding the only state that needs to persist
+/// across calls is the prefix of an incomplete multibyte sequence.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct mbstate_t {
+    /// Number of pending bytes held in `bytes`.
+    pub count: ::sysapi::ffi::c_int,
+    /// Buffered leading bytes of an incomplete sequence.
+    pub bytes: [u8; 4],
+}

--- a/src/libs/libc_wchar/src/multibyte.rs
+++ b/src/libs/libc_wchar/src/multibyte.rs
@@ -1,0 +1,714 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    mbstate::mbstate_t,
+    wchar_t::wchar_t,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EILSEQ,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Return value used by the byte-counting functions to signal an error.
+const SIZE_ERR: usize = usize::MAX;
+
+/// Return value used by the restartable functions to signal an incomplete sequence.
+const SIZE_INCOMPLETE: usize = usize::MAX - 1;
+
+//==================================================================================================
+// Internal Conversion State
+//==================================================================================================
+
+/// Per-thread internal conversion state used by the restartable functions when the caller passes a
+/// null `mbstate_t`.
+///
+/// On the host `std` build the unit-test harness runs tests on multiple threads, so the implicit
+/// state is kept thread-local to avoid data races. On the guest `no_std` build there is no
+/// thread-local support, so a process-global state is used instead, matching the conventional
+/// single-threaded C library behavior.
+#[cfg(feature = "std")]
+mod internal_state {
+    use crate::mbstate::mbstate_t;
+    use ::core::cell::Cell;
+
+    std::thread_local! {
+        static MBRTOWC_STATE: Cell<mbstate_t> =
+            const { Cell::new(mbstate_t { count: 0, bytes: [0; 4] }) };
+        static MBRLEN_STATE: Cell<mbstate_t> =
+            const { Cell::new(mbstate_t { count: 0, bytes: [0; 4] }) };
+    }
+
+    /// Returns a pointer to the thread-local internal state used by `mbrtowc()`.
+    pub(super) fn mbrtowc_state() -> *mut mbstate_t {
+        MBRTOWC_STATE.with(Cell::as_ptr)
+    }
+
+    /// Returns a pointer to the thread-local internal state used by `mbrlen()`.
+    pub(super) fn mbrlen_state() -> *mut mbstate_t {
+        MBRLEN_STATE.with(Cell::as_ptr)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod internal_state {
+    use crate::mbstate::mbstate_t;
+
+    /// Internal state used by `mbrtowc()` when the caller passes a null `mbstate_t`.
+    static mut MBRTOWC_STATE: mbstate_t = mbstate_t {
+        count: 0,
+        bytes: [0; 4],
+    };
+
+    /// Internal state used by `mbrlen()` when the caller passes a null `mbstate_t`.
+    static mut MBRLEN_STATE: mbstate_t = mbstate_t {
+        count: 0,
+        bytes: [0; 4],
+    };
+
+    /// Returns a pointer to the process-global internal state used by `mbrtowc()`.
+    pub(super) fn mbrtowc_state() -> *mut mbstate_t {
+        ::core::ptr::addr_of_mut!(MBRTOWC_STATE)
+    }
+
+    /// Returns a pointer to the process-global internal state used by `mbrlen()`.
+    pub(super) fn mbrlen_state() -> *mut mbstate_t {
+        ::core::ptr::addr_of_mut!(MBRLEN_STATE)
+    }
+}
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Sets `errno` to `code`.
+fn set_errno(code: c_int) {
+    // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
+    unsafe {
+        *__errno_location() = code;
+    }
+}
+
+/// Reinterprets a raw `char` byte as an unsigned byte without a sign-changing `as` cast.
+fn byte_of(c: c_char) -> u8 {
+    c.to_ne_bytes()[0]
+}
+
+/// Reinterprets an unsigned byte as the platform `char` type without a sign-changing `as` cast.
+fn cchar_of(b: u8) -> c_char {
+    c_char::from_ne_bytes([b])
+}
+
+/// Reinterprets a wide character as an unsigned code point.
+fn cp_of(wc: wchar_t) -> u32 {
+    u32::from_ne_bytes(wc.to_ne_bytes())
+}
+
+/// Core of the restartable multibyte-to-wide conversion. Nanvix currently supports the C/POSIX
+/// locale, where every byte value is a valid single-byte character.
+///
+/// # Safety
+///
+/// `s` (when non-null) must reference at least `n` valid bytes, and `pwc` (when non-null) must be
+/// writable.
+unsafe fn mbrtowc_core(
+    pwc: *mut wchar_t,
+    s: *const c_char,
+    n: usize,
+    state: &mut mbstate_t,
+) -> usize {
+    if s.is_null() {
+        state.count = 0;
+        return 0;
+    }
+
+    state.count = 0;
+    if n == 0 {
+        return SIZE_INCOMPLETE;
+    }
+
+    let b: u8 = byte_of(unsafe { *s });
+    if !pwc.is_null() {
+        unsafe { *pwc = wchar_t::from(b) };
+    }
+    if b == 0 {
+        0
+    } else {
+        1
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Determines the number of bytes in the multibyte character pointed to by `s`, storing the wide
+/// character in `*pwc`. The C/POSIX locale is stateless and maps bytes directly to wide values.
+///
+/// # Safety
+///
+/// `s` (when non-null) must reference at least `n` valid bytes, and `pwc` (when non-null) must be
+/// writable.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbtowc(pwc: *mut wchar_t, s: *const c_char, n: usize) -> c_int {
+    if s.is_null() {
+        return 0;
+    }
+
+    if n == 0 {
+        return -1;
+    }
+
+    let b: u8 = byte_of(unsafe { *s });
+    if !pwc.is_null() {
+        unsafe { *pwc = wchar_t::from(b) };
+    }
+    if b == 0 {
+        0
+    } else {
+        1
+    }
+}
+
+/// Determines the number of bytes in the multibyte character pointed to by `s`. Equivalent to
+/// `mbtowc(NULL, s, n)` for the stateless UTF-8 encoding.
+///
+/// # Safety
+///
+/// `s` (when non-null) must reference at least `n` valid bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mblen(s: *const c_char, n: usize) -> c_int {
+    unsafe { mbtowc(core::ptr::null_mut(), s, n) }
+}
+
+/// Stores the multibyte representation of `wc` in `s`, returning the number of bytes written.
+///
+/// # Safety
+///
+/// `s` (when non-null) must have room for at least `MB_LEN_MAX` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wctomb(s: *mut c_char, wc: wchar_t) -> c_int {
+    if s.is_null() {
+        return 0;
+    }
+
+    let cp: u32 = cp_of(wc);
+    if cp <= 0xff {
+        unsafe { *s = cchar_of(u8::try_from(cp).unwrap_or(0)) };
+        1
+    } else {
+        set_errno(EILSEQ);
+        -1
+    }
+}
+
+/// Converts the multibyte string `src` to a wide-character string `dst`, writing at most `n` wide
+/// characters. Returns the number of wide characters (excluding the terminator), or `(size_t)-1`
+/// on an invalid sequence.
+///
+/// # Safety
+///
+/// `src` must be a valid, null-terminated multibyte string and `dst` (when non-null) must have
+/// room for `n` wide characters.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbstowcs(dst: *mut wchar_t, src: *const c_char, n: usize) -> usize {
+    let mut s: *const c_char = src;
+    let mut count: usize = 0;
+
+    loop {
+        if !dst.is_null() && count >= n {
+            return count;
+        }
+
+        let b: u8 = byte_of(unsafe { *s });
+        if b == 0 {
+            if !dst.is_null() {
+                unsafe { *dst.add(count) = 0 };
+            }
+            return count;
+        }
+        if !dst.is_null() {
+            unsafe { *dst.add(count) = wchar_t::from(b) };
+        }
+        count += 1;
+        s = unsafe { s.add(1) };
+    }
+}
+
+/// Converts the wide-character string `src` to a multibyte string `dst`, writing at most `n`
+/// bytes. Returns the number of bytes (excluding the terminator), or `(size_t)-1` on an invalid
+/// wide character.
+///
+/// # Safety
+///
+/// `src` must be a valid, null-terminated wide string and `dst` (when non-null) must have room for
+/// `n` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstombs(dst: *mut c_char, src: *const wchar_t, n: usize) -> usize {
+    let mut count: usize = 0;
+    let mut i: usize = 0;
+
+    loop {
+        let wc: wchar_t = unsafe { *src.add(i) };
+        if wc == 0 {
+            if !dst.is_null() && count < n {
+                unsafe { *dst.add(count) = 0 };
+            }
+            return count;
+        }
+
+        let cp: u32 = cp_of(wc);
+        if cp > 0xff {
+            set_errno(EILSEQ);
+            return SIZE_ERR;
+        }
+        if dst.is_null() {
+            count += 1;
+        } else {
+            if count >= n {
+                return count;
+            }
+            unsafe { *dst.add(count) = cchar_of(u8::try_from(cp).unwrap_or(0)) };
+            count += 1;
+        }
+        i += 1;
+    }
+}
+
+/// Restartable conversion of a single multibyte character to a wide character.
+///
+/// # Safety
+///
+/// See [`mbrtowc_core`].
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbrtowc(
+    pwc: *mut wchar_t,
+    s: *const c_char,
+    n: usize,
+    ps: *mut mbstate_t,
+) -> usize {
+    if ps.is_null() {
+        // SAFETY: the internal state pointer is valid and the state is only accessed from this
+        // function (per-thread under `std`, process-global under `no_std`).
+        unsafe { mbrtowc_core(pwc, s, n, &mut *internal_state::mbrtowc_state()) }
+    } else {
+        unsafe { mbrtowc_core(pwc, s, n, &mut *ps) }
+    }
+}
+
+/// Restartable computation of the length in bytes of the next multibyte character.
+///
+/// # Safety
+///
+/// `s` (when non-null) must reference at least `n` valid bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbrlen(s: *const c_char, n: usize, ps: *mut mbstate_t) -> usize {
+    if ps.is_null() {
+        // SAFETY: the internal state pointer is valid and the state is only accessed from this
+        // function (per-thread under `std`, process-global under `no_std`).
+        unsafe { mbrtowc_core(core::ptr::null_mut(), s, n, &mut *internal_state::mbrlen_state()) }
+    } else {
+        unsafe { mbrtowc_core(core::ptr::null_mut(), s, n, &mut *ps) }
+    }
+}
+
+/// Restartable conversion of a single wide character to its multibyte representation. UTF-8 is
+/// stateless, so `ps` is only consulted to honour the null-`s` reset convention.
+///
+/// # Safety
+///
+/// `s` (when non-null) must have room for at least `MB_LEN_MAX` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcrtomb(s: *mut c_char, wc: wchar_t, _ps: *mut mbstate_t) -> usize {
+    // With a null buffer the call is equivalent to encoding a null wide character.
+    if s.is_null() {
+        return 1;
+    }
+
+    let cp: u32 = cp_of(wc);
+    if cp <= 0xff {
+        unsafe { *s = cchar_of(u8::try_from(cp).unwrap_or(0)) };
+        1
+    } else {
+        set_errno(EILSEQ);
+        SIZE_ERR
+    }
+}
+
+/// Reports whether `ps` describes an initial conversion state.
+///
+/// # Safety
+///
+/// `ps` (when non-null) must be a valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbsinit(ps: *const mbstate_t) -> c_int {
+    if ps.is_null() {
+        return 1;
+    }
+    if unsafe { (*ps).count } == 0 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Restartable conversion of a multibyte string to a wide-character string.
+///
+/// # Safety
+///
+/// `src` must point to a valid pointer to a null-terminated multibyte string. `dst` (when
+/// non-null) must have room for `n` wide characters.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbsrtowcs(
+    dst: *mut wchar_t,
+    src: *mut *const c_char,
+    n: usize,
+    ps: *mut mbstate_t,
+) -> usize {
+    let mut state: mbstate_t = if ps.is_null() {
+        mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        }
+    } else {
+        unsafe { *ps }
+    };
+    let mut s: *const c_char = unsafe { *src };
+    let mut count: usize = 0;
+
+    loop {
+        if !dst.is_null() && count >= n {
+            if !ps.is_null() {
+                unsafe { *ps = state };
+            }
+            unsafe { *src = s };
+            return count;
+        }
+
+        let mut wc: wchar_t = 0;
+        let res: usize = unsafe { mbrtowc_core(&mut wc, s, 4, &mut state) };
+        if res == SIZE_ERR || res == SIZE_INCOMPLETE {
+            set_errno(EILSEQ);
+            return SIZE_ERR;
+        }
+        if wc == 0 {
+            // Per POSIX, the pointer object pointed to by `src` is updated only when `dst` is
+            // non-null. When `dst` is null the call merely measures the converted length and must
+            // leave `*src` untouched.
+            if !dst.is_null() {
+                unsafe { *dst.add(count) = 0 };
+                unsafe { *src = core::ptr::null() };
+            }
+            if !ps.is_null() {
+                unsafe { *ps = state };
+            }
+            return count;
+        }
+        if !dst.is_null() {
+            unsafe { *dst.add(count) = wc };
+        }
+        count += 1;
+        s = unsafe { s.add(res) };
+    }
+}
+
+/// Restartable conversion of a wide-character string to a multibyte string.
+///
+/// # Safety
+///
+/// `src` must point to a valid pointer to a null-terminated wide string. `dst` (when non-null)
+/// must have room for `n` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsrtombs(
+    dst: *mut c_char,
+    src: *mut *const wchar_t,
+    n: usize,
+    _ps: *mut mbstate_t,
+) -> usize {
+    let mut w: *const wchar_t = unsafe { *src };
+    let mut count: usize = 0;
+
+    loop {
+        let wc: wchar_t = unsafe { *w };
+        if wc == 0 {
+            // Per POSIX, the pointer object pointed to by `src` is updated only when `dst` is
+            // non-null. When `dst` is null the call merely measures the converted length and must
+            // leave `*src` untouched.
+            if !dst.is_null() {
+                if count < n {
+                    // There is room for the terminating null byte: store it and signal that
+                    // conversion stopped at the terminator by nulling `*src`.
+                    unsafe { *dst.add(count) = 0 };
+                    unsafe { *src = core::ptr::null() };
+                } else {
+                    // No room remains for the terminating null byte, so conversion stops early due
+                    // to the length limit. `*src` is left pointing at the terminator.
+                    unsafe { *src = w };
+                }
+            }
+            return count;
+        }
+
+        let cp: u32 = cp_of(wc);
+        if cp > 0xff {
+            if !dst.is_null() {
+                unsafe { *src = w };
+            }
+            set_errno(EILSEQ);
+            return SIZE_ERR;
+        }
+        if dst.is_null() {
+            count += 1;
+        } else {
+            if count >= n {
+                unsafe { *src = w };
+                return count;
+            }
+            unsafe { *dst.add(count) = cchar_of(u8::try_from(cp).unwrap_or(0)) };
+            count += 1;
+        }
+        w = unsafe { w.add(1) };
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        cchar_of,
+        mbrlen,
+        mbrtowc,
+        mbsinit,
+        mbsrtowcs,
+        wcrtomb,
+        wcsrtombs,
+        SIZE_INCOMPLETE,
+    };
+    use crate::{
+        mbstate::mbstate_t,
+        wchar_t::wchar_t,
+    };
+
+    fn as_chars(bytes: &[u8]) -> ::std::vec::Vec<::sysapi::ffi::c_char> {
+        bytes.iter().map(|&byte| cchar_of(byte)).collect()
+    }
+
+    #[test]
+    fn test_mbsinit_null_is_initial() {
+        // A null state pointer designates the initial conversion state.
+        assert_eq!(unsafe { mbsinit(core::ptr::null()) }, 1);
+    }
+
+    #[test]
+    fn test_mbsinit_zero_count_is_initial() {
+        let st: mbstate_t = mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        };
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_mbsinit_pending_is_not_initial() {
+        // A non-zero pending-byte count means the state is mid-sequence.
+        let st: mbstate_t = mbstate_t {
+            count: 2,
+            bytes: [0; 4],
+        };
+        assert_eq!(unsafe { mbsinit(&st) }, 0);
+    }
+
+    #[test]
+    fn test_mbrtowc_null_source_resets_state() {
+        let mut st: mbstate_t = mbstate_t {
+            count: 1,
+            bytes: [0; 4],
+        };
+        let ret: usize = unsafe { mbrtowc(core::ptr::null_mut(), core::ptr::null(), 0, &mut st) };
+        assert_eq!(ret, 0);
+        assert_eq!(st.count, 0);
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_mbrtowc_accepts_high_byte_in_posix_locale() {
+        let mut st: mbstate_t = mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        };
+        let mut wc: wchar_t = 0;
+        let input: [::sysapi::ffi::c_char; 1] = [cchar_of(0xff)];
+        let ret: usize = unsafe { mbrtowc(&mut wc, input.as_ptr(), 1, &mut st) };
+        assert_eq!(ret, 1);
+        assert_eq!(wc, 0xff);
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_mbrtowc_empty_input_is_incomplete() {
+        let mut st: mbstate_t = mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        };
+        let input: [::sysapi::ffi::c_char; 1] = [cchar_of(0x61)];
+        let ret: usize = unsafe { mbrtowc(core::ptr::null_mut(), input.as_ptr(), 0, &mut st) };
+        assert_eq!(ret, SIZE_INCOMPLETE);
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_mbrtowc_nul_character_returns_zero() {
+        let mut st: mbstate_t = mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        };
+        let input: [::sysapi::ffi::c_char; 1] = [0];
+        let mut wc: wchar_t = -1;
+        let ret: usize = unsafe { mbrtowc(&mut wc, input.as_ptr(), 1, &mut st) };
+        assert_eq!(ret, 0);
+        assert_eq!(wc, 0);
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_mbrlen_reports_complete_character_length() {
+        let input = as_chars(&[0xff]);
+        let mut st: mbstate_t = mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        };
+        let ret: usize = unsafe { mbrlen(input.as_ptr(), input.len(), &mut st) };
+        assert_eq!(ret, 1);
+        assert_eq!(unsafe { mbsinit(&st) }, 1);
+    }
+
+    #[test]
+    fn test_wcrtomb_encodes_nul_character() {
+        let mut output: [::sysapi::ffi::c_char; 4] = [-1; 4];
+        let ret: usize = unsafe { wcrtomb(output.as_mut_ptr(), 0, core::ptr::null_mut()) };
+        assert_eq!(ret, 1);
+        assert_eq!(output[0], 0);
+    }
+
+    #[test]
+    fn test_mbsrtowcs_updates_source_after_partial_output() {
+        let input = as_chars(b"ab\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let mut output: [wchar_t; 1] = [0];
+        let ret: usize = unsafe {
+            mbsrtowcs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 1);
+        assert_eq!(output, [0x61]);
+        assert_eq!(src, unsafe { input.as_ptr().add(1) });
+    }
+
+    #[test]
+    fn test_mbsrtowcs_nulls_source_after_terminator() {
+        let input = as_chars(b"a\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let mut output: [wchar_t; 2] = [-1; 2];
+        let ret: usize = unsafe {
+            mbsrtowcs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 1);
+        assert_eq!(output, [0x61, 0]);
+        assert!(src.is_null());
+    }
+
+    #[test]
+    fn test_wcsrtombs_updates_source_after_partial_output() {
+        let input: [wchar_t; 3] = [0x61, 0xff, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 1] = [0];
+        let ret: usize = unsafe {
+            wcsrtombs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 1);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(src, unsafe { input.as_ptr().add(1) });
+    }
+
+    #[test]
+    fn test_wcsrtombs_updates_source_on_encoding_error_after_prefix() {
+        let input: [wchar_t; 3] = [0x61, 0x100, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 2] = [-1; 2];
+        let ret: usize = unsafe {
+            wcsrtombs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, usize::MAX);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(src, unsafe { input.as_ptr().add(1) });
+    }
+
+    #[test]
+    fn test_wcsrtombs_nulls_source_after_terminator() {
+        let input: [wchar_t; 2] = [0x61, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 2] = [-1; 2];
+        let ret: usize = unsafe {
+            wcsrtombs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 1);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(output[1], 0);
+        assert!(src.is_null());
+    }
+
+    #[test]
+    fn test_mbsrtowcs_null_dst_leaves_source_unchanged() {
+        // In measuring mode (null `dst`) POSIX requires `*src` to be left untouched.
+        let input = as_chars(b"ab\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let ret: usize =
+            unsafe { mbsrtowcs(core::ptr::null_mut(), &mut src, 0, core::ptr::null_mut()) };
+        assert_eq!(ret, 2);
+        assert_eq!(src, input.as_ptr());
+    }
+
+    #[test]
+    fn test_wcsrtombs_null_dst_leaves_source_unchanged() {
+        // In measuring mode (null `dst`) POSIX requires `*src` to be left untouched.
+        let input: [wchar_t; 3] = [0x61, 0x62, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let ret: usize =
+            unsafe { wcsrtombs(core::ptr::null_mut(), &mut src, 0, core::ptr::null_mut()) };
+        assert_eq!(ret, 2);
+        assert_eq!(src, input.as_ptr());
+    }
+
+    #[test]
+    fn test_wcsrtombs_no_room_for_terminator_keeps_source() {
+        // When the buffer is exactly filled by the content, there is no room for the terminating
+        // null byte, so conversion stops early due to the length limit and `*src` is left pointing
+        // at the terminator rather than being nulled.
+        let input: [wchar_t; 3] = [0x61, 0x62, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 2] = [-1; 2];
+        let ret: usize = unsafe {
+            wcsrtombs(output.as_mut_ptr(), &mut src, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 2);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(output[1], cchar_of(0x62));
+        assert_eq!(src, unsafe { input.as_ptr().add(2) });
+    }
+}

--- a/src/libs/libc_wchar/src/utf8.rs
+++ b/src/libs/libc_wchar/src/utf8.rs
@@ -1,0 +1,238 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// Outcome of decoding a single UTF-8 multibyte sequence.
+pub enum Decoded {
+    /// A complete code point was decoded, consuming the given number of bytes.
+    Ok(u32, usize),
+    /// The available bytes are a valid prefix of a longer sequence.
+    Incomplete,
+    /// The bytes do not form a valid UTF-8 sequence.
+    Invalid,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns the total length of the UTF-8 sequence introduced by the leading byte `b`, or `None`
+/// if `b` is not a valid leading byte.
+fn seq_len(b: u8) -> Option<usize> {
+    if b & 0x80 == 0x00 {
+        Some(1)
+    } else if b & 0xe0 == 0xc0 {
+        Some(2)
+    } else if b & 0xf0 == 0xe0 {
+        Some(3)
+    } else if b & 0xf8 == 0xf0 {
+        Some(4)
+    } else {
+        None
+    }
+}
+
+/// Decodes a single UTF-8 sequence from `bytes`.
+pub fn decode(bytes: &[u8]) -> Decoded {
+    let first: u8 = match bytes.first() {
+        Some(&b) => b,
+        None => return Decoded::Incomplete,
+    };
+
+    let len: usize = match seq_len(first) {
+        Some(l) => l,
+        None => return Decoded::Invalid,
+    };
+
+    if len == 1 {
+        return Decoded::Ok(u32::from(first), 1);
+    }
+
+    if bytes.len() < len {
+        // Validate the available continuation bytes before declaring the prefix incomplete.
+        for &c in &bytes[1..] {
+            if c & 0xc0 != 0x80 {
+                return Decoded::Invalid;
+            }
+        }
+        return Decoded::Incomplete;
+    }
+
+    let mut cp: u32 = match len {
+        2 => u32::from(first & 0x1f),
+        3 => u32::from(first & 0x0f),
+        _ => u32::from(first & 0x07),
+    };
+    for &c in &bytes[1..len] {
+        if c & 0xc0 != 0x80 {
+            return Decoded::Invalid;
+        }
+        cp = (cp << 6) | u32::from(c & 0x3f);
+    }
+
+    // Reject overlong encodings, surrogates, and out-of-range code points.
+    let min: u32 = match len {
+        2 => 0x80,
+        3 => 0x800,
+        _ => 0x10000,
+    };
+    if cp < min || cp > 0x10_ffff || (0xd800..=0xdfff).contains(&cp) {
+        return Decoded::Invalid;
+    }
+
+    Decoded::Ok(cp, len)
+}
+
+/// Encodes the code point `cp` as UTF-8 into `out`, returning the number of bytes written, or
+/// `None` if `cp` is not a valid Unicode scalar value.
+pub fn encode(cp: u32, out: &mut [u8; 4]) -> Option<usize> {
+    if cp > 0x10_ffff || (0xd800..=0xdfff).contains(&cp) {
+        return None;
+    }
+    if cp < 0x80 {
+        out[0] = u8::try_from(cp).unwrap_or(0);
+        Some(1)
+    } else if cp < 0x800 {
+        out[0] = u8::try_from(0xc0 | (cp >> 6)).unwrap_or(0);
+        out[1] = u8::try_from(0x80 | (cp & 0x3f)).unwrap_or(0);
+        Some(2)
+    } else if cp < 0x10000 {
+        out[0] = u8::try_from(0xe0 | (cp >> 12)).unwrap_or(0);
+        out[1] = u8::try_from(0x80 | ((cp >> 6) & 0x3f)).unwrap_or(0);
+        out[2] = u8::try_from(0x80 | (cp & 0x3f)).unwrap_or(0);
+        Some(3)
+    } else {
+        out[0] = u8::try_from(0xf0 | (cp >> 18)).unwrap_or(0);
+        out[1] = u8::try_from(0x80 | ((cp >> 12) & 0x3f)).unwrap_or(0);
+        out[2] = u8::try_from(0x80 | ((cp >> 6) & 0x3f)).unwrap_or(0);
+        out[3] = u8::try_from(0x80 | (cp & 0x3f)).unwrap_or(0);
+        Some(4)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        decode,
+        encode,
+        Decoded,
+    };
+
+    /// Extracts the decoded code point and consumed length, or `None` for non-`Ok` outcomes.
+    fn as_ok(d: Decoded) -> Option<(u32, usize)> {
+        match d {
+            Decoded::Ok(cp, len) => Some((cp, len)),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn test_decode_ascii() {
+        assert_eq!(as_ok(decode(&[0x41])), Some((0x41, 1)));
+        assert_eq!(as_ok(decode(&[0x00])), Some((0x00, 1)));
+    }
+
+    #[test]
+    fn test_decode_two_byte() {
+        // U+00E9 (LATIN SMALL LETTER E WITH ACUTE) = 0xC3 0xA9.
+        assert_eq!(as_ok(decode(&[0xC3, 0xA9])), Some((0xE9, 2)));
+    }
+
+    #[test]
+    fn test_decode_three_byte() {
+        // U+20AC (EURO SIGN) = 0xE2 0x82 0xAC.
+        assert_eq!(as_ok(decode(&[0xE2, 0x82, 0xAC])), Some((0x20AC, 3)));
+    }
+
+    #[test]
+    fn test_decode_four_byte() {
+        // U+1F600 (GRINNING FACE) = 0xF0 0x9F 0x98 0x80.
+        assert_eq!(as_ok(decode(&[0xF0, 0x9F, 0x98, 0x80])), Some((0x1F600, 4)));
+    }
+
+    #[test]
+    fn test_decode_incomplete() {
+        // A valid two-byte lead with no continuation byte available yet.
+        assert!(matches!(decode(&[0xC3]), Decoded::Incomplete));
+    }
+
+    #[test]
+    fn test_decode_invalid_lead() {
+        // 0xFF is never a valid leading byte.
+        assert!(matches!(decode(&[0xFF]), Decoded::Invalid));
+    }
+
+    #[test]
+    fn test_decode_invalid_continuation() {
+        // The second byte is not a continuation byte.
+        assert!(matches!(decode(&[0xC3, 0x00]), Decoded::Invalid));
+    }
+
+    #[test]
+    fn test_decode_rejects_overlong() {
+        // 0xC0 0x80 is an overlong encoding of U+0000.
+        assert!(matches!(decode(&[0xC0, 0x80]), Decoded::Invalid));
+    }
+
+    #[test]
+    fn test_decode_rejects_surrogate() {
+        // 0xED 0xA0 0x80 encodes the surrogate U+D800.
+        assert!(matches!(decode(&[0xED, 0xA0, 0x80]), Decoded::Invalid));
+    }
+
+    #[test]
+    fn test_encode_ascii() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0x41, &mut out), Some(1));
+        assert_eq!(out[0], 0x41);
+    }
+
+    #[test]
+    fn test_encode_two_byte() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0xE9, &mut out), Some(2));
+        assert_eq!(&out[..2], &[0xC3, 0xA9]);
+    }
+
+    #[test]
+    fn test_encode_three_byte() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0x20AC, &mut out), Some(3));
+        assert_eq!(&out[..3], &[0xE2, 0x82, 0xAC]);
+    }
+
+    #[test]
+    fn test_encode_four_byte() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0x1F600, &mut out), Some(4));
+        assert_eq!(&out[..4], &[0xF0, 0x9F, 0x98, 0x80]);
+    }
+
+    #[test]
+    fn test_encode_rejects_out_of_range() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0x11_0000, &mut out), None);
+    }
+
+    #[test]
+    fn test_encode_rejects_surrogate() {
+        let mut out: [u8; 4] = [0; 4];
+        assert_eq!(encode(0xD800, &mut out), None);
+    }
+
+    #[test]
+    fn test_round_trip() {
+        for cp in [0x41u32, 0xE9, 0x20AC, 0x1F600] {
+            let mut out: [u8; 4] = [0; 4];
+            let len: usize = encode(cp, &mut out).unwrap_or_default();
+            assert_eq!(as_ok(decode(&out[..len])), Some((cp, len)));
+        }
+    }
+}

--- a/src/libs/libc_wchar/src/wchar_t.rs
+++ b/src/libs/libc_wchar/src/wchar_t.rs
@@ -1,0 +1,17 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Wide character type (matches Linux/Nanvix convention).
+#[allow(non_camel_case_types)]
+pub type wchar_t = i32;
+
+/// Wide integer type for wide character I/O.
+#[allow(non_camel_case_types)]
+pub type wint_t = i32;
+
+/// End-of-file indicator for wide character I/O.
+pub const WEOF: wint_t = -1;

--- a/src/libs/libc_wchar/src/wcs_narrow.rs
+++ b/src/libs/libc_wchar/src/wcs_narrow.rs
@@ -1,0 +1,109 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// External Symbols
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Owned narrow copy of the ASCII prefix of a wide string.
+pub(crate) struct NarrowString {
+    ptr: *mut c_char,
+}
+
+impl NarrowString {
+    /// Returns a pointer to the null-terminated narrow string.
+    pub(crate) fn as_ptr(&self) -> *const c_char {
+        self.ptr.cast_const()
+    }
+}
+
+impl Drop for NarrowString {
+    fn drop(&mut self) {
+        unsafe { free(self.ptr.cast::<c_void>()) };
+    }
+}
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Copies the ASCII prefix of a wide numeric string to a heap-allocated narrow string.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string.
+pub(crate) unsafe fn to_narrow_alloc(nptr: *const wchar_t) -> Option<NarrowString> {
+    let mut len: usize = 0;
+    loop {
+        let c: wchar_t = unsafe { *nptr.add(len) };
+        if c == 0 {
+            break;
+        }
+        let cp: u32 = u32::from_ne_bytes(c.to_ne_bytes());
+        if cp > 0x7f {
+            break;
+        }
+        len += 1;
+    }
+
+    let size: c_size_t = c_size_t::try_from(len.saturating_add(1)).ok()?;
+    let ptr: *mut c_char = unsafe { malloc(size) }.cast::<c_char>();
+    if ptr.is_null() {
+        return None;
+    }
+    for i in 0..len {
+        let c: wchar_t = unsafe { *nptr.add(i) };
+        let cp: u32 = u32::from_ne_bytes(c.to_ne_bytes());
+        unsafe { *ptr.add(i) = c_char::from_ne_bytes([(cp & 0xff) as u8]) };
+    }
+    unsafe { *ptr.add(len) = 0 };
+    Some(NarrowString { ptr })
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_to_narrow_alloc_copies_long_prefix() {
+        let mut wide: [wchar_t; 82] = [0; 82];
+        for c in wide.iter_mut().take(80) {
+            *c = 0x31;
+        }
+        wide[80] = 0x78;
+
+        let narrow: NarrowString =
+            unsafe { to_narrow_alloc(wide.as_ptr()) }.expect("narrow allocation should succeed");
+        for i in 0..80 {
+            assert_eq!(unsafe { *narrow.as_ptr().add(i) }, c_char::from_ne_bytes(*b"1"));
+        }
+        assert_eq!(unsafe { *narrow.as_ptr().add(80) }, c_char::from_ne_bytes(*b"x"));
+        assert_eq!(unsafe { *narrow.as_ptr().add(81) }, 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcscat.rs
+++ b/src/libs/libc_wchar/src/wcscat.rs
@@ -1,0 +1,106 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Appends the wide string `src` to the end of the wide string `dest`, including the null
+/// terminator.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination null-terminated wide string.
+/// - `src`: Pointer to the source null-terminated wide string.
+///
+/// # Return Value
+///
+/// Returns `dest`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dest` or `src` is null, or if the destination buffer is not large
+/// enough to hold the concatenated result.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcscat(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t {
+    debug_assert!(!dest.is_null());
+    debug_assert!(!src.is_null());
+
+    // Find the end of dest.
+    let mut d: c_size_t = 0;
+    while unsafe { *dest.add(d as usize) } != 0 {
+        d += 1;
+    }
+
+    // Copy src to the end of dest.
+    let mut s: c_size_t = 0;
+    loop {
+        let c: wchar_t = unsafe { *src.add(s as usize) };
+        unsafe { *dest.add(d as usize) = c };
+        if c == 0 {
+            break;
+        }
+        d += 1;
+        s += 1;
+    }
+    dest
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcscat_basic() {
+        // "AB" + "CD" = "ABCD"
+        let mut dest: [wchar_t; 8] = [0x41, 0x42, 0, 0, 0, 0, 0, 0];
+        let src: [wchar_t; 3] = [0x43, 0x44, 0];
+        let ret: *mut wchar_t = unsafe { wcscat(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(ret, dest.as_mut_ptr());
+        assert_eq!(dest[0], 0x41);
+        assert_eq!(dest[1], 0x42);
+        assert_eq!(dest[2], 0x43);
+        assert_eq!(dest[3], 0x44);
+        assert_eq!(dest[4], 0);
+    }
+
+    #[test]
+    fn test_wcscat_empty_src() {
+        let mut dest: [wchar_t; 4] = [0x41, 0, 0, 0];
+        let src: [wchar_t; 1] = [0];
+        unsafe { wcscat(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dest[0], 0x41);
+        assert_eq!(dest[1], 0);
+    }
+
+    #[test]
+    fn test_wcscat_empty_dest() {
+        let mut dest: [wchar_t; 4] = [0; 4];
+        let src: [wchar_t; 3] = [0x41, 0x42, 0];
+        unsafe { wcscat(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dest[0], 0x41);
+        assert_eq!(dest[1], 0x42);
+        assert_eq!(dest[2], 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcschr.rs
+++ b/src/libs/libc_wchar/src/wcschr.rs
@@ -1,0 +1,87 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates the first occurrence of the wide character `c` in the wide string `s`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated wide string.
+/// - `c`: Wide character to search for.
+///
+/// # Return Value
+///
+/// Returns a pointer to the first occurrence of `c` in `s`, or a null pointer if `c` is not found.
+/// If `c` is the null wide character, a pointer to the terminating null is returned.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s` is null or does not point to a valid null-terminated wide string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcschr(s: *const wchar_t, c: wchar_t) -> *mut wchar_t {
+    debug_assert!(!s.is_null());
+
+    let mut i: c_size_t = 0;
+    loop {
+        let ch: wchar_t = unsafe { *s.add(i as usize) };
+        if ch == c {
+            return unsafe { s.add(i as usize) as *mut wchar_t };
+        }
+        if ch == 0 {
+            return ::core::ptr::null_mut();
+        }
+        i += 1;
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcschr_found() {
+        let s: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let result: *mut wchar_t = unsafe { wcschr(s.as_ptr(), 0x42) };
+        assert!(!result.is_null());
+        assert_eq!(unsafe { *result }, 0x42);
+    }
+
+    #[test]
+    fn test_wcschr_not_found() {
+        let s: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let result: *mut wchar_t = unsafe { wcschr(s.as_ptr(), 0x44) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcschr_null_char() {
+        let s: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let result: *mut wchar_t = unsafe { wcschr(s.as_ptr(), 0) };
+        assert!(!result.is_null());
+        assert_eq!(unsafe { *result }, 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcscmp.rs
+++ b/src/libs/libc_wchar/src/wcscmp.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares two wide strings lexicographically.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated wide string.
+/// - `s2`: Pointer to the second null-terminated wide string.
+///
+/// # Return Value
+///
+/// Returns a negative value if `s1` is less than `s2`, zero if they are equal, or a positive value
+/// if `s1` is greater than `s2`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s1` or `s2` is null or does not point to a valid null-terminated wide
+/// string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcscmp(s1: *const wchar_t, s2: *const wchar_t) -> c_int {
+    debug_assert!(!s1.is_null());
+    debug_assert!(!s2.is_null());
+
+    let mut i: c_size_t = 0;
+    loop {
+        let c1: wchar_t = unsafe { *s1.add(i as usize) };
+        let c2: wchar_t = unsafe { *s2.add(i as usize) };
+        let diff: i64 = i64::from(c1) - i64::from(c2);
+        if diff != 0 || c1 == 0 {
+            return diff.signum() as c_int;
+        }
+        i += 1;
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcscmp_equal() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        assert_eq!(unsafe { wcscmp(s1.as_ptr(), s2.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn test_wcscmp_less() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x44, 0];
+        assert!(unsafe { wcscmp(s1.as_ptr(), s2.as_ptr()) } < 0);
+    }
+
+    #[test]
+    fn test_wcscmp_greater() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x44, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        assert!(unsafe { wcscmp(s1.as_ptr(), s2.as_ptr()) } > 0);
+    }
+
+    #[test]
+    fn test_wcscmp_prefix() {
+        let s1: [wchar_t; 3] = [0x41, 0x42, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        assert!(unsafe { wcscmp(s1.as_ptr(), s2.as_ptr()) } < 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcscoll.rs
+++ b/src/libs/libc_wchar/src/wcscoll.rs
@@ -1,0 +1,51 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcscmp::wcscmp,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Compares two wide-character strings according to the current locale collation order.
+///
+/// Nanvix currently supports the C/POSIX locale, where collation is equivalent to `wcscmp()`.
+///
+/// # Safety
+///
+/// `s1` and `s2` must point to valid null-terminated wide-character strings.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcscoll(s1: *const wchar_t, s2: *const wchar_t) -> c_int {
+    unsafe { wcscmp(s1, s2) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcscoll_equal() {
+        let s1: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let s2: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        assert_eq!(unsafe { wcscoll(s1.as_ptr(), s2.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn test_wcscoll_uses_posix_codepoint_order() {
+        let lower: [wchar_t; 2] = [0x61, 0];
+        let upper: [wchar_t; 2] = [0x41, 0];
+        assert!(unsafe { wcscoll(lower.as_ptr(), upper.as_ptr()) } > 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcscpy.rs
+++ b/src/libs/libc_wchar/src/wcscpy.rs
@@ -1,0 +1,81 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies a wide string from `src` to `dest`, including the null terminator.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination wide string buffer.
+/// - `src`: Pointer to the source null-terminated wide string.
+///
+/// # Return Value
+///
+/// Returns `dest`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dest` or `src` is null, or if the destination buffer is not large
+/// enough to hold the source string including its null terminator.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcscpy(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t {
+    debug_assert!(!dest.is_null());
+    debug_assert!(!src.is_null());
+
+    let mut i: c_size_t = 0;
+    loop {
+        let c: wchar_t = unsafe { *src.add(i as usize) };
+        unsafe { *dest.add(i as usize) = c };
+        if c == 0 {
+            break;
+        }
+        i += 1;
+    }
+    dest
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcscpy_empty() {
+        let src: [wchar_t; 1] = [0];
+        let mut dest: [wchar_t; 1] = [-1];
+        unsafe { wcscpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dest[0], 0);
+    }
+
+    #[test]
+    fn test_wcscpy_hello() {
+        let src: [wchar_t; 6] = [0x68, 0x65, 0x6C, 0x6C, 0x6F, 0];
+        let mut dest: [wchar_t; 6] = [0; 6];
+        let ret: *mut wchar_t = unsafe { wcscpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(ret, dest.as_mut_ptr());
+        assert_eq!(dest, src);
+    }
+}

--- a/src/libs/libc_wchar/src/wcslen.rs
+++ b/src/libs/libc_wchar/src/wcslen.rs
@@ -1,0 +1,75 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the length of a wide string.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated wide string.
+///
+/// # Return Value
+///
+/// The number of wide characters preceding the null terminator.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s` is null or does not point to a valid null-terminated wide string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcslen(s: *const wchar_t) -> c_size_t {
+    debug_assert!(!s.is_null());
+
+    let mut i: c_size_t = 0;
+    while unsafe { *s.add(i as usize) } != 0 {
+        i += 1;
+    }
+    i
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcslen_empty() {
+        let s: [wchar_t; 1] = [0];
+        assert_eq!(unsafe { wcslen(s.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn test_wcslen_hello() {
+        // "hello" as wide characters
+        let s: [wchar_t; 6] = [0x68, 0x65, 0x6C, 0x6C, 0x6F, 0];
+        assert_eq!(unsafe { wcslen(s.as_ptr()) }, 5);
+    }
+
+    #[test]
+    fn test_wcslen_single() {
+        let s: [wchar_t; 2] = [0x41, 0];
+        assert_eq!(unsafe { wcslen(s.as_ptr()) }, 1);
+    }
+}

--- a/src/libs/libc_wchar/src/wcsncmp.rs
+++ b/src/libs/libc_wchar/src/wcsncmp.rs
@@ -1,0 +1,101 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares at most `n` wide characters of two wide strings lexicographically.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated wide string.
+/// - `s2`: Pointer to the second null-terminated wide string.
+/// - `n`: Maximum number of wide characters to compare.
+///
+/// # Return Value
+///
+/// Returns a negative value if `s1` is less than `s2`, zero if they are equal up to `n`
+/// characters, or a positive value if `s1` is greater than `s2`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s1` or `s2` is null or does not point to a valid wide string of at
+/// least `n` characters (or null-terminated before `n`).
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsncmp(s1: *const wchar_t, s2: *const wchar_t, n: c_size_t) -> c_int {
+    debug_assert!(!s1.is_null());
+    debug_assert!(!s2.is_null());
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        let c1: wchar_t = unsafe { *s1.add(i as usize) };
+        let c2: wchar_t = unsafe { *s2.add(i as usize) };
+        let diff: i64 = i64::from(c1) - i64::from(c2);
+        if diff != 0 {
+            return diff.signum() as c_int;
+        }
+        if c1 == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+    0
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcsncmp_equal_prefix() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x44, 0];
+        assert_eq!(unsafe { wcsncmp(s1.as_ptr(), s2.as_ptr(), 2) }, 0);
+    }
+
+    #[test]
+    fn test_wcsncmp_different_in_range() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x44, 0];
+        assert!(unsafe { wcsncmp(s1.as_ptr(), s2.as_ptr(), 3) } < 0);
+    }
+
+    #[test]
+    fn test_wcsncmp_n_zero() {
+        let s1: [wchar_t; 2] = [0x41, 0];
+        let s2: [wchar_t; 2] = [0x42, 0];
+        assert_eq!(unsafe { wcsncmp(s1.as_ptr(), s2.as_ptr(), 0) }, 0);
+    }
+
+    #[test]
+    fn test_wcsncmp_equal_full() {
+        let s1: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let s2: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        assert_eq!(unsafe { wcsncmp(s1.as_ptr(), s2.as_ptr(), 3) }, 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wcsncpy.rs
+++ b/src/libs/libc_wchar/src/wcsncpy.rs
@@ -1,0 +1,104 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies at most `n` wide characters from `src` to `dest`. If `src` is shorter than `n`
+/// characters, the remainder of `dest` is padded with null wide characters.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination wide string buffer.
+/// - `src`: Pointer to the source null-terminated wide string.
+/// - `n`: Maximum number of wide characters to copy.
+///
+/// # Return Value
+///
+/// Returns `dest`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dest` or `src` is null, or if the destination buffer has fewer than
+/// `n` wide character positions.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsncpy(
+    dest: *mut wchar_t,
+    src: *const wchar_t,
+    n: c_size_t,
+) -> *mut wchar_t {
+    debug_assert!(!dest.is_null());
+    debug_assert!(!src.is_null());
+
+    let mut i: c_size_t = 0;
+    // Copy characters from src.
+    while i < n {
+        let c: wchar_t = unsafe { *src.add(i as usize) };
+        unsafe { *dest.add(i as usize) = c };
+        if c == 0 {
+            i += 1;
+            break;
+        }
+        i += 1;
+    }
+    // Pad remainder with null wide characters.
+    while i < n {
+        unsafe { *dest.add(i as usize) = 0 };
+        i += 1;
+    }
+    dest
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcsncpy_exact() {
+        // Source fits exactly in n (including null).
+        let src: [wchar_t; 3] = [0x41, 0x42, 0];
+        let mut dest: [wchar_t; 3] = [-1; 3];
+        unsafe { wcsncpy(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        assert_eq!(dest, [0x41, 0x42, 0]);
+    }
+
+    #[test]
+    fn test_wcsncpy_shorter_src() {
+        // Source is shorter than n: remainder should be zero-padded.
+        let src: [wchar_t; 2] = [0x41, 0];
+        let mut dest: [wchar_t; 5] = [-1; 5];
+        unsafe { wcsncpy(dest.as_mut_ptr(), src.as_ptr(), 5) };
+        assert_eq!(dest, [0x41, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_wcsncpy_longer_src() {
+        // Source is longer than n: result is not null-terminated.
+        let src: [wchar_t; 6] = [0x41, 0x42, 0x43, 0x44, 0x45, 0];
+        let mut dest: [wchar_t; 3] = [-1; 3];
+        unsafe { wcsncpy(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        assert_eq!(dest, [0x41, 0x42, 0x43]);
+    }
+}

--- a/src/libs/libc_wchar/src/wcsrchr.rs
+++ b/src/libs/libc_wchar/src/wcsrchr.rs
@@ -1,0 +1,89 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates the last occurrence of the wide character `c` in the wide string `s`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated wide string.
+/// - `c`: Wide character to search for.
+///
+/// # Return Value
+///
+/// Returns a pointer to the last occurrence of `c` in `s`, or a null pointer if `c` is not found.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s` is null or does not point to a valid null-terminated wide string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsrchr(s: *const wchar_t, c: wchar_t) -> *mut wchar_t {
+    debug_assert!(!s.is_null());
+
+    let mut last: *mut wchar_t = ::core::ptr::null_mut();
+    let mut i: c_size_t = 0;
+    loop {
+        let ch: wchar_t = unsafe { *s.add(i as usize) };
+        if ch == c {
+            last = unsafe { s.add(i as usize) as *mut wchar_t };
+        }
+        if ch == 0 {
+            return last;
+        }
+        i += 1;
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcsrchr_found_last() {
+        // Search for 0x41 which appears at positions 0 and 3.
+        let s: [wchar_t; 5] = [0x41, 0x42, 0x43, 0x41, 0];
+        let result: *mut wchar_t = unsafe { wcsrchr(s.as_ptr(), 0x41) };
+        assert!(!result.is_null());
+        // Should point to the last occurrence (index 3).
+        assert_eq!(result, s.as_ptr().wrapping_add(3) as *mut wchar_t);
+    }
+
+    #[test]
+    fn test_wcsrchr_not_found() {
+        let s: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let result: *mut wchar_t = unsafe { wcsrchr(s.as_ptr(), 0x44) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcsrchr_single_occurrence() {
+        let s: [wchar_t; 4] = [0x41, 0x42, 0x43, 0];
+        let result: *mut wchar_t = unsafe { wcsrchr(s.as_ptr(), 0x42) };
+        assert!(!result.is_null());
+        assert_eq!(result, s.as_ptr().wrapping_add(1) as *mut wchar_t);
+    }
+}

--- a/src/libs/libc_wchar/src/wcsstr.rs
+++ b/src/libs/libc_wchar/src/wcsstr.rs
@@ -1,0 +1,82 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Locates the first occurrence of the wide substring `needle` in the wide string `haystack`.
+///
+/// # Safety
+///
+/// `haystack` and `needle` must point to valid, null-terminated wide strings.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsstr(haystack: *const wchar_t, needle: *const wchar_t) -> *mut wchar_t {
+    if unsafe { *needle } == 0 {
+        return haystack.cast_mut();
+    }
+
+    let mut h: *const wchar_t = haystack;
+    while unsafe { *h } != 0 {
+        let mut a: *const wchar_t = h;
+        let mut b: *const wchar_t = needle;
+        while unsafe { *b } != 0 && unsafe { *a } == unsafe { *b } {
+            a = unsafe { a.add(1) };
+            b = unsafe { b.add(1) };
+        }
+        if unsafe { *b } == 0 {
+            return h.cast_mut();
+        }
+        h = unsafe { h.add(1) };
+    }
+    core::ptr::null_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcsstr_found() {
+        // haystack = "hello", needle = "ll".
+        let haystack: [wchar_t; 6] = [0x68, 0x65, 0x6C, 0x6C, 0x6F, 0];
+        let needle: [wchar_t; 3] = [0x6C, 0x6C, 0];
+        let result: *mut wchar_t = unsafe { wcsstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert_eq!(result.cast_const(), unsafe { haystack.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_wcsstr_not_found() {
+        let haystack: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let needle: [wchar_t; 2] = [0x64, 0];
+        let result: *mut wchar_t = unsafe { wcsstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcsstr_empty_needle() {
+        // An empty needle matches at the start of the haystack.
+        let haystack: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let needle: [wchar_t; 1] = [0];
+        let result: *mut wchar_t = unsafe { wcsstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert_eq!(result.cast_const(), haystack.as_ptr());
+    }
+
+    #[test]
+    fn test_wcsstr_whole_string() {
+        let haystack: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let needle: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let result: *mut wchar_t = unsafe { wcsstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert_eq!(result.cast_const(), haystack.as_ptr());
+    }
+}

--- a/src/libs/libc_wchar/src/wcstod.rs
+++ b/src/libs/libc_wchar/src/wcstod.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::{
+        to_narrow_alloc,
+        NarrowString,
+    },
+};
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Converts the initial portion of the wide string `nptr` to a `double` value.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string. `endptr`, if non-null, must be a
+/// valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstod(nptr: *const wchar_t, endptr: *mut *mut wchar_t) -> f64 {
+    extern "C" {
+        fn strtod(s: *const c_char, e: *mut *mut c_char) -> f64;
+    }
+    let narrow: NarrowString = match unsafe { to_narrow_alloc(nptr) } {
+        Some(narrow) => narrow,
+        None => {
+            if !endptr.is_null() {
+                unsafe { *endptr = nptr.cast_mut() };
+            }
+            return 0.0;
+        },
+    };
+    let mut nend: *mut c_char = core::ptr::null_mut();
+    let val: f64 = unsafe { strtod(narrow.as_ptr(), &mut nend) };
+    if !endptr.is_null() {
+        let consumed: usize = (nend as usize) - (narrow.as_ptr() as usize);
+        unsafe { *endptr = nptr.add(consumed).cast_mut() };
+    }
+    val
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstod_simple() {
+        // "3.50" parses to 3.5 and leaves the end pointer at the terminator.
+        let s: [wchar_t; 5] = [0x33, 0x2E, 0x35, 0x30, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: f64 = unsafe { wcstod(s.as_ptr(), &mut end) };
+        assert!((v - 3.5).abs() < 1e-9);
+        assert_eq!(unsafe { *end }, 0);
+    }
+
+    #[test]
+    fn test_wcstod_partial() {
+        // "2.5x" parses 2.5 and stops at 'x'.
+        let s: [wchar_t; 5] = [0x32, 0x2E, 0x35, 0x78, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: f64 = unsafe { wcstod(s.as_ptr(), &mut end) };
+        assert!((v - 2.5).abs() < 1e-9);
+        assert_eq!(unsafe { *end }, 0x78);
+    }
+
+    #[test]
+    fn test_wcstod_null_endptr() {
+        // A null end pointer is accepted.
+        let s: [wchar_t; 3] = [0x31, 0x30, 0];
+        let v: f64 = unsafe { wcstod(s.as_ptr(), core::ptr::null_mut()) };
+        assert!((v - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_wcstod_endptr_after_long_subject_sequence() {
+        let mut s: [wchar_t; 112] = [0; 112];
+        s[0] = 0x31;
+        s[1] = 0x2E;
+        for c in s.iter_mut().take(110).skip(2) {
+            *c = 0x31;
+        }
+        s[110] = 0x78;
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let _v: f64 = unsafe { wcstod(s.as_ptr(), &mut end) };
+        assert_eq!(end.cast_const(), unsafe { s.as_ptr().add(110) });
+    }
+}

--- a/src/libs/libc_wchar/src/wcstok.rs
+++ b/src/libs/libc_wchar/src/wcstok.rs
@@ -1,0 +1,128 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Returns `true` if the wide character `c` appears in the null-terminated delimiter set `delim`.
+///
+/// # Safety
+///
+/// `delim` must point to a valid, null-terminated wide string.
+unsafe fn is_delim(c: wchar_t, delim: *const wchar_t) -> bool {
+    let mut d: *const wchar_t = delim;
+    while unsafe { *d } != 0 {
+        if unsafe { *d } == c {
+            return true;
+        }
+        d = unsafe { d.add(1) };
+    }
+    false
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Extracts the next token from the wide string `wcs`, delimited by any character in `delim`. The
+/// parsing state is kept in `*ptr`, making this function reentrant.
+///
+/// # Safety
+///
+/// `delim` must point to a valid, null-terminated wide string, `ptr` must be a valid pointer, and
+/// `wcs` (when non-null) must point to a valid, null-terminated wide string.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstok(
+    wcs: *mut wchar_t,
+    delim: *const wchar_t,
+    ptr: *mut *mut wchar_t,
+) -> *mut wchar_t {
+    let mut s: *mut wchar_t = if wcs.is_null() { unsafe { *ptr } } else { wcs };
+    if s.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Skip leading delimiters.
+    while unsafe { *s } != 0 && unsafe { is_delim(*s, delim) } {
+        s = unsafe { s.add(1) };
+    }
+    if unsafe { *s } == 0 {
+        unsafe { *ptr = s };
+        return core::ptr::null_mut();
+    }
+
+    let token: *mut wchar_t = s;
+
+    // Find end of token.
+    while unsafe { *s } != 0 && !unsafe { is_delim(*s, delim) } {
+        s = unsafe { s.add(1) };
+    }
+    if unsafe { *s } != 0 {
+        unsafe { *s = 0 };
+        s = unsafe { s.add(1) };
+    }
+    unsafe { *ptr = s };
+    token
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstok_basic() {
+        // "a,b,c" tokenized on ",".
+        let mut buf: [wchar_t; 6] = [0x61, 0x2C, 0x62, 0x2C, 0x63, 0];
+        let delim: [wchar_t; 2] = [0x2C, 0];
+        let mut state: *mut wchar_t = core::ptr::null_mut();
+
+        let t1: *mut wchar_t = unsafe { wcstok(buf.as_mut_ptr(), delim.as_ptr(), &mut state) };
+        assert!(!t1.is_null());
+        assert_eq!(unsafe { *t1 }, 0x61);
+
+        let t2: *mut wchar_t = unsafe { wcstok(core::ptr::null_mut(), delim.as_ptr(), &mut state) };
+        assert!(!t2.is_null());
+        assert_eq!(unsafe { *t2 }, 0x62);
+
+        let t3: *mut wchar_t = unsafe { wcstok(core::ptr::null_mut(), delim.as_ptr(), &mut state) };
+        assert!(!t3.is_null());
+        assert_eq!(unsafe { *t3 }, 0x63);
+
+        let t4: *mut wchar_t = unsafe { wcstok(core::ptr::null_mut(), delim.as_ptr(), &mut state) };
+        assert!(t4.is_null());
+    }
+
+    #[test]
+    fn test_wcstok_leading_delimiters() {
+        // Leading delimiters are skipped before the first token.
+        let mut buf: [wchar_t; 5] = [0x2C, 0x2C, 0x61, 0x62, 0];
+        let delim: [wchar_t; 2] = [0x2C, 0];
+        let mut state: *mut wchar_t = core::ptr::null_mut();
+
+        let t1: *mut wchar_t = unsafe { wcstok(buf.as_mut_ptr(), delim.as_ptr(), &mut state) };
+        assert!(!t1.is_null());
+        assert_eq!(unsafe { *t1 }, 0x61);
+        assert_eq!(unsafe { *t1.add(1) }, 0x62);
+    }
+
+    #[test]
+    fn test_wcstok_all_delimiters() {
+        // A string made up solely of delimiters yields no tokens.
+        let mut buf: [wchar_t; 3] = [0x2C, 0x2C, 0];
+        let delim: [wchar_t; 2] = [0x2C, 0];
+        let mut state: *mut wchar_t = core::ptr::null_mut();
+        let t1: *mut wchar_t = unsafe { wcstok(buf.as_mut_ptr(), delim.as_ptr(), &mut state) };
+        assert!(t1.is_null());
+    }
+}

--- a/src/libs/libc_wchar/src/wcstol.rs
+++ b/src/libs/libc_wchar/src/wcstol.rs
@@ -1,0 +1,110 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::{
+        to_narrow_alloc,
+        NarrowString,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_long,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Converts the initial portion of the wide string `nptr` to a `long` value.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string. `endptr`, if non-null, must be a
+/// valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstol(
+    nptr: *const wchar_t,
+    endptr: *mut *mut wchar_t,
+    base: c_int,
+) -> c_long {
+    extern "C" {
+        fn strtol(s: *const c_char, e: *mut *mut c_char, b: c_int) -> c_long;
+    }
+    let narrow: NarrowString = match unsafe { to_narrow_alloc(nptr) } {
+        Some(narrow) => narrow,
+        None => {
+            if !endptr.is_null() {
+                unsafe { *endptr = nptr.cast_mut() };
+            }
+            return 0;
+        },
+    };
+    let mut nend: *mut c_char = core::ptr::null_mut();
+    let val: c_long = unsafe { strtol(narrow.as_ptr(), &mut nend, base) };
+    if !endptr.is_null() {
+        let consumed: usize = (nend as usize) - (narrow.as_ptr() as usize);
+        unsafe { *endptr = nptr.add(consumed).cast_mut() };
+    }
+    val
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+// Only positive values are asserted: `c_long` is 32-bit on the x86 guest but 64-bit on the x86_64
+// host, while the host `strtol` returns a 32-bit `long`. Positive results are read consistently on
+// both; negative/oversized results are not, so they are not asserted here. The end-pointer checks
+// are width-independent.
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstol_decimal() {
+        // "123" base 10 -> 123; the end pointer lands on the terminator.
+        let s: [wchar_t; 4] = [0x31, 0x32, 0x33, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: c_long = unsafe { wcstol(s.as_ptr(), &mut end, 10) };
+        assert_eq!(v, 123);
+        assert_eq!(unsafe { *end }, 0);
+    }
+
+    #[test]
+    fn test_wcstol_hex() {
+        // "ff" base 16 -> 255.
+        let s: [wchar_t; 3] = [0x66, 0x66, 0];
+        let v: c_long = unsafe { wcstol(s.as_ptr(), core::ptr::null_mut(), 16) };
+        assert_eq!(v, 255);
+    }
+
+    #[test]
+    fn test_wcstol_endptr_stops_at_non_digit() {
+        // "42xyz" parses 42 and leaves the end pointer at 'x' (index 2). The narrow byte offset is
+        // mapped back to a wide-character offset, which is width-independent.
+        let s: [wchar_t; 6] = [0x34, 0x32, 0x78, 0x79, 0x7A, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: c_long = unsafe { wcstol(s.as_ptr(), &mut end, 10) };
+        assert_eq!(v, 42);
+        assert_eq!(end.cast_const(), unsafe { s.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_wcstol_endptr_after_long_subject_sequence() {
+        let mut s: [wchar_t; 82] = [0; 82];
+        for c in s.iter_mut().take(80) {
+            *c = 0x31;
+        }
+        s[80] = 0x78;
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let _v: c_long = unsafe { wcstol(s.as_ptr(), &mut end, 10) };
+        assert_eq!(end.cast_const(), unsafe { s.as_ptr().add(80) });
+    }
+}

--- a/src/libs/libc_wchar/src/wcstoll.rs
+++ b/src/libs/libc_wchar/src/wcstoll.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::{
+        to_narrow_alloc,
+        NarrowString,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_longlong,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Converts the initial portion of the wide string `nptr` to a `long long` value.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string. `endptr`, if non-null, must be a
+/// valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstoll(
+    nptr: *const wchar_t,
+    endptr: *mut *mut wchar_t,
+    base: c_int,
+) -> c_longlong {
+    extern "C" {
+        fn strtoll(s: *const c_char, e: *mut *mut c_char, b: c_int) -> c_longlong;
+    }
+    let narrow: NarrowString = match unsafe { to_narrow_alloc(nptr) } {
+        Some(narrow) => narrow,
+        None => {
+            if !endptr.is_null() {
+                unsafe { *endptr = nptr.cast_mut() };
+            }
+            return 0;
+        },
+    };
+    let mut nend: *mut c_char = core::ptr::null_mut();
+    let val: c_longlong = unsafe { strtoll(narrow.as_ptr(), &mut nend, base) };
+    if !endptr.is_null() {
+        let consumed: usize = (nend as usize) - (narrow.as_ptr() as usize);
+        unsafe { *endptr = nptr.add(consumed).cast_mut() };
+    }
+    val
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstoll_large_value() {
+        // 10_000_000_000 exceeds 32 bits, exercising long long width.
+        let s: [wchar_t; 12] = [
+            0x31, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0,
+        ];
+        let v: c_longlong = unsafe { wcstoll(s.as_ptr(), core::ptr::null_mut(), 10) };
+        assert_eq!(v, 10_000_000_000);
+    }
+
+    #[test]
+    fn test_wcstoll_negative() {
+        // "-75" base 10 -> -75.
+        let s: [wchar_t; 4] = [0x2D, 0x37, 0x35, 0];
+        let v: c_longlong = unsafe { wcstoll(s.as_ptr(), core::ptr::null_mut(), 10) };
+        assert_eq!(v, -75);
+    }
+}

--- a/src/libs/libc_wchar/src/wcstoul.rs
+++ b/src/libs/libc_wchar/src/wcstoul.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::{
+        to_narrow_alloc,
+        NarrowString,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_ulong,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Converts the initial portion of the wide string `nptr` to an `unsigned long` value.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string. `endptr`, if non-null, must be a
+/// valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstoul(
+    nptr: *const wchar_t,
+    endptr: *mut *mut wchar_t,
+    base: c_int,
+) -> c_ulong {
+    extern "C" {
+        fn strtoul(s: *const c_char, e: *mut *mut c_char, b: c_int) -> c_ulong;
+    }
+    let narrow: NarrowString = match unsafe { to_narrow_alloc(nptr) } {
+        Some(narrow) => narrow,
+        None => {
+            if !endptr.is_null() {
+                unsafe { *endptr = nptr.cast_mut() };
+            }
+            return 0;
+        },
+    };
+    let mut nend: *mut c_char = core::ptr::null_mut();
+    let val: c_ulong = unsafe { strtoul(narrow.as_ptr(), &mut nend, base) };
+    if !endptr.is_null() {
+        let consumed: usize = (nend as usize) - (narrow.as_ptr() as usize);
+        unsafe { *endptr = nptr.add(consumed).cast_mut() };
+    }
+    val
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+// `c_ulong` is 32-bit on the x86 guest but 64-bit on the x86_64 host, while the host `strtoul`
+// returns a 32-bit `unsigned long`. The asserted values fit in 32 bits and are read consistently on
+// both targets; the end-pointer checks are width-independent.
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstoul_decimal() {
+        // "123" base 10 -> 123.
+        let s: [wchar_t; 4] = [0x31, 0x32, 0x33, 0];
+        let v: c_ulong = unsafe { wcstoul(s.as_ptr(), core::ptr::null_mut(), 10) };
+        assert_eq!(v, 123);
+    }
+
+    #[test]
+    fn test_wcstoul_hex() {
+        // "ff" base 16 -> 255; the end pointer lands on the terminator.
+        let s: [wchar_t; 3] = [0x66, 0x66, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: c_ulong = unsafe { wcstoul(s.as_ptr(), &mut end, 16) };
+        assert_eq!(v, 255);
+        assert_eq!(unsafe { *end }, 0);
+    }
+
+    #[test]
+    fn test_wcstoul_endptr_stops_at_non_digit() {
+        // "99.5" parses 99 and leaves the end pointer at '.' (index 2).
+        let s: [wchar_t; 5] = [0x39, 0x39, 0x2E, 0x35, 0];
+        let mut end: *mut wchar_t = core::ptr::null_mut();
+        let v: c_ulong = unsafe { wcstoul(s.as_ptr(), &mut end, 10) };
+        assert_eq!(v, 99);
+        assert_eq!(end.cast_const(), unsafe { s.as_ptr().add(2) });
+    }
+}

--- a/src/libs/libc_wchar/src/wcstoull.rs
+++ b/src/libs/libc_wchar/src/wcstoull.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::{
+        to_narrow_alloc,
+        NarrowString,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_ulonglong,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Converts the initial portion of the wide string `nptr` to an `unsigned long long` value.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string. `endptr`, if non-null, must be a
+/// valid pointer.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcstoull(
+    nptr: *const wchar_t,
+    endptr: *mut *mut wchar_t,
+    base: c_int,
+) -> c_ulonglong {
+    extern "C" {
+        fn strtoull(s: *const c_char, e: *mut *mut c_char, b: c_int) -> c_ulonglong;
+    }
+    let narrow: NarrowString = match unsafe { to_narrow_alloc(nptr) } {
+        Some(narrow) => narrow,
+        None => {
+            if !endptr.is_null() {
+                unsafe { *endptr = nptr.cast_mut() };
+            }
+            return 0;
+        },
+    };
+    let mut nend: *mut c_char = core::ptr::null_mut();
+    let val: c_ulonglong = unsafe { strtoull(narrow.as_ptr(), &mut nend, base) };
+    if !endptr.is_null() {
+        let consumed: usize = (nend as usize) - (narrow.as_ptr() as usize);
+        unsafe { *endptr = nptr.add(consumed).cast_mut() };
+    }
+    val
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcstoull_large_value() {
+        // 20_000_000_000 exceeds 32 bits, exercising unsigned long long width.
+        let s: [wchar_t; 12] = [
+            0x32, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0,
+        ];
+        let v: c_ulonglong = unsafe { wcstoull(s.as_ptr(), core::ptr::null_mut(), 10) };
+        assert_eq!(v, 20_000_000_000);
+    }
+
+    #[test]
+    fn test_wcstoull_hex() {
+        // "abc" base 16 -> 2748.
+        let s: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let v: c_ulonglong = unsafe { wcstoull(s.as_ptr(), core::ptr::null_mut(), 16) };
+        assert_eq!(v, 2748);
+    }
+}

--- a/src/libs/libc_wchar/src/wcsxfrm.rs
+++ b/src/libs/libc_wchar/src/wcsxfrm.rs
@@ -1,0 +1,88 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcslen::wcslen,
+};
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Transforms a wide-character string for locale-aware collation.
+///
+/// Nanvix currently supports the C/POSIX locale, so the transformed string is identical to `src`.
+/// The return value is the full transformed length, excluding the null terminator.
+///
+/// # Safety
+///
+/// `src` must point to a valid null-terminated wide-character string. If `n` is greater than zero,
+/// `dest` must point to an array of at least `n` wide characters.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsxfrm(dest: *mut wchar_t, src: *const wchar_t, n: c_size_t) -> c_size_t {
+    let len: c_size_t = unsafe { wcslen(src) };
+
+    if n == 0 {
+        return len;
+    }
+
+    let mut i: c_size_t = 0;
+    while i + 1 < n && i < len {
+        unsafe { *dest.add(i as usize) = *src.add(i as usize) };
+        i += 1;
+    }
+    unsafe { *dest.add(i as usize) = 0 };
+    len
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcsxfrm_copies_identity_transform() {
+        let src: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let mut dest: [wchar_t; 4] = [-1; 4];
+        let len: c_size_t = unsafe {
+            wcsxfrm(
+                dest.as_mut_ptr(),
+                src.as_ptr(),
+                c_size_t::try_from(dest.len()).expect("destination length should fit in c_size_t"),
+            )
+        };
+        assert_eq!(len, 3);
+        assert_eq!(dest, src);
+    }
+
+    #[test]
+    fn test_wcsxfrm_zero_size_returns_required_length() {
+        let src: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let len: c_size_t = unsafe { wcsxfrm(core::ptr::null_mut(), src.as_ptr(), 0) };
+        assert_eq!(len, 3);
+    }
+
+    #[test]
+    fn test_wcsxfrm_truncates_but_terminates_when_space_exists() {
+        let src: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let mut dest: [wchar_t; 2] = [-1; 2];
+        let len: c_size_t = unsafe {
+            wcsxfrm(
+                dest.as_mut_ptr(),
+                src.as_ptr(),
+                c_size_t::try_from(dest.len()).expect("destination length should fit in c_size_t"),
+            )
+        };
+        assert_eq!(len, 3);
+        assert_eq!(dest, [0x61, 0]);
+    }
+}

--- a/src/libs/libc_wchar/src/wctob.rs
+++ b/src/libs/libc_wchar/src/wctob.rs
@@ -1,0 +1,82 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wint_t;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// End-of-file indicator for byte I/O.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a wide character to a single-byte character. In the POSIX locale, wide-character values
+/// in the range 0..=255 are representable as single-byte characters.
+///
+/// # Parameters
+///
+/// - `c`: Wide character to convert.
+///
+/// # Return Value
+///
+/// The single-byte representation of `c`, or `EOF` if `c` cannot be represented as a single byte.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn wctob(c: wint_t) -> c_int {
+    if (0..=255).contains(&c) {
+        c as c_int
+    } else {
+        EOF
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wctob_ascii() {
+        assert_eq!(wctob(0x41), 0x41); // 'A'
+        assert_eq!(wctob(0), 0); // null
+        assert_eq!(wctob(127), 127); // DEL
+    }
+
+    #[test]
+    fn test_wctob_posix_locale_accepts_all_bytes() {
+        assert_eq!(wctob(128), 128);
+        assert_eq!(wctob(255), 255);
+    }
+
+    #[test]
+    fn test_wctob_out_of_byte_range() {
+        assert_eq!(wctob(256), EOF);
+        assert_eq!(wctob(0x1F600), EOF); // emoji codepoint
+    }
+
+    #[test]
+    fn test_wctob_weof() {
+        assert_eq!(wctob(-1), EOF);
+    }
+}

--- a/src/libs/libc_wchar/src/wmemchr.rs
+++ b/src/libs/libc_wchar/src/wmemchr.rs
@@ -1,0 +1,75 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Finds the first occurrence of `c` in the first `n` wide characters of `s`.
+///
+/// # Safety
+///
+/// `s` must point to an array of at least `n` wide characters.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wmemchr(s: *const wchar_t, c: wchar_t, n: c_size_t) -> *mut wchar_t {
+    debug_assert!(!s.is_null());
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        if unsafe { *s.add(i as usize) } == c {
+            return unsafe { s.add(i as usize).cast_mut() };
+        }
+        i += 1;
+    }
+    core::ptr::null_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wmemchr_finds_first_match() {
+        let buf: [wchar_t; 4] = [0x41, 0x42, 0x41, 0x43];
+        let ret: *mut wchar_t = unsafe { wmemchr(buf.as_ptr(), 0x41, 4) };
+        assert_eq!(ret.cast_const(), buf.as_ptr());
+    }
+
+    #[test]
+    fn test_wmemchr_finds_match_after_first() {
+        let buf: [wchar_t; 4] = [0x41, 0x42, 0x43, 0x44];
+        let ret: *mut wchar_t = unsafe { wmemchr(buf.as_ptr(), 0x43, 4) };
+        assert_eq!(ret.cast_const(), unsafe { buf.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_wmemchr_returns_null_when_absent() {
+        let buf: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let ret: *mut wchar_t = unsafe { wmemchr(buf.as_ptr(), 0x44, 3) };
+        assert!(ret.is_null());
+    }
+
+    #[test]
+    fn test_wmemchr_zero_count() {
+        let buf: [wchar_t; 1] = [0x41];
+        let ret: *mut wchar_t = unsafe { wmemchr(buf.as_ptr(), 0x41, 0) };
+        assert!(ret.is_null());
+    }
+}

--- a/src/libs/libc_wchar/src/wmemcmp.rs
+++ b/src/libs/libc_wchar/src/wmemcmp.rs
@@ -1,0 +1,98 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares `n` wide characters from the arrays `s1` and `s2`.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first wide character array.
+/// - `s2`: Pointer to the second wide character array.
+/// - `n`: Number of wide characters to compare.
+///
+/// # Return Value
+///
+/// Returns a negative value if `s1` is less than `s2`, zero if they are equal, or a positive value
+/// if `s1` is greater than `s2`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s1` or `s2` is null, or if either buffer has fewer than `n` wide
+/// character positions.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wmemcmp(s1: *const wchar_t, s2: *const wchar_t, n: c_size_t) -> c_int {
+    debug_assert!(!s1.is_null());
+    debug_assert!(!s2.is_null());
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        let c1: wchar_t = unsafe { *s1.add(i as usize) };
+        let c2: wchar_t = unsafe { *s2.add(i as usize) };
+        let diff: i64 = i64::from(c1) - i64::from(c2);
+        if diff != 0 {
+            return diff.signum() as c_int;
+        }
+        i += 1;
+    }
+    0
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wmemcmp_equal() {
+        let s1: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let s2: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        assert_eq!(unsafe { wmemcmp(s1.as_ptr(), s2.as_ptr(), 3) }, 0);
+    }
+
+    #[test]
+    fn test_wmemcmp_less() {
+        let s1: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let s2: [wchar_t; 3] = [0x41, 0x42, 0x44];
+        assert!(unsafe { wmemcmp(s1.as_ptr(), s2.as_ptr(), 3) } < 0);
+    }
+
+    #[test]
+    fn test_wmemcmp_greater() {
+        let s1: [wchar_t; 3] = [0x41, 0x42, 0x44];
+        let s2: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        assert!(unsafe { wmemcmp(s1.as_ptr(), s2.as_ptr(), 3) } > 0);
+    }
+
+    #[test]
+    fn test_wmemcmp_zero_count() {
+        let s1: [wchar_t; 2] = [0x41, 0x42];
+        let s2: [wchar_t; 2] = [0x43, 0x44];
+        assert_eq!(unsafe { wmemcmp(s1.as_ptr(), s2.as_ptr(), 0) }, 0);
+    }
+}

--- a/src/libs/libc_wchar/src/wmemcpy.rs
+++ b/src/libs/libc_wchar/src/wmemcpy.rs
@@ -1,0 +1,82 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies `n` wide characters from `src` to `dest`. The memory regions must not overlap.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination wide character array.
+/// - `src`: Pointer to the source wide character array.
+/// - `n`: Number of wide characters to copy.
+///
+/// # Return Value
+///
+/// Returns `dest`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dest` or `src` is null, if the memory regions overlap, or if either
+/// buffer has fewer than `n` wide character positions.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wmemcpy(
+    dest: *mut wchar_t,
+    src: *const wchar_t,
+    n: c_size_t,
+) -> *mut wchar_t {
+    debug_assert!(!dest.is_null());
+    debug_assert!(!src.is_null());
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        unsafe { *dest.add(i as usize) = *src.add(i as usize) };
+        i += 1;
+    }
+    dest
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wmemcpy_basic() {
+        let src: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let mut dest: [wchar_t; 3] = [0; 3];
+        let ret: *mut wchar_t = unsafe { wmemcpy(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        assert_eq!(ret, dest.as_mut_ptr());
+        assert_eq!(dest, [0x41, 0x42, 0x43]);
+    }
+
+    #[test]
+    fn test_wmemcpy_zero() {
+        let src: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let mut dest: [wchar_t; 3] = [-1; 3];
+        unsafe { wmemcpy(dest.as_mut_ptr(), src.as_ptr(), 0) };
+        assert_eq!(dest, [-1, -1, -1]);
+    }
+}

--- a/src/libs/libc_wchar/src/wmemmove.rs
+++ b/src/libs/libc_wchar/src/wmemmove.rs
@@ -1,0 +1,112 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies `n` wide characters from `src` to `dest`, handling overlapping memory regions correctly.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination wide character array.
+/// - `src`: Pointer to the source wide character array.
+/// - `n`: Number of wide characters to copy.
+///
+/// # Return Value
+///
+/// Returns `dest`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dest` or `src` is null, or if either buffer has fewer than `n` wide
+/// character positions.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wmemmove(
+    dest: *mut wchar_t,
+    src: *const wchar_t,
+    n: c_size_t,
+) -> *mut wchar_t {
+    debug_assert!(!dest.is_null());
+    debug_assert!(!src.is_null());
+
+    if (dest as *const wchar_t) <= src {
+        // Copy forward.
+        let mut i: c_size_t = 0;
+        while i < n {
+            unsafe { *dest.add(i as usize) = *src.add(i as usize) };
+            i += 1;
+        }
+    } else {
+        // Copy backward to handle overlap.
+        let mut i: c_size_t = n;
+        while i > 0 {
+            i -= 1;
+            unsafe { *dest.add(i as usize) = *src.add(i as usize) };
+        }
+    }
+    dest
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wmemmove_non_overlapping() {
+        let src: [wchar_t; 3] = [0x41, 0x42, 0x43];
+        let mut dest: [wchar_t; 3] = [0; 3];
+        let ret: *mut wchar_t = unsafe { wmemmove(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        assert_eq!(ret, dest.as_mut_ptr());
+        assert_eq!(dest, [0x41, 0x42, 0x43]);
+    }
+
+    #[test]
+    fn test_wmemmove_overlap_forward() {
+        // [1, 2, 3, 4, 5] — copy elements [0..3] to [1..4].
+        let mut buf: [wchar_t; 5] = [1, 2, 3, 4, 5];
+        unsafe {
+            wmemmove(buf.as_mut_ptr().add(1), buf.as_ptr(), 3);
+        }
+        assert_eq!(buf, [1, 1, 2, 3, 5]);
+    }
+
+    #[test]
+    fn test_wmemmove_overlap_backward() {
+        // [1, 2, 3, 4, 5] — copy elements [1..4] to [0..3].
+        let mut buf: [wchar_t; 5] = [1, 2, 3, 4, 5];
+        unsafe {
+            wmemmove(buf.as_mut_ptr(), buf.as_ptr().add(1), 3);
+        }
+        assert_eq!(buf, [2, 3, 4, 4, 5]);
+    }
+
+    #[test]
+    fn test_wmemmove_zero_count() {
+        let src: [wchar_t; 2] = [0x41, 0x42];
+        let mut dest: [wchar_t; 2] = [-1; 2];
+        unsafe { wmemmove(dest.as_mut_ptr(), src.as_ptr(), 0) };
+        assert_eq!(dest, [-1, -1]);
+    }
+}

--- a/src/libs/libc_wchar/src/wmemset.rs
+++ b/src/libs/libc_wchar/src/wmemset.rs
@@ -1,0 +1,75 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets `n` wide characters in the array `s` to the value `c`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the wide character array to fill.
+/// - `c`: Wide character value to set.
+/// - `n`: Number of wide characters to set.
+///
+/// # Return Value
+///
+/// Returns `s`.
+///
+/// # Safety
+///
+/// Behavior is undefined if `s` is null or if the buffer has fewer than `n` wide character
+/// positions.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wmemset(s: *mut wchar_t, c: wchar_t, n: c_size_t) -> *mut wchar_t {
+    debug_assert!(!s.is_null());
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        unsafe { *s.add(i as usize) = c };
+        i += 1;
+    }
+    s
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wmemset_fill() {
+        let mut buf: [wchar_t; 4] = [0; 4];
+        let ret: *mut wchar_t = unsafe { wmemset(buf.as_mut_ptr(), 0x58, 4) };
+        assert_eq!(ret, buf.as_mut_ptr());
+        assert_eq!(buf, [0x58, 0x58, 0x58, 0x58]);
+    }
+
+    #[test]
+    fn test_wmemset_zero_count() {
+        let mut buf: [wchar_t; 3] = [-1; 3];
+        unsafe { wmemset(buf.as_mut_ptr(), 0x41, 0) };
+        assert_eq!(buf, [-1, -1, -1]);
+    }
+}


### PR DESCRIPTION
## Description

Adds a new `no_std` guest library crate, `libc_wchar`, that implements a POSIX-conforming subset of `<wchar.h>` (The Open Group Base Specifications Issue 8).

All C-facing symbols are gated with `#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]` (matching the `libc_assert` convention), so the guest build exports the C ABI while host `std` unit tests link cleanly.

## Implemented APIs

- **String operations:** `wcslen`, `wcscpy`, `wcsncpy`, `wcscat`
- **Comparison:** `wcscmp`, `wcsncmp`, `wcscoll`, `wcsxfrm`
- **Search:** `wcschr`, `wcsrchr`, `wcsstr`, `wcstok`
- **Numeric conversion:** `wcstol`, `wcstoul`, `wcstoll`, `wcstoull`, `wcstod`
- **Wide memory ops:** `wmemcpy`, `wmemmove`, `wmemset`, `wmemcmp`, `wmemchr`
- **Byte/wide conversion:** `btowc`, `wctob`
- **Restartable multibyte/wide conversion:** `mbrtowc`, `wcrtomb`, `mbrlen`, `mbsinit`, `mbsrtowcs`, `wcsrtombs` (plus `mbtowc`, `mblen`, `wctomb`, `mbstowcs`, `wcstombs`), backed by a stateless UTF-8 codec

`wcscoll`/`wcsxfrm` implement C/POSIX-locale semantics (code-point order and identity transform). Types and constants follow the spec: `wchar_t` (int), `wint_t` (int, ABI-matched to the Rust definition), `mbstate_t`, and `WEOF`.

## Header generation

- Adds `header.toml` describing the generated `wchar.h`, scanning `libc_wchar` and `libc_stdio` (the latter owns `swprintf`/`vswprintf`).
- Declares only implemented symbols to avoid advertising missing APIs.

## Build and test wiring

- Registers `libc_wchar` in the workspace members and dependencies.
- Adds it to `ALL_GUEST_RUST_LIBS` and `ALL_GUEST_RUST_LIBS_TEST_LIST` in the `Makefile`, so it builds and runs under `run-unit-tests`.
- Adds a Windows-only host-test `__errno_location` shim so `std` unit tests link against MSVC, mirroring `libc_inttypes`.

## Testing

- `make test-guest-rlib-libc_wchar`: 103 passed, 0 failed
- `cargo clippy ... -p libc_wchar --tests -- -D warnings`: clean
- `cargo fmt -p libc_wchar`: clean
