### PR TITLE
[vfs] Unify sockets into flat fd namespace

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -128,6 +128,26 @@ pub(crate) fn handle_close_with_hostfs(
         return None;
     }
 
+    // Socket close: the slot is a flat descriptor vfsd owns, but the endpoint lives in networkd.
+    // Capture whether this drops the last reference before releasing the slot; if so, forward the
+    // endpoint close to networkd so the remote descriptor does not leak. The networkd close is
+    // fire-and-forget, so the response is returned synchronously.
+    if let Some(remote_fd) = ::vfs::fd::vfs_socket_remote_fd(fd) {
+        let last_ref: bool = ::vfs::fd::vfs_socket_is_last_ref(fd);
+        let response: Message = super::short::handle_close(source, msg);
+        if last_ref {
+            if let Err(e) = crate::networkd::send_close_request(remote_fd) {
+                ::syslog::warn!(
+                    "socket close: failed to forward endpoint close to networkd (remote_fd={}, \
+                     error={:?})",
+                    remote_fd,
+                    e
+                );
+            }
+        }
+        return Some(response);
+    }
+
     Some(super::short::handle_close(source, msg))
 }
 
@@ -170,6 +190,8 @@ pub(crate) fn handle_dup2(
         ::vfs::fd::vfs_pipe_id(newfd).filter(|_| ::vfs::fd::vfs_pipe_is_last_ref(newfd));
     let displaced_hostfs: Option<i32> =
         ::vfs::fd::vfs_hostfs_remote_fd(newfd).filter(|_| ::vfs::fd::vfs_hostfs_is_last_ref(newfd));
+    let displaced_socket: Option<i32> =
+        ::vfs::fd::vfs_socket_remote_fd(newfd).filter(|_| ::vfs::fd::vfs_socket_is_last_ref(newfd));
 
     // Perform the authoritative table mutation: `newfd` now aliases `oldfd`'s description. This
     // drops the displaced description locally; its external reclaim is performed below.
@@ -193,6 +215,17 @@ pub(crate) fn handle_dup2(
         {
             ::syslog::warn!(
                 "dup2: failed to close displaced hostfs handle (remote_fd={}, error={:?})",
+                remote_fd,
+                e
+            );
+        }
+    }
+
+    // A displaced socket last reference must have its networkd endpoint closed so it does not leak.
+    if let Some(remote_fd) = displaced_socket {
+        if let Err(e) = crate::networkd::send_close_request(remote_fd) {
+            ::syslog::warn!(
+                "dup2: failed to close displaced socket endpoint (remote_fd={}, error={:?})",
                 remote_fd,
                 e
             );

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -48,6 +48,8 @@ use ::syscall::{
         FileSyncResponse,
         FileTruncateRequest,
         FileTruncateResponse,
+        RegisterSocketRequest,
+        RegisterSocketResponse,
         ResolveFdRequest,
         ResolveFdResponse,
         SeekRequest,
@@ -101,6 +103,30 @@ pub(crate) fn handle_resolve_fd(source: ThreadIdentifier, msg: SystemCallMessage
         },
         // No slot for this descriptor in the caller's table: it is unroutable.
         None => build_error(source, ErrorCode::BadFile),
+    }
+}
+
+/// Allocates a flat descriptor slot for a socket endpoint that `networkd` already created.
+///
+/// libposix sends this as the second step of socket creation: `networkd` owns the endpoint, and
+/// vfsd binds it to the lowest free flat descriptor so the socket joins the flat namespace like any
+/// other object. The response carries that flat descriptor and the current table generation (the
+/// coherence epoch) so the caller can seed its resolution cache with a coherent entry.
+pub(crate) fn handle_register_socket(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
+    let req: RegisterSocketRequest = RegisterSocketRequest::from_bytes(msg.payload);
+    let remote_fd: i32 = req.remote_fd;
+    match ::vfs::fd::vfs_register_socket(remote_fd) {
+        Ok(fd) => {
+            let epoch: u64 = ::vfs::fd::vfs_current_generation();
+            RegisterSocketResponse::build(
+                source,
+                fd,
+                epoch,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
+        },
+        Err(e) => build_error(source, fat32_to_error_code(&e)),
     }
 }
 

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     handler,
     hostfs,
+    networkd,
     pending::PendingQueue,
     pipe_wait::PipeWaitTable,
 };
@@ -193,6 +194,20 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                             );
                         }
                     }
+                    for remote_fd in reclaim.orphaned_socket_fds {
+                        // Fire-and-forget close of the socket endpoint on networkd: the process is
+                        // gone and cannot close it itself, mirroring the hostfs orphan-close above.
+                        // networkd's acknowledgement is discarded by the main event loop.
+                        if let Err(e) = networkd::send_close_request(remote_fd) {
+                            ::syslog::warn!(
+                                "failed to close orphaned socket fd on process exit (pid={:?}, \
+                                 remote_fd={}, error={:?})",
+                                pid,
+                                remote_fd,
+                                e
+                            );
+                        }
+                    }
                     ::syslog::info!("reclaimed filesystem state (pid={:?})", pid);
                     Ok(false)
                 },
@@ -228,6 +243,19 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                         ) {
                             ::syslog::warn!(
                                 "failed to close orphaned hostfs fd on exec (pid={:?}, \
+                                 remote_fd={}, error={:?})",
+                                pid,
+                                remote_fd,
+                                e
+                            );
+                        }
+                    }
+                    for remote_fd in reclaim.orphaned_socket_fds {
+                        // A `FD_CLOEXEC` socket is released at exec: forward its endpoint close to
+                        // networkd, fire-and-forget, mirroring the hostfs orphan-close above.
+                        if let Err(e) = networkd::send_close_request(remote_fd) {
+                            ::syslog::warn!(
+                                "failed to close orphaned socket fd on exec (pid={:?}, \
                                  remote_fd={}, error={:?})",
                                 pid,
                                 remote_fd,
@@ -327,6 +355,10 @@ pub(crate) fn handle_ipc_message(
         },
         SystemCallMessageHeader::ResolveFdRequest => {
             let response: Message = handler::handle_resolve_fd(source_tid, syscall_msg);
+            send_response(&response);
+        },
+        SystemCallMessageHeader::RegisterSocketRequest => {
+            let response: Message = handler::handle_register_socket(source_tid, syscall_msg);
             send_response(&response);
         },
         SystemCallMessageHeader::Dup2Request => {

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -18,6 +18,7 @@ mod handler;
 mod hostfs;
 mod init;
 mod ipc;
+mod networkd;
 mod pending;
 mod pipe_wait;
 
@@ -194,6 +195,12 @@ pub fn main() {
                         ::syscall::SystemCallMessage::try_from_bytes(message.payload)
                     {
                         let header: SystemCallMessageHeader = syscall_msg.header;
+                        // networkd acknowledges a forwarded socket-endpoint close with an IKC
+                        // `CloseResponse`. That close is fire-and-forget — vfsd does not wait on it
+                        // — so the acknowledgement is expected and silently discarded.
+                        if header == SystemCallMessageHeader::CloseResponse {
+                            continue;
+                        }
                         // Multi-part response stream: assemble parts before dispatch.
                         // The op_id is *not* at the standard payload[2..6] offset for
                         // these messages (those bytes carry SystemCallMessagePart

--- a/src/daemons/vfsd/src/networkd.rs
+++ b/src/daemons/vfsd/src/networkd.rs
@@ -1,0 +1,52 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! networkd forwarding module for vfsd.
+//!
+//! Sockets are flat descriptors in vfsd's slot table, but their I/O backend is networkd. When the
+//! last reference to a socket slot is dropped — by `close`, a `dup2` that displaces it, or process
+//! exit/exec — vfsd forwards the endpoint close to networkd so the remote descriptor does not leak.
+//!
+//! This mirrors the hostfs orphan-close pattern: the request is fire-and-forget (the closing
+//! process is gone or does not wait on it), and networkd's acknowledgement is discarded by the main
+//! event loop. The close is addressed to [`ProcessIdentifier::NETWORKD`] as an IKC message, exactly
+//! as a guest socket close would be.
+
+use ::sys::{
+    error::ErrorCode,
+    ipc::{
+        Message,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::syscall::unistd::message::CloseRequest;
+
+/// Forwards a socket endpoint close to networkd, best-effort.
+///
+/// `remote_fd` is the descriptor networkd assigned to the socket (the value stored in the slot's
+/// socket handle). The close is fire-and-forget: vfsd does not block on networkd's acknowledgement,
+/// which arrives later as an IKC `CloseResponse` and is discarded by the main event loop. The
+/// request is sent from vfsd's thread identifier so networkd routes its reply back to vfsd.
+pub fn send_close_request(remote_fd: i32) -> Result<(), ErrorCode> {
+    let request: Message = CloseRequest::build(
+        ThreadIdentifier::VFSD,
+        remote_fd,
+        ProcessIdentifier::NETWORKD,
+        MessageType::Ikc,
+    );
+    match ::sys::kcall::ipc::__kcall_send(&request) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            ::syslog::error!(
+                "networkd: failed to send close request (remote_fd={}, error={:?})",
+                remote_fd,
+                e
+            );
+            Err(ErrorCode::IoErr)
+        },
+    }
+}

--- a/src/libs/config/src/fds.rs
+++ b/src/libs/config/src/fds.rs
@@ -7,15 +7,11 @@
 // File Descriptor Ranges
 //==================================================================================================
 
-/// Base file descriptor number for socket handles managed by networkd.
+/// Base value of `networkd`'s internal socket descriptor space.
 ///
-/// Socket file descriptors occupy the range `[SOCKET_FD_BASE, ..)`. Under the flat descriptor
-/// namespace, vfsd-served descriptors are allocated lowest-free below this base, so this range stays
-/// reserved for `networkd` and never collides with a vfsd descriptor (the interim reservation until
-/// sockets are unified into the flat table).
+/// `networkd` numbers the endpoints it owns by offsetting its host-side descriptors by this base.
+/// These numbers are an implementation detail of `networkd` and are never seen by applications:
+/// under the flat descriptor namespace, `vfsd` owns each socket's application-visible slot and a
+/// socket is allocated the lowest free flat descriptor like any other object. This base only keeps
+/// `networkd`'s own descriptor space from clashing with the standard streams it inherits.
 pub const SOCKET_FD_BASE: i32 = 2048;
-
-/// Returns `true` if the given file descriptor belongs to the socket fd range.
-pub fn is_socket_fd(fd: i32) -> bool {
-    fd >= SOCKET_FD_BASE
-}

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -5,16 +5,15 @@
 //!
 //! Under the flat namespace a descriptor's number no longer encodes its backend: `open` hands out
 //! the lowest free number (typically a small one), so a value like `4` could be a regular file, a
-//! pipe end, a directory, or a host file. One range keeps a fixed meaning in the interim:
-//! `[SOCKET_FD_BASE, …)` is always a `networkd` socket. Every lower descriptor is whatever `vfsd`'s
+//! pipe end, a directory, a host file, or a socket. Every descriptor is whatever `vfsd`'s
 //! authoritative slot table says it is.
 //!
 //! This module routes a descriptor through a single seam, [`resolve`]. The answer comes from, in
-//! order: a coherent cache entry; the fixed socket range ([`derive`], no round-trip); otherwise an
-//! authoritative query to `vfsd` ([`resolve_via_vfsd`]). If no guest `vfsd` exists in the current
-//! run mode, the standard streams fall back to the kernel console by number. A descriptor created
-//! locally (`open`, `pipe`, `socket`) or learned from `vfsd` is recorded, so the `vfsd` query is
-//! reached only on a genuine miss or after an entry goes stale.
+//! order: a coherent cache entry; otherwise an authoritative query to `vfsd` ([`resolve_via_vfsd`]).
+//! If no guest `vfsd` exists in the current run mode, the standard streams fall back to the kernel
+//! console by number. A descriptor created locally (`open`, `pipe`, `socket`) or learned from
+//! `vfsd` is recorded, so the `vfsd` query is reached only on a genuine miss or after an entry goes
+//! stale.
 //!
 //! Coherence is load-bearing here. Each entry carries the `vfsd` table generation it was learned at
 //! (its *epoch*), and [`EXPECTED_EPOCH`] tracks the newest generation this process has observed from
@@ -23,8 +22,6 @@
 
 #[cfg(any(feature = "standalone", test))]
 use ::alloc::collections::BTreeMap;
-#[cfg(any(feature = "standalone", test))]
-use ::config::fds::is_socket_fd;
 #[cfg(test)]
 use ::core::sync::atomic::AtomicBool;
 #[cfg(any(feature = "standalone", test))]
@@ -128,23 +125,6 @@ fn observe_epoch(epoch: u64) {
     EXPECTED_EPOCH.fetch_max(epoch, Ordering::Relaxed);
 }
 
-/// Derives the routing decision implied by a descriptor number alone.
-///
-/// Only the reserved socket range owned by `networkd` is answered here. Every lower descriptor,
-/// including `0`/`1`/`2`, is flat namespace state owned by `vfsd` and must be resolved there so a
-/// closed standard descriptor can be reused by a non-console object.
-#[cfg(any(feature = "standalone", test))]
-fn derive(fd: i32) -> Option<Resolution> {
-    if is_socket_fd(fd) {
-        Some(Resolution {
-            route: Route::Socket,
-            backend_fd: fd,
-        })
-    } else {
-        None
-    }
-}
-
 /// Derives the fallback console route for run modes that have no guest `vfsd`.
 #[cfg(any(feature = "standalone", test))]
 fn derive_console(fd: i32) -> Option<Resolution> {
@@ -173,8 +153,8 @@ fn is_coherent(entry_epoch: u64) -> bool {
 /// Resolves a descriptor to its backend route.
 ///
 /// This is the hot-path lookup used by every descriptor system call. The answer comes from, in
-/// order: a cached entry that is still coherent; the fixed socket number range ([`derive`], no
-/// round-trip); otherwise an authoritative query to `vfsd` ([`resolve_via_vfsd`]).
+/// order: a cached entry that is still coherent; otherwise an authoritative query to `vfsd`
+/// ([`resolve_via_vfsd`]).
 /// A cache hit on a coherent entry holds the lock only across a single map probe and never
 /// round-trips, so tight `read`/`write` loops stay local.
 #[cfg(any(feature = "standalone", test))]
@@ -190,10 +170,8 @@ pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
             }
         }
     }
-    // The fixed ranges answer without a round-trip; everything else is the authority's to decide.
-    if let Some(resolution) = derive(fd) {
-        return Some(resolution);
-    }
+    // The cache missed or went stale; the authority decides, falling back to the console by number
+    // only when no guest `vfsd` is available to answer.
     match resolve_via_vfsd(fd) {
         VfsdResolution::Hit(resolution) => Some(resolution),
         VfsdResolution::BadFile => None,
@@ -225,6 +203,34 @@ pub(crate) fn resolve_vfs(fd: i32, syscall_name: &str) -> Result<i32, Error> {
 /// descriptor directly.
 #[cfg(not(feature = "standalone"))]
 pub(crate) fn resolve_vfs(fd: i32, _syscall_name: &str) -> Result<i32, Error> {
+    Ok(fd)
+}
+
+/// Resolves `fd` and returns the `networkd` descriptor backing the socket.
+///
+/// Socket I/O syscalls take a flat descriptor but must address `networkd` by the descriptor it
+/// assigned (the backend fd). In standalone mode this consults the resolution cache (querying
+/// `vfsd` on a miss); a descriptor that is not a socket is rejected with `ENOTSOCK`. The flat
+/// descriptor never reaches `networkd`.
+#[cfg(feature = "standalone")]
+pub(crate) fn resolve_socket(fd: i32, syscall_name: &str) -> Result<i32, Error> {
+    use ::sys::error::ErrorCode;
+
+    match resolve(fd) {
+        Some(resolution) if resolution.route == Route::Socket => Ok(resolution.backend_fd),
+        _ => {
+            ::syslog::warn!("{syscall_name}(): not a socket fd={fd}");
+            Err(Error::new(ErrorCode::NotSocketFile, "fd is not a socket"))
+        },
+    }
+}
+
+/// Resolves `fd` to the descriptor expected by the socket backend in hosted mode.
+///
+/// Non-standalone builds route socket syscalls to the host, which interprets the caller-facing
+/// descriptor directly, so the descriptor is returned unchanged.
+#[cfg(not(feature = "standalone"))]
+pub(crate) fn resolve_socket(fd: i32, _syscall_name: &str) -> Result<i32, Error> {
     Ok(fd)
 }
 
@@ -282,10 +288,10 @@ pub(crate) fn record(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
 
 /// Queries `vfsd` for the authoritative route of `fd` and records the answer.
 ///
-/// Reached only when the cache misses (or holds a stale entry) and the number is not in the fixed
-/// socket range — i.e. for a `vfsd`-owned descriptor that this process did not itself create, or
-/// one whose entry went stale. The answer is recorded so subsequent uses hit the cache. Returns
-/// `None` if `vfsd` reports no slot for `fd` (an invalid descriptor).
+/// Reached only when the cache misses (or holds a stale entry) — i.e. for a `vfsd`-owned descriptor
+/// that this process did not itself create, or one whose entry went stale. The answer is recorded
+/// so subsequent uses hit the cache. Returns `None` if `vfsd` reports no slot for `fd` (an invalid
+/// descriptor).
 #[cfg(all(feature = "standalone", not(test)))]
 fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
     use crate::{
@@ -410,7 +416,6 @@ fn clear() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::config::fds::SOCKET_FD_BASE;
 
     /// Serializes the cache tests: they share the process-global [`CACHE`], [`EXPECTED_EPOCH`], and
     /// [`MOCK_VFSD`], so they must not run concurrently with one another.
@@ -421,21 +426,28 @@ mod tests {
         MOCK_VFSD.lock().insert(fd, (route, backend_fd, epoch));
     }
 
-    /// Tests that only the reserved socket range resolves without consulting `vfsd`. A low flat
-    /// number with nothing cached or modeled in `vfsd` is unroutable.
+    /// Tests that a socket descriptor is a flat slot resolved through `vfsd` like any other object:
+    /// its number carries no meaning, and `vfsd` reports the `Socket` route together with the
+    /// `networkd` descriptor it routes to. A flat number with nothing cached or modeled in `vfsd`
+    /// is unroutable.
     #[test]
-    fn derive_routes_socket_by_number() {
+    fn socket_resolves_via_vfsd() {
         let _guard = CACHE_TEST_GUARD.lock();
         clear();
 
+        // vfsd owns the socket slot and reports the networkd descriptor it routes to.
+        mock_vfsd(4, Route::Socket, 2050, 1);
         assert_eq!(
-            resolve(SOCKET_FD_BASE).map(|r| r.route),
-            Some(Route::Socket),
-            "a socket descriptor must route to networkd by number"
+            resolve(4),
+            Some(Resolution {
+                route: Route::Socket,
+                backend_fd: 2050
+            }),
+            "a socket descriptor must resolve through vfsd's flat table to its networkd descriptor"
         );
-        // Low flat numbers are not a fixed range; with no cache entry and no vfsd slot they are
-        // unroutable rather than silently assumed to be console or vfsd files.
-        for fd in [0, 1, 2, 4] {
+        // Flat numbers are not a fixed range; with no cache entry and no vfsd slot they are
+        // unroutable rather than silently assumed to be a socket, console, or vfsd file.
+        for fd in [0, 1, 2, 5] {
             assert_eq!(resolve(fd), None, "an unknown flat descriptor must be unroutable");
         }
 
@@ -517,6 +529,20 @@ mod tests {
         let backend_fd: i32 =
             resolve_table_op(9, "test").expect("hosted resolve_table_op should succeed");
         assert_eq!(backend_fd, 9, "hosted mode must pass raw descriptors through");
+
+        clear();
+    }
+
+    /// Tests that hosted builds leave socket descriptor interpretation to the host backend, passing
+    /// the descriptor through unchanged.
+    #[test]
+    fn hosted_resolve_socket_returns_raw_fd() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        let backend_fd: i32 =
+            resolve_socket(11, "test").expect("hosted resolve_socket should succeed");
+        assert_eq!(backend_fd, 11, "hosted mode must pass raw descriptors through");
 
         clear();
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -105,10 +105,7 @@ pub mod safe;
 // Imports
 //==================================================================================================
 
-pub use ::config::fds::{
-    is_socket_fd,
-    SOCKET_FD_BASE,
-};
+pub use ::config::fds::SOCKET_FD_BASE;
 use ::core::{
     convert::TryFrom,
     mem,
@@ -282,6 +279,8 @@ pub enum SystemCallMessageHeader {
     ResolveFdResponse,
     Dup2Request,
     Dup2Response,
+    RegisterSocketRequest,
+    RegisterSocketResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -448,6 +447,8 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == ResolveFdResponse as u16 => Ok(ResolveFdResponse),
             x if x == Dup2Request as u16 => Ok(Dup2Request),
             x if x == Dup2Response as u16 => Ok(Dup2Response),
+            x if x == RegisterSocketRequest as u16 => Ok(RegisterSocketRequest),
+            x if x == RegisterSocketResponse as u16 => Ok(RegisterSocketResponse),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -33,8 +33,12 @@ use ::sysapi::ffi::c_int;
 pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address `networkd` by the descriptor it assigned to the listening socket: the caller passes a
+    // flat descriptor, which resolves to the backend (`networkd`) fd.
+    let backend_fd: c_int = crate::fdtable::resolve_socket(sockfd, "accept")?;
+
     // Build request and send it.
-    let request: Message = AcceptSocketRequest::build(tid, sockfd);
+    let request: Message = AcceptSocketRequest::build(tid, backend_fd);
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
@@ -56,8 +60,24 @@ pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
                 SystemCallMessageHeader::AcceptSocketResponse => {
                     let response: AcceptSocketResponse =
                         AcceptSocketResponse::from_bytes(message.payload);
+                    let remote_fd: c_int = response.sockfd;
+                    let sockaddr: SocketAddr = SocketAddr::try_from(&response.sockaddr)?;
 
-                    Ok((response.sockfd, SocketAddr::try_from(&response.sockaddr)?))
+                    // `networkd` created the accepted endpoint (the remote fd); `vfsd` allocates the
+                    // application-visible flat descriptor that routes to it.
+                    #[cfg(feature = "standalone")]
+                    {
+                        if remote_fd < 0 {
+                            Ok((remote_fd, sockaddr))
+                        } else {
+                            let fd: c_int = super::register_socket_slot(remote_fd)?;
+                            Ok((fd, sockaddr))
+                        }
+                    }
+                    #[cfg(not(feature = "standalone"))]
+                    {
+                        Ok((remote_fd, sockaddr))
+                    }
                 },
                 // Response was not successfully parsed.
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -33,6 +33,9 @@ pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
 
     let sockaddr: sockaddr = sockaddr::from(sockaddr);
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "bind")?;
+
     // Build request and send it.
     let request: Message = BindSocketRequest::build(tid, sockfd, &sockaddr);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -53,6 +53,9 @@ pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
 
     let (sockaddr, socklen): (sockaddr, socklen_t) = From::<&SocketAddr>::from(sockaddr);
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "connect")?;
+
     // Build request and send it.
     let request: Message = ConnectSocketRequest::build(tid, sockfd, &sockaddr, socklen);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -49,6 +49,9 @@ pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "getpeername")?;
+
     // Build request and send it.
     let request: Message = GetPeerNameRequest::build(tid, sockfd);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -49,6 +49,9 @@ pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "getsockname")?;
+
     // Build request and send it.
     let request: Message = GetSockNameRequest::build(tid, sockfd);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -27,6 +27,9 @@ use ::sysapi::ffi::c_int;
 pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "listen")?;
+
     // Build request and send it.
     let request: Message = ListenSocketRequest::build(tid, sockfd, backlog);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/mod.rs
@@ -34,3 +34,105 @@ pub use self::{
     socket::socket,
     socketpair::socketpair,
 };
+
+//==================================================================================================
+// Socket-slot registration helpers (standalone)
+//==================================================================================================
+
+/// Registers a `networkd` socket endpoint as a flat descriptor slot in vfsd.
+///
+/// This is the second step of socket creation under the flat namespace: `networkd` owns the
+/// endpoint (`remote_fd`) and remains the I/O backend, while vfsd allocates the application-visible
+/// flat descriptor that routes to it. The returned flat descriptor is recorded in the resolution
+/// cache (`route = Socket`, `backend_fd = remote_fd`) so socket I/O resolves to `remote_fd` without
+/// a further `vfsd` round-trip. If the registration fails on either leg, the `networkd` endpoint is
+/// closed so a failed creation never strands an endpoint.
+#[cfg(feature = "standalone")]
+pub(crate) fn register_socket_slot(
+    remote_fd: ::sysapi::ffi::c_int,
+) -> Result<::sysapi::ffi::c_int, ::sys::error::Error> {
+    use crate::{
+        unistd::message::{
+            RegisterSocketRequest,
+            RegisterSocketResponse,
+        },
+        SystemCallMessage,
+        SystemCallMessageHeader,
+    };
+    use ::sys::error::{
+        Error,
+        ErrorCode,
+    };
+
+    let tid = match ::sys::kcall::pm::__kcall_gettid() {
+        Ok(tid) => tid,
+        Err(e) => {
+            close_networkd_endpoint(remote_fd);
+            return Err(e);
+        },
+    };
+    let request = RegisterSocketRequest::build(
+        tid,
+        remote_fd,
+        crate::VFS_DESTINATION,
+        crate::VFS_MESSAGE_TYPE,
+    );
+    if let Err(e) = ::sys::kcall::ipc::__kcall_send(&request) {
+        close_networkd_endpoint(remote_fd);
+        return Err(e);
+    }
+    let response = match ::sys::kcall::ipc::__kcall_recv() {
+        Ok(response) => response,
+        Err(e) => {
+            close_networkd_endpoint(remote_fd);
+            return Err(e);
+        },
+    };
+    if response.status != 0 {
+        close_networkd_endpoint(remote_fd);
+        let error_code = ErrorCode::try_from(response.status).unwrap_or(ErrorCode::InvalidMessage);
+        return Err(Error::new(error_code, "failed to register socket slot"));
+    }
+    let message = match SystemCallMessage::try_from_bytes(response.payload) {
+        Ok(message) => message,
+        Err(_) => {
+            close_networkd_endpoint(remote_fd);
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid response"));
+        },
+    };
+    match message.header {
+        SystemCallMessageHeader::RegisterSocketResponse => {
+            let resp = RegisterSocketResponse::from_bytes(message.payload);
+            // `RegisterSocketResponse` is `#[repr(C, packed)]`; read each field through a raw
+            // pointer to avoid forming an unaligned reference.
+            let fd: ::sysapi::ffi::c_int =
+                unsafe { ::core::ptr::addr_of!(resp.fd).read_unaligned() };
+            let epoch: u64 = unsafe { ::core::ptr::addr_of!(resp.epoch).read_unaligned() };
+            crate::fdtable::record(fd, crate::fdtable::Route::Socket, remote_fd, epoch);
+            Ok(fd)
+        },
+        _ => {
+            close_networkd_endpoint(remote_fd);
+            Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header"))
+        },
+    }
+}
+
+/// Closes a `networkd` socket endpoint directly, best-effort.
+///
+/// Used to roll back the `networkd` endpoint when binding its flat slot in vfsd fails, so a failed
+/// socket creation does not strand an endpoint. The acknowledgement is drained but its status is
+/// ignored: the creation has already failed and there is nothing to retry.
+#[cfg(feature = "standalone")]
+fn close_networkd_endpoint(remote_fd: ::sysapi::ffi::c_int) {
+    use crate::unistd::message::CloseRequest;
+    use ::sys::ipc::MessageType;
+
+    let Ok(tid) = ::sys::kcall::pm::__kcall_gettid() else {
+        return;
+    };
+    let request = CloseRequest::build(tid, remote_fd, crate::NETWORK_DESTINATION, MessageType::Ikc);
+    if ::sys::kcall::ipc::__kcall_send(&request).is_ok() {
+        let _ = ::sys::kcall::ipc::__kcall_recv();
+    }
+}

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -31,6 +31,9 @@ use ::sysapi::ffi::c_int;
 pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "recv")?;
+
     // Check if count is invalid.
     if buffer.is_empty() {
         return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -34,6 +34,9 @@ use ::sysapi::{
 pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "send")?;
+
     // Check if count is invalid.
     if buffer.is_empty() {
         return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -30,6 +30,9 @@ use ::sysapi::ffi::c_int;
 pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd = crate::fdtable::resolve_socket(sockfd, "shutdown")?;
+
     // Build request and send it.
     let request: Message = ShutdownSocketRequest::build(tid, sockfd, how);
     ::sys::kcall::ipc::__kcall_send(&request)?;

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -58,17 +58,26 @@ pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Res
                 SystemCallMessageHeader::CreateSocketResponse => {
                     let response: CreateSocketResponse =
                         CreateSocketResponse::from_bytes(message.payload);
-                    let sockfd: c_int = response.sockfd;
+                    let remote_fd: c_int = response.sockfd;
 
-                    // Seed the resolution cache so the new socket resolves from the cache rather
-                    // than by number. Sockets carry no vfsd table generation, so the epoch is 0.
+                    // Under the flat namespace, `networkd` owns the endpoint (the remote fd) while
+                    // `vfsd` allocates the application-visible flat descriptor that routes to it.
+                    // The flat slot is recorded in the resolution cache so socket I/O reaches
+                    // `networkd` directly by `remote_fd`.
                     #[cfg(feature = "standalone")]
-                    if sockfd >= 0 {
-                        crate::fdtable::record(sockfd, crate::fdtable::Route::Socket, sockfd, 0);
+                    {
+                        if remote_fd < 0 {
+                            Ok(remote_fd)
+                        } else {
+                            super::register_socket_slot(remote_fd)
+                        }
                     }
-
-                    // Return system call result.
-                    Ok(sockfd)
+                    // Hosted mode has no guest `vfsd`: the backend numbers the descriptor and the
+                    // application sees it directly.
+                    #[cfg(not(feature = "standalone"))]
+                    {
+                        Ok(remote_fd)
+                    }
                 },
                 _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
             },

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -88,9 +88,47 @@ pub fn socketpair(
                 let response: CreateSocketPairResponse =
                     CreateSocketPairResponse::from_bytes(message.payload);
 
-                // Store file descriptors.
-                socket_fds[0] = response.sockfd_0;
-                socket_fds[1] = response.sockfd_1;
+                let remote_fd_0: c_int = response.sockfd_0;
+                let remote_fd_1: c_int = response.sockfd_1;
+
+                // `networkd` owns both endpoints (the remote fds); `vfsd` allocates the
+                // application-visible flat descriptors that route to them. If either registration
+                // fails, the other endpoint is closed so a half-registered pair never strands an
+                // endpoint on networkd.
+                #[cfg(feature = "standalone")]
+                {
+                    if remote_fd_0 < 0 || remote_fd_1 < 0 {
+                        socket_fds[0] = remote_fd_0;
+                        socket_fds[1] = remote_fd_1;
+                        return Ok(());
+                    }
+                    let fd0: c_int = match super::register_socket_slot(remote_fd_0) {
+                        Ok(fd0) => fd0,
+                        Err(e) => {
+                            // The first registration failed and already closed `remote_fd_0`; the
+                            // second endpoint was never registered, so close it directly on
+                            // networkd to avoid stranding it.
+                            super::close_networkd_endpoint(remote_fd_1);
+                            return Err(e);
+                        },
+                    };
+                    let fd1: c_int = match super::register_socket_slot(remote_fd_1) {
+                        Ok(fd1) => fd1,
+                        Err(e) => {
+                            // Roll back the already-registered first slot; closing it releases the
+                            // vfsd slot and forwards the endpoint close to networkd.
+                            let _ = crate::unistd::close(fd0);
+                            return Err(e);
+                        },
+                    };
+                    socket_fds[0] = fd0;
+                    socket_fds[1] = fd1;
+                }
+                #[cfg(not(feature = "standalone"))]
+                {
+                    socket_fds[0] = remote_fd_0;
+                    socket_fds[1] = remote_fd_1;
+                }
 
                 Ok(())
             },

--- a/src/libs/syscall/src/unistd/message/mod.rs
+++ b/src/libs/syscall/src/unistd/message/mod.rs
@@ -24,6 +24,7 @@ mod pread;
 mod pwrite;
 mod read;
 mod readlinkat;
+mod register_socket;
 mod resolve_fd;
 mod symlinkat;
 mod write;
@@ -108,6 +109,10 @@ pub use self::{
     readlinkat::{
         ReadLinkAtRequest,
         ReadLinkAtResponse,
+    },
+    register_socket::{
+        RegisterSocketRequest,
+        RegisterSocketResponse,
     },
     resolve_fd::{
         ResolveFdRequest,

--- a/src/libs/syscall/src/unistd/message/register_socket.rs
+++ b/src/libs/syscall/src/unistd/message/register_socket.rs
@@ -1,0 +1,165 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::{
+    fmt,
+    mem,
+};
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+//==================================================================================================
+// RegisterSocketRequest
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Request message that asks vfsd to allocate a flat descriptor slot for a socket endpoint that
+/// `networkd` has already created. libposix sends this as the second step of socket creation: once
+/// `networkd` returns the endpoint's remote descriptor, vfsd hands out the lowest free flat number
+/// and binds it to a socket routing token holding `remote_fd`.
+///
+#[repr(C, packed)]
+pub struct RegisterSocketRequest {
+    /// The descriptor `networkd` assigned to the endpoint (its remote fd).
+    pub remote_fd: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(RegisterSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl RegisterSocketRequest {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+
+    fn new(remote_fd: i32) -> Self {
+        Self {
+            remote_fd,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        remote_fd: i32,
+        destination: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: RegisterSocketRequest = RegisterSocketRequest::new(remote_fd);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::RegisterSocketRequest,
+            message.into_bytes(),
+        );
+        Message::new(
+            MessageSender::from(tid),
+            MessageReceiver::from(destination),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+impl fmt::Debug for RegisterSocketRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let remote_fd: i32 = self.remote_fd;
+        write!(f, "{{ remote_fd: {remote_fd} }}")
+    }
+}
+
+//==================================================================================================
+// RegisterSocketResponse
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Response message of [`RegisterSocketRequest`]. It carries the flat descriptor vfsd allocated for
+/// the socket and the vfsd table generation the slot was created at (its coherence epoch), so the
+/// caller can seed its resolution cache with an entry that is coherent against the table state that
+/// produced it.
+///
+#[repr(C, packed)]
+pub struct RegisterSocketResponse {
+    /// The flat descriptor vfsd allocated for the socket.
+    pub fd: i32,
+    /// The vfsd table generation this slot was created at.
+    pub epoch: u64,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(RegisterSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl RegisterSocketResponse {
+    pub const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u64>();
+
+    fn new(fd: i32, epoch: u64) -> Self {
+        Self {
+            fd,
+            epoch,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        fd: i32,
+        epoch: u64,
+        source: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let message: RegisterSocketResponse = RegisterSocketResponse::new(fd, epoch);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::RegisterSocketResponse,
+            message.into_bytes(),
+        );
+        Message::new(
+            MessageSender::from(source),
+            MessageReceiver::from(tid),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+impl fmt::Debug for RegisterSocketResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let fd: i32 = self.fd;
+        let epoch: u64 = self.epoch;
+        write!(f, "{{ fd: {fd}, epoch: {epoch} }}")
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -57,9 +57,12 @@ pub fn close(fd: i32) -> Result<(), Error> {
                 Route::Console => {
                     close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE, true)
                 },
-                // Sockets are closed by networkd.
+                // A socket occupies a flat slot owned by vfsd: closing it releases that slot, and
+                // vfsd forwards the endpoint close to networkd when the last reference is dropped.
+                // The slot is addressed by the caller-facing flat descriptor, not the networkd
+                // descriptor `backend_fd` routes I/O to.
                 Route::Socket => {
-                    close_ipc(res.backend_fd, crate::NETWORK_DESTINATION, MessageType::Ikc, false)
+                    close_ipc(fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE, false)
                 },
             },
             // Unknown fd: no handler available.

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -22,12 +22,14 @@
 
 use crate::fat32_backend;
 use ::alloc::{
-    collections::BTreeMap,
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
     string::String,
     sync::Arc,
     vec::Vec,
 };
-use ::config::fds::SOCKET_FD_BASE;
 use ::core::sync::atomic::{
     AtomicBool,
     AtomicI32,
@@ -212,8 +214,8 @@ pub enum VfsFileHandle {
     /// Routing token for a socket, holding the descriptor assigned by `networkd`.
     ///
     /// Socket I/O is not served by vfsd; like [`VfsFileHandle::HostFs`] this token only stores the
-    /// remote descriptor so vfsd can own the slot and its per-descriptor flags. No production path
-    /// constructs this variant yet (that lands in a later plan).
+    /// remote descriptor so vfsd can own the slot and its per-descriptor flags. vfsd closes the
+    /// remote descriptor on `networkd` when the last reference to the slot is dropped.
     Socket(SocketHandle),
 }
 
@@ -321,8 +323,8 @@ impl ConsoleHandle {
 ///
 /// A socket handle stores the descriptor that `networkd` assigned to the socket (its remote fd),
 /// analogous to [`HostFsHandle::remote_fd`]. Socket I/O is not served by vfsd; this token only lets
-/// vfsd own the descriptor slot and its per-descriptor flags. Closing the remote descriptor when the
-/// last reference is dropped is wired in a later plan.
+/// vfsd own the descriptor slot and its per-descriptor flags. vfsd closes the remote descriptor on
+/// `networkd` when the last reference to the slot is dropped.
 pub struct SocketHandle {
     /// Descriptor assigned by `networkd` (the remote fd).
     remote_fd: i32,
@@ -769,6 +771,13 @@ fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
         .ok_or(Fat32Error::InvalidFd)
 }
 
+/// Upper bound (exclusive) of the flat per-process descriptor namespace.
+///
+/// The allocator hands out the lowest free descriptor in `[0, MAX_OPEN_FDS)`. Every object —
+/// sockets, regular files, pipes, and console streams — draws from this single range, so there is
+/// no carved-out sub-range. Exhausting it yields [`Fat32Error::TooManyOpenFiles`].
+const MAX_OPEN_FDS: c_int = 2048;
+
 /// Allocates a new file descriptor for the given handle in the current process.
 ///
 /// Allocation is flat and lowest-free: the descriptor is the smallest non-negative number not
@@ -776,17 +785,17 @@ fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
 /// that same table, so the first `open` in a fresh process returns `3`, and a number freed by
 /// `close` is reused before any higher one — matching POSIX.
 ///
-/// The search stops below [`SOCKET_FD_BASE`], so a VFS descriptor can never be handed out inside the
-/// `networkd`-owned socket range. This is the interim reservation that lets the flat namespace ship
-/// before sockets are unified into this table; it is removed once `networkd` joins the flat
-/// namespace.
+/// The search spans the whole flat namespace `[0, MAX_OPEN_FDS)`: sockets, files, pipes, and
+/// console streams all draw from this single range, with no carved-out sub-range. A socket's
+/// application-visible number is therefore the lowest free flat descriptor like any other object,
+/// while the `networkd` descriptor that backs it lives in `networkd`'s own space and is invisible
+/// here.
 fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
     let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
         PROCESSES.lock();
     let state: &mut ProcessState = procs.entry(current_pid()).or_insert_with(ProcessState::new);
-    // Lowest free descriptor across the whole flat namespace, bounded below the reserved socket
-    // range so an allocated number can never collide with a networkd-owned socket descriptor.
-    let fd: c_int = (0..SOCKET_FD_BASE)
+    // Lowest free descriptor across the whole flat namespace.
+    let fd: c_int = (0..MAX_OPEN_FDS)
         .find(|candidate| !state.slots.contains_key(candidate))
         .ok_or(Fat32Error::TooManyOpenFiles)?;
     let file: OpenFile = Arc::new(Mutex::new(VfsEntry {
@@ -971,6 +980,9 @@ pub struct ProcessExitReclaim {
     /// Remote file descriptors of host-backed descriptions for which the process held the final
     /// reference. Each must be closed on hostfsd or the remote handle leaks.
     pub orphaned_hostfs_fds: Vec<i32>,
+    /// `networkd` descriptors of socket slots for which the process held the final reference. Each
+    /// must be closed on `networkd` or the socket endpoint leaks.
+    pub orphaned_socket_fds: Vec<i32>,
     /// Pipe ends whose reference count reached zero because the process held the final reference.
     pub pipe_closures: Vec<PipeClosure>,
 }
@@ -984,10 +996,13 @@ pub struct ProcessExitReclaim {
 ///
 /// Returns the resources the daemon must act on: the remote file descriptors of any host-backed
 /// open file descriptions for which `pid` held the final reference (which it must close on hostfsd,
-/// because the process is gone and can no longer close them itself), and the pipe ends whose
-/// reference count reached zero (so the daemon can fire EOF/`EPIPE` wakeups for any suspended
-/// counterparts). Descriptions still shared with a surviving process are not returned.
-#[must_use = "the returned hostfs fds must be closed and pipe closures must trigger wakeups"]
+/// because the process is gone and can no longer close them itself), the `networkd` descriptors of
+/// any socket slots for which `pid` held the final reference (which it must close on `networkd` for
+/// the same reason), and the pipe ends whose reference count reached zero (so the daemon can fire
+/// EOF/`EPIPE` wakeups for any suspended counterparts). Descriptions still shared with a surviving
+/// process are not returned.
+#[must_use = "the returned hostfs and socket fds must be closed and pipe closures must trigger \
+              wakeups"]
 pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // Detach the process's state while holding the registry lock, but defer dropping it until the
     // lock is released. Dropping an open file description may run backend teardown; deferring keeps
@@ -1000,6 +1015,7 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     let Some(state) = removed else {
         return ProcessExitReclaim {
             orphaned_hostfs_fds: Vec::new(),
+            orphaned_socket_fds: Vec::new(),
             pipe_closures: Vec::new(),
         };
     };
@@ -1008,10 +1024,20 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // A host-backed handle must therefore be closed on hostfsd, and a pipe end's count drops to
     // zero (which the dropped end's `Drop` applies just below). As the sole owner, the lock is
     // uncontended.
+    let removed_slots: Vec<Slot> = state.slots.into_values().collect();
+    let mut removed_ref_counts: BTreeMap<*const Mutex<VfsEntry>, usize> = BTreeMap::new();
+    for slot in &removed_slots {
+        let file_id: *const Mutex<VfsEntry> = Arc::as_ptr(&slot.file);
+        *removed_ref_counts.entry(file_id).or_insert(0) += 1;
+    }
     let mut orphaned: Vec<i32> = Vec::new();
+    let mut orphaned_sockets: Vec<i32> = Vec::new();
+    let mut seen_files: BTreeSet<*const Mutex<VfsEntry>> = BTreeSet::new();
     let mut pipe_closures: Vec<PipeClosure> = Vec::new();
-    for slot in state.slots.into_values() {
-        if Arc::strong_count(&slot.file) != 1 {
+    for slot in removed_slots {
+        let file_id: *const Mutex<VfsEntry> = Arc::as_ptr(&slot.file);
+        let removed_refs: usize = *removed_ref_counts.get(&file_id).unwrap_or(&0);
+        if !seen_files.insert(file_id) || Arc::strong_count(&slot.file) != removed_refs {
             continue;
         }
         match &slot.file.lock().handle {
@@ -1022,10 +1048,10 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
             }),
             // A console token holds no external resource, so it contributes nothing to reclaim.
             VfsFileHandle::Console(_) => {},
-            // A socket token holds the `networkd` descriptor, but closing it on last reference is
-            // wired in a later plan; nothing is reclaimed here yet. This arm must stay distinct so
-            // a socket is never mistaken for a hostfs or pipe handle.
-            VfsFileHandle::Socket(_) => {},
+            // A socket token holds the `networkd` descriptor: as the final reference, the endpoint
+            // must be closed on `networkd` so it does not leak. This arm must stay distinct so a
+            // socket is never mistaken for a hostfs or pipe handle.
+            VfsFileHandle::Socket(h) => orphaned_sockets.push(h.remote_fd()),
             _ => {},
         }
         // `slot` — and the open file description it holds — is dropped here, after the registry lock
@@ -1034,6 +1060,7 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
     }
     ProcessExitReclaim {
         orphaned_hostfs_fds: orphaned,
+        orphaned_socket_fds: orphaned_sockets,
         pipe_closures,
     }
 }
@@ -1043,7 +1070,8 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
 /// Walks `pid`'s slot table and drops every descriptor whose per-descriptor flags carry
 /// `FD_CLOEXEC`, leaving the surviving descriptors at their original numbers. Each dropped slot
 /// runs the same last-reference accounting as [`vfs_process_exit`]: a host-backed description for
-/// which `pid` held the final reference is surfaced for closing on hostfsd, and a pipe end whose
+/// which `pid` held the final reference is surfaced for closing on hostfsd, a socket slot for which
+/// `pid` held the final reference is surfaced for closing on `networkd`, and a pipe end whose
 /// reference count reaches zero is surfaced so the daemon can fire the EOF/`EPIPE` wakeup for any
 /// suspended counterpart. Descriptions still shared with a surviving descriptor — in this process
 /// (for example a non-`FD_CLOEXEC` `dup` sibling) or another (a forked relative) — are not
@@ -1058,7 +1086,8 @@ pub fn vfs_process_exit(pid: ProcessIdentifier) -> ProcessExitReclaim {
 /// The barrier in the process manager daemon guarantees this runs before the new image issues any
 /// descriptor operation, so a descriptor flagged `FD_CLOEXEC` is provably gone before the new image
 /// can observe it.
-#[must_use = "the returned hostfs fds must be closed and pipe closures must trigger wakeups"]
+#[must_use = "the returned hostfs and socket fds must be closed and pipe closures must trigger \
+              wakeups"]
 pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // Detach the close-on-exec slots while holding the registry lock, but defer dropping the open
     // file descriptions they hold until the lock is released. Dropping a description may run
@@ -1070,6 +1099,7 @@ pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
         let Some(state) = procs.get_mut(&pid) else {
             return ProcessExitReclaim {
                 orphaned_hostfs_fds: Vec::new(),
+                orphaned_socket_fds: Vec::new(),
                 pipe_closures: Vec::new(),
             };
         };
@@ -1084,6 +1114,7 @@ pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
         if cloexec_fds.is_empty() {
             return ProcessExitReclaim {
                 orphaned_hostfs_fds: Vec::new(),
+                orphaned_socket_fds: Vec::new(),
                 pipe_closures: Vec::new(),
             };
         }
@@ -1103,10 +1134,19 @@ pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
     // open file description, exactly as in `vfs_process_exit`. A host-backed handle must therefore
     // be closed on hostfsd, and a pipe end's count drops to zero (which the dropped end's `Drop`
     // applies as each slot leaves scope below).
+    let mut removed_ref_counts: BTreeMap<*const Mutex<VfsEntry>, usize> = BTreeMap::new();
+    for slot in &removed_slots {
+        let file_id: *const Mutex<VfsEntry> = Arc::as_ptr(&slot.file);
+        *removed_ref_counts.entry(file_id).or_insert(0) += 1;
+    }
     let mut orphaned: Vec<i32> = Vec::new();
+    let mut orphaned_sockets: Vec<i32> = Vec::new();
+    let mut seen_files: BTreeSet<*const Mutex<VfsEntry>> = BTreeSet::new();
     let mut pipe_closures: Vec<PipeClosure> = Vec::new();
     for slot in removed_slots {
-        if Arc::strong_count(&slot.file) != 1 {
+        let file_id: *const Mutex<VfsEntry> = Arc::as_ptr(&slot.file);
+        let removed_refs: usize = *removed_ref_counts.get(&file_id).unwrap_or(&0);
+        if !seen_files.insert(file_id) || Arc::strong_count(&slot.file) != removed_refs {
             continue;
         }
         match &slot.file.lock().handle {
@@ -1117,10 +1157,10 @@ pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
             }),
             // A console token holds no external resource, so it contributes nothing to reclaim.
             VfsFileHandle::Console(_) => {},
-            // A socket token holds the `networkd` descriptor, but closing it on last reference is
-            // wired in a later plan; nothing is reclaimed here yet. This arm must stay distinct so
-            // a socket is never mistaken for a hostfs or pipe handle.
-            VfsFileHandle::Socket(_) => {},
+            // A socket token holds the `networkd` descriptor: as the final reference, the endpoint
+            // must be closed on `networkd` so it does not leak. This arm must stay distinct so a
+            // socket is never mistaken for a hostfs or pipe handle.
+            VfsFileHandle::Socket(h) => orphaned_sockets.push(h.remote_fd()),
             _ => {},
         }
         // `slot` — and the open file description it holds — is dropped here, after the registry lock
@@ -1128,6 +1168,7 @@ pub fn vfs_exec_cloexec(pid: ProcessIdentifier) -> ProcessExitReclaim {
     }
     ProcessExitReclaim {
         orphaned_hostfs_fds: orphaned,
+        orphaned_socket_fds: orphaned_sockets,
         pipe_closures,
     }
 }
@@ -1232,6 +1273,58 @@ pub fn vfs_hostfs_set_readdir_offset(fd: c_int, offset: u32) -> bool {
             true
         },
         _ => false,
+    }
+}
+
+//==================================================================================================
+// Socket FD Helpers
+//==================================================================================================
+
+/// Allocates a flat descriptor slot for a socket endpoint that `networkd` already created.
+///
+/// This is the second step of socket creation: once `networkd` returns the endpoint's remote
+/// descriptor, libposix asks vfsd to bind it to a flat slot via this function. The returned
+/// descriptor is the lowest free flat number — the same allocation every other object goes through
+/// — and the slot holds a [`SocketHandle`] so vfsd owns the socket's per-descriptor flags and its
+/// place in `fork`/`exec`/`close` accounting. Socket I/O still flows directly to `networkd`, keyed
+/// off `remote_fd`.
+pub fn vfs_register_socket(remote_fd: i32) -> Result<c_int, Fat32Error> {
+    alloc_fd(VfsFileHandle::Socket(SocketHandle::new(remote_fd)))
+}
+
+/// Returns the `networkd` descriptor backing a socket file descriptor, or `None` if `fd` is not a
+/// socket slot in the current process.
+///
+/// vfsd uses this to forward a last-reference socket close to `networkd`, the socket analogue of
+/// [`vfs_hostfs_remote_fd`].
+pub fn vfs_socket_remote_fd(fd: c_int) -> Option<i32> {
+    let file: OpenFile = entry_arc(fd).ok()?;
+    let guard = file.lock();
+    match &guard.handle {
+        VfsFileHandle::Socket(h) => Some(h.remote_fd()),
+        _ => None,
+    }
+}
+
+/// Reports whether closing `fd` would drop the final reference to a socket endpoint.
+///
+/// Returns `true` when `fd` refers to a socket slot and the current process holds the only
+/// descriptor for that endpoint's open file description, so closing it (or the owning process
+/// exiting) must close the `networkd` endpoint. Returns `false` when other descriptors still share
+/// it (for example in a forked child), when `fd` is not a socket, or when `fd` is invalid. This
+/// does not modify the descriptor table.
+pub fn vfs_socket_is_last_ref(fd: c_int) -> bool {
+    let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
+    let Some(state) = procs.get(&current_pid()) else {
+        return false;
+    };
+    match state.slots.get(&fd) {
+        Some(slot) => {
+            // Must be a socket and the sole reference for closing to release the endpoint.
+            Arc::strong_count(&slot.file) == 1
+                && matches!(&slot.file.lock().handle, VfsFileHandle::Socket(_))
+        },
+        None => false,
     }
 }
 
@@ -1791,9 +1884,8 @@ pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
 /// cloned, so the two descriptors share one file offset and status flags, exactly as POSIX `dup`
 /// and `fcntl(F_DUPFD)` require. The duplicate carries its own per-descriptor flags with
 /// `FD_CLOEXEC` cleared, because POSIX mandates that a duplicate start with close-on-exec off; the
-/// source descriptor's flags are untouched. Allocation is lowest-free within the flat namespace and
-/// bounded below the reserved socket range, so the returned number is the smallest free one that is
-/// at least `min_fd`.
+/// source descriptor's flags are untouched. Allocation is lowest-free within the flat namespace, so
+/// the returned number is the smallest free one that is at least `min_fd`.
 ///
 /// This is the single primitive behind both `dup` (`min_fd == 0`) and `fcntl(F_DUPFD, arg)`
 /// (`min_fd == arg`).
@@ -1802,8 +1894,8 @@ pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
 ///
 /// - [`Fat32Error::InvalidFd`] if `oldfd` refers to no open descriptor in the current process.
 /// - [`Fat32Error::InvalidArgument`] if `min_fd` is negative.
-/// - [`Fat32Error::TooManyOpenFiles`] if no free descriptor at or above `min_fd` exists below the
-///   reserved socket range.
+/// - [`Fat32Error::TooManyOpenFiles`] if no free descriptor at or above `min_fd` exists within the
+///   flat namespace.
 pub fn vfs_dup_from(oldfd: c_int, min_fd: c_int) -> Result<c_int, Fat32Error> {
     if min_fd < 0 {
         return Err(Fat32Error::InvalidArgument);
@@ -1818,9 +1910,8 @@ pub fn vfs_dup_from(oldfd: c_int, min_fd: c_int) -> Result<c_int, Fat32Error> {
         .get(&oldfd)
         .map(|slot| slot.file.clone())
         .ok_or(Fat32Error::InvalidFd)?;
-    // Lowest free descriptor at or above `min_fd`, bounded below the reserved socket range so a
-    // duplicate can never collide with a networkd-owned socket descriptor.
-    let fd: c_int = (min_fd..SOCKET_FD_BASE)
+    // Lowest free descriptor at or above `min_fd` within the flat namespace.
+    let fd: c_int = (min_fd..MAX_OPEN_FDS)
         .find(|candidate| !state.slots.contains_key(candidate))
         .ok_or(Fat32Error::TooManyOpenFiles)?;
     // `Slot::new` starts from default (empty) per-descriptor flags, so `FD_CLOEXEC` is cleared on
@@ -1857,10 +1948,10 @@ pub fn vfs_dup(oldfd: c_int) -> Result<c_int, Fat32Error> {
 /// # Errors
 ///
 /// - [`Fat32Error::InvalidFd`] if `oldfd` refers to no open descriptor, or if `newfd` is negative
-///   or falls in the reserved socket range (where vfsd may not place a descriptor).
+///   or outside the flat namespace.
 pub fn vfs_dup2(oldfd: c_int, newfd: c_int) -> Result<c_int, Fat32Error> {
-    // `newfd` must be a legal descriptor number outside the reserved socket range.
-    if !(0..SOCKET_FD_BASE).contains(&newfd) {
+    // `newfd` must be a legal descriptor number within the flat namespace.
+    if !(0..MAX_OPEN_FDS).contains(&newfd) {
         return Err(Fat32Error::InvalidFd);
     }
     // Re-point the slot while holding the registry lock, but defer dropping the displaced open file
@@ -2709,10 +2800,10 @@ mod tests {
     // -- flat allocation & resolution tests --------------------------------------
 
     /// Tests that allocation is flat and lowest-free: descriptors are handed out from `0` upward and
-    /// a freed number is reused before any higher one. No descriptor ever falls in the reserved
-    /// socket range.
+    /// a freed number is reused before any higher one. Every object draws from one flat range, so an
+    /// allocated descriptor is simply the smallest free number.
     #[test]
-    fn alloc_is_lowest_free_and_below_socket_range() {
+    fn alloc_is_lowest_free() {
         let _guard = FORK_TEST_GUARD.lock();
         let pid: ProcessIdentifier = ProcessIdentifier::from(0x7401);
         set_current_process(pid);
@@ -2723,8 +2814,8 @@ mod tests {
         let c: c_int = vfs_alloc_hostfs(12, false, None).expect("alloc c");
         assert_eq!((a, b, c), (0, 1, 2), "flat allocation hands out the lowest free numbers");
         assert!(
-            [a, b, c].iter().all(|fd| !::config::fds::is_socket_fd(*fd)),
-            "an allocated descriptor must never fall in the reserved socket range"
+            [a, b, c].iter().all(|fd| (0..MAX_OPEN_FDS).contains(fd)),
+            "an allocated descriptor must fall within the flat namespace"
         );
 
         // Freeing the middle descriptor makes it the lowest free, so the next alloc reuses it.
@@ -3371,6 +3462,93 @@ mod tests {
         assert_eq!(handle.remote_fd(), 7, "socket handle should report its networkd descriptor");
     }
 
+    /// Tests that [`vfs_register_socket`] allocates a flat slot bound to a socket token, so the
+    /// descriptor resolves to the `networkd` descriptor it routes to, is reported as a socket, and
+    /// is the last reference when held alone.
+    #[test]
+    fn register_socket_allocates_flat_slot() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7220);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_register_socket(2050).expect("register socket should succeed");
+        // The first allocation in a fresh process is the lowest free flat number.
+        assert_eq!(fd, 0, "a socket is allocated the lowest free flat descriptor");
+        assert_eq!(
+            vfs_resolve(fd),
+            Some((VfsRoute::Socket, 2050)),
+            "a socket slot resolves to its networkd descriptor"
+        );
+        assert_eq!(vfs_socket_remote_fd(fd), Some(2050), "the socket reports its remote fd");
+        assert!(vfs_socket_is_last_ref(fd), "the sole reference is the last reference");
+        // A non-socket descriptor is not reported as a socket.
+        let file_fd: c_int = vfs_alloc_hostfs(70, false, None).expect("alloc file");
+        assert_eq!(vfs_socket_remote_fd(file_fd), None, "a hostfs descriptor is not a socket");
+        assert!(!vfs_socket_is_last_ref(file_fd), "a non-socket is never a socket last reference");
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that a close-on-exec socket is released at exec: its `networkd` descriptor is surfaced
+    /// in [`ProcessExitReclaim::orphaned_socket_fds`] so the daemon closes the endpoint, while a
+    /// non-close-on-exec socket survives at its original number.
+    #[test]
+    fn exec_cloexec_reclaims_socket() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7221);
+        set_current_process(pid);
+
+        // A close-on-exec socket and a surviving socket.
+        let cloexec_fd: c_int = vfs_register_socket(2060).expect("register cloexec socket");
+        let mut flags: FdFlags = FdFlags::default();
+        flags.set_close_on_exec(true);
+        vfs_set_fd_flags(cloexec_fd, flags).expect("set close-on-exec");
+        let survivor_fd: c_int = vfs_register_socket(2061).expect("register surviving socket");
+
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert_eq!(reclaim.orphaned_socket_fds.len(), 1, "only the cloexec socket is reclaimed");
+        assert_eq!(
+            reclaim.orphaned_socket_fds[0], 2060,
+            "the cloexec socket's networkd descriptor is surfaced for closing"
+        );
+        // The surviving socket is still resolvable at its original number.
+        assert_eq!(
+            vfs_resolve(survivor_fd),
+            Some((VfsRoute::Socket, 2061)),
+            "a non-cloexec socket survives exec"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that close-on-exec reports a duplicated socket endpoint only once when every alias is
+    /// flagged close-on-exec. The daemon sends one close per reported `networkd` descriptor, so a
+    /// shared socket open-file description must not surface duplicate reclaim records.
+    #[test]
+    fn exec_cloexec_reclaims_duplicated_socket_once() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7222);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_register_socket(2062).expect("register socket");
+        let dup_fd: c_int = vfs_dup(fd).expect("dup socket");
+        let mut cloexec: FdFlags = FdFlags::default();
+        cloexec.set_close_on_exec(true);
+        vfs_set_fd_flags(fd, cloexec).expect("set close-on-exec on original");
+        vfs_set_fd_flags(dup_fd, cloexec).expect("set close-on-exec on duplicate");
+
+        let reclaim: ProcessExitReclaim = vfs_exec_cloexec(pid);
+        assert_eq!(
+            reclaim.orphaned_socket_fds,
+            [2062],
+            "a duplicated socket endpoint must be reclaimed exactly once"
+        );
+        assert_eq!(vfs_get_fd_flags(fd), None, "the original alias is dropped");
+        assert_eq!(vfs_get_fd_flags(dup_fd), None, "the duplicate alias is dropped");
+
+        forget_processes(&[pid]);
+    }
+
     /// Tests that `fork()` copies a slot's per-descriptor flags into the child and that the copies
     /// are independent, so changing the child's flags does not affect the parent's. This is the
     /// per-descriptor semantics the later close-on-exec/close-on-fork plans depend on.
@@ -3672,12 +3850,12 @@ mod tests {
         forget_processes(&[parent, child]);
     }
 
-    /// Tests that a lone console or socket token contributes nothing to [`ProcessExitReclaim`] at
-    /// process exit: a console holds no external resource, and a socket's `networkd` descriptor is
-    /// closed by a later plan rather than reclaimed here. Crucially, neither is mistaken for a
-    /// hostfs or pipe handle.
+    /// Tests that at process exit a lone socket token surfaces its `networkd` descriptor in
+    /// [`ProcessExitReclaim::orphaned_socket_fds`] (so the daemon closes the endpoint), while a lone
+    /// console token contributes nothing. Crucially, neither is mistaken for a hostfs or pipe
+    /// handle.
     #[test]
-    fn process_exit_reclaims_nothing_for_console_and_socket() {
+    fn process_exit_reclaims_socket_and_nothing_for_console() {
         let _guard = FORK_TEST_GUARD.lock();
         let pid: ProcessIdentifier = ProcessIdentifier::from(0x7211);
         set_current_process(pid);
@@ -3688,7 +3866,8 @@ mod tests {
         alloc_fd(VfsFileHandle::Socket(SocketHandle::new(99)))
             .expect("socket alloc should succeed");
 
-        // Exit must reclaim neither a hostfs descriptor nor a pipe end for these inert tokens.
+        // Exit reclaims the socket's networkd descriptor as the sole reference, and nothing for the
+        // inert console token or for hostfs/pipe handles.
         let reclaim: ProcessExitReclaim = vfs_process_exit(pid);
         assert!(
             reclaim.orphaned_hostfs_fds.is_empty(),
@@ -3698,6 +3877,40 @@ mod tests {
             reclaim.pipe_closures.is_empty(),
             "console and socket tokens trigger no pipe closures"
         );
+        assert_eq!(
+            reclaim.orphaned_socket_fds.len(),
+            1,
+            "exactly one socket descriptor is reclaimed"
+        );
+        assert_eq!(
+            reclaim.orphaned_socket_fds[0], 99,
+            "a sole-reference socket surfaces its networkd descriptor for closing"
+        );
+
+        forget_processes(&[pid]);
+    }
+
+    /// Tests that process exit reports a duplicated socket endpoint only once. A `dup` sibling
+    /// shares the same open-file description, so vfsd must not ask `networkd` to close the same
+    /// remote endpoint once per descriptor slot when the process exits with both aliases live.
+    #[test]
+    fn process_exit_reclaims_duplicated_socket_once() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7212);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_register_socket(100).expect("register socket");
+        let dup_fd: c_int = vfs_dup(fd).expect("dup socket");
+
+        let reclaim: ProcessExitReclaim = vfs_process_exit(pid);
+        assert_eq!(
+            reclaim.orphaned_socket_fds,
+            [100],
+            "a duplicated socket endpoint must be reclaimed exactly once"
+        );
+        assert!(reclaim.orphaned_hostfs_fds.is_empty(), "no hostfs fds were opened");
+        assert!(reclaim.pipe_closures.is_empty(), "no pipe ends were opened");
+        let _ = dup_fd;
 
         forget_processes(&[pid]);
     }
@@ -3997,11 +4210,11 @@ mod tests {
 
         // An invalid source descriptor is rejected.
         assert_eq!(vfs_dup2(4096, fd).unwrap_err(), Fat32Error::InvalidFd, "bad oldfd rejected");
-        // A newfd in the reserved socket range is rejected.
+        // A newfd outside the flat namespace is rejected.
         assert_eq!(
-            vfs_dup2(fd, SOCKET_FD_BASE).unwrap_err(),
+            vfs_dup2(fd, MAX_OPEN_FDS).unwrap_err(),
             Fat32Error::InvalidFd,
-            "newfd in the socket range is rejected"
+            "newfd outside the flat namespace is rejected"
         );
 
         forget_processes(&[pid]);

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -3915,6 +3915,99 @@ mod tests {
         forget_processes(&[pid]);
     }
 
+    /// Tests that a socket inherited across `fork()` is reference-counted, not shared: a child
+    /// closing its inherited copy must not tear down the parent's socket endpoint. This is the core
+    /// regression guard for `nanvix/nanvix#2609`. Before the child closes, neither process is the
+    /// last reference (so vfsd would not forward the close to `networkd`); once the child has
+    /// closed, the parent is the sole, last reference and its socket remains fully resolvable.
+    #[test]
+    fn fork_socket_close_is_isolated() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let (parent, child): (ProcessIdentifier, ProcessIdentifier) =
+            (ProcessIdentifier::from(0x7231), ProcessIdentifier::from(0x7232));
+
+        // Parent creates a socket; it is the sole reference before the fork.
+        set_current_process(parent);
+        let fd: c_int = vfs_register_socket(2070).expect("register socket should succeed");
+        assert!(vfs_socket_is_last_ref(fd), "the only descriptor is the last reference");
+
+        // Fork: parent and child now share the same socket open-file description.
+        vfs_fork_clone(parent, child).expect("fork clone should succeed");
+        set_current_process(parent);
+        assert!(!vfs_socket_is_last_ref(fd), "parent must not be the last reference after fork");
+        set_current_process(child);
+        assert!(!vfs_socket_is_last_ref(fd), "child must not be the last reference after fork");
+
+        // The child closes its inherited copy. Because it is not the last reference, vfsd would not
+        // forward the endpoint close to `networkd`, so the parent's socket survives.
+        vfs_close(fd).expect("child close should succeed");
+        assert_eq!(vfs_socket_remote_fd(fd), None, "the child's socket descriptor is gone");
+
+        // The parent's socket is untouched and is now the sole, last reference.
+        set_current_process(parent);
+        assert_eq!(
+            vfs_socket_remote_fd(fd),
+            Some(2070),
+            "the parent's socket must survive the child's close (nanvix/nanvix#2609)"
+        );
+        assert!(
+            vfs_socket_is_last_ref(fd),
+            "the parent becomes the last reference once the child has closed"
+        );
+
+        forget_processes(&[parent, child]);
+    }
+
+    /// Tests that a child exiting while it still holds an inherited socket does not close the shared
+    /// endpoint: `vfs_process_exit` surfaces no orphaned socket because the parent still references
+    /// it. Only when the last holder (the parent) exits is the endpoint reclaimed — exactly once —
+    /// so there is neither a premature close (`nanvix/nanvix#2609`) nor a leak. This covers the
+    /// issue's "implicitly when the child exits" case, which the explicit-close acceptance test does
+    /// not exercise.
+    #[test]
+    fn fork_socket_child_exit_preserves_parent() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let (parent, child): (ProcessIdentifier, ProcessIdentifier) =
+            (ProcessIdentifier::from(0x7241), ProcessIdentifier::from(0x7242));
+
+        // Parent creates a socket and forks; the child inherits a shared reference.
+        set_current_process(parent);
+        let fd: c_int = vfs_register_socket(2071).expect("register socket should succeed");
+        vfs_fork_clone(parent, child).expect("fork clone should succeed");
+
+        // The child exits without closing its inherited socket. The endpoint must not be orphaned,
+        // because the parent still holds a reference to it.
+        let child_reclaim: ProcessExitReclaim = vfs_process_exit(child);
+        assert!(
+            child_reclaim.orphaned_socket_fds.is_empty(),
+            "a child exiting while the parent holds the socket must not close the endpoint \
+             (nanvix/nanvix#2609)"
+        );
+
+        // The parent's socket is intact and is now the sole, last reference.
+        set_current_process(parent);
+        assert_eq!(
+            vfs_socket_remote_fd(fd),
+            Some(2071),
+            "the parent's socket must survive the child's exit"
+        );
+        assert!(
+            vfs_socket_is_last_ref(fd),
+            "the parent is the last reference after the child exits"
+        );
+
+        // When the last holder exits, the endpoint is reclaimed exactly once so `networkd` closes
+        // it — no leak.
+        let parent_reclaim: ProcessExitReclaim = vfs_process_exit(parent);
+        assert_eq!(
+            parent_reclaim.orphaned_socket_fds,
+            [2071],
+            "the last holder's exit closes the endpoint exactly once (no leak)"
+        );
+
+        forget_processes(&[parent, child]);
+    }
+
     // -- root console seeding tests ----------------------------------------------
 
     /// Tests that seeding the root installs console tokens at descriptors `0`/`1`/`2` carrying the

--- a/src/tests/network-rust/src/tests/inet.rs
+++ b/src/tests/network-rust/src/tests/inet.rs
@@ -6,6 +6,17 @@
 //==================================================================================================
 
 use ::sys::error::Error;
+#[cfg(feature = "standalone")]
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pid_t,
+    sys_wait::{
+        wexitstatus,
+        wifexited,
+    },
+};
+#[cfg(feature = "standalone")]
+use ::syscall::unistd::bindings;
 use ::syscall::{
     netinet::in_::{
         Ipv4Addr,
@@ -33,6 +44,18 @@ use ::syscall::{
 //==================================================================================================
 
 const LISTEN_BACKLOG: i32 = 5;
+
+/// Port used by the process-exit socket reclaim regression test.
+#[cfg(feature = "standalone")]
+const SOCKET_RECLAIM_PORT: u16 = 1993;
+
+/// Exit status used by a child that completed the socket reclaim setup.
+#[cfg(feature = "standalone")]
+const CHILD_EXIT_SUCCESS: c_int = 0;
+
+/// Exit status used by a child that failed the socket reclaim setup.
+#[cfg(feature = "standalone")]
+const CHILD_EXIT_FAILURE: c_int = 101;
 
 //==================================================================================================
 // Helper Functions
@@ -133,6 +156,125 @@ fn test_accept() -> Result<(), Error> {
     Ok(())
 }
 
+/// Tests that a socket draws its application-visible descriptor from the flat namespace, exactly
+/// like a file or pipe: two live sockets hold distinct numbers, and a number freed by `close` is
+/// the lowest free one, so the next socket reuses it. This is the unified lowest-free allocation
+/// that replaced the former reserved socket range — a socket is no longer numbered apart from every
+/// other object.
+#[cfg(feature = "standalone")]
+fn test_socket_fd_is_flat() -> Result<(), Error> {
+    let first: i32 = new_unbound_socket()?;
+    let second: i32 = new_unbound_socket()?;
+    assert_ne!(first, second, "two live sockets must hold distinct descriptors");
+    assert!(second > first, "the second socket takes the next free flat descriptor");
+
+    // Freeing the lower descriptor makes it the lowest free, so the next socket reuses it rather
+    // than advancing to a higher number.
+    close(first)?;
+    let reused: i32 = new_unbound_socket()?;
+    assert_eq!(reused, first, "a freed socket descriptor is reused as the lowest free number");
+
+    close(second)?;
+    close(reused)?;
+    Ok(())
+}
+
+/// Tests that `dup2` of a socket shares the underlying `networkd` endpoint and that the endpoint
+/// survives until its last descriptor is closed. The duplicate is a second flat descriptor backed
+/// by the same socket slot, so it reports the same bound address; closing the original — not the
+/// last reference — must leave the duplicate fully usable, and only closing the duplicate drops the
+/// last reference that releases the endpoint on `networkd`.
+#[cfg(feature = "standalone")]
+fn test_dup2_socket_shares_endpoint() -> Result<(), Error> {
+    use ::syscall::unistd::dup2;
+
+    // Bind to an ephemeral port so the OS assigns a concrete address to compare against.
+    let listen_addr: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new([127, 0, 0, 1]), 0));
+    let sockfd: i32 = new_listening_socket(&listen_addr)?;
+
+    let mut bound_addr: SocketAddr = SocketAddr::V4(SocketAddrV4::default());
+    getsockname(sockfd, &mut bound_addr)?;
+
+    // Obtain a descriptor number known to be free by allocating one and releasing it, then
+    // duplicate the socket onto it. `dup2` is served authoritatively by vfsd, which clones the
+    // socket slot, so both descriptors alias the same endpoint.
+    let target: i32 = new_unbound_socket()?;
+    close(target)?;
+    let dupfd: i32 = dup2(sockfd, target)?;
+    assert_eq!(dupfd, target, "dup2 returns the requested target descriptor");
+    assert_ne!(dupfd, sockfd, "the duplicate is a distinct descriptor");
+
+    let mut dup_addr: SocketAddr = SocketAddr::V4(SocketAddrV4::default());
+    getsockname(dupfd, &mut dup_addr)?;
+    assert_eq!(bound_addr, dup_addr, "a duplicated socket shares the original endpoint's address");
+
+    // Close the original. It is not the last reference, so the endpoint must stay alive.
+    close(sockfd)?;
+
+    // The duplicate still resolves to the live endpoint and reports the same address.
+    let mut survivor_addr: SocketAddr = SocketAddr::V4(SocketAddrV4::default());
+    getsockname(dupfd, &mut survivor_addr)?;
+    assert_eq!(
+        bound_addr, survivor_addr,
+        "the endpoint survives closing a non-last socket reference"
+    );
+
+    // Close the last reference, which releases the endpoint on networkd.
+    close(dupfd)?;
+    Ok(())
+}
+
+/// Creates a duplicated socket endpoint and leaves both descriptors open for process exit.
+#[cfg(feature = "standalone")]
+fn leave_duplicated_socket_for_exit(addr: &SocketAddr) -> Result<(), Error> {
+    use ::syscall::unistd::dup2;
+
+    let sockfd: i32 = new_bound_socket(addr)?;
+    let target: i32 = new_unbound_socket()?;
+    close(target)?;
+
+    let dupfd: i32 = dup2(sockfd, target)?;
+    assert_eq!(dupfd, target, "dup2 returns the requested target descriptor");
+    assert_ne!(dupfd, sockfd, "the duplicate is a distinct descriptor");
+
+    Ok(())
+}
+
+/// Tests that process exit reclaims a duplicated socket endpoint exactly enough for the address to
+/// be immediately reusable by the parent. The child exits with both aliases open; vfsd must treat
+/// them as one underlying `networkd` endpoint when forwarding exit-time close requests.
+#[cfg(feature = "standalone")]
+fn test_process_exit_reclaims_duplicated_socket_endpoint() -> Result<(), Error> {
+    let addr: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new([127, 0, 0, 1]), SOCKET_RECLAIM_PORT));
+
+    let child_pid: pid_t = bindings::fork::fork();
+    if child_pid == 0 {
+        let exit_status: c_int = match leave_duplicated_socket_for_exit(&addr) {
+            Ok(()) => CHILD_EXIT_SUCCESS,
+            Err(_) => CHILD_EXIT_FAILURE,
+        };
+        unsafe { bindings::_exit::_exit(exit_status) };
+    }
+
+    assert!(child_pid > 0, "fork() failed in parent (ret={})", child_pid);
+
+    let mut status: c_int = 0;
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(child_pid, &raw mut status, 0) };
+    assert_eq!(reaped, child_pid, "waitpid() must reap the child that held duplicated sockets");
+    assert!(wifexited(status), "child must exit normally (status={})", status);
+    assert_eq!(
+        wexitstatus(status),
+        CHILD_EXIT_SUCCESS,
+        "child must complete duplicated socket setup before exit"
+    );
+
+    let sockfd: i32 = new_bound_socket(&addr)?;
+    close(sockfd)?;
+    Ok(())
+}
+
 //==================================================================================================
 // Entry Point
 //==================================================================================================
@@ -147,6 +289,14 @@ pub fn run() -> Result<(), Error> {
     test_getsockname_bound_socket(&addr)?;
     test_getsockname_listening_socket(&addr)?;
     test_accept()?;
+
+    // Flat-namespace socket behavior is implemented only for the standalone (networkd) backend.
+    #[cfg(feature = "standalone")]
+    {
+        test_socket_fd_is_flat()?;
+        test_dup2_socket_shares_endpoint()?;
+        test_process_exit_reclaims_duplicated_socket_endpoint()?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Folds sockets into the single lowest-free flat descriptor namespace alongside files, pipes, and console streams. Previously sockets occupied a reserved descriptor range (`[SOCKET_FD_BASE, ..)`) that vfsd's flat allocator deliberately stayed below, so a socket's number encoded its backend. This removes that interim reservation: `networkd` still owns the endpoint, but `vfsd` now allocates the application-visible flat descriptor that routes to it.

## Changes

### Descriptor allocation & routing
- **vfs**: replace the `SOCKET_FD_BASE` bound with `MAX_OPEN_FDS`; `alloc_fd`, `vfs_dup_from`, and `vfs_dup2` now span `[0, MAX_OPEN_FDS)` for every object.
- **config**: drop `is_socket_fd()`; `SOCKET_FD_BASE` is now documented as `networkd`'s internal descriptor space, never seen by applications.
- **syscall/fdtable**: remove the by-number `derive()` socket shortcut so a socket resolves through `vfsd` like any other object; add `resolve_socket` to map a flat descriptor to its `networkd` backend fd (`ENOTSOCK` on a non-socket; pass-through in hosted mode).

### Socket creation (libposix)
- Add `RegisterSocket` request/response and `register_socket_slot`: after `networkd` returns the endpoint, `vfsd` binds it to the lowest free flat slot and the caller seeds its resolution cache with the returned epoch. `socket()`, `accept()`, and `socketpair()` now register the slot; failures roll back the `networkd` endpoint so creation never strands it.
- Route `bind`/`connect`/`listen`/`accept`/`send`/`recv`/`shutdown`/`getsockname`/`getpeername` through `resolve_socket` to address `networkd` by backend fd.
- `close()` now releases the flat slot via `vfsd`; `vfsd` forwards the endpoint close to `networkd` only on the last reference.

### Last-reference reclaim (vfs/vfsd)
- **vfs**: add `vfs_register_socket`, `vfs_socket_remote_fd`, and `vfs_socket_is_last_ref`; surface `orphaned_socket_fds` from `vfs_process_exit` and `vfs_exec_cloexec`, deduplicating shared (dup'd) open-file descriptions so an endpoint is reported exactly once.
- **vfsd**: new `networkd` module forwards fire-and-forget endpoint closes on `close`, displacing `dup2`, process exit, and exec close-on-exec; the `CloseResponse` acknowledgement is discarded by the main event loop.

## Tests
- **vfs**: flat allocation, register-socket slot, and exit/exec reclaim (including dup'd-endpoint deduplication) unit tests.
- **network-rust**: standalone regression tests for flat socket numbering, `dup2` endpoint sharing, and process-exit endpoint reclaim.


## Issues

Closes #2600 
Closes #2609