### PR TITLE
[vfs] dup/dup2/F_DUPFD on the flat descriptor table

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -23,7 +23,10 @@
 extern crate alloc;
 
 use crate::{
-    error::build_error,
+    error::{
+        build_error,
+        fat32_to_error_code,
+    },
     hostfs,
     pending::{
         PendingOp,
@@ -34,7 +37,10 @@ use crate::{
 };
 use ::sys::{
     error::ErrorCode,
-    ipc::Message,
+    ipc::{
+        Message,
+        MessageType,
+    },
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
@@ -43,6 +49,8 @@ use ::sys::{
 use ::syscall::{
     unistd::message::{
         CloseRequest,
+        Dup2Request,
+        Dup2Response,
         FileSyncRequest,
         FileTruncateRequest,
         ReadRequest,
@@ -121,6 +129,77 @@ pub(crate) fn handle_close_with_hostfs(
     }
 
     Some(super::short::handle_close(source, msg))
+}
+
+/// Handles `dup2(oldfd, newfd)` as an authoritative slot-table operation.
+///
+/// `newfd` is re-pointed at `oldfd`'s open file description, which works uniformly across every
+/// backend — including the cross-backend redirections the old split descriptor model could not
+/// express (e.g. `dup2(file_fd, 1)` so a subsequent `write(1)` lands in the file). The descriptor
+/// previously held by `newfd` is closed with the *same* last-reference accounting as a real
+/// `close`: a displaced pipe end fires its EOF/`EPIPE` wakeup, and a displaced host-backed last
+/// reference has its remote handle closed on hostfsd. That remote close is fire-and-forget — POSIX
+/// specifies that `dup2`'s implicit close ignores errors — so no pending op is registered and the
+/// main loop discards hostfsd's acknowledgement via the `FIRE_AND_FORGET` sentinel.
+///
+/// Because the remote reclaim never blocks, this returns a response synchronously rather than
+/// deferring like the hostfs-aware close path.
+pub(crate) fn handle_dup2(
+    source: ThreadIdentifier,
+    msg: SystemCallMessage,
+    pipe_wait: &mut PipeWaitTable,
+) -> Message {
+    let req: Dup2Request = Dup2Request::from_bytes(msg.payload);
+    let oldfd: i32 = req.oldfd;
+    let newfd: i32 = req.newfd;
+
+    // POSIX: an invalid source descriptor fails with `EBADF` and leaves `newfd` untouched.
+    if ::vfs::fd::vfs_resolve(oldfd).is_none() {
+        return build_error(source, ErrorCode::BadFile);
+    }
+
+    // `dup2(fd, fd)` returns `fd` and performs no implicit close.
+    if oldfd == newfd {
+        return Dup2Response::build(source, newfd, ProcessIdentifier::VFSD, MessageType::Ipc);
+    }
+
+    // Capture whatever last-reference reclaim the descriptor displaced from `newfd` owes — exactly
+    // as a close of `newfd` would — before re-pointing the slot. If `newfd` already aliases
+    // `oldfd`'s description it is not a last reference, so nothing is reclaimed.
+    let displaced_pipe: Option<(u64, bool)> =
+        ::vfs::fd::vfs_pipe_id(newfd).filter(|_| ::vfs::fd::vfs_pipe_is_last_ref(newfd));
+    let displaced_hostfs: Option<i32> =
+        ::vfs::fd::vfs_hostfs_remote_fd(newfd).filter(|_| ::vfs::fd::vfs_hostfs_is_last_ref(newfd));
+
+    // Perform the authoritative table mutation: `newfd` now aliases `oldfd`'s description. This
+    // drops the displaced description locally; its external reclaim is performed below.
+    if let Err(e) = ::vfs::fd::vfs_dup2(oldfd, newfd) {
+        return build_error(source, fat32_to_error_code(&e));
+    }
+
+    // A displaced pipe end fires the same EOF/`EPIPE` wakeup that closing it would.
+    if let Some((pipe_id, was_write)) = displaced_pipe {
+        if was_write {
+            super::pipe::wake_all_readers_eof(pipe_id, pipe_wait);
+        } else {
+            super::pipe::fail_all_writers_epipe(pipe_id, pipe_wait);
+        }
+    }
+
+    // A displaced host-backed last reference must have its remote handle closed so it does not leak.
+    if let Some(remote_fd) = displaced_hostfs {
+        if let Err(e) =
+            hostfs::send_close_request(remote_fd, ::hostfs_api::OperationId::FIRE_AND_FORGET)
+        {
+            ::syslog::warn!(
+                "dup2: failed to close displaced hostfs handle (remote_fd={}, error={:?})",
+                remote_fd,
+                e
+            );
+        }
+    }
+
+    Dup2Response::build(source, newfd, ProcessIdentifier::VFSD, MessageType::Ipc)
 }
 
 pub(crate) fn handle_seek_with_hostfs(

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -167,16 +167,52 @@ pub(crate) fn handle_fadvise(source: ThreadIdentifier, msg: SystemCallMessage) -
 }
 
 pub(crate) fn handle_fcntl(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
+    use ::sysapi::fcntl::file_control_request::{
+        F_DUPFD,
+        F_DUPFD_CLOEXEC,
+        F_DUPFD_CLOFORK,
+    };
+
     let req: FileControlRequest = FileControlRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
     let cmd: i32 = req.cmd;
     let arg: i32 = req.arg;
-    match ::vfs::fd::vfs_fcntl(fd, cmd, arg) {
+    // The duplication commands are slot-table allocations rather than flag queries: route them to
+    // the shared `dup` primitive, which aliases `fd`'s open file description into the lowest free
+    // descriptor at or above `arg`. The close-on-exec / close-on-fork variants set the matching
+    // per-descriptor flag on the freshly allocated duplicate (which otherwise starts cleared).
+    let result: Result<i32, ::vfs::Fat32Error> = match cmd {
+        F_DUPFD => ::vfs::fd::vfs_dup_from(fd, arg),
+        F_DUPFD_CLOEXEC => dup_from_with_flag(fd, arg, true, false),
+        F_DUPFD_CLOFORK => dup_from_with_flag(fd, arg, false, true),
+        _ => ::vfs::fd::vfs_fcntl(fd, cmd, arg),
+    };
+    match result {
         Ok(ret) => {
             FileControlResponse::build(source, ret, ProcessIdentifier::VFSD, MessageType::Ipc)
         },
         Err(e) => build_error(source, fat32_to_error_code(&e)),
     }
+}
+
+/// Duplicates `fd` into the lowest free descriptor at or above `min_fd`, then sets the requested
+/// per-descriptor flags on the duplicate.
+///
+/// This backs the `F_DUPFD_CLOEXEC` / `F_DUPFD_CLOFORK` `fcntl` commands, which differ from plain
+/// `F_DUPFD` only in that the new descriptor is born with close-on-exec or close-on-fork set rather
+/// than cleared.
+fn dup_from_with_flag(
+    fd: i32,
+    min_fd: i32,
+    close_on_exec: bool,
+    close_on_fork: bool,
+) -> Result<i32, ::vfs::Fat32Error> {
+    let new_fd: i32 = ::vfs::fd::vfs_dup_from(fd, min_fd)?;
+    let mut flags: ::vfs::fd::FdFlags = ::vfs::fd::FdFlags::default();
+    flags.set_close_on_exec(close_on_exec);
+    flags.set_close_on_fork(close_on_fork);
+    ::vfs::fd::vfs_set_fd_flags(new_fd, flags)?;
+    Ok(new_fd)
 }
 
 pub(crate) fn handle_fchmod(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -268,6 +268,10 @@ pub(crate) fn handle_ipc_message(
             let response: Message = handler::handle_resolve_fd(source_tid, syscall_msg);
             send_response(&response);
         },
+        SystemCallMessageHeader::Dup2Request => {
+            let response: Message = handler::handle_dup2(source_tid, syscall_msg, pipe_wait);
+            send_response(&response);
+        },
         SystemCallMessageHeader::SeekRequest => {
             if let Some(response) =
                 handler::handle_seek_with_hostfs(source_tid, syscall_msg, pending)

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -29,7 +29,10 @@ use ::sysapi::ffi::c_int;
 
 pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     ::syslog::trace!("fcntl(): fd={:?}, cmd={:?}, arg={:?}", fd, cmd, arg);
-    let backend_fd: i32 = crate::fdtable::resolve_vfs(fd, "fcntl")?;
+    // Flag queries and the F_DUPFD duplication family are served by vfsd on the slot it owns, so
+    // they are addressed by the flat descriptor — for console descriptors too, whose slot vfsd owns
+    // even though their I/O is routed to the kernel by stream number.
+    let backend_fd: i32 = crate::fdtable::resolve_table_op(fd, "fcntl")?;
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Build request and send it.
@@ -47,7 +50,7 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
     // Check whether system call succeeded or not.
-    if response.status == -1 {
+    if response.status != 0 {
         ::syslog::warn!(
             "fcntl(): failed (fd={:?}, cmd={:?}, arg={:?}, status={:?})",
             fd,
@@ -85,6 +88,14 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
             SystemCallMessageHeader::FileControlResponse => {
                 let message: FileControlResponse = FileControlResponse::from_bytes(message.payload);
                 let ret: c_int = message.ret;
+                // A duplication command (`F_DUPFD` and its close-on-exec/close-on-fork variants)
+                // returns a freshly allocated descriptor. Drop any cached resolution for that
+                // number so its first use re-resolves against vfsd's table rather than answering
+                // from an entry that described the number's previous occupant.
+                #[cfg(feature = "standalone")]
+                if is_dup_command(cmd) && ret >= 0 {
+                    crate::fdtable::invalidate(ret);
+                }
                 Ok(ret)
             },
             // Response was not successfully parsed.
@@ -100,4 +111,17 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
             },
         }
     }
+}
+
+/// Returns whether `cmd` is one of the descriptor-duplication `fcntl` commands (`F_DUPFD` and its
+/// close-on-exec / close-on-fork variants), which allocate a new descriptor rather than querying or
+/// setting a flag.
+#[cfg(feature = "standalone")]
+fn is_dup_command(cmd: i32) -> bool {
+    use ::sysapi::fcntl::file_control_request::{
+        F_DUPFD,
+        F_DUPFD_CLOEXEC,
+        F_DUPFD_CLOFORK,
+    };
+    matches!(cmd, F_DUPFD | F_DUPFD_CLOEXEC | F_DUPFD_CLOFORK)
 }

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -228,6 +228,38 @@ pub(crate) fn resolve_vfs(fd: i32, _syscall_name: &str) -> Result<i32, Error> {
     Ok(fd)
 }
 
+/// Resolves `fd` for an operation that `vfsd` serves on its flat slot table itself — the descriptor
+/// flag and identity queries (`fcntl(F_GETFD/F_SETFD/F_GETFL/F_SETFL)`, `fstat`) and the descriptor
+/// duplication family (`dup`/`dup2`/`fcntl(F_DUPFD)`).
+///
+/// Unlike [`resolve_vfs`], this accepts a console descriptor as well as a `vfsd`-served one, and it
+/// returns the *caller-facing flat descriptor* rather than the resolved `backend_fd`. That
+/// distinction matters for the console: its `backend_fd` is the standard stream number used to
+/// route I/O to the kernel, but these operations act on the slot `vfsd` owns, which is addressed by
+/// the flat number. Sockets and unknown descriptors are rejected (socket participation in this
+/// table lands in a later plan).
+#[cfg(feature = "standalone")]
+pub(crate) fn resolve_table_op(fd: i32, syscall_name: &str) -> Result<i32, Error> {
+    use ::sys::error::ErrorCode;
+
+    match resolve(fd) {
+        Some(resolution) if matches!(resolution.route, Route::Vfs | Route::Console) => Ok(fd),
+        _ => {
+            ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
+            Err(Error::new(ErrorCode::BadFile, "fd is not a vfsd table descriptor"))
+        },
+    }
+}
+
+/// Resolves `fd` for a `vfsd` flat-table operation in hosted mode.
+///
+/// Non-standalone builds route these syscalls to `linuxd`, which interprets the caller-facing
+/// descriptor directly, so the descriptor is returned unchanged.
+#[cfg(not(feature = "standalone"))]
+pub(crate) fn resolve_table_op(fd: i32, _syscall_name: &str) -> Result<i32, Error> {
+    Ok(fd)
+}
+
 /// Records the resolution learned for `fd` from a backend response, stamped with the `epoch` the
 /// backend reported.
 ///
@@ -471,6 +503,20 @@ mod tests {
 
         let backend_fd: i32 = resolve_vfs(7, "test").expect("hosted resolve_vfs should succeed");
         assert_eq!(backend_fd, 7, "hosted mode must pass raw descriptors through");
+
+        clear();
+    }
+
+    /// Tests that hosted builds pass a flat-table operation's descriptor through unchanged, leaving
+    /// interpretation to linuxd.
+    #[test]
+    fn hosted_resolve_table_op_returns_raw_fd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        let backend_fd: i32 =
+            resolve_table_op(9, "test").expect("hosted resolve_table_op should succeed");
+        assert_eq!(backend_fd, 9, "hosted mode must pass raw descriptors through");
 
         clear();
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -280,6 +280,8 @@ pub enum SystemCallMessageHeader {
     HostFsReadDirResponsePart,
     ResolveFdRequest,
     ResolveFdResponse,
+    Dup2Request,
+    Dup2Response,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -444,6 +446,8 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == HostFsPathStatResponse as u16 => Ok(HostFsPathStatResponse),
             x if x == ResolveFdRequest as u16 => Ok(ResolveFdRequest),
             x if x == ResolveFdResponse as u16 => Ok(ResolveFdResponse),
+            x if x == Dup2Request as u16 => Ok(Dup2Request),
+            x if x == Dup2Response as u16 => Ok(Dup2Response),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -37,9 +37,9 @@ use sysapi::sys_stat;
 pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
     ::syslog::trace!("fstat(): fd={:?}", fd);
 
-    // In standalone mode, route by the descriptor's resolved backend. Console descriptors get a
-    // synthesized character-device stat so that common libc patterns (isatty, buffering heuristics)
-    // continue to work.
+    // In standalone mode, route by the descriptor's resolved backend. Both vfsd-served objects and
+    // console descriptors are answered by vfsd from the slot it owns; the console reports as a
+    // character device with a stable, dup-shared identity synthesized by vfsd.
     let backend_fd: i32 = {
         #[cfg(feature = "standalone")]
         {
@@ -48,31 +48,11 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
                 Route,
             };
             match resolve(fd) {
-                // VFS-backed descriptors fall through to the vfsd stat path below.
-                Some(res) if res.route == Route::Vfs => res.backend_fd,
-                // The console reports as a character device.
-                Some(res) if res.route == Route::Console => {
-                    use ::sysapi::sys_stat::{
-                        file_mode,
-                        file_type,
-                    };
-                    // SAFETY: zeroes all bytes of `buf` before field assignment.
-                    unsafe {
-                        ::core::ptr::write_bytes(buf, 0, 1);
-                    }
-                    buf.st_mode = file_type::S_IFCHR | file_mode::S_IRUSR | file_mode::S_IWUSR;
-                    // Block size matches the page-sized granularity of push/pull kernel calls.
-                    buf.st_blksize = ::arch::mem::PAGE_SIZE as i64;
-                    // Timestamp set to Unix epoch (1970-01-01T00:00:00 UTC).
-                    let ts = ::sysapi::time::timespec {
-                        tv_sec: 0,
-                        tv_nsec: 0,
-                    };
-                    buf.st_atim = ts;
-                    buf.st_mtim = ts;
-                    buf.st_ctim = ts;
-                    return Ok(());
-                },
+                // A vfsd-served object or a console descriptor: vfsd answers `fstat` from the slot
+                // it owns, addressed by the caller-facing flat descriptor. For a console this is the
+                // slot number, not the stream number used to route I/O — the slot is the operand,
+                // so a `dup`'d console descriptor shares its source's character-device identity.
+                Some(res) if matches!(res.route, Route::Vfs | Route::Console) => fd,
                 // Sockets and unroutable descriptors have no stat here.
                 _ => {
                     ::syslog::warn!("fstat(): bad file descriptor fd={fd} in standalone mode");

--- a/src/libs/syscall/src/unistd/bindings/dup.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup.rs
@@ -6,7 +6,6 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
-use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
 use ::syslog::trace_syscall;
 
@@ -48,10 +47,14 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dup(fd: c_int) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/587
-    ::syslog::debug!("dup(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    match crate::unistd::dup(fd) {
+        Ok(newfd) => newfd,
+        Err(error) => {
+            ::syslog::warn!("dup(): failed ({:?})", error);
+            unsafe {
+                *__errno_location() = error.code.get();
+            }
+            -1
+        },
     }
-    -1
 }

--- a/src/libs/syscall/src/unistd/bindings/dup2.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup2.rs
@@ -6,7 +6,6 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
-use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
 use ::syslog::trace_syscall;
 
@@ -40,6 +39,13 @@ use ::syslog::trace_syscall;
 /// `-1` and sets `errno` to indicate the error. Common error conditions include invalid file
 /// descriptor, `newfd` out of range, or system resource limitations.
 ///
+/// # Availability
+///
+/// This function is available only in standalone mode, where vfsd owns the flat descriptor table
+/// that `dup2()` re-points. In hosted mode it returns `-1` with `errno` set to `ENOSYS`. This
+/// differs from `dup()`, which is expressed as `fcntl(fd, F_DUPFD, 0)` and is therefore served by
+/// linuxd in hosted mode; naming an exact target slot, as `dup2()` does, has no linuxd equivalent.
+///
 /// # Safety
 ///
 /// This function is unsafe because it may dereference raw pointers and modify global state.
@@ -52,10 +58,14 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dup2(oldfd: c_int, newfd: c_int) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/354
-    ::syslog::debug!("dup2(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    match crate::unistd::dup2(oldfd, newfd) {
+        Ok(fd) => fd,
+        Err(error) => {
+            ::syslog::warn!("dup2(): failed ({:?})", error);
+            unsafe {
+                *__errno_location() = error.code.get();
+            }
+            -1
+        },
     }
-    -1
 }

--- a/src/libs/syscall/src/unistd/message/dup2.rs
+++ b/src/libs/syscall/src/unistd/message/dup2.rs
@@ -1,0 +1,158 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::{
+    fmt,
+    mem,
+};
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+//==================================================================================================
+// Dup2Request
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Request message of the `dup2()` system call. It carries the source and target descriptor numbers
+/// as the flat slot numbers vfsd owns, so vfsd re-points `newfd` at `oldfd`'s open file description
+/// directly on its authoritative table.
+///
+#[repr(C, packed)]
+pub struct Dup2Request {
+    /// Descriptor whose open file description is duplicated.
+    pub oldfd: i32,
+    /// Descriptor that is made to alias `oldfd`, closing whatever it previously referred to.
+    pub newfd: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(Dup2Request, SystemCallMessage::PAYLOAD_SIZE);
+
+impl Dup2Request {
+    pub const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<i32>();
+
+    fn new(oldfd: i32, newfd: i32) -> Self {
+        Self {
+            oldfd,
+            newfd,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        oldfd: i32,
+        newfd: i32,
+        destination: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: Dup2Request = Dup2Request::new(oldfd, newfd);
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::Dup2Request, message.into_bytes());
+        Message::new(
+            MessageSender::from(tid),
+            MessageReceiver::from(destination),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+impl fmt::Debug for Dup2Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let oldfd: i32 = self.oldfd;
+        let newfd: i32 = self.newfd;
+        write!(f, "{{ oldfd: {oldfd}, newfd: {newfd} }}")
+    }
+}
+
+//==================================================================================================
+// Dup2Response
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Response message of the `dup2()` system call. It carries the descriptor that now aliases the
+/// source, which equals `newfd` on success.
+///
+#[repr(C, packed)]
+pub struct Dup2Response {
+    /// The descriptor that now aliases the source (equals `newfd` on success).
+    pub ret: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(Dup2Response, SystemCallMessage::PAYLOAD_SIZE);
+
+impl Dup2Response {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+
+    fn new(ret: i32) -> Self {
+        Self {
+            ret,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        ret: i32,
+        source: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: Dup2Response = Dup2Response::new(ret);
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::Dup2Response, message.into_bytes());
+        Message::new(
+            MessageSender::from(source),
+            MessageReceiver::from(tid),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+impl fmt::Debug for Dup2Response {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ret: i32 = self.ret;
+        write!(f, "{{ ret: {ret} }}")
+    }
+}

--- a/src/libs/syscall/src/unistd/message/mod.rs
+++ b/src/libs/syscall/src/unistd/message/mod.rs
@@ -7,6 +7,7 @@
 
 mod chdir;
 mod close;
+mod dup2;
 mod faccessat;
 mod fchdir;
 mod fchown;
@@ -39,6 +40,10 @@ pub use self::{
     close::{
         CloseRequest,
         CloseResponse,
+    },
+    dup2::{
+        Dup2Request,
+        Dup2Response,
     },
     faccessat::{
         FileAccessAtRequest,

--- a/src/libs/syscall/src/unistd/mod.rs
+++ b/src/libs/syscall/src/unistd/mod.rs
@@ -30,6 +30,8 @@ cfg_if::cfg_if! {
             faccessat,
             chdir,
             close,
+            dup,
+            dup2,
             _exit,
             fdatasync,
             fchown,

--- a/src/libs/syscall/src/unistd/syscall/dup.rs
+++ b/src/libs/syscall/src/unistd/syscall/dup.rs
@@ -1,0 +1,28 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::Error;
+use ::sysapi::{
+    fcntl::file_control_request::F_DUPFD,
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Duplicates `fd` into the lowest-numbered available descriptor.
+///
+/// POSIX `dup(fd)` is exactly `fcntl(fd, F_DUPFD, 0)`: it allocates the lowest free descriptor that
+/// aliases `fd`'s open file description, sharing its offset and status flags while starting with
+/// close-on-exec cleared. Routing it through `fcntl` reuses the descriptor-table resolution and
+/// cache-refresh logic, so the duplication is performed authoritatively by vfsd's flat slot table
+/// and works uniformly for console, file, pipe, and host-backed descriptors.
+pub fn dup(fd: c_int) -> Result<c_int, Error> {
+    ::syslog::trace!("dup(): fd={:?}", fd);
+    crate::fcntl::fcntl(fd, F_DUPFD, Some(0))
+}

--- a/src/libs/syscall/src/unistd/syscall/dup2.rs
+++ b/src/libs/syscall/src/unistd/syscall/dup2.rs
@@ -1,0 +1,93 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Duplicates `oldfd` onto the specific descriptor `newfd`.
+///
+/// `newfd` is made to alias `oldfd`'s open file description; if `newfd` was already open it is first
+/// closed (with the same last-reference accounting as a real `close`). `dup2(fd, fd)` is a no-op
+/// that returns `fd`. The operation is performed authoritatively by vfsd's flat slot table, so it
+/// works across every backend — including the cross-backend redirections (`dup2(file_fd, 1)`) that
+/// the previous split descriptor model could not express.
+///
+/// This is standalone-only. Unlike `dup`/`fcntl(F_DUPFD)` — which name no target slot and so are
+/// served by linuxd in hosted mode — re-pointing an exact descriptor requires vfsd's authoritative
+/// slot table, which exists only in standalone mode. In hosted mode this returns
+/// `ErrorCode::InvalidSysCall` (`ENOSYS`).
+pub fn dup2(oldfd: c_int, newfd: c_int) -> Result<c_int, Error> {
+    ::syslog::trace!("dup2(): oldfd={:?}, newfd={:?}", oldfd, newfd);
+
+    // dup2 is an authoritative slot-table operation owned by vfsd; it is only meaningful where vfsd
+    // owns the descriptor table (standalone mode).
+    #[cfg(feature = "standalone")]
+    {
+        dup2_via_vfsd(oldfd, newfd)
+    }
+    #[cfg(not(feature = "standalone"))]
+    {
+        let _ = (oldfd, newfd);
+        Err(Error::new(ErrorCode::InvalidSysCall, "dup2() is only supported in standalone mode"))
+    }
+}
+
+/// Re-points `newfd` at `oldfd` by asking vfsd to perform the slot-table mutation on its
+/// authoritative table.
+#[cfg(feature = "standalone")]
+fn dup2_via_vfsd(oldfd: c_int, newfd: c_int) -> Result<c_int, Error> {
+    use crate::{
+        unistd::message::{
+            Dup2Request,
+            Dup2Response,
+        },
+        SystemCallMessage,
+        SystemCallMessageHeader,
+    };
+    use ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    };
+
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+
+    // Build request and send it. The descriptors are the caller-facing flat numbers vfsd owns.
+    let request: Message =
+        Dup2Request::build(tid, oldfd, newfd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+
+    // Check whether the system call succeeded or not.
+    if response.status != 0 {
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        ::syslog::warn!("dup2(): failed (oldfd={oldfd}, newfd={newfd}, error={error_code})");
+        return Err(Error::new(error_code, "dup2() failed"));
+    }
+
+    // Parse response.
+    let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+    match message.header {
+        SystemCallMessageHeader::Dup2Response => {
+            let response: Dup2Response = Dup2Response::from_bytes(message.payload);
+            let ret: c_int = response.ret;
+            // `newfd` now aliases `oldfd`'s description, so its routing changed. Drop any cached
+            // resolution for it; the next descriptor syscall re-resolves it against vfsd's table.
+            crate::fdtable::invalidate(newfd);
+            Ok(ret)
+        },
+        _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/mod.rs
+++ b/src/libs/syscall/src/unistd/syscall/mod.rs
@@ -8,6 +8,8 @@
 mod _exit;
 mod chdir;
 mod close;
+mod dup;
+mod dup2;
 mod faccessat;
 mod fchdir;
 mod fchown;
@@ -47,6 +49,8 @@ pub use self::{
     _exit::_exit,
     chdir::chdir,
     close::close,
+    dup::dup,
+    dup2::dup2,
     faccessat::faccessat,
     fchdir::fchdir,
     fchown::fchown,

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -530,6 +530,30 @@ type OpenFile = Arc<Mutex<VfsEntry>>;
 pub struct FdFlags(c_int);
 
 impl FdFlags {
+    /// Builds the descriptor flags from a raw `fcntl(F_SETFD)` argument, rejecting any bit outside
+    /// the recognized set (`FD_CLOEXEC`, `FD_CLOFORK`).
+    ///
+    /// POSIX requires `fcntl(F_SETFD)` to fail with `EINVAL` when an unsupported descriptor-flag bit
+    /// is set rather than silently masking it. Rejecting here keeps this layer in agreement with the
+    /// syscall-side validation in `syscall::safe::FileDescriptorFlags` and prevents a later
+    /// `F_GETFD` from reporting flags the caller never set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Fat32Error::InvalidArgument`] if `raw` sets any bit other than `FD_CLOEXEC` or
+    /// `FD_CLOFORK`.
+    pub fn try_from_bits(raw: c_int) -> Result<Self, Fat32Error> {
+        if raw & !(FD_CLOEXEC | FD_CLOFORK) != 0 {
+            return Err(Fat32Error::InvalidArgument);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Returns the raw flag bits, as reported by `fcntl(F_GETFD)`.
+    pub const fn bits(self) -> c_int {
+        self.0
+    }
+
     /// Returns whether the close-on-exec (`FD_CLOEXEC`) flag is set.
     pub const fn close_on_exec(self) -> bool {
         self.0 & FD_CLOEXEC != 0
@@ -1568,12 +1592,55 @@ fn populate_pipe_stat_fields(buf: &mut ::sysapi::sys_stat::stat, pipe_id: u64) {
     };
 }
 
+/// Populates stat fields for a console-backed descriptor (a character device).
+///
+/// A console stream reports as a character device (`S_IFCHR`) with a stable identity: a synthetic
+/// console `st_dev` distinct from the VFS file device (1) and the pipefs device (2), and an `st_ino`
+/// derived from the stream so the three standard streams have distinct, stable inodes. Because the
+/// inode follows the stream rather than the slot, a `dup`'d console descriptor reports the same
+/// `(st_dev, st_ino)` as its source, matching POSIX shared-identity expectations. A console carries
+/// no size or on-disk blocks, so both are zero.
+fn populate_console_stat_fields(buf: &mut ::sysapi::sys_stat::stat, stream: ConsoleStream) {
+    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
+    const FIXED_EPOCH: i64 = 1_704_067_200;
+
+    // Stable per-stream inode: stdin/stdout/stderr get distinct values that a duplicate inherits.
+    let ino: u64 = match stream {
+        ConsoleStream::Stdin => 1,
+        ConsoleStream::Stdout => 2,
+        ConsoleStream::Stderr => 3,
+    };
+    buf.st_size = 0;
+    buf.st_nlink = 1;
+    buf.st_dev = 3; // Synthetic console device, distinct from VFS file (1) and pipefs (2).
+    buf.st_ino = ino;
+    buf.st_mode = file_type::S_IFCHR | file_mode::S_IRUSR | file_mode::S_IWUSR;
+    buf.st_blksize = STAT_BLOCK_SIZE;
+    buf.st_blocks = 0;
+    buf.st_atim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_mtim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+    buf.st_ctim = timespec {
+        tv_sec: FIXED_EPOCH,
+        tv_nsec: 0,
+    };
+}
+
 /// Gets file status for a VFS file descriptor.
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
     let pipe_id: Option<u64> = entry.handle.pipe_end().map(|end| end.pipe_id());
+    let console_stream: Option<ConsoleStream> = match &entry.handle {
+        VfsFileHandle::Console(h) => Some(h.stream()),
+        _ => None,
+    };
     let is_dir: bool = matches!(&entry.handle, VfsFileHandle::Directory(_));
     let size: u64 = entry.handle.size()?;
 
@@ -1582,7 +1649,11 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
 
-    if let Some(pipe_id) = pipe_id {
+    if let Some(stream) = console_stream {
+        // A console descriptor is a character device with a stable, dup-shared identity; the kernel
+        // does not serve `fstat` on the console, so vfsd synthesizes it from the slot it owns.
+        populate_console_stat_fields(buf, stream);
+    } else if let Some(pipe_id) = pipe_id {
         populate_pipe_stat_fields(buf, pipe_id);
     } else {
         populate_stat_fields(buf, size, is_dir);
@@ -1618,6 +1689,116 @@ pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
         Some(_slot) => Ok(()),
         None => Err(Fat32Error::InvalidFd),
     }
+}
+
+/// Duplicates a descriptor into the lowest free slot at or above `min_fd`.
+///
+/// The new descriptor refers to the *same* open file description as `oldfd` — the shared [`Arc`] is
+/// cloned, so the two descriptors share one file offset and status flags, exactly as POSIX `dup`
+/// and `fcntl(F_DUPFD)` require. The duplicate carries its own per-descriptor flags with
+/// `FD_CLOEXEC` cleared, because POSIX mandates that a duplicate start with close-on-exec off; the
+/// source descriptor's flags are untouched. Allocation is lowest-free within the flat namespace and
+/// bounded below the reserved socket range, so the returned number is the smallest free one that is
+/// at least `min_fd`.
+///
+/// This is the single primitive behind both `dup` (`min_fd == 0`) and `fcntl(F_DUPFD, arg)`
+/// (`min_fd == arg`).
+///
+/// # Errors
+///
+/// - [`Fat32Error::InvalidFd`] if `oldfd` refers to no open descriptor in the current process.
+/// - [`Fat32Error::InvalidArgument`] if `min_fd` is negative.
+/// - [`Fat32Error::TooManyOpenFiles`] if no free descriptor at or above `min_fd` exists below the
+///   reserved socket range.
+pub fn vfs_dup_from(oldfd: c_int, min_fd: c_int) -> Result<c_int, Fat32Error> {
+    if min_fd < 0 {
+        return Err(Fat32Error::InvalidArgument);
+    }
+
+    let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
+        PROCESSES.lock();
+    let state: &mut ProcessState = procs.get_mut(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
+    // Clone the source's shared open file description; the duplicate aliases it (shared offset).
+    let file: OpenFile = state
+        .slots
+        .get(&oldfd)
+        .map(|slot| slot.file.clone())
+        .ok_or(Fat32Error::InvalidFd)?;
+    // Lowest free descriptor at or above `min_fd`, bounded below the reserved socket range so a
+    // duplicate can never collide with a networkd-owned socket descriptor.
+    let fd: c_int = (min_fd..SOCKET_FD_BASE)
+        .find(|candidate| !state.slots.contains_key(candidate))
+        .ok_or(Fat32Error::TooManyOpenFiles)?;
+    // `Slot::new` starts from default (empty) per-descriptor flags, so `FD_CLOEXEC` is cleared on
+    // the duplicate while the source slot's flags are left untouched.
+    state.slots.insert(fd, Slot::new(file));
+    // Duplicating a descriptor graduates a lazily-inserted placeholder into an active state and
+    // mutates the table; advance the coherence generation.
+    state.initialized = true;
+    state.bump_generation();
+    Ok(fd)
+}
+
+/// Duplicates `oldfd` into the lowest free descriptor (POSIX `dup`).
+///
+/// Equivalent to [`vfs_dup_from`] with a minimum of `0`: the new descriptor is the lowest free
+/// number in the flat namespace and aliases `oldfd`'s open file description with `FD_CLOEXEC`
+/// cleared.
+pub fn vfs_dup(oldfd: c_int) -> Result<c_int, Fat32Error> {
+    vfs_dup_from(oldfd, 0)
+}
+
+/// Re-points `newfd` at `oldfd`'s open file description (POSIX `dup2`).
+///
+/// After a successful call `newfd` aliases the same open file description as `oldfd` — sharing its
+/// offset and status flags — and carries its own per-descriptor flags with `FD_CLOEXEC` cleared.
+/// `dup2(fd, fd)` is a no-op that returns `fd`, provided `fd` is open. When `newfd` was already
+/// open, its previous slot is dropped here, but the caller must first capture any last-reference
+/// reclaim it owes (a host-backed remote close, or a pipe EOF/`EPIPE` wakeup) exactly as it would
+/// for [`vfs_close`]; this routine performs only the table mutation.
+///
+/// The displaced open file description is dropped *after* the registry lock is released, mirroring
+/// [`vfs_close`], so backend teardown never nests under the registry lock.
+///
+/// # Errors
+///
+/// - [`Fat32Error::InvalidFd`] if `oldfd` refers to no open descriptor, or if `newfd` is negative
+///   or falls in the reserved socket range (where vfsd may not place a descriptor).
+pub fn vfs_dup2(oldfd: c_int, newfd: c_int) -> Result<c_int, Fat32Error> {
+    // `newfd` must be a legal descriptor number outside the reserved socket range.
+    if !(0..SOCKET_FD_BASE).contains(&newfd) {
+        return Err(Fat32Error::InvalidFd);
+    }
+    // Re-point the slot while holding the registry lock, but defer dropping the displaced open file
+    // description until the lock is released: its drop may run backend teardown (e.g. `File::drop`,
+    // which takes a global VFS lock), and deferring keeps the registry lock from nesting with
+    // backend locks — the same discipline as `vfs_close`.
+    let displaced: Option<Slot> = {
+        let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
+            PROCESSES.lock();
+        let state: &mut ProcessState =
+            procs.get_mut(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
+        // `oldfd` must be open.
+        let file: OpenFile = state
+            .slots
+            .get(&oldfd)
+            .map(|slot| slot.file.clone())
+            .ok_or(Fat32Error::InvalidFd)?;
+        // `dup2(fd, fd)` returns `fd` without disturbing the slot or the generation.
+        if oldfd == newfd {
+            return Ok(newfd);
+        }
+        // Re-point `newfd` at `oldfd`'s description with fresh per-descriptor flags (`FD_CLOEXEC`
+        // cleared); the previous occupant, if any, is returned for deferred drop.
+        let displaced: Option<Slot> = state.slots.insert(newfd, Slot::new(file));
+        state.initialized = true;
+        state.bump_generation();
+        displaced
+    };
+    // The displaced slot — and the open file description it held — is dropped here, after the
+    // registry lock has been released.
+    drop(displaced);
+    Ok(newfd)
 }
 
 /// Gets file status for a path through the VFS.
@@ -1942,21 +2123,34 @@ pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
 
 /// File control operation on a VFS file descriptor.
 ///
-/// Supports the file-descriptor flag commands (`F_GETFD`/`F_SETFD`, which have no effect because
-/// the VFS implements no close-on-exec) and the file-status-flag commands (`F_GETFL`/`F_SETFL`).
-/// `F_SETFL` stores the mutable status-flag subset (currently only `O_NONBLOCK`) on the open file
-/// description; `F_GETFL` returns it. Other commands return [`Fat32Error::NotSupported`].
+/// Serves the per-descriptor flag commands and the open-file status-flag commands directly from the
+/// state vfsd owns:
+///
+/// - `F_GETFD`/`F_SETFD` read and write the per-descriptor flags (`FD_CLOEXEC`, `FD_CLOFORK`) stored
+///   on the slot. Because these flags live per descriptor, setting them on one descriptor never
+///   affects another that shares the same open file description through `dup` or `fork`.
+/// - `F_GETFL`/`F_SETFL` read and write the open-file status flags. `F_SETFL` stores only the
+///   mutable subset (currently `O_NONBLOCK`); the access-mode and creation bits are not changeable
+///   per POSIX.
+///
+/// The duplication command `F_DUPFD` is *not* handled here: it is a slot-table allocation that the
+/// daemon routes to [`vfs_dup_from`]. Any other command returns [`Fat32Error::NotSupported`].
 pub fn vfs_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> Result<c_int, Fat32Error> {
-    let file: OpenFile = entry_arc(fd)?;
-
     match cmd {
-        file_control_request::F_GETFD => Ok(0), // No FD flags (no close-on-exec for VFS).
-        file_control_request::F_SETFD => Ok(0), // Accept but ignore (no close-on-exec).
-        file_control_request::F_GETFL => Ok(file.lock().status_flags),
+        // Per-descriptor flags live on the slot, so duplicates keep independent close-on-exec /
+        // close-on-fork settings.
+        file_control_request::F_GETFD => {
+            Ok(vfs_get_fd_flags(fd).ok_or(Fat32Error::InvalidFd)?.bits())
+        },
+        file_control_request::F_SETFD => {
+            vfs_set_fd_flags(fd, FdFlags::try_from_bits(arg)?)?;
+            Ok(0)
+        },
+        file_control_request::F_GETFL => Ok(entry_arc(fd)?.lock().status_flags),
         file_control_request::F_SETFL => {
             // Persist only the mutable status-flag subset (currently `O_NONBLOCK`). The remaining
             // bits (access mode, creation flags) are not changeable via `F_SETFL` per POSIX.
-            file.lock().status_flags = arg & file_status_flags::O_NONBLOCK;
+            entry_arc(fd)?.lock().status_flags = arg & file_status_flags::O_NONBLOCK;
             Ok(0)
         },
         _ => Err(Fat32Error::NotSupported), // Other commands not supported.
@@ -3039,6 +3233,30 @@ mod tests {
         assert!(flags.close_on_fork(), "close-on-fork must remain set");
     }
 
+    /// Tests that [`FdFlags::try_from_bits`] accepts the recognized descriptor-flag bits and rejects
+    /// any bit outside `FD_CLOEXEC`/`FD_CLOFORK` with [`Fat32Error::InvalidArgument`], matching POSIX
+    /// `fcntl(F_SETFD)` `EINVAL` semantics rather than silently masking unknown bits.
+    #[test]
+    fn fd_flags_try_from_bits_validates() {
+        use ::sysapi::fcntl::file_descriptor_flags::{
+            FD_CLOEXEC,
+            FD_CLOFORK,
+        };
+
+        // Recognized bits — alone and combined — are accepted and round-trip exactly.
+        assert_eq!(FdFlags::try_from_bits(0).map(FdFlags::bits), Ok(0));
+        assert_eq!(FdFlags::try_from_bits(FD_CLOEXEC).map(FdFlags::bits), Ok(FD_CLOEXEC));
+        assert_eq!(FdFlags::try_from_bits(FD_CLOFORK).map(FdFlags::bits), Ok(FD_CLOFORK));
+        assert_eq!(
+            FdFlags::try_from_bits(FD_CLOEXEC | FD_CLOFORK).map(FdFlags::bits),
+            Ok(FD_CLOEXEC | FD_CLOFORK),
+        );
+
+        // Any bit outside the recognized set is rejected, even alongside a recognized bit.
+        assert_eq!(FdFlags::try_from_bits(0x4), Err(Fat32Error::InvalidArgument));
+        assert_eq!(FdFlags::try_from_bits(FD_CLOEXEC | 0x4), Err(Fat32Error::InvalidArgument));
+    }
+
     /// Tests that a [`ConsoleHandle`] reports the standard stream it was created for.
     #[test]
     fn console_handle_tracks_stream() {
@@ -3145,10 +3363,9 @@ mod tests {
         forget_processes(&[parent, child]);
     }
 
-    /// Documents the deferred `F_SETFD`/`F_GETFD` round trip tracked by
-    /// <https://github.com/nanvix/nanvix/issues/2604>.
+    /// Tests that `F_SETFD` stores the per-descriptor flags and `F_GETFD` reads them back
+    /// (<https://github.com/nanvix/nanvix/issues/2604>).
     #[test]
-    #[ignore = "TODO(#2604): wire vfs_fcntl(F_GETFD/F_SETFD) to FdFlags"]
     fn fcntl_fd_flags_round_trip() {
         let _guard = FORK_TEST_GUARD.lock();
         let pid: ProcessIdentifier = ProcessIdentifier::from(0x7221);
@@ -3173,10 +3390,9 @@ mod tests {
         forget_processes(&[pid]);
     }
 
-    /// Documents that `F_SETFD` must update only the addressed descriptor, as tracked by
-    /// <https://github.com/nanvix/nanvix/issues/2604>.
+    /// Tests that `F_SETFD` updates only the addressed descriptor, so a forked child and its parent
+    /// keep independent flags (<https://github.com/nanvix/nanvix/issues/2604>).
     #[test]
-    #[ignore = "TODO(#2604): wire vfs_fcntl(F_GETFD/F_SETFD) to FdFlags"]
     fn fcntl_fd_flags_are_per_descriptor_after_fork() {
         let _guard = FORK_TEST_GUARD.lock();
         let (parent, child): (ProcessIdentifier, ProcessIdentifier) =
@@ -3406,5 +3622,209 @@ mod tests {
         assert_eq!(err, Fat32Error::AlreadyExists, "active child must be rejected even when empty");
 
         forget_processes(&[parent, child]);
+    }
+
+    // -- dup / dup2 / F_DUPFD slot-table tests ------------------------------------
+
+    /// Tests that `vfs_dup` aliases the source's open file description into the lowest free slot and
+    /// that the duplicate starts with `FD_CLOEXEC` cleared without disturbing the source's flags.
+    #[test]
+    fn dup_aliases_description_and_clears_cloexec() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7501);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_alloc_hostfs(60, false, None).expect("alloc");
+        // Mark the source close-on-exec so we can prove the duplicate does not inherit it.
+        let mut flags: FdFlags = FdFlags::default();
+        flags.set_close_on_exec(true);
+        vfs_set_fd_flags(fd, flags).expect("set source flags");
+
+        let dup_fd: c_int = vfs_dup(fd).expect("dup");
+        assert_eq!(dup_fd, fd + 1, "dup returns the lowest free descriptor");
+
+        // The duplicate shares the source's open file description (same offset).
+        {
+            let procs = PROCESSES.lock();
+            let state = procs.get(&pid).expect("state");
+            assert!(
+                Arc::ptr_eq(&state.slots[&fd].file, &state.slots[&dup_fd].file),
+                "dup must alias the same open file description"
+            );
+        }
+        // POSIX: the duplicate has close-on-exec cleared; the source keeps its own flag.
+        assert!(
+            !vfs_get_fd_flags(dup_fd).expect("dup flags").close_on_exec(),
+            "a dup'd descriptor must start with FD_CLOEXEC cleared"
+        );
+        assert!(
+            vfs_get_fd_flags(fd).expect("source flags").close_on_exec(),
+            "the source descriptor's flags must be unaffected by dup"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that `vfs_dup_from` (the `fcntl(F_DUPFD, arg)` primitive) allocates the lowest free
+    /// descriptor at or above the requested minimum.
+    #[test]
+    fn dup_from_allocates_at_or_above_min() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7502);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_alloc_hostfs(61, false, None).expect("alloc");
+        // Request a duplicate no lower than 10; nothing is allocated there yet, so it lands on 10.
+        let high: c_int = vfs_dup_from(fd, 10).expect("dup_from");
+        assert_eq!(high, 10, "F_DUPFD must return the lowest free fd >= arg");
+        // A second request with the same floor skips the now-occupied 10 and lands on 11.
+        let higher: c_int = vfs_dup_from(fd, 10).expect("dup_from again");
+        assert_eq!(higher, 11, "the next duplicate skips the occupied floor");
+        assert!(
+            Arc::ptr_eq(&entry_arc(fd).unwrap(), &entry_arc(high).unwrap()),
+            "F_DUPFD must alias the same open file description"
+        );
+
+        assert_eq!(
+            vfs_dup_from(fd, -1).unwrap_err(),
+            Fat32Error::InvalidArgument,
+            "F_DUPFD with a negative floor must be rejected"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that `vfs_dup2` re-points `newfd` at `oldfd`'s description across backends and that the
+    /// previous occupant of `newfd` is released.
+    #[test]
+    fn dup2_repoints_across_backends() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7503);
+        set_current_process(pid);
+
+        // A console descriptor and an independent host-backed file descriptor.
+        let console_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+                .expect("console alloc");
+        let file_fd: c_int = vfs_alloc_hostfs(62, false, None).expect("file alloc");
+        // The file is the sole reference before dup2.
+        assert!(vfs_hostfs_is_last_ref(file_fd), "file should be the last reference pre-dup2");
+
+        // dup2(file_fd, console_fd): the console slot now aliases the file's description — the
+        // cross-backend redirection the old split model could not express.
+        let ret: c_int = vfs_dup2(file_fd, console_fd).expect("dup2");
+        assert_eq!(ret, console_fd, "dup2 returns newfd");
+        assert!(
+            Arc::ptr_eq(&entry_arc(file_fd).unwrap(), &entry_arc(console_fd).unwrap()),
+            "newfd must alias oldfd's open file description after dup2"
+        );
+        // Resolution now reports the former console descriptor as a vfsd-served file.
+        assert_eq!(
+            vfs_resolve(console_fd),
+            Some((VfsRoute::Vfs, console_fd)),
+            "the redirected descriptor must resolve to the file backend"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that `dup2(fd, fd)` is a no-op that returns `fd` and leaves the table generation
+    /// unchanged, while `dup2` with an invalid `oldfd` or an out-of-range `newfd` is rejected.
+    #[test]
+    fn dup2_noop_and_invalid_arguments() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7504);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_alloc_hostfs(63, false, None).expect("alloc");
+        let before: u64 = vfs_current_generation();
+        assert_eq!(vfs_dup2(fd, fd).expect("dup2 self"), fd, "dup2(fd, fd) returns fd");
+        assert_eq!(
+            vfs_current_generation(),
+            before,
+            "a no-op dup2 must not advance the generation"
+        );
+
+        // An invalid source descriptor is rejected.
+        assert_eq!(vfs_dup2(4096, fd).unwrap_err(), Fat32Error::InvalidFd, "bad oldfd rejected");
+        // A newfd in the reserved socket range is rejected.
+        assert_eq!(
+            vfs_dup2(fd, SOCKET_FD_BASE).unwrap_err(),
+            Fat32Error::InvalidFd,
+            "newfd in the socket range is rejected"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that when `dup2` displaces the last reference to a host-backed description, that
+    /// reference is dropped so the caller (vfsd) becomes responsible for reclaiming the remote
+    /// handle. The replaced slot must no longer reference the old description.
+    #[test]
+    fn dup2_releases_displaced_last_reference() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7505);
+        set_current_process(pid);
+
+        let src_fd: c_int = vfs_alloc_hostfs(64, false, None).expect("src alloc");
+        let victim_fd: c_int = vfs_alloc_hostfs(65, false, None).expect("victim alloc");
+        // The victim is the only reference to remote fd 65, so the daemon would inspect it for
+        // reclaim before calling dup2.
+        assert!(vfs_hostfs_is_last_ref(victim_fd), "victim is the last reference pre-dup2");
+        assert_eq!(vfs_hostfs_remote_fd(victim_fd), Some(65));
+
+        vfs_dup2(src_fd, victim_fd).expect("dup2");
+        // The victim slot now points at the source's remote fd, and the displaced description is
+        // gone (its Arc was dropped by dup2).
+        assert_eq!(
+            vfs_hostfs_remote_fd(victim_fd),
+            Some(64),
+            "the displaced slot must now alias the source's remote handle"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    // -- console fstat tests ------------------------------------------------------
+
+    /// Tests that `vfs_fstat` reports a console descriptor as a character device with a stable
+    /// identity, and that a `dup`'d console descriptor shares that identity.
+    #[test]
+    fn fstat_console_reports_stable_character_device() {
+        use ::sysapi::sys_stat::file_type;
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7507);
+        set_current_process(pid);
+
+        let console_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+                .expect("console alloc");
+
+        let mut st: ::sysapi::sys_stat::stat = Default::default();
+        vfs_fstat(console_fd, &mut st).expect("fstat console");
+        assert_eq!(
+            st.st_mode & file_type::S_IFMT,
+            file_type::S_IFCHR,
+            "a console descriptor must report as a character device"
+        );
+        assert_eq!(st.st_size, 0, "a console has no size");
+        let (dev, ino): (_, _) = (st.st_dev, st.st_ino);
+
+        // fstat is stable across calls.
+        let mut st2: ::sysapi::sys_stat::stat = Default::default();
+        vfs_fstat(console_fd, &mut st2).expect("fstat console again");
+        assert_eq!((st2.st_dev, st2.st_ino), (dev, ino), "console identity must be stable");
+
+        // A dup'd console descriptor shares the same identity.
+        let dup_fd: c_int = vfs_dup(console_fd).expect("dup console");
+        let mut st3: ::sysapi::sys_stat::stat = Default::default();
+        vfs_fstat(dup_fd, &mut st3).expect("fstat dup'd console");
+        assert_eq!(
+            (st3.st_dev, st3.st_ino),
+            (dev, ino),
+            "a dup'd console descriptor must share its source's identity"
+        );
+
+        forget_processes(&[pid]);
     }
 }

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -43,6 +43,7 @@ use ::sysapi::{
     fcntl::{
         file_control_request,
         file_creation_flags,
+        file_descriptor_flags,
     },
     sys_stat::{
         file_type,
@@ -90,6 +91,7 @@ pub fn main() -> Result<(), Error> {
     test_fstat_directory_and_timestamps()?;
     test_stat_timestamps()?;
     test_fcntl_fd_flags()?;
+    test_dup()?;
     test_resolve_path()?;
     test_chmod()?;
     test_fchmodat()?;
@@ -782,6 +784,17 @@ fn test_fcntl_fd_flags() -> Result<(), Error> {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_SETFD should return 0"));
     }
 
+    // F_SETFD must reject descriptor-flag bits outside the recognized {FD_CLOEXEC, FD_CLOFORK} set
+    // rather than silently masking them, matching POSIX `EINVAL` semantics. 0x4 is the lowest such
+    // bit; it is rejected even when combined with a recognized flag.
+    let unsupported: i32 = file_descriptor_flags::FD_CLOEXEC | 0x4;
+    if vfs::fd::vfs_fcntl(fd, file_control_request::F_SETFD, unsupported).is_ok() {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "F_SETFD must reject unsupported descriptor-flag bits",
+        ));
+    }
+
     // F_GETFL and F_SETFL should still work.
     let fl: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFL, 0)
         .map_err(|e| fat_err(e, "fcntl F_GETFL"))?;
@@ -789,7 +802,8 @@ fn test_fcntl_fd_flags() -> Result<(), Error> {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_GETFL should return 0"));
     }
 
-    // An unsupported command (e.g. F_DUPFD) should fail.
+    // F_DUPFD is a slot-table allocation that the daemon routes to `vfs_dup_from`, not a flag
+    // query, so `vfs_fcntl` itself does not handle it and rejects it here.
     if vfs::fd::vfs_fcntl(fd, file_control_request::F_DUPFD, 0).is_ok() {
         return Err(Error::new(ErrorCode::InvalidArgument, "F_DUPFD should fail on VFS"));
     }
@@ -801,6 +815,107 @@ fn test_fcntl_fd_flags() -> Result<(), Error> {
     vfs::unmount("/fcn").map_err(|e| fat_err(e, "unmount /fcn"))?;
 
     ::syslog::info!("vfs-test: test_fcntl_fd_flags passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: dup / dup2 / F_DUPFD
+//==================================================================================================
+
+/// Tests that `vfs_dup`, `vfs_dup_from`, and `vfs_dup2` duplicate descriptors authoritatively on the
+/// flat slot table: the duplicate aliases the source's open file description (so the file offset is
+/// shared), starts with close-on-exec cleared without disturbing the source, honors the `F_DUPFD`
+/// minimum, and re-points an existing descriptor with `dup2`.
+fn test_dup() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_dup begin");
+
+    vfs::create_mount("/dup", 128 * 1024).map_err(|e| fat_err(e, "create_mount /dup failed"))?;
+
+    // Seed a file with known content.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/dup/d.txt")
+            .map_err(|e| fat_err(e, "create d.txt"))?;
+        file.write(b"DUPDATA")
+            .map_err(|e| fat_err(e, "write d.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush d.txt"))?;
+    }
+
+    let fd: i32 = vfs::fd::vfs_open("/dup/d.txt", 0).map_err(|e| fat_err(e, "open d.txt"))?;
+
+    // Read the first three bytes; the open file description's offset is now at 3.
+    let mut head: [u8; 3] = [0; 3];
+    let n: u32 = vfs::fd::vfs_read(fd, &mut head).map_err(|e| fat_err(e, "read head"))?;
+    if n != 3 || &head != b"DUP" {
+        return Err(Error::new(ErrorCode::InvalidArgument, "initial read mismatch"));
+    }
+
+    // Mark the source close-on-exec so we can prove the duplicate does not inherit it.
+    vfs::fd::vfs_fcntl(fd, file_control_request::F_SETFD, file_descriptor_flags::FD_CLOEXEC)
+        .map_err(|e| fat_err(e, "set CLOEXEC on source"))?;
+
+    // dup() aliases the same open file description, so reading the duplicate continues from the
+    // shared offset and returns the remainder of the file.
+    let dup_fd: i32 = vfs::fd::vfs_dup(fd).map_err(|e| fat_err(e, "vfs_dup"))?;
+    if dup_fd == fd {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dup must allocate a distinct fd"));
+    }
+    let mut tail: [u8; 4] = [0; 4];
+    let m: u32 =
+        vfs::fd::vfs_read(dup_fd, &mut tail).map_err(|e| fat_err(e, "read tail via dup"))?;
+    if m != 4 || &tail != b"DATA" {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dup must share the file offset"));
+    }
+
+    // The duplicate starts with close-on-exec cleared; the source keeps its own flag.
+    if vfs::fd::vfs_fcntl(dup_fd, file_control_request::F_GETFD, 0)
+        .map_err(|e| fat_err(e, "getfd dup"))?
+        != 0
+    {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dup must clear FD_CLOEXEC"));
+    }
+    if vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFD, 0)
+        .map_err(|e| fat_err(e, "getfd source"))?
+        & file_descriptor_flags::FD_CLOEXEC
+        == 0
+    {
+        return Err(Error::new(ErrorCode::InvalidArgument, "source must keep FD_CLOEXEC"));
+    }
+
+    // F_DUPFD-style allocation returns the lowest free descriptor at or above the floor.
+    let high: i32 = vfs::fd::vfs_dup_from(fd, 100).map_err(|e| fat_err(e, "vfs_dup_from"))?;
+    if high < 100 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "F_DUPFD must honor the minimum fd"));
+    }
+    if vfs::fd::vfs_dup_from(fd, -1) != Err(vfs::Fat32Error::InvalidArgument) {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "F_DUPFD must reject a negative minimum fd",
+        ));
+    }
+
+    // dup2 re-points an existing descriptor: the previously open file is closed and `other` now
+    // aliases the source's description. dup2(fd, fd) is a no-op that returns fd.
+    let other: i32 =
+        vfs::fd::vfs_open("/dup/d.txt", 0).map_err(|e| fat_err(e, "open d.txt again"))?;
+    let ret: i32 = vfs::fd::vfs_dup2(fd, other).map_err(|e| fat_err(e, "vfs_dup2"))?;
+    if ret != other {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dup2 must return newfd"));
+    }
+    if vfs::fd::vfs_dup2(fd, fd).map_err(|e| fat_err(e, "vfs_dup2 self"))? != fd {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dup2(fd, fd) must return fd"));
+    }
+
+    // Clean up descriptors and the mount.
+    for descriptor in [fd, dup_fd, high, other] {
+        let _ = vfs::fd::vfs_close(descriptor);
+    }
+    vfs::unlink("/dup/d.txt").map_err(|e| fat_err(e, "unlink d.txt"))?;
+    vfs::unmount("/dup").map_err(|e| fat_err(e, "unmount /dup"))?;
+
+    ::syslog::info!("vfs-test: test_dup passed");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implements POSIX descriptor duplication (`dup`, `dup2`, and the `fcntl` `F_DUPFD` family) authoritatively on vfsd's flat slot table, so duplication works uniformly across console, file, pipe, and host-backed descriptors — including the cross-backend redirections (e.g. `dup2(file_fd, 1)`) that the previous split descriptor model could not express.

## Changes

**vfs (`src/libs/vfs/src/fd.rs`)**
- Add `vfs_dup_from` (the lowest-free-at-or-above primitive behind `dup` and `F_DUPFD`), `vfs_dup`, and `vfs_dup2`. Duplicates alias the source's open file description (shared offset/status flags) and start with `FD_CLOEXEC` cleared per POSIX, without disturbing the source. Allocation stays below the reserved socket range; `vfs_dup2` defers dropping the displaced slot until the registry lock is released, mirroring `vfs_close`.
- Wire `vfs_fcntl(F_GETFD/F_SETFD)` to per-descriptor `FdFlags` (independent across `dup`/`fork`); add `FdFlags::from_bits`/`bits`.
- Synthesize console `fstat` as a character device with a stable, dup-shared `(st_dev, st_ino)` identity.

**syscall (`src/libs/syscall`)**
- Implement the `dup`/`dup2` syscall + C bindings; `dup` is `fcntl(fd, F_DUPFD, 0)`. `dup2` is standalone-only (returns `ENOSYS` in hosted mode). Add the `Dup2Request`/`Dup2Response` IPC message and header variants.
- Route `fcntl`/`fstat` through a new `resolve_table_op` that addresses the slot vfsd owns by the flat descriptor (covering console descriptors), and invalidate the client fd cache for newly allocated duplicates.

**vfsd (`src/daemons/vfsd`)**
- Add `handle_dup2`: re-points `newfd`, closing the displaced descriptor with the same last-reference accounting as `close` (pipe EOF/`EPIPE` wakeup, fire-and-forget hostfs remote close). Route `F_DUPFD`/`F_DUPFD_CLOEXEC`/`F_DUPFD_CLOFORK` through `vfs_dup_from`.

## Testing

- Un-ignore the per-descriptor `F_SETFD`/`F_GETFD` round-trip tests (#2604).
- Add unit tests for `dup`/`dup2`/`F_DUPFD` slot behavior and console `fstat` identity.
- Add integration `test_dup` to `vfs-test`.

## Issues

Closes #2598 