### PR TITLE
[syscall] Flat file-descriptor namespace

### DIFF
--- a/src/daemons/linuxd/src/linux/unistd.rs
+++ b/src/daemons/linuxd/src/linux/unistd.rs
@@ -794,7 +794,8 @@ pub fn do_pipe<T>(
             let write_fd: i32 = fds[1];
 
             debug!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");
-            Ok(PipeResponse::build(tid, read_fd, write_fd, ::syscall::LINUXD, MessageType::Ikc))
+            // Hosted pipes have no vfsd table, so the coherence epoch is 0.
+            Ok(PipeResponse::build(tid, read_fd, write_fd, 0, ::syscall::LINUXD, MessageType::Ikc))
         },
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };

--- a/src/daemons/vfsd/src/handler/pipe.rs
+++ b/src/daemons/vfsd/src/handler/pipe.rs
@@ -166,11 +166,15 @@ fn try_serve_reader(
 pub(crate) fn handle_pipe_create(source: ThreadIdentifier) -> Message {
     match vfs_pipe() {
         Ok((read_fd, write_fd)) => {
+            // Both descriptors are allocated by the same `vfs_pipe` table mutation, so they share
+            // the post-mutation generation; report it so libposix stamps both cache entries.
+            let epoch: u64 = ::vfs::fd::vfs_current_generation();
             ::syslog::trace!("pipe(): read_fd={}, write_fd={}", read_fd, write_fd);
             PipeResponse::build(
                 source,
                 read_fd,
                 write_fd,
+                epoch,
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,
             )

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -10,6 +10,7 @@ use crate::error::{
     fat32_to_error_code,
 };
 use ::sys::{
+    error::ErrorCode,
     ipc::{
         Message,
         MessageType,
@@ -47,11 +48,14 @@ use ::syscall::{
         FileSyncResponse,
         FileTruncateRequest,
         FileTruncateResponse,
+        ResolveFdRequest,
+        ResolveFdResponse,
         SeekRequest,
         SeekResponse,
     },
     SystemCallMessage,
 };
+use ::vfs::fd::VfsRoute;
 
 //==================================================================================================
 // Short Request Handlers
@@ -63,6 +67,40 @@ pub(crate) fn handle_close(source: ThreadIdentifier, msg: SystemCallMessage) -> 
     match ::vfs::fd::vfs_close(fd) {
         Ok(()) => CloseResponse::build(source, 0, ProcessIdentifier::VFSD, MessageType::Ipc),
         Err(e) => build_error(source, fat32_to_error_code(&e)),
+    }
+}
+
+/// Handles a descriptor-resolution query: reports the authoritative backend of a flat descriptor.
+///
+/// libposix sends this on a resolution-cache miss once descriptor numbers no longer encode their
+/// backend. The answer is taken from vfsd's slot table via [`vfs_resolve`](::vfs::fd::vfs_resolve):
+/// the backend route, the descriptor that backend expects, and the current table generation (the
+/// coherence epoch). A descriptor with no slot is reported as a bad file descriptor.
+pub(crate) fn handle_resolve_fd(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
+    let req: ResolveFdRequest = ResolveFdRequest::from_bytes(msg.payload);
+    let pid: ProcessIdentifier = req.pid;
+    let fd: i32 = req.fd;
+    ::vfs::fd::set_current_process(pid);
+    ::vfs::fd::vfs_seed_root_console(pid);
+    match ::vfs::fd::vfs_resolve(fd) {
+        Some((route, backend_fd)) => {
+            let wire_route: u32 = match route {
+                VfsRoute::Console => ResolveFdResponse::ROUTE_CONSOLE,
+                VfsRoute::Vfs => ResolveFdResponse::ROUTE_VFS,
+                VfsRoute::Socket => ResolveFdResponse::ROUTE_SOCKET,
+            };
+            let epoch: u64 = ::vfs::fd::vfs_current_generation();
+            ResolveFdResponse::build(
+                source,
+                wire_route,
+                backend_fd,
+                epoch,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
+        },
+        // No slot for this descriptor in the caller's table: it is unroutable.
+        None => build_error(source, ErrorCode::BadFile),
     }
 }
 

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -264,6 +264,10 @@ pub(crate) fn handle_ipc_message(
                 send_response(&response);
             }
         },
+        SystemCallMessageHeader::ResolveFdRequest => {
+            let response: Message = handler::handle_resolve_fd(source_tid, syscall_msg);
+            send_response(&response);
+        },
         SystemCallMessageHeader::SeekRequest => {
             if let Some(response) =
                 handler::handle_seek_with_hostfs(source_tid, syscall_msg, pending)

--- a/src/libs/config/src/fds.rs
+++ b/src/libs/config/src/fds.rs
@@ -7,25 +7,13 @@
 // File Descriptor Ranges
 //==================================================================================================
 
-/// Base file descriptor number for VFS-managed handles.
-///
-/// VFS file descriptors occupy the range `[VFS_FD_BASE, VFS_FD_BASE + VFS_MAX_OPEN_FILES)`.
-/// This range must not overlap with stdio (0–2), socket, or linuxd-assigned file descriptors.
-pub const VFS_FD_BASE: i32 = 1024;
-
-/// Maximum number of simultaneously open VFS files.
-pub const VFS_MAX_OPEN_FILES: usize = 64;
-
 /// Base file descriptor number for socket handles managed by networkd.
 ///
-/// Socket file descriptors occupy the range `[SOCKET_FD_BASE, ..)`.
-/// This range must not overlap with stdio (0–2) or VFS-managed descriptors.
+/// Socket file descriptors occupy the range `[SOCKET_FD_BASE, ..)`. Under the flat descriptor
+/// namespace, vfsd-served descriptors are allocated lowest-free below this base, so this range stays
+/// reserved for `networkd` and never collides with a vfsd descriptor (the interim reservation until
+/// sockets are unified into the flat table).
 pub const SOCKET_FD_BASE: i32 = 2048;
-
-/// Returns `true` if the given file descriptor belongs to the VFS fd range.
-pub fn is_vfs_fd(fd: i32) -> bool {
-    fd >= VFS_FD_BASE && fd < VFS_FD_BASE + VFS_MAX_OPEN_FILES as i32
-}
 
 /// Returns `true` if the given file descriptor belongs to the socket fd range.
 pub fn is_socket_fd(fd: i32) -> bool {

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -62,11 +62,12 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
         GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let backend_fd: c_int = crate::fdtable::resolve_vfs(fd, "posix_getdents")?;
 
     // Build request message.
     let request: Message = GetDirectoryEntriesRequest::build(
         tid,
-        fd,
+        backend_fd,
         count,
         crate::VFS_DESTINATION,
         crate::VFS_MESSAGE_TYPE,

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -55,12 +55,13 @@ pub fn posix_fadvise(
         len,
         advice
     );
+    let backend_fd: RawFileDescriptor = crate::fdtable::resolve_vfs(fd, "posix_fadvise")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileAdvisoryInformationRequest::build(
         tid,
-        fd,
+        backend_fd,
         offset,
         len,
         advice,

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -42,12 +42,13 @@ use sysapi::sys_types::off_t;
 ///
 pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Result<(), Error> {
     ::syslog::trace!("posix_fallocate(): fd={:?}, offset={:?}, len={:?}", fd, offset, len);
+    let backend_fd: RawFileDescriptor = crate::fdtable::resolve_vfs(fd, "posix_fallocate")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileSpaceControlRequest::build(
         tid,
-        fd,
+        backend_fd,
         offset,
         len,
         crate::VFS_DESTINATION,

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -29,12 +29,13 @@ use ::sysapi::ffi::c_int;
 
 pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     ::syslog::trace!("fcntl(): fd={:?}, cmd={:?}, arg={:?}", fd, cmd, arg);
+    let backend_fd: i32 = crate::fdtable::resolve_vfs(fd, "fcntl")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileControlRequest::build(
         tid,
-        fd,
+        backend_fd,
         cmd,
         arg.unwrap_or(0),
         crate::VFS_DESTINATION,

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -3,29 +3,39 @@
 
 //! Client-side file-descriptor resolution cache.
 //!
-//! In standalone mode a descriptor's number encodes the backend that serves it: `0`/`1`/`2` are the
-//! console (kernel), the high `[VFS_FD_BASE, …)` range is `vfsd`, and `[SOCKET_FD_BASE, …)` is
-//! `networkd`. Every descriptor system call therefore decided where to route by inspecting the
-//! number directly.
+//! Under the flat namespace a descriptor's number no longer encodes its backend: `open` hands out
+//! the lowest free number (typically a small one), so a value like `4` could be a regular file, a
+//! pipe end, a directory, or a host file. One range keeps a fixed meaning in the interim:
+//! `[SOCKET_FD_BASE, …)` is always a `networkd` socket. Every lower descriptor is whatever `vfsd`'s
+//! authoritative slot table says it is.
 //!
-//! This module memoizes that decision behind a single seam, [`resolve`], so that routing is asked
-//! for rather than recomputed inline at each call site. The cache maps a descriptor to its
-//! [`Route`] and the descriptor number the route's backend expects ([`Resolution::backend_fd`]),
-//! together with the `vfsd` table generation the entry was learned at (its *epoch*).
+//! This module routes a descriptor through a single seam, [`resolve`]. The answer comes from, in
+//! order: a coherent cache entry; the fixed socket range ([`derive`], no round-trip); otherwise an
+//! authoritative query to `vfsd` ([`resolve_via_vfsd`]). If no guest `vfsd` exists in the current
+//! run mode, the standard streams fall back to the kernel console by number. A descriptor created
+//! locally (`open`, `pipe`, `socket`) or learned from `vfsd` is recorded, so the `vfsd` query is
+//! reached only on a genuine miss or after an entry goes stale.
 //!
-//! The cache is **behavior-preserving** here: every entry agrees with the number rules it is seeded
-//! from (see [`derive`]), so a resolution answers exactly as the old number-keyed code did. The
-//! epoch is plumbed and checked ([`is_coherent`]) but inert — because the route still follows the
-//! number, no generation can change a routing decision. It is the coherence substrate a later plan
-//! activates once descriptor numbers stop encoding their backend and a stale entry could otherwise
-//! route I/O to the wrong place.
+//! Coherence is load-bearing here. Each entry carries the `vfsd` table generation it was learned at
+//! (its *epoch*), and [`EXPECTED_EPOCH`] tracks the newest generation this process has observed from
+//! `vfsd`. An entry older than that ([`is_coherent`]) is treated as stale and re-resolved, so a
+//! number reused for a different backend can never be answered from an outdated entry.
 
+#[cfg(any(feature = "standalone", test))]
 use ::alloc::collections::BTreeMap;
-use ::config::fds::{
-    is_socket_fd,
-    is_vfs_fd,
+#[cfg(any(feature = "standalone", test))]
+use ::config::fds::is_socket_fd;
+#[cfg(test)]
+use ::core::sync::atomic::AtomicBool;
+#[cfg(any(feature = "standalone", test))]
+use ::core::sync::atomic::{
+    AtomicU64,
+    Ordering,
 };
+#[cfg(any(feature = "standalone", test))]
 use ::spin::Mutex;
+use ::sys::error::Error;
+#[cfg(any(feature = "standalone", test))]
 use ::sysapi::unistd::{
     STDERR_FILENO,
     STDIN_FILENO,
@@ -37,6 +47,7 @@ use ::sysapi::unistd::{
 //==================================================================================================
 
 /// The backend that serves a descriptor's operations.
+#[cfg(any(feature = "standalone", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Route {
     /// A console stream (`stdin`/`stdout`/`stderr`); I/O flows directly to the kernel.
@@ -50,9 +61,11 @@ pub(crate) enum Route {
 /// A resolved routing decision: which backend serves a descriptor and the descriptor number that
 /// backend expects.
 ///
-/// In this plan `backend_fd` always equals the descriptor passed to [`resolve`], because numbers
-/// are not yet remapped onto a flat namespace; it is carried so call sites already address their
-/// backend through it when a later plan makes the two diverge.
+/// `backend_fd` may differ from the descriptor passed to [`resolve`]: a console descriptor reports
+/// the standard stream number it aliases (`0`/`1`/`2`), and a socket reports the descriptor
+/// `networkd` assigned. Call sites address their backend through `backend_fd` rather than the
+/// caller-facing number.
+#[cfg(any(feature = "standalone", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Resolution {
     /// The backend that serves the descriptor.
@@ -62,6 +75,7 @@ pub(crate) struct Resolution {
 }
 
 /// A cached resolution together with the `vfsd` table generation it was learned at.
+#[cfg(any(feature = "standalone", test))]
 #[derive(Debug, Clone, Copy)]
 struct CacheEntry {
     /// The backend that serves the descriptor.
@@ -70,6 +84,18 @@ struct CacheEntry {
     backend_fd: i32,
     /// The `vfsd` table generation this entry was learned at (its coherence epoch).
     epoch: u64,
+}
+
+/// Outcome of asking `vfsd` for an authoritative descriptor route.
+#[cfg(any(feature = "standalone", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VfsdResolution {
+    /// `vfsd` returned an authoritative route.
+    Hit(Resolution),
+    /// `vfsd` answered and reported that the descriptor has no slot.
+    BadFile,
+    /// The query could not be delivered or answered because no `vfsd` is available.
+    Unavailable,
 }
 
 //==================================================================================================
@@ -81,25 +107,35 @@ struct CacheEntry {
 /// Guarded by a [`spin::Mutex`] held only for the duration of a single map operation so the hot
 /// `read`/`write` path is never blocked on anything but a peer lookup, and never allocates on a
 /// resolve.
+#[cfg(any(feature = "standalone", test))]
 static CACHE: Mutex<BTreeMap<i32, CacheEntry>> = Mutex::new(BTreeMap::new());
+
+/// The newest `vfsd` table generation this process has observed.
+///
+/// Every `vfsd` answer that carries a generation ([`record`] from `open`/`pipe`, and the
+/// resolution query) advances this through [`observe_epoch`]. A cache entry learned at an older
+/// generation is stale ([`is_coherent`]) and must be re-resolved, because the descriptor it
+/// describes may since have been closed and the number reused for a different backend.
+#[cfg(any(feature = "standalone", test))]
+static EXPECTED_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+/// Records that `vfsd` has advanced its table generation to at least `epoch`.
+///
+/// Monotonic via a max, so an out-of-order or duplicated response can never move the observed
+/// generation backwards and resurrect a stale entry.
+#[cfg(any(feature = "standalone", test))]
+fn observe_epoch(epoch: u64) {
+    EXPECTED_EPOCH.fetch_max(epoch, Ordering::Relaxed);
+}
 
 /// Derives the routing decision implied by a descriptor number alone.
 ///
-/// This encodes the number rules that governed routing before the cache existed and is what every
-/// cache entry is seeded from, so a resolve answers identically whether it hits the cache or falls
-/// back here. Returns `None` for a number that belongs to no backend range.
+/// Only the reserved socket range owned by `networkd` is answered here. Every lower descriptor,
+/// including `0`/`1`/`2`, is flat namespace state owned by `vfsd` and must be resolved there so a
+/// closed standard descriptor can be reused by a non-console object.
+#[cfg(any(feature = "standalone", test))]
 fn derive(fd: i32) -> Option<Resolution> {
-    if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
-        Some(Resolution {
-            route: Route::Console,
-            backend_fd: fd,
-        })
-    } else if is_vfs_fd(fd) {
-        Some(Resolution {
-            route: Route::Vfs,
-            backend_fd: fd,
-        })
-    } else if is_socket_fd(fd) {
+    if is_socket_fd(fd) {
         Some(Resolution {
             route: Route::Socket,
             backend_fd: fd,
@@ -109,22 +145,39 @@ fn derive(fd: i32) -> Option<Resolution> {
     }
 }
 
-/// Reports whether a cache entry learned at `_entry_epoch` is still coherent with the authoritative
+/// Derives the fallback console route for run modes that have no guest `vfsd`.
+#[cfg(any(feature = "standalone", test))]
+fn derive_console(fd: i32) -> Option<Resolution> {
+    if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+        Some(Resolution {
+            route: Route::Console,
+            backend_fd: fd,
+        })
+    } else {
+        None
+    }
+}
+
+/// Reports whether a cache entry learned at `entry_epoch` is still coherent with the authoritative
 /// `vfsd` table.
 ///
-/// Inert in this plan: a descriptor's route is implied by its number, which never goes stale, so an
-/// entry is coherent regardless of the generation it was learned at. A later plan replaces this with
-/// a comparison against the live `vfsd` generation, at which point the epoch becomes load-bearing
-/// and a mismatch forces re-resolution.
-fn is_coherent(_entry_epoch: u64) -> bool {
-    true
+/// An entry is coherent only if it was learned no earlier than the newest generation this process
+/// has observed from `vfsd`. A descriptor-table mutation advances that generation, so an entry that
+/// predates the latest one is treated as stale and re-resolved, guaranteeing a reused number is
+/// never answered from an entry that described its previous occupant.
+#[cfg(any(feature = "standalone", test))]
+fn is_coherent(entry_epoch: u64) -> bool {
+    entry_epoch >= EXPECTED_EPOCH.load(Ordering::Relaxed)
 }
 
 /// Resolves a descriptor to its backend route.
 ///
-/// This is the hot-path lookup used by every descriptor system call. A cached entry is returned
-/// when present and coherent; otherwise the decision is derived from the descriptor number. The
-/// lookup is allocation-free and holds the cache lock only across a single map probe.
+/// This is the hot-path lookup used by every descriptor system call. The answer comes from, in
+/// order: a cached entry that is still coherent; the fixed socket number range ([`derive`], no
+/// round-trip); otherwise an authoritative query to `vfsd` ([`resolve_via_vfsd`]).
+/// A cache hit on a coherent entry holds the lock only across a single map probe and never
+/// round-trips, so tight `read`/`write` loops stay local.
+#[cfg(any(feature = "standalone", test))]
 pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
     {
         let cache: ::spin::MutexGuard<'_, BTreeMap<i32, CacheEntry>> = CACHE.lock();
@@ -137,15 +190,54 @@ pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
             }
         }
     }
-    derive(fd)
+    // The fixed ranges answer without a round-trip; everything else is the authority's to decide.
+    if let Some(resolution) = derive(fd) {
+        return Some(resolution);
+    }
+    match resolve_via_vfsd(fd) {
+        VfsdResolution::Hit(resolution) => Some(resolution),
+        VfsdResolution::BadFile => None,
+        VfsdResolution::Unavailable => derive_console(fd),
+    }
+}
+
+/// Resolves `fd` and returns the descriptor expected by `vfsd`.
+///
+/// In standalone mode, fd-taking VFS syscalls must reject console, socket, and invalid descriptors
+/// rather than sending the caller-facing number directly to `vfsd`. In hosted mode descriptors are
+/// still interpreted by `linuxd`, so the raw descriptor is already the backend descriptor.
+#[cfg(feature = "standalone")]
+pub(crate) fn resolve_vfs(fd: i32, syscall_name: &str) -> Result<i32, Error> {
+    use ::sys::error::ErrorCode;
+
+    match resolve(fd) {
+        Some(resolution) if resolution.route == Route::Vfs => Ok(resolution.backend_fd),
+        _ => {
+            ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
+            Err(Error::new(ErrorCode::BadFile, "fd is not a VFS fd"))
+        },
+    }
+}
+
+/// Resolves `fd` and returns the descriptor expected by the VFS backend.
+///
+/// Non-standalone builds route these syscalls to `linuxd`, which interprets the caller-facing
+/// descriptor directly.
+#[cfg(not(feature = "standalone"))]
+pub(crate) fn resolve_vfs(fd: i32, _syscall_name: &str) -> Result<i32, Error> {
+    Ok(fd)
 }
 
 /// Records the resolution learned for `fd` from a backend response, stamped with the `epoch` the
 /// backend reported.
 ///
-/// Called when a descriptor is created (`open`/`socket`) so the cache holds an authoritative entry
-/// rather than relying on re-derivation. An existing entry for `fd` is replaced.
+/// Called when a descriptor is created (`open`/`pipe`/`socket`) or learned from a `vfsd` resolution
+/// so the cache holds an authoritative entry rather than re-querying on every use. The reported
+/// generation also advances [`EXPECTED_EPOCH`], so an entry recorded now is coherent against the
+/// table state that produced it. An existing entry for `fd` is replaced.
+#[cfg(any(feature = "standalone", test))]
 pub(crate) fn record(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
+    observe_epoch(epoch);
     CACHE.lock().insert(
         fd,
         CacheEntry {
@@ -156,18 +248,127 @@ pub(crate) fn record(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
     );
 }
 
+/// Queries `vfsd` for the authoritative route of `fd` and records the answer.
+///
+/// Reached only when the cache misses (or holds a stale entry) and the number is not in the fixed
+/// socket range — i.e. for a `vfsd`-owned descriptor that this process did not itself create, or
+/// one whose entry went stale. The answer is recorded so subsequent uses hit the cache. Returns
+/// `None` if `vfsd` reports no slot for `fd` (an invalid descriptor).
+#[cfg(all(feature = "standalone", not(test)))]
+fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
+    use crate::{
+        unistd::message::{
+            ResolveFdRequest,
+            ResolveFdResponse,
+        },
+        SystemCallMessage,
+        SystemCallMessageHeader,
+    };
+    use ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    };
+
+    let tid: ThreadIdentifier = match ::sys::kcall::pm::__kcall_gettid() {
+        Ok(tid) => tid,
+        Err(_) => return VfsdResolution::Unavailable,
+    };
+    let pid: ::sys::pm::ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+        Ok(pid) => pid,
+        Err(_) => return VfsdResolution::Unavailable,
+    };
+
+    // Send the resolution query to vfsd and await its authoritative answer.
+    let request: Message =
+        ResolveFdRequest::build(tid, pid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    if ::sys::kcall::ipc::__kcall_send(&request).is_err() {
+        return VfsdResolution::Unavailable;
+    }
+    let response: Message = match ::sys::kcall::ipc::__kcall_recv() {
+        Ok(response) => response,
+        Err(_) => return VfsdResolution::Unavailable,
+    };
+
+    // A non-zero status means vfsd holds no slot for this descriptor: it is unroutable.
+    if response.status != 0 {
+        return VfsdResolution::BadFile;
+    }
+
+    let message: SystemCallMessage = match SystemCallMessage::try_from_bytes(response.payload) {
+        Ok(message) => message,
+        Err(_) => return VfsdResolution::BadFile,
+    };
+    let resolved: ResolveFdResponse = match message.header {
+        SystemCallMessageHeader::ResolveFdResponse => {
+            ResolveFdResponse::from_bytes(message.payload)
+        },
+        _ => {
+            ::syslog::warn!("resolve_via_vfsd(): unexpected response header (fd={fd})");
+            return VfsdResolution::BadFile;
+        },
+    };
+    // `ResolveFdResponse` is `#[repr(C, packed)]`, so read each field through a raw pointer to avoid
+    // forming an unaligned reference (undefined behavior on targets that fault on misaligned loads).
+    let route_tag: u32 = unsafe { ::core::ptr::addr_of!(resolved.route).read_unaligned() };
+    let backend_fd: i32 = unsafe { ::core::ptr::addr_of!(resolved.backend_fd).read_unaligned() };
+    let epoch: u64 = unsafe { ::core::ptr::addr_of!(resolved.epoch).read_unaligned() };
+    let route: Route = match route_tag {
+        ResolveFdResponse::ROUTE_CONSOLE => Route::Console,
+        ResolveFdResponse::ROUTE_VFS => Route::Vfs,
+        ResolveFdResponse::ROUTE_SOCKET => Route::Socket,
+        other => {
+            ::syslog::warn!("resolve_via_vfsd(): unknown route tag {other} (fd={fd})");
+            return VfsdResolution::BadFile;
+        },
+    };
+    record(fd, route, backend_fd, epoch);
+    VfsdResolution::Hit(Resolution { route, backend_fd })
+}
+
+/// Test stand-in for the `vfsd` resolution query.
+///
+/// Host unit tests run without the `standalone` feature, so they cannot perform the real IPC. This
+/// reads the descriptor's authoritative route from [`MOCK_VFSD`], which a test populates to model
+/// `vfsd`'s table, and records it exactly as the production path would.
+#[cfg(test)]
+fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
+    if MOCK_VFSD_UNAVAILABLE.load(Ordering::Relaxed) {
+        return VfsdResolution::Unavailable;
+    }
+    let Some((route, backend_fd, epoch)) = MOCK_VFSD.lock().get(&fd).copied() else {
+        return VfsdResolution::BadFile;
+    };
+    record(fd, route, backend_fd, epoch);
+    VfsdResolution::Hit(Resolution { route, backend_fd })
+}
+
+/// Test model of `vfsd`'s authoritative slot table, consulted by the test [`resolve_via_vfsd`].
+#[cfg(test)]
+static MOCK_VFSD: Mutex<BTreeMap<i32, (Route, i32, u64)>> = Mutex::new(BTreeMap::new());
+
+/// Test switch that models a run mode without a guest `vfsd`.
+#[cfg(test)]
+static MOCK_VFSD_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
+
 /// Drops any cached resolution for `fd`.
 ///
 /// Called when a descriptor is destroyed (`close`) so a number later reused by a different backend
 /// cannot be answered from a stale entry.
+#[cfg(any(feature = "standalone", test))]
 pub(crate) fn invalidate(fd: i32) {
     CACHE.lock().remove(&fd);
 }
 
-/// Drops every cached resolution.
+/// Drops every cached resolution and resets the coherence and mock state.
+///
+/// Restores the process-global statics to their initial values so each test starts from a pristine
+/// cache, observed generation, and modeled `vfsd` table.
 #[cfg(test)]
 fn clear() {
     CACHE.lock().clear();
+    EXPECTED_EPOCH.store(0, Ordering::Relaxed);
+    MOCK_VFSD.lock().clear();
+    MOCK_VFSD_UNAVAILABLE.store(false, Ordering::Relaxed);
 }
 
 //==================================================================================================
@@ -177,97 +378,166 @@ fn clear() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::config::fds::{
-        SOCKET_FD_BASE,
-        VFS_FD_BASE,
-    };
+    use ::config::fds::SOCKET_FD_BASE;
 
-    /// Serializes the cache tests: they share the process-global [`CACHE`], so they must not run
-    /// concurrently with one another.
+    /// Serializes the cache tests: they share the process-global [`CACHE`], [`EXPECTED_EPOCH`], and
+    /// [`MOCK_VFSD`], so they must not run concurrently with one another.
     static CACHE_TEST_GUARD: Mutex<()> = Mutex::new(());
 
-    /// Tests that a descriptor with no cached entry resolves by the number rules.
+    /// Seeds the modeled `vfsd` table for the duration of a test.
+    fn mock_vfsd(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
+        MOCK_VFSD.lock().insert(fd, (route, backend_fd, epoch));
+    }
+
+    /// Tests that only the reserved socket range resolves without consulting `vfsd`. A low flat
+    /// number with nothing cached or modeled in `vfsd` is unroutable.
     #[test]
-    fn derive_seeds_from_number_rules() {
+    fn derive_routes_socket_by_number() {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
         assert_eq!(
-            resolve(STDIN_FILENO),
-            Some(Resolution {
-                route: Route::Console,
-                backend_fd: STDIN_FILENO
-            }),
-            "stdin must route to the console"
-        );
-        assert_eq!(
-            resolve(STDOUT_FILENO).map(|r| r.route),
-            Some(Route::Console),
-            "stdout must route to the console"
-        );
-        assert_eq!(
-            resolve(STDERR_FILENO).map(|r| r.route),
-            Some(Route::Console),
-            "stderr must route to the console"
-        );
-        assert_eq!(
-            resolve(VFS_FD_BASE),
-            Some(Resolution {
-                route: Route::Vfs,
-                backend_fd: VFS_FD_BASE
-            }),
-            "a high descriptor must route to vfsd"
-        );
-        assert_eq!(
             resolve(SOCKET_FD_BASE).map(|r| r.route),
             Some(Route::Socket),
-            "a socket descriptor must route to networkd"
+            "a socket descriptor must route to networkd by number"
         );
-        assert_eq!(resolve(7), None, "a descriptor in no backend range is unroutable");
+        // Low flat numbers are not a fixed range; with no cache entry and no vfsd slot they are
+        // unroutable rather than silently assumed to be console or vfsd files.
+        for fd in [0, 1, 2, 4] {
+            assert_eq!(resolve(fd), None, "an unknown flat descriptor must be unroutable");
+        }
 
         clear();
     }
 
-    /// Tests that a recorded entry is returned by `resolve`, overriding number-rule derivation.
+    /// Tests that standard descriptors are flat slots whose console route comes from `vfsd`, not
+    /// from their number.
+    #[test]
+    fn standard_descriptor_consults_vfsd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        mock_vfsd(1, Route::Console, 1, 3);
+        assert_eq!(
+            resolve(1),
+            Some(Resolution {
+                route: Route::Console,
+                backend_fd: 1
+            }),
+            "a standard descriptor must resolve through vfsd's flat table"
+        );
+
+        clear();
+    }
+
+    /// Tests that a present `vfsd` owns standard descriptor validity: an authoritative bad-fd
+    /// answer must not fall back to the console by number.
+    #[test]
+    fn standard_descriptor_bad_file_does_not_fallback() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        assert_eq!(resolve(STDOUT_FILENO), None, "vfsd bad-fd must stay authoritative");
+
+        clear();
+    }
+
+    /// Tests the direct-ELF run mode where no guest `vfsd` is available: standard descriptors still
+    /// route to the kernel console so stdout/stderr tests can report results.
+    #[test]
+    fn standard_descriptor_falls_back_when_vfsd_unavailable() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        MOCK_VFSD_UNAVAILABLE.store(true, Ordering::Relaxed);
+        assert_eq!(
+            resolve(STDOUT_FILENO),
+            Some(Resolution {
+                route: Route::Console,
+                backend_fd: STDOUT_FILENO
+            }),
+            "stdio must fall back to the kernel console when no vfsd exists"
+        );
+        assert_eq!(resolve(4), None, "non-stdio flat descriptors do not fall back");
+
+        clear();
+    }
+
+    /// Tests that hosted builds leave VFS descriptor interpretation to linuxd.
+    #[test]
+    fn hosted_resolve_vfs_returns_raw_fd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        let backend_fd: i32 = resolve_vfs(7, "test").expect("hosted resolve_vfs should succeed");
+        assert_eq!(backend_fd, 7, "hosted mode must pass raw descriptors through");
+
+        clear();
+    }
+
+    /// Tests that a recorded entry is returned by `resolve` without a `vfsd` round-trip, and that
+    /// `backend_fd` may differ from the caller-facing descriptor.
     #[test]
     fn record_then_resolve_hits_cache() {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
-        // A number that derives to nothing still resolves once recorded, proving the cache — not the
-        // number — is consulted first, and that `backend_fd` may differ from the descriptor.
-        record(7, Route::Vfs, VFS_FD_BASE + 5, 1);
+        // Model a contradictory vfsd answer to prove a coherent cache hit never consults it.
+        mock_vfsd(4, Route::Socket, 999, 0);
+        record(4, Route::Vfs, 41, 0);
         assert_eq!(
-            resolve(7),
+            resolve(4),
             Some(Resolution {
                 route: Route::Vfs,
-                backend_fd: VFS_FD_BASE + 5
+                backend_fd: 41
             }),
-            "a recorded entry must win over number-rule derivation"
+            "a coherent recorded entry must be returned without querying vfsd"
         );
 
         clear();
     }
 
-    /// Tests that `invalidate` drops a single entry, after which resolution falls back to the number
-    /// rules.
+    /// Tests that a cache miss on a flat descriptor consults `vfsd`, returns its authoritative
+    /// answer, and caches it so the next use hits the cache.
+    #[test]
+    fn cache_miss_consults_vfsd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        mock_vfsd(5, Route::Vfs, 5, 7);
+        assert_eq!(
+            resolve(5),
+            Some(Resolution {
+                route: Route::Vfs,
+                backend_fd: 5
+            }),
+            "a cache miss on a flat descriptor must consult vfsd"
+        );
+        // The answer is now cached at the reported epoch, so removing the vfsd model leaves the hot
+        // path intact.
+        MOCK_VFSD.lock().clear();
+        assert_eq!(
+            resolve(5).map(|r| r.route),
+            Some(Route::Vfs),
+            "the resolved descriptor must now hit the cache"
+        );
+
+        clear();
+    }
+
+    /// Tests that `invalidate` drops a single entry, after which resolution re-consults `vfsd`.
     #[test]
     fn invalidate_drops_entry() {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
-        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 3);
-        invalidate(VFS_FD_BASE);
-        // Re-derives to the same answer here, but from the number rather than the dropped entry.
-        assert_eq!(
-            resolve(VFS_FD_BASE).map(|r| r.route),
-            Some(Route::Vfs),
-            "after invalidation the descriptor re-derives from its number"
-        );
-        // A recorded-only number reverts to unroutable once invalidated.
-        record(7, Route::Socket, 7, 3);
-        invalidate(7);
-        assert_eq!(resolve(7), None, "an invalidated recorded-only entry is gone");
+        mock_vfsd(6, Route::Vfs, 6, 2);
+        assert!(resolve(6).is_some(), "the descriptor resolves and is cached");
+        invalidate(6);
+        // With the entry gone, the next resolve falls through to vfsd again rather than answering
+        // from the dropped entry.
+        MOCK_VFSD.lock().clear();
+        assert_eq!(resolve(6), None, "an invalidated entry must not survive as a stale answer");
 
         clear();
     }
@@ -278,29 +548,61 @@ mod tests {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
-        record(7, Route::Vfs, 7, 1);
-        record(8, Route::Socket, 8, 1);
+        record(4, Route::Vfs, 4, 1);
+        record(5, Route::Vfs, 5, 1);
         clear();
-        assert_eq!(resolve(7), None, "clear must drop recorded entries");
-        assert_eq!(resolve(8), None, "clear must drop recorded entries");
+        assert_eq!(resolve(4), None, "clear must drop recorded entries");
+        assert_eq!(resolve(5), None, "clear must drop recorded entries");
 
         clear();
     }
 
-    /// Tests that the epoch is inert: a descriptor's route does not depend on the generation its
-    /// entry was learned at.
+    /// Tests the stale-route hazard the flat namespace introduces: an entry learned at an older
+    /// generation must be refetched once `vfsd`'s table advances, and the fresh backend used — never
+    /// the entry that described the number's previous occupant.
     #[test]
-    fn epoch_does_not_change_routing() {
+    fn stale_entry_is_refetched_from_vfsd() {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
-        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 1);
-        let early: Option<Route> = resolve(VFS_FD_BASE).map(|r| r.route);
-        // Re-learn the same descriptor at a much newer generation.
-        record(VFS_FD_BASE, Route::Vfs, VFS_FD_BASE, 9_999);
-        let late: Option<Route> = resolve(VFS_FD_BASE).map(|r| r.route);
-        assert_eq!(early, Some(Route::Vfs));
-        assert_eq!(early, late, "bumping the epoch must not change the routing decision");
+        // Descriptor 4 is learned as a vfsd file at generation 1.
+        record(4, Route::Vfs, 4, 1);
+        assert_eq!(resolve(4).map(|r| r.route), Some(Route::Vfs), "initially a vfsd file");
+
+        // A later table mutation (e.g. another open) advances the observed generation, and the
+        // number has since been reused for a different backend in vfsd's table.
+        record(9, Route::Vfs, 9, 5);
+        mock_vfsd(4, Route::Socket, 4, 5);
+
+        // The stale entry must not be used: resolution refetches and reflects the new backend.
+        assert_eq!(
+            resolve(4),
+            Some(Resolution {
+                route: Route::Socket,
+                backend_fd: 4
+            }),
+            "a stale entry must be refetched, not trusted"
+        );
+
+        clear();
+    }
+
+    /// Tests that a coherent entry is never refetched: once the observed generation matches the
+    /// entry's epoch, the hot path answers from the cache even if `vfsd` would say otherwise.
+    #[test]
+    fn coherent_entry_skips_vfsd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        // Entry and observed generation agree at 5.
+        record(4, Route::Vfs, 4, 5);
+        // A contradictory vfsd model would change the answer if it were consulted.
+        mock_vfsd(4, Route::Socket, 4, 5);
+        assert_eq!(
+            resolve(4).map(|r| r.route),
+            Some(Route::Vfs),
+            "a coherent entry must be served from the cache without a vfsd round-trip"
+        );
 
         clear();
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -93,9 +93,8 @@ pub(crate) mod path;
 
 /// Client-side file-descriptor resolution cache.
 ///
-/// Compiled for standalone routing (where descriptor numbers encode their backend) and for the
-/// crate's own unit tests, which exercise the cache logic without the `standalone` feature.
-#[cfg(any(feature = "standalone", test))]
+/// Compiled for descriptor syscalls that need VFS routing helpers and for standalone cache tests.
+#[cfg(any(feature = "syscall", feature = "standalone", test))]
 pub(crate) mod fdtable;
 
 // Safe wrappers.
@@ -108,7 +107,6 @@ pub mod safe;
 
 pub use ::config::fds::{
     is_socket_fd,
-    is_vfs_fd,
     SOCKET_FD_BASE,
 };
 use ::core::{
@@ -280,6 +278,8 @@ pub enum SystemCallMessageHeader {
     // values of existing variants (this enum is `#[repr(u16)]` with implicit,
     // sequential discriminants used directly as IPC/IKC message tags).
     HostFsReadDirResponsePart,
+    ResolveFdRequest,
+    ResolveFdResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -442,6 +442,8 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == HostFsPathStatRequest as u16 => Ok(HostFsPathStatRequest),
             x if x == HostFsPathStatRequestPart as u16 => Ok(HostFsPathStatRequestPart),
             x if x == HostFsPathStatResponse as u16 => Ok(HostFsPathStatResponse),
+            x if x == ResolveFdRequest as u16 => Ok(ResolveFdRequest),
+            x if x == ResolveFdResponse as u16 => Ok(ResolveFdResponse),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -41,12 +41,13 @@ use ::sysapi::time::timespec;
 ///
 pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Error> {
     ::syslog::warn!("futimens(): fd={:?}, times={:?}", fd, times);
+    let backend_fd: RawFileDescriptor = crate::fdtable::resolve_vfs(fd, "futimens")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = UpdateFileAccessTimeRequest::build(
         tid,
-        fd,
+        backend_fd,
         times,
         crate::VFS_DESTINATION,
         crate::VFS_MESSAGE_TYPE,

--- a/src/libs/syscall/src/unistd/message/mod.rs
+++ b/src/libs/syscall/src/unistd/message/mod.rs
@@ -23,6 +23,7 @@ mod pread;
 mod pwrite;
 mod read;
 mod readlinkat;
+mod resolve_fd;
 mod symlinkat;
 mod write;
 
@@ -102,6 +103,10 @@ pub use self::{
     readlinkat::{
         ReadLinkAtRequest,
         ReadLinkAtResponse,
+    },
+    resolve_fd::{
+        ResolveFdRequest,
+        ResolveFdResponse,
     },
     symlinkat::{
         SymbolicLinkAtRequest,

--- a/src/libs/syscall/src/unistd/message/pipe.rs
+++ b/src/libs/syscall/src/unistd/message/pipe.rs
@@ -78,17 +78,24 @@ impl PipeRequest {
 pub struct PipeResponse {
     pub read_fd: i32,
     pub write_fd: i32,
+    /// The `vfsd` table generation at the time these descriptors were allocated.
+    ///
+    /// libposix stamps both descriptors' resolution-cache entries with this epoch so a later table
+    /// mutation can mark them stale. Hosted (`linuxd`) pipes have no `vfsd` table and report `0`.
+    pub epoch: u64,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(PipeResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl PipeResponse {
-    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - 2 * mem::size_of::<i32>();
+    pub const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - 2 * mem::size_of::<i32>() - mem::size_of::<u64>();
 
-    fn new(read_fd: i32, write_fd: i32) -> Self {
+    fn new(read_fd: i32, write_fd: i32, epoch: u64) -> Self {
         Self {
             read_fd,
             write_fd,
+            epoch,
             _padding: [0; Self::PADDING_SIZE],
         }
     }
@@ -105,10 +112,11 @@ impl PipeResponse {
         tid: ThreadIdentifier,
         read_fd: i32,
         write_fd: i32,
+        epoch: u64,
         source: ProcessIdentifier,
         message_type: MessageType,
     ) -> Message {
-        let message: PipeResponse = PipeResponse::new(read_fd, write_fd);
+        let message: PipeResponse = PipeResponse::new(read_fd, write_fd, epoch);
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::PipeResponse, message.into_bytes());
         let message: Message = Message::new(

--- a/src/libs/syscall/src/unistd/message/resolve_fd.rs
+++ b/src/libs/syscall/src/unistd/message/resolve_fd.rs
@@ -1,0 +1,176 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::{
+    fmt,
+    mem,
+};
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+//==================================================================================================
+// ResolveFdRequest
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Request message of the descriptor-resolution query. libposix sends this to vfsd on a
+/// resolution-cache miss to learn the authoritative backend of a flat descriptor number.
+///
+#[repr(C, packed)]
+pub struct ResolveFdRequest {
+    /// Process whose descriptor table owns `fd`.
+    pub pid: ProcessIdentifier,
+    /// The descriptor whose backend route is being queried.
+    pub fd: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(ResolveFdRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl ResolveFdRequest {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<ProcessIdentifier>()
+        - mem::size_of::<i32>();
+
+    fn new(pid: ProcessIdentifier, fd: i32) -> Self {
+        Self {
+            pid,
+            fd,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        pid: ProcessIdentifier,
+        fd: i32,
+        destination: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: ResolveFdRequest = ResolveFdRequest::new(pid, fd);
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::ResolveFdRequest, message.into_bytes());
+        Message::new(
+            MessageSender::from(tid),
+            MessageReceiver::from(destination),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+impl fmt::Debug for ResolveFdRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let pid: ProcessIdentifier = self.pid;
+        let fd: i32 = self.fd;
+        write!(f, "{{ pid: {pid:?}, fd: {fd} }}")
+    }
+}
+
+//==================================================================================================
+// ResolveFdResponse
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Response message of the descriptor-resolution query. It carries the descriptor's backend route,
+/// the descriptor number that backend expects, and the vfsd table generation the answer was learned
+/// at (its coherence epoch).
+///
+/// The route is carried as a small integer rather than an enum so the wire layout is fixed: `0` is
+/// the console (kernel), `1` is vfsd, and `2` is a `networkd` socket. A descriptor with no slot in
+/// the process is reported by an error response (non-zero status), not by this message.
+///
+#[repr(C, packed)]
+pub struct ResolveFdResponse {
+    /// The backend route: `0` = console, `1` = vfsd, `2` = socket.
+    pub route: u32,
+    /// The descriptor number the backend expects.
+    pub backend_fd: i32,
+    /// The vfsd table generation this answer was learned at.
+    pub epoch: u64,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(ResolveFdResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl ResolveFdResponse {
+    /// Wire value for a console-backed descriptor.
+    pub const ROUTE_CONSOLE: u32 = 0;
+    /// Wire value for a vfsd-served descriptor.
+    pub const ROUTE_VFS: u32 = 1;
+    /// Wire value for a `networkd` socket descriptor.
+    pub const ROUTE_SOCKET: u32 = 2;
+
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<u32>()
+        - mem::size_of::<i32>()
+        - mem::size_of::<u64>();
+
+    fn new(route: u32, backend_fd: i32, epoch: u64) -> Self {
+        Self {
+            route,
+            backend_fd,
+            epoch,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        route: u32,
+        backend_fd: i32,
+        epoch: u64,
+        source: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: ResolveFdResponse = ResolveFdResponse::new(route, backend_fd, epoch);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ResolveFdResponse,
+            message.into_bytes(),
+        );
+        Message::new(
+            MessageSender::from(source),
+            MessageReceiver::from(tid),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -46,8 +46,11 @@ pub fn close(fd: i32) -> Result<(), Error> {
                 Route::Vfs => {
                     close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)
                 },
-                // Console descriptors alias the kernel streams and own no resource to release here.
-                Route::Console => Ok(()),
+                // Console descriptors still occupy slots in vfsd's flat table; closing one must
+                // release that slot so the descriptor number can be reused.
+                Route::Console => {
+                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)
+                },
                 // Sockets are closed by networkd.
                 Route::Socket => {
                     close_ipc(res.backend_fd, crate::NETWORK_DESTINATION, MessageType::Ikc)

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -43,17 +43,23 @@ pub fn close(fd: i32) -> Result<(), Error> {
         let result: Result<(), Error> = match resolve(fd) {
             Some(res) => match res.route {
                 // VFS-backed descriptors are closed by vfsd.
-                Route::Vfs => {
-                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)
-                },
-                // Console descriptors still occupy slots in vfsd's flat table; closing one must
-                // release that slot so the descriptor number can be reused.
+                Route::Vfs => close_ipc(
+                    res.backend_fd,
+                    crate::VFS_DESTINATION,
+                    crate::VFS_MESSAGE_TYPE,
+                    false,
+                ),
+                // When a guest vfsd exists, a console descriptor also occupies a slot in vfsd's
+                // flat table; closing one must release that slot so the descriptor number can be
+                // reused. When no guest vfsd exists (direct-ELF standalone), resolve() routes the
+                // stream to the console by number and there is no slot to free, so the close is a
+                // no-op: the request cannot be delivered and that delivery failure is tolerated.
                 Route::Console => {
-                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)
+                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE, true)
                 },
                 // Sockets are closed by networkd.
                 Route::Socket => {
-                    close_ipc(res.backend_fd, crate::NETWORK_DESTINATION, MessageType::Ikc)
+                    close_ipc(res.backend_fd, crate::NETWORK_DESTINATION, MessageType::Ikc, false)
                 },
             },
             // Unknown fd: no handler available.
@@ -73,21 +79,43 @@ pub fn close(fd: i32) -> Result<(), Error> {
 
     #[cfg(not(feature = "standalone"))]
     {
-        close_ipc(fd, crate::LINUXD, MessageType::Ikc)
+        close_ipc(fd, crate::LINUXD, MessageType::Ikc, false)
     }
 }
 
 /// Forwards a `close` request via IPC to the given destination.
+///
+/// When `tolerate_missing_backend` is set, a failure to deliver the request (no such backend
+/// process) is reported as success rather than an error. This is used for console descriptors,
+/// which own no local resource: in a run mode with no guest vfsd there is no flat-table slot to
+/// release, so closing one is a no-op. The backend's own response is always honored, so a genuine
+/// error returned by a reachable backend still propagates.
 fn close_ipc(
     fd: i32,
     destination: ProcessIdentifier,
     message_type: MessageType,
+    tolerate_missing_backend: bool,
 ) -> Result<(), Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let tid: ThreadIdentifier = match ::sys::kcall::pm::__kcall_gettid() {
+        Ok(tid) => tid,
+        Err(error) => {
+            return if tolerate_missing_backend {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        },
+    };
 
     // Build request and send it.
     let request: Message = CloseRequest::build(tid, fd, destination, message_type);
-    ::sys::kcall::ipc::__kcall_send(&request)?;
+    if let Err(error) = ::sys::kcall::ipc::__kcall_send(&request) {
+        return if tolerate_missing_backend {
+            Ok(())
+        } else {
+            Err(error)
+        };
+    }
 
     // Receive response.
     let response: Message = ::sys::kcall::ipc::__kcall_recv()?;

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -36,11 +36,12 @@ use ::sysapi::ffi::c_int;
 ///
 pub fn fchdir(fd: c_int) -> Result<(), Error> {
     ::syslog::trace!("fchdir(): fd={:?}", fd);
+    let backend_fd: c_int = crate::fdtable::resolve_vfs(fd, "fchdir")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it
     let request: Message =
-        FileChdirRequest::build(tid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+        FileChdirRequest::build(tid, backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -39,11 +39,16 @@ use ::sys::{
 ///
 pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
     ::syslog::trace!("fdatasync(): fd={:?}", fd);
+    let backend_fd: RawFileDescriptor = crate::fdtable::resolve_vfs(fd, "fdatasync")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
-    let request: Message =
-        FileDataSyncRequest::build(tid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    let request: Message = FileDataSyncRequest::build(
+        tid,
+        backend_fd,
+        crate::VFS_DESTINATION,
+        crate::VFS_MESSAGE_TYPE,
+    );
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -39,11 +39,12 @@ use ::sysapi::ffi::c_int;
 ///
 pub fn fsync(fd: c_int) -> Result<(), Error> {
     ::syslog::trace!("fsync(): fd={:?}", fd);
+    let backend_fd: c_int = crate::fdtable::resolve_vfs(fd, "fsync")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message =
-        FileSyncRequest::build(tid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+        FileSyncRequest::build(tid, backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -43,12 +43,13 @@ use ::sysapi::{
 ///
 pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
     ::syslog::debug!("ftruncate(): fd={}, length={}", fd, length);
+    let backend_fd: c_int = crate::fdtable::resolve_vfs(fd, "ftruncate")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
     let request: Message = FileTruncateRequest::build(
         tid,
-        fd,
+        backend_fd,
         length,
         crate::VFS_DESTINATION,
         crate::VFS_MESSAGE_TYPE,

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -90,12 +90,38 @@ fn parse_pipe_response(response: Message) -> Result<[i32; 2], Error> {
                     // Parse response.
                     let response: PipeResponse = PipeResponse::from_bytes(message.payload);
 
-                    ::syslog::trace!(
-                        "pipe(): read_fd={:?}, write_fd={:?}",
-                        { response.read_fd },
-                        { response.write_fd },
-                    );
-                    Ok([response.read_fd, response.write_fd])
+                    let read_fd: i32 = response.read_fd;
+                    let write_fd: i32 = response.write_fd;
+                    ::syslog::trace!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");
+
+                    // Seed the resolution cache so both pipe ends resolve from the cache rather than
+                    // by number. They are vfsd-served descriptors carrying the table generation they
+                    // were allocated at. (Hosted pipes report epoch 0 and are not cached.)
+                    #[cfg(feature = "standalone")]
+                    {
+                        // `PipeResponse` is `#[repr(C, packed)]`, so read `epoch` through a raw
+                        // pointer to avoid forming an unaligned reference.
+                        let epoch: u64 =
+                            unsafe { ::core::ptr::addr_of!(response.epoch).read_unaligned() };
+                        if read_fd >= 0 {
+                            crate::fdtable::record(
+                                read_fd,
+                                crate::fdtable::Route::Vfs,
+                                read_fd,
+                                epoch,
+                            );
+                        }
+                        if write_fd >= 0 {
+                            crate::fdtable::record(
+                                write_fd,
+                                crate::fdtable::Route::Vfs,
+                                write_fd,
+                                epoch,
+                            );
+                        }
+                    }
+
+                    Ok([read_fd, write_fd])
                 },
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -167,9 +167,8 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         ::syslog::trace!("read(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    // In standalone mode, route by the descriptor's resolved backend. The resolution memoizes the
-    // number rules used before the cache existed, so the dispatch is identical to inspecting the
-    // descriptor number directly.
+    // In standalone mode, route by the descriptor's resolved backend so flat descriptors are
+    // dispatched through vfsd's authoritative table.
     #[cfg(feature = "standalone")]
     {
         use crate::fdtable::{

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -137,9 +137,8 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         ::syslog::trace!("write(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    // In standalone mode, route by the descriptor's resolved backend. The resolution memoizes the
-    // number rules used before the cache existed, so the dispatch is identical to inspecting the
-    // descriptor number directly.
+    // In standalone mode, route by the descriptor's resolved backend so flat descriptors are
+    // dispatched through vfsd's authoritative table.
     #[cfg(feature = "standalone")]
     {
         use crate::fdtable::{

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -27,10 +27,7 @@ use ::alloc::{
     sync::Arc,
     vec::Vec,
 };
-use ::config::fds::{
-    VFS_FD_BASE,
-    VFS_MAX_OPEN_FILES,
-};
+use ::config::fds::SOCKET_FD_BASE;
 use ::core::sync::atomic::{
     AtomicBool,
     AtomicI32,
@@ -593,11 +590,12 @@ impl Slot {
 /// gives the child a copy of this state: the descriptor slots are cloned as shared references to
 /// the parent's open file descriptions, while the working directory is deep-copied.
 ///
-/// The slot table is a flat map keyed by the raw descriptor number, so it can hold both the low
-/// console descriptors (`0`/`1`/`2`, seeded by [`vfs_seed_root_console`]) and the high VFS range
-/// allocated by [`alloc_fd`] in the same structure. Only the storage is flat: [`alloc_fd`] still
-/// hands out descriptors in `[VFS_FD_BASE, VFS_FD_BASE + VFS_MAX_OPEN_FILES)` and the descriptor
-/// operations below still resolve only that high range, so numbering and routing are unchanged.
+/// The slot table is a flat map keyed by the raw descriptor number: it holds the low console
+/// descriptors (`0`/`1`/`2`, seeded by [`vfs_seed_root_console`]) and the descriptors handed out by
+/// [`alloc_fd`] in one structure. [`alloc_fd`] allocates the lowest free number across that whole
+/// namespace, so the first `open` in a fresh process returns `3` and a freed number is reused
+/// before any higher one. A descriptor number therefore no longer encodes its backend; vfsd answers
+/// what each number is through [`vfs_resolve`].
 struct ProcessState {
     /// File descriptor slots keyed by the raw file descriptor number.
     slots: BTreeMap<c_int, Slot>,
@@ -730,24 +728,14 @@ pub(crate) fn current_cwd() -> String {
         .unwrap_or_else(|| String::from("/"))
 }
 
-/// Validates that `fd` falls within the VFS descriptor range.
-///
-/// vfsd now stores the console descriptors (`0`/`1`/`2`) alongside the high VFS range in a single
-/// flat table, but it serves no I/O on the console slots: those still flow `libposix → kernel` by
-/// number. Its descriptor operations therefore resolve only the high range, exactly as they did
-/// before the storage was generalized, so a descriptor below [`VFS_FD_BASE`] (or past the range)
-/// is rejected here.
-fn check_vfs_fd(fd: c_int) -> Result<(), Fat32Error> {
-    if is_vfs_fd(fd) {
-        Ok(())
-    } else {
-        Err(Fat32Error::InvalidFd)
-    }
-}
-
 /// Returns a shared reference to the open file description for `fd` in the current process.
+///
+/// Indexing is flat: the descriptor number is the slot key directly, so the low console slots
+/// (`0`/`1`/`2`) and the descriptors handed out by [`alloc_fd`] are looked up the same way. A
+/// descriptor with no slot in the current process is rejected. vfsd serves no I/O on console or
+/// socket tokens; the I/O methods on [`VfsFileHandle`] reject those handles, so this accessor does
+/// not need to special-case them.
 fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
-    check_vfs_fd(fd)?;
     let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
     let state: &ProcessState = procs.get(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
     state
@@ -758,15 +746,24 @@ fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
 }
 
 /// Allocates a new file descriptor for the given handle in the current process.
+///
+/// Allocation is flat and lowest-free: the descriptor is the smallest non-negative number not
+/// already present in the process's slot table. Console descriptors `0`/`1`/`2` occupy low keys in
+/// that same table, so the first `open` in a fresh process returns `3`, and a number freed by
+/// `close` is reused before any higher one — matching POSIX.
+///
+/// The search stops below [`SOCKET_FD_BASE`], so a VFS descriptor can never be handed out inside the
+/// `networkd`-owned socket range. This is the interim reservation that lets the flat namespace ship
+/// before sockets are unified into this table; it is removed once `networkd` joins the flat
+/// namespace.
 fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
     let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
         PROCESSES.lock();
     let state: &mut ProcessState = procs.entry(current_pid()).or_insert_with(ProcessState::new);
-    // Find the lowest free descriptor in the high VFS range. Console descriptors live at low keys
-    // in the same flat table but are never handed out here, so numbering is unchanged.
-    let fd: c_int = (0..VFS_MAX_OPEN_FILES)
-        .map(|i| VFS_FD_BASE + i as c_int)
-        .find(|fd| !state.slots.contains_key(fd))
+    // Lowest free descriptor across the whole flat namespace, bounded below the reserved socket
+    // range so an allocated number can never collide with a networkd-owned socket descriptor.
+    let fd: c_int = (0..SOCKET_FD_BASE)
+        .find(|candidate| !state.slots.contains_key(candidate))
         .ok_or(Fat32Error::TooManyOpenFiles)?;
     let file: OpenFile = Arc::new(Mutex::new(VfsEntry {
         handle,
@@ -892,10 +889,10 @@ static ROOT_CONSOLE_SEEDED: AtomicBool = AtomicBool::new(false);
 /// This installs a [`ConsoleHandle`] for stdin, stdout, and stderr into `pid`'s descriptor table so
 /// that vfsd becomes the authoritative bookkeeper of those slots and forks propagate them onward.
 ///
-/// The seeding is behavior-preserving: the console slots are inert routing tokens (vfsd serves no
-/// I/O on them — console `read`/`write` still flow `libposix → kernel` by number), and [`alloc_fd`]
-/// continues to hand out descriptors only in the high `[VFS_FD_BASE, …)` range, so `open` numbering
-/// is untouched.
+/// The console slots are inert routing tokens: vfsd serves no I/O on them, but it is the authority
+/// that tells libposix to route console `read`/`write` to the kernel. They occupy descriptors
+/// `0`/`1`/`2` in the flat table, so the lowest-free [`alloc_fd`] hands the first `open` descriptor
+/// `3`.
 ///
 /// The call is idempotent and root-only. vfsd may invoke it both on regular syscall dispatch and
 /// when a fork-clone notification names a parent; non-root pids are ignored without consuming the
@@ -1024,9 +1021,6 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
 /// `false` if other descriptors — for example in a forked child — still share it, or if `fd` is
 /// invalid. This does not modify the descriptor table.
 pub fn vfs_hostfs_is_last_ref(fd: c_int) -> bool {
-    if check_vfs_fd(fd).is_err() {
-        return false;
-    }
     let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
     let Some(state) = procs.get(&current_pid()) else {
         return false;
@@ -1047,9 +1041,6 @@ pub fn vfs_hostfs_is_last_ref(fd: c_int) -> bool {
 /// end (for example in a forked child), when `fd` is not a pipe, or when `fd` is invalid. This does
 /// not modify the descriptor table.
 pub fn vfs_pipe_is_last_ref(fd: c_int) -> bool {
-    if check_vfs_fd(fd).is_err() {
-        return false;
-    }
     let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
     let Some(state) = procs.get(&current_pid()) else {
         return false;
@@ -1228,7 +1219,6 @@ pub fn vfs_get_status_flags(fd: c_int) -> c_int {
 /// stored per descriptor, so descriptors that share one open file description through `dup` or
 /// `fork` report them independently.
 pub fn vfs_get_fd_flags(fd: c_int) -> Option<FdFlags> {
-    check_vfs_fd(fd).ok()?;
     let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
     let state: &ProcessState = procs.get(&current_pid())?;
     Some(state.slots.get(&fd)?.fd_flags)
@@ -1240,7 +1230,6 @@ pub fn vfs_get_fd_flags(fd: c_int) -> Option<FdFlags> {
 /// flags are stored per descriptor, updating one descriptor does not affect another that shares the
 /// same open file description.
 pub fn vfs_set_fd_flags(fd: c_int, flags: FdFlags) -> Result<(), Fat32Error> {
-    check_vfs_fd(fd)?;
     let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
         PROCESSES.lock();
     let state: &mut ProcessState = procs.get_mut(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
@@ -1281,20 +1270,67 @@ pub fn is_vfs_path(path: &str) -> bool {
     fat32_backend::exists(path)
 }
 
-/// Returns `true` if the given file descriptor belongs to the VFS.
-pub fn is_vfs_fd(fd: c_int) -> bool {
-    ::config::fds::is_vfs_fd(fd)
+/// The backend a descriptor's slot is bound to, as reported by [`vfs_resolve`].
+///
+/// vfsd is the routing authority once descriptor numbers no longer encode their backend: it answers
+/// what a flat number like `4` actually is — a console stream, a vfsd-served object, or a socket —
+/// from its authoritative slot table.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VfsRoute {
+    /// A console stream; the `backend_fd` is the standard stream number (`0`/`1`/`2`).
+    Console,
+    /// A vfsd-served object (regular file, directory, host file, or pipe end).
+    Vfs,
+    /// A socket; the `backend_fd` is the descriptor `networkd` assigned.
+    Socket,
+}
+
+/// Resolves a flat descriptor to its backend route and the descriptor that backend expects.
+///
+/// This is the authoritative answer libposix consults on a resolution-cache miss once numbers stop
+/// encoding their backend. The route follows the slot's handle: a console token reports
+/// [`VfsRoute::Console`] and the stream number it stands for, a socket token reports
+/// [`VfsRoute::Socket`] and its `networkd` descriptor, and every vfsd-served handle reports
+/// [`VfsRoute::Vfs`] addressed by the raw descriptor. Returns `None` if the current process holds no
+/// slot for `fd`.
+pub fn vfs_resolve(fd: c_int) -> Option<(VfsRoute, c_int)> {
+    // Clone the shared open file description out from under the registry lock, then inspect its
+    // handle without nesting the registry lock under the per-entry lock.
+    let file: OpenFile = {
+        let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
+            PROCESSES.lock();
+        procs.get(&current_pid())?.slots.get(&fd)?.file.clone()
+    };
+    let guard = file.lock();
+    let resolution: (VfsRoute, c_int) = match &guard.handle {
+        VfsFileHandle::Console(h) => (
+            VfsRoute::Console,
+            match h.stream() {
+                ConsoleStream::Stdin => STDIN_FILENO,
+                ConsoleStream::Stdout => STDOUT_FILENO,
+                ConsoleStream::Stderr => STDERR_FILENO,
+            },
+        ),
+        VfsFileHandle::Socket(h) => (VfsRoute::Socket, h.remote_fd()),
+        // Every other handle is served by vfsd, addressed by the raw descriptor.
+        VfsFileHandle::Fat32(_)
+        | VfsFileHandle::DirectRead(_)
+        | VfsFileHandle::Directory(_)
+        | VfsFileHandle::HostFs(_)
+        | VfsFileHandle::Pipe(_) => (VfsRoute::Vfs, fd),
+    };
+    Some(resolution)
 }
 
 /// Resolves a `dirfd` + `path` pair into an absolute VFS path.
 ///
 /// If `path` is absolute, it is returned as-is (dirfd is ignored per POSIX).
 /// If `dirfd` is `AT_FDCWD`, the path is resolved against the VFS current
-/// working directory. If `dirfd` is a VFS directory fd, the path is resolved
+/// working directory. If `dirfd` is a directory descriptor, the path is resolved
 /// relative to that directory's path.
 ///
-/// Returns `None` if `dirfd` is not a VFS fd and not `AT_FDCWD`, indicating
-/// that VFS cannot handle this request.
+/// Returns `None` if `dirfd` is neither `AT_FDCWD` nor a directory descriptor of the current
+/// process, indicating that VFS cannot handle this request.
 ///
 /// # Limitations
 ///
@@ -1321,11 +1357,9 @@ pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<String> {
         };
     }
 
-    // Relative path with a VFS directory fd: resolve against that directory.
-    if !is_vfs_fd(dirfd) {
-        return None;
-    }
-
+    // Relative path with a directory descriptor: resolve against that directory. Validity is the
+    // slot's handle type, not the descriptor number — a non-directory or absent descriptor yields
+    // `None` below rather than being pre-screened by a number range.
     let file: OpenFile = entry_arc(dirfd).ok()?;
     let guard = file.lock();
     let dir_path: &str = match &guard.handle {
@@ -1558,8 +1592,10 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
 }
 
 /// Closes a VFS file descriptor.
+///
+/// In the flat namespace any descriptor present in the process's slot table can be closed by its
+/// raw number, including a low console slot — freeing it for the lowest-free allocator to reuse.
 pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
-    check_vfs_fd(fd)?;
     // Detach the descriptor while holding the registry lock, but defer dropping the open file
     // description until the lock is released. Its drop may run backend teardown (e.g. `File::drop`,
     // which takes a global VFS lock); deferring keeps the registry lock from ever nesting with
@@ -2382,33 +2418,90 @@ mod tests {
         assert_eq!(size, 100);
     }
 
-    // -- FD range tests ----------------------------------------------------------
+    // -- flat allocation & resolution tests --------------------------------------
 
-    /// Tests that VFS FD base is outside linuxd range.
+    /// Tests that allocation is flat and lowest-free: descriptors are handed out from `0` upward and
+    /// a freed number is reused before any higher one. No descriptor ever falls in the reserved
+    /// socket range.
     #[test]
-    fn vfs_fd_base_is_high() {
-        const { assert!(VFS_FD_BASE >= 1024, "VFS FD base should be >= 1024 to avoid linuxd conflicts") };
+    fn alloc_is_lowest_free_and_below_socket_range() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7401);
+        set_current_process(pid);
+
+        // A fresh process with no console seeded allocates from 0 upward.
+        let a: c_int = vfs_alloc_hostfs(10, false, None).expect("alloc a");
+        let b: c_int = vfs_alloc_hostfs(11, false, None).expect("alloc b");
+        let c: c_int = vfs_alloc_hostfs(12, false, None).expect("alloc c");
+        assert_eq!((a, b, c), (0, 1, 2), "flat allocation hands out the lowest free numbers");
+        assert!(
+            [a, b, c].iter().all(|fd| !::config::fds::is_socket_fd(*fd)),
+            "an allocated descriptor must never fall in the reserved socket range"
+        );
+
+        // Freeing the middle descriptor makes it the lowest free, so the next alloc reuses it.
+        vfs_close(b).expect("close b");
+        let d: c_int = vfs_alloc_hostfs(13, false, None).expect("alloc d");
+        assert_eq!(d, b, "a freed number is reused before any higher one");
+
+        forget_processes(&[pid]);
     }
 
-    /// Tests is_vfs_fd with FDs in range.
+    /// Tests that the first `open` in a process whose console slots are seeded returns `3`, because
+    /// `0`/`1`/`2` are occupied by the standard streams — the POSIX lowest-free expectation.
     #[test]
-    fn is_vfs_fd_in_range() {
-        assert!(is_vfs_fd(VFS_FD_BASE), "base FD should be a VFS FD");
-        assert!(
-            is_vfs_fd(VFS_FD_BASE + VFS_MAX_OPEN_FILES as c_int - 1),
-            "last FD should be a VFS FD"
-        );
+    fn first_open_after_console_seed_returns_three() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let root: ProcessIdentifier = root_process_identifier();
+
+        vfs_seed_root_console(root);
+        set_current_process(root);
+        let fd: c_int = vfs_alloc_hostfs(20, false, None).expect("alloc after seed");
+        assert_eq!(fd, 3, "console occupies 0/1/2, so the first open returns 3");
+
+        // Closing stdin frees slot 0, which the lowest-free allocator then reuses ahead of 4.
+        vfs_close(STDIN_FILENO).expect("close stdin");
+        let reused: c_int = vfs_alloc_hostfs(21, false, None).expect("alloc after closing stdin");
+        assert_eq!(reused, STDIN_FILENO, "closing stdin makes 0 the lowest free number");
+
+        forget_processes(&[root]);
     }
 
-    /// Tests is_vfs_fd with FDs out of range.
+    /// Tests that [`vfs_resolve`] answers a descriptor's backend from its slot handle: a console
+    /// token reports its stream number, a socket token its networkd descriptor, and every
+    /// vfsd-served handle the raw descriptor. An absent descriptor resolves to `None`.
     #[test]
-    fn is_vfs_fd_out_of_range() {
-        assert!(!is_vfs_fd(0), "FD 0 should not be a VFS FD");
-        assert!(!is_vfs_fd(VFS_FD_BASE - 1), "FD below base should not be a VFS FD");
-        assert!(
-            !is_vfs_fd(VFS_FD_BASE + VFS_MAX_OPEN_FILES as c_int),
-            "FD past max should not be a VFS FD"
+    fn vfs_resolve_reports_backend_by_handle() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7411);
+        set_current_process(pid);
+
+        let console_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+                .expect("console alloc");
+        let socket_fd: c_int =
+            alloc_fd(VfsFileHandle::Socket(SocketHandle::new(77))).expect("socket alloc");
+        let file_fd: c_int = vfs_alloc_hostfs(30, false, None).expect("hostfs alloc");
+
+        // The console token's backend is its stream number (stdout = 1), not its slot number.
+        assert_eq!(
+            vfs_resolve(console_fd),
+            Some((VfsRoute::Console, STDOUT_FILENO)),
+            "a console token resolves to its stream number"
         );
+        assert_eq!(
+            vfs_resolve(socket_fd),
+            Some((VfsRoute::Socket, 77)),
+            "a socket token resolves to its networkd descriptor"
+        );
+        assert_eq!(
+            vfs_resolve(file_fd),
+            Some((VfsRoute::Vfs, file_fd)),
+            "a vfsd-served handle resolves to its raw descriptor"
+        );
+        assert_eq!(vfs_resolve(4096), None, "an absent descriptor resolves to None");
+
+        forget_processes(&[pid]);
     }
 
     // -- fork() per-process descriptor table tests -------------------------------

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -1591,7 +1591,7 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     Ok(())
 }
 
-/// Closes a VFS file descriptor.
+/// Closes a descriptor held in the process's flat slot table.
 ///
 /// In the flat namespace any descriptor present in the process's slot table can be closed by its
 /// raw number, including a low console slot — freeing it for the lowest-free allocator to reuse.

--- a/src/tests/mount-test/src/main.rs
+++ b/src/tests/mount-test/src/main.rs
@@ -35,6 +35,7 @@ mod file_ops;
 mod fs_ops;
 mod mount_lifecycle;
 mod readdir_ops;
+mod stdio_reuse;
 mod symlink_ops;
 
 //==================================================================================================
@@ -70,6 +71,9 @@ pub fn main() -> Result<(), Error> {
 
     // Phase 3.7: Invalid-dirfd rejection for hostfs-routed *at() operations.
     dirfd_reject::test()?;
+
+    // Phase 3.8: Standard descriptor close/reuse semantics under the flat namespace.
+    stdio_reuse::test()?;
 
     // Phase 4: Cross-filesystem consistency tests (RAMFS vs HostFS).
     cross_fs::test()?;

--- a/src/tests/mount-test/src/stdio_reuse.rs
+++ b/src/tests/mount-test/src/stdio_reuse.rs
@@ -1,0 +1,130 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Integration tests proving that closing a standard descriptor releases its slot in `vfsd`'s flat
+//! descriptor table, so the freed number becomes the lowest free descriptor and is handed back to a
+//! later `open()`.
+//!
+//! Under the flat namespace a descriptor's number no longer encodes its backend: `0`/`1`/`2` are
+//! seeded as console descriptors in `vfsd` for a normally-launched process, but they live in the
+//! same per-process table as every other descriptor. Closing one must therefore free its number for
+//! reuse, exactly like closing any regular file. These tests exercise that end-to-end through
+//! libposix and `vfsd`.
+//!
+//! `stdout` (`1`) is deliberately left untouched: the harness needs it for the success sentinel.
+//! Only `stdin` (`0`) and `stderr` (`2`) are closed, and both are restored to a free state before
+//! returning. Guest `syslog` writes through the kernel debug channel, not `stderr`, so closing `2`
+//! does not affect diagnostics.
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    fcntl::{
+        file_access_mode::O_RDWR,
+        file_creation_flags::{
+            O_CREAT,
+            O_TRUNC,
+        },
+    },
+    ffi::c_int,
+    sys_types::mode_t,
+    unistd::{
+        file_seek::SEEK_SET,
+        STDERR_FILENO,
+        STDIN_FILENO,
+    },
+};
+use ::syscall::{
+    fcntl,
+    unistd,
+};
+
+/// Permission bits for a user read/write scratch file (`0o600`).
+const FILE_MODE: mode_t = 0o600;
+
+/// Open flags for a truncating read/write scratch file.
+const SCRATCH_FLAGS: c_int = O_RDWR | O_CREAT | O_TRUNC;
+
+/// Runs the standard-descriptor close/reuse tests.
+pub fn test() -> Result<(), Error> {
+    test_close_stdin_reuses_zero()?;
+    test_close_stderr_reuses_two()?;
+    ::syslog::info!("mount-test: [PASS] stdio descriptor close/reuse");
+    Ok(())
+}
+
+/// Closing `stdin` frees descriptor `0`; the next `open()` must hand it back, and the reused
+/// descriptor must behave as a real file rather than a stale console token.
+fn test_close_stdin_reuses_zero() -> Result<(), Error> {
+    const PATH: &str = "/mnt/stdio-reuse-stdin.txt";
+    const DATA: &[u8] = b"reuse-stdin";
+
+    // `stdin` starts open as a console descriptor seeded by `vfsd`; closing it releases slot `0`.
+    unistd::close(STDIN_FILENO)?;
+
+    // With `0` released, it is the lowest free descriptor, so the next `open()` must reuse it.
+    let fd: c_int = fcntl::open(PATH, SCRATCH_FLAGS, FILE_MODE)?;
+    if fd != STDIN_FILENO {
+        ::syslog::error!("mount-test: expected closed stdin to be reused as fd 0, got {fd}");
+        return Err(Error::new(ErrorCode::InvalidArgument, "closed stdin was not reused as fd 0"));
+    }
+
+    // The reused descriptor must be a fully functional file: write, rewind, and read back.
+    let written: usize = unistd::write(fd, DATA)? as usize;
+    if written != DATA.len() {
+        return Err(Error::new(ErrorCode::IoErr, "short write on the reused descriptor"));
+    }
+    unistd::lseek(fd, 0, SEEK_SET)?;
+    let mut buf: [u8; 16] = [0u8; 16];
+    let read: usize = unistd::read(fd, &mut buf)? as usize;
+    if &buf[..read] != DATA {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "read-back through the reused descriptor mismatched",
+        ));
+    }
+
+    // Release the reused descriptor (freeing `0` again) and remove the scratch file.
+    unistd::close(fd)?;
+    unistd::unlink(PATH)?;
+
+    ::syslog::info!("mount-test: [PASS] close(stdin) frees fd 0 for reuse");
+    Ok(())
+}
+
+/// Closing `stderr` frees descriptor `2`; with `0` and `1` held, the next `open()` must hand back
+/// exactly `2`. This proves a freed standard descriptor is reused by its own number, not merely by
+/// the lowest one overall.
+fn test_close_stderr_reuses_two() -> Result<(), Error> {
+    const OCCUPY_PATH: &str = "/mnt/stdio-reuse-occupy.txt";
+    const PATH: &str = "/mnt/stdio-reuse-stderr.txt";
+
+    // Hold descriptor `0` (freed by the previous test) so that, together with `stdout` at `1`, the
+    // only lower number left free once `stderr` is closed is `2` itself.
+    let occupy_fd: c_int = fcntl::open(OCCUPY_PATH, SCRATCH_FLAGS, FILE_MODE)?;
+    if occupy_fd != STDIN_FILENO {
+        ::syslog::error!("mount-test: expected occupying open to take fd 0, got {occupy_fd}");
+        return Err(Error::new(ErrorCode::InvalidArgument, "occupying open did not take fd 0"));
+    }
+
+    // `stderr` is still a console descriptor seeded by `vfsd`; closing it releases slot `2`.
+    unistd::close(STDERR_FILENO)?;
+
+    // With `0` and `1` held, descriptor `2` is now the lowest free number and must be reused.
+    let fd: c_int = fcntl::open(PATH, SCRATCH_FLAGS, FILE_MODE)?;
+    if fd != STDERR_FILENO {
+        ::syslog::error!("mount-test: expected closed stderr to be reused as fd 2, got {fd}");
+        return Err(Error::new(ErrorCode::InvalidArgument, "closed stderr was not reused as fd 2"));
+    }
+
+    // Release both descriptors (freeing `0` and `2` again) and remove the scratch files.
+    unistd::close(fd)?;
+    unistd::close(occupy_fd)?;
+    unistd::unlink(PATH)?;
+    unistd::unlink(OCCUPY_PATH)?;
+
+    ::syslog::info!("mount-test: [PASS] close(stderr) frees fd 2 for reuse");
+    Ok(())
+}

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -497,7 +497,10 @@ fn test_open_directory() -> Result<(), Error> {
 
     // The returned fd should resolve to a vfsd-served descriptor.
     if vfs::fd::vfs_resolve(fd) != Some((vfs::fd::VfsRoute::Vfs, fd)) {
-        return Err(Error::new(ErrorCode::InvalidArgument, "fd should be a VFS fd"));
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "fd should resolve to a vfsd-served descriptor",
+        ));
     }
 
     // Reading from a directory handle should fail.

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -495,8 +495,8 @@ fn test_open_directory() -> Result<(), Error> {
     let fd: i32 = vfs::fd::vfs_open("/odir/sub", file_creation_flags::O_DIRECTORY)
         .map_err(|e| fat_err(e, "vfs_open O_DIRECTORY failed"))?;
 
-    // The returned fd should be a VFS fd.
-    if !vfs::fd::is_vfs_fd(fd) {
+    // The returned fd should resolve to a vfsd-served descriptor.
+    if vfs::fd::vfs_resolve(fd) != Some((vfs::fd::VfsRoute::Vfs, fd)) {
         return Err(Error::new(ErrorCode::InvalidArgument, "fd should be a VFS fd"));
     }
 
@@ -837,12 +837,13 @@ fn test_resolve_path() -> Result<(), Error> {
         return Err(Error::new(ErrorCode::InvalidArgument, "dirfd path mismatch"));
     }
 
-    // Non-VFS fd should return None.
-    if vfs::fd::vfs_resolve_path(3, "file.txt").is_some() {
-        return Err(Error::new(ErrorCode::InvalidArgument, "non-VFS fd should return None"));
-    }
-
+    // A descriptor with no slot should return None. Under the flat namespace this is determined by
+    // the slot's handle type, not a number range: close the directory fd so it is absent, then it
+    // no longer resolves.
     vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+    if vfs::fd::vfs_resolve_path(dir_fd, "file.txt").is_some() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "absent fd should return None"));
+    }
 
     // Clean up.
     vfs::chdir("/").map_err(|e| fat_err(e, "chdir / failed"))?;


### PR DESCRIPTION
## Summary

Activates the flat file-descriptor namespace: `open()` now hands out the lowest
free descriptor, so a number no longer encodes its backend. `vfsd` becomes the
authoritative owner of the per-process descriptor table (including the standard
streams), the resolution-cache coherence epoch becomes load-bearing, and the
client cache resolves against `vfsd` instead of the number. Builds directly on
the prior `client-side fd resolution cache` change.

## Changes

### Number ranges (`config`)
- Remove `VFS_FD_BASE`, `VFS_MAX_OPEN_FILES`, and `is_vfs_fd`.
- Keep `SOCKET_FD_BASE` / `is_socket_fd` as the interim `networkd` reservation
  (allocation stays below it) until sockets join the flat table.

### Authoritative flat table (`vfs`)
- `alloc_fd()` hands out the lowest free number in `[0, SOCKET_FD_BASE)`, so a
  freed number (including a low one) is reused before any higher one.
- Add `Console`/`Socket` handle tokens so `vfsd` owns the slot and per-descriptor
  flags while console/socket I/O is served elsewhere.
- `vfs_seed_root_console()` seeds `0`/`1`/`2` for the root; a fork clones every
  slot (offsets shared) so children inherit stdio.
- `vfs_close()` releases any slot by its raw number, including a low console
  slot, freeing it for reuse.
- `vfs_resolve()` reports a descriptor's backend from its slot handle; the
  per-process generation counter is now load-bearing.

### Authoritative resolution query (`syscall`, `vfsd`)
- Add `ResolveFdRequest{pid, fd}` / `ResolveFdResponse{route, backend_fd, epoch}`
  and register the new message headers.
- `handle_resolve_fd()` selects the caller's process by the request PID (not the
  reply TID, which differs after `execv`) before reading its slot table; a
  descriptor with no slot is reported as `EBADF`.

### Client cache (`syscall/fdtable`)
- `derive()` now answers only the fixed socket range; every lower number
  (including `0`/`1`/`2`) is resolved through `vfsd`.
- The epoch is load-bearing: `is_coherent()` compares an entry against the newest
  observed `vfsd` generation, so a number reused for a different backend is never
  answered from a stale entry.
- `resolve_via_vfsd()` returns `Hit` / `BadFile` / `Unavailable`; when no guest
  `vfsd` exists (direct-ELF runs), the standard streams fall back to the kernel
  console by number so stdout/stderr still work.
- Add `resolve_vfs()` to gate fd-taking VFS syscalls (`EBADF` for non-VFS
  descriptors in standalone; raw pass-through when hosted by `linuxd`).

### Call-site routing
- `close()` releases console descriptors through `vfsd` and invalidates the
  cache, so a closed standard descriptor frees its number.
- `fsync`, `fdatasync`, `ftruncate`, `fchdir`, `fcntl`, `posix_fadvise`,
  `posix_fallocate`, `futimens`, and `getdents` route through `resolve_vfs()`
  and address the backend via `backend_fd`.

### Pipe epoch threading
- `PipeResponse` carries the `vfsd` table generation; `vfsd` stamps the
  post-mutation generation; hosted `linuxd` pipes report `0`; libposix seeds both
  pipe ends into the cache at that epoch.

### Tests
- Update `fdtable` unit tests (socket-by-number, standard descriptor via `vfsd`,
  authoritative bad-file vs no-`vfsd` console fallback, stale-entry refetch,
  coherent-entry skip).
- Update `vfs-test` to assert backends via `vfs_resolve`.
- Add a `mount-test` integration phase that demonstrates `close()` releasing a
  standard stream's slot and the freed number being reused by a later `open()`
  (stdin -> fd 0, and stderr -> fd 2 with 0/1 held).

## Testing

- `./z build -- run-unit-tests`
- `./z build -- run-nanvix-tests` (standalone microvm) — `[OK] Build complete.`;
  the new `mount-test` `[PASS]` markers appear and `mount-test` reports `ok`.
- `cargo clippy ... -p syscall` and `-p vfs` (host, `--features=std`).

## Notes

- `SOCKET_FD_BASE` remains a reserved `networkd` range; unifying sockets into the
  flat table is left to a follow-up.


## Issues

Closes #2597 
