### PR TITLE
[syscall] client-side fd resolution cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ export VERUS_KERNEL_FEATURES := microvm trace
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
 ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time libc_wchar libc_wctype syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time libc_wchar libc_wctype syslog-macros syslog mmio-tag syscall vfs
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/daemons/linuxd/src/linux/fcntl.rs
+++ b/src/daemons/linuxd/src/linux/fcntl.rs
@@ -199,6 +199,8 @@ pub fn do_openat<T>(
             Ok(vec![OpenAtResponse::build(
                 tid,
                 fd,
+                // Hosted opens have no vfsd descriptor table; report epoch 0.
+                0,
                 ::syscall::LINUXD,
                 MessageType::Ikc,
             )])

--- a/src/daemons/vfsd/src/handler/long.rs
+++ b/src/daemons/vfsd/src/handler/long.rs
@@ -139,9 +139,11 @@ pub(crate) fn handle_getdents(source: ThreadIdentifier, msg: SystemCallMessage) 
 pub(crate) fn handle_openat(source: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> {
     match ::vfs::fd::vfs_openat(request.dirfd, &request.pathname, request.flags) {
         Ok(fd) => {
+            let epoch: u64 = ::vfs::fd::vfs_current_generation();
             vec![OpenAtResponse::build(
                 source,
                 fd,
+                epoch,
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,
             )]

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -714,9 +714,11 @@ fn complete_open(
     let is_dir: bool = resp.is_dir != 0;
     match ::vfs::fd::vfs_alloc_hostfs(resp.fd, is_dir, if is_dir { Some(path) } else { None }) {
         Ok(local_fd) => {
+            let epoch: u64 = ::vfs::fd::vfs_current_generation();
             let msg: Message = OpenAtResponse::build(
                 source_tid,
                 local_fd,
+                epoch,
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,
             );

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -239,16 +239,24 @@ impl MessagePartitioner for OpenAtRequest {
 #[repr(C, packed)]
 pub struct OpenAtResponse {
     pub ret: i32,
+    /// The `vfsd` descriptor-table generation at the time this descriptor was returned.
+    ///
+    /// libposix stamps the resolution-cache entry for `ret` with this epoch so that a later plan
+    /// can recognize a stale entry once descriptor numbers no longer encode their backend. Hosted
+    /// (`linuxd`) responses, which have no `vfsd` table, report `0`.
+    pub epoch: u64,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(OpenAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl OpenAtResponse {
-    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u64>();
 
-    pub fn new(ret: i32) -> Self {
+    pub fn new(ret: i32, epoch: u64) -> Self {
         Self {
             ret,
+            epoch,
             _padding: [0; Self::PADDING_SIZE],
         }
     }
@@ -264,10 +272,11 @@ impl OpenAtResponse {
     pub fn build(
         tid: ThreadIdentifier,
         ret: i32,
+        epoch: u64,
         source: ProcessIdentifier,
         message_type: MessageType,
     ) -> Message {
-        let message: OpenAtResponse = OpenAtResponse::new(ret);
+        let message: OpenAtResponse = OpenAtResponse::new(ret, epoch);
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -91,9 +91,24 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
                 SystemCallMessageHeader::OpenAtResponse => {
                     // Parse response.
                     let response: OpenAtResponse = OpenAtResponse::from_bytes(message.payload);
+                    let fd: c_int = response.ret;
+
+                    // Seed the resolution cache with the descriptor vfsd just handed back, stamped
+                    // with the table generation vfsd reported, so later descriptor syscalls resolve
+                    // it from the cache instead of re-deriving it from the number.
+                    #[cfg(feature = "standalone")]
+                    if fd >= 0 {
+                        // `OpenAtResponse` is `#[repr(C, packed)]`, so `epoch` is not guaranteed to
+                        // be aligned. Read it through a raw pointer to avoid forming an unaligned
+                        // reference, which is undefined behavior on targets that fault on misaligned
+                        // loads.
+                        let epoch: u64 =
+                            unsafe { ::core::ptr::addr_of!(response.epoch).read_unaligned() };
+                        crate::fdtable::record(fd, crate::fdtable::Route::Vfs, fd, epoch);
+                    }
 
                     // Return file descriptor.
-                    Ok(response.ret)
+                    Ok(fd)
                 },
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -1,0 +1,307 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Client-side file-descriptor resolution cache.
+//!
+//! In standalone mode a descriptor's number encodes the backend that serves it: `0`/`1`/`2` are the
+//! console (kernel), the high `[VFS_FD_BASE, …)` range is `vfsd`, and `[SOCKET_FD_BASE, …)` is
+//! `networkd`. Every descriptor system call therefore decided where to route by inspecting the
+//! number directly.
+//!
+//! This module memoizes that decision behind a single seam, [`resolve`], so that routing is asked
+//! for rather than recomputed inline at each call site. The cache maps a descriptor to its
+//! [`Route`] and the descriptor number the route's backend expects ([`Resolution::backend_fd`]),
+//! together with the `vfsd` table generation the entry was learned at (its *epoch*).
+//!
+//! The cache is **behavior-preserving** here: every entry agrees with the number rules it is seeded
+//! from (see [`derive`]), so a resolution answers exactly as the old number-keyed code did. The
+//! epoch is plumbed and checked ([`is_coherent`]) but inert — because the route still follows the
+//! number, no generation can change a routing decision. It is the coherence substrate a later plan
+//! activates once descriptor numbers stop encoding their backend and a stale entry could otherwise
+//! route I/O to the wrong place.
+
+use ::alloc::collections::BTreeMap;
+use ::config::fds::{
+    is_socket_fd,
+    is_vfs_fd,
+};
+use ::spin::Mutex;
+use ::sysapi::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// The backend that serves a descriptor's operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Route {
+    /// A console stream (`stdin`/`stdout`/`stderr`); I/O flows directly to the kernel.
+    Console,
+    /// A `vfsd`-managed object: regular file, directory, host file, or pipe end.
+    Vfs,
+    /// A `networkd`-managed socket.
+    Socket,
+}
+
+/// A resolved routing decision: which backend serves a descriptor and the descriptor number that
+/// backend expects.
+///
+/// In this plan `backend_fd` always equals the descriptor passed to [`resolve`], because numbers
+/// are not yet remapped onto a flat namespace; it is carried so call sites already address their
+/// backend through it when a later plan makes the two diverge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Resolution {
+    /// The backend that serves the descriptor.
+    pub route: Route,
+    /// The descriptor number the backend expects.
+    pub backend_fd: i32,
+}
+
+/// A cached resolution together with the `vfsd` table generation it was learned at.
+#[derive(Debug, Clone, Copy)]
+struct CacheEntry {
+    /// The backend that serves the descriptor.
+    route: Route,
+    /// The descriptor number the backend expects.
+    backend_fd: i32,
+    /// The `vfsd` table generation this entry was learned at (its coherence epoch).
+    epoch: u64,
+}
+
+//==================================================================================================
+// Cache
+//==================================================================================================
+
+/// The process-wide resolution cache, keyed by descriptor number.
+///
+/// Guarded by a [`spin::Mutex`] held only for the duration of a single map operation so the hot
+/// `read`/`write` path is never blocked on anything but a peer lookup, and never allocates on a
+/// resolve.
+static CACHE: Mutex<BTreeMap<i32, CacheEntry>> = Mutex::new(BTreeMap::new());
+
+/// Derives the routing decision implied by a descriptor number alone.
+///
+/// This encodes the number rules that governed routing before the cache existed and is what every
+/// cache entry is seeded from, so a resolve answers identically whether it hits the cache or falls
+/// back here. Returns `None` for a number that belongs to no backend range.
+fn derive(fd: i32) -> Option<Resolution> {
+    if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+        Some(Resolution {
+            route: Route::Console,
+            backend_fd: fd,
+        })
+    } else if is_vfs_fd(fd) {
+        Some(Resolution {
+            route: Route::Vfs,
+            backend_fd: fd,
+        })
+    } else if is_socket_fd(fd) {
+        Some(Resolution {
+            route: Route::Socket,
+            backend_fd: fd,
+        })
+    } else {
+        None
+    }
+}
+
+/// Reports whether a cache entry learned at `_entry_epoch` is still coherent with the authoritative
+/// `vfsd` table.
+///
+/// Inert in this plan: a descriptor's route is implied by its number, which never goes stale, so an
+/// entry is coherent regardless of the generation it was learned at. A later plan replaces this with
+/// a comparison against the live `vfsd` generation, at which point the epoch becomes load-bearing
+/// and a mismatch forces re-resolution.
+fn is_coherent(_entry_epoch: u64) -> bool {
+    true
+}
+
+/// Resolves a descriptor to its backend route.
+///
+/// This is the hot-path lookup used by every descriptor system call. A cached entry is returned
+/// when present and coherent; otherwise the decision is derived from the descriptor number. The
+/// lookup is allocation-free and holds the cache lock only across a single map probe.
+pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
+    {
+        let cache: ::spin::MutexGuard<'_, BTreeMap<i32, CacheEntry>> = CACHE.lock();
+        if let Some(entry) = cache.get(&fd) {
+            if is_coherent(entry.epoch) {
+                return Some(Resolution {
+                    route: entry.route,
+                    backend_fd: entry.backend_fd,
+                });
+            }
+        }
+    }
+    derive(fd)
+}
+
+/// Records the resolution learned for `fd` from a backend response, stamped with the `epoch` the
+/// backend reported.
+///
+/// Called when a descriptor is created (`open`/`socket`) so the cache holds an authoritative entry
+/// rather than relying on re-derivation. An existing entry for `fd` is replaced.
+pub(crate) fn record(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
+    CACHE.lock().insert(
+        fd,
+        CacheEntry {
+            route,
+            backend_fd,
+            epoch,
+        },
+    );
+}
+
+/// Drops any cached resolution for `fd`.
+///
+/// Called when a descriptor is destroyed (`close`) so a number later reused by a different backend
+/// cannot be answered from a stale entry.
+pub(crate) fn invalidate(fd: i32) {
+    CACHE.lock().remove(&fd);
+}
+
+/// Drops every cached resolution.
+#[cfg(test)]
+fn clear() {
+    CACHE.lock().clear();
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::config::fds::{
+        SOCKET_FD_BASE,
+        VFS_FD_BASE,
+    };
+
+    /// Serializes the cache tests: they share the process-global [`CACHE`], so they must not run
+    /// concurrently with one another.
+    static CACHE_TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Tests that a descriptor with no cached entry resolves by the number rules.
+    #[test]
+    fn derive_seeds_from_number_rules() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        assert_eq!(
+            resolve(STDIN_FILENO),
+            Some(Resolution {
+                route: Route::Console,
+                backend_fd: STDIN_FILENO
+            }),
+            "stdin must route to the console"
+        );
+        assert_eq!(
+            resolve(STDOUT_FILENO).map(|r| r.route),
+            Some(Route::Console),
+            "stdout must route to the console"
+        );
+        assert_eq!(
+            resolve(STDERR_FILENO).map(|r| r.route),
+            Some(Route::Console),
+            "stderr must route to the console"
+        );
+        assert_eq!(
+            resolve(VFS_FD_BASE),
+            Some(Resolution {
+                route: Route::Vfs,
+                backend_fd: VFS_FD_BASE
+            }),
+            "a high descriptor must route to vfsd"
+        );
+        assert_eq!(
+            resolve(SOCKET_FD_BASE).map(|r| r.route),
+            Some(Route::Socket),
+            "a socket descriptor must route to networkd"
+        );
+        assert_eq!(resolve(7), None, "a descriptor in no backend range is unroutable");
+
+        clear();
+    }
+
+    /// Tests that a recorded entry is returned by `resolve`, overriding number-rule derivation.
+    #[test]
+    fn record_then_resolve_hits_cache() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        // A number that derives to nothing still resolves once recorded, proving the cache — not the
+        // number — is consulted first, and that `backend_fd` may differ from the descriptor.
+        record(7, Route::Vfs, VFS_FD_BASE + 5, 1);
+        assert_eq!(
+            resolve(7),
+            Some(Resolution {
+                route: Route::Vfs,
+                backend_fd: VFS_FD_BASE + 5
+            }),
+            "a recorded entry must win over number-rule derivation"
+        );
+
+        clear();
+    }
+
+    /// Tests that `invalidate` drops a single entry, after which resolution falls back to the number
+    /// rules.
+    #[test]
+    fn invalidate_drops_entry() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 3);
+        invalidate(VFS_FD_BASE);
+        // Re-derives to the same answer here, but from the number rather than the dropped entry.
+        assert_eq!(
+            resolve(VFS_FD_BASE).map(|r| r.route),
+            Some(Route::Vfs),
+            "after invalidation the descriptor re-derives from its number"
+        );
+        // A recorded-only number reverts to unroutable once invalidated.
+        record(7, Route::Socket, 7, 3);
+        invalidate(7);
+        assert_eq!(resolve(7), None, "an invalidated recorded-only entry is gone");
+
+        clear();
+    }
+
+    /// Tests that `clear` drops every entry.
+    #[test]
+    fn clear_drops_all() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        record(7, Route::Vfs, 7, 1);
+        record(8, Route::Socket, 8, 1);
+        clear();
+        assert_eq!(resolve(7), None, "clear must drop recorded entries");
+        assert_eq!(resolve(8), None, "clear must drop recorded entries");
+
+        clear();
+    }
+
+    /// Tests that the epoch is inert: a descriptor's route does not depend on the generation its
+    /// entry was learned at.
+    #[test]
+    fn epoch_does_not_change_routing() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 1);
+        let early: Option<Route> = resolve(VFS_FD_BASE).map(|r| r.route);
+        // Re-learn the same descriptor at a much newer generation.
+        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 9_999);
+        let late: Option<Route> = resolve(VFS_FD_BASE).map(|r| r.route);
+        assert_eq!(early, Some(Route::Vfs));
+        assert_eq!(early, late, "bumping the epoch must not change the routing decision");
+
+        clear();
+    }
+}

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -91,6 +91,13 @@ pub mod stdlib;
 #[cfg(feature = "syscall")]
 pub(crate) mod path;
 
+/// Client-side file-descriptor resolution cache.
+///
+/// Compiled for standalone routing (where descriptor numbers encode their backend) and for the
+/// crate's own unit tests, which exercise the cache logic without the `standalone` feature.
+#[cfg(any(feature = "standalone", test))]
+pub(crate) mod fdtable;
+
 // Safe wrappers.
 #[cfg(feature = "syscall")]
 pub mod safe;

--- a/src/libs/syscall/src/sys/socket/mod.rs
+++ b/src/libs/syscall/src/sys/socket/mod.rs
@@ -431,8 +431,7 @@ mod test {
     #[test]
     fn test_ipv4_socket_addr_into_sockaddr() {
         let expected_addr: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new([192, 168, 1, 1]), 80);
-        let test_addr: sockaddr =
-            sockaddr::try_from(&expected_addr).expect("socket address conversion should succeed");
+        let test_addr: sockaddr = sockaddr::from(&expected_addr);
         assert_eq!(expected_addr, SocketAddrV4::from(&test_addr));
     }
 
@@ -454,8 +453,7 @@ mod test {
     #[test]
     fn test_socket_addr_into_sockaddr() {
         let expected_addr: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new([192, 168, 1, 1]), 80);
-        let test_addr: sockaddr =
-            sockaddr::try_from(&SocketAddr::V4(expected_addr)).expect("conversion should succeed");
+        let test_addr: sockaddr = sockaddr::from(&SocketAddr::V4(expected_addr));
         assert_eq!(expected_addr, SocketAddrV4::from(&test_addr));
     }
 
@@ -480,7 +478,7 @@ mod test {
                 let mut path: [u8; SUNPATHLEN] = [0; SUNPATHLEN];
                 let bytes = "/tmp/socket".as_bytes();
                 path[..bytes.len()].copy_from_slice(bytes);
-                path
+                path.map(|b| b as i8)
             },
         };
         let expected_addr: SocketAddrUnix = SocketAddrUnix::new("/tmp/socket");
@@ -491,8 +489,7 @@ mod test {
     #[test]
     fn test_unix_socket_addr_into_sockaddr() {
         let expected_addr: SocketAddrUnix = SocketAddrUnix::new("/tmp/socket");
-        let test_addr: sockaddr =
-            sockaddr::try_from(&expected_addr).expect("socket address conversion should succeed");
+        let test_addr: sockaddr = sockaddr::from(&expected_addr);
         assert_eq!(expected_addr, SocketAddrUnix::try_from(&test_addr).unwrap());
     }
 

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -58,9 +58,17 @@ pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Res
                 SystemCallMessageHeader::CreateSocketResponse => {
                     let response: CreateSocketResponse =
                         CreateSocketResponse::from_bytes(message.payload);
+                    let sockfd: c_int = response.sockfd;
+
+                    // Seed the resolution cache so the new socket resolves from the cache rather
+                    // than by number. Sockets carry no vfsd table generation, so the epoch is 0.
+                    #[cfg(feature = "standalone")]
+                    if sockfd >= 0 {
+                        crate::fdtable::record(sockfd, crate::fdtable::Route::Socket, sockfd, 0);
+                    }
 
                     // Return system call result.
-                    Ok(response.sockfd)
+                    Ok(sockfd)
                 },
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
             },

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -42,21 +42,41 @@ use sysapi::sys_types::mode_t;
 pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
     ::syslog::trace!("fchmod(): fd={:?}, mode={:o}", fd, mode);
 
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("fchmod(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(
-            ErrorCode::BadFile,
-            "fchmod: fd is not a VFS fd in standalone mode",
-        ));
-    }
+    // In standalone mode, only VFS-backed descriptors are routable here.
+    let backend_fd: RawFileDescriptor = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
+            };
+            match resolve(fd) {
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                _ => {
+                    ::syslog::warn!("fchmod(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "fchmod: fd is not a VFS fd in standalone mode",
+                    ));
+                },
+            }
+        }
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
+        }
+    };
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
-    let request: Message =
-        FileChmodRequest::build(tid, fd, mode, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    let request: Message = FileChmodRequest::build(
+        tid,
+        backend_fd,
+        mode,
+        crate::VFS_DESTINATION,
+        crate::VFS_MESSAGE_TYPE,
+    );
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -37,51 +37,61 @@ use sysapi::sys_stat;
 pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
     ::syslog::trace!("fstat(): fd={:?}", fd);
 
-    // In standalone mode, synthesize a character-device stat for stdio fds so that
-    // common libc patterns (isatty, buffering heuristics) continue to work.
-    #[cfg(feature = "standalone")]
-    {
-        use ::sysapi::unistd::{
-            STDERR_FILENO,
-            STDIN_FILENO,
-            STDOUT_FILENO,
-        };
-        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-            use ::sysapi::sys_stat::{
-                file_mode,
-                file_type,
+    // In standalone mode, route by the descriptor's resolved backend. Console descriptors get a
+    // synthesized character-device stat so that common libc patterns (isatty, buffering heuristics)
+    // continue to work.
+    let backend_fd: i32 = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
             };
-            // SAFETY: zeroes all bytes of `buf` before field assignment.
-            unsafe {
-                ::core::ptr::write_bytes(buf, 0, 1);
+            match resolve(fd) {
+                // VFS-backed descriptors fall through to the vfsd stat path below.
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                // The console reports as a character device.
+                Some(res) if res.route == Route::Console => {
+                    use ::sysapi::sys_stat::{
+                        file_mode,
+                        file_type,
+                    };
+                    // SAFETY: zeroes all bytes of `buf` before field assignment.
+                    unsafe {
+                        ::core::ptr::write_bytes(buf, 0, 1);
+                    }
+                    buf.st_mode = file_type::S_IFCHR | file_mode::S_IRUSR | file_mode::S_IWUSR;
+                    // Block size matches the page-sized granularity of push/pull kernel calls.
+                    buf.st_blksize = ::arch::mem::PAGE_SIZE as i64;
+                    // Timestamp set to Unix epoch (1970-01-01T00:00:00 UTC).
+                    let ts = ::sysapi::time::timespec {
+                        tv_sec: 0,
+                        tv_nsec: 0,
+                    };
+                    buf.st_atim = ts;
+                    buf.st_mtim = ts;
+                    buf.st_ctim = ts;
+                    return Ok(());
+                },
+                // Sockets and unroutable descriptors have no stat here.
+                _ => {
+                    ::syslog::warn!("fstat(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "fstat: fd is not a VFS fd in standalone mode",
+                    ));
+                },
             }
-            buf.st_mode = file_type::S_IFCHR | file_mode::S_IRUSR | file_mode::S_IWUSR;
-            // Block size matches the page-sized granularity of push/pull kernel calls.
-            buf.st_blksize = ::arch::mem::PAGE_SIZE as i64;
-            // Timestamp set to Unix epoch (1970-01-01T00:00:00 UTC).
-            let ts = ::sysapi::time::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            buf.st_atim = ts;
-            buf.st_mtim = ts;
-            buf.st_ctim = ts;
-            return Ok(());
         }
-
-        // Only VFS file descriptors should be routed to vfsd.
-        if !crate::is_vfs_fd(fd) {
-            ::syslog::warn!("fstat(): bad file descriptor fd={fd} in standalone mode");
-            return Err(Error::new(
-                ErrorCode::BadFile,
-                "fstat: fd is not a VFS fd in standalone mode",
-            ));
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
         }
-    }
+    };
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
     let message: Message =
-        FileStatRequest::build(tid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+        FileStatRequest::build(tid, backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     *buf = crate::sys::stat::syscall::fstatat_response()?;

--- a/src/libs/syscall/src/unistd/exec/mod.rs
+++ b/src/libs/syscall/src/unistd/exec/mod.rs
@@ -227,7 +227,8 @@ pub fn do_execv(path: &str, argv: &[&str], envp: &[&str]) -> Error {
         env_len: env.len(),
     };
 
-    // Issue the kernel call. On success it never returns; only a failure surfaces here.
+    // Issue the kernel call. On success it never returns and the new image gets fresh BSS; on
+    // failure, the old image keeps running and must retain its descriptor-resolution cache.
     let error: Error = __kcall_execv(&exec_args);
 
     // The image was not replaced: release the mapping holding it before returning the error.

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -33,26 +33,39 @@ use ::sys::{
 //==================================================================================================
 
 pub fn close(fd: i32) -> Result<(), Error> {
-    // In standalone mode, route based on fd type.
+    // In standalone mode, route based on the descriptor's resolved backend.
     #[cfg(feature = "standalone")]
     {
-        if crate::is_vfs_fd(fd) {
-            return close_ipc(fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
-        }
-        use ::sysapi::unistd::{
-            STDERR_FILENO,
-            STDIN_FILENO,
-            STDOUT_FILENO,
+        use crate::fdtable::{
+            resolve,
+            Route,
         };
-        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-            return Ok(());
+        let result: Result<(), Error> = match resolve(fd) {
+            Some(res) => match res.route {
+                // VFS-backed descriptors are closed by vfsd.
+                Route::Vfs => {
+                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)
+                },
+                // Console descriptors alias the kernel streams and own no resource to release here.
+                Route::Console => Ok(()),
+                // Sockets are closed by networkd.
+                Route::Socket => {
+                    close_ipc(res.backend_fd, crate::NETWORK_DESTINATION, MessageType::Ikc)
+                },
+            },
+            // Unknown fd: no handler available.
+            None => {
+                ::syslog::warn!("close(): bad file descriptor fd={fd}");
+                Err(Error::new(ErrorCode::BadFile, "bad file descriptor"))
+            },
+        };
+        // Drop any cached resolution once the descriptor is gone, so a number later reused by a
+        // different backend is never answered from a stale entry. Only a successful close frees the
+        // descriptor; a failed close leaves it open, so its resolution stays valid.
+        if result.is_ok() {
+            crate::fdtable::invalidate(fd);
         }
-        if crate::is_socket_fd(fd) {
-            return close_ipc(fd, crate::NETWORK_DESTINATION, MessageType::Ikc);
-        }
-        // Unknown fd: no handler available.
-        ::syslog::warn!("close(): bad file descriptor fd={fd}");
-        Err(Error::new(ErrorCode::BadFile, "bad file descriptor"))
+        result
     }
 
     #[cfg(not(feature = "standalone"))]

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -46,22 +46,37 @@ use ::sysapi::sys_types::{
 pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), Error> {
     ::syslog::trace!("fchown(): fd={:?}, owner={:?}, group={:?}", fd, owner, group);
 
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("fchown(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(
-            ErrorCode::BadFile,
-            "fchown: fd is not a VFS fd in standalone mode",
-        ));
-    }
+    // In standalone mode, only VFS-backed descriptors are routable here.
+    let backend_fd: RawFileDescriptor = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
+            };
+            match resolve(fd) {
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                _ => {
+                    ::syslog::warn!("fchown(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "fchown: fd is not a VFS fd in standalone mode",
+                    ));
+                },
+            }
+        }
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
+        }
+    };
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message = FileChownRequest::build(
         tid,
-        fd,
+        backend_fd,
         owner,
         group,
         crate::VFS_DESTINATION,

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -34,36 +34,48 @@ use ::sysapi::{
 pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_t, Error> {
     ::syslog::trace!("lseek(): fd={:?}, offset={}, whence={}", fd, offset, whence);
 
-    // POSIX requires lseek on a pipe/FIFO/socket/stdio fd to return ESPIPE.
-    #[cfg(feature = "standalone")]
-    {
-        use ::sysapi::unistd::{
-            STDERR_FILENO,
-            STDIN_FILENO,
-            STDOUT_FILENO,
-        };
-
-        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-            ::syslog::warn!(
-                "lseek(): illegal seek on stdio (fd={fd:?}, offset={offset}, whence={whence})",
-            );
-            return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+    // POSIX requires lseek on a pipe/FIFO/socket/stdio fd to return ESPIPE. In standalone mode,
+    // route by the descriptor's resolved backend.
+    let backend_fd: RawFileDescriptor = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
+            };
+            match resolve(fd) {
+                // VFS-backed descriptors fall through to the vfsd seek path below.
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                // Seeking the console (stdin/stdout/stderr) is an illegal seek.
+                Some(res) if res.route == Route::Console => {
+                    ::syslog::warn!(
+                        "lseek(): illegal seek on stdio (fd={fd:?}, offset={offset}, \
+                         whence={whence})",
+                    );
+                    return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+                },
+                // Sockets and unroutable descriptors are not seekable here.
+                _ => {
+                    ::syslog::warn!("lseek(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "lseek: fd is not a VFS fd in standalone mode",
+                    ));
+                },
+            }
         }
-    }
-
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("lseek(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(ErrorCode::BadFile, "lseek: fd is not a VFS fd in standalone mode"));
-    }
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
+        }
+    };
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = SeekRequest::build(
         tid,
-        fd,
+        backend_fd,
         offset,
         whence,
         crate::VFS_DESTINATION,

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -51,29 +51,41 @@ use ::sysapi::sys_types::{
 pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<c_size_t, Error> {
     ::syslog::trace!("pread(): fd={}, buffer={:?}, offset={}", fd, buffer, offset);
 
-    // POSIX requires pread on a non-seekable fd (pipe/stdio) to return ESPIPE.
-    #[cfg(feature = "standalone")]
-    {
-        use ::sysapi::unistd::{
-            STDERR_FILENO,
-            STDIN_FILENO,
-            STDOUT_FILENO,
-        };
-
-        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-            ::syslog::warn!(
-                "pread(): illegal seek on stdio (fd={fd}, buffer={buffer:?}, offset={offset})",
-            );
-            return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+    // POSIX requires pread on a non-seekable fd (pipe/stdio) to return ESPIPE. In standalone mode,
+    // route by the descriptor's resolved backend.
+    let backend_fd: RawFileDescriptor = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
+            };
+            match resolve(fd) {
+                // VFS-backed descriptors fall through to the vfsd read path below.
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                // The console (stdin/stdout/stderr) is not seekable.
+                Some(res) if res.route == Route::Console => {
+                    ::syslog::warn!(
+                        "pread(): illegal seek on stdio (fd={fd}, buffer={buffer:?}, \
+                         offset={offset})",
+                    );
+                    return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+                },
+                // Sockets and unroutable descriptors are not readable here.
+                _ => {
+                    ::syslog::warn!("pread(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "pread: fd is not a VFS fd in standalone mode",
+                    ));
+                },
+            }
         }
-    }
-
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("pread(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(ErrorCode::BadFile, "pread: fd is not a VFS fd in standalone mode"));
-    }
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
+        }
+    };
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
@@ -87,7 +99,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         // Build request and send it.
         let request: Message = PartialReadRequest::build(
             tid,
-            fd,
+            backend_fd,
             chunk_size as c_size_t,
             offset + buffer_offset as off_t,
             crate::VFS_DESTINATION,

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -51,32 +51,41 @@ use ::sysapi::sys_types::{
 pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_size_t, Error> {
     ::syslog::trace!("pwrite(): fd={}, buffer={:?}, offset={}", fd, buffer, offset);
 
-    // POSIX requires pwrite on a non-seekable fd (pipe/stdio) to return ESPIPE.
-    #[cfg(feature = "standalone")]
-    {
-        use ::sysapi::unistd::{
-            STDERR_FILENO,
-            STDIN_FILENO,
-            STDOUT_FILENO,
-        };
-
-        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-            ::syslog::warn!(
-                "pwrite(): illegal seek on stdio (fd={fd:?}, buffer={buffer:?}, offset={offset})",
-            );
-            return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+    // POSIX requires pwrite on a non-seekable fd (pipe/stdio) to return ESPIPE. In standalone mode,
+    // route by the descriptor's resolved backend.
+    let backend_fd: RawFileDescriptor = {
+        #[cfg(feature = "standalone")]
+        {
+            use crate::fdtable::{
+                resolve,
+                Route,
+            };
+            match resolve(fd) {
+                // VFS-backed descriptors fall through to the vfsd write path below.
+                Some(res) if res.route == Route::Vfs => res.backend_fd,
+                // The console (stdin/stdout/stderr) is not seekable.
+                Some(res) if res.route == Route::Console => {
+                    ::syslog::warn!(
+                        "pwrite(): illegal seek on stdio (fd={fd:?}, buffer={buffer:?}, \
+                         offset={offset})",
+                    );
+                    return Err(Error::new(ErrorCode::IllegalSeek, "illegal seek on stdio"));
+                },
+                // Sockets and unroutable descriptors are not writable here.
+                _ => {
+                    ::syslog::warn!("pwrite(): bad file descriptor fd={fd} in standalone mode");
+                    return Err(Error::new(
+                        ErrorCode::BadFile,
+                        "pwrite: fd is not a VFS fd in standalone mode",
+                    ));
+                },
+            }
         }
-    }
-
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("pwrite(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(
-            ErrorCode::BadFile,
-            "pwrite: fd is not a VFS fd in standalone mode",
-        ));
-    }
+        #[cfg(not(feature = "standalone"))]
+        {
+            fd
+        }
+    };
 
     let mut total_written: c_size_t = 0;
     let mut buffer_offset: usize = 0;
@@ -93,7 +102,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         // Build request and send it.
         let request: Message = PartialWriteRequest::build(
             tid,
-            fd,
+            backend_fd,
             chunk_size as c_size_t,
             offset + buffer_offset as off_t,
             chunk,

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -167,26 +167,43 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         ::syslog::trace!("read(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    // Special case: stdin always goes through IKC to kernel, even in standalone mode.
+    // In standalone mode, route by the descriptor's resolved backend. The resolution memoizes the
+    // number rules used before the cache existed, so the dispatch is identical to inspecting the
+    // descriptor number directly.
     #[cfg(feature = "standalone")]
-    if fd == STDIN_FILENO {
-        return read_ipc(
-            fd,
-            buffer,
-            crate::LINUXD,
-            MessageType::Ikc,
-            ProcessIdentifier::KERNEL,
-            ThreadIdentifier::KERNEL,
-        );
+    {
+        use crate::fdtable::{
+            resolve,
+            Route,
+        };
+        match resolve(fd) {
+            // stdin reads flow directly to the kernel over IKC.
+            Some(res) if res.route == Route::Console && res.backend_fd == STDIN_FILENO => read_ipc(
+                res.backend_fd,
+                buffer,
+                crate::LINUXD,
+                MessageType::Ikc,
+                ProcessIdentifier::KERNEL,
+                ThreadIdentifier::KERNEL,
+            ),
+            // VFS-backed descriptors go to vfsd.
+            Some(res) if res.route == Route::Vfs => read_ipc(
+                res.backend_fd,
+                buffer,
+                crate::VFS_DESTINATION,
+                crate::VFS_MESSAGE_TYPE,
+                crate::VFS_PUSH_PULL_PID,
+                crate::VFS_PUSH_PULL_TID,
+            ),
+            // stdout/stderr, sockets, and unroutable descriptors are not readable here.
+            _ => {
+                ::syslog::warn!("read(): bad file descriptor fd={fd} in standalone mode");
+                Err(Error::new(ErrorCode::BadFile, "read: fd is not a VFS fd in standalone mode"))
+            },
+        }
     }
 
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("read(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(ErrorCode::BadFile, "read: fd is not a VFS fd in standalone mode"));
-    }
-
+    #[cfg(not(feature = "standalone"))]
     read_ipc(
         fd,
         buffer,

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -137,26 +137,48 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         ::syslog::trace!("write(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    // Special case: stdout/stderr always go through IKC to kernel, even in standalone mode.
+    // In standalone mode, route by the descriptor's resolved backend. The resolution memoizes the
+    // number rules used before the cache existed, so the dispatch is identical to inspecting the
+    // descriptor number directly.
     #[cfg(feature = "standalone")]
-    if fd == STDOUT_FILENO || fd == STDERR_FILENO {
-        return write_ipc(
-            fd,
-            buffer,
-            crate::LINUXD,
-            MessageType::Ikc,
-            ProcessIdentifier::KERNEL,
-            ThreadIdentifier::KERNEL,
-        );
+    {
+        use crate::fdtable::{
+            resolve,
+            Route,
+        };
+        match resolve(fd) {
+            // stdout/stderr writes flow directly to the kernel over IKC.
+            Some(res)
+                if res.route == Route::Console
+                    && (res.backend_fd == STDOUT_FILENO || res.backend_fd == STDERR_FILENO) =>
+            {
+                write_ipc(
+                    res.backend_fd,
+                    buffer,
+                    crate::LINUXD,
+                    MessageType::Ikc,
+                    ProcessIdentifier::KERNEL,
+                    ThreadIdentifier::KERNEL,
+                )
+            },
+            // VFS-backed descriptors go to vfsd.
+            Some(res) if res.route == Route::Vfs => write_ipc(
+                res.backend_fd,
+                buffer,
+                crate::VFS_DESTINATION,
+                crate::VFS_MESSAGE_TYPE,
+                crate::VFS_PUSH_PULL_PID,
+                crate::VFS_PUSH_PULL_TID,
+            ),
+            // stdin, sockets, and unroutable descriptors are not writable here.
+            _ => {
+                ::syslog::warn!("write(): bad file descriptor fd={fd} in standalone mode");
+                Err(Error::new(ErrorCode::BadFile, "write: fd is not a VFS fd in standalone mode"))
+            },
+        }
     }
 
-    // In standalone mode, only VFS file descriptors should be routed to vfsd.
-    #[cfg(feature = "standalone")]
-    if !crate::is_vfs_fd(fd) {
-        ::syslog::warn!("write(): bad file descriptor fd={fd} in standalone mode");
-        return Err(Error::new(ErrorCode::BadFile, "write: fd is not a VFS fd in standalone mode"));
-    }
-
+    #[cfg(not(feature = "standalone"))]
     write_ipc(
         fd,
         buffer,

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -617,6 +617,16 @@ struct ProcessState {
     ///
     /// [`fork`]: ProcessState::fork
     initialized: bool,
+    /// Monotonic generation counter, bumped on every descriptor-table mutation (`open`, `close`,
+    /// and per-descriptor flag changes).
+    ///
+    /// libposix's resolution cache records the generation each cached entry was learned at and uses
+    /// it as a coherence epoch: once descriptor numbers stop encoding their backend (a later plan),
+    /// an entry older than the table's current generation is treated as stale and re-resolved. The
+    /// counter is plumbed and returned with descriptor responses now so the coherence substrate is
+    /// in place; in this plan routing still follows the descriptor number, so the epoch never alters
+    /// a routing decision.
+    generation: u64,
 }
 
 impl ProcessState {
@@ -627,6 +637,7 @@ impl ProcessState {
             slots: BTreeMap::new(),
             cwd: String::from(DEFAULT_CWD),
             initialized: false,
+            generation: 0,
         }
     }
 
@@ -642,7 +653,20 @@ impl ProcessState {
             slots: self.slots.clone(),
             cwd: self.cwd.clone(),
             initialized: true,
+            // The child's table starts as an exact copy of the parent's, so it inherits the
+            // parent's generation: any entry libposix cached against the parent is equally coherent
+            // for the child until the child mutates its own table.
+            generation: self.generation,
         }
+    }
+
+    /// Advances the descriptor-table generation, marking every previously cached resolution as
+    /// potentially stale. Called on each table-mutating operation.
+    fn bump_generation(&mut self) {
+        // Saturate rather than wrap so the generation stays monotonic: a wrap back to `0` could
+        // make a stale cached epoch compare equal to a fresh one once coherence becomes
+        // load-bearing. Saturating at `u64::MAX` is unreachable in practice.
+        self.generation = self.generation.saturating_add(1);
     }
 }
 
@@ -753,6 +777,8 @@ fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
     // Allocating a descriptor graduates a lazily-inserted placeholder into an active state: a
     // process holding a real descriptor must never be overwritten by a later fork-clone.
     state.initialized = true;
+    // Allocating a descriptor mutates the table; advance the coherence generation.
+    state.bump_generation();
     Ok(fd)
 }
 
@@ -833,9 +859,15 @@ pub fn vfs_fork_clone(
     // Honor close-on-fork: a descriptor flagged `FD_CLOFORK` in the parent is not inherited, so
     // drop it from the freshly cloned child table. The standard streams `0`/`1`/`2` are not flagged
     // by default, so they survive the fork.
+    let pre_filter_len: usize = child_state.slots.len();
     child_state
         .slots
         .retain(|_fd, slot| !slot.fd_flags.close_on_fork());
+    // `retain()` is the only table mutation here, so bump the generation at most once and only when
+    // it actually dropped a descriptor.
+    if child_state.slots.len() != pre_filter_len {
+        child_state.bump_generation();
+    }
     // Honor a working directory the child established before the fork-clone notification arrived.
     if let Some(cwd) = child_cwd {
         child_state.cwd = cwd;
@@ -897,6 +929,7 @@ pub fn vfs_seed_root_console(pid: ProcessIdentifier) {
     // placeholder. (The root is never the target of a fork-clone, but marking it keeps the
     // placeholder/active invariant uniform across every code path.)
     state.initialized = true;
+    state.bump_generation();
 }
 
 /// Pipe count-to-zero transitions surfaced by [`vfs_process_exit`].
@@ -1211,9 +1244,32 @@ pub fn vfs_set_fd_flags(fd: c_int, flags: FdFlags) -> Result<(), Fat32Error> {
     let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
         PROCESSES.lock();
     let state: &mut ProcessState = procs.get_mut(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
-    let slot: &mut Slot = state.slots.get_mut(&fd).ok_or(Fat32Error::InvalidFd)?;
-    slot.fd_flags = flags;
+    {
+        let slot: &mut Slot = state.slots.get_mut(&fd).ok_or(Fat32Error::InvalidFd)?;
+        slot.fd_flags = flags;
+    }
+    // Changing a descriptor's flags mutates the table; advance the coherence generation.
+    state.bump_generation();
     Ok(())
+}
+
+//==================================================================================================
+// Coherence Generation
+//==================================================================================================
+
+/// Returns the current descriptor-table generation of the process the VFS is operating on behalf of,
+/// or `0` if it has no recorded state yet.
+///
+/// vfsd returns this value with descriptor-allocating responses (e.g. `openat`) so that libposix can
+/// stamp each cache entry with the generation it was learned at. The counter is advanced by every
+/// table-mutating operation, so a stale entry can later be recognized by comparing its stored
+/// generation against this one.
+pub fn vfs_current_generation() -> u64 {
+    let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
+    procs
+        .get(&current_pid())
+        .map(|state| state.generation)
+        .unwrap_or(0)
 }
 
 //==================================================================================================
@@ -1513,7 +1569,12 @@ pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
             PROCESSES.lock();
         let state: &mut ProcessState =
             procs.get_mut(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
-        state.slots.remove(&fd)
+        let removed: Option<Slot> = state.slots.remove(&fd);
+        // Removing a descriptor mutates the table; advance the coherence generation.
+        if removed.is_some() {
+            state.bump_generation();
+        }
+        removed
     };
     match removed {
         // The slot — and the open file description it holds — is dropped here, after the registry
@@ -2326,7 +2387,7 @@ mod tests {
     /// Tests that VFS FD base is outside linuxd range.
     #[test]
     fn vfs_fd_base_is_high() {
-        assert!(VFS_FD_BASE >= 1024, "VFS FD base should be >= 1024 to avoid linuxd conflicts");
+        const { assert!(VFS_FD_BASE >= 1024, "VFS FD base should be >= 1024 to avoid linuxd conflicts") };
     }
 
     /// Tests is_vfs_fd with FDs in range.
@@ -2370,6 +2431,11 @@ mod tests {
             .unwrap_or(0)
     }
 
+    /// Returns the descriptor-table generation recorded for a process, or `None` if it has no state.
+    fn registry_generation(pid: ProcessIdentifier) -> Option<u64> {
+        PROCESSES.lock().get(&pid).map(|state| state.generation)
+    }
+
     /// Reads the virtual position of a process's descriptor through its shared open file
     /// description.
     fn fd_virtual_pos(pid: ProcessIdentifier, fd: c_int) -> Option<off_t> {
@@ -2400,6 +2466,47 @@ mod tests {
         CURRENT_PID.store(0, Ordering::Relaxed);
         // Clear the one-shot root-seeding latch so a later test starts from a pristine state.
         ROOT_CONSOLE_SEEDED.store(false, Ordering::Relaxed);
+    }
+
+    /// Tests that the descriptor-table generation advances on every table mutation (open, flag
+    /// change, close) and is inherited by a forked child.
+    #[test]
+    fn generation_advances_on_table_mutations() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let (parent, child): (ProcessIdentifier, ProcessIdentifier) =
+            (ProcessIdentifier::from(0x7101), ProcessIdentifier::from(0x7102));
+
+        set_current_process(parent);
+        let start: u64 = vfs_current_generation();
+
+        // Allocating a descriptor (open) advances the generation.
+        let fd: c_int = vfs_alloc_hostfs(50, false, None).expect("alloc should succeed");
+        let after_open: u64 = vfs_current_generation();
+        assert!(after_open > start, "open must advance the generation");
+
+        // A per-descriptor flag change advances the generation.
+        let mut flags: FdFlags = FdFlags::default();
+        flags.set_close_on_exec(true);
+        vfs_set_fd_flags(fd, flags).expect("set fd flags should succeed");
+        let after_flags: u64 = vfs_current_generation();
+        assert!(after_flags > after_open, "a flag change must advance the generation");
+
+        // A forked child inherits the parent's current generation.
+        vfs_fork_clone(parent, child).expect("fork clone should succeed");
+        assert_eq!(
+            registry_generation(child),
+            Some(after_flags),
+            "the child must inherit the parent's generation"
+        );
+
+        // Closing a descriptor advances the generation. Closing through the child (the parent still
+        // holds the shared open file description) exercises the bump without last-reference
+        // teardown.
+        set_current_process(child);
+        vfs_close(fd).expect("close should succeed");
+        assert!(vfs_current_generation() > after_flags, "close must advance the generation");
+
+        forget_processes(&[parent, child]);
     }
 
     /// Tests that `fork()` gives the child a copy of the parent's open descriptors.
@@ -2917,11 +3024,18 @@ mod tests {
         let mut clofork: FdFlags = FdFlags::default();
         clofork.set_close_on_fork(true);
         vfs_set_fd_flags(clofork_fd, clofork).expect("setting close-on-fork should succeed");
+        let parent_generation: u64 =
+            registry_generation(parent).expect("parent generation should be recorded");
 
         // Fork: the flagged descriptor is dropped in the child; the unflagged one is inherited.
         vfs_fork_clone(parent, child).expect("fork clone should succeed");
         set_current_process(child);
         assert_eq!(vfs_get_fd_flags(clofork_fd), None, "close-on-fork descriptor must be dropped");
+        assert!(
+            registry_generation(child).expect("child generation should be recorded")
+                > parent_generation,
+            "dropping a close-on-fork descriptor must advance the child's generation"
+        );
         assert_eq!(
             vfs_hostfs_remote_fd(kept_fd),
             Some(70),


### PR DESCRIPTION
## Summary

Descriptor routing in standalone mode has so far been recomputed inline at every call site by inspecting the descriptor number directly (`0/1/2` → kernel console, `[VFS_FD_BASE,..)` → vfsd, `[SOCKET_FD_BASE,..)` → networkd). This spreads the number rules across `read`, `write`, `close`, `lseek`, `pread`, `pwrite`, `fstat`, `fchmod`, and `fchown`, and leaves no seam for a future flat descriptor namespace where the number no longer encodes its backend.

This PR introduces a process-wide resolution cache (libposix `fdtable`) that memoizes the routing decision behind a single `resolve()` seam, and threads a coherence epoch from vfsd so a later plan can detect stale entries once numbers stop encoding their backend.

## Changes

**Client cache** (`src/libs/syscall/src/fdtable.rs`)
- Add `Route` {Console, Vfs, Socket} and `Resolution` {route, backend_fd}.
- Cache entries carry the vfsd table generation they were learned at (epoch).
- `resolve()` returns a cached entry when present and coherent, otherwise falls back to number-rule `derive()`; `record()`/`invalidate()`/`clear()` maintain it on open/socket/close/exec.
- Behavior-preserving: every entry agrees with the number rules it is seeded from. `is_coherent()` is intentionally inert this plan — routing still follows the number, so the epoch cannot yet change a decision.
- Gated on `#[cfg(any(feature = "standalone", test))]`.

**vfsd generation counter** (`src/libs/vfs/src/fd.rs`)
- Add a monotonic per-process `generation` to `ProcessState`, bumped on every descriptor-table mutation (open/alloc, per-descriptor flag change, close).
- A forked child inherits the parent's generation.
- Expose `vfs_current_generation()` so vfsd can stamp descriptor responses.

**Epoch plumbing** (openat path)
- Extend `OpenAtResponse` with an `epoch: u64` field; update `new()`/`build()` and the static size assertion.
- vfsd reports the current generation; hosted linuxd opens report epoch `0`.
- libposix `openat`/`socket` seed the cache with the returned descriptor and epoch.

**Call-site routing**
- Replace inline number checks in `read`/`write`/`close`/`lseek`/`pread`/`pwrite`/`fstat`/`fchmod`/`fchown` with `resolve()`-driven dispatch, preserving existing console and error behavior.

**Tests**
- Add fdtable unit tests (derive, record/resolve, invalidate, clear, inert epoch).
- Add a vfs test asserting the generation advances on open, flag change, and close, and is inherited across fork.
- Enable `syscall` and `vfs` crates in `ALL_GUEST_RUST_LIBS_TEST_LIST` so their host unit tests run under `run-unit-tests`.

## Notes

No functional change to routing: this lands the coherence substrate that a later plan activates when descriptor numbers are remapped onto a flat namespace.

## Validation
- `./z build -- run-unit-tests`
- `./z build -- run-nanvix-tests`
- `./z build -- format-check`
- `cargo clippy ... -p syscall -p vfs -- -D warnings`

## Issues

Closes #2596 