### PR TITLE
[kernel] Guarantee per-process creation-before-termination event ordering

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -216,13 +216,21 @@ struct EventManagerInner {
     pending_exceptions:
         [LinkedList<(EventDescriptor, ExceptionEventInformation, Condvar)>; usize::BITS as usize],
     scheduling_owner: Option<ProcessIdentifier>,
-    pending_scheduling:
-        [LinkedList<(EventDescriptor, SchedulingNotification)>; SchedulingEvent::NUMBER_EVENTS],
-    /// Round-robin cursor selecting which scheduling sub-queue is scanned first on the next
-    /// delivery. Advanced past a sub-queue each time an event is delivered from it, so successive
-    /// deliveries alternate between sub-queues and neither process-creation nor process-termination
-    /// events can starve the other.
-    scheduling_cursor: usize,
+    /// Pending scheduling-event notifications delivered in strict FIFO order. A single
+    /// totally-ordered queue (rather than per-event-type sub-queues drained round-robin) guarantees
+    /// that a process's creation event is delivered before its termination event: the kernel main
+    /// loop publishes a process's creation ahead of its termination, and a process is always created
+    /// before it terminates, so the creation is enqueued before the termination and FIFO delivery
+    /// preserves that order. This per-process creation-before-termination invariant lets the
+    /// scheduling-event owner (`procd`) record a child's lineage from its creation before handling
+    /// its termination, with no out-of-order reconciliation.
+    ///
+    /// Each entry also carries the global [`EventDescriptor`] stamped at generation time. Delivery
+    /// does not consult it today, because this single FIFO queue already yields insertion order
+    /// (hence event-id order); it is retained for uniformity with the interrupt and exception
+    /// queues, which likewise stamp every entry, and for the planned unified FIFO-by-event-id
+    /// delivery tracked in #2558.
+    pending_scheduling: LinkedList<(EventDescriptor, SchedulingNotification)>,
 }
 
 impl EventManagerInner {
@@ -505,69 +513,43 @@ impl EventManagerInner {
 
             // Check if any scheduling events were triggered.
             if ((self.nevents + i) % Self::NUMBER_EVENTS) == 2 {
-                // Deliver scheduling events with a round-robin sub-queue scan rather than a fixed
-                // priority, so neither process-creation nor process-termination events can starve
-                // the other. The scan starts at `scheduling_cursor`, which is advanced past a
-                // sub-queue each time an event is delivered from it (below). Because the cursor
-                // advances on delivery rather than on event generation, successive deliveries
-                // alternate between sub-queues even while a subscriber drains an already-queued
-                // backlog with no new events being generated: a sustained stream of one event class
-                // cannot indefinitely delay delivery of the other. The scan returns on the first
-                // hit, so at most one scheduling event is delivered per call.
-                //
-                // Delivery order is an optimization, not a correctness requirement: this scan does
-                // not prefer creations, so a termination can be delivered before a creation that is
-                // queued at the same time (including on the first delivery, when the cursor still
-                // starts at slot 0). `procd` records a child's lineage from its creation event;
-                // if it instead observes an orphan termination first, it buffers the exit status in
-                // `early_terminations` and reconciles it once the creation arrives. Publishing
-                // creations ahead of terminations in the kernel main loop only biases delivery
-                // toward the creation-first order and keeps that buffering window small in the
-                // common case, while the round-robin here guarantees terminations are never starved
-                // behind a continuous burst of creations (and vice versa).
-                //
-                // FIXME(#2558): this round-robin only approximates fairness. Replacing it with
-                // FIFO delivery ordered by the global event id stamped on each queued entry would
-                // be structurally starvation-free without cursor bookkeeping. Tracked as follow-up
-                // work.
-                for k in 0..SchedulingEvent::NUMBER_EVENTS {
-                    let slot: usize = (self.scheduling_cursor + k) % SchedulingEvent::NUMBER_EVENTS;
-                    if (scheduling & (1 << slot)) != 0 {
-                        if let Some((_ev, notification)) = self.pending_scheduling[slot].pop_front()
-                        {
-                            // Serialize the notification into the head of the message payload. The
-                            // two notification variants have different serialized sizes, so each is
-                            // copied using its own length.
-                            let mut payload: [u8; Message::PAYLOAD_SIZE] =
-                                [0u8; Message::PAYLOAD_SIZE];
-                            let message_type: MessageType = match notification {
-                                SchedulingNotification::Termination(info) => {
-                                    let info_bytes = info.to_ne_bytes();
-                                    payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
-                                    MessageType::ProcessTerminationEvent
-                                },
-                                SchedulingNotification::Creation(info) => {
-                                    let info_bytes = info.to_ne_bytes();
-                                    payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
-                                    MessageType::ProcessCreationEvent
-                                },
-                            };
+                // Deliver scheduling events in strict FIFO order from a single totally-ordered
+                // queue. Because the kernel main loop publishes a process's creation event before
+                // its termination event, and a process is always created before it terminates, the
+                // creation is enqueued ahead of the termination; FIFO delivery therefore guarantees
+                // that the owner (`procd`) observes a process's creation before its termination, so
+                // it can record the child's lineage before handling the termination with no
+                // out-of-order reconciliation. The non-zero `scheduling` mask means the calling
+                // process owns the scheduling-event class. The scan returns on the first entry, so
+                // at most one scheduling event is delivered per call.
+                if scheduling != 0 {
+                    if let Some((_ev, notification)) = self.pending_scheduling.pop_front() {
+                        // Serialize the notification into the head of the message payload. The
+                        // two notification variants have different serialized sizes, so each is
+                        // copied using its own length.
+                        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+                        let message_type: MessageType = match notification {
+                            SchedulingNotification::Termination(info) => {
+                                let info_bytes = info.to_ne_bytes();
+                                payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
+                                MessageType::ProcessTerminationEvent
+                            },
+                            SchedulingNotification::Creation(info) => {
+                                let info_bytes = info.to_ne_bytes();
+                                payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
+                                MessageType::ProcessCreationEvent
+                            },
+                        };
 
-                            let message: Message = Message {
-                                source: MessageSender::from(ProcessIdentifier::KERNEL),
-                                destination: MessageReceiver::from(pid),
-                                message_type,
-                                status: 0,
-                                payload,
-                            };
+                        let message: Message = Message {
+                            source: MessageSender::from(ProcessIdentifier::KERNEL),
+                            destination: MessageReceiver::from(pid),
+                            message_type,
+                            status: 0,
+                            payload,
+                        };
 
-                            // Advance the round-robin cursor past the sub-queue just delivered
-                            // from, so the next delivery scans the other sub-queue first and the
-                            // two sub-queues take turns.
-                            self.scheduling_cursor = (slot + 1) % SchedulingEvent::NUMBER_EVENTS;
-
-                            return Ok(Some(message));
-                        }
+                        return Ok(Some(message));
                     }
                 }
             }
@@ -803,12 +785,13 @@ impl EventManagerInner {
         notification: SchedulingNotification,
     ) -> Result<(), Error> {
         let event: SchedulingEvent = notification.event();
-        let idx: usize = event as usize;
 
-        // Buffer the notification for delivery. The queue is bounded by the maximum number of
-        // processes so that pending entries cannot accumulate without limit while no subscriber
-        // drains them; once the queue is full, further notifications are dropped.
-        if self.pending_scheduling[idx].len() >= ::config::kernel::MAX_PROCESSES {
+        // Buffer the notification for delivery in a single FIFO queue. The queue is bounded so that
+        // pending entries cannot accumulate without limit while no subscriber drains them; once the
+        // queue is full, further notifications are dropped. The bound is twice the maximum number of
+        // processes because each process can have at most one creation and one termination
+        // notification awaiting delivery at the same time.
+        if self.pending_scheduling.len() >= 2 * ::config::kernel::MAX_PROCESSES {
             let reason: &str = "scheduling-event queue is full";
             error!("reason={:?}, event={:?}", reason, event);
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
@@ -816,7 +799,7 @@ impl EventManagerInner {
 
         self.nevents += 1;
         let eventid: EventDescriptor = EventDescriptor::new(self.nevents, Event::from(event));
-        self.pending_scheduling[idx].push_back((eventid, notification));
+        self.pending_scheduling.push_back((eventid, notification));
 
         // Wake the owning process if the scheduling-event class is currently owned. When there is
         // no owner yet, the notification stays buffered and is delivered once a subscriber
@@ -828,7 +811,7 @@ impl EventManagerInner {
                     // Waking the owner failed. Remove the notification we just buffered so that no
                     // error path of this function leaves a partially-delivered entry behind. This
                     // lets callers safely retry without risking a duplicate buffered event.
-                    self.pending_scheduling[idx].pop_back();
+                    self.pending_scheduling.pop_back();
                     return Err(e);
                 }
             },
@@ -1338,11 +1321,8 @@ pub fn init() -> Result<(), Error> {
         *entry = None;
     }
 
-    let mut pending_scheduling: [LinkedList<(EventDescriptor, SchedulingNotification)>;
-        SchedulingEvent::NUMBER_EVENTS] = unsafe { mem::zeroed() };
-    for list in pending_scheduling.iter_mut() {
-        *list = LinkedList::default();
-    }
+    let pending_scheduling: LinkedList<(EventDescriptor, SchedulingNotification)> =
+        LinkedList::default();
 
     let scheduling_owner: Option<ProcessIdentifier> = None;
 
@@ -1394,7 +1374,6 @@ pub fn init() -> Result<(), Error> {
         exception_ownership,
         pending_scheduling,
         scheduling_owner,
-        scheduling_cursor: 0,
         waiting_threads: VecDeque::new(),
         wait: Some(Condvar::new()),
     });

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -95,14 +95,13 @@ pub fn kcall_handler() -> ExitStatus {
         }
 
         // Publish process-creation scheduling events before process-termination events. A process
-        // is always created before it terminates, so draining creations first biases delivery
-        // toward a child's creation reaching `procd` ahead of its termination: when it does,
-        // `procd` records the child's lineage from the creation event before acting on the
-        // termination, keeping the termination off its `early_terminations` reconciliation path.
-        // This is only a bias, not a guarantee: `EventManager::try_wait()` scans the creation and
-        // termination sub-queues round-robin, so a termination can still be delivered ahead of a
-        // queued creation (which `procd` reconciles). Each pending record is drained while no
-        // reference to the process manager is held, so subscribers can be woken safely.
+        // is always created before it terminates, so draining creations first enqueues a child's
+        // creation ahead of its termination in the event manager's single FIFO scheduling-event
+        // queue. Because that queue is delivered in strict FIFO order, `procd` is guaranteed to
+        // observe a child's creation before its termination, so it records the child's lineage from
+        // the creation event before acting on the termination — no out-of-order reconciliation is
+        // needed. Each pending record is drained while no reference to the process manager is held,
+        // so subscribers can be woken safely.
         let mut notified_creation: bool = false;
         while let Some(info) = pm!().take_pending_creation() {
             // SAFETY: the calling process does not hold a reference to the inner state of the
@@ -123,9 +122,12 @@ pub fn kcall_handler() -> ExitStatus {
         }
 
         // Publish process-termination scheduling events for harvested processes after attempting to
-        // publish any pending creations. This preserves creation-before-termination ordering when
-        // both events can be delivered; under backpressure (e.g., the creation scheduling queue is
-        // full), terminations may still be published and `procd` may need to reconcile them.
+        // publish any pending creations. Draining terminations after creations enqueues each
+        // termination behind the matching creation in the event manager's single FIFO
+        // scheduling-event queue, so `procd` always observes a creation before the matching
+        // termination. The ordering also holds under backpressure: the shared queue fills while
+        // draining creations above, so a termination whose creation could not be enqueued simply
+        // fails to enqueue too and is requeued for a later iteration.
         let mut notified_termination: bool = false;
         while let Some(info) = pm!().take_pending_termination() {
             // SAFETY: the calling process does not hold a reference to the inner state of the

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -169,18 +169,6 @@ pub struct ProcessDaemon {
     /// Parents currently blocked in a `Wait` operation. A blocking `waitpid()` is parked here and
     /// answered later, when a `ProcessTermination` event for a matching child arrives.
     blocked: Vec<BlockedWaiter>,
-    /// Terminations observed before the corresponding process-creation event, stored as
-    /// `(pid, status)` pairs. The kernel publishes creation events ahead of termination events in
-    /// its main loop, so lineage is usually recorded before the termination arrives. A termination
-    /// can still be observed first for two reasons: the creation event may not have been
-    /// delivered yet (e.g. the scheduling-event queue was momentarily full and the creation was
-    /// requeued), and even when both are already queued the kernel scans the creation and
-    /// termination sub-queues round-robin, so it may deliver the termination first. In either case
-    /// procd can learn that a child died while the child is still unknown. The status is buffered
-    /// here and replayed once the creation event records the child's lineage, so the exit status
-    /// is never dropped and a parent blocked in `waitpid()` is always answered. A `Vec` suffices
-    /// because only a handful of terminations are ever pending reconciliation at once.
-    early_terminations: Vec<(ProcessIdentifier, i32)>,
 }
 
 impl ProcessDaemon {
@@ -211,7 +199,6 @@ impl ProcessDaemon {
             pending_fork_syncs: Vec::new(),
             pending_execs: Vec::new(),
             blocked: Vec::new(),
-            early_terminations: Vec::new(),
         })
     }
 
@@ -371,30 +358,6 @@ impl ProcessDaemon {
             }
         }
 
-        // Replay a termination that was observed before this creation event. The kernel normally
-        // publishes creations ahead of terminations, but a termination can still arrive first when
-        // the creation event could not be delivered yet (e.g. the scheduling-event queue was
-        // momentarily full and the creation was requeued), so procd may have seen this child die
-        // while it was still unknown and buffered the exit status. Now that the child's lineage is
-        // recorded and its fork-clone has been dispatched to the filesystem daemon above, reclaim
-        // its filesystem state (ordered after the fork-clone, so the snapshot is taken before it is
-        // torn down) and finalize the termination, so a parent blocked in `waitpid()` receives the
-        // exit status instead of blocking forever on a child that can never terminate again.
-        if let Some(pos) = self
-            .early_terminations
-            .iter()
-            .position(|(p, _)| *p == child)
-        {
-            let (_, status) = self.early_terminations.swap_remove(pos);
-            ::syslog::info!(
-                "reconciling buffered termination (child={:?}, status={:?})",
-                child,
-                status
-            );
-            self.cleanup_terminated(child);
-            self.finalize_forked_child_termination(child, status)?;
-        }
-
         Ok(())
     }
 
@@ -459,38 +422,13 @@ impl ProcessDaemon {
 
             // A forked user process terminated. Finalizing it re-parents its surviving children,
             // reaps its zombie children, and either retains it as a reapable zombie or drops it —
-            // all of which require the child's lineage to be recorded. The kernel normally
-            // publishes a process's creation event before its termination event, so the lineage is
-            // usually already recorded; it can still be missing when the creation event has not been
-            // delivered yet (e.g. the scheduling-event queue was momentarily full and the creation
-            // was requeued), or when the process signed up before its creation event was processed
-            // (its record exists with a name but no recorded parent). Buffer the `(pid, status)` and
-            // defer every side effect — filesystem-state reclamation, re-parenting, reaping, and
-            // waking a blocked waiter — until the creation event records the lineage and
-            // `handle_process_creation_event()` replays it. The creation event is guaranteed to
-            // follow: the kernel buffers it at fork time and the main loop re-publishes it until it
-            // is delivered. Deferring the filesystem-exit notification also keeps it ordered after
-            // the fork-clone that the creation handler dispatches, so the child's filesystem
-            // snapshot is taken before it is reclaimed.
+            // all of which require the child's lineage to be recorded. The kernel guarantees that a
+            // process's creation event is delivered before its termination event (a single FIFO
+            // scheduling-event queue), so by the time this termination is handled the creation event
+            // has already recorded the child's lineage. The filesystem-exit notification issued by
+            // `cleanup_terminated()` is therefore ordered after the fork-clone that the creation
+            // handler dispatched, so the child's filesystem snapshot is taken before it is reclaimed.
             ProcessRole::User => {
-                let record_ready: bool = self
-                    .processes
-                    .get(&pid)
-                    .map(|record| record.parent.is_some())
-                    .unwrap_or(false);
-                if !record_ready {
-                    ::syslog::info!(
-                        "termination observed before creation (pid={:?}, status={:?}) — buffering",
-                        pid,
-                        status
-                    );
-                    // Replace any stale entry for this pid before recording the new status,
-                    // preserving an at-most-one-entry-per-pid invariant across pid reuse.
-                    self.early_terminations.retain(|(p, _)| *p != pid);
-                    self.early_terminations.push((pid, status));
-                    return Ok(None);
-                }
-
                 self.cleanup_terminated(pid);
                 self.finalize_forked_child_termination(pid, status)?;
                 Ok(None)
@@ -523,8 +461,7 @@ impl ProcessDaemon {
     /// until shutdown), re-parents its surviving live children to the init process, then decides
     /// reapability: if a live parent can still reap it, it is retained as a zombie and a parent
     /// already blocked in `waitpid()` is woken; otherwise it is dropped rather than left as an
-    /// unreapable zombie. Shared by the termination handler and the early-termination reconciliation
-    /// in `handle_process_creation_event()`.
+    /// unreapable zombie.
     fn finalize_forked_child_termination(
         &mut self,
         pid: ProcessIdentifier,

--- a/src/tests/testd/src/pm/duplicate_burst.rs
+++ b/src/tests/testd/src/pm/duplicate_burst.rs
@@ -15,7 +15,7 @@
 //! time this test runs `procd` already owns the scheduling-event class and drains creation and
 //! termination events asynchronously. A rapid burst of `duplicate()` calls therefore produces
 //! events faster than `procd` can consume them, exercising the kernel-side buffering
-//! (`pending_creations`, `pending_terminations`, the per-event `pending_scheduling` queues, and
+//! (`pending_creations`, `pending_terminations`, the single FIFO `pending_scheduling` queue, and
 //! zombie harvesting). If that buffering were insufficient, events would be lost or the kernel
 //! would become unstable under the burst.
 //!
@@ -26,24 +26,28 @@
 //! required because `duplicate()` refuses a caller that owns special resources (including a
 //! non-empty mailbox). Tearing each child down with [`__kcall_terminate`] confirms that the kernel
 //! tracked every burst-created process — a child lost to a buffer overflow would fail with
-//! `NoSuchProcess`.
+//! `NoSuchProcess`. Reaping each child with `waitpid()` then confirms that `procd` observed the
+//! raw-duplicate child's process-creation event before its process-termination event and recorded
+//! the child as reapable under the parent.
 //!
-//! ## Reaping between rounds
+//! ## Reaping after termination
 //!
 //! `terminate()` only marks a child as a zombie; the child's thread slot is not released until the
-//! kernel's idle-loop harvester reaps that zombie. The harvester runs only when no user process is
-//! runnable, so a parent that bursts without ever yielding would accumulate un-reaped zombies and
-//! exhaust the system-wide thread limit (`MAX_THREADS`) after a few rounds. To keep the live thread
-//! count bounded and the test deterministic, the parent yields the processor once at the end of
-//! each round. Because the burst performs no IPC, the parent is then the only runnable user
-//! process, so the kernel idle thread is scheduled and drains every pending zombie before the next
-//! round begins.
+//! kernel's idle-loop harvester reaps that zombie and publishes a termination scheduling event.
+//! Blocking in `wait()` after each termination makes that path deterministic: the parent sleeps,
+//! the kernel harvests the child, `procd` receives the creation and termination events, and the
+//! wait reply proves that the child was recorded as reapable before the next burst starts.
 
 //==================================================================================================
 // Imports
 //==================================================================================================
 
 use ::arch::mem::PAGE_SIZE;
+use ::proc::{
+    wait,
+    WaitOutcome,
+    WaitTarget,
+};
 use ::sys::{
     kcall::{
         mm,
@@ -195,15 +199,19 @@ fn test_duplicate_burst() -> bool {
             }
         }
 
-        // Phase 3: yield the processor so the kernel's idle-loop harvester reaps this round's
-        // zombies before the next round starts. terminate() above only zombified the children; the
-        // harvester is what actually releases each child's thread slot, and it runs only when no
-        // user process is runnable. Without this yield the parent never quiesces during the burst,
-        // so the zombies accumulate across rounds and eventually exhaust the system-wide thread
-        // limit (`MAX_THREADS`). Because the burst performs no IPC, the parent is the only runnable
-        // user process here, so a single yield is enough for the kernel idle thread to drain every
-        // pending zombie.
-        let _ = sched::__kcall_sched_yield();
+        // Phase 3: reap every child through procd. Raw duplicate() does not perform the fork-sync
+        // handshake, so the parent can terminate children before procd has drained their
+        // process-creation scheduling events. waitpid() returning each child PID confirms that the
+        // FIFO scheduling-event stream delivered every creation before its matching termination,
+        // letting procd record the child's lineage before finalizing its exit status.
+        if success {
+            for child in children.iter().flatten() {
+                match wait(WaitTarget::Pid(*child), 0) {
+                    Ok(WaitOutcome::Reaped { child: reaped, .. }) if reaped == *child => {},
+                    _ => success = false,
+                }
+            }
+        }
 
         // Phase 4: reclaim the stack mappings owned by the parent. `mmap()` reserves `STACK_PAGES`
         // pages per stack in a single call, but `munmap()` unmaps a single page at a time, so every


### PR DESCRIPTION
## Summary

Replace the kernel's per-event-type scheduling sub-queues (drained round-robin via `scheduling_cursor`) with a single totally-ordered FIFO `pending_scheduling` queue, and remove procd's now-unnecessary out-of-order reconciliation machinery.

Previously the kernel buffered process-creation and process-termination scheduling events in separate sub-queues scanned round-robin in `try_wait()`. That scan could deliver a termination ahead of a still-queued creation, so procd had to compensate with an `early_terminations` buffer and a replay path in `handle_process_creation_event()`. Reconstructing a consistent per-process lifecycle from an out-of-order stream was the source of repeated race-dependent bugs (#2541, #2559, #2534, #2535).

Because the kernel main loop publishes a process's creation event before its termination event, and a process is always created before it terminates, enqueuing both into one FIFO queue makes creation-before-termination a hard, structural invariant: FIFO delivery preserves insertion order, so procd always observes a child's creation (and records its lineage) before handling its termination.

## Changes

### Kernel (`event/manager.rs`)
- Replace the `[LinkedList; SchedulingEvent::NUMBER_EVENTS]` sub-queue array and `scheduling_cursor` field with a single `LinkedList<(EventDescriptor, SchedulingNotification)>`.
- Deliver scheduling events in strict FIFO order in `try_wait()`, gated only on the caller owning the (class-wide) scheduling-event class.
- Bound the queue at `2 * MAX_PROCESSES` (each process can have at most one pending creation and one pending termination at a time).
- Simplify `notify_scheduling()` and `init()` accordingly.

### Kernel main loop (`kcall/handler.rs`)
- Update the publish-order comments to describe the FIFO guarantee instead of the previous "bias, not a guarantee".

### procd (`libs/proc/src/daemon/mod.rs`)
- Remove the `early_terminations` buffer, its replay path in `handle_process_creation_event()`, and the "termination observed before creation" buffering branch in `handle_process_termination_event()`.
- A `User` termination now finalizes directly, since the child's lineage is guaranteed to be recorded by the time the termination is handled.

### Test (`tests/testd/src/pm/duplicate_burst.rs`)
- Update buffering documentation to reference the single FIFO `pending_scheduling` queue.
- Reap each burst child with `wait()` after termination, asserting that procd observed the raw-duplicate child's creation event before its termination event.

## Validation

- `./z build -- run-unit-tests`
- `./z build -- run-nanvix-tests`
- `lint-check` (pre-commit) passes.

## Notes

Delivery fairness across event classes remains tracked by #2558.

Closes #2618.