### PR TITLE
[uservm] Decouple vmbus stdout from WHP lock

### DIFF
--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -829,6 +829,14 @@ pub fn build_input_fn(
 /// A boxed closure compatible with the VMM's stdout handler implementation.
 ///
 pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
+    // On Windows/WHP the closure below runs on the vCPU thread while it holds the WHP partition
+    // lock (held across `Emulator::handle_pmio_access()`). Sending directly on the bounded channel
+    // there would block the vCPU thread under the lock whenever the asynchronous consumer is
+    // momentarily starved, freezing the guest (issue #2603). `IkcStdoutSink` interposes a dedicated
+    // forwarding thread on Windows so the under-lock enqueue never blocks (lossless hand-off;
+    // back-pressure applied off the partition lock). On Linux the frames are sent directly.
+    let sink: crate::pal::IkcStdoutSink = crate::pal::IkcStdoutSink::new(queue);
+
     // Output function used for emulating I/O port writes.
     let output =
         move |vm: &Arc<Mutex<VirtualMemory>>, envelope: &::sys::ipc::VmBusMessage| -> Result<()> {
@@ -858,7 +866,7 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
                 );
 
                 trace!("output(): forwarding message to system VM");
-                if let Err(e) = queue.blocking_send(IkcFrame::Message(message)) {
+                if let Err(e) = sink.send(IkcFrame::Message(message)) {
                     let reason: String = format!("failed to send message: {e:?}");
                     error!("output(): {reason}");
                     anyhow::bail!(reason);
@@ -892,7 +900,7 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
                 let bulk: DataChunk = DataChunk::new(header, data);
 
                 trace!("output(): forwarding data chunk transfer ({data_len} bytes)");
-                if let Err(e) = queue.blocking_send(IkcFrame::Bulk(bulk)) {
+                if let Err(e) = sink.send(IkcFrame::Bulk(bulk)) {
                     let reason: String = format!("failed to send data chunk transfer: {e:?}");
                     error!("output(): {reason}");
                     anyhow::bail!(reason);

--- a/src/uservm/src/pal/linux.rs
+++ b/src/uservm/src/pal/linux.rs
@@ -27,6 +27,8 @@ use ::std::{
     ptr,
     slice,
 };
+use ::sys::ipc::IkcFrame;
+use ::tokio::sync::mpsc::Sender;
 
 //==================================================================================================
 // Structures
@@ -546,6 +548,65 @@ fn page_size() -> usize {
         size
     });
     *PAGE_SIZE
+}
+
+//==================================================================================================
+// IKC Stdout Sink
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Hands guest IKC (application/stdout) frames to the asynchronous I/O consumer over a bounded
+/// channel.
+///
+/// On Linux/KVM the frame is sent directly on the bounded channel: a full channel applies
+/// back-pressure by blocking the caller, as before. The KVM backend does not hold a partition-wide
+/// lock across the guest I/O exit, so this blocking does not freeze the guest (contrast with the
+/// Windows/WHP path; see issue #2603 and the Windows `IkcStdoutSink`).
+///
+pub struct IkcStdoutSink {
+    /// Bounded channel used to forward IKC frames to the asynchronous I/O consumer.
+    queue: Sender<IkcFrame>,
+}
+
+impl IkcStdoutSink {
+    ///
+    /// # Description
+    ///
+    /// Builds a sink around the bounded `queue`.
+    ///
+    /// # Parameters
+    ///
+    /// - `queue`: Bounded channel used to forward IKC frames to the asynchronous I/O consumer.
+    ///
+    /// # Returns
+    ///
+    /// A new [`IkcStdoutSink`].
+    ///
+    pub fn new(queue: Sender<IkcFrame>) -> Self {
+        Self { queue }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Forwards a single IKC frame to the consumer, blocking the caller while the bounded channel
+    /// is full (back-pressure).
+    ///
+    /// # Parameters
+    ///
+    /// - `frame`: IKC frame emitted by the guest.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` once the frame has been accepted, or an error if the consumer has gone away.
+    ///
+    pub fn send(&self, frame: IkcFrame) -> Result<()> {
+        self.queue
+            .blocking_send(frame)
+            .map_err(|e| ::anyhow::anyhow!("channel closed: {e}"))
+    }
 }
 
 //==================================================================================================

--- a/src/uservm/src/pal/windows.rs
+++ b/src/uservm/src/pal/windows.rs
@@ -17,13 +17,34 @@ use ::log::{
     warn,
 };
 use ::std::{
+    collections::VecDeque,
     fs::{
         self,
         File,
     },
     os::windows::io::AsRawHandle,
     path::Path,
+    sync::{
+        Arc,
+        Condvar,
+        Mutex,
+        MutexGuard,
+    },
+    thread::{
+        self,
+        JoinHandle,
+    },
+    time::{
+        Duration,
+        Instant,
+    },
 };
+use ::sys::ipc::{
+    DataChunkHeader,
+    IkcFrame,
+    Message,
+};
+use ::tokio::sync::mpsc::Sender;
 use ::windows::Win32::{
     Foundation::{
         CloseHandle,
@@ -219,6 +240,304 @@ impl Drop for FileMapping {
 }
 
 //==================================================================================================
+// IKC Stdout Sink
+//==================================================================================================
+
+/// Upper bound on how long [`IkcStdoutSink`]'s drop handler waits for the drain thread to flush and
+/// stop before detaching it. A wedged drain thread (blocked in a host send against a consumer that
+/// never drains) must not block VM teardown.
+const DRAIN_JOIN_GRACE: Duration = Duration::from_secs(2);
+
+/// Maximum host memory budget used by [`IkcStdoutSink`] for IKC frames that have been accepted by
+/// the producer but not yet handed to the downstream bounded channel.
+const IKC_SINK_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+
+///
+/// # Description
+///
+/// State shared between the producer (vCPU thread) and the drain thread.
+///
+struct IkcSinkState {
+    /// IKC frames awaiting hand-off to the bounded channel.
+    data: VecDeque<IkcFrame>,
+    /// Total accounted bytes accepted by the producer but not yet handed to the bounded channel.
+    buffered_bytes: usize,
+    /// Set when the producer is shutting down; the drain thread flushes then exits.
+    closing: bool,
+    /// Set once the drain thread has stopped (clean exit or the downstream channel closed).
+    stopped: bool,
+}
+
+///
+/// # Description
+///
+/// Synchronization primitives shared with the drain thread.
+///
+struct IkcSinkChannel {
+    /// Shared mutable state.
+    state: Mutex<IkcSinkState>,
+    /// Signaled when a frame is enqueued or `closing` is set.
+    nonempty: Condvar,
+    /// Signaled when the drain thread stops.
+    stopped: Condvar,
+}
+
+///
+/// # Description
+///
+/// Decouples the guest's vmbus stdout (application/IKC) output path from the WHP partition lock.
+///
+/// On Windows/WHP the vCPU run loop holds the partition lock across
+/// `Emulator::handle_pmio_access()`. For a guest `write()` (vmbus stdout port, Dword width) that
+/// call invokes the closure built by `output_fn()`, which forwards the IKC frame to the
+/// asynchronous I/O consumer over a bounded channel. Sending directly with
+/// [`Sender::blocking_send()`] blocks the vCPU thread while it holds the partition lock whenever
+/// the consumer is momentarily starved (for example a tokio task starved under heavy host load on
+/// Windows), freezing the guest — see issue #2603. This is the same coupling that issue #2579 /
+/// PR #2583 fixed for the per-byte console path (port `0xE9`).
+///
+/// [`IkcStdoutSink`] breaks this coupling for the application path: [`IkcStdoutSink::send()`] only
+/// appends the frame to a budgeted in-process queue and returns immediately (it never blocks),
+/// while a dedicated drain thread drains the queue to the bounded channel off the partition lock.
+/// Back-pressure is therefore applied to the drain thread, never to the vCPU thread, so the guest
+/// is never gated on the host's ability to drain the channel. If the consumer remains starved long
+/// enough to exhaust the in-process budget, `send()` returns an error instead of growing host
+/// memory without bound.
+///
+pub struct IkcStdoutSink {
+    /// Shared channel between the producer and the drain thread.
+    channel: Arc<IkcSinkChannel>,
+    /// Handle to the drain thread, joined on drop.
+    handle: Option<JoinHandle<()>>,
+}
+
+impl IkcSinkChannel {
+    ///
+    /// # Description
+    ///
+    /// Locks the shared state, recovering the guard if the mutex was poisoned.
+    ///
+    /// # Returns
+    ///
+    /// A guard for the shared state.
+    ///
+    fn lock(&self) -> MutexGuard<'_, IkcSinkState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl IkcStdoutSink {
+    ///
+    /// # Description
+    ///
+    /// Wraps `queue` so that IKC frames are decoupled from the caller's lock. A dedicated thread
+    /// owns `queue` and performs the (potentially blocking) [`Sender::blocking_send()`].
+    ///
+    /// # Parameters
+    ///
+    /// - `queue`: Bounded channel to which buffered frames are forwarded.
+    ///
+    /// # Returns
+    ///
+    /// A new [`IkcStdoutSink`].
+    ///
+    pub fn new(queue: Sender<IkcFrame>) -> Self {
+        let channel: Arc<IkcSinkChannel> = Arc::new(IkcSinkChannel {
+            state: Mutex::new(IkcSinkState {
+                data: VecDeque::new(),
+                buffered_bytes: 0,
+                closing: false,
+                stopped: false,
+            }),
+            nonempty: Condvar::new(),
+            stopped: Condvar::new(),
+        });
+
+        let drain_channel: Arc<IkcSinkChannel> = channel.clone();
+        let handle: Option<JoinHandle<()>> = match thread::Builder::new()
+            .name("nanvix-ikc".to_string())
+            .spawn(move || drain_loop(&drain_channel, queue))
+        {
+            Ok(handle) => Some(handle),
+            // If the drain thread could not be spawned, log the underlying I/O error and mark the
+            // sink stopped so that `send()` surfaces the failure instead of buffering frames
+            // forever behind a thread that does not exist.
+            Err(e) => {
+                error!("IkcStdoutSink::new(): failed to spawn IKC drain thread: {e}");
+                channel.lock().stopped = true;
+                None
+            },
+        };
+
+        Self { channel, handle }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Appends a frame to the in-process queue for the drain thread. This never blocks, so the vCPU
+    /// thread is never stalled on host I/O while it holds the partition lock.
+    ///
+    /// # Parameters
+    ///
+    /// - `frame`: IKC frame emitted by the guest.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` once the frame has been queued, or an error if the drain thread has stopped because
+    /// the downstream consumer went away or if the in-process queue budget is exhausted.
+    ///
+    pub fn send(&self, frame: IkcFrame) -> Result<()> {
+        let mut state: MutexGuard<'_, IkcSinkState> = self.channel.lock();
+
+        // If the drain thread is gone, the downstream consumer has closed; surface the failure so
+        // the emulator unwinds, matching the prior `blocking_send()` error behavior.
+        if state.stopped {
+            anyhow::bail!("IKC stdout sink drain thread has stopped (downstream closed)");
+        }
+
+        let frame_size: usize = frame_size_bytes(&frame);
+        if frame_size > IKC_SINK_BUDGET_BYTES
+            || state.buffered_bytes > IKC_SINK_BUDGET_BYTES - frame_size
+        {
+            anyhow::bail!(
+                "IKC stdout sink queue budget exceeded (buffered_bytes={}, frame_bytes={}, \
+                 budget_bytes={})",
+                state.buffered_bytes,
+                frame_size,
+                IKC_SINK_BUDGET_BYTES
+            );
+        }
+
+        let was_empty: bool = state.data.is_empty();
+        state.buffered_bytes += frame_size;
+        state.data.push_back(frame);
+        drop(state);
+
+        // Wake the drain thread only on an empty -> non-empty transition: while the queue is
+        // non-empty the drain thread is guaranteed to revisit it without an explicit wakeup.
+        if was_empty {
+            self.channel.nonempty.notify_one();
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for IkcStdoutSink {
+    fn drop(&mut self) {
+        // Signal shutdown and wake the drain thread so it flushes buffered frames.
+        self.channel.lock().closing = true;
+        self.channel.nonempty.notify_one();
+
+        // Wait briefly for the drain thread to finish flushing. If it is wedged in a blocking send
+        // against a consumer that never drains, do NOT block teardown on it: leave it detached so
+        // that process exit reclaims it. Joining unconditionally here would reintroduce the very
+        // hang this sink exists to prevent.
+        let stopped: bool = {
+            let mut state: MutexGuard<'_, IkcSinkState> = self.channel.lock();
+            let deadline: Instant = Instant::now() + DRAIN_JOIN_GRACE;
+            while !state.stopped {
+                let now: Instant = Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                let (guard, _timeout) = self
+                    .channel
+                    .stopped
+                    .wait_timeout(state, deadline - now)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                state = guard;
+            }
+            state.stopped
+        };
+
+        if stopped {
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        } else {
+            warn!(
+                "IkcStdoutSink: IKC drain thread still busy at shutdown; detaching to avoid \
+                 blocking VM teardown"
+            );
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Drains buffered frames to `downstream` until the sink is closing and the queue is empty.
+///
+/// # Parameters
+///
+/// - `channel`: Shared channel between the producer and the drain thread.
+/// - `downstream`: Bounded channel owned by the drain thread.
+///
+fn drain_loop(channel: &Arc<IkcSinkChannel>, downstream: Sender<IkcFrame>) {
+    let mut scratch: Vec<IkcFrame> = Vec::new();
+    loop {
+        let mut state: MutexGuard<'_, IkcSinkState> = channel.lock();
+        while state.data.is_empty() && !state.closing {
+            state = channel
+                .nonempty
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        if state.data.is_empty() && state.closing {
+            state.stopped = true;
+            channel.stopped.notify_all();
+            return;
+        }
+        scratch.clear();
+        scratch.extend(state.data.drain(..));
+        drop(state);
+
+        // Forward the batch off the lock. Each `blocking_send()` may block while the bounded
+        // channel is full, applying back-pressure here instead of on the vCPU thread.
+        for frame in scratch.drain(..) {
+            let frame_size: usize = frame_size_bytes(&frame);
+            if downstream.blocking_send(frame).is_err() {
+                // Downstream consumer is gone; nothing more can be delivered.
+                let mut state: MutexGuard<'_, IkcSinkState> = channel.lock();
+                state.stopped = true;
+                channel.stopped.notify_all();
+                drop(state);
+                warn!("IkcStdoutSink: downstream channel closed; remaining IKC frames discarded");
+                return;
+            }
+
+            let mut state: MutexGuard<'_, IkcSinkState> = channel.lock();
+            state.buffered_bytes = state.buffered_bytes.saturating_sub(frame_size);
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Returns the number of host bytes charged against [`IkcStdoutSink`]'s in-process budget for
+/// `frame`.
+///
+/// # Parameters
+///
+/// - `frame`: IKC frame to account.
+///
+/// # Returns
+///
+/// The fixed IKC message size or the data chunk header plus payload size.
+///
+fn frame_size_bytes(frame: &IkcFrame) -> usize {
+    match frame {
+        IkcFrame::Message(_) => ::std::mem::size_of::<Message>(),
+        IkcFrame::Bulk(chunk) => DataChunkHeader::SIZE + chunk.data().len(),
+    }
+}
+
+//==================================================================================================
 // Tests
 //==================================================================================================
 
@@ -290,5 +609,199 @@ mod tests {
     fn open_returns_error_for_missing_file() {
         let result: Result<FileMapping> = FileMapping::open("/non/existent/path/to/file");
         assert!(result.is_err());
+    }
+}
+
+//==================================================================================================
+// IKC Stdout Sink Tests
+//==================================================================================================
+
+/// Unit tests for the asynchronous IKC stdout sink.
+///
+/// These reproduce the issue #2603 hang mechanism deterministically and verify that the sink
+/// decouples the producer from back-pressure without dropping or reordering frames.
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod ikc_tests {
+    use super::{
+        IKC_SINK_BUDGET_BYTES,
+        IkcStdoutSink,
+    };
+    use ::std::{
+        sync::{
+            Arc,
+            mpsc as std_mpsc,
+        },
+        thread,
+        time::Duration,
+    };
+    use ::sys::{
+        ipc::{
+            DataChunk,
+            DataChunkHeader,
+            IkcFrame,
+            Message,
+        },
+        pm::{
+            ProcessIdentifier,
+            ThreadIdentifier,
+        },
+    };
+    use ::tokio::sync::mpsc;
+
+    /// Builds an IKC message frame tagged with a sequence number in its payload prefix.
+    fn message_frame(seq: u32) -> IkcFrame {
+        let mut message: Message = Message::default();
+        message.payload[..4].copy_from_slice(&seq.to_le_bytes());
+        IkcFrame::Message(message)
+    }
+
+    /// Extracts the sequence number from a frame produced by [`message_frame`].
+    fn seq_of(frame: &IkcFrame) -> Option<u32> {
+        match frame {
+            IkcFrame::Message(message) => {
+                let bytes: [u8; 4] = message.payload[..4].try_into().expect("4 payload bytes");
+                Some(u32::from_le_bytes(bytes))
+            },
+            IkcFrame::Bulk(_) => None,
+        }
+    }
+
+    /// Builds a data chunk frame with `bytes` payload bytes.
+    fn bulk_frame(bytes: usize) -> IkcFrame {
+        let data_len: u32 = u32::try_from(bytes).expect("payload length fits in u32");
+        let header: DataChunkHeader = DataChunkHeader::new(
+            ProcessIdentifier::from(0),
+            ThreadIdentifier::from(0),
+            ProcessIdentifier::from(0),
+            ThreadIdentifier::from(0),
+            0,
+            data_len,
+        );
+        IkcFrame::Bulk(DataChunk::new(header, vec![0u8; bytes]))
+    }
+
+    /// Reproduces the issue #2603 mechanism at the channel level: a direct `blocking_send()` on a
+    /// full bounded channel blocks the caller indefinitely while the consumer is starved. In the
+    /// buggy code this call ran on the vCPU thread while it held the WHP partition lock, freezing
+    /// the guest. [`IkcStdoutSink`] (exercised by the next test) breaks this coupling.
+    #[test]
+    fn direct_blocking_send_blocks_when_full_reproducing_the_bug() {
+        let (tx, rx) = mpsc::channel::<IkcFrame>(1);
+        tx.blocking_send(message_frame(0))
+            .expect("first send fits in the channel");
+
+        let (done_tx, done_rx) = std_mpsc::channel::<()>();
+        let sender = thread::spawn(move || {
+            // No consumer drains `rx`, so this second send blocks until the channel is closed.
+            let _ = tx.blocking_send(message_frame(1));
+            let _ = done_tx.send(());
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(500)).is_err(),
+            "blocking_send unexpectedly returned on a full channel; the bug repro is invalid",
+        );
+
+        // Closing the channel releases the blocked sender so the helper thread can exit.
+        drop(rx);
+        sender.join().expect("join sender thread");
+    }
+
+    /// The sink's producer-side `send()` must never block, even when the downstream channel is full
+    /// and nothing is consuming it. This is the behavior that fixes issue #2603.
+    #[test]
+    fn producer_never_blocks_when_downstream_full_and_consumer_starved() {
+        const FRAMES: u32 = 1000;
+        let total: usize = usize::try_from(FRAMES).expect("frame count fits in usize");
+
+        // Tiny downstream capacity with no initial consumer: the drain thread blocks after filling
+        // it, modeling a starved consumer under heavy host load.
+        let (tx, mut rx) = mpsc::channel::<IkcFrame>(2);
+        let sink: Arc<IkcStdoutSink> = Arc::new(IkcStdoutSink::new(tx));
+
+        let producer_sink: Arc<IkcStdoutSink> = sink.clone();
+        let (done_tx, done_rx) = std_mpsc::channel::<()>();
+        let producer = thread::spawn(move || {
+            for seq in 0..FRAMES {
+                producer_sink
+                    .send(message_frame(seq))
+                    .expect("send must not fail while the consumer is alive");
+            }
+            let _ = done_tx.send(());
+        });
+
+        // If `send()` blocked under back-pressure (the bug), this would time out.
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("producer blocked under back-pressure (regression of issue #2603)");
+        producer.join().expect("join producer thread");
+
+        // Draining the downstream now must yield every frame, in order: the hand-off is lossless.
+        let mut received: Vec<u32> = Vec::with_capacity(total);
+        while received.len() < total {
+            let frame: IkcFrame = rx
+                .blocking_recv()
+                .expect("sink dropped before delivering all frames");
+            if let Some(seq) = seq_of(&frame) {
+                received.push(seq);
+            }
+        }
+        let expected: Vec<u32> = (0..FRAMES).collect();
+        assert_eq!(received, expected, "frames must be delivered losslessly and in order");
+
+        drop(sink);
+    }
+
+    /// Frames still buffered when the sink is dropped must be flushed to the downstream before the
+    /// channel closes, so application output emitted just before shutdown is not lost.
+    #[test]
+    fn drop_flushes_all_buffered_frames_in_order() {
+        const FRAMES: u32 = 256;
+        let (tx, mut rx) = mpsc::channel::<IkcFrame>(4);
+        let sink: IkcStdoutSink = IkcStdoutSink::new(tx);
+        for seq in 0..FRAMES {
+            sink.send(message_frame(seq)).expect("send");
+        }
+
+        // Collect on a separate thread so the drain thread can make progress (the small channel
+        // blocks it) while the sink is being dropped and flushed.
+        let collector = thread::spawn(move || {
+            let mut received: Vec<u32> = Vec::new();
+            while let Some(frame) = rx.blocking_recv() {
+                if let Some(seq) = seq_of(&frame) {
+                    received.push(seq);
+                }
+            }
+            received
+        });
+
+        // Dropping the sink flushes the backlog and then drops the downstream sender, which ends
+        // the collector's stream.
+        drop(sink);
+
+        let received: Vec<u32> = collector.join().expect("join collector thread");
+        let expected: Vec<u32> = (0..FRAMES).collect();
+        assert_eq!(received, expected, "drop must flush all buffered frames in order");
+    }
+
+    /// The sink's producer-side queue is budgeted: if the downstream channel is full and the
+    /// consumer remains starved, `send()` must fail cleanly instead of buffering guest bulk writes
+    /// until the host process runs out of memory.
+    #[test]
+    fn producer_fails_when_in_process_budget_is_exhausted() {
+        let (tx, rx) = mpsc::channel::<IkcFrame>(1);
+        tx.blocking_send(message_frame(0))
+            .expect("pre-fill downstream channel");
+        let sink: IkcStdoutSink = IkcStdoutSink::new(tx);
+
+        sink.send(bulk_frame(IKC_SINK_BUDGET_BYTES - DataChunkHeader::SIZE))
+            .expect("first frame exactly consumes the budget");
+
+        let result = sink.send(message_frame(1));
+        assert!(result.is_err(), "send past the budget must fail");
+
+        drop(rx);
+        drop(sink);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Windows/WHP guest freeze described in #2603 (follow-up to #2579 / #2583).

On Windows/WHP the vCPU run loop holds the partition lock across `Emulator::handle_pmio_access()`. For a guest `write()` on the vmbus stdout port, that path forwarded the IKC frame with a **blocking** send on the bounded `vcpu_thread_stdout_tx` channel **while the lock was held**. Under heavy host load the asynchronous consumer is starved, the channel fills, the blocking send parks the vCPU thread under the lock, and the guest freezes. This is the application/IKC analog of the console-path (`0xE9`) freeze fixed by #2583.

## Changes

- **`pal/windows.rs` — `IkcStdoutSink`:** hands frames to a dedicated `nanvix-ikc` drain thread via an in-process queue. `send()` only appends and returns immediately, so the under-lock enqueue never blocks; the drain thread performs the blocking send to the bounded channel **off** the partition lock. Lossless under normal back-pressure but bounded by a **64 MiB** budget (`IKC_SINK_BUDGET_BYTES`): if a starved consumer exhausts it, `send()` returns an error rather than growing host memory without bound. `Drop` flushes the backlog (join with a 2s grace, detach if wedged) so output emitted just before shutdown is still delivered.
- **`pal/linux.rs` — `IkcStdoutSink`:** sends directly on the bounded channel (unchanged blocking back-pressure). KVM does not hold a partition-wide lock across the guest I/O exit, so this does not freeze the guest.
- **`lib.rs`:** `output_fn` now routes the message and bulk sends through `crate::pal::IkcStdoutSink`.

## Tests

New Windows unit tests:
- `direct_blocking_send_blocks_when_full_reproducing_the_bug` — deterministically reproduces the hang mechanism.
- `producer_never_blocks_when_downstream_full_and_consumer_starved` — the producer never blocks under back-pressure.
- `drop_flushes_all_buffered_frames_in_order` — buffered frames are flushed in order on teardown.
- `producer_fails_when_in_process_budget_is_exhausted` — the in-process budget is enforced.

## Validation (Windows / WHP)

- `all-uservm` build, `format-check-uservm`, `rust-lint-check-uservm` (clippy `--tests -D warnings`): clean.
- `test-uservm`: all unit tests pass, including the new ones.
- Full release build OK; release standalone smoke test passes (exit code 4) across a 5/5 stability batch.

Closes #2603.