### PR TITLE
[procd] Apply FD_CLOEXEC across execv

### DIFF
--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -20,6 +20,8 @@ use crate::{
     pipe_wait::PipeWaitTable,
 };
 use ::proc::{
+    exec_ack,
+    ExecMessage,
     ForkCloneMessage,
     ProcessExitMessage,
     ProcessManagementMessage,
@@ -192,6 +194,65 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                         }
                     }
                     ::syslog::info!("reclaimed filesystem state (pid={:?})", pid);
+                    Ok(false)
+                },
+                ProcessManagementMessageHeader::Exec => {
+                    let exec: ExecMessage = ExecMessage::from_bytes(pm_msg.payload);
+                    let pid: ProcessIdentifier = exec.pid;
+                    // Bind the VFS to the exec'ing process and seed the root console if this is the
+                    // root's first VFS-visible event, mirroring the fork-clone and syscall paths so
+                    // close-on-exec is applied against a consistent table. The seed helper is
+                    // root-only and idempotent.
+                    ::vfs::fd::set_current_process(pid);
+                    ::vfs::fd::vfs_seed_root_console(pid);
+                    // Drop the process's `FD_CLOEXEC` descriptors, leaving the survivors in place.
+                    // Each last-reference drop must fire the same side effects as `close`: a
+                    // host-backed handle for which this process held the final reference is closed
+                    // on hostfsd, and a pipe end whose count reaches zero wakes its suspended
+                    // counterpart (readers see EOF, writers see `EPIPE`). The process stays alive,
+                    // so its parked pipe requests are NOT purged.
+                    let reclaim: ::vfs::fd::ProcessExitReclaim = ::vfs::fd::vfs_exec_cloexec(pid);
+                    for closure in reclaim.pipe_closures {
+                        if closure.was_write {
+                            handler::pipe::wake_all_readers_eof(closure.pipe_id, pipe_wait);
+                        } else {
+                            handler::pipe::fail_all_writers_epipe(closure.pipe_id, pipe_wait);
+                        }
+                    }
+                    for remote_fd in reclaim.orphaned_hostfs_fds {
+                        // Fire-and-forget close: the descriptor is gone from the exec'd image, so
+                        // there is no caller to acknowledge, exactly as on process exit.
+                        if let Err(e) = hostfs::send_close_request(
+                            remote_fd,
+                            ::hostfs_api::OperationId::FIRE_AND_FORGET,
+                        ) {
+                            ::syslog::warn!(
+                                "failed to close orphaned hostfs fd on exec (pid={:?}, \
+                                 remote_fd={}, error={:?})",
+                                pid,
+                                remote_fd,
+                                e
+                            );
+                        }
+                    }
+                    // Acknowledge the process manager daemon that close-on-exec has been applied, so
+                    // it can release the held process. The acknowledgement is necessarily ordered
+                    // after the table mutation above, so the released image's cache rebuild observes
+                    // the post-close-on-exec table.
+                    match exec_ack(
+                        ProcessIdentifier::VFSD,
+                        ProcessIdentifier::PROCD,
+                        pid,
+                        ::proc::ExecAckMessage::STATUS_SUCCESS,
+                    ) {
+                        Ok(ack) => send_response(&ack),
+                        Err(e) => ::syslog::error!(
+                            "failed to build exec acknowledgement (pid={:?}, error={:?})",
+                            pid,
+                            e
+                        ),
+                    }
+                    ::syslog::info!("applied close-on-exec (pid={:?})", pid);
                     Ok(false)
                 },
                 _ => {

--- a/src/libs/posix/src/start.rs
+++ b/src/libs/posix/src/start.rs
@@ -180,6 +180,14 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
         __nanvix_env_init(environ as *const *const c_char);
     }
 
+    // Synchronize with the process daemons before any application code runs. A successful `execv`
+    // replaces the image in place and transfers control here without notifying `vfsd`, so the
+    // inherited descriptor table still carries its `FD_CLOEXEC` descriptors and this image's
+    // resolution cache was wiped with BSS. The barrier holds this process until `vfsd` has dropped
+    // those descriptors, so the cache — rebuilt lazily on first use — observes the
+    // post-close-on-exec table. In run modes without a guest `vfsd`, this is a no-op.
+    ::syscall::unistd::exec_startup_barrier();
+
     // Dispatch into the application's `main` via the binary-supplied
     // trampoline.  `__nanvix_main` is `nvx-crt0::__nanvix_main`, which
     // selects between the C and Rust trampoline at the binary's link

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -8,6 +8,7 @@
 use crate::{
     identity::ProcessIdentity,
     message,
+    ExecAckMessage,
     ForkSyncAckMessage,
     ForkSyncMessage,
     LookupMessage,
@@ -157,6 +158,14 @@ pub struct ProcessDaemon {
     /// used rather than a map because only a handful of fork operations are ever pending
     /// concurrently, so a linear scan is cheaper than the overhead of an ordered map.
     pending_fork_syncs: Vec<(ProcessIdentifier, ProcessIdentifier)>,
+    /// Processes held at the exec synchronization barrier, awaiting the filesystem daemon's
+    /// acknowledgement that close-on-exec has been applied to their inherited descriptor table.
+    /// Populated when a freshly `exec`'d process requests the barrier and the close-on-exec
+    /// notification is dispatched to the filesystem daemon; drained when that daemon acknowledges,
+    /// at which point the process is released. A `Vec` is used rather than a map because only a
+    /// handful of exec operations are ever pending concurrently, so a linear scan is cheaper than
+    /// the overhead of an ordered map.
+    pending_execs: Vec<ProcessIdentifier>,
     /// Parents currently blocked in a `Wait` operation. A blocking `waitpid()` is parked here and
     /// answered later, when a `ProcessTermination` event for a matching child arrives.
     blocked: Vec<BlockedWaiter>,
@@ -200,6 +209,7 @@ impl ProcessDaemon {
             processes: BTreeMap::new(),
             init_proc: None,
             pending_fork_syncs: Vec::new(),
+            pending_execs: Vec::new(),
             blocked: Vec::new(),
             early_terminations: Vec::new(),
         })
@@ -496,6 +506,10 @@ impl ProcessDaemon {
     fn cleanup_terminated(&mut self, pid: ProcessIdentifier) {
         // Drop any stale fork-sync bookkeeping for the terminating process.
         self.pending_fork_syncs.retain(|(child, _)| *child != pid);
+        // Drop any exec-barrier bookkeeping owned by the terminating process. A process that died
+        // while held at the exec barrier can never be released, so leaving its entry behind would
+        // strand it and leak the slot across pid reuse.
+        self.pending_execs.retain(|process| *process != pid);
         // Drop any blocked-wait bookkeeping owned by the terminating process. A process that was
         // itself parked in `waitpid()` can never be answered once it is gone, so leaving its entry
         // behind would leak memory and strand a stale waiter.
@@ -773,6 +787,26 @@ impl ProcessDaemon {
                     let message: ForkSyncMessage = ForkSyncMessage::from_bytes(message.payload);
                     self.handle_fork_sync(destination, message.child);
                 },
+                ProcessManagementMessageHeader::Exec => {
+                    // A freshly `exec`'d process announces that it has replaced its image. The
+                    // source is attributed by the kernel, so the subject is the source itself: a
+                    // process can only ever request the barrier for itself, never for another.
+                    self.handle_exec_sync(destination);
+                },
+                ProcessManagementMessageHeader::ExecAck => {
+                    // The filesystem daemon confirms whether close-on-exec was applied. Only it may
+                    // drive this acknowledgement; one from any other source is a forgery that could
+                    // release a process before its descriptors were dropped, so it is dropped
+                    // without effect. The daemon's outcome (`status`) is forwarded unchanged to the
+                    // held process so that a best-effort failure can be signalled rather than masked
+                    // as success.
+                    if destination == ProcessIdentifier::VFSD {
+                        let ack: ExecAckMessage = ExecAckMessage::from_bytes(message.payload);
+                        self.handle_exec_ack(ack.pid, ack.status);
+                    } else {
+                        ::syslog::warn!("dropping forged exec-ack (source={:?})", destination);
+                    }
+                },
                 ProcessManagementMessageHeader::Wait => {
                     let message: WaitMessage = WaitMessage::from_bytes(message.payload);
                     // The reply is deferred (no send here) when the waiter blocks; it is produced
@@ -1023,6 +1057,110 @@ impl ProcessDaemon {
                     "notify_process_exit: failed to build process-exit request (pid={:?}, \
                      error={:?})",
                     pid,
+                    e
+                );
+            },
+        }
+    }
+
+    /// Handles an exec-sync request from a freshly `exec`'d `process` whose new image must be held
+    /// until the filesystem daemon has applied close-on-exec to its inherited descriptor table.
+    ///
+    /// Relays the close-on-exec request to the filesystem daemon and records the process as
+    /// awaiting that daemon's acknowledgement, which `handle_exec_ack()` resolves. If the relay
+    /// could not be dispatched, the process is released immediately with a failure acknowledgement:
+    /// its image has already been replaced and the `exec` cannot be undone, so it proceeds on a
+    /// best-effort basis rather than blocking forever on an acknowledgement that will never come.
+    fn handle_exec_sync(&mut self, process: ProcessIdentifier) {
+        ::syslog::info!("exec-sync request (process={:?})", process);
+        if self.notify_exec(process) {
+            // Replace any stale entry for this process before recording the new one, preserving the
+            // at-most-one-pending-exec-per-process invariant across pid reuse.
+            self.pending_execs.retain(|p| *p != process);
+            self.pending_execs.push(process);
+        } else {
+            ::syslog::warn!(
+                "exec close-on-exec not dispatched, failing exec-sync (process={:?})",
+                process
+            );
+            self.release_exec_sync(process, ErrorCode::TryAgain.get());
+        }
+    }
+
+    /// Notifies the filesystem daemon to apply close-on-exec to `process`'s descriptor table,
+    /// mirroring how `notify_fork_clone` dispatches a fork-clone.
+    ///
+    /// Returns `true` if the request was handed to the kernel for delivery, and `false` if it could
+    /// not be built or sent. The daemon does not block on an acknowledgement here: the filesystem
+    /// daemon's acknowledgement is delivered asynchronously and resolved in `handle_exec_ack()`,
+    /// so that the receive path never risks swallowing an unrelated message.
+    fn notify_exec(&self, process: ProcessIdentifier) -> bool {
+        match message::exec_request(ProcessIdentifier::PROCD, ProcessIdentifier::VFSD, process) {
+            Ok(request) => match ::sys::kcall::ipc::__kcall_send(&request) {
+                Ok(()) => true,
+                Err(e) => {
+                    ::syslog::warn!(
+                        "notify_exec: failed to notify vfsd to apply close-on-exec (process={:?}, \
+                         error={:?})",
+                        process,
+                        e
+                    );
+                    false
+                },
+            },
+            Err(e) => {
+                ::syslog::warn!(
+                    "notify_exec: failed to build exec request (process={:?}, error={:?})",
+                    process,
+                    e
+                );
+                false
+            },
+        }
+    }
+
+    /// Handles an exec acknowledgement from the filesystem daemon, releasing the held `process`
+    /// whose close-on-exec has now been resolved with outcome `status`.
+    ///
+    /// Only a process recorded as awaiting acknowledgement is released, so a stale or duplicated
+    /// acknowledgement — or one naming a process that never requested the barrier — cannot release
+    /// a process spuriously. The filesystem daemon's `status` is forwarded unchanged to the
+    /// released process: `0` reports that close-on-exec was applied, while a non-zero code lets the
+    /// process proceed on a best-effort basis after the daemon could not complete it.
+    fn handle_exec_ack(&mut self, process: ProcessIdentifier, status: i32) {
+        if let Some(pos) = self.pending_execs.iter().position(|p| *p == process) {
+            self.pending_execs.swap_remove(pos);
+            self.release_exec_sync(process, status);
+        } else {
+            ::syslog::warn!(
+                "ignoring exec-ack for process not awaiting the barrier (process={:?})",
+                process
+            );
+        }
+    }
+
+    /// Releases a `process` held at the exec barrier by acknowledging it with `status`. A `0`
+    /// status releases it after close-on-exec has been applied; a non-zero status releases it on a
+    /// best-effort basis after the barrier could not be completed.
+    fn release_exec_sync(&self, process: ProcessIdentifier, status: i32) {
+        match message::exec_ack(ProcessIdentifier::PROCD, process, process, status) {
+            Ok(ack) => {
+                if let Err(e) = ::sys::kcall::ipc::__kcall_send(&ack) {
+                    ::syslog::warn!(
+                        "release_exec_sync: failed to acknowledge (process={:?}, status={:?}, \
+                         error={:?})",
+                        process,
+                        status,
+                        e
+                    );
+                }
+            },
+            Err(e) => {
+                ::syslog::warn!(
+                    "release_exec_sync: failed to build acknowledgement (process={:?}, \
+                     status={:?}, error={:?})",
+                    process,
+                    status,
                     e
                 );
             },

--- a/src/libs/proc/src/lib.rs
+++ b/src/libs/proc/src/lib.rs
@@ -31,6 +31,8 @@ extern crate alloc;
 //==================================================================================================
 
 pub use message::{
+    exec_ack,
+    exec_request,
     fork_clone_request,
     fork_sync_ack,
     fork_sync_request,
@@ -42,6 +44,8 @@ pub use message::{
     signup_response,
     wait_request,
     wait_response,
+    ExecAckMessage,
+    ExecMessage,
     ForkCloneMessage,
     ForkSyncAckMessage,
     ForkSyncMessage,

--- a/src/libs/proc/src/message/exec.rs
+++ b/src/libs/proc/src/message/exec.rs
@@ -1,0 +1,285 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::message::{
+    ProcessManagementMessage,
+    ProcessManagementMessageHeader,
+};
+use ::core::mem;
+use ::sys::{
+    error::Error,
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+        SystemMessage,
+        SystemMessageHeader,
+    },
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A message that drives the `exec` synchronization barrier. It is sent on two hops, distinguished
+/// by the kernel-attributed message source:
+///
+/// - by a freshly `exec`'d process to the process manager daemon, announcing that it has replaced
+///   its image and must be held until its inherited descriptor table has had close-on-exec applied;
+///   and
+/// - by the process manager daemon to the filesystem daemon, asking it to drop the `FD_CLOEXEC`
+///   descriptors of `pid` and rebuild its table generation.
+///
+/// The `pid` it carries names the subject process. On the first hop it is informational (the
+/// process manager daemon authoritatively uses the kernel-attributed source instead, so a process
+/// can only ever request the barrier for itself); on the second hop it is the subject the
+/// filesystem daemon acts on.
+///
+#[repr(C, packed)]
+pub struct ExecMessage {
+    /// Process identifier of the subject process (the one that replaced its image).
+    pub pid: ProcessIdentifier,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+
+// NOTE: The size of an exec message must match the size of a process management message payload.
+::static_assert::assert_eq_size!(ExecMessage, ProcessManagementMessage::PAYLOAD_SIZE);
+
+///
+/// # Description
+///
+/// A message that acknowledges the `exec` synchronization barrier. It is sent on two hops,
+/// distinguished by the kernel-attributed message source:
+///
+/// - by the filesystem daemon to the process manager daemon, confirming that close-on-exec has been
+///   applied to `pid`'s table; and
+/// - by the process manager daemon to the subject process, releasing it so that its new image's
+///   `crt0` may proceed.
+///
+/// The `status` field conveys the outcome: `0` when close-on-exec was applied, or a non-zero error
+/// code when the barrier could not be completed. A non-zero status lets the held process proceed on
+/// a best-effort basis rather than block forever, since its image has already been replaced and the
+/// `exec` cannot be undone.
+///
+#[repr(C, packed)]
+pub struct ExecAckMessage {
+    /// Process identifier of the subject process the acknowledgement concerns.
+    pub pid: ProcessIdentifier,
+    /// Outcome of the barrier: `0` on success, or a non-zero error code on failure.
+    pub status: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+
+// NOTE: The size of an exec acknowledgement message must match the size of a process management
+// message payload.
+::static_assert::assert_eq_size!(ExecAckMessage, ProcessManagementMessage::PAYLOAD_SIZE);
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ExecMessage {
+    /// Size of padding.
+    pub const PADDING_SIZE: usize =
+        ProcessManagementMessage::PAYLOAD_SIZE - mem::size_of::<ProcessIdentifier>();
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new exec message.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Process identifier of the subject process.
+    ///
+    pub fn new(pid: ProcessIdentifier) -> Self {
+        Self {
+            pid,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a byte array into an exec message.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Byte array.
+    ///
+    /// # Returns
+    ///
+    /// An exec message.
+    ///
+    pub fn from_bytes(bytes: [u8; ProcessManagementMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts an exec message into a byte array.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding byte array.
+    ///
+    pub fn into_bytes(self) -> [u8; ProcessManagementMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl ExecAckMessage {
+    /// Status value that marks a successful exec synchronization.
+    pub const STATUS_SUCCESS: i32 = 0;
+
+    /// Size of padding.
+    pub const PADDING_SIZE: usize = ProcessManagementMessage::PAYLOAD_SIZE
+        - mem::size_of::<ProcessIdentifier>()
+        - mem::size_of::<i32>();
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new exec acknowledgement message.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Process identifier of the subject process.
+    /// - `status`: Outcome of the barrier (`0` on success, a non-zero error code on failure).
+    ///
+    pub fn new(pid: ProcessIdentifier, status: i32) -> Self {
+        Self {
+            pid,
+            status,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a byte array into an exec acknowledgement message.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Byte array.
+    ///
+    /// # Returns
+    ///
+    /// An exec acknowledgement message.
+    ///
+    pub fn from_bytes(bytes: [u8; ProcessManagementMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts an exec acknowledgement message into a byte array.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding byte array.
+    ///
+    pub fn into_bytes(self) -> [u8; ProcessManagementMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Wraps a process management message destined to `destination` into an IPC message sent from
+/// `source`.
+fn wrap(
+    source: ProcessIdentifier,
+    destination: ProcessIdentifier,
+    pm_message: ProcessManagementMessage,
+) -> Message {
+    let system_message: SystemMessage =
+        SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
+
+    Message::new(
+        MessageSender::from(source),
+        MessageReceiver::from(destination),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    )
+}
+
+///
+/// # Description
+///
+/// Builds an exec request message announcing that `pid` has replaced its image.
+///
+/// # Parameters
+///
+/// - `source`: Process identifier of the sender (the subject process when announcing to the process
+///   manager daemon, or the process manager daemon when notifying the filesystem daemon).
+/// - `destination`: Process identifier of the recipient.
+/// - `pid`: Process identifier of the subject process.
+///
+/// # Returns
+///
+/// Upon successful completion, an exec request message is returned. Otherwise, an error is returned
+/// instead.
+///
+pub fn exec_request(
+    source: ProcessIdentifier,
+    destination: ProcessIdentifier,
+    pid: ProcessIdentifier,
+) -> Result<Message, Error> {
+    let exec_message: ExecMessage = ExecMessage::new(pid);
+    let pm_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::Exec,
+        exec_message.into_bytes(),
+    );
+
+    Ok(wrap(source, destination, pm_message))
+}
+
+///
+/// # Description
+///
+/// Builds an exec acknowledgement message for the synchronization barrier of `pid`.
+///
+/// # Parameters
+///
+/// - `source`: Process identifier of the sender (the filesystem daemon when confirming to the
+///   process manager daemon, or the process manager daemon when releasing the subject process).
+/// - `destination`: Process identifier of the recipient.
+/// - `pid`: Process identifier of the subject process the acknowledgement concerns.
+/// - `status`: Outcome of the barrier (`0` on success, a non-zero error code on failure).
+///
+/// # Returns
+///
+/// Upon successful completion, an exec acknowledgement message is returned. Otherwise, an error is
+/// returned instead.
+///
+pub fn exec_ack(
+    source: ProcessIdentifier,
+    destination: ProcessIdentifier,
+    pid: ProcessIdentifier,
+    status: i32,
+) -> Result<Message, Error> {
+    let ack_message: ExecAckMessage = ExecAckMessage::new(pid, status);
+    let pm_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::ExecAck,
+        ack_message.into_bytes(),
+    );
+
+    Ok(wrap(source, destination, pm_message))
+}

--- a/src/libs/proc/src/message/mod.rs
+++ b/src/libs/proc/src/message/mod.rs
@@ -5,6 +5,7 @@
 // Modules
 //==================================================================================================
 
+mod exec;
 mod fork_clone;
 mod fork_sync;
 mod lookup;
@@ -17,6 +18,7 @@ mod wait;
 // Exports
 //==================================================================================================
 
+pub use exec::*;
 pub use fork_clone::*;
 pub use fork_sync::*;
 pub use lookup::*;
@@ -78,6 +80,13 @@ pub enum ProcessManagementMessageHeader {
     /// Process-exit notification (used to notify other daemons to reclaim a terminated process's
     /// per-process state).
     ProcessExit = 13,
+    /// Exec notification (a freshly `exec`'d process asks the process manager daemon to apply
+    /// close-on-exec to its inherited descriptor table, and the process manager daemon relays this
+    /// to the filesystem daemon).
+    Exec = 14,
+    /// Exec acknowledgement (the filesystem daemon confirms close-on-exec was applied, and the
+    /// process manager daemon releases the held process).
+    ExecAck = 15,
 }
 
 impl TryFrom<u8> for ProcessManagementMessageHeader {
@@ -96,6 +105,8 @@ impl TryFrom<u8> for ProcessManagementMessageHeader {
             11 => Ok(ProcessManagementMessageHeader::ForkSync),
             12 => Ok(ProcessManagementMessageHeader::ForkSyncAck),
             13 => Ok(ProcessManagementMessageHeader::ProcessExit),
+            14 => Ok(ProcessManagementMessageHeader::Exec),
+            15 => Ok(ProcessManagementMessageHeader::ExecAck),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid process management message")),
         }
     }
@@ -115,6 +126,8 @@ impl From<&ProcessManagementMessageHeader> for u8 {
             ProcessManagementMessageHeader::ForkSync => 11,
             ProcessManagementMessageHeader::ForkSyncAck => 12,
             ProcessManagementMessageHeader::ProcessExit => 13,
+            ProcessManagementMessageHeader::Exec => 14,
+            ProcessManagementMessageHeader::ExecAck => 15,
         }
     }
 }

--- a/src/libs/syscall/src/unistd/exec/mod.rs
+++ b/src/libs/syscall/src/unistd/exec/mod.rs
@@ -417,3 +417,194 @@ pub unsafe fn execv_inherit_env_from_c(path: *const c_char, argv: *const *const 
 
     do_execv(path, &argv_vec, &env_tokens)
 }
+
+//==================================================================================================
+// Exec Startup Barrier
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Synchronizes a freshly started image with the process daemons before it runs `main`, applying
+/// the close-on-exec half of POSIX `execv()` semantics.
+///
+/// A successful `execv()` never returns: the kernel replaces the image in place and transfers
+/// control to the new image's `crt0`, which calls this. Two facts make a barrier necessary here.
+/// First, the per-process descriptor table lives in `vfsd` and survives the image replacement, but
+/// `vfsd` is not told the `exec` happened, so its `FD_CLOEXEC` descriptors are still present.
+/// Second, this image's resolution cache was wiped along with BSS, so it must be rebuilt against the
+/// post-close-on-exec table — never the pre-`exec` one.
+///
+/// This requests that the process manager daemon hold the calling process until `vfsd` has dropped
+/// its `FD_CLOEXEC` descriptors, then proceeds. Because the daemon releases the process only after
+/// that close-on-exec has been applied, the empty cache is afterwards rebuilt lazily on first use
+/// (each miss resolves authoritatively against `vfsd`) and a descriptor flagged `FD_CLOEXEC` is
+/// provably gone before this image can observe it.
+///
+/// The barrier is best-effort: the image has already been replaced and an `exec` cannot be undone,
+/// so any failure to reach the daemons is logged and tolerated rather than blocking `main` forever.
+///
+/// This runs at the start of every standalone image — both a genuine `exec` and a fresh process
+/// start. For a fresh start there are no `FD_CLOEXEC` descriptors to drop, so the round-trip is a
+/// harmless no-op against an empty or console-only table. The process manager daemon itself (and
+/// any minimal deployment whose root image runs as pid `PROCD`) has no distinct peer to query, so
+/// it skips the barrier entirely rather than address the request to itself.
+///
+#[cfg(feature = "standalone")]
+pub fn exec_startup_barrier() {
+    use ::proc::{
+        exec_request,
+        ExecAckMessage,
+        ProcessManagementMessage,
+        ProcessManagementMessageHeader,
+    };
+    use ::sys::{
+        ipc::{
+            Message,
+            MessageType,
+            SystemMessage,
+            SystemMessageHeader,
+        },
+        pm::ProcessIdentifier,
+    };
+
+    // Identify ourselves so the barrier names the right subject and the process manager daemon can
+    // release us by pid.
+    let pid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+        Ok(pid) => pid,
+        Err(error) => {
+            ::syslog::warn!("exec_startup_barrier(): failed to get pid: {error:?}");
+            return;
+        },
+    };
+
+    // If this image is itself the process manager daemon, there is no distinct peer to synchronize
+    // with: the request below is addressed to `PROCD`, which is our own pid, so it would loop
+    // straight back to us instead of eliciting an independent acknowledgement — and a process
+    // parked in this barrier cannot service its own mailbox to produce one, so the wait could never
+    // complete. This also covers minimal deployments where the root image runs as pid `PROCD` with
+    // no separate daemon. In either case there is no foreign descriptor table to reconcile, so the
+    // barrier is a no-op.
+    if pid == ProcessIdentifier::PROCD {
+        return;
+    }
+
+    // Announce the image start to the process manager daemon and ask to be held until the
+    // filesystem daemon has applied close-on-exec to our inherited descriptor table.
+    let request: Message = match exec_request(pid, ProcessIdentifier::PROCD, pid) {
+        Ok(request) => request,
+        Err(error) => {
+            ::syslog::warn!("exec_startup_barrier(): failed to build exec request: {error:?}");
+            return;
+        },
+    };
+    if let Err(error) = ::sys::kcall::ipc::__kcall_send(&request) {
+        ::syslog::warn!("exec_startup_barrier(): failed to send exec request: {error:?}");
+        return;
+    }
+
+    // Wait for the process manager daemon to release us. `execv` succeeds only when the kernel can
+    // replace the image, and procd answers an exec request exactly once — with success once vfsd
+    // has applied close-on-exec, or with a failure status if the relay could not be dispatched — so
+    // exactly one acknowledgement is expected, and it is the only message in flight before `main`.
+    //
+    // The wait is therefore a single receive: validate the reply and proceed. The image has already
+    // been replaced and the exec cannot be undone, so a malformed, misdelivered, or failing reply
+    // is logged and tolerated rather than retried. A retry loop would be unsafe here, not just
+    // unhelpful: crt0 has no non-blocking or timed receive primitive, so a second receive after an
+    // unexpected first message would block with nothing left to deliver. The self-addressed case
+    // (this image is `PROCD`) is already excluded above, so a separate procd is guaranteed to be
+    // the sender; a genuinely silent procd is a daemon-crash scenario beyond what the barrier can
+    // recover, exactly as for the fork barrier this mirrors.
+    let message: Message = match ::sys::kcall::ipc::__kcall_recv() {
+        Ok(message) => message,
+        Err(error) => {
+            ::syslog::warn!("exec_startup_barrier(): failed to receive exec ack: {error:?}");
+            return;
+        },
+    };
+
+    let sender = message.source;
+    let source: ProcessIdentifier = match sender.as_id() {
+        Ok(source) => source,
+        Err(tid) => {
+            ::syslog::warn!(
+                "exec_startup_barrier(): unexpected non-process message source while awaiting \
+                 exec ack (tid={tid:?})"
+            );
+            return;
+        },
+    };
+    if source != ProcessIdentifier::PROCD {
+        ::syslog::warn!(
+            "exec_startup_barrier(): unexpected message source while awaiting exec ack \
+             (source={source:?})"
+        );
+        return;
+    }
+    if !matches!(message.message_type, MessageType::Ipc) {
+        ::syslog::warn!(
+            "exec_startup_barrier(): unexpected message type while awaiting exec ack ({:?})",
+            message.message_type
+        );
+        return;
+    }
+    let system_message: SystemMessage = match SystemMessage::from_bytes(message.payload) {
+        Ok(system_message) => system_message,
+        Err(error) => {
+            ::syslog::warn!("exec_startup_barrier(): malformed system message: {error:?}");
+            return;
+        },
+    };
+    if !matches!(system_message.header, SystemMessageHeader::ProcessManagement) {
+        ::syslog::warn!(
+            "exec_startup_barrier(): unexpected system message while awaiting exec ack ({:?})",
+            system_message.header
+        );
+        return;
+    }
+    let pm_message: ProcessManagementMessage =
+        match ProcessManagementMessage::from_bytes(system_message.payload) {
+            Ok(pm_message) => pm_message,
+            Err(error) => {
+                ::syslog::warn!("exec_startup_barrier(): malformed process message: {error:?}");
+                return;
+            },
+        };
+    match pm_message.header {
+        ProcessManagementMessageHeader::ExecAck => {
+            let ack: ExecAckMessage = ExecAckMessage::from_bytes(pm_message.payload);
+            let ack_pid: ProcessIdentifier = ack.pid;
+            if ack_pid != pid {
+                ::syslog::warn!(
+                    "exec_startup_barrier(): exec ack named another process (expected={pid:?}, \
+                     got={:?})",
+                    ack_pid
+                );
+                return;
+            }
+            let status: i32 = ack.status;
+            if status != ExecAckMessage::STATUS_SUCCESS {
+                ::syslog::warn!(
+                    "exec_startup_barrier(): barrier reported failure (status={status})"
+                );
+            }
+        },
+        header => {
+            ::syslog::warn!(
+                "exec_startup_barrier(): unexpected process message while awaiting exec ack \
+                 ({header:?})"
+            );
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// In run modes without a guest `vfsd`/`procd`, descriptors are interpreted directly by the host
+/// and there is no flat descriptor table to synchronize with, so the exec startup barrier is a
+/// no-op.
+///
+#[cfg(not(feature = "standalone"))]
+pub fn exec_startup_barrier() {}

--- a/src/libs/syscall/src/unistd/mod.rs
+++ b/src/libs/syscall/src/unistd/mod.rs
@@ -22,6 +22,7 @@ cfg_if::cfg_if! {
         pub mod exec;
         pub use self::exec::{
             do_execv,
+            exec_startup_barrier,
             execv_from_c,
             execv_inherit_env_from_c,
         };

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -1038,6 +1038,100 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     }
 }
 
+/// Applies close-on-exec to a process's descriptor table when it replaces its image.
+///
+/// Walks `pid`'s slot table and drops every descriptor whose per-descriptor flags carry
+/// `FD_CLOEXEC`, leaving the surviving descriptors at their original numbers. Each dropped slot
+/// runs the same last-reference accounting as [`vfs_process_exit`]: a host-backed description for
+/// which `pid` held the final reference is surfaced for closing on hostfsd, and a pipe end whose
+/// reference count reaches zero is surfaced so the daemon can fire the EOF/`EPIPE` wakeup for any
+/// suspended counterpart. Descriptions still shared with a surviving descriptor — in this process
+/// (for example a non-`FD_CLOEXEC` `dup` sibling) or another (a forked relative) — are not
+/// reclaimed.
+///
+/// The table generation is bumped once when at least one descriptor is dropped, so the new image's
+/// resolution cache (rebuilt after this returns) observes the post-close-on-exec table rather than
+/// the pre-exec one. Unlike [`vfs_process_exit`], the process itself is retained: only its
+/// close-on-exec descriptors are removed. Applying close-on-exec to an unknown `pid`, or to one
+/// with no `FD_CLOEXEC` descriptor, is a no-op that reclaims nothing.
+///
+/// The barrier in the process manager daemon guarantees this runs before the new image issues any
+/// descriptor operation, so a descriptor flagged `FD_CLOEXEC` is provably gone before the new image
+/// can observe it.
+#[must_use = "the returned hostfs fds must be closed and pipe closures must trigger wakeups"]
+pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
+    // Detach the close-on-exec slots while holding the registry lock, but defer dropping the open
+    // file descriptions they hold until the lock is released. Dropping a description may run
+    // backend teardown; deferring keeps the registry lock from ever nesting with backend locks,
+    // matching `vfs_close` and `vfs_process_exit`.
+    let removed_slots: Vec<Slot> = {
+        let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
+            PROCESSES.lock();
+        let Some(state) = procs.get_mut(&pid) else {
+            return ProcessExitReclaim {
+                orphaned_hostfs_fds: Vec::new(),
+                pipe_closures: Vec::new(),
+            };
+        };
+        // Identify the close-on-exec descriptors first, then remove them. Collecting the numbers up
+        // front avoids mutating the map while iterating it.
+        let cloexec_fds: Vec<c_int> = state
+            .slots
+            .iter()
+            .filter(|(_, slot)| slot.fd_flags.close_on_exec())
+            .map(|(fd, _)| *fd)
+            .collect();
+        if cloexec_fds.is_empty() {
+            return ProcessExitReclaim {
+                orphaned_hostfs_fds: Vec::new(),
+                pipe_closures: Vec::new(),
+            };
+        }
+        let mut removed: Vec<Slot> = Vec::with_capacity(cloexec_fds.len());
+        for fd in cloexec_fds {
+            if let Some(slot) = state.slots.remove(&fd) {
+                removed.push(slot);
+            }
+        }
+        // The removals are the only table mutation here, so bump the generation exactly once now
+        // that at least one descriptor was dropped.
+        state.bump_generation();
+        removed
+    };
+    // The registry lock has been released and the removed slots are owned here, so an `Arc` strong
+    // count of one means no surviving descriptor — in this or any other process — still shares the
+    // open file description, exactly as in `vfs_process_exit`. A host-backed handle must therefore
+    // be closed on hostfsd, and a pipe end's count drops to zero (which the dropped end's `Drop`
+    // applies as each slot leaves scope below).
+    let mut orphaned: Vec<i32> = Vec::new();
+    let mut pipe_closures: Vec<PipeClosure> = Vec::new();
+    for slot in removed_slots {
+        if Arc::strong_count(&slot.file) != 1 {
+            continue;
+        }
+        match &slot.file.lock().handle {
+            VfsFileHandle::HostFs(h) => orphaned.push(h.remote_fd()),
+            VfsFileHandle::Pipe(end) => pipe_closures.push(PipeClosure {
+                pipe_id: end.pipe_id(),
+                was_write: end.is_write(),
+            }),
+            // A console token holds no external resource, so it contributes nothing to reclaim.
+            VfsFileHandle::Console(_) => {},
+            // A socket token holds the `networkd` descriptor, but closing it on last reference is
+            // wired in a later plan; nothing is reclaimed here yet. This arm must stay distinct so
+            // a socket is never mistaken for a hostfs or pipe handle.
+            VfsFileHandle::Socket(_) => {},
+            _ => {},
+        }
+        // `slot` — and the open file description it holds — is dropped here, after the registry lock
+        // has been released; a pipe end's `Drop` decrements its reader/writer count as part of that.
+    }
+    ProcessExitReclaim {
+        orphaned_hostfs_fds: orphaned,
+        pipe_closures,
+    }
+}
+
 /// Reports whether `fd` is the last descriptor referencing its open file description.
 ///
 /// Returns `true` if closing `fd` in the current process would drop the final reference to the
@@ -3361,6 +3455,162 @@ mod tests {
         );
 
         forget_processes(&[parent, child]);
+    }
+
+    /// Tests that applying close-on-exec drops only the descriptors flagged `FD_CLOEXEC`, leaves
+    /// every other descriptor at its number, and advances the table generation so the new image's
+    /// cache is rebuilt against the post-close-on-exec table.
+    #[test]
+    fn exec_cloexec_drops_flagged_and_keeps_others() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7261);
+        set_current_process(pid);
+
+        // One descriptor flagged close-on-exec, one left unflagged.
+        let cloexec_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+                .expect("console alloc should succeed");
+        let kept_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stderr)))
+                .expect("console alloc should succeed");
+        let mut cloexec: FdFlags = FdFlags::default();
+        cloexec.set_close_on_exec(true);
+        vfs_set_fd_flags(cloexec_fd, cloexec).expect("setting close-on-exec should succeed");
+        let generation_before: u64 =
+            registry_generation(pid).expect("generation should be recorded");
+
+        // A console token holds no external resource, so nothing is reclaimed.
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "console drop orphans no hostfs fd");
+        assert!(reclaim.pipe_closures.is_empty(), "console drop closes no pipe end");
+
+        // The flagged descriptor is gone; the unflagged one survives at its number.
+        assert_eq!(vfs_get_fd_flags(cloexec_fd), None, "close-on-exec descriptor must be dropped");
+        assert!(vfs_resolve(cloexec_fd).is_none(), "the dropped descriptor must not resolve");
+        assert!(vfs_get_fd_flags(kept_fd).is_some(), "an unflagged descriptor must survive");
+        assert!(vfs_resolve(kept_fd).is_some(), "the surviving descriptor must still resolve");
+        assert!(
+            registry_generation(pid).expect("generation should be recorded") > generation_before,
+            "dropping a close-on-exec descriptor must advance the generation"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that applying close-on-exec runs the same last-reference accounting as `close`: a
+    /// host-backed descriptor for which the process held the final reference is surfaced for
+    /// closing on hostfsd, and a pipe end whose count reaches zero is surfaced so the daemon can
+    /// wake its counterpart.
+    #[test]
+    fn exec_cloexec_reports_pipe_and_hostfs_reclaim() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7262);
+        set_current_process(pid);
+
+        // A pipe whose write end is flagged close-on-exec; the read end stays unflagged.
+        let (read_fd, write_fd): (c_int, c_int) = vfs_pipe().expect("pipe creation should succeed");
+        let (pipe_id, _): (u64, bool) = vfs_pipe_id(write_fd).expect("write fd should be a pipe");
+        let mut cloexec: FdFlags = FdFlags::default();
+        cloexec.set_close_on_exec(true);
+        vfs_set_fd_flags(write_fd, cloexec).expect("setting close-on-exec should succeed");
+        // A host-backed descriptor, also flagged close-on-exec, for which this process is the sole
+        // reference.
+        let hostfs_fd: c_int =
+            vfs_alloc_hostfs(70, false, None).expect("hostfs alloc should succeed");
+        vfs_set_fd_flags(hostfs_fd, cloexec).expect("setting close-on-exec should succeed");
+
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert_eq!(
+            reclaim.orphaned_hostfs_fds.len(),
+            1,
+            "the host-backed descriptor's remote fd must be reclaimed"
+        );
+        assert_eq!(reclaim.orphaned_hostfs_fds[0], 70, "the reclaimed remote fd must be 70");
+        assert_eq!(reclaim.pipe_closures.len(), 1, "exactly the write end is reclaimed");
+        assert_eq!(reclaim.pipe_closures[0].pipe_id, pipe_id, "the closure targets our pipe");
+        assert!(reclaim.pipe_closures[0].was_write, "the reclaimed end is the write end");
+
+        // The read end survives because it was not flagged.
+        assert!(vfs_resolve(read_fd).is_some(), "the unflagged read end must survive");
+        assert_eq!(vfs_get_fd_flags(write_fd), None, "the flagged write end must be dropped");
+        assert_eq!(
+            vfs_get_fd_flags(hostfs_fd),
+            None,
+            "the flagged hostfs descriptor must be dropped"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that applying close-on-exec to a process with no flagged descriptor is a no-op: every
+    /// descriptor survives, nothing is reclaimed, and the generation is left unchanged.
+    #[test]
+    fn exec_cloexec_without_flagged_is_noop() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7263);
+        set_current_process(pid);
+
+        let fd: c_int = alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+            .expect("console alloc should succeed");
+        let generation_before: u64 =
+            registry_generation(pid).expect("generation should be recorded");
+
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "nothing is reclaimed");
+        assert!(reclaim.pipe_closures.is_empty(), "nothing is reclaimed");
+        assert!(vfs_resolve(fd).is_some(), "the unflagged descriptor survives");
+        assert_eq!(
+            registry_generation(pid).expect("generation should be recorded"),
+            generation_before,
+            "a no-op must not advance the generation"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that applying close-on-exec to an unregistered process reclaims nothing and does not
+    /// panic.
+    #[test]
+    fn exec_cloexec_unknown_pid_is_noop() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7264);
+        // Deliberately leave the process unregistered.
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "an unknown process reclaims nothing");
+        assert!(reclaim.pipe_closures.is_empty(), "an unknown process reclaims nothing");
+    }
+
+    /// Tests that close-on-exec last-reference accounting respects shared open file descriptions: a
+    /// host-backed description still referenced by a surviving `dup` sibling is not reclaimed when
+    /// its close-on-exec alias is dropped.
+    #[test]
+    fn exec_cloexec_shared_description_not_reclaimed() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7265);
+        set_current_process(pid);
+
+        // A host-backed descriptor duplicated onto a second number: the two share one description.
+        let hostfs_fd: c_int =
+            vfs_alloc_hostfs(71, false, None).expect("hostfs alloc should succeed");
+        let dup_fd: c_int = vfs_dup(hostfs_fd).expect("dup should succeed");
+        // Flag only the original close-on-exec; the dup sibling stays unflagged.
+        let mut cloexec: FdFlags = FdFlags::default();
+        cloexec.set_close_on_exec(true);
+        vfs_set_fd_flags(hostfs_fd, cloexec).expect("setting close-on-exec should succeed");
+
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert!(
+            reclaim.orphaned_hostfs_fds.is_empty(),
+            "a description still held by a dup sibling must not be reclaimed"
+        );
+        assert_eq!(vfs_get_fd_flags(hostfs_fd), None, "the flagged alias must be dropped");
+        assert_eq!(
+            vfs_hostfs_remote_fd(dup_fd),
+            Some(71),
+            "the surviving dup sibling must keep the description"
+        );
+
+        forget_processes(&[pid]);
     }
 
     /// Tests that `F_SETFD` stores the per-descriptor flags and `F_GETFD` reads them back

--- a/src/tests/execv-target/src/main.rs
+++ b/src/tests/execv-target/src/main.rs
@@ -13,9 +13,70 @@ extern crate libc_string;
 extern crate nvx;
 extern crate nvx_crt0;
 
-use ::sys::error::Error;
-use ::sysapi::unistd::STDOUT_FILENO;
-use ::syscall::unistd;
+use ::core::sync::atomic::Ordering;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    fcntl::file_control_request::F_GETFD,
+    unistd::STDOUT_FILENO,
+};
+use ::syscall::{
+    fcntl,
+    unistd,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns the second command-line argument, which carries the descriptor number opened by the
+/// image that called `execv()`.
+fn inherited_fd_arg() -> Result<&'static str, Error> {
+    let argc: i32 = ::nvx_crt0::ARGC.load(Ordering::SeqCst);
+    if argc < 2 {
+        ::syslog::error!("execv-target: missing inherited fd argument (argc={argc})");
+        return Err(Error::new(ErrorCode::InvalidArgument, "missing inherited fd argument"));
+    }
+    let argv: *const *const u8 = ::nvx_crt0::ARGV.load(Ordering::SeqCst) as *const *const u8;
+    if argv.is_null() {
+        ::syslog::error!("execv-target: argv is null");
+        return Err(Error::new(ErrorCode::InvalidArgument, "argv is null"));
+    }
+    let arg: *const u8 = unsafe { *argv.add(1) };
+    if arg.is_null() {
+        ::syslog::error!("execv-target: fd argument is null");
+        return Err(Error::new(ErrorCode::InvalidArgument, "fd argument is null"));
+    }
+    unsafe { ::core::ffi::CStr::from_ptr(arg.cast()) }
+        .to_str()
+        .map_err(|_| {
+            ::syslog::error!("execv-target: fd argument is not UTF-8");
+            Error::new(ErrorCode::InvalidArgument, "fd argument is not UTF-8")
+        })
+}
+
+/// Parses a non-negative decimal file descriptor.
+fn parse_fd(arg: &str) -> Result<i32, Error> {
+    let mut value: i32 = 0;
+    if arg.is_empty() {
+        ::syslog::error!("execv-target: empty fd argument");
+        return Err(Error::new(ErrorCode::InvalidArgument, "empty fd argument"));
+    }
+    for byte in arg.bytes() {
+        if !byte.is_ascii_digit() {
+            ::syslog::error!("execv-target: fd argument is not decimal (arg={arg:?})");
+            return Err(Error::new(ErrorCode::InvalidArgument, "fd argument is not decimal"));
+        }
+        let digit: i32 = i32::from(byte - b'0');
+        value = value
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(digit))
+            .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "fd argument overflowed"))?;
+    }
+    Ok(value)
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -30,6 +91,24 @@ use ::syscall::unistd;
 ///
 #[unsafe(no_mangle)]
 pub fn main() -> Result<(), Error> {
+    let fd: i32 = parse_fd(inherited_fd_arg()?)?;
+    match fcntl::fcntl(fd, F_GETFD, None) {
+        Ok(_) => {
+            ::syslog::error!("execv-target: FD_CLOEXEC descriptor survived (fd={fd})");
+            unistd::write(STDOUT_FILENO, "failed".as_bytes())?;
+            return Err(Error::new(
+                ErrorCode::InvalidFileDescriptor,
+                "FD_CLOEXEC descriptor survived",
+            ));
+        },
+        Err(error)
+            if matches!(error.code, ErrorCode::InvalidFileDescriptor | ErrorCode::BadFile) => {},
+        Err(error) => {
+            ::syslog::error!("execv-target: fcntl(F_GETFD) failed unexpectedly (error={error:?})");
+            return Err(error);
+        },
+    }
+
     let magic_string: &[u8] = "ok".as_bytes();
     unistd::write(STDOUT_FILENO, magic_string)?;
 

--- a/src/tests/execv-test/src/main.rs
+++ b/src/tests/execv-test/src/main.rs
@@ -14,7 +14,19 @@ extern crate nvx;
 extern crate nvx_crt0;
 
 use ::sys::error::Error;
-use ::syscall::unistd::do_execv;
+use ::sysapi::fcntl::{
+    atflags::AT_FDCWD,
+    file_access_mode::O_RDONLY,
+    file_control_request::{
+        F_DUPFD,
+        F_SETFD,
+    },
+    file_descriptor_flags::FD_CLOEXEC,
+};
+use ::syscall::{
+    fcntl,
+    unistd::do_execv,
+};
 
 //==================================================================================================
 // Constants
@@ -22,6 +34,34 @@ use ::syscall::unistd::do_execv;
 
 /// Path of the target program in the mounted ramfs (mounted at the filesystem root).
 const TARGET_PATH: &str = "/target";
+/// Maximum length of a decimal file descriptor string plus NUL terminator.
+const FD_ARG_CAPACITY: usize = 12;
+/// Minimum descriptor number used for the close-on-exec probe.
+const CLOEXEC_PROBE_MIN_FD: i32 = 32;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Formats `fd` as a decimal string in `buffer` and returns the initialized prefix.
+fn format_fd_arg(fd: i32, buffer: &mut [u8; FD_ARG_CAPACITY]) -> &str {
+    let mut value: u32 = fd as u32;
+    let mut digits: [u8; FD_ARG_CAPACITY] = [0; FD_ARG_CAPACITY];
+    let mut len: usize = 0;
+    loop {
+        digits[len] = b'0' + (value % 10) as u8;
+        value /= 10;
+        len += 1;
+        if value == 0 {
+            break;
+        }
+    }
+    for index in 0..len {
+        buffer[index] = digits[len - 1 - index];
+    }
+    // SAFETY: all bytes written above are ASCII decimal digits.
+    unsafe { ::core::str::from_utf8_unchecked(&buffer[..len]) }
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -36,9 +76,16 @@ const TARGET_PATH: &str = "/target";
 ///
 #[unsafe(no_mangle)]
 pub fn main() -> Result<(), Error> {
+    let fd: i32 = fcntl::openat(AT_FDCWD, TARGET_PATH, O_RDONLY, 0)?;
+    let cloexec_fd: i32 = fcntl::fcntl(fd, F_DUPFD, Some(CLOEXEC_PROBE_MIN_FD))?;
+    ::syscall::unistd::close(fd)?;
+    fcntl::fcntl(cloexec_fd, F_SETFD, Some(FD_CLOEXEC))?;
+    let mut fd_arg_buffer: [u8; FD_ARG_CAPACITY] = [0; FD_ARG_CAPACITY];
+    let fd_arg: &str = format_fd_arg(cloexec_fd, &mut fd_arg_buffer);
+
     // Replace this image with the target program. The argument vector's first element is the
     // conventional program name.
-    let error: Error = do_execv(TARGET_PATH, &["target"], &[]);
+    let error: Error = do_execv(TARGET_PATH, &["target", fd_arg], &[]);
 
     // Only reached if execv() failed; surface the error so the test fails with a non-zero status.
     ::syslog::error!("execv({TARGET_PATH}) failed: {error:?}");


### PR DESCRIPTION
## Summary

Implements the close-on-exec half of POSIX `execv()`. A successful `execv()` replaces the image in place and transfers control to the new image's `crt0` without notifying `vfsd`, so `vfsd`'s per-process flat descriptor table still carries the previous image's `FD_CLOEXEC` descriptors, and the new image's resolution cache was wiped with BSS. This change has the freshly started image synchronize with the process daemons before any application code runs, so `FD_CLOEXEC` descriptors are dropped before the new image can observe them.

## Flow

- The new image calls `exec_startup_barrier()` from `crt0` (before `main`) and asks `procd` to hold it until close-on-exec has been applied.
- `procd` relays the request to `vfsd` and parks the caller in `pending_execs`.
- `vfsd` drops the process's `FD_CLOEXEC` descriptors, runs the same last-reference accounting as `close` (hostfs remote close, pipe EOF/`EPIPE` wakeups), bumps the table generation, and acknowledges `procd`.
- `procd` releases the held process, so its lazily rebuilt resolution cache observes the post-close-on-exec table.

## Changes

- **proc**: add `Exec`/`ExecAck` process-management messages, headers, and `exec_request`/`exec_ack` builders/exports.
- **proc daemon**: track `pending_execs`; add `handle_exec_sync`, `notify_exec`, `handle_exec_ack`, `release_exec_sync`. Relay failures release the process best-effort rather than stranding it; pending-exec bookkeeping is dropped on termination to avoid leaking across pid reuse. `ExecAck` is accepted only from `vfsd`.
- **vfsd ipc**: handle the `Exec` message — bind the VFS to the exec'ing process, seed the root console if needed, apply close-on-exec, fire pipe wakeups, fire-and-forget close orphaned hostfs fds, and acknowledge `procd`.
- **vfs**: add `vfs_exec_cloexec`, which removes every `FD_CLOEXEC` slot, defers dropping open file descriptions until the registry lock is released, surfaces hostfs/pipe reclaim for last references, and bumps the table generation once. Unknown/unflagged pids are a no-op.
- **syscall**: add `exec_startup_barrier` (standalone) that announces the image to `procd` and blocks for the release ack, validating it is an `ExecAck` from `PROCD` naming the current pid; a no-op variant covers run modes without a guest `vfsd`/`procd`.
- **posix**: invoke `exec_startup_barrier` from `__nanvix_libc_start_main` before dispatching into `main`.

## Testing

- Extends the `execv-small` integration test to cover close-on-exec across `execv`: the caller opens `/target`, duplicates it to a high descriptor, marks that descriptor `FD_CLOEXEC`, and passes it to the target; the target confirms the descriptor is gone after image replacement before printing the success sentinel.
- Validated with `vfs` host unit tests, `./z build -- run-unit-tests`, and `./z build -- run-nanvix-tests` (`execv-small` and `execv-big` pass).


## Issues

Closes #2599