### PR TITLE
[syscall] Idempotent pthread mutex/cond init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,8 @@ dependencies = [
  "nvx-crt0",
  "sys",
  "sysalloc",
+ "sysapi",
+ "syscall",
  "syslog",
 ]
 

--- a/src/libs/syscall/src/pthread/syscall/cond.rs
+++ b/src/libs/syscall/src/pthread/syscall/cond.rs
@@ -81,20 +81,16 @@ pub fn pthread_cond_init(
     cond: &mut pthread_cond_t,
     attr: &pthread_condattr_t,
 ) -> Result<(), Error> {
-    // Check if condition variable is not initialized.
-    if let Entry::Vacant(entry) = CONDITIONS
+    // Register (or re-register) the condition variable's attributes.
+    //
+    // Initialization is idempotent for the same reasons as `pthread_mutex_init`: it matches the
+    // kernel's lazy, per-process recreation model and keeps the userspace registry consistent
+    // across `fork()`, where the child inherits this map through copy-on-write memory while the
+    // kernel deliberately drops and lazily recreates the underlying objects.
+    CONDITIONS
         .lock()
-        .entry(cond as *const pthread_cond_t as usize)
-    {
-        // Condition variable is not initialized.
-        entry.insert(*attr);
-        Ok(())
-    } else {
-        // Condition variable is already initialized.
-        let reason: &str = "condition variable is already initialized";
-        ::syslog::warn!("pthread_cond_init(): {}", reason);
-        Err(Error::new(ErrorCode::ResourceBusy, reason))
-    }
+        .insert(cond as *const pthread_cond_t as usize, *attr);
+    Ok(())
 }
 
 pub fn pthread_cond_destroy(cond: &mut pthread_cond_t) -> Result<(), Error> {

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -50,19 +50,21 @@ pub fn pthread_mutex_init(
     mutex: &mut pthread_mutex_t,
     attr: &pthread_mutexattr_t,
 ) -> Result<(), Error> {
-    // Check if mutex is not initialized.
-    if let Entry::Vacant(entry) = MUTEXES
+    // Register (or re-register) the mutex's attributes.
+    //
+    // Initialization is idempotent: an existing entry for this address is overwritten rather than
+    // rejected. This mirrors the kernel, which keeps mutexes in a per-process table and lazily
+    // (re)creates them on access (`Process::get_mutex` uses `or_insert_with`). It is also what
+    // makes `fork()` work: the kernel intentionally drops the child's inherited mutexes and
+    // recreates them lazily, but this userspace registry is inherited through copy-on-write
+    // memory, so a child that re-initializes a mutex (e.g. CPython rebuilding its GIL in
+    // `PyOS_AfterFork_Child`) would otherwise observe a stale, already-registered entry and fail.
+    // POSIX leaves re-initialization of an initialized mutex undefined and glibc/musl tolerate it;
+    // Nanvix defines it as "reset", consistent with its lazy, kernel-backed model.
+    MUTEXES
         .lock()
-        .entry(mutex as *const pthread_mutex_t as usize)
-    {
-        // Mutex was is not initialized.
-        entry.insert(*attr);
-        Ok(())
-    } else {
-        let reason: &str = "mutex is not initialized";
-        ::syslog::warn!("pthread_mutex_init(): {}", reason);
-        Err(Error::new(ErrorCode::InvalidArgument, reason))
-    }
+        .insert(mutex as *const pthread_mutex_t as usize, *attr);
+    Ok(())
 }
 
 pub fn pthread_mutex_destroy(mutex: &mut pthread_mutex_t) -> Result<(), Error> {

--- a/src/tests/test-fork-kcall/Cargo.toml
+++ b/src/tests/test-fork-kcall/Cargo.toml
@@ -19,6 +19,8 @@ nvx-crt0 = { workspace = true, features = ["rust-main", "provides-allocator"] }
 sysalloc = { workspace = true }
 libc_string = { workspace = true }
 sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
 syslog = { workspace = true, default-features = true }
 
 [build-dependencies]
@@ -27,13 +29,13 @@ cfg-if = { workspace = true }
 
 [features]
 default = ["panic"]
-standalone = []
-trace = ["nvx/trace", "syslog/trace", "nvx-crt0/trace"]
-debug = ["nvx/debug", "syslog/debug", "nvx-crt0/debug"]
-info = ["nvx/info", "syslog/info", "nvx-crt0/info"]
-warn = ["nvx/warn", "syslog/warn", "nvx-crt0/warn"]
-error = ["nvx/error", "syslog/error", "nvx-crt0/error"]
-panic = ["nvx/panic", "syslog/panic", "nvx-crt0/panic"]
+standalone = ["syscall/standalone"]
+trace = ["nvx/trace", "syscall/trace", "syslog/trace", "nvx-crt0/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug", "nvx-crt0/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info", "nvx-crt0/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn", "nvx-crt0/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error", "nvx-crt0/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic", "nvx-crt0/panic"]
 
 [lints]
 workspace = true

--- a/src/tests/test-fork-kcall/src/tests/fork.rs
+++ b/src/tests/test-fork-kcall/src/tests/fork.rs
@@ -11,6 +11,12 @@
 //!    `fork()` is invisible to the child, and a write performed by the child is invisible to the
 //!    parent.
 //! 3. The child's parent linkage is correct: `getppid()` in the child returns the parent's PID.
+//! 4. A process owning a mutex and a condition variable — accessed through the userspace pthread
+//!    interface — is correctly duplicated, and the child can re-initialize the inherited objects
+//!    after `fork()` (as a threaded runtime does, e.g. CPython's `PyOS_AfterFork_Child`). This
+//!    doubles as a regression test for the userspace pthread-registry bug fixed by PR #2606: the
+//!    address-keyed registry is inherited copy-on-write, so before the fix the child's
+//!    `pthread_mutex_init`/`pthread_cond_init` reject the re-initialization.
 //!
 //! The parent and child rendezvous over IPC so that the parent's post-`fork()` write is
 //! guaranteed to happen before the child observes the shared byte. This turns a copy-on-write
@@ -26,13 +32,20 @@
 // Imports
 //==================================================================================================
 
-use ::core::sync::atomic::{
-    AtomicU8,
-    AtomicU32,
-    Ordering,
+use ::core::{
+    ptr,
+    sync::atomic::{
+        AtomicU8,
+        AtomicU32,
+        Ordering,
+    },
+    time::Duration,
 };
 use ::sys::{
-    error::Error,
+    error::{
+        Error,
+        ErrorCode,
+    },
     ipc::{
         Message,
         MessageReceiver,
@@ -45,6 +58,27 @@ use ::sys::{
         pm,
     },
     pm::ProcessIdentifier,
+    time::SystemTime,
+};
+use ::sysapi::{
+    pthread::{
+        PTHREAD_COND_INITIALIZER,
+        PTHREAD_MUTEX_INITIALIZER,
+    },
+    sys_types::{
+        pthread_cond_t,
+        pthread_condattr_t,
+        pthread_mutex_t,
+        pthread_mutexattr_t,
+    },
+};
+use ::syscall::pthread::{
+    pthread_cond_init,
+    pthread_cond_signal,
+    pthread_cond_timedwait,
+    pthread_mutex_init,
+    pthread_mutex_lock,
+    pthread_mutex_unlock,
 };
 
 //==================================================================================================
@@ -69,6 +103,20 @@ const CHILD_EXIT_OK: i32 = 0;
 /// Exit status used by the child when one of its checks fails.
 const CHILD_EXIT_FAIL: i32 = 1;
 
+/// Timeout used for the condition-variable waits performed by [`exercise_mutex_condvar`]. No other
+/// thread in the same process signals the condition, so each wait is expected to elapse and report
+/// [`ErrorCode::OperationTimedOut`]. Chosen long enough to avoid a premature return on a loaded
+/// host, yet short enough to keep the test responsive.
+const COND_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Status byte sent by the child when it successfully exercised the inherited mutex and condition
+/// variable.
+const MC_CHILD_OK: u8 = 1;
+
+/// Status byte sent by the child when it failed to exercise the inherited synchronization
+/// primitives.
+const MC_CHILD_FAIL: u8 = 0;
+
 //==================================================================================================
 // Global State
 //==================================================================================================
@@ -79,6 +127,15 @@ static SHARED_BYTE: AtomicU8 = AtomicU8::new(0);
 
 /// Parent PID, recorded before `fork()` so the child can recover it from copy-on-write memory.
 static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
+
+/// Mutex driven through the userspace pthread interface. The parent initializes and uses it before
+/// `fork()`; the child re-initializes it afterwards. It lives in the program's data segment and is
+/// inherited copy-on-write, so the userspace pthread registry entry the parent created for it is
+/// inherited by the child as well.
+static mut MC_MUTEX: pthread_mutex_t = PTHREAD_MUTEX_INITIALIZER;
+
+/// Condition variable handled exactly like [`MC_MUTEX`].
+static mut MC_COND: pthread_cond_t = PTHREAD_COND_INITIALIZER;
 
 //==================================================================================================
 // Child Path
@@ -311,6 +368,277 @@ fn test_fork_pid_cache_invalidation() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Mutex / Condition-Variable Inheritance
+//==================================================================================================
+
+/// Computes an absolute deadline [`COND_WAIT_TIMEOUT`] in the future from the monotonic clock.
+fn cond_wait_deadline() -> Result<SystemTime, Error> {
+    let mut now: SystemTime = SystemTime::default();
+    pm::__kcall_gettime(&mut now)?;
+    now.checked_add_duration(&COND_WAIT_TIMEOUT)
+        .ok_or_else(|| Error::new(ErrorCode::ValueOutOfRange, "condition wait deadline overflow"))
+}
+
+/// Initializes the mutex and condition variable through `pthread_mutex_init`/`pthread_cond_init`.
+///
+/// The parent calls this once to register the objects. The child calls it again after `fork()` to
+/// re-initialize the inherited objects — exactly what a threaded runtime does in its post-`fork()`
+/// child (for example CPython's `PyOS_AfterFork_Child`, which resets the GIL's lock in place). On a
+/// correct implementation both calls succeed.
+///
+/// The child's call is the operation that reproduces the userspace-registry bug fixed by PR #2606:
+/// the address-keyed pthread registry is inherited copy-on-write, so it still lists the addresses
+/// the parent registered. Before the fix `pthread_mutex_init` rejects the re-initialization with
+/// `InvalidArgument` (EINVAL) and `pthread_cond_init` with `ResourceBusy` (EBUSY), even though the
+/// kernel already dropped the underlying objects in the child.
+fn init_mutex_condvar() -> Result<(), Error> {
+    let mutex_attr: pthread_mutexattr_t = pthread_mutexattr_t::default();
+    let cond_attr: pthread_condattr_t = pthread_condattr_t::default();
+    // SAFETY: the process is single-threaded here, so each reference is exclusive, does not alias,
+    // and is confined to its `pthread_*_init` call.
+    unsafe {
+        pthread_mutex_init(&mut *ptr::addr_of_mut!(MC_MUTEX), &mutex_attr)?;
+        pthread_cond_init(&mut *ptr::addr_of_mut!(MC_COND), &cond_attr)?;
+    }
+    Ok(())
+}
+
+/// Drives the mutex and condition variable through the userspace pthread interface, proving they
+/// are functional in the calling process.
+///
+/// Performs a canonical lock / wait / unlock / signal cycle:
+///
+/// 1. Locks the mutex via `pthread_mutex_lock`. A forked process must acquire it without
+///    deadlocking.
+/// 2. Reads the mutex-guarded byte [`SHARED_BYTE`] under the lock and remembers it.
+/// 3. Waits on the condition variable via `pthread_cond_timedwait` with [`COND_WAIT_TIMEOUT`]. With
+///    no signaler in this process the wait must elapse and report [`ErrorCode::OperationTimedOut`],
+///    which also exercises the mutex release/reacquire performed inside the wait.
+/// 4. Writes `write_value` to the guarded byte, still under the reacquired lock, taking a private
+///    copy-on-write page.
+/// 5. Unlocks the mutex via `pthread_mutex_unlock`.
+/// 6. Signals the condition variable via `pthread_cond_signal`. With no waiters the call simply
+///    succeeds.
+///
+/// Returns the value observed in step 2.
+fn exercise_mutex_condvar(write_value: u8) -> Result<u8, Error> {
+    // Step 1: acquire the mutex.
+    // SAFETY: single-threaded; the reference is exclusive and confined to this call.
+    unsafe { pthread_mutex_lock(&mut *ptr::addr_of_mut!(MC_MUTEX))? };
+
+    // Step 2: observe the guarded data under the lock.
+    let observed: u8 = SHARED_BYTE.load(ORDER);
+
+    // Step 3: wait on the condition variable; with no signaler in this process it must time out.
+    let deadline: SystemTime = cond_wait_deadline()?;
+    // SAFETY: single-threaded; the shared references are confined to this call and the mutex is
+    // held, as `pthread_cond_timedwait` requires.
+    let wait: Result<(), Error> = unsafe {
+        pthread_cond_timedwait(&*ptr::addr_of!(MC_COND), &*ptr::addr_of!(MC_MUTEX), Some(deadline))
+    };
+    match wait {
+        Err(e) if e.code == ErrorCode::OperationTimedOut => {},
+        Err(e) => {
+            return Err(Error::new(e.code, "pthread_cond_timedwait returned an unexpected error"));
+        },
+        Ok(()) => {
+            return Err(Error::new(
+                ErrorCode::OperationNotPermitted,
+                "pthread_cond_timedwait returned without a signal; expected a timeout",
+            ));
+        },
+    }
+
+    // Step 4: take a private copy of the guarded data, still holding the reacquired lock.
+    SHARED_BYTE.store(write_value, ORDER);
+
+    // Step 5: release the mutex.
+    // SAFETY: single-threaded; the reference is exclusive and confined to this call.
+    unsafe { pthread_mutex_unlock(&mut *ptr::addr_of_mut!(MC_MUTEX))? };
+
+    // Step 6: signal the condition variable; with no waiters this simply succeeds.
+    // SAFETY: single-threaded; the shared reference is confined to this call.
+    unsafe { pthread_cond_signal(&*ptr::addr_of!(MC_COND))? };
+
+    Ok(observed)
+}
+
+/// Runs the child's post-`fork()` re-initialization and mutex/condition-variable exercise, then
+/// reports the outcome to the parent.
+///
+/// The payload carries a status byte ([`MC_CHILD_OK`] or [`MC_CHILD_FAIL`]), the bytes observed
+/// before and after the child's own write, and the raw error code of the first failing operation
+/// (zero on success). This makes the PR #2606 regression deterministic and self-describing: before
+/// the fix the child reports [`MC_CHILD_FAIL`] with the `pthread_mutex_init`/`pthread_cond_init`
+/// error code, so the parent's assertion names it instead of the test hanging.
+fn run_child_mutex_condvar(parent_pid: ProcessIdentifier) -> Result<(), Error> {
+    let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
+
+    // Barrier: block until the parent signals that its post-fork write has completed.
+    ipc::__kcall_recv()?;
+
+    // Re-initialize the inherited objects (the bug trigger), then drive them, taking a private copy
+    // via PATTERN_CHILD.
+    let outcome: Result<u8, Error> =
+        init_mutex_condvar().and_then(|()| exercise_mutex_condvar(PATTERN_CHILD));
+    let (status, observed_before, observed_after, errcode): (u8, u8, u8, i32) = match outcome {
+        Ok(observed) => (MC_CHILD_OK, observed, SHARED_BYTE.load(ORDER), 0),
+        Err(e) => (MC_CHILD_FAIL, 0, 0, i32::from(e.code)),
+    };
+
+    // Report observations to the parent: status, observed bytes, and the failing error code.
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    payload[0] = status;
+    payload[1] = observed_before;
+    payload[2] = observed_after;
+    payload[4..8].copy_from_slice(&errcode.to_le_bytes());
+    let reply: Message = Message::new(
+        MessageSender::from(my_pid),
+        MessageReceiver::from(parent_pid),
+        MessageType::Ipc,
+        None,
+        payload,
+    );
+    ipc::__kcall_send(&reply)?;
+
+    Ok(())
+}
+
+/// Verifies that a process owning a mutex and a condition variable — accessed through the userspace
+/// pthread interface — is correctly duplicated by `fork()`, and that the child can re-initialize the
+/// inherited objects, conforming to the POSIX `fork()` contract
+/// (<https://pubs.opengroup.org/onlinepubs/9799919799/functions/fork.html>).
+///
+/// POSIX makes the child a single-threaded replica of the calling thread and its address space, and
+/// requires both processes to execute independently afterwards. A threaded runtime typically resets
+/// its inherited locks in the child (CPython does this in `PyOS_AfterFork_Child`). This test mirrors
+/// that: the parent initializes and exercises the mutex and condition variable, then `fork()`s; the
+/// child re-initializes the inherited objects and drives them through a full lock / wait / unlock /
+/// signal cycle. The parent does not hold the lock across `fork()`, so the child never operates on a
+/// parent-held non-process-shared lock (undefined behavior per POSIX).
+///
+/// The re-initialization reproduces the userspace-registry bug fixed by PR #2606: the address-keyed
+/// pthread registry is inherited copy-on-write, so before the fix `pthread_mutex_init`/
+/// `pthread_cond_init` reject the child's reset with `InvalidArgument`/`ResourceBusy` and this test
+/// fails; with the fix they reset the entry and the test passes. The mutex-guarded byte additionally
+/// validates the POSIX MAP_PRIVATE (copy-on-write) data rules.
+fn test_fork_mutex_condvar() -> Result<(), Error> {
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Prime the guarded byte with the pre-fork pattern.
+    SHARED_BYTE.store(PATTERN_INIT, ORDER);
+
+    // Initialize and exercise the mutex and condition variable in the parent before forking. The
+    // init calls register the objects' addresses in the userspace pthread registry; that registry
+    // is what the child inherits copy-on-write. The mutex is locked and unlocked here (not held
+    // across `fork()`).
+    init_mutex_condvar()?;
+    // SAFETY: single-threaded; each reference is exclusive and confined to its call.
+    unsafe {
+        pthread_mutex_lock(&mut *ptr::addr_of_mut!(MC_MUTEX))?;
+        pthread_mutex_unlock(&mut *ptr::addr_of_mut!(MC_MUTEX))?;
+    }
+
+    // Fork the calling process. Both processes resume execution at this point.
+    let child_pid: ProcessIdentifier = fork::__kcall_fork()?;
+
+    // Child: `fork()` returns a process identifier of zero. It re-initializes and drives the
+    // inherited primitives, reports to the parent, and terminates without returning to the shared
+    // test flow.
+    if child_pid == ProcessIdentifier::from(0) {
+        let parent: ProcessIdentifier =
+            match ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER)) {
+                Ok(pid) => pid,
+                // The freshly forked child is at a safe point to terminate; it holds no locks or
+                // resources that require explicit cleanup.
+                Err(_) => pm::__kcall_exit(CHILD_EXIT_FAIL)?,
+            };
+        let status: i32 = match run_child_mutex_condvar(parent) {
+            Ok(()) => CHILD_EXIT_OK,
+            Err(_) => CHILD_EXIT_FAIL,
+        };
+        // The child terminates here and never returns.
+        pm::__kcall_exit(status)?;
+    }
+
+    // Parent: reaching here means this is the parent. `fork()` failures are surfaced as an error by
+    // `__kcall_fork()` above.
+    assert!(child_pid != parent_pid, "child PID must differ from parent PID");
+
+    // The parent drives its own independent mutex and condition variable, taking a private copy via
+    // PATTERN_PARENT.
+    let parent_observed_before: u8 = exercise_mutex_condvar(PATTERN_PARENT)?;
+    assert!(
+        parent_observed_before == PATTERN_INIT,
+        "parent observed {:#x} before its own write; expected {:#x}",
+        parent_observed_before,
+        PATTERN_INIT
+    );
+
+    // Release the child to perform its observation.
+    let go: Message = Message::new(
+        MessageSender::from(parent_pid),
+        MessageReceiver::from(child_pid),
+        MessageType::Ipc,
+        None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    ipc::__kcall_send(&go)?;
+
+    // Receive the child's report.
+    let reply: Message = ipc::__kcall_recv()?;
+    assert!(reply.message_type == MessageType::Ipc, "expected IPC reply from child");
+
+    let child_status: u8 = reply.payload[0];
+    let child_observed_before: u8 = reply.payload[1];
+    let child_observed_after: u8 = reply.payload[2];
+    let child_errcode: i32 = i32::from_le_bytes([
+        reply.payload[4],
+        reply.payload[5],
+        reply.payload[6],
+        reply.payload[7],
+    ]);
+    let parent_observed: u8 = SHARED_BYTE.load(ORDER);
+
+    // The child must have re-initialized and driven the inherited mutex and condition variable.
+    // Before PR #2606 the child's `pthread_mutex_init`/`pthread_cond_init` fail on the inherited
+    // registry entry, so this assertion fires with the reported EINVAL/EBUSY code.
+    assert!(
+        child_status == MC_CHILD_OK,
+        "child failed to re-initialize/exercise the inherited mutex and condition variable after \
+         fork() (error code={}); this is the PR #2606 stale userspace-registry bug \
+         (pthread_mutex_init -> EINVAL / pthread_cond_init -> EBUSY on the inherited entry)",
+        child_errcode
+    );
+    // CoW invariant 1: the parent's post-fork write is invisible to the child.
+    assert!(
+        child_observed_before == PATTERN_INIT,
+        "child observed {:#x} before its own write; expected {:#x} (parent->child isolation \
+         broken)",
+        child_observed_before,
+        PATTERN_INIT
+    );
+    // The child's own write under the lock must be visible to itself.
+    assert!(
+        child_observed_after == PATTERN_CHILD,
+        "child observed {:#x} after its own write; expected {:#x}",
+        child_observed_after,
+        PATTERN_CHILD
+    );
+    // CoW invariant 2: the child's write is invisible to the parent.
+    assert!(
+        parent_observed == PATTERN_PARENT,
+        "parent observed {:#x} after child's write; expected {:#x} (child->parent isolation \
+         broken)",
+        parent_observed,
+        PATTERN_PARENT
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
 // Public Entry Point
 //==================================================================================================
 
@@ -321,5 +649,7 @@ pub fn run() -> Result<(), Error> {
     ::syslog::info!("test-fork-kcall: PASS - fork_cow_and_lineage");
     test_fork_pid_cache_invalidation()?;
     ::syslog::info!("test-fork-kcall: PASS - fork_pid_cache_invalidation");
+    test_fork_mutex_condvar()?;
+    ::syslog::info!("test-fork-kcall: PASS - fork_mutex_condvar");
     Ok(())
 }

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -16,10 +16,13 @@
 
 use ::alloc::alloc::Layout;
 use ::arch::mem::PAGE_SIZE;
-use ::core::sync::atomic::{
-    AtomicU32,
-    AtomicU8,
-    Ordering,
+use ::core::{
+    sync::atomic::{
+        AtomicU32,
+        AtomicU8,
+        Ordering,
+    },
+    time::Duration,
 };
 use ::sys::{
     error::{
@@ -40,9 +43,12 @@ use ::sys::{
     mm::VirtualAddress,
     pm::{
         Capability,
+        ConditionAddress,
+        MutexAddress,
         ProcessIdentifier,
         ThreadCreateArgs,
     },
+    time::SystemTime,
 };
 
 //==================================================================================================
@@ -72,6 +78,20 @@ const CHILD_STACK_SIZE: usize = 4 * PAGE_SIZE;
 /// requests on the basis of their invalid `user_fn`/`user_stack_base` fields.
 const DUMMY_STACK_SIZE: usize = 8192;
 
+/// Timeout used for the condition-variable waits performed by [`exercise_mutex_condvar`].  No
+/// other thread in the same process signals the condition, so each wait is expected to elapse and
+/// report [`ErrorCode::OperationTimedOut`].  Chosen long enough to avoid a premature return on a
+/// loaded host, yet short enough to keep the test responsive.
+const COND_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Status byte sent by the child when it successfully exercised the inherited mutex and condition
+/// variable.
+const MC_CHILD_OK: u8 = 1;
+
+/// Status byte sent by the child when it failed to exercise the inherited synchronization
+/// primitives.
+const MC_CHILD_FAIL: u8 = 0;
+
 //==================================================================================================
 // Global State
 //==================================================================================================
@@ -83,6 +103,16 @@ static SHARED_BYTE: AtomicU8 = AtomicU8::new(0);
 /// Parent process identifier, written before `duplicate()` so that the child can recover it
 /// from the inherited (copy-on-write) memory image.
 static PARENT_PID_RAW: AtomicU32 = AtomicU32::new(0);
+
+/// Backing storage whose *address* identifies the duplicate-test mutex to the kernel.  The kernel
+/// keys synchronization objects by their user-space address only and never dereferences this
+/// storage, so a single zero byte is sufficient.  Duplicated copy-on-write into the child, giving
+/// it the same address but an independent, process-private kernel mutex object.
+static MC_MUTEX_SLOT: u8 = 0;
+
+/// Backing storage whose *address* identifies the duplicate-test condition variable, mirroring
+/// [`MC_MUTEX_SLOT`].
+static MC_COND_SLOT: u8 = 0;
 
 //==================================================================================================
 // Child Entry Point
@@ -437,6 +467,311 @@ fn test_duplicate_cow_refork() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Mutex / Condition-Variable Duplication Test
+//==================================================================================================
+
+/// Returns the kernel mutex address identified by [`MC_MUTEX_SLOT`].
+fn mc_mutex_addr() -> MutexAddress {
+    let ptr: *const u8 = &raw const MC_MUTEX_SLOT;
+    MutexAddress::from(ptr as usize)
+}
+
+/// Returns the kernel condition-variable address identified by [`MC_COND_SLOT`].
+fn mc_cond_addr() -> ConditionAddress {
+    let ptr: *const u8 = &raw const MC_COND_SLOT;
+    ConditionAddress::from(ptr as usize)
+}
+
+/// Computes an absolute deadline [`COND_WAIT_TIMEOUT`] in the future from the monotonic clock.
+fn cond_wait_deadline() -> Result<SystemTime, Error> {
+    let mut now: SystemTime = SystemTime::default();
+    pm::__kcall_gettime(&mut now)?;
+    now.checked_add_duration(&COND_WAIT_TIMEOUT)
+        .ok_or_else(|| Error::new(ErrorCode::ValueOutOfRange, "condition wait deadline overflow"))
+}
+
+/// Drives the process-private mutex and condition variable identified by [`MC_MUTEX_SLOT`] and
+/// [`MC_COND_SLOT`], proving they are functional in the calling process.
+///
+/// Performs a canonical lock / wait / unlock / signal cycle:
+///
+/// 1. Locks the mutex.  A duplicated process must be able to acquire it without deadlocking.
+/// 2. Reads the mutex-guarded byte [`SHARED_BYTE`] under the lock and remembers it.
+/// 3. Waits on the condition variable with [`COND_WAIT_TIMEOUT`].  Because no other thread in this
+///    process signals it, the wait must elapse and report [`ErrorCode::OperationTimedOut`].  This
+///    also proves the mutex/condition coupling: the kernel atomically releases the mutex on entry
+///    and reacquires it before returning.
+/// 4. Writes `write_value` to the guarded byte, still under the reacquired lock, taking a private
+///    copy-on-write page.
+/// 5. Unlocks the mutex.
+/// 6. Signals the condition variable.  With no waiters, exactly zero threads must be awakened.
+///
+/// Returns the value observed in step 2.
+fn exercise_mutex_condvar(write_value: u8) -> Result<u8, Error> {
+    let mutex: MutexAddress = mc_mutex_addr();
+    let cond: ConditionAddress = mc_cond_addr();
+
+    // Step 1: acquire the inherited mutex.
+    pm::__kcall_lock_mutex(mutex, None)?;
+
+    // Step 2: observe the guarded data under the lock.
+    let observed: u8 = SHARED_BYTE.load(ORDER);
+
+    // Step 3: wait on the condition variable; with no signaler in this process it must time out.
+    let deadline: SystemTime = cond_wait_deadline()?;
+    match pm::__kcall_wait_cond(cond, mutex, Some(deadline)) {
+        Err(e) if e.code == ErrorCode::OperationTimedOut => {},
+        Err(e) => return Err(Error::new(e.code, "wait_cond returned an unexpected error")),
+        Ok(()) => {
+            return Err(Error::new(
+                ErrorCode::OperationNotPermitted,
+                "wait_cond returned without a signal; expected a timeout",
+            ))
+        },
+    }
+
+    // Step 4: take a private copy of the guarded data, still holding the reacquired lock.
+    SHARED_BYTE.store(write_value, ORDER);
+
+    // Step 5: release the mutex.
+    pm::__kcall_unlock_mutex(mutex)?;
+
+    // Step 6: signal the condition variable; with no waiters, zero threads must wake.
+    let awakened: usize = pm::__kcall_signal_cond(cond, false)?;
+    if awakened != 0 {
+        return Err(Error::new(
+            ErrorCode::OperationNotPermitted,
+            "signal_cond awakened a thread when none were waiting",
+        ));
+    }
+
+    Ok(observed)
+}
+
+/// Entry point for the child spawned by [`test_duplicate_mutex_condvar`].
+///
+/// The child invalidates the inherited pid cache, synchronizes with the parent over IPC, drives
+/// the inherited mutex and condition variable, and reports the outcome back to the parent.  It then
+/// spins until the parent terminates it (mirroring [`child_entry`]).
+extern "C" fn child_entry_mutex_condvar(_arg: usize) -> usize {
+    // Drop the parent's cached pid inherited through the duplicated address space.
+    pm::invalidate_cached_pid();
+
+    // Run the child scenario.  Its result is reported to the parent over IPC inside the helper and
+    // the parent drives termination regardless, so any error here is intentionally discarded.
+    let _ = child_mutex_condvar_report();
+
+    // Spin until the parent terminates us.
+    loop {
+        let _ = sched::__kcall_sched_yield();
+    }
+}
+
+/// Synchronizes with the parent, drives the inherited synchronization primitives, and reports the
+/// result to the parent over IPC.
+///
+/// The payload carries a status byte ([`MC_CHILD_OK`] or [`MC_CHILD_FAIL`]) followed by the byte
+/// observed before and after the child's own write, so a failure surfaces as a deterministic
+/// assertion in the parent rather than as a hang.
+fn child_mutex_condvar_report() -> Result<(), Error> {
+    let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
+    let parent_pid: ProcessIdentifier = ProcessIdentifier::try_from(PARENT_PID_RAW.load(ORDER))?;
+
+    // Barrier: block until the parent signals that its post-duplicate write has completed.
+    ipc::__kcall_recv()?;
+
+    // Drive the inherited mutex and condition variable, taking a private copy via PATTERN_CHILD.
+    let (status, observed_before, observed_after): (u8, u8, u8) =
+        match exercise_mutex_condvar(PATTERN_CHILD) {
+            Ok(observed) => (MC_CHILD_OK, observed, SHARED_BYTE.load(ORDER)),
+            Err(_) => (MC_CHILD_FAIL, 0, 0),
+        };
+
+    // Report observations to the parent.
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+    payload[0] = status;
+    payload[1] = observed_before;
+    payload[2] = observed_after;
+    let reply: Message = Message::new(
+        MessageSender::from(my_pid),
+        MessageReceiver::from(parent_pid),
+        MessageType::Ipc,
+        None,
+        payload,
+    );
+    ipc::__kcall_send(&reply)?;
+
+    Ok(())
+}
+
+/// Verifies that a process owning a mutex and a condition variable is correctly duplicated by
+/// `duplicate()`, conforming to the POSIX `fork()` contract
+/// (<https://pubs.opengroup.org/onlinepubs/9799919799/functions/fork.html>).
+///
+/// POSIX requires the child to be a single-threaded replica of the calling thread and its entire
+/// address space, "possibly including the states of mutexes and other resources", and that the
+/// parent and child be able to execute independently afterwards.  It further specifies that, for a
+/// non-process-shared lock *held* by the parent at fork time, any operation by the child on that
+/// lock is undefined behavior.  This test therefore stays within the well-defined regime: the
+/// parent establishes and exercises the mutex and condition variable but does **not** hold the
+/// lock across `duplicate()`.  After duplication, each process independently drives its own
+/// process-private mutex and condition variable through a full lock / wait / unlock / signal cycle.
+///
+/// The mutex-guarded byte additionally validates the POSIX MAP_PRIVATE (copy-on-write) data rules:
+/// the value written before `duplicate()` is visible to the child, while each side's later writes
+/// remain private to itself.
+///
+/// Sequence:
+///
+/// 1. The parent primes the guarded byte with [`PATTERN_INIT`] and exercises the mutex and
+///    condition variable once (registering and releasing them) before duplicating.
+/// 2. `duplicate()` creates the child, which runs [`child_entry_mutex_condvar`].
+/// 3. The parent drives its own mutex and condition variable, writing [`PATTERN_PARENT`], then
+///    releases the child over IPC.
+/// 4. The child drives its inherited mutex and condition variable, observing the guarded byte
+///    (which must still read [`PATTERN_INIT`]) and writing [`PATTERN_CHILD`].
+/// 5. The parent asserts the child succeeded, that copy-on-write isolation held in both
+///    directions, and tears the child down.
+fn test_duplicate_mutex_condvar() -> Result<(), Error> {
+    // Record the parent's PID where the child can find it via copy-on-write memory.
+    let parent_pid: ProcessIdentifier = pm::getpid_uncached()?;
+    PARENT_PID_RAW.store(u32::try_from(parent_pid)?, ORDER);
+
+    // Prime the guarded byte with the pre-duplicate pattern while the page is still private.
+    SHARED_BYTE.store(PATTERN_INIT, ORDER);
+
+    // Establish ownership of the mutex and condition variable in the parent before duplicating: a
+    // lock/unlock pair plus a no-waiter signal registers and exercises them.  The lock is released
+    // here so that the child never operates on a parent-held non-process-shared lock, which POSIX
+    // declares to be undefined behavior.
+    pm::__kcall_lock_mutex(mc_mutex_addr(), None)?;
+    pm::__kcall_unlock_mutex(mc_mutex_addr())?;
+    let _: usize = pm::__kcall_signal_cond(mc_cond_addr(), false)?;
+
+    // Allocate a page-aligned stack for the child's main thread.
+    let layout: Layout = Layout::from_size_align(CHILD_STACK_SIZE, PAGE_SIZE)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "bad stack layout"))?;
+    // SAFETY: layout has non-zero size.
+    let stack_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
+    if stack_ptr.is_null() {
+        return Err(Error::new(ErrorCode::OutOfMemory, "failed to allocate child stack"));
+    }
+    let stack_base: VirtualAddress = VirtualAddress::from_raw_value(stack_ptr as usize);
+
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(child_entry_mutex_condvar as *const () as usize),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: stack_base,
+        user_stack_size: CHILD_STACK_SIZE,
+        user_tda: None,
+    };
+
+    // Duplicate the calling process.
+    let child_pid: ProcessIdentifier = pm::__kcall_duplicate(&args)?;
+
+    // Run the observation scenario, capturing its result so the child and its stack are always
+    // reclaimed afterwards.
+    let scenario: Result<(), Error> = (|| {
+        assert!(child_pid != parent_pid, "child_pid must differ from parent_pid");
+
+        // The parent drives its own independent mutex and condition variable, taking a private copy
+        // via PATTERN_PARENT.
+        let parent_observed_before: u8 = exercise_mutex_condvar(PATTERN_PARENT)?;
+        assert!(
+            parent_observed_before == PATTERN_INIT,
+            "parent observed {:#x} before its own write; expected {:#x}",
+            parent_observed_before,
+            PATTERN_INIT
+        );
+
+        // Release the child to perform its observation and write.
+        let go: Message = Message::new(
+            MessageSender::from(parent_pid),
+            MessageReceiver::from(child_pid),
+            MessageType::Ipc,
+            None,
+            [0u8; Message::PAYLOAD_SIZE],
+        );
+        ipc::__kcall_send(&go)?;
+
+        // Receive the child's report.
+        let reply: Message = ipc::__kcall_recv()?;
+        let reply_type: MessageType = { reply.message_type };
+        assert!(reply_type == MessageType::Ipc, "expected IPC reply");
+
+        let child_status: u8 = reply.payload[0];
+        let child_observed_before: u8 = reply.payload[1];
+        let child_observed_after: u8 = reply.payload[2];
+        let parent_observed: u8 = SHARED_BYTE.load(ORDER);
+
+        // The child must have driven the inherited mutex and condition variable successfully.
+        assert!(
+            child_status == MC_CHILD_OK,
+            "child failed to exercise the inherited mutex/condition variable (status={:#x})",
+            child_status
+        );
+        // CoW invariant 1: the parent's post-duplicate write is invisible to the child.
+        assert!(
+            child_observed_before == PATTERN_INIT,
+            "child observed {:#x} before its own write; expected {:#x} (parent->child isolation \
+             broken)",
+            child_observed_before,
+            PATTERN_INIT
+        );
+        // The child's own write under the lock must be visible to itself.
+        assert!(
+            child_observed_after == PATTERN_CHILD,
+            "child observed {:#x} after its own write; expected {:#x}",
+            child_observed_after,
+            PATTERN_CHILD
+        );
+        // CoW invariant 2: the child's write is invisible to the parent.
+        assert!(
+            parent_observed == PATTERN_PARENT,
+            "parent observed {:#x} after child's write; expected {:#x} (child->parent isolation \
+             broken)",
+            parent_observed,
+            PATTERN_PARENT
+        );
+
+        Ok(())
+    })();
+
+    // Acquire the process-management capability to terminate the child, tear it down, then release
+    // it.  Mirrors the teardown used by the other duplicate tests: the capability is released only
+    // when this path acquired it, and `ResourceBusy` means it is already held.
+    let acquired: Result<bool, Error> =
+        match pm::__kcall_capctl(Capability::ProcessManagement, true) {
+            Ok(()) => Ok(true),
+            Err(e) if e.code == ErrorCode::ResourceBusy => Ok(false),
+            Err(e) => Err(e),
+        };
+    let teardown: Result<(), Error> = match acquired {
+        Ok(acquired) => {
+            let terminate: Result<(), Error> = pm::__kcall_terminate(child_pid);
+            let release: Result<(), Error> = if acquired {
+                pm::__kcall_capctl(Capability::ProcessManagement, false)
+            } else {
+                Ok(())
+            };
+            terminate.and(release)
+        },
+        Err(e) => Err(e),
+    };
+
+    // Reclaim the child stack only once teardown confirmed the child was terminated; otherwise the
+    // child may still be running on it, so leak the stack rather than risk a use-after-free.
+    if teardown.is_ok() {
+        // SAFETY: `stack_ptr`/`layout` came from the matching `alloc::alloc::alloc` above and the
+        // child has been terminated, so it no longer references these stack pages.
+        unsafe { ::alloc::alloc::dealloc(stack_ptr, layout) };
+    }
+
+    scenario.and(teardown)
+}
+
+//==================================================================================================
 // Public Entry Point
 //==================================================================================================
 
@@ -455,6 +790,9 @@ pub fn run() -> Result<(), Error> {
 
     test_duplicate_cow_refork()?;
     ::syslog::info!("test-kernel: duplicate: PASS - duplicate_cow_refork");
+
+    test_duplicate_mutex_condvar()?;
+    ::syslog::info!("test-kernel: duplicate: PASS - duplicate_mutex_condvar");
 
     ::syslog::info!("test-kernel: duplicate: all tests passed");
 


### PR DESCRIPTION
## Summary

Fixes a post-`fork()` crash where a child that re-initializes inherited synchronization
objects (e.g. CPython's `PyOS_AfterFork_Child` resetting the GIL via `pthread_mutex_init`/
`pthread_cond_init`) died with a fatal error, and adds regression coverage for mutex/condition
variable duplication across both `duplicate()` and `fork()`.

## Changes

- **[syscall] Idempotent pthread mutex/cond init.** `pthread_mutex_init`/`pthread_cond_init`
  now overwrite an existing userspace registry entry instead of returning `EINVAL`/`EBUSY`.
  The address-keyed userspace registry (`MUTEXES`/`CONDITIONS`) is inherited copy-on-write
  across `fork()`, while the kernel intentionally drops and lazily recreates the per-process
  objects; making init idempotent keeps the two layers consistent. POSIX leaves
  re-initialization of an initialized object undefined and glibc/musl tolerate it; Nanvix
  defines it as a reset, consistent with its lazy, kernel-backed model.
- **[tests] fork/duplicate mutex+condvar tests.**
  - `test-kernel` → `test_duplicate_mutex_condvar`: raw-kcall test that a process owning a
    mutex and condition variable is correctly duplicated by `duplicate()`, with copy-on-write
    data isolation in both directions, per the POSIX `fork()` contract.
  - `test-fork-kcall` → `test_fork_mutex_condvar`: drives the userspace pthread interface and
    has the child re-initialize the inherited objects (the CPython pattern). This
    deterministically reproduces the bug without CPython — red before the fix (child
    `pthread_mutex_init` → `EINVAL`/22), green after.

## Verification

- `format-check`, build, and clippy (`-D warnings`) pass for both test crates.
- Standalone integration run (HTTP + terminal executors): all green with the fix applied;
  `test_fork_mutex_condvar` reproduces the failure (VM exit 3, `EINVAL`=22) when the fix is
  reverted.

## Follow-up

The shipped change is the minimal, POSIX-conformant fix (re-initialization of an initialized
object is undefined behavior, and the recommended `EBUSY` is informative only). More robust
long-term designs — registry as a pure lazy cache, self-contained objects (the glibc/musl
model), or generation/epoch tagging to restore the recommended `EBUSY` double-init diagnostic
— are tracked as a follow-up in #2612.

Relates to #2606.
