### PR TITLE
[libc_stdlib] Add stdlib.h implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ export VERUS_KERNEL_FEATURES := microvm trace
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
 ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_string libc_time libc_wchar libc_wctype syslog-macros syslog mmio-tag syscall vfs
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype syslog-macros syslog mmio-tag syscall vfs
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -10,15 +10,60 @@
  * @file stdlib.h
  * @brief General utilities.
  *
- * Declares memory allocation and environment interfaces implemented by the
- * libc_stdlib Rust crate.
+ * Declares memory allocation, string conversion, integer arithmetic, searching
+ * and sorting, pseudo-random sequence generation, environment, and process
+ * control interfaces implemented by the libc_stdlib Rust crate.
  */
 
 #include <stddef.h>
+#include <sys/wait.h>
+#include <fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0 /**< Successful termination for exit(). */
+#endif
+
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1 /**< Unsuccessful termination for exit(). */
+#endif
+
+#ifndef RAND_MAX
+#define RAND_MAX 32767 /**< Maximum value returned by rand(). */
+#endif
+
+#ifndef MB_CUR_MAX
+#define MB_CUR_MAX ((size_t)1) /**< Maximum number of bytes in a character for the current locale. */
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Structure type returned by the div() function. */
+typedef struct {
+    int quot; /**< Quotient.  */
+    int rem;  /**< Remainder. */
+} div_t;
+
+/** @brief Structure type returned by the ldiv() function. */
+typedef struct {
+    long quot; /**< Quotient.  */
+    long rem;  /**< Remainder. */
+} ldiv_t;
+
+/** @brief Structure type returned by the lldiv() function. */
+typedef struct {
+    long long quot; /**< Quotient.  */
+    long long rem;  /**< Remainder. */
+} lldiv_t;
 
 /*==================================================================================================
  * Memory Allocation
@@ -28,16 +73,103 @@ extern void *malloc(size_t size);
 extern void free(void *ptr);
 extern void *calloc(size_t nmemb, size_t size);
 extern void *realloc(void *ptr, size_t size);
+extern void *reallocarray(void *ptr, size_t nelem, size_t elsize);
 extern void *aligned_alloc(size_t alignment, size_t size);
 extern int posix_memalign(void **memptr, size_t alignment, size_t size);
+
+/*==================================================================================================
+ * String Conversion
+ *==================================================================================================*/
+
+extern double atof(const char *nptr);
+extern int atoi(const char *nptr);
+extern long atol(const char *nptr);
+extern long long atoll(const char *nptr);
+extern double strtod(const char *restrict nptr, char **restrict endptr);
+extern float strtof(const char *restrict nptr, char **restrict endptr);
+extern double strtold(const char *restrict nptr, char **restrict endptr);
+extern long strtol(const char *restrict nptr, char **restrict endptr, int base);
+extern long long strtoll(const char *restrict nptr, char **restrict endptr, int base);
+extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);
+extern unsigned long long strtoull(const char *restrict nptr, char **restrict endptr, int base);
+
+/*==================================================================================================
+ * Integer Arithmetic
+ *==================================================================================================*/
+
+extern int abs(int j);
+extern long labs(long j);
+extern long long llabs(long long j);
+extern div_t div(int numer, int denom);
+extern ldiv_t ldiv(long numer, long denom);
+extern lldiv_t lldiv(long long numer, long long denom);
+
+/*==================================================================================================
+ * Searching and Sorting
+ *==================================================================================================*/
+
+extern void *bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));
+extern void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));
+extern void qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *arg);
+
+/*==================================================================================================
+ * Pseudo-Random Sequence Generation
+ *==================================================================================================*/
+
+extern int rand(void);
+extern void srand(unsigned int seed);
 
 /*==================================================================================================
  * Environment
  *==================================================================================================*/
 
 extern char *getenv(const char *name);
+extern char *secure_getenv(const char *name);
 extern int setenv(const char *name, const char *value, int overwrite);
 extern int unsetenv(const char *name);
+extern int putenv(char *string);
+extern int getsubopt(char **restrict optionp, char *const *restrict tokens, char **restrict valuep);
+
+/*==================================================================================================
+ * Process Control
+ *==================================================================================================*/
+
+extern _Noreturn void _Exit(int status);
+extern _Noreturn void abort(void);
+extern int at_quick_exit(void (*func)(void));
+extern int atexit(void (*func)(void));
+extern _Noreturn void exit(int status);
+extern _Noreturn void quick_exit(int status);
+extern int system(const char *command);
+
+/*==================================================================================================
+ * Multibyte Conversion
+ *==================================================================================================*/
+
+extern int mblen(const char *s, size_t n);
+extern int mbtowc(wchar_t *restrict pwc, const char *restrict s, size_t n);
+extern size_t mbstowcs(wchar_t *restrict dst, const char *restrict src, size_t n);
+extern int wctomb(char *s, wchar_t wc);
+extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n);
+
+/*==================================================================================================
+ * Temporary Files and Terminals
+ *==================================================================================================*/
+
+extern char *mkdtemp(char *template);
+extern int mkostemp(char *template, int flags);
+extern int mkstemp(char *template);
+extern int posix_openpt(int flags);
+extern char *ptsname(int fildes);
+extern int ptsname_r(int fildes, char *name, size_t namesize);
+extern int unlockpt(int fildes);
+extern int grantpt(int fildes);
+
+/*==================================================================================================
+ * Path Utilities
+ *==================================================================================================*/
+
+extern char *realpath(const char *restrict path, char *restrict resolved_path);
 
 #ifdef __cplusplus
 }

--- a/src/libs/libc_stdio/src/fflush.rs
+++ b/src/libs/libc_stdio/src/fflush.rs
@@ -38,5 +38,6 @@ use ::sysapi::ffi::c_int;
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn fflush(_stream: *mut FILE) -> c_int {
     // No-op: this implementation uses unbuffered I/O.
+    // TODO (#2631): implement real flush semantics once `libc_stdio` supports stream buffering.
     0
 }

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -8,10 +8,73 @@
 file = "stdlib.h"
 brief = "General utilities."
 description = """
-Declares memory allocation and environment interfaces implemented by the
-libc_stdlib Rust crate."""
-includes = ["stddef.h"]
+Declares memory allocation, string conversion, integer arithmetic, searching
+and sorting, pseudo-random sequence generation, environment, and process
+control interfaces implemented by the libc_stdlib Rust crate."""
+includes = ["stddef.h", "sys/wait.h", "fcntl.h"]
 guard = "_NANVIX_STDLIB_H"
+content_order = [
+    "macros",
+    "types",
+    "section:0",
+    "section:1",
+    "section:2",
+    "section:3",
+    "section:4",
+    "section:5",
+    "section:6",
+    "section:7",
+    "section:8",
+    "section:9",
+]
+
+[[macros]]
+name = "EXIT_SUCCESS"
+value = "0"
+comment = "Successful termination for exit()."
+guard = "EXIT_SUCCESS"
+
+[[macros]]
+name = "EXIT_FAILURE"
+value = "1"
+comment = "Unsuccessful termination for exit()."
+guard = "EXIT_FAILURE"
+
+[[macros]]
+name = "RAND_MAX"
+value = "32767"
+comment = "Maximum value returned by rand()."
+guard = "RAND_MAX"
+
+[[macros]]
+name = "MB_CUR_MAX"
+value = "((size_t)1)"
+comment = "Maximum number of bytes in a character for the current locale."
+guard = "MB_CUR_MAX"
+
+[[types]]
+text = """
+/** @brief Structure type returned by the div() function. */
+typedef struct {
+    int quot; /**< Quotient.  */
+    int rem;  /**< Remainder. */
+} div_t;"""
+
+[[types]]
+text = """
+/** @brief Structure type returned by the ldiv() function. */
+typedef struct {
+    long quot; /**< Quotient.  */
+    long rem;  /**< Remainder. */
+} ldiv_t;"""
+
+[[types]]
+text = """
+/** @brief Structure type returned by the lldiv() function. */
+typedef struct {
+    long long quot; /**< Quotient.  */
+    long long rem;  /**< Remainder. */
+} lldiv_t;"""
 
 [[sections]]
 title = "Memory Allocation"
@@ -20,10 +83,135 @@ functions = [
     "free",
     "calloc",
     "realloc",
+    "reallocarray",
     "aligned_alloc",
     "posix_memalign",
 ]
 
 [[sections]]
+title = "String Conversion"
+functions = [
+    "atof",
+    "atoi",
+    "atol",
+    "atoll",
+    "strtod",
+    "strtof",
+    "strtold",
+    "strtol",
+    "strtoll",
+    "strtoul",
+    "strtoull",
+]
+
+[[sections]]
+title = "Integer Arithmetic"
+functions = ["abs", "labs", "llabs", "div", "ldiv", "lldiv"]
+
+[[sections]]
+title = "Searching and Sorting"
+functions = ["bsearch", "qsort", "qsort_r"]
+
+[[sections]]
+title = "Pseudo-Random Sequence Generation"
+functions = ["rand", "srand"]
+
+[[sections]]
 title = "Environment"
-functions = ["getenv", "setenv", "unsetenv"]
+functions = [
+    "getenv",
+    "secure_getenv",
+    "setenv",
+    "unsetenv",
+    "putenv",
+    "getsubopt",
+]
+
+[[sections]]
+title = "Process Control"
+functions = [
+    "_Exit",
+    "abort",
+    "at_quick_exit",
+    "atexit",
+    "exit",
+    "quick_exit",
+    "system",
+]
+
+[[sections]]
+title = "Multibyte Conversion"
+functions = ["mblen", "mbtowc", "mbstowcs", "wctomb", "wcstombs"]
+
+[[sections]]
+title = "Temporary Files and Terminals"
+functions = [
+    "mkdtemp",
+    "mkostemp",
+    "mkstemp",
+    "posix_openpt",
+    "ptsname",
+    "ptsname_r",
+    "unlockpt",
+    "grantpt",
+]
+
+[[sections]]
+title = "Path Utilities"
+functions = ["realpath"]
+
+[overrides]
+_Exit = '''
+extern _Noreturn void _Exit(int status);'''
+abort = '''
+extern _Noreturn void abort(void);'''
+exit = '''
+extern _Noreturn void exit(int status);'''
+quick_exit = '''
+extern _Noreturn void quick_exit(int status);'''
+strtod = '''
+extern double strtod(const char *restrict nptr, char **restrict endptr);'''
+strtof = '''
+extern float strtof(const char *restrict nptr, char **restrict endptr);'''
+strtold = '''
+extern double strtold(const char *restrict nptr, char **restrict endptr);'''
+strtol = '''
+extern long strtol(const char *restrict nptr, char **restrict endptr, int base);'''
+strtoll = '''
+extern long long strtoll(const char *restrict nptr, char **restrict endptr, int base);'''
+strtoul = '''
+extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);'''
+strtoull = '''
+extern unsigned long long strtoull(const char *restrict nptr, char **restrict endptr, int base);'''
+getsubopt = '''
+extern int getsubopt(char **restrict optionp, char *const *restrict tokens, char **restrict valuep);'''
+qsort_r = '''
+extern void qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *arg);'''
+mbtowc = '''
+extern int mbtowc(wchar_t *restrict pwc, const char *restrict s, size_t n);'''
+mblen = '''
+extern int mblen(const char *s, size_t n);'''
+wctomb = '''
+extern int wctomb(char *s, wchar_t wc);'''
+mbstowcs = '''
+extern size_t mbstowcs(wchar_t *restrict dst, const char *restrict src, size_t n);'''
+wcstombs = '''
+extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n);'''
+mkdtemp = '''
+extern char *mkdtemp(char *template);'''
+mkostemp = '''
+extern int mkostemp(char *template, int flags);'''
+mkstemp = '''
+extern int mkstemp(char *template);'''
+posix_openpt = '''
+extern int posix_openpt(int flags);'''
+ptsname = '''
+extern char *ptsname(int fildes);'''
+ptsname_r = '''
+extern int ptsname_r(int fildes, char *name, size_t namesize);'''
+unlockpt = '''
+extern int unlockpt(int fildes);'''
+grantpt = '''
+extern int grantpt(int fildes);'''
+realpath = '''
+extern char *realpath(const char *restrict path, char *restrict resolved_path);'''

--- a/src/libs/libc_stdlib/src/abort.rs
+++ b/src/libs/libc_stdlib/src/abort.rs
@@ -1,0 +1,51 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pid_t,
+};
+
+//==================================================================================================
+// External Declarations
+//==================================================================================================
+
+extern "C" {
+    fn _exit(status: c_int) -> !;
+    fn getpid() -> pid_t;
+    fn kill(pid: pid_t, sig: c_int) -> c_int;
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Signal number for SIGABRT.
+const SIGABRT: c_int = 6;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Causes abnormal process termination by raising `SIGABRT`.
+///
+/// # Safety
+///
+/// This function is unsafe because it terminates the process.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/abort.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn abort() -> ! {
+    let _ = kill(getpid(), SIGABRT);
+    _exit(134)
+}

--- a/src/libs/libc_stdlib/src/abs_fn.rs
+++ b/src/libs/libc_stdlib/src/abs_fn.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the absolute value of an integer.
+///
+/// # Parameters
+///
+/// - `j`: Integer value.
+///
+/// # Returns
+///
+/// The absolute value of `j`. If the result cannot be represented (i.e., `j` equals `INT_MIN`),
+/// the behavior is undefined.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/abs.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn abs(j: c_int) -> c_int {
+    if j < 0 {
+        j.wrapping_neg()
+    } else {
+        j
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::abs;
+
+    #[test]
+    fn positive_value() {
+        assert_eq!(unsafe { abs(42) }, 42);
+    }
+
+    #[test]
+    fn negative_value() {
+        assert_eq!(unsafe { abs(-42) }, 42);
+    }
+
+    #[test]
+    fn zero_value() {
+        assert_eq!(unsafe { abs(0) }, 0);
+    }
+}

--- a/src/libs/libc_stdlib/src/aligned_alloc.rs
+++ b/src/libs/libc_stdlib/src/aligned_alloc.rs
@@ -18,7 +18,6 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -61,11 +60,18 @@ pub unsafe extern "C" fn aligned_alloc(alignment: c_size_t, size: c_size_t) -> *
         return null_mut();
     }
 
-    // Check for null alignment.
-    if alignment == 0 {
-        // Zero-size alignments have implementation-defined behavior,
-        // thus log a warning message and return null.
-        warn!("aligned_alloc(): zero-size alignment (alignment={alignment:?}, size={size:?})");
+    // Check for invalid alignment.
+    if !BlockHeader::supports_alignment(alignment as usize) {
+        warn!("aligned_alloc(): invalid alignment (alignment={alignment:?}, size={size:?})");
+        set_errno(EINVAL);
+        return null_mut();
+    }
+
+    if !size.is_multiple_of(alignment) {
+        warn!(
+            "aligned_alloc(): size is not a multiple of alignment (alignment={alignment:?}, \
+             size={size:?})"
+        );
         set_errno(EINVAL);
         return null_mut();
     }
@@ -86,10 +92,7 @@ mod tests {
     use super::aligned_alloc;
     use crate::set_errno;
     use ::sysapi::{
-        errno::{
-            EINVAL,
-            ENOMEM,
-        },
+        errno::EINVAL,
         ffi::c_int,
         sys_types::c_size_t,
     };
@@ -119,7 +122,7 @@ mod tests {
     fn valid_allocation_multiple() {
         let alignment: c_size_t = 64;
         let size: c_size_t = 256; // multiple of alignment
-        let p = unsafe { aligned_alloc(alignment, size) } as *mut u8;
+        let p = unsafe { aligned_alloc(alignment, size) }.cast::<u8>();
         assert!(!p.is_null());
         let addr = p as usize;
         assert_eq!(addr & (alignment as usize - 1), 0, "pointer {addr:#x} not {alignment}-aligned");
@@ -129,15 +132,12 @@ mod tests {
     }
 
     #[test]
-    fn valid_allocation_non_multiple() {
+    fn size_not_multiple_of_alignment_fails() {
+        set_errno(0);
         let alignment: c_size_t = 64;
         let size: c_size_t = 130; // not a multiple of alignment
-        let p = unsafe { aligned_alloc(alignment, size) } as *mut u8;
-        assert!(!p.is_null());
-        let addr = p as usize;
-        assert_eq!(addr & (alignment as usize - 1), 0, "pointer {addr:#x} not {alignment}-aligned");
-        unsafe {
-            crate::free(p.cast());
-        }
+        let p = unsafe { aligned_alloc(alignment, size) }.cast::<u8>();
+        assert!(p.is_null());
+        assert_eq!(get_errno(), EINVAL);
     }
 }

--- a/src/libs/libc_stdlib/src/atexit.rs
+++ b/src/libs/libc_stdlib/src/atexit.rs
@@ -1,0 +1,119 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of atexit handlers that can be registered.
+const MAX_ATEXIT_HANDLERS: usize = 32;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Table of registered atexit handler functions.
+static mut ATEXIT_HANDLERS: [Option<unsafe extern "C" fn()>; MAX_ATEXIT_HANDLERS] =
+    [None; MAX_ATEXIT_HANDLERS];
+
+/// Number of currently registered atexit handlers.
+static mut ATEXIT_COUNT: usize = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Registers a function to be called at normal process termination.
+///
+/// # Parameters
+///
+/// - `func`: Function to be called at exit.
+///
+/// # Returns
+///
+/// `0` on success, or `-1` if the handler table is full or `func` is `None`.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses global mutable state.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/atexit.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn atexit(func: Option<unsafe extern "C" fn()>) -> c_int {
+    let func = match func {
+        Some(f) => f,
+        None => return -1,
+    };
+
+    if ATEXIT_COUNT >= MAX_ATEXIT_HANDLERS {
+        return -1;
+    }
+
+    ATEXIT_HANDLERS[ATEXIT_COUNT] = Some(func);
+    ATEXIT_COUNT += 1;
+    0
+}
+
+/// Invokes all registered atexit handlers in reverse order of registration.
+pub(crate) unsafe fn call_atexit_handlers() {
+    while ATEXIT_COUNT > 0 {
+        ATEXIT_COUNT -= 1;
+        if let Some(f) = ATEXIT_HANDLERS[ATEXIT_COUNT] {
+            f();
+            ATEXIT_HANDLERS[ATEXIT_COUNT] = None;
+        }
+    }
+}
+
+/// Resets the atexit handler table. Used for test isolation.
+#[cfg(test)]
+pub(crate) unsafe fn reset_atexit_handlers() {
+    ATEXIT_COUNT = 0;
+    // Use indexed assignment (a place expression) rather than `&mut ATEXIT_HANDLERS` to avoid
+    // creating a reference to a mutable static. A `while` loop sidesteps `needless_range_loop`,
+    // which would otherwise suggest the disallowed iterator form.
+    let mut i = 0;
+    while i < MAX_ATEXIT_HANDLERS {
+        ATEXIT_HANDLERS[i] = None;
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        atexit,
+        reset_atexit_handlers,
+    };
+
+    unsafe extern "C" fn dummy_handler() {}
+
+    #[test]
+    fn register_handler() {
+        unsafe { reset_atexit_handlers() };
+        assert_eq!(unsafe { atexit(Some(dummy_handler)) }, 0);
+        unsafe { reset_atexit_handlers() };
+    }
+
+    #[test]
+    fn register_too_many() {
+        unsafe { reset_atexit_handlers() };
+        for _ in 0..32 {
+            assert_eq!(unsafe { atexit(Some(dummy_handler)) }, 0);
+        }
+        assert_eq!(unsafe { atexit(Some(dummy_handler)) }, -1);
+        unsafe { reset_atexit_handlers() };
+    }
+}

--- a/src/libs/libc_stdlib/src/atof.rs
+++ b/src/libs/libc_stdlib/src/atof.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::strtod::strtod;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `f64`.
+///
+/// This function is equivalent to `strtod(nptr, null)`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the null-terminated string to be converted.
+///
+/// # Returns
+///
+/// The converted `f64` value. Returns `0.0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/atof.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn atof(nptr: *const c_char) -> f64 {
+    strtod(nptr, core::ptr::null_mut())
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::atof;
+    use ::sysapi::ffi::c_char;
+
+    /// Helper to compare floats within an epsilon.
+    fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() < eps
+    }
+
+    #[test]
+    fn basic_decimal() {
+        let s = b"3.25\0";
+        let result: f64 = unsafe { atof(s.as_ptr().cast::<c_char>()) };
+        assert!(approx_eq(result, 3.25, 1e-10), "expected 3.25, got {result}");
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-2.5\0";
+        let result: f64 = unsafe { atof(s.as_ptr().cast::<c_char>()) };
+        assert!(approx_eq(result, -2.5, 1e-10), "expected -2.5, got {result}");
+    }
+
+    #[test]
+    fn no_valid_conversion() {
+        let s = b"abc\0";
+        let result: f64 = unsafe { atof(s.as_ptr().cast::<c_char>()) };
+        assert!(approx_eq(result, 0.0, 1e-10), "expected 0.0, got {result}");
+    }
+}

--- a/src/libs/libc_stdlib/src/atoi.rs
+++ b/src/libs/libc_stdlib/src/atoi.rs
@@ -1,0 +1,118 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `c_int`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+///
+/// # Returns
+///
+/// The converted value. Returns `0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/atoi.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn atoi(nptr: *const c_char) -> c_int {
+    if nptr.is_null() {
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Parse digits using wrapping arithmetic (overflow is undefined behavior in C).
+    let mut result: c_int = 0;
+    while (*p as u8) >= b'0' && (*p as u8) <= b'9' {
+        let digit = c_int::from((*p as u8) - b'0');
+        result = result.wrapping_mul(10).wrapping_add(digit);
+        p = p.add(1);
+    }
+
+    if negative {
+        result.wrapping_neg()
+    } else {
+        result
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::atoi;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn positive_value() {
+        let s = b"123\0";
+        assert_eq!(unsafe { atoi(s.as_ptr().cast::<c_char>()) }, 123);
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-456\0";
+        assert_eq!(unsafe { atoi(s.as_ptr().cast::<c_char>()) }, -456);
+    }
+
+    #[test]
+    fn with_whitespace_and_sign() {
+        let s = b"  +789\0";
+        assert_eq!(unsafe { atoi(s.as_ptr().cast::<c_char>()) }, 789);
+    }
+
+    #[test]
+    fn non_numeric() {
+        let s = b"abc\0";
+        assert_eq!(unsafe { atoi(s.as_ptr().cast::<c_char>()) }, 0);
+    }
+
+    #[test]
+    fn overflow_wraps() {
+        let s = b"99999999999\0";
+        // Overflow is undefined in C; just verify no crash.
+        let _ = unsafe { atoi(s.as_ptr().cast::<c_char>()) };
+    }
+}

--- a/src/libs/libc_stdlib/src/atol.rs
+++ b/src/libs/libc_stdlib/src/atol.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_long,
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `c_long`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+///
+/// # Returns
+///
+/// The converted value. Returns `0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/atol.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn atol(nptr: *const c_char) -> c_long {
+    if nptr.is_null() {
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Parse digits using wrapping arithmetic (overflow is undefined behavior in C).
+    let mut result: c_long = 0;
+    while (*p as u8) >= b'0' && (*p as u8) <= b'9' {
+        let digit = c_long::from((*p as u8) - b'0');
+        result = result.wrapping_mul(10).wrapping_add(digit);
+        p = p.add(1);
+    }
+
+    if negative {
+        result.wrapping_neg()
+    } else {
+        result
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::atol;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn positive_value() {
+        let s = b"123\0";
+        assert_eq!(unsafe { atol(s.as_ptr().cast::<c_char>()) }, 123);
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-456\0";
+        assert_eq!(unsafe { atol(s.as_ptr().cast::<c_char>()) }, -456);
+    }
+}

--- a/src/libs/libc_stdlib/src/atoll.rs
+++ b/src/libs/libc_stdlib/src/atoll.rs
@@ -1,0 +1,105 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_longlong,
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `c_longlong`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+///
+/// # Returns
+///
+/// The converted value. Returns `0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/atoll.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn atoll(nptr: *const c_char) -> c_longlong {
+    if nptr.is_null() {
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Parse digits using wrapping arithmetic (overflow is undefined behavior in C).
+    let mut result: c_longlong = 0;
+    while (*p as u8) >= b'0' && (*p as u8) <= b'9' {
+        let digit = c_longlong::from((*p as u8) - b'0');
+        result = result.wrapping_mul(10).wrapping_add(digit);
+        p = p.add(1);
+    }
+
+    if negative {
+        result.wrapping_neg()
+    } else {
+        result
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::atoll;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn positive_value() {
+        let s = b"123\0";
+        assert_eq!(unsafe { atoll(s.as_ptr().cast::<c_char>()) }, 123);
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-456\0";
+        assert_eq!(unsafe { atoll(s.as_ptr().cast::<c_char>()) }, -456);
+    }
+
+    #[test]
+    fn large_value() {
+        let s = b"1000000000000\0";
+        assert_eq!(unsafe { atoll(s.as_ptr().cast::<c_char>()) }, 1_000_000_000_000);
+    }
+}

--- a/src/libs/libc_stdlib/src/block_header.rs
+++ b/src/libs/libc_stdlib/src/block_header.rs
@@ -17,7 +17,6 @@ use ::core::{
         null_mut,
     },
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Constants
@@ -61,6 +60,11 @@ pub(crate) struct BlockHeader {
 //==================================================================================================
 
 impl BlockHeader {
+    /// Returns `true` if `alignment` is supported by this allocator.
+    pub(crate) fn supports_alignment(alignment: usize) -> bool {
+        alignment.is_power_of_two() && alignment <= MAX_ALIGNMENT
+    }
+
     /// # Description
     ///
     /// Allocates a block of memory.
@@ -94,7 +98,7 @@ impl BlockHeader {
         let alignment: usize = alignment.unwrap_or(1);
 
         // Validate alignment invariants so that free() can trust the header.
-        if !alignment.is_power_of_two() || alignment > MAX_ALIGNMENT {
+        if !Self::supports_alignment(alignment) {
             warn!("alloc(): invalid alignment (alignment={alignment:?}, size={size:?})");
             return null_mut();
         }

--- a/src/libs/libc_stdlib/src/bsearch.rs
+++ b/src/libs/libc_stdlib/src/bsearch.rs
@@ -1,0 +1,154 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::ptr::null_mut;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Searches an array of `nmemb` elements for a member that matches `key`, using binary search.
+/// The array must be sorted in ascending order according to the comparison function.
+///
+/// # Parameters
+///
+/// - `key`: Pointer to the key to search for.
+/// - `base`: Pointer to the first element of the sorted array.
+/// - `nmemb`: Number of elements in the array.
+/// - `size`: Size of each element in bytes.
+/// - `compar`: Comparison function.
+///
+/// # Returns
+///
+/// A pointer to a matching element, or null if no match is found.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers and calls a function pointer.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/bsearch.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn bsearch(
+    key: *const c_void,
+    base: *const c_void,
+    nmemb: c_size_t,
+    size: c_size_t,
+    compar: Option<unsafe extern "C" fn(*const c_void, *const c_void) -> c_int>,
+) -> *mut c_void {
+    let compar = match compar {
+        Some(f) => f,
+        None => return null_mut(),
+    };
+
+    if key.is_null() || base.is_null() || nmemb == 0 || size == 0 {
+        return null_mut();
+    }
+
+    let base_ptr: *const u8 = base.cast::<u8>();
+    let size = size as usize;
+    let mut low: usize = 0;
+    let mut high: usize = nmemb as usize;
+
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let elem = base_ptr.add(mid * size).cast::<c_void>();
+        let cmp = compar(key, elem);
+
+        if cmp < 0 {
+            high = mid;
+        } else if cmp > 0 {
+            low = mid + 1;
+        } else {
+            return elem.cast_mut();
+        }
+    }
+
+    null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::bsearch;
+    use ::sysapi::ffi::{
+        c_int,
+        c_void,
+    };
+
+    unsafe extern "C" fn compare_ints(a: *const c_void, b: *const c_void) -> c_int {
+        let a_val: c_int = *a.cast::<c_int>();
+        let b_val: c_int = *b.cast::<c_int>();
+        if a_val < b_val {
+            -1
+        } else if a_val > b_val {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[test]
+    fn found() {
+        let arr: [c_int; 5] = [1, 2, 3, 4, 5];
+        let key: c_int = 3;
+        let result = unsafe {
+            bsearch(
+                (&key as *const c_int).cast::<c_void>(),
+                arr.as_ptr().cast::<c_void>(),
+                5,
+                4,
+                Some(compare_ints),
+            )
+        };
+        assert!(!result.is_null());
+        assert_eq!(unsafe { *result.cast::<c_int>() }, 3);
+    }
+
+    #[test]
+    fn not_found() {
+        let arr: [c_int; 5] = [1, 2, 3, 4, 5];
+        let key: c_int = 6;
+        let result = unsafe {
+            bsearch(
+                (&key as *const c_int).cast::<c_void>(),
+                arr.as_ptr().cast::<c_void>(),
+                5,
+                4,
+                Some(compare_ints),
+            )
+        };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn empty_array() {
+        let arr: [c_int; 0] = [];
+        let key: c_int = 1;
+        let result = unsafe {
+            bsearch(
+                (&key as *const c_int).cast::<c_void>(),
+                arr.as_ptr().cast::<c_void>(),
+                0,
+                4,
+                Some(compare_ints),
+            )
+        };
+        assert!(result.is_null());
+    }
+}

--- a/src/libs/libc_stdlib/src/calloc.rs
+++ b/src/libs/libc_stdlib/src/calloc.rs
@@ -18,7 +18,6 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -124,7 +123,7 @@ mod tests {
         let nmemb: c_size_t = 16;
         let size: c_size_t = 8;
         let total: usize = (nmemb * size) as usize;
-        let p = unsafe { calloc(nmemb, size) } as *mut u8;
+        let p = unsafe { calloc(nmemb, size) }.cast::<u8>();
         assert!(!p.is_null());
         unsafe {
             for i in 0..total {

--- a/src/libs/libc_stdlib/src/div_fn.rs
+++ b/src/libs/libc_stdlib/src/div_fn.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Result type for the `div()` function containing quotient and remainder.
+#[repr(C)]
+pub struct div_t {
+    pub quot: c_int,
+    pub rem: c_int,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the quotient and remainder of an integer division.
+///
+/// # Parameters
+///
+/// - `numer`: Numerator.
+/// - `denom`: Denominator.
+///
+/// # Returns
+///
+/// A `div_t` structure containing the quotient and remainder.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention. The caller must ensure that
+/// `denom` is not zero.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/div.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn div(numer: c_int, denom: c_int) -> div_t {
+    div_t {
+        quot: numer.wrapping_div(denom),
+        rem: numer.wrapping_rem(denom),
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::div;
+
+    #[test]
+    fn positive_division() {
+        let result = unsafe { div(10, 3) };
+        assert_eq!(result.quot, 3);
+        assert_eq!(result.rem, 1);
+    }
+
+    #[test]
+    fn negative_dividend() {
+        let result = unsafe { div(-10, 3) };
+        assert_eq!(result.quot, -3);
+        assert_eq!(result.rem, -1);
+    }
+}

--- a/src/libs/libc_stdlib/src/env_table.rs
+++ b/src/libs/libc_stdlib/src/env_table.rs
@@ -32,10 +32,16 @@ pub type SetenvCallback = fn(&str, &[u8]);
 
 /// A single environment variable entry.
 struct EnvEntry {
-    /// Variable name.
-    key: String,
-    /// Null-terminated "KEY=VALUE" C string for pointer stability from `getenv()`.
-    raw: Vec<u8>,
+    /// Storage for the null-terminated `KEY=VALUE` C string.
+    storage: EnvStorage,
+}
+
+/// Storage backing for an environment variable entry.
+enum EnvStorage {
+    /// Owned storage used by `setenv()` and process startup initialization.
+    Owned(Vec<u8>),
+    /// Caller-owned storage installed by `putenv()`.
+    Borrowed(usize),
 }
 
 //==================================================================================================
@@ -128,10 +134,8 @@ pub unsafe fn init_from_raw(envp: *const *const c_char) {
 pub fn get(key: &str) -> *const c_char {
     let table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
     for entry in table.iter() {
-        if entry.key == key {
-            // Return pointer to the value portion, which starts after "KEY=".
-            let offset: usize = entry.key.len() + 1;
-            return entry.raw[offset..].as_ptr().cast::<c_char>();
+        if let Some(value_ptr) = entry.value_ptr_if_key(key) {
+            return value_ptr;
         }
     }
     ::core::ptr::null()
@@ -165,9 +169,9 @@ pub fn set(key: &str, value: &[u8], overwrite: bool) -> Result<bool, ()> {
 
     // Check if the key already exists.
     for entry in table.iter_mut() {
-        if entry.key == key {
+        if entry.matches_key(key) {
             if overwrite {
-                entry.raw = make_raw(key, value);
+                *entry = EnvEntry::owned(key, value);
                 // Release the lock before invoking the callback.
                 drop(table);
                 invoke_setenv_callback(key, value);
@@ -196,7 +200,53 @@ pub fn set(key: &str, value: &[u8], overwrite: bool) -> Result<bool, ()> {
 ///
 pub fn unset(key: &str) {
     let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
-    table.retain(|entry| entry.key != key);
+    table.retain(|entry| !entry.matches_key(key));
+}
+
+///
+/// # Description
+///
+/// Installs a caller-owned `KEY=VALUE` string in the environment.
+///
+/// # Parameters
+///
+/// - `string`: Pointer to the caller-owned null-terminated environment string.
+///
+/// # Returns
+///
+/// `Ok(())` if the entry was installed, or `Err(())` if the string is not of the form
+/// `KEY=VALUE` with a non-empty UTF-8 key.
+///
+/// # Safety
+///
+/// `string` must be a valid null-terminated C string. The caller must keep the storage valid while
+/// it remains part of the environment.
+///
+#[allow(clippy::result_unit_err)]
+pub unsafe fn put_raw(string: *mut c_char) -> Result<(), ()> {
+    let bytes: &[u8] = ffi::CStr::from_ptr(string).to_bytes();
+    let Some(eq_pos) = bytes.iter().position(|&b| b == b'=') else {
+        return Err(());
+    };
+    if eq_pos == 0 {
+        return Err(());
+    }
+    let key: &str = ::core::str::from_utf8(&bytes[..eq_pos]).map_err(|_| ())?;
+    let value: &[u8] = &bytes[eq_pos + 1..];
+
+    let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
+    for entry in table.iter_mut() {
+        if entry.matches_key(key) {
+            *entry = EnvEntry::borrowed(string);
+            drop(table);
+            invoke_setenv_callback(key, value);
+            return Ok(());
+        }
+    }
+    table.push(EnvEntry::borrowed(string));
+    drop(table);
+    invoke_setenv_callback(key, value);
+    Ok(())
 }
 
 ///
@@ -221,7 +271,8 @@ pub fn snapshot() -> Vec<String> {
     let mut out: Vec<String> = Vec::with_capacity(table.len());
     for entry in table.iter() {
         // `raw` is a NUL-terminated "KEY=VALUE" C string; drop the trailing NUL before decoding.
-        let bytes: &[u8] = &entry.raw[..entry.raw.len().saturating_sub(1)];
+        let bytes: &[u8] = entry.raw_bytes_with_nul();
+        let bytes: &[u8] = &bytes[..bytes.len().saturating_sub(1)];
         if let Ok(token) = ::core::str::from_utf8(bytes) {
             out.push(String::from(token));
         }
@@ -268,22 +319,69 @@ fn make_raw(key: &str, value: &[u8]) -> Vec<u8> {
 
 /// Inserts a new entry into the table.
 fn insert_entry(table: &mut Vec<EnvEntry>, key: &str, value: &[u8]) {
-    let raw: Vec<u8> = make_raw(key, value);
-    table.push(EnvEntry {
-        key: String::from(key),
-        raw,
-    });
+    table.push(EnvEntry::owned(key, value));
 }
 
 /// Inserts or updates an entry in the table. If `key` already exists, its value is replaced.
 fn upsert_entry(table: &mut Vec<EnvEntry>, key: &str, value: &[u8]) {
     for entry in table.iter_mut() {
-        if entry.key == key {
-            entry.raw = make_raw(key, value);
+        if entry.matches_key(key) {
+            *entry = EnvEntry::owned(key, value);
             return;
         }
     }
     insert_entry(table, key, value);
+}
+
+impl EnvEntry {
+    /// Creates an owned environment entry.
+    fn owned(key: &str, value: &[u8]) -> Self {
+        Self {
+            storage: EnvStorage::Owned(make_raw(key, value)),
+        }
+    }
+
+    /// Creates a borrowed environment entry.
+    fn borrowed(ptr: *mut c_char) -> Self {
+        Self {
+            storage: EnvStorage::Borrowed(ptr as usize),
+        }
+    }
+
+    /// Returns the raw null-terminated `KEY=VALUE` bytes.
+    fn raw_bytes_with_nul(&self) -> &[u8] {
+        match &self.storage {
+            EnvStorage::Owned(raw) => raw,
+            EnvStorage::Borrowed(addr) => unsafe {
+                ffi::CStr::from_ptr((*addr) as *const c_char).to_bytes_with_nul()
+            },
+        }
+    }
+
+    /// Returns the offset of the value if this entry currently names `key`.
+    fn value_offset_if_key(&self, key: &str) -> Option<usize> {
+        let bytes: &[u8] = self.raw_bytes_with_nul();
+        let eq_pos: usize = bytes.iter().position(|&b| b == b'=')?;
+        if ::core::str::from_utf8(&bytes[..eq_pos]).ok()? == key {
+            Some(eq_pos + 1)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if this entry currently names `key`.
+    fn matches_key(&self, key: &str) -> bool {
+        self.value_offset_if_key(key).is_some()
+    }
+
+    /// Returns the value pointer if this entry currently names `key`.
+    fn value_ptr_if_key(&self, key: &str) -> Option<*const c_char> {
+        let offset: usize = self.value_offset_if_key(key)?;
+        match &self.storage {
+            EnvStorage::Owned(raw) => Some(raw[offset..].as_ptr().cast::<c_char>()),
+            EnvStorage::Borrowed(addr) => Some((*addr + offset) as *const c_char),
+        }
+    }
 }
 
 //==================================================================================================

--- a/src/libs/libc_stdlib/src/exit.rs
+++ b/src/libs/libc_stdlib/src/exit.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// External Declarations
+//==================================================================================================
+
+extern "C" {
+    fn _exit(status: c_int) -> !;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Terminates the calling process. Registered `atexit` handlers are called in reverse order
+/// before the process exits.
+///
+/// POSIX also requires `exit()` to flush all open streams with unwritten buffered data and close
+/// their file descriptors before terminating. That flush is not performed here: `libc_stdio` is
+/// currently unbuffered (so there is no buffered state to lose), and `libc_stdlib` is linked by
+/// guests that do not link `libc_stdio`, so referencing `fflush` directly would break their link.
+///
+/// # Parameters
+///
+/// - `status`: Exit status code.
+///
+/// # Safety
+///
+/// This function is unsafe because it terminates the process and calls registered handlers.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/exit.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn exit(status: c_int) -> ! {
+    crate::atexit::call_atexit_handlers();
+    // TODO (#2631): flush and close open stdio streams once `libc_stdio` supports buffering,
+    // without creating a hard `libc_stdlib -> libc_stdio` link dependency for non-stdio guests.
+    _exit(status)
+}
+
+///
+/// # Description
+///
+/// Terminates the calling process without calling `atexit()` handlers or flushing streams.
+///
+/// # Parameters
+///
+/// - `status`: Exit status code.
+///
+/// # Safety
+///
+/// This function is unsafe because it terminates the process.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/_Exit.html
+///
+#[allow(non_snake_case)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn _Exit(status: c_int) -> ! {
+    _exit(status)
+}

--- a/src/libs/libc_stdlib/src/getenv.rs
+++ b/src/libs/libc_stdlib/src/getenv.rs
@@ -43,7 +43,7 @@ use ::sysapi::ffi::c_char;
 pub unsafe extern "C" fn getenv(name: *const c_char) -> *mut c_char {
     // Check if `name` is null.
     if name.is_null() {
-        ::syslog::warn!("getenv(): name is null");
+        warn!("getenv(): name is null");
         return ::core::ptr::null_mut();
     }
 
@@ -51,14 +51,14 @@ pub unsafe extern "C" fn getenv(name: *const c_char) -> *mut c_char {
     let name_str: &str = match ffi::CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => {
-            ::syslog::warn!("getenv(): invalid name (name={name:?})");
+            warn!("getenv(): invalid name (name={name:?})");
             return ::core::ptr::null_mut();
         },
     };
 
     // Empty name or name containing '=' is invalid per POSIX.
     if name_str.is_empty() || name_str.contains('=') {
-        ::syslog::warn!("getenv(): invalid name (name={name_str:?})");
+        warn!("getenv(): invalid name (name={name_str:?})");
         return ::core::ptr::null_mut();
     }
 

--- a/src/libs/libc_stdlib/src/labs.rs
+++ b/src/libs/libc_stdlib/src/labs.rs
@@ -1,0 +1,62 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_long;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the absolute value of a long integer.
+///
+/// # Parameters
+///
+/// - `j`: Long integer value.
+///
+/// # Returns
+///
+/// The absolute value of `j`.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/labs.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn labs(j: c_long) -> c_long {
+    if j < 0 {
+        j.wrapping_neg()
+    } else {
+        j
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::labs;
+
+    #[test]
+    fn positive_value() {
+        assert_eq!(unsafe { labs(42) }, 42);
+    }
+
+    #[test]
+    fn negative_value() {
+        assert_eq!(unsafe { labs(-42) }, 42);
+    }
+
+    #[test]
+    fn zero_value() {
+        assert_eq!(unsafe { labs(0) }, 0);
+    }
+}

--- a/src/libs/libc_stdlib/src/ldiv.rs
+++ b/src/libs/libc_stdlib/src/ldiv.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_long;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Result type for the `ldiv()` function containing quotient and remainder.
+#[repr(C)]
+pub struct ldiv_t {
+    pub quot: c_long,
+    pub rem: c_long,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the quotient and remainder of a long integer division.
+///
+/// # Parameters
+///
+/// - `numer`: Numerator.
+/// - `denom`: Denominator.
+///
+/// # Returns
+///
+/// An `ldiv_t` structure containing the quotient and remainder.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention. The caller must ensure that
+/// `denom` is not zero.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/ldiv.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ldiv(numer: c_long, denom: c_long) -> ldiv_t {
+    ldiv_t {
+        quot: numer.wrapping_div(denom),
+        rem: numer.wrapping_rem(denom),
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::ldiv;
+
+    #[test]
+    fn positive_division() {
+        let result = unsafe { ldiv(17, 5) };
+        assert_eq!(result.quot, 3);
+        assert_eq!(result.rem, 2);
+    }
+
+    #[test]
+    fn negative_dividend() {
+        let result = unsafe { ldiv(-17, 5) };
+        assert_eq!(result.quot, -3);
+        assert_eq!(result.rem, -2);
+    }
+}

--- a/src/libs/libc_stdlib/src/lib.rs
+++ b/src/libs/libc_stdlib/src/lib.rs
@@ -12,7 +12,12 @@
 #![forbid(clippy::unwrap_used)]
 #![forbid(clippy::expect_used)]
 #![forbid(clippy::cast_possible_wrap)]
-#![forbid(clippy::cast_precision_loss)]
+// `deny` (not `forbid`) so the inherently-lossy integer→float conversions in the
+// float parsers (`strtod`/`strtof`) can opt out with a justified, local
+// `#[allow(clippy::cast_precision_loss)]`. `forbid` would make those `#[allow]`s
+// a hard E0453 error; the conversions are unavoidable when building an `f64`/`f32`
+// from parsed digits.
+#![deny(clippy::cast_precision_loss)]
 #![forbid(clippy::char_lit_as_u8)]
 #![forbid(clippy::fn_to_numeric_cast)]
 #![forbid(clippy::fn_to_numeric_cast_with_truncation)]
@@ -23,31 +28,86 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
-// The following lints need to be handled case-by-case depending on the target pointer width.
-#![cfg_attr(target_pointer_width = "32", expect(clippy::cast_possible_truncation))]
+// `clippy::cast_possible_truncation` is handled per target pointer width. On 32-bit targets `usize`
+// and `c_size_t` are both 32-bit, so width-narrowing casts are harmless and the lint is allowed. On
+// 64-bit targets it is `deny` (not `forbid`) so that the unavoidable `f64 as f32` narrowing in
+// `strtof` can opt out with a justified, local `#[allow(clippy::cast_possible_truncation)]`,
+// mirroring the `cast_precision_loss` handling above; `forbid` would make that `#[allow]` a hard
+// E0453.
+#![cfg_attr(target_pointer_width = "32", allow(clippy::cast_possible_truncation))]
 #![cfg_attr(
     not(target_pointer_width = "32"),
-    forbid(clippy::cast_possible_truncation)
+    deny(clippy::cast_possible_truncation)
 )]
-// Features
-#![feature(stmt_expr_attributes)] // Used in `malloc_usable_size()`.
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/// Crate-local diagnostic logging shim.
+///
+/// On the guest (`no_std`) build this forwards to `syslog`'s `warn!` macro. Under the `std` feature
+/// used by host unit tests, `syslog` exposes no logging macros (its standalone logger relies on
+/// guest-only kernel calls), so the shim expands to a no-op that still references its arguments to
+/// avoid unused-variable warnings.
+///
+/// The shim is made available through textual scoping (it is defined before the module declarations
+/// below) rather than a `pub(crate) use`, because the name `warn` collides with the built-in `warn`
+/// attribute when imported through a path.
+#[cfg(not(feature = "std"))]
+macro_rules! warn {
+    ($($arg:tt)*) => { ::syslog::warn!($($arg)*) };
+}
+
+#[cfg(feature = "std")]
+macro_rules! warn {
+    ($($arg:tt)*) => {{ let _ = ::core::format_args!($($arg)*); }};
+}
 
 //==================================================================================================
 // Modules
 //==================================================================================================
 
+mod abort;
+mod abs_fn;
 mod aligned_alloc;
+mod atexit;
+mod atof;
+mod atoi;
+mod atol;
+mod atoll;
 mod block_header;
+mod bsearch;
 mod calloc;
+mod div_fn;
 pub mod env_table;
+mod exit;
 mod free;
 mod getenv;
+mod labs;
+mod ldiv;
+mod llabs;
+mod lldiv;
 mod malloc;
 mod malloc_usable_size;
 mod memalign;
 mod posix_memalign;
+mod putenv;
+mod qsort;
+mod quick_exit;
+mod rand;
 mod realloc;
+mod reallocarray;
+mod secure_getenv;
 mod setenv;
+mod strtod;
+mod strtof;
+mod strtol;
+mod strtold;
+mod strtoll;
+mod strtoul;
+mod strtoull;
+mod system;
 mod unsetenv;
 
 //==================================================================================================
@@ -66,16 +126,65 @@ use ::sysapi::{
 // Exports
 //==================================================================================================
 
+pub use abort::abort;
+pub use abs_fn::abs;
 pub use aligned_alloc::aligned_alloc;
+pub use atexit::atexit;
+pub use atof::atof;
+pub use atoi::atoi;
+pub use atol::atol;
+pub use atoll::atoll;
+pub use bsearch::bsearch;
 pub use calloc::calloc;
+pub use div_fn::{
+    div,
+    div_t,
+};
+pub use exit::{
+    _Exit,
+    exit,
+};
 pub use free::free;
 pub use getenv::getenv;
+pub use labs::labs;
+pub use ldiv::{
+    ldiv,
+    ldiv_t,
+};
+pub use llabs::llabs;
+pub use lldiv::{
+    lldiv,
+    lldiv_t,
+};
 pub use malloc::malloc;
 pub use malloc_usable_size::malloc_usable_size;
 pub use memalign::memalign;
 pub use posix_memalign::posix_memalign;
+pub use putenv::putenv;
+pub use qsort::{
+    qsort,
+    qsort_r,
+};
+pub use quick_exit::{
+    at_quick_exit,
+    quick_exit,
+};
+pub use rand::{
+    rand,
+    srand,
+};
 pub use realloc::realloc;
+pub use reallocarray::reallocarray;
+pub use secure_getenv::secure_getenv;
 pub use setenv::setenv;
+pub use strtod::strtod;
+pub use strtof::strtof;
+pub use strtol::strtol;
+pub use strtold::strtold;
+pub use strtoll::strtoll;
+pub use strtoul::strtoul;
+pub use strtoull::strtoull;
+pub use system::system;
 pub use unsetenv::unsetenv;
 
 //==================================================================================================
@@ -96,5 +205,28 @@ fn set_errno(code: c_int) {
     // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
     unsafe {
         *__errno_location() = code;
+    }
+}
+
+//==================================================================================================
+// Test Support
+//==================================================================================================
+
+/// Host-only `__errno_location` shim for unit tests.
+///
+/// On the guest, `errno` is provided by the C runtime. The Windows host test binary has no such
+/// symbol (the MSVC runtime exposes `_errno` instead), so this supplies a thread-local stand-in.
+/// Linux hosts resolve the symbol from their C library (glibc/musl) and therefore must not redefine
+/// it. The shim lives in its own module so that its `#[no_mangle]` definition provides the global C
+/// symbol without colliding with the `sysapi::errno::__errno_location` import used above.
+#[cfg(all(test, feature = "std", not(target_os = "linux")))]
+mod errno_shim {
+    #[unsafe(no_mangle)]
+    extern "C" fn __errno_location() -> *mut ::sysapi::ffi::c_int {
+        thread_local! {
+            static ERRNO: ::core::cell::UnsafeCell<::sysapi::ffi::c_int> =
+                const { ::core::cell::UnsafeCell::new(0) };
+        }
+        ERRNO.with(|cell| cell.get())
     }
 }

--- a/src/libs/libc_stdlib/src/llabs.rs
+++ b/src/libs/libc_stdlib/src/llabs.rs
@@ -1,0 +1,62 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_longlong;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the absolute value of a long long integer.
+///
+/// # Parameters
+///
+/// - `j`: Long long integer value.
+///
+/// # Returns
+///
+/// The absolute value of `j`.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/llabs.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn llabs(j: c_longlong) -> c_longlong {
+    if j < 0 {
+        j.wrapping_neg()
+    } else {
+        j
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::llabs;
+
+    #[test]
+    fn positive_value() {
+        assert_eq!(unsafe { llabs(42) }, 42);
+    }
+
+    #[test]
+    fn negative_value() {
+        assert_eq!(unsafe { llabs(-42) }, 42);
+    }
+
+    #[test]
+    fn large_value() {
+        assert_eq!(unsafe { llabs(-1_000_000_000_000) }, 1_000_000_000_000);
+    }
+}

--- a/src/libs/libc_stdlib/src/lldiv.rs
+++ b/src/libs/libc_stdlib/src/lldiv.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_longlong;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Result type for the `lldiv()` function containing quotient and remainder.
+#[repr(C)]
+pub struct lldiv_t {
+    pub quot: c_longlong,
+    pub rem: c_longlong,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the quotient and remainder of a long long integer division.
+///
+/// # Parameters
+///
+/// - `numer`: Numerator.
+/// - `denom`: Denominator.
+///
+/// # Returns
+///
+/// An `lldiv_t` structure containing the quotient and remainder.
+///
+/// # Safety
+///
+/// This function is unsafe because it has C calling convention. The caller must ensure that
+/// `denom` is not zero.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/lldiv.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn lldiv(numer: c_longlong, denom: c_longlong) -> lldiv_t {
+    lldiv_t {
+        quot: numer.wrapping_div(denom),
+        rem: numer.wrapping_rem(denom),
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::lldiv;
+
+    #[test]
+    fn positive_division() {
+        let result = unsafe { lldiv(100, 7) };
+        assert_eq!(result.quot, 14);
+        assert_eq!(result.rem, 2);
+    }
+
+    #[test]
+    fn large_values() {
+        let result = unsafe { lldiv(1_000_000_000_000, 7) };
+        assert_eq!(result.quot, 142_857_142_857);
+        assert_eq!(result.rem, 1);
+    }
+}

--- a/src/libs/libc_stdlib/src/malloc.rs
+++ b/src/libs/libc_stdlib/src/malloc.rs
@@ -18,7 +18,6 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -77,10 +76,7 @@ mod tests {
     use crate::set_errno;
     use ::sysapi::{
         errno::EINVAL,
-        ffi::{
-            c_int,
-            c_void,
-        },
+        ffi::c_int,
         sys_types::c_size_t,
     };
 

--- a/src/libs/libc_stdlib/src/malloc_usable_size.rs
+++ b/src/libs/libc_stdlib/src/malloc_usable_size.rs
@@ -61,27 +61,16 @@ pub unsafe extern "C" fn malloc_usable_size(ptr: *mut c_void) -> c_size_t {
 
     let size: usize = BlockHeader::usable_size(ptr.cast::<u8>());
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_pointer_width = "32")] {
-        // On all 32-bit platforms, the following cast is safe.
-            #[allow(clippy::cast_possible_truncation)]
-            size as c_size_t
-        } else if #[cfg(test)] {
-            // When testing, the following cast is acceptable.
-            size.try_into().unwrap_or(c_size_t::MAX)
-        } else {
-            compile_error!("malloc_usable_size is only supported on 32-bit platforms");
-        }
-    }
+    // `c_size_t` may be narrower than `usize` (it is on the 64-bit host used for unit testing), so
+    // saturate on the practically unreachable overflow rather than truncating. On 32-bit targets the
+    // value always fits and the conversion is exact.
+    size.try_into().unwrap_or(c_size_t::MAX)
 }
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::malloc_usable_size;
-    use ::sysapi::{
-        ffi::c_void,
-        sys_types::c_size_t,
-    };
+    use ::sysapi::sys_types::c_size_t;
 
     #[test]
     fn null_pointer_returns_zero() {
@@ -114,11 +103,11 @@ mod tests {
 
     #[test]
     fn aligned_alloc_and_query() {
-        let p = unsafe { crate::aligned_alloc(128, 300) };
+        let p = unsafe { crate::aligned_alloc(128, 384) };
         assert!(!p.is_null());
         let sz = unsafe { malloc_usable_size(p) };
-        assert!(sz as usize >= 300);
-        assert_eq!(sz, 300);
+        assert!(sz as usize >= 384);
+        assert_eq!(sz, 384);
         unsafe { crate::free(p) };
     }
 }

--- a/src/libs/libc_stdlib/src/memalign.rs
+++ b/src/libs/libc_stdlib/src/memalign.rs
@@ -6,16 +6,18 @@
 //==================================================================================================
 
 use crate::{
-    aligned_alloc::aligned_alloc,
+    block_header::BlockHeader,
     set_errno,
 };
 use ::core::ptr::null_mut;
 use ::sysapi::{
-    errno::EINVAL,
+    errno::{
+        EINVAL,
+        ENOMEM,
+    },
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -29,7 +31,7 @@ use ::syslog::warn;
 ///
 /// `memalign()` is the legacy SVID / BSD alignment allocator. Unlike `aligned_alloc()` it does
 /// not require `size` to be a multiple of `alignment`; the only constraint enforced here is that
-/// `alignment` is a power of two, which the backing allocator requires.
+/// `alignment` is a power of two that the backing allocator supports, which is validated up front.
 ///
 /// # Parameters
 ///
@@ -49,10 +51,11 @@ use ::syslog::warn;
 /// embedded runtime when extension `.so`s are loaded.
 ///
 /// The allocation itself is delegated to [`aligned_alloc()`], which shares the same backing
-/// allocator. `memalign()` keeps its own argument validation up front so that an invalid
-/// (non-power-of-two) alignment fails with `EINVAL` -- the error `memalign()` is specified to
-/// return -- rather than the `ENOMEM` that the allocator would surface for the same input, and so
-/// that diagnostics are attributed to `memalign()`.
+/// allocator. `memalign()` keeps its own argument validation up front so that an unsupported
+/// alignment (one that is not a power of two, or that exceeds the allocator's maximum) fails with
+/// `EINVAL` -- the error `memalign()` is specified to return -- rather than the `ENOMEM` that the
+/// allocator would surface for the same input, and so that diagnostics are attributed to
+/// `memalign()`.
 ///
 /// # Safety
 ///
@@ -82,19 +85,25 @@ pub unsafe extern "C" fn memalign(alignment: c_size_t, size: c_size_t) -> *mut c
         return null_mut();
     }
 
-    // Check for invalid alignment. memalign() requires a power-of-two alignment and is specified
-    // to fail with EINVAL otherwise; validating here (instead of letting the allocator reject it
-    // with ENOMEM) preserves that contract.
-    if !(alignment as usize).is_power_of_two() {
+    // Check for invalid alignment. memalign() requires a power-of-two alignment that the backing
+    // allocator can satisfy and is specified to fail with EINVAL otherwise; validating here
+    // (instead of letting the allocator reject it with ENOMEM) preserves that contract. This also
+    // rejects power-of-two alignments above the allocator's maximum, which would otherwise surface
+    // as ENOMEM from the allocation below.
+    if !BlockHeader::supports_alignment(alignment as usize) {
         warn!("memalign(): invalid alignment (alignment={alignment:?}, size={size:?})");
         set_errno(EINVAL);
         return null_mut();
     }
 
-    // Delegate the allocation to aligned_alloc(), which shares the same backing allocator. The
-    // arguments are already validated above, so any failure here is a genuine out-of-memory
-    // condition for which aligned_alloc() sets errno appropriately.
-    aligned_alloc(alignment, size)
+    let ptr: *mut u8 = BlockHeader::alloc(size as usize, Some(alignment as usize));
+    if ptr.is_null() {
+        warn!("memalign(): allocation failed (alignment={alignment:?}, size={size:?})");
+        set_errno(ENOMEM);
+        return null_mut();
+    }
+
+    ptr.cast::<c_void>()
 }
 
 #[cfg(all(test, feature = "std"))]
@@ -137,10 +146,20 @@ mod tests {
     }
 
     #[test]
+    fn alignment_above_maximum() {
+        // A power-of-two alignment beyond the allocator's maximum must fail with EINVAL rather
+        // than the ENOMEM the allocator would otherwise surface.
+        set_errno(0);
+        let p = unsafe { memalign(8192, 128) };
+        assert!(p.is_null());
+        assert_eq!(get_errno(), EINVAL);
+    }
+
+    #[test]
     fn valid_allocation() {
         let alignment: c_size_t = 128;
         let size: c_size_t = 130; // not a multiple of alignment
-        let p = unsafe { memalign(alignment, size) } as *mut u8;
+        let p = unsafe { memalign(alignment, size) }.cast::<u8>();
         assert!(!p.is_null());
         let addr = p as usize;
         assert_eq!(addr & (alignment as usize - 1), 0, "pointer {addr:#x} not {alignment}-aligned");

--- a/src/libs/libc_stdlib/src/posix_memalign.rs
+++ b/src/libs/libc_stdlib/src/posix_memalign.rs
@@ -17,7 +17,6 @@ use ::sysapi::{
     },
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -104,7 +103,6 @@ pub unsafe extern "C" fn posix_memalign(
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use super::posix_memalign;
     use crate::set_errno;
     use ::sysapi::{
         errno::EINVAL,

--- a/src/libs/libc_stdlib/src/putenv.rs
+++ b/src/libs/libc_stdlib/src/putenv.rs
@@ -1,0 +1,142 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    env_table,
+    set_errno,
+};
+use ::sysapi::{
+    errno::EINVAL,
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Adds or changes the environment variable described by `string`, which must have the form
+/// `"NAME=VALUE"`. If `string` contains no `'='`, the named variable is removed.
+///
+/// # Description
+///
+/// The string pointed to by `string` becomes part of the environment, so subsequent modifications
+/// to that storage are reflected in later environment lookups.
+///
+/// # Safety
+///
+/// `string` must be a valid, null-terminated string.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn putenv(string: *mut c_char) -> c_int {
+    if string.is_null() {
+        set_errno(EINVAL);
+        return -1;
+    }
+
+    let mut p: *mut c_char = string;
+    while *p != 0 {
+        if *p as u8 == b'=' {
+            return match env_table::put_raw(string) {
+                Ok(()) => 0,
+                Err(()) => {
+                    set_errno(EINVAL);
+                    -1
+                },
+            };
+        }
+        p = p.add(1);
+    }
+
+    crate::unsetenv::unsetenv(string)
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::putenv;
+    use crate::{
+        getenv::getenv,
+        set_errno,
+    };
+    use ::sysapi::{
+        errno::EINVAL,
+        ffi::{
+            c_char,
+            c_int,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *::sysapi::errno::__errno_location() }
+    }
+
+    /// Returns `true` if the C string at `ptr` equals `expected` (excluding the terminator).
+    unsafe fn cstr_eq(ptr: *const c_char, expected: &[u8]) -> bool {
+        if ptr.is_null() {
+            return false;
+        }
+        for (i, &b) in expected.iter().enumerate() {
+            if *ptr.add(i) as u8 != b {
+                return false;
+            }
+        }
+        *ptr.add(expected.len()) as u8 == 0
+    }
+
+    #[test]
+    fn sets_variable() {
+        // Use a unique name to avoid colliding with other tests that share the
+        // process-global environment table.
+        let entry = b"NANVIX_PUTENV_SET=hello\0";
+        assert_eq!(unsafe { putenv(entry.as_ptr().cast::<c_char>().cast_mut()) }, 0);
+
+        let name = b"NANVIX_PUTENV_SET\0";
+        let value = unsafe { getenv(name.as_ptr().cast::<c_char>()) };
+        assert!(unsafe { cstr_eq(value, b"hello") });
+    }
+
+    #[test]
+    fn uses_caller_storage() {
+        let mut entry = *b"NANVIX_PUTENV_MUT=before\0";
+        assert_eq!(unsafe { putenv(entry.as_mut_ptr().cast::<c_char>()) }, 0);
+
+        let value_start: usize = b"NANVIX_PUTENV_MUT=".len();
+        entry[value_start..value_start + b"second".len()].copy_from_slice(b"second");
+
+        let name = b"NANVIX_PUTENV_MUT\0";
+        let value = unsafe { getenv(name.as_ptr().cast::<c_char>()) };
+        assert!(unsafe { cstr_eq(value, b"second") });
+
+        // `putenv()` installs a pointer to the caller's storage in the process-global environment
+        // table. Remove the entry while `entry` is still alive so the table never retains a
+        // dangling pointer into this stack frame, which a later (or concurrent) environment lookup
+        // would otherwise dereference.
+        let remove = b"NANVIX_PUTENV_MUT\0";
+        assert_eq!(unsafe { putenv(remove.as_ptr().cast::<c_char>().cast_mut()) }, 0);
+    }
+
+    #[test]
+    fn removes_variable_without_equals() {
+        let entry = b"NANVIX_PUTENV_DEL=value\0";
+        assert_eq!(unsafe { putenv(entry.as_ptr().cast::<c_char>().cast_mut()) }, 0);
+
+        // A string without '=' removes the named variable.
+        let remove = b"NANVIX_PUTENV_DEL\0";
+        assert_eq!(unsafe { putenv(remove.as_ptr().cast::<c_char>().cast_mut()) }, 0);
+
+        let value = unsafe { getenv(remove.as_ptr().cast::<c_char>()) };
+        assert!(value.is_null());
+    }
+
+    #[test]
+    fn null_string_fails() {
+        set_errno(0);
+        assert_eq!(unsafe { putenv(::core::ptr::null_mut()) }, -1);
+        assert_eq!(get_errno(), EINVAL);
+    }
+}

--- a/src/libs/libc_stdlib/src/qsort.rs
+++ b/src/libs/libc_stdlib/src/qsort.rs
@@ -1,0 +1,234 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Swaps two elements of `size` bytes at the given pointers.
+///
+/// # Safety
+///
+/// Both `a` and `b` must point to valid, non-overlapping memory regions of at least `size` bytes.
+unsafe fn swap_elements(a: *mut u8, b: *mut u8, size: usize) {
+    for i in 0..size {
+        let tmp = *a.add(i);
+        *a.add(i) = *b.add(i);
+        *b.add(i) = tmp;
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sorts an array of `nmemb` elements, each of `size` bytes, using the comparison function
+/// pointed to by `compar`. This implementation uses insertion sort for simplicity.
+///
+/// # Parameters
+///
+/// - `base`: Pointer to the first element of the array.
+/// - `nmemb`: Number of elements in the array.
+/// - `size`: Size of each element in bytes.
+/// - `compar`: Comparison function returning negative, zero, or positive.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers and calls a function pointer.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/qsort.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn qsort(
+    base: *mut c_void,
+    nmemb: c_size_t,
+    size: c_size_t,
+    compar: Option<unsafe extern "C" fn(*const c_void, *const c_void) -> c_int>,
+) {
+    let compar = match compar {
+        Some(f) => f,
+        None => return,
+    };
+
+    if base.is_null() || nmemb <= 1 || size == 0 {
+        return;
+    }
+
+    let base_ptr: *mut u8 = base.cast::<u8>();
+    let size = size as usize;
+    let nmemb = nmemb as usize;
+
+    // Insertion sort.
+    for i in 1..nmemb {
+        let mut j = i;
+        while j > 0 {
+            let a = base_ptr.add(j * size);
+            let b = base_ptr.add((j - 1) * size);
+            if compar(a.cast_const().cast::<c_void>(), b.cast_const().cast::<c_void>()) < 0 {
+                swap_elements(a, b, size);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Sorts an array like [`qsort`], passing `arg` through to the comparison function.
+///
+/// # Parameters
+///
+/// - `base`: Pointer to the first element of the array.
+/// - `nmemb`: Number of elements in the array.
+/// - `size`: Size of each element in bytes.
+/// - `compar`: Comparison function returning negative, zero, or positive.
+/// - `arg`: Opaque context pointer passed to `compar`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers and calls a function pointer.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/qsort.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn qsort_r(
+    base: *mut c_void,
+    nmemb: c_size_t,
+    size: c_size_t,
+    compar: Option<unsafe extern "C" fn(*const c_void, *const c_void, *mut c_void) -> c_int>,
+    arg: *mut c_void,
+) {
+    let compar = match compar {
+        Some(f) => f,
+        None => return,
+    };
+
+    if base.is_null() || nmemb <= 1 || size == 0 {
+        return;
+    }
+
+    let base_ptr: *mut u8 = base.cast::<u8>();
+    let size = size as usize;
+    let nmemb = nmemb as usize;
+
+    for i in 1..nmemb {
+        let mut j = i;
+        while j > 0 {
+            let a = base_ptr.add(j * size);
+            let b = base_ptr.add((j - 1) * size);
+            if compar(a.cast_const().cast::<c_void>(), b.cast_const().cast::<c_void>(), arg) < 0 {
+                swap_elements(a, b, size);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        qsort,
+        qsort_r,
+    };
+    use ::sysapi::ffi::{
+        c_int,
+        c_void,
+    };
+
+    unsafe extern "C" fn compare_ints(a: *const c_void, b: *const c_void) -> c_int {
+        let a_val: c_int = *a.cast::<c_int>();
+        let b_val: c_int = *b.cast::<c_int>();
+        if a_val < b_val {
+            -1
+        } else if a_val > b_val {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[test]
+    fn sort_integers() {
+        let mut arr: [c_int; 5] = [5, 3, 1, 4, 2];
+        unsafe {
+            qsort(arr.as_mut_ptr().cast::<c_void>(), 5, 4, Some(compare_ints));
+        }
+        assert_eq!(arr, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn empty_array() {
+        let mut arr: [c_int; 0] = [];
+        unsafe {
+            qsort(arr.as_mut_ptr().cast::<c_void>(), 0, 4, Some(compare_ints));
+        }
+        assert_eq!(arr, []);
+    }
+
+    #[test]
+    fn single_element() {
+        let mut arr: [c_int; 1] = [42];
+        unsafe {
+            qsort(arr.as_mut_ptr().cast::<c_void>(), 1, 4, Some(compare_ints));
+        }
+        assert_eq!(arr, [42]);
+    }
+
+    #[test]
+    fn already_sorted() {
+        let mut arr: [c_int; 4] = [1, 2, 3, 4];
+        unsafe {
+            qsort(arr.as_mut_ptr().cast::<c_void>(), 4, 4, Some(compare_ints));
+        }
+        assert_eq!(arr, [1, 2, 3, 4]);
+    }
+
+    unsafe extern "C" fn compare_ints_with_direction(
+        a: *const c_void,
+        b: *const c_void,
+        arg: *mut c_void,
+    ) -> c_int {
+        let direction: c_int = *arg.cast::<c_int>();
+        compare_ints(a, b) * direction
+    }
+
+    #[test]
+    fn sort_with_context() {
+        let mut arr: [c_int; 5] = [5, 3, 1, 4, 2];
+        let mut direction: c_int = -1;
+        unsafe {
+            qsort_r(
+                arr.as_mut_ptr().cast::<c_void>(),
+                5,
+                4,
+                Some(compare_ints_with_direction),
+                (&mut direction as *mut c_int).cast::<c_void>(),
+            );
+        }
+        assert_eq!(arr, [5, 4, 3, 2, 1]);
+    }
+}

--- a/src/libs/libc_stdlib/src/quick_exit.rs
+++ b/src/libs/libc_stdlib/src/quick_exit.rs
@@ -1,0 +1,132 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of quick-exit handlers that can be registered.
+const MAX_AT_QUICK_EXIT_HANDLERS: usize = 32;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Table of registered quick-exit handler functions.
+static mut AT_QUICK_EXIT_HANDLERS: [Option<unsafe extern "C" fn()>; MAX_AT_QUICK_EXIT_HANDLERS] =
+    [None; MAX_AT_QUICK_EXIT_HANDLERS];
+
+/// Number of currently registered quick-exit handlers.
+static mut AT_QUICK_EXIT_COUNT: usize = 0;
+
+//==================================================================================================
+// External Declarations
+//==================================================================================================
+
+extern "C" {
+    fn _exit(status: c_int) -> !;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Registers a function to be called by [`quick_exit`].
+///
+/// # Parameters
+///
+/// - `func`: Function to be called at quick exit.
+///
+/// # Returns
+///
+/// `0` on success, or a non-zero value on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses global mutable state.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/at_quick_exit.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn at_quick_exit(func: Option<unsafe extern "C" fn()>) -> c_int {
+    let func = match func {
+        Some(func) => func,
+        None => return -1,
+    };
+
+    if AT_QUICK_EXIT_COUNT >= MAX_AT_QUICK_EXIT_HANDLERS {
+        return -1;
+    }
+
+    AT_QUICK_EXIT_HANDLERS[AT_QUICK_EXIT_COUNT] = Some(func);
+    AT_QUICK_EXIT_COUNT += 1;
+    0
+}
+
+///
+/// # Description
+///
+/// Terminates the process after calling handlers registered by [`at_quick_exit`].
+///
+/// # Parameters
+///
+/// - `status`: Exit status code.
+///
+/// # Safety
+///
+/// This function is unsafe because it terminates the process and calls registered handlers.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/quick_exit.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn quick_exit(status: c_int) -> ! {
+    while AT_QUICK_EXIT_COUNT > 0 {
+        AT_QUICK_EXIT_COUNT -= 1;
+        if let Some(func) = AT_QUICK_EXIT_HANDLERS[AT_QUICK_EXIT_COUNT] {
+            func();
+            AT_QUICK_EXIT_HANDLERS[AT_QUICK_EXIT_COUNT] = None;
+        }
+    }
+    _exit(status)
+}
+
+/// Resets the quick-exit handler table. Used for test isolation.
+#[cfg(test)]
+pub(crate) unsafe fn reset_at_quick_exit_handlers() {
+    AT_QUICK_EXIT_COUNT = 0;
+    let mut i: usize = 0;
+    while i < MAX_AT_QUICK_EXIT_HANDLERS {
+        AT_QUICK_EXIT_HANDLERS[i] = None;
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        at_quick_exit,
+        reset_at_quick_exit_handlers,
+    };
+
+    unsafe extern "C" fn dummy_handler() {}
+
+    #[test]
+    fn register_handler() {
+        unsafe { reset_at_quick_exit_handlers() };
+        assert_eq!(unsafe { at_quick_exit(Some(dummy_handler)) }, 0);
+        unsafe { reset_at_quick_exit_handlers() };
+    }
+}

--- a/src/libs/libc_stdlib/src/rand.rs
+++ b/src/libs/libc_stdlib/src/rand.rs
@@ -1,0 +1,104 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_int,
+    c_uint,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Modulus for the LCG output range. `rand()` returns values in `[0, RAND_RANGE - 1]`.
+const RAND_RANGE: c_uint = 32768;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Internal LCG seed state.
+static mut NEXT: c_uint = 1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Generates a pseudo-random integer in the range `[0, 32767]`.
+///
+/// # Returns
+///
+/// A pseudo-random integer.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses global mutable state.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/rand.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn rand() -> c_int {
+    NEXT = NEXT.wrapping_mul(1_103_515_245).wrapping_add(12345);
+    c_int::try_from((NEXT / 65536) % RAND_RANGE).unwrap_or_default()
+}
+
+///
+/// # Description
+///
+/// Seeds the pseudo-random number generator used by `rand()`.
+///
+/// # Parameters
+///
+/// - `seed`: Seed value.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses global mutable state.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/srand.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn srand(seed: c_uint) {
+    NEXT = seed;
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        rand,
+        srand,
+    };
+
+    const RAND_MAX: i32 = 32767;
+
+    #[test]
+    fn deterministic_sequence() {
+        unsafe { srand(1) };
+        let first = unsafe { rand() };
+        let second = unsafe { rand() };
+        unsafe { srand(1) };
+        assert_eq!(unsafe { rand() }, first);
+        assert_eq!(unsafe { rand() }, second);
+    }
+
+    #[test]
+    fn values_in_range() {
+        unsafe { srand(42) };
+        for _ in 0..100 {
+            let val = unsafe { rand() };
+            assert!(val >= 0);
+            assert!(val <= RAND_MAX);
+        }
+    }
+}

--- a/src/libs/libc_stdlib/src/realloc.rs
+++ b/src/libs/libc_stdlib/src/realloc.rs
@@ -17,7 +17,6 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
-use ::syslog::warn;
 
 //==================================================================================================
 // Standalone Functions
@@ -80,7 +79,6 @@ mod tests {
     use super::realloc;
     use crate::set_errno;
     use ::sysapi::{
-        errno::EINVAL,
         ffi::{
             c_int,
             c_void,
@@ -120,36 +118,44 @@ mod tests {
     fn realloc_grow_and_shrink() {
         // Allocate initial block.
         let initial: c_size_t = 32;
-        let p = unsafe { realloc(core::ptr::null_mut(), initial) } as *mut u8;
+        let p = unsafe { realloc(core::ptr::null_mut(), initial) }.cast::<u8>();
         assert!(!p.is_null());
         unsafe {
-            for i in 0..initial {
-                p.add(i).write(i as u8);
+            for i in 0..initial as usize {
+                p.add(i).write(u8::try_from(i).unwrap_or_default());
             }
         }
         // Grow block.
         let grown: c_size_t = 64;
-        let p2 = unsafe { realloc(p as *mut c_void, grown) } as *mut u8;
+        let p2 = unsafe { realloc(p.cast::<c_void>(), grown) }.cast::<u8>();
         assert!(!p2.is_null());
         unsafe {
-            for i in 0..initial {
-                assert_eq!(p2.add(i).read(), i as u8, "realloc data mismatch at {i} after grow");
+            for i in 0..initial as usize {
+                assert_eq!(
+                    p2.add(i).read(),
+                    u8::try_from(i).unwrap_or_default(),
+                    "realloc data mismatch at {i} after grow"
+                );
             }
-            for i in initial..grown {
-                p2.add(i).write(i as u8);
+            for i in initial as usize..grown as usize {
+                p2.add(i).write(u8::try_from(i).unwrap_or_default());
             }
         }
         // Shrink block.
         let shrunk: c_size_t = 16;
-        let p3 = unsafe { realloc(p2 as *mut c_void, shrunk) } as *mut u8;
+        let p3 = unsafe { realloc(p2.cast::<c_void>(), shrunk) }.cast::<u8>();
         assert!(!p3.is_null());
         unsafe {
-            for i in 0..shrunk {
-                assert_eq!(p3.add(i).read(), i as u8, "realloc data mismatch at {i} after shrink");
+            for i in 0..shrunk as usize {
+                assert_eq!(
+                    p3.add(i).read(),
+                    u8::try_from(i).unwrap_or_default(),
+                    "realloc data mismatch at {i} after shrink"
+                );
             }
         }
         unsafe {
-            crate::free(p3 as *mut c_void);
+            crate::free(p3.cast::<c_void>());
         }
     }
 }

--- a/src/libs/libc_stdlib/src/reallocarray.rs
+++ b/src/libs/libc_stdlib/src/reallocarray.rs
@@ -1,0 +1,96 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    realloc,
+    set_errno,
+};
+use ::core::ptr::null_mut;
+use ::sysapi::{
+    errno::ENOMEM,
+    ffi::c_void,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reallocates memory for an array, failing if `nelem * elsize` overflows.
+///
+/// # Parameters
+///
+/// - `ptr`: Pointer to the memory block to be reallocated.
+/// - `nelem`: Number of elements.
+/// - `elsize`: Size of each element in bytes.
+///
+/// # Returns
+///
+/// On success, this function returns a pointer to the reallocated memory. On failure, it returns a
+/// null pointer and leaves the original block of memory pointed to by `ptr` unchanged.
+///
+/// # Safety
+///
+/// This function is unsafe because it interacts with the global memory allocator.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/realloc.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn reallocarray(
+    ptr: *mut c_void,
+    nelem: c_size_t,
+    elsize: c_size_t,
+) -> *mut c_void {
+    let size: c_size_t = match nelem.checked_mul(elsize) {
+        Some(size) => size,
+        None => {
+            set_errno(ENOMEM);
+            return null_mut();
+        },
+    };
+
+    realloc(ptr, size)
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::reallocarray;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ENOMEM,
+        ffi::{
+            c_int,
+            c_void,
+        },
+        sys_types::c_size_t,
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *::sysapi::errno::__errno_location() }
+    }
+
+    #[test]
+    fn reallocarray_allocates_product_size() {
+        let ptr: *mut c_void = unsafe { reallocarray(core::ptr::null_mut(), 4, 16) };
+        assert!(!ptr.is_null());
+        assert_eq!(unsafe { crate::malloc_usable_size(ptr) }, 64);
+        unsafe { crate::free(ptr) };
+    }
+
+    #[test]
+    fn reallocarray_overflow_fails() {
+        set_errno(0);
+        let ptr: *mut c_void = unsafe { reallocarray(core::ptr::null_mut(), c_size_t::MAX, 2) };
+        assert!(ptr.is_null());
+        assert_eq!(get_errno(), ENOMEM);
+    }
+}

--- a/src/libs/libc_stdlib/src/secure_getenv.rs
+++ b/src/libs/libc_stdlib/src/secure_getenv.rs
@@ -1,0 +1,54 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets an environment variable when the process is not running in a privileged context.
+///
+/// Nanvix does not currently support set-user-ID or set-group-ID execution, so the security
+/// criteria are equivalent to those of [`crate::getenv`].
+///
+/// # Parameters
+///
+/// - `name`: Environment-variable name.
+///
+/// # Returns
+///
+/// A pointer to the value associated with `name`, or a null pointer if not found.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers through [`crate::getenv`].
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/getenv.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn secure_getenv(name: *const c_char) -> *mut c_char {
+    crate::getenv(name)
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::secure_getenv;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn missing_variable_returns_null() {
+        let name = b"NANVIX_SECURE_GETENV_MISSING\0";
+        let ptr: *mut c_char = unsafe { secure_getenv(name.as_ptr().cast::<c_char>()) };
+        assert!(ptr.is_null());
+    }
+}

--- a/src/libs/libc_stdlib/src/setenv.rs
+++ b/src/libs/libc_stdlib/src/setenv.rs
@@ -60,14 +60,14 @@ pub unsafe extern "C" fn setenv(
 ) -> c_int {
     // Check if `name` is null.
     if name.is_null() {
-        ::syslog::warn!("setenv(): name is null");
+        warn!("setenv(): name is null");
         set_errno(EINVAL);
         return -1;
     }
 
     // Check if `value` is null.
     if value.is_null() {
-        ::syslog::warn!("setenv(): value is null");
+        warn!("setenv(): value is null");
         set_errno(EINVAL);
         return -1;
     }
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn setenv(
     let name_str: &str = match ffi::CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => {
-            ::syslog::warn!("setenv(): invalid name (name={name:?})");
+            warn!("setenv(): invalid name (name={name:?})");
             set_errno(EINVAL);
             return -1;
         },
@@ -91,10 +91,7 @@ pub unsafe extern "C" fn setenv(
     match env_table::set(name_str, value_bytes, should_overwrite) {
         Ok(_) => 0,
         Err(()) => {
-            ::syslog::warn!(
-                "setenv(): failed (name={name_str:?}, value_len={})",
-                value_bytes.len()
-            );
+            warn!("setenv(): failed (name={name_str:?}, value_len={})", value_bytes.len());
             set_errno(EINVAL);
             -1
         },

--- a/src/libs/libc_stdlib/src/strtod.rs
+++ b/src/libs/libc_stdlib/src/strtod.rs
@@ -1,0 +1,534 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::ERANGE,
+    ffi::c_char,
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b: u8 = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+/// Returns `true` if the given character is an ASCII digit.
+fn is_digit(c: c_char) -> bool {
+    let b: u8 = c as u8;
+    b.is_ascii_digit()
+}
+
+/// Returns `true` if the given character is an ASCII hexadecimal digit.
+fn is_hex_digit(c: c_char) -> bool {
+    let b: u8 = c as u8;
+    b.is_ascii_hexdigit()
+}
+
+/// Returns the numeric value of an ASCII digit character.
+fn digit_val(c: c_char) -> u8 {
+    (c as u8) - b'0'
+}
+
+/// Returns the numeric value of an ASCII hexadecimal digit character.
+fn hex_digit_val(c: c_char) -> u8 {
+    match c as u8 {
+        b'0'..=b'9' => (c as u8) - b'0',
+        b'a'..=b'f' => (c as u8) - b'a' + 10,
+        b'A'..=b'F' => (c as u8) - b'A' + 10,
+        _ => 0,
+    }
+}
+
+/// Returns `true` if the bytes at `p` case-insensitively match the ASCII keyword `kw`.
+///
+/// # Safety
+///
+/// `p` must point into a valid, NUL-terminated string. Comparison stops at the first mismatch, and
+/// because a keyword never contains a NUL byte, at most `kw.len()` bytes are read and never past the
+/// terminator.
+unsafe fn match_keyword(p: *const c_char, kw: &[u8]) -> bool {
+    let mut i: usize = 0;
+    while i < kw.len() {
+        let c: u8 = *p.add(i) as u8;
+        if c == 0 || c.to_ascii_lowercase() != kw[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Parses a hexadecimal floating-point subject sequence starting at `p`.
+///
+/// # Safety
+///
+/// `p` must point into a valid, NUL-terminated string.
+unsafe fn parse_hex_float(p: *const c_char) -> Option<(*const c_char, f64, bool)> {
+    if *p as u8 != b'0' {
+        return None;
+    }
+    let marker: u8 = *p.add(1) as u8;
+    if marker != b'x' && marker != b'X' {
+        return None;
+    }
+
+    let mut q: *const c_char = p.add(2);
+    let mut value: f64 = 0.0;
+    let mut parsed_digit: bool = false;
+    let mut parsed_nonzero_digit: bool = false;
+
+    while is_hex_digit(*q) {
+        let digit: u8 = hex_digit_val(*q);
+        parsed_digit = true;
+        parsed_nonzero_digit |= digit != 0;
+        value = value * 16.0 + f64::from(digit);
+        q = q.add(1);
+    }
+
+    if *q as u8 == b'.' {
+        q = q.add(1);
+        let mut divisor: f64 = 16.0;
+        while is_hex_digit(*q) {
+            let digit: u8 = hex_digit_val(*q);
+            parsed_digit = true;
+            parsed_nonzero_digit |= digit != 0;
+            value += f64::from(digit) / divisor;
+            divisor *= 16.0;
+            q = q.add(1);
+        }
+    }
+
+    if !parsed_digit {
+        return None;
+    }
+
+    if *q as u8 == b'p' || *q as u8 == b'P' {
+        let exponent_marker: *const c_char = q;
+        q = q.add(1);
+
+        let exp_negative: bool = *q as u8 == b'-';
+        if *q as u8 == b'+' || *q as u8 == b'-' {
+            q = q.add(1);
+        }
+
+        if is_digit(*q) {
+            let mut exp: i32 = 0;
+            while is_digit(*q) {
+                exp = exp
+                    .saturating_mul(10)
+                    .saturating_add(i32::from(digit_val(*q)));
+                q = q.add(1);
+            }
+            if exp_negative {
+                exp = exp.saturating_neg();
+            }
+            value *= pow2(exp);
+        } else {
+            q = exponent_marker;
+        }
+    }
+
+    Some((q, value, parsed_nonzero_digit))
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `f64`.
+///
+/// The expected form of the subject sequence is an optional sign (`+` or `-`), followed by one of:
+/// - A non-empty sequence of decimal digits optionally containing a decimal-point character,
+///   optionally followed by an exponent part (`e` or `E` with optional sign and digits).
+/// - A `0x` or `0X` prefix followed by a non-empty sequence of hexadecimal digits optionally
+///   containing a decimal-point character, optionally followed by a binary exponent part (`p` or
+///   `P` with optional sign and digits).
+/// - One of `INF` or `INFINITY`, ignoring case.
+/// - One of `NAN` or `NAN(n-char-sequence)`, ignoring case.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the null-terminated string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+///
+/// # Returns
+///
+/// The converted `f64` value. Returns `0.0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtod.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_precision_loss)]
+pub unsafe extern "C" fn strtod(nptr: *const c_char, endptr: *mut *mut c_char) -> f64 {
+    if nptr.is_null() {
+        if !endptr.is_null() {
+            *endptr = core::ptr::null_mut();
+        }
+        return 0.0;
+    }
+
+    let mut p: *const c_char = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative: bool = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Recognize the `INF`/`INFINITY` and `NAN` spellings (case-insensitive) before digit parsing.
+    if match_keyword(p, b"inf") {
+        // Consume the longer `infinity` spelling when present, otherwise just `inf`.
+        let len: usize = if match_keyword(p, b"infinity") { 8 } else { 3 };
+        p = p.add(len);
+        if !endptr.is_null() {
+            *endptr = p.cast_mut();
+        }
+        return if negative {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+    }
+    if match_keyword(p, b"nan") {
+        p = p.add(3);
+        // Optionally consume a parenthesized n-char-sequence: '(' [0-9A-Za-z_]* ')'.
+        if *p as u8 == b'(' {
+            let mut q: *const c_char = p.add(1);
+            loop {
+                let c: u8 = *q as u8;
+                if c != b'_' && !c.is_ascii_alphanumeric() {
+                    break;
+                }
+                q = q.add(1);
+            }
+            if *q as u8 == b')' {
+                p = q.add(1);
+            }
+        }
+        if !endptr.is_null() {
+            *endptr = p.cast_mut();
+        }
+        return if negative { -f64::NAN } else { f64::NAN };
+    }
+
+    let start: *const c_char = p;
+
+    if let Some((end, value, parsed_nonzero_digit)) = parse_hex_float(p) {
+        let result: f64 = if negative { -value } else { value };
+        if result.is_infinite()
+            || (parsed_nonzero_digit && (result == 0.0 || result.abs() < f64::MIN_POSITIVE))
+        {
+            set_errno(ERANGE);
+        }
+        if !endptr.is_null() {
+            *endptr = end.cast_mut();
+        }
+        return result;
+    }
+
+    // Parse integer part.
+    let mut int_part: f64 = 0.0;
+    let mut parsed_nonzero_digit: bool = false;
+    while is_digit(*p) {
+        let digit: u8 = digit_val(*p);
+        parsed_nonzero_digit |= digit != 0;
+        int_part = int_part * 10.0 + f64::from(digit);
+        p = p.add(1);
+    }
+
+    // Parse fractional part.
+    let mut frac_part: f64 = 0.0;
+    if *p as u8 == b'.' {
+        p = p.add(1);
+        let mut divisor: f64 = 10.0;
+        while is_digit(*p) {
+            let digit: u8 = digit_val(*p);
+            parsed_nonzero_digit |= digit != 0;
+            frac_part += f64::from(digit) / divisor;
+            divisor *= 10.0;
+            p = p.add(1);
+        }
+    }
+
+    // If no digits were parsed at all, set endptr to nptr.
+    if p == start || (p == start.add(1) && *start as u8 == b'.') {
+        // Check if the only character parsed was a lone '.'.
+        let parsed_any_digits: bool = p != start && !(p == start.add(1) && *start as u8 == b'.');
+        if !parsed_any_digits {
+            if !endptr.is_null() {
+                *endptr = nptr.cast_mut();
+            }
+            return 0.0;
+        }
+    }
+
+    let mut result: f64 = int_part + frac_part;
+
+    // Parse exponent part.
+    if *p as u8 == b'e' || *p as u8 == b'E' {
+        let saved: *const c_char = p;
+        p = p.add(1);
+
+        let exp_negative: bool = *p as u8 == b'-';
+        if *p as u8 == b'+' || *p as u8 == b'-' {
+            p = p.add(1);
+        }
+
+        if is_digit(*p) {
+            let mut exp: i32 = 0;
+            while is_digit(*p) {
+                exp = exp
+                    .saturating_mul(10)
+                    .saturating_add(i32::from(digit_val(*p)));
+                p = p.add(1);
+            }
+
+            if exp_negative {
+                exp = exp.saturating_neg();
+            }
+
+            result *= pow10(exp);
+        } else {
+            // No digits after 'e'/'E', rewind.
+            p = saved;
+        }
+    }
+
+    if negative {
+        result = -result;
+    }
+
+    // A finite subject sequence whose magnitude is too large to represent overflows to infinity;
+    // POSIX requires `errno` to be set to `ERANGE` in that case. The `INF`/`NAN` spellings return
+    // earlier, so reaching infinity here can only be the result of overflow.
+    if result.is_infinite() {
+        set_errno(ERANGE);
+    }
+    if parsed_nonzero_digit && (result == 0.0 || result.abs() < f64::MIN_POSITIVE) {
+        set_errno(ERANGE);
+    }
+
+    if !endptr.is_null() {
+        *endptr = p.cast_mut();
+    }
+
+    result
+}
+
+/// Computes 10 raised to the power `exp`.
+#[allow(clippy::cast_precision_loss)]
+fn pow10(exp: i32) -> f64 {
+    let mut result: f64 = 1.0;
+    let mut base: f64 = 10.0;
+    let mut n: u32 = exp.unsigned_abs();
+
+    while n > 0 {
+        if n & 1 != 0 {
+            result *= base;
+        }
+        base *= base;
+        n >>= 1;
+    }
+
+    if exp < 0 {
+        1.0 / result
+    } else {
+        result
+    }
+}
+
+/// Computes 2 raised to the power `exp`.
+fn pow2(exp: i32) -> f64 {
+    let mut result: f64 = 1.0;
+    let mut base: f64 = 2.0;
+    let mut n: u32 = exp.unsigned_abs();
+
+    while n > 0 {
+        if n & 1 != 0 {
+            result *= base;
+        }
+        base *= base;
+        n >>= 1;
+    }
+
+    if exp < 0 {
+        1.0 / result
+    } else {
+        result
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtod;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *::sysapi::errno::__errno_location() }
+    }
+
+    /// Helper to compare floats within an epsilon.
+    fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() < eps
+    }
+
+    #[test]
+    fn basic_decimal() {
+        let s = b"3.25\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 3.25, 1e-10), "expected 3.25, got {result}");
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-1.5\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, -1.5, 1e-10), "expected -1.5, got {result}");
+    }
+
+    #[test]
+    fn exponent_positive() {
+        let s = b"1e10\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 1e10, 1.0), "expected 1e10, got {result}");
+    }
+
+    #[test]
+    fn exponent_negative() {
+        let s = b"1.5e-3\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 1.5e-3, 1e-12), "expected 1.5e-3, got {result}");
+    }
+
+    #[test]
+    fn hexadecimal_without_exponent() {
+        let s = b"0x10tail\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(approx_eq(result, 16.0, 1e-10), "expected 16.0, got {result}");
+        assert_eq!(unsafe { *end } as u8, b't');
+    }
+
+    #[test]
+    fn hexadecimal_with_binary_exponent() {
+        let s = b"0x1.8p+1\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 3.0, 1e-10), "expected 3.0, got {result}");
+    }
+
+    #[test]
+    fn no_decimal() {
+        let s = b"42\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 42.0, 1e-10), "expected 42.0, got {result}");
+    }
+
+    #[test]
+    fn endptr_set() {
+        let s = b"3.25abc\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(approx_eq(result, 3.25, 1e-10), "expected 3.25, got {result}");
+        assert!(!end.is_null());
+        assert_eq!(unsafe { *end } as u8, b'a');
+    }
+
+    #[test]
+    fn leading_whitespace() {
+        let s = b"  +42.5\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 42.5, 1e-10), "expected 42.5, got {result}");
+    }
+
+    #[test]
+    fn no_valid_conversion() {
+        let s = b"abc\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(approx_eq(result, 0.0, 1e-10), "expected 0.0, got {result}");
+        assert_eq!(end, s.as_ptr().cast_mut().cast::<c_char>());
+    }
+
+    #[test]
+    fn parses_infinity() {
+        let s = b"inf\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(result.is_infinite() && result > 0.0, "expected +inf, got {result}");
+    }
+
+    #[test]
+    fn parses_negative_infinity_long_form() {
+        let s = b"-INFINITY\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(result.is_infinite() && result < 0.0, "expected -inf, got {result}");
+        // The whole token is consumed.
+        assert_eq!(unsafe { *end } as u8, 0);
+    }
+
+    #[test]
+    fn parses_nan() {
+        let s = b"NaN\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(result.is_nan(), "expected NaN, got {result}");
+    }
+
+    #[test]
+    fn parses_nan_with_sequence() {
+        let s = b"nan(123)x\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(result.is_nan(), "expected NaN, got {result}");
+        // The parenthesized sequence is consumed; endptr points just past it.
+        assert_eq!(unsafe { *end } as u8, b'x');
+    }
+
+    #[test]
+    fn overflow_sets_erange() {
+        set_errno(0);
+        let s = b"1e400\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(result.is_infinite(), "expected inf, got {result}");
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn underflow_sets_erange() {
+        set_errno(0);
+        let s = b"1e-4000\0";
+        let result: f64 = unsafe { strtod(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert_eq!(result, 0.0);
+        assert_eq!(get_errno(), ERANGE);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtof.rs
+++ b/src/libs/libc_stdlib/src/strtof.rs
@@ -1,0 +1,135 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    set_errno,
+    strtod::strtod,
+};
+use ::sysapi::{
+    errno::ERANGE,
+    ffi::c_char,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to `f32`.
+///
+/// This function delegates to `strtod` and narrows the result to `f32`. It accepts the same subject
+/// sequences as `strtod`, including the `INF`/`INFINITY` and `NAN` spellings. If the value is finite
+/// but too large to represent as `f32`, `errno` is set to `ERANGE` and an infinity is returned.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the null-terminated string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+///
+/// # Returns
+///
+/// The converted `f32` value. Returns `0.0` if no valid conversion could be performed.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtof.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn strtof(nptr: *const c_char, endptr: *mut *mut c_char) -> f32 {
+    let value: f64 = strtod(nptr, endptr);
+    let narrowed: f32 = value as f32;
+    // A finite double that narrows to infinity overflowed the `float` range; POSIX requires
+    // `ERANGE`. When `strtod` itself overflowed, `value` is already infinite (and it has set
+    // `ERANGE`), so this guard does not fire twice.
+    if narrowed.is_infinite() && value.is_finite() {
+        set_errno(ERANGE);
+    }
+    if value != 0.0 && (narrowed == 0.0 || narrowed.abs() < f32::MIN_POSITIVE) {
+        set_errno(ERANGE);
+    }
+    narrowed
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtof;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *::sysapi::errno::__errno_location() }
+    }
+
+    /// Helper to compare floats within an epsilon.
+    fn approx_eq(a: f32, b: f32, eps: f32) -> bool {
+        (a - b).abs() < eps
+    }
+
+    #[test]
+    fn basic_decimal() {
+        let s = b"3.25\0";
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 3.25, 1e-5), "expected 3.25, got {result}");
+    }
+
+    #[test]
+    fn negative_value() {
+        let s = b"-1.5\0";
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, -1.5, 1e-5), "expected -1.5, got {result}");
+    }
+
+    #[test]
+    fn exponent() {
+        let s = b"2.5e3\0";
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(approx_eq(result, 2500.0, 1.0), "expected 2500.0, got {result}");
+    }
+
+    #[test]
+    fn endptr_set() {
+        let s = b"1.0xyz\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), &mut end) };
+        assert!(approx_eq(result, 1.0, 1e-5), "expected 1.0, got {result}");
+        assert!(!end.is_null());
+        assert_eq!(unsafe { *end } as u8, b'x');
+    }
+
+    #[test]
+    fn overflow_sets_erange() {
+        set_errno(0);
+        // `1e40` is representable as `f64` but overflows `f32`.
+        let s = b"1e40\0";
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert!(result.is_infinite(), "expected inf, got {result}");
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn underflow_sets_erange() {
+        set_errno(0);
+        let s = b"1e-50\0";
+        let result: f32 = unsafe { strtof(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert_eq!(result, 0.0);
+        assert_eq!(get_errno(), ERANGE);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtol.rs
+++ b/src/libs/libc_stdlib/src/strtol.rs
@@ -1,0 +1,303 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::{
+        EINVAL,
+        ERANGE,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_long,
+    },
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+/// Returns the numeric value of a digit character for the given base, or `None` if invalid.
+fn digit_value(c: c_char, base: c_int) -> Option<u8> {
+    let b = c as u8;
+    let val = match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'z' => b - b'a' + 10,
+        b'A'..=b'Z' => b - b'A' + 10,
+        _ => return None,
+    };
+    if c_int::from(val) < base {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to a `c_long` value
+/// according to the given `base`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+/// - `base`: Number base to use (0 for auto-detection, or 2-36).
+///
+/// # Returns
+///
+/// The converted value. On overflow, returns `c_long::MAX` or `c_long::MIN` and sets `errno`
+/// to `ERANGE`. If no conversion could be performed, returns `0` and sets `*endptr` to `nptr`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `nptr` points to a valid null-terminated string.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtol.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtol(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_long {
+    if nptr.is_null() {
+        if !endptr.is_null() {
+            *endptr = core::ptr::null_mut();
+        }
+        return 0;
+    }
+
+    // Validate base.
+    if base != 0 && !(2..=36).contains(&base) {
+        set_errno(EINVAL);
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Determine actual base from prefix.
+    let actual_base = detect_base(&mut p, base);
+
+    // Parse digits using i128 to detect overflow.
+    let start = p;
+    let mut result: i128 = 0;
+    let mut overflowed = false;
+    let base_i128 = i128::from(actual_base);
+
+    while let Some(d) = digit_value(*p, actual_base) {
+        if !overflowed {
+            match result
+                .checked_mul(base_i128)
+                .and_then(|r| r.checked_add(i128::from(d)))
+            {
+                Some(r) => result = r,
+                None => overflowed = true,
+            }
+        }
+        p = p.add(1);
+    }
+
+    // If no digits were parsed, set endptr to nptr.
+    if p == start {
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    // Set endptr to first unconverted character.
+    if !endptr.is_null() {
+        *endptr = p.cast_mut();
+    }
+
+    // Check for overflow.
+    let max_val = i128::from(c_long::MAX);
+    let min_magnitude = i128::from(c_long::MAX) + 1; // |c_long::MIN|
+
+    if overflowed || (!negative && result > max_val) || (negative && result > min_magnitude) {
+        set_errno(ERANGE);
+        return if negative { c_long::MIN } else { c_long::MAX };
+    }
+
+    // Apply sign and convert to c_long.
+    let signed_result = if negative { -result } else { result };
+    match c_long::try_from(signed_result) {
+        Ok(v) => v,
+        Err(_) => {
+            set_errno(ERANGE);
+            if negative {
+                c_long::MIN
+            } else {
+                c_long::MAX
+            }
+        },
+    }
+}
+
+/// Detects the numeric base from a string prefix and advances the pointer past the prefix.
+///
+/// # Safety
+///
+/// The caller must ensure `p` points to a valid, dereferenceable position in a null-terminated
+/// string.
+unsafe fn detect_base(p: &mut *const c_char, base: c_int) -> c_int {
+    let mut actual_base = base;
+
+    if **p as u8 == b'0' {
+        let next = *p.add(1);
+        if (next as u8 == b'x' || next as u8 == b'X') && (actual_base == 0 || actual_base == 16) {
+            // Only consume the "0x" prefix if a valid hex digit follows.
+            if digit_value(*p.add(2), 16).is_some() {
+                actual_base = 16;
+                *p = p.add(2);
+            } else if actual_base == 0 {
+                actual_base = 8;
+            }
+        } else if actual_base == 0 {
+            actual_base = 8;
+        }
+    } else if actual_base == 0 {
+        actual_base = 10;
+    }
+
+    actual_base
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtol;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+            c_long,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *sysapi::errno::__errno_location() }
+    }
+
+    #[test]
+    fn decimal() {
+        let s = b"123\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn negative_decimal() {
+        let s = b"-456\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, -456);
+    }
+
+    #[test]
+    fn hex_with_prefix() {
+        let s = b"0xff\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 16) };
+        assert_eq!(result, 255);
+    }
+
+    #[test]
+    fn octal_with_prefix() {
+        let s = b"077\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 8) };
+        assert_eq!(result, 63);
+    }
+
+    #[test]
+    fn base_zero_auto_detect_hex() {
+        let s = b"0x1a\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 0) };
+        assert_eq!(result, 26);
+    }
+
+    #[test]
+    fn base_zero_auto_detect_octal() {
+        let s = b"077\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 0) };
+        assert_eq!(result, 63);
+    }
+
+    #[test]
+    fn base_zero_auto_detect_decimal() {
+        let s = b"123\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 0) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn overflow_positive() {
+        set_errno(0);
+        // Value exceeds 64-bit `c_long` (tests run on the 64-bit host), so it overflows on every
+        // supported target width.
+        let s = b"9999999999999999999999999\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_long::MAX);
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn overflow_negative() {
+        set_errno(0);
+        let s = b"-9999999999999999999999999\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_long::MIN);
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn endptr_set() {
+        let s = b"123abc\0";
+        let mut end: *mut c_char = core::ptr::null_mut();
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), &mut end, 10) };
+        assert_eq!(result, 123);
+        assert!(!end.is_null());
+        assert_eq!(unsafe { *end } as u8, b'a');
+    }
+
+    #[test]
+    fn invalid_base() {
+        set_errno(0);
+        let s = b"123\0";
+        let result = unsafe { strtol(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 1) };
+        assert_eq!(result, 0);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtold.rs
+++ b/src/libs/libc_stdlib/src/strtold.rs
@@ -1,0 +1,57 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to a floating-point value.
+///
+/// Nanvix computes the result at `double` precision and the generated C declaration returns
+/// `double` to match. This keeps the implementation and the C prototype in agreement on the
+/// return-value ABI (a `long double` prototype would expect the value in the x87 register on the
+/// supported targets, corrupting callers).
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the null-terminated string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+///
+/// # Returns
+///
+/// The converted floating-point value.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers through [`crate::strtod`].
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtod.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtold(nptr: *const c_char, endptr: *mut *mut c_char) -> f64 {
+    crate::strtod(nptr, endptr)
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtold;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn delegates_to_strtod() {
+        let s = b"0x1.8p+1\0";
+        let value: f64 = unsafe { strtold(s.as_ptr().cast::<c_char>(), core::ptr::null_mut()) };
+        assert_eq!(value, 3.0);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtoll.rs
+++ b/src/libs/libc_stdlib/src/strtoll.rs
@@ -1,0 +1,257 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::{
+        EINVAL,
+        ERANGE,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_longlong,
+    },
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+/// Returns the numeric value of a digit character for the given base, or `None` if invalid.
+fn digit_value(c: c_char, base: c_int) -> Option<u8> {
+    let b = c as u8;
+    let val = match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'z' => b - b'a' + 10,
+        b'A'..=b'Z' => b - b'A' + 10,
+        _ => return None,
+    };
+    if c_int::from(val) < base {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to a `c_longlong` value
+/// according to the given `base`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+/// - `base`: Number base to use (0 for auto-detection, or 2-36).
+///
+/// # Returns
+///
+/// The converted value. On overflow, returns `c_longlong::MAX` or `c_longlong::MIN` and sets
+/// `errno` to `ERANGE`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoll.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoll(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_longlong {
+    if nptr.is_null() {
+        if !endptr.is_null() {
+            *endptr = core::ptr::null_mut();
+        }
+        return 0;
+    }
+
+    // Validate base.
+    if base != 0 && !(2..=36).contains(&base) {
+        set_errno(EINVAL);
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign.
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Determine actual base from prefix.
+    let actual_base = detect_base(&mut p, base);
+
+    // Parse digits using i128 to detect overflow.
+    let start = p;
+    let mut result: i128 = 0;
+    let mut overflowed = false;
+    let base_i128 = i128::from(actual_base);
+
+    while let Some(d) = digit_value(*p, actual_base) {
+        if !overflowed {
+            match result
+                .checked_mul(base_i128)
+                .and_then(|r| r.checked_add(i128::from(d)))
+            {
+                Some(r) => result = r,
+                None => overflowed = true,
+            }
+        }
+        p = p.add(1);
+    }
+
+    // If no digits were parsed, set endptr to nptr.
+    if p == start {
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    // Set endptr.
+    if !endptr.is_null() {
+        *endptr = p.cast_mut();
+    }
+
+    // Check for overflow.
+    let max_val = i128::from(c_longlong::MAX);
+    let min_magnitude = i128::from(c_longlong::MAX) + 1; // |c_longlong::MIN|
+
+    if overflowed || (!negative && result > max_val) || (negative && result > min_magnitude) {
+        set_errno(ERANGE);
+        return if negative {
+            c_longlong::MIN
+        } else {
+            c_longlong::MAX
+        };
+    }
+
+    // Apply sign and convert to c_longlong.
+    let signed_result = if negative { -result } else { result };
+    match c_longlong::try_from(signed_result) {
+        Ok(v) => v,
+        Err(_) => {
+            set_errno(ERANGE);
+            if negative {
+                c_longlong::MIN
+            } else {
+                c_longlong::MAX
+            }
+        },
+    }
+}
+
+/// Detects the numeric base from a string prefix and advances the pointer past the prefix.
+///
+/// # Safety
+///
+/// The caller must ensure `p` points to a valid, dereferenceable position in a null-terminated
+/// string.
+unsafe fn detect_base(p: &mut *const c_char, base: c_int) -> c_int {
+    let mut actual_base = base;
+
+    if **p as u8 == b'0' {
+        let next = *p.add(1);
+        if (next as u8 == b'x' || next as u8 == b'X') && (actual_base == 0 || actual_base == 16) {
+            if digit_value(*p.add(2), 16).is_some() {
+                actual_base = 16;
+                *p = p.add(2);
+            } else if actual_base == 0 {
+                actual_base = 8;
+            }
+        } else if actual_base == 0 {
+            actual_base = 8;
+        }
+    } else if actual_base == 0 {
+        actual_base = 10;
+    }
+
+    actual_base
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtoll;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+            c_longlong,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *sysapi::errno::__errno_location() }
+    }
+
+    #[test]
+    fn decimal() {
+        let s = b"123\0";
+        let result = unsafe { strtoll(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn large_positive() {
+        let s = b"9223372036854775807\0"; // i64::MAX
+        let result = unsafe { strtoll(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_longlong::MAX);
+    }
+
+    #[test]
+    fn large_negative() {
+        let s = b"-9223372036854775808\0"; // i64::MIN
+        let result = unsafe { strtoll(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_longlong::MIN);
+    }
+
+    #[test]
+    fn overflow_positive() {
+        set_errno(0);
+        let s = b"9223372036854775808\0"; // i64::MAX + 1
+        let result = unsafe { strtoll(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_longlong::MAX);
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn overflow_negative() {
+        set_errno(0);
+        let s = b"-9223372036854775809\0"; // i64::MIN - 1
+        let result = unsafe { strtoll(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_longlong::MIN);
+        assert_eq!(get_errno(), ERANGE);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtoul.rs
+++ b/src/libs/libc_stdlib/src/strtoul.rs
@@ -1,0 +1,247 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::{
+        EINVAL,
+        ERANGE,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_ulong,
+    },
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+/// Returns the numeric value of a digit character for the given base, or `None` if invalid.
+fn digit_value(c: c_char, base: c_int) -> Option<u8> {
+    let b = c as u8;
+    let val = match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'z' => b - b'a' + 10,
+        b'A'..=b'Z' => b - b'A' + 10,
+        _ => return None,
+    };
+    if c_int::from(val) < base {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to a `c_ulong` value
+/// according to the given `base`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+/// - `base`: Number base to use (0 for auto-detection, or 2-36).
+///
+/// # Returns
+///
+/// The converted value. On overflow, returns `c_ulong::MAX` and sets `errno` to `ERANGE`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoul.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoul(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_ulong {
+    if nptr.is_null() {
+        if !endptr.is_null() {
+            *endptr = core::ptr::null_mut();
+        }
+        return 0;
+    }
+
+    // Validate base.
+    if base != 0 && !(2..=36).contains(&base) {
+        set_errno(EINVAL);
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign (C standard: strtoul accepts a leading minus and wraps).
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Determine actual base from prefix.
+    let actual_base = detect_base(&mut p, base);
+
+    // Parse digits.
+    let start = p;
+    let mut result: u64 = 0;
+    let mut overflowed = false;
+    let base_u64 = u64::from(actual_base as u32);
+
+    while let Some(d) = digit_value(*p, actual_base) {
+        if !overflowed {
+            match result
+                .checked_mul(base_u64)
+                .and_then(|r| r.checked_add(u64::from(d)))
+            {
+                Some(r) => result = r,
+                None => overflowed = true,
+            }
+        }
+        p = p.add(1);
+    }
+
+    // If no digits were parsed, set endptr to nptr.
+    if p == start {
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    // Set endptr.
+    if !endptr.is_null() {
+        *endptr = p.cast_mut();
+    }
+
+    // Check for overflow.
+    // `u64::from` is a real widening on 32-bit targets (where `c_ulong` is `u32`) but a no-op on
+    // 64-bit hosts; allow the resulting useless-conversion lint in the latter case.
+    #[allow(clippy::useless_conversion)]
+    let max_val = u64::from(c_ulong::MAX);
+    if overflowed || result > max_val {
+        set_errno(ERANGE);
+        return c_ulong::MAX;
+    }
+
+    // Convert to c_ulong (wrapping for negative per C standard).
+    let unsigned_result = match c_ulong::try_from(result) {
+        Ok(v) => v,
+        Err(_) => {
+            set_errno(ERANGE);
+            return c_ulong::MAX;
+        },
+    };
+
+    if negative {
+        unsigned_result.wrapping_neg()
+    } else {
+        unsigned_result
+    }
+}
+
+/// Detects the numeric base from a string prefix and advances the pointer past the prefix.
+///
+/// # Safety
+///
+/// The caller must ensure `p` points to a valid, dereferenceable position in a null-terminated
+/// string.
+unsafe fn detect_base(p: &mut *const c_char, base: c_int) -> c_int {
+    let mut actual_base = base;
+
+    if **p as u8 == b'0' {
+        let next = *p.add(1);
+        if (next as u8 == b'x' || next as u8 == b'X') && (actual_base == 0 || actual_base == 16) {
+            if digit_value(*p.add(2), 16).is_some() {
+                actual_base = 16;
+                *p = p.add(2);
+            } else if actual_base == 0 {
+                actual_base = 8;
+            }
+        } else if actual_base == 0 {
+            actual_base = 8;
+        }
+    } else if actual_base == 0 {
+        actual_base = 10;
+    }
+
+    actual_base
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtoul;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+            c_ulong,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *sysapi::errno::__errno_location() }
+    }
+
+    #[test]
+    fn basic_decimal() {
+        let s = b"123\0";
+        let result = unsafe { strtoul(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn hex_value() {
+        let s = b"0xff\0";
+        let result = unsafe { strtoul(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 16) };
+        assert_eq!(result, 255);
+    }
+
+    #[test]
+    fn overflow() {
+        set_errno(0);
+        // Value exceeds 64-bit `c_ulong` (tests run on the 64-bit host), so it overflows on every
+        // supported target width.
+        let s = b"9999999999999999999999999\0";
+        let result = unsafe { strtoul(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_ulong::MAX);
+        assert_eq!(get_errno(), ERANGE);
+    }
+
+    #[test]
+    fn negative_wraps() {
+        let s = b"-1\0";
+        let result = unsafe { strtoul(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_ulong::MAX);
+    }
+}

--- a/src/libs/libc_stdlib/src/strtoull.rs
+++ b/src/libs/libc_stdlib/src/strtoull.rs
@@ -1,0 +1,235 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::{
+        EINVAL,
+        ERANGE,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_ulonglong,
+    },
+};
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` if the given character is an ASCII whitespace character.
+fn is_whitespace(c: c_char) -> bool {
+    let b = c as u8;
+    b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' || b == 0x0b || b == 0x0c
+}
+
+/// Returns the numeric value of a digit character for the given base, or `None` if invalid.
+fn digit_value(c: c_char, base: c_int) -> Option<u8> {
+    let b = c as u8;
+    let val = match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'z' => b - b'a' + 10,
+        b'A'..=b'Z' => b - b'A' + 10,
+        _ => return None,
+    };
+    if c_int::from(val) < base {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts the initial portion of the string pointed to by `nptr` to a `c_ulonglong` value
+/// according to the given `base`.
+///
+/// # Parameters
+///
+/// - `nptr`: Pointer to the string to be converted.
+/// - `endptr`: If not null, receives a pointer to the first character not converted.
+/// - `base`: Number base to use (0 for auto-detection, or 2-36).
+///
+/// # Returns
+///
+/// The converted value. On overflow, returns `c_ulonglong::MAX` and sets `errno` to `ERANGE`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+///
+/// # References
+///
+/// - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoull.html
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoull(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_ulonglong {
+    if nptr.is_null() {
+        if !endptr.is_null() {
+            *endptr = core::ptr::null_mut();
+        }
+        return 0;
+    }
+
+    // Validate base.
+    if base != 0 && !(2..=36).contains(&base) {
+        set_errno(EINVAL);
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    let mut p = nptr;
+
+    // Skip leading whitespace.
+    while is_whitespace(*p) {
+        p = p.add(1);
+    }
+
+    // Handle optional sign (C standard: strtoull accepts a leading minus and wraps).
+    let negative = *p as u8 == b'-';
+    if *p as u8 == b'+' || *p as u8 == b'-' {
+        p = p.add(1);
+    }
+
+    // Determine actual base from prefix.
+    let actual_base = detect_base(&mut p, base);
+
+    // Parse digits using u128 to detect overflow.
+    let start = p;
+    let mut result: u128 = 0;
+    let mut overflowed = false;
+    let base_u128 = u128::from(actual_base as u32);
+
+    while let Some(d) = digit_value(*p, actual_base) {
+        if !overflowed {
+            match result
+                .checked_mul(base_u128)
+                .and_then(|r| r.checked_add(u128::from(d)))
+            {
+                Some(r) => result = r,
+                None => overflowed = true,
+            }
+        }
+        p = p.add(1);
+    }
+
+    // If no digits were parsed, set endptr to nptr.
+    if p == start {
+        if !endptr.is_null() {
+            *endptr = nptr.cast_mut();
+        }
+        return 0;
+    }
+
+    // Set endptr.
+    if !endptr.is_null() {
+        *endptr = p.cast_mut();
+    }
+
+    // Check for overflow.
+    let max_val = u128::from(c_ulonglong::MAX);
+    if overflowed || result > max_val {
+        set_errno(ERANGE);
+        return c_ulonglong::MAX;
+    }
+
+    // Convert to c_ulonglong (wrapping for negative per C standard).
+    let unsigned_result = match c_ulonglong::try_from(result) {
+        Ok(v) => v,
+        Err(_) => {
+            set_errno(ERANGE);
+            return c_ulonglong::MAX;
+        },
+    };
+
+    if negative {
+        unsigned_result.wrapping_neg()
+    } else {
+        unsigned_result
+    }
+}
+
+/// Detects the numeric base from a string prefix and advances the pointer past the prefix.
+///
+/// # Safety
+///
+/// The caller must ensure `p` points to a valid, dereferenceable position in a null-terminated
+/// string.
+unsafe fn detect_base(p: &mut *const c_char, base: c_int) -> c_int {
+    let mut actual_base = base;
+
+    if **p as u8 == b'0' {
+        let next = *p.add(1);
+        if (next as u8 == b'x' || next as u8 == b'X') && (actual_base == 0 || actual_base == 16) {
+            if digit_value(*p.add(2), 16).is_some() {
+                actual_base = 16;
+                *p = p.add(2);
+            } else if actual_base == 0 {
+                actual_base = 8;
+            }
+        } else if actual_base == 0 {
+            actual_base = 8;
+        }
+    } else if actual_base == 0 {
+        actual_base = 10;
+    }
+
+    actual_base
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::strtoull;
+    use crate::set_errno;
+    use ::sysapi::{
+        errno::ERANGE,
+        ffi::{
+            c_char,
+            c_int,
+            c_ulonglong,
+        },
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *sysapi::errno::__errno_location() }
+    }
+
+    #[test]
+    fn basic_decimal() {
+        let s = b"123\0";
+        let result = unsafe { strtoull(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, 123);
+    }
+
+    #[test]
+    fn large_value() {
+        let s = b"18446744073709551615\0"; // u64::MAX
+        let result = unsafe { strtoull(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_ulonglong::MAX);
+    }
+
+    #[test]
+    fn overflow() {
+        set_errno(0);
+        let s = b"18446744073709551616\0"; // u64::MAX + 1
+        let result = unsafe { strtoull(s.as_ptr().cast::<c_char>(), core::ptr::null_mut(), 10) };
+        assert_eq!(result, c_ulonglong::MAX);
+        assert_eq!(get_errno(), ERANGE);
+    }
+}

--- a/src/libs/libc_stdlib/src/system.rs
+++ b/src/libs/libc_stdlib/src/system.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::ENOSYS,
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Executes a shell command.
+///
+/// # Parameters
+///
+/// - `command`: The command to execute, or null to query for a command processor.
+///
+/// # Returns
+///
+/// Non-zero when `command` is null; otherwise -1 with `errno` set to `ENOSYS`.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference `command`; the pointer is, however, not
+/// dereferenced by this stub.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/system.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn system(command: *const c_char) -> c_int {
+    if command.is_null() {
+        return 1;
+    }
+    set_errno(ENOSYS);
+    -1
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::system;
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn null_command_reports_processor() {
+        assert_ne!(unsafe { system(::core::ptr::null()) }, 0);
+    }
+
+    #[test]
+    fn non_null_command_returns_error() {
+        let command = b"true\0";
+        assert_eq!(unsafe { system(command.as_ptr().cast::<c_char>()) }, -1);
+    }
+}

--- a/src/libs/libc_stdlib/src/unsetenv.rs
+++ b/src/libs/libc_stdlib/src/unsetenv.rs
@@ -51,7 +51,7 @@ use ::sysapi::{
 pub unsafe extern "C" fn unsetenv(name: *const c_char) -> c_int {
     // Check if `name` is null.
     if name.is_null() {
-        ::syslog::warn!("unsetenv(): name is null");
+        warn!("unsetenv(): name is null");
         set_errno(EINVAL);
         return -1;
     }
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn unsetenv(name: *const c_char) -> c_int {
     let name_str: &str = match ffi::CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => {
-            ::syslog::warn!("unsetenv(): invalid name (name={name:?})");
+            warn!("unsetenv(): invalid name (name={name:?})");
             set_errno(EINVAL);
             return -1;
         },
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn unsetenv(name: *const c_char) -> c_int {
 
     // Empty name or name containing '=' is invalid per POSIX.
     if name_str.is_empty() || name_str.contains('=') {
-        ::syslog::warn!("unsetenv(): invalid name (name={name_str:?})");
+        warn!("unsetenv(): invalid name (name={name_str:?})");
         set_errno(EINVAL);
         return -1;
     }


### PR DESCRIPTION
## Summary

Implements the C standard library''s `<stdlib.h>` surface in the `libc_stdlib`
crate and aligns the generated `include/stdlib.h` header with the POSIX.1-2024
(Issue 8) specification.

### New interfaces
- **Memory:** `reallocarray`; validation hardening for `aligned_alloc`,
  `posix_memalign`, `memalign`, `calloc`, `realloc`, and `malloc_usable_size`.
- **String conversion:** `atof`, `atoi`, `atol`, `atoll`, `strtod`, `strtof`,
  `strtold`, `strtol`, `strtoll`, `strtoul`, `strtoull`.
- **Integer arithmetic:** `abs`, `labs`, `llabs`, `div`, `ldiv`, `lldiv`.
- **Searching/sorting:** `bsearch`, `qsort`, `qsort_r`.
- **Pseudo-random:** `rand`, `srand`.
- **Environment:** `getenv`, `secure_getenv`, `setenv`, `unsetenv`, `putenv`.
- **Process control:** `_Exit`, `abort`, `atexit`, `at_quick_exit`, `exit`,
  `quick_exit`, `system`.

### POSIX conformance fixes
- `strtod`/`strtof`: parse hexadecimal floating-point subject sequences
  (`0x...p...`) and report `ERANGE` on underflow.
- `aligned_alloc`: reject sizes that are not a multiple of the alignment and
  unsupported alignments with `EINVAL`, while keeping `memalign`''s legacy
  (non-multiple) behavior.
- `putenv`: install the caller''s buffer into the environment so later mutations
  are reflected, instead of copying.
- `system(NULL)`: return non-zero to indicate a command processor.
- `abort`: raise `SIGABRT` via `kill(getpid(), SIGABRT)` rather than a plain
  `_exit(134)`, without forcing a `libc_signal` link dependency.
- Header: declare `strtold`, `reallocarray`, `secure_getenv`, `qsort_r`,
  `_Exit`, `quick_exit`, `at_quick_exit`, and the remaining mandated prototypes;
  define `MB_CUR_MAX` as `size_t` and make the header self-contained for
  `NULL`/`size_t`/`wchar_t`.

### Notes
- `exit()` does not yet flush stdio streams because `libc_stdio` is unbuffered
  and is not linked by all guests; tracked in #2631.
- `libc_stdlib` added to `ALL_GUEST_RUST_LIBS_TEST_LIST` so its unit tests run
  in CI.
- `include/stdlib.h` regenerated from the updated `header.toml`.

## Testing
- `cargo test -p libc_stdlib` (142 passed); `libc_wchar`, `libc_signal`,
  `libc_stdio` unit tests pass.
- Host + guest (`x86-user`) clippy with `-D warnings`.
- `gen-headers --check` reports headers up to date.
- `z.ps1 build -- run-nanvix-tests` (Windows standalone) completes.
