### PR TITLE
[libc_string] Expand POSIX <string.h> coverage

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -24,16 +24,39 @@ extern "C" {
  * Memory Operations
  *==================================================================================================*/
 
+extern void *memccpy(void *dest, const void *src, int c, size_t n);
+extern void *memchr(const void *s, int c, size_t n);
+extern int memcmp(const void *ptr1, const void *ptr2, size_t len);
 extern void *memcpy(void *dest, const void *src, size_t len);
 extern void *memmove(void *dest, const void *src, size_t len);
 extern void *memset(void *ptr, int val, size_t len);
-extern int memcmp(const void *ptr1, const void *ptr2, size_t len);
 
 /*==================================================================================================
  * String Operations
  *==================================================================================================*/
 
+extern char *strcat(char *dest, const char *src);
+extern char *strchr(const char *s, int c);
+extern int strcmp(const char *s1, const char *s2);
+extern char *strcpy(char *dest, const char *src);
+extern size_t strcspn(const char *s, const char *reject);
+extern char *strdup(const char *s);
+extern char *strerror(int errnum);
+extern int strerror_r(int errnum, char *buf, size_t buflen);
+extern size_t strlcat(char *dest, const char *src, size_t size);
+extern size_t strlcpy(char *dest, const char *src, size_t size);
 extern size_t strlen(const char *s);
+extern char *strncat(char *dest, const char *src, size_t n);
+extern int strncmp(const char *s1, const char *s2, size_t n);
+extern char *strncpy(char *dest, const char *src, size_t n);
+extern char *strndup(const char *s, size_t n);
+extern size_t strnlen(const char *s, size_t maxlen);
+extern char *strpbrk(const char *s, const char *accept);
+extern char *strrchr(const char *s, int c);
+extern size_t strspn(const char *s, const char *accept);
+extern char *strstr(const char *haystack, const char *needle);
+extern char *strtok(char *s, const char *delim);
+extern char *strtok_r(char *s, const char *delim, char **saveptr);
 
 #ifdef __cplusplus
 }

--- a/src/libs/libc_string/header.toml
+++ b/src/libs/libc_string/header.toml
@@ -15,8 +15,31 @@ guard = "_NANVIX_STRING_H"
 
 [[sections]]
 title = "Memory Operations"
-functions = ["memcpy", "memmove", "memset", "memcmp"]
+functions = ["memccpy", "memchr", "memcmp", "memcpy", "memmove", "memset"]
 
 [[sections]]
 title = "String Operations"
-functions = ["strlen"]
+functions = [
+    "strcat",
+    "strchr",
+    "strcmp",
+    "strcpy",
+    "strcspn",
+    "strdup",
+    "strerror",
+    "strerror_r",
+    "strlcat",
+    "strlcpy",
+    "strlen",
+    "strncat",
+    "strncmp",
+    "strncpy",
+    "strndup",
+    "strnlen",
+    "strpbrk",
+    "strrchr",
+    "strspn",
+    "strstr",
+    "strtok",
+    "strtok_r",
+]

--- a/src/libs/libc_string/src/bcmp.rs
+++ b/src/libs/libc_string/src/bcmp.rs
@@ -1,0 +1,80 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares the first `n` bytes of the memory areas `s1` and `s2` (legacy BSD interface).
+///
+/// # Returns
+///
+/// Zero if the byte ranges are equal, and non-zero otherwise.
+///
+/// # Safety
+///
+/// Both `s1` and `s2` must point to at least `n` readable bytes.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/bcmp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> c_int {
+    let a: *const u8 = s1.cast::<u8>();
+    let b: *const u8 = s2.cast::<u8>();
+    let mut i: c_size_t = 0;
+    while i < n {
+        if *a.add(i as usize) != *b.add(i as usize) {
+            return 1;
+        }
+        i += 1;
+    }
+    0
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::bcmp;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_bcmp_equal() {
+        let a: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let b: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let ret: c_int = unsafe { bcmp(a.as_ptr().cast(), b.as_ptr().cast(), 5) };
+        assert_eq!(ret, 0, "bcmp should return 0 for equal byte ranges");
+    }
+
+    #[test]
+    fn test_bcmp_differ() {
+        let a: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let b: Vec<u8> = vec![1, 2, 0, 4, 5];
+        let ret: c_int = unsafe { bcmp(a.as_ptr().cast(), b.as_ptr().cast(), 5) };
+        assert_ne!(ret, 0, "bcmp should return non-zero for differing byte ranges");
+    }
+
+    #[test]
+    fn test_bcmp_zero_length() {
+        let a: Vec<u8> = vec![1, 2, 3];
+        let b: Vec<u8> = vec![4, 5, 6];
+        let ret: c_int = unsafe { bcmp(a.as_ptr().cast(), b.as_ptr().cast(), 0) };
+        assert_eq!(ret, 0, "bcmp with zero length should return 0");
+    }
+}

--- a/src/libs/libc_string/src/bcopy.rs
+++ b/src/libs/libc_string/src/bcopy.rs
@@ -1,0 +1,108 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_uchar,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies bytes in memory (legacy).
+///
+/// This function copies `n` bytes from memory area `src` to memory area `dest`. The memory areas
+/// may overlap. Note that the parameter order is reversed from `memcpy` (src comes first).
+///
+/// # Parameters
+///
+/// - `src`: Pointer to the source memory area.
+/// - `dest`: Pointer to the destination memory area.
+/// - `n`: Number of bytes to copy.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It performs unchecked writes to the memory region pointed to by `dest`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn bcopy(src: *const c_void, dest: *mut c_void, n: c_size_t) {
+    debug_assert!(!src.is_null(), "bcopy(): null source pointer");
+    debug_assert!(!dest.is_null(), "bcopy(): null destination pointer");
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_uchar>()),
+        "bcopy(): source pointer is not properly aligned"
+    );
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_uchar>()),
+        "bcopy(): destination pointer is not properly aligned"
+    );
+
+    let d: *mut c_uchar = dest.cast::<c_uchar>();
+    let s: *const c_uchar = src.cast::<c_uchar>();
+    let n: usize = n as usize;
+
+    if n == 0 || core::ptr::eq(d.cast_const(), s) {
+        return;
+    }
+
+    // Handle overlapping regions like memmove.
+    if (d as usize) < (s as usize) || (d as usize) >= (s as usize + n) {
+        // Forward copy.
+        let mut i: usize = 0;
+        while i < n {
+            *d.add(i) = *s.add(i);
+            i += 1;
+        }
+    } else {
+        // Backward copy.
+        let mut i: usize = n;
+        while i != 0 {
+            i -= 1;
+            *d.add(i) = *s.add(i);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::bcopy;
+
+    #[test]
+    fn test_bcopy_basic() {
+        let src: [u8; 5] = [1, 2, 3, 4, 5];
+        let mut dest: [u8; 5] = [0; 5];
+        unsafe { bcopy(src.as_ptr().cast(), dest.as_mut_ptr().cast(), 5) };
+        assert_eq!(dest, [1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_bcopy_overlapping() {
+        let mut buf: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        unsafe {
+            let src: *const core::ffi::c_void = buf.as_ptr().cast();
+            let dest: *mut core::ffi::c_void = buf[2..].as_mut_ptr().cast();
+            bcopy(src, dest, 4);
+        }
+        assert_eq!(buf, [1, 2, 1, 2, 3, 4, 7, 8]);
+    }
+}

--- a/src/libs/libc_string/src/bzero.rs
+++ b/src/libs/libc_string/src/bzero.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_uchar,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Zeros a byte string (legacy).
+///
+/// This function writes `n` zeroed bytes to the memory area pointed to by `s`. This is equivalent
+/// to `memset(s, 0, n)`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the memory area to zero.
+/// - `n`: Number of bytes to zero.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It performs unchecked writes to the memory region pointed to by `s`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn bzero(s: *mut c_void, n: c_size_t) {
+    debug_assert!(!s.is_null(), "bzero(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_uchar>()),
+        "bzero(): pointer is not properly aligned"
+    );
+
+    let dst: *mut c_uchar = s.cast::<c_uchar>();
+    let n: usize = n as usize;
+    let mut i: usize = 0;
+    while i < n {
+        *dst.add(i) = 0;
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::bzero;
+    use ::std::vec::Vec;
+
+    #[test]
+    fn test_bzero_basic() {
+        let mut buf: Vec<u8> = vec![0xFF; 10];
+        unsafe { bzero(buf.as_mut_ptr().cast(), 10) };
+        assert!(buf.iter().all(|&b| b == 0), "all bytes should be zero");
+    }
+}

--- a/src/libs/libc_string/src/ffs.rs
+++ b/src/libs/libc_string/src/ffs.rs
@@ -1,0 +1,79 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Finds the position of the first (least significant) set bit in `i`.
+///
+/// # Returns
+///
+/// The 1-based index of the first set bit, or 0 if `i` is zero.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffs.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ffs(i: c_int) -> c_int {
+    if i == 0 {
+        return 0;
+    }
+    // For a non-zero `i32`, `trailing_zeros()` ∈ 0..=31, so the 1-based index
+    // (`+ 1`) is 1..=32 and always converts cleanly to `c_int` (the `Err` arm is
+    // unreachable). Using `try_from` avoids an unchecked `as` cast, which this
+    // crate forbids (clippy::cast_possible_truncation / cast_possible_wrap).
+    match c_int::try_from(i.trailing_zeros()) {
+        Ok(n) => n + 1,
+        Err(_) => 0,
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::ffs;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_ffs_zero() {
+        assert_eq!(ffs(0), 0, "ffs(0) should be 0");
+    }
+
+    #[test]
+    fn test_ffs_low_bit() {
+        assert_eq!(ffs(1), 1, "ffs(1) should be 1");
+    }
+
+    #[test]
+    fn test_ffs_second_bit() {
+        assert_eq!(ffs(2), 2, "ffs(2) should be 2");
+    }
+
+    #[test]
+    fn test_ffs_mixed_bits() {
+        // 0b1100 has its least-significant set bit at position 3 (1-based).
+        assert_eq!(ffs(12), 3, "ffs(12) should be 3");
+    }
+
+    #[test]
+    fn test_ffs_high_bit() {
+        // 0x80 has its least-significant set bit at position 8 (1-based).
+        assert_eq!(ffs(0x80), 8, "ffs(0x80) should be 8");
+    }
+
+    #[test]
+    fn test_ffs_sign_bit() {
+        // i32::MIN has only bit 31 set, so the 1-based index is 32.
+        assert_eq!(ffs(c_int::MIN), 32, "ffs(i32::MIN) should be 32");
+    }
+}

--- a/src/libs/libc_string/src/lib.rs
+++ b/src/libs/libc_string/src/lib.rs
@@ -29,8 +29,39 @@
 // Modules
 //==================================================================================================
 
+pub mod bcmp;
+pub mod bcopy;
+pub mod bzero;
+pub mod ffs;
+pub mod memccpy;
+pub mod memchr;
 pub mod memcmp;
 pub mod memcpy;
 pub mod memmove;
+pub mod memrchr;
 pub mod memset;
+pub mod strcasecmp;
+pub mod strcat;
+pub mod strchr;
+pub mod strcmp;
+pub mod strcpy;
+pub mod strcspn;
+pub mod strdup;
+pub mod strerror;
+pub mod strerror_r;
+pub mod strlcat;
+pub mod strlcpy;
 pub mod strlen;
+pub mod strncasecmp;
+pub mod strncat;
+pub mod strncmp;
+pub mod strncpy;
+pub mod strndup;
+pub mod strnlen;
+pub mod strpbrk;
+pub mod strrchr;
+pub mod strsep;
+pub mod strspn;
+pub mod strstr;
+pub mod strtok;
+pub mod strtok_r;

--- a/src/libs/libc_string/src/memccpy.rs
+++ b/src/libs/libc_string/src/memccpy.rs
@@ -1,0 +1,139 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uchar,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies bytes from one memory region to another, stopping after the first occurrence of byte `c`
+/// or after `n` bytes have been copied, whichever comes first.
+///
+/// # Parameters
+///
+/// - `dest`: Destination pointer where bytes will be written.
+/// - `src`: Source pointer from which bytes will be read.
+/// - `c`: Byte value to stop copying after (interpreted as `unsigned char`).
+/// - `n`: Maximum number of bytes to copy.
+///
+/// # Return Value
+///
+/// Returns a pointer to the byte in `dest` immediately after the copy of `c`, if `c` was found
+/// in the first `n` bytes of `src`. Returns a null pointer if `c` was not found.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It performs unchecked writes to the memory region pointed to by `dest`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn memccpy(
+    dest: *mut c_void,
+    src: *const c_void,
+    c: c_int,
+    n: c_size_t,
+) -> *mut c_void {
+    debug_assert!(!dest.is_null(), "memccpy(): null destination pointer");
+    debug_assert!(!src.is_null(), "memccpy(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_uchar>()),
+        "memccpy(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_uchar>()),
+        "memccpy(): source pointer is not properly aligned"
+    );
+
+    let target: c_uchar = c.to_le_bytes()[0];
+    let d: *mut c_uchar = dest.cast::<c_uchar>();
+    let s: *const c_uchar = src.cast::<c_uchar>();
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        let byte: c_uchar = *s.add(i as usize);
+        *d.add(i as usize) = byte;
+        if byte == target {
+            return d.add(i as usize + 1).cast::<c_void>();
+        }
+        i += 1;
+    }
+
+    core::ptr::null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::memccpy;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        ffi::c_int,
+        sys_types::c_size_t,
+    };
+
+    #[test]
+    fn test_memccpy_char_found() {
+        let src: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let mut dst: Vec<u8> = vec![0; 5];
+        let ret: *mut core::ffi::c_void = unsafe {
+            memccpy(
+                dst.as_mut_ptr().cast(),
+                src.as_ptr().cast(),
+                3 as c_int,
+                c_size_t::try_from(src.len()).expect("len fits in c_size_t"),
+            )
+        };
+        assert!(!ret.is_null(), "memccpy should return non-null when char is found");
+        // Bytes up to and including the target should be copied.
+        assert_eq!(dst[0], 1);
+        assert_eq!(dst[1], 2);
+        assert_eq!(dst[2], 3);
+        // Return pointer should be one past the copied target byte.
+        let expected_offset: usize = 3;
+        let actual_offset: usize = (ret as usize) - (dst.as_ptr() as usize);
+        assert_eq!(actual_offset, expected_offset, "return pointer should be one past target");
+    }
+
+    #[test]
+    fn test_memccpy_char_not_found() {
+        let src: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let mut dst: Vec<u8> = vec![0; 5];
+        let ret: *mut core::ffi::c_void = unsafe {
+            memccpy(
+                dst.as_mut_ptr().cast(),
+                src.as_ptr().cast(),
+                9 as c_int,
+                c_size_t::try_from(src.len()).expect("len fits in c_size_t"),
+            )
+        };
+        assert!(ret.is_null(), "memccpy should return null when char is not found");
+        // All bytes should still be copied.
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_memccpy_zero_length() {
+        let src: Vec<u8> = vec![1, 2, 3];
+        let mut dst: Vec<u8> = vec![0xFF; 3];
+        let ret: *mut core::ffi::c_void =
+            unsafe { memccpy(dst.as_mut_ptr().cast(), src.as_ptr().cast(), 1 as c_int, 0) };
+        assert!(ret.is_null(), "memccpy with zero length should return null");
+        assert!(dst.iter().all(|&b| b == 0xFF), "destination should be unchanged");
+    }
+}

--- a/src/libs/libc_string/src/memchr.rs
+++ b/src/libs/libc_string/src/memchr.rs
@@ -1,0 +1,98 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uchar,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Scans memory for a byte.
+///
+/// This function scans the initial `n` bytes of the memory area pointed to by `s` for the first
+/// instance of `c`. Both `c` and the bytes of the memory area pointed to by `s` are interpreted as
+/// unsigned chars.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the memory area to search.
+/// - `c`: Byte value to search for.
+/// - `n`: Number of bytes to search.
+///
+/// # Return Value
+///
+/// Returns a pointer to the matching byte, or a null pointer if the byte is not found within the
+/// first `n` bytes.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory region pointed to by `s` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, n: c_size_t) -> *mut c_void {
+    debug_assert!(!s.is_null(), "memchr(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_uchar>()),
+        "memchr(): pointer is not properly aligned"
+    );
+
+    let target: c_uchar = c.to_le_bytes()[0];
+    let p: *const c_uchar = s.cast::<c_uchar>();
+    let n: usize = n as usize;
+    let mut i: usize = 0;
+    while i < n {
+        if *p.add(i) == target {
+            return s.add(i).cast_mut();
+        }
+        i += 1;
+    }
+
+    core::ptr::null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::memchr;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_memchr_found() {
+        let buf: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let ret: *mut core::ffi::c_void = unsafe { memchr(buf.as_ptr().cast(), 3 as c_int, 5) };
+        assert!(!ret.is_null(), "memchr should find the byte");
+        let offset: usize = (ret as usize) - (buf.as_ptr() as usize);
+        assert_eq!(offset, 2, "byte 3 is at index 2");
+    }
+
+    #[test]
+    fn test_memchr_not_found() {
+        let buf: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let ret: *mut core::ffi::c_void = unsafe { memchr(buf.as_ptr().cast(), 9 as c_int, 5) };
+        assert!(ret.is_null(), "memchr should return null when byte not found");
+    }
+
+    #[test]
+    fn test_memchr_zero_length() {
+        let buf: Vec<u8> = vec![1, 2, 3];
+        let ret: *mut core::ffi::c_void = unsafe { memchr(buf.as_ptr().cast(), 1 as c_int, 0) };
+        assert!(ret.is_null(), "memchr should return null with zero length");
+    }
+}

--- a/src/libs/libc_string/src/memcmp.rs
+++ b/src/libs/libc_string/src/memcmp.rs
@@ -65,7 +65,7 @@ use ::sysapi::{
 ///
 /// Violating any of these conditions results in undefined behavior.
 ///
-#[unsafe(no_mangle)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn memcmp(ptr1: *const c_void, ptr2: *const c_void, len: c_size_t) -> c_int {
     debug_assert!(!ptr1.is_null(), "memcmp(): null pointer");
     debug_assert!(!ptr2.is_null(), "memcmp(): null pointer");

--- a/src/libs/libc_string/src/memcpy.rs
+++ b/src/libs/libc_string/src/memcpy.rs
@@ -63,7 +63,7 @@ use ::sysapi::{
 ///
 /// Violating any of these conditions results in undefined behavior.
 ///
-#[unsafe(no_mangle)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn memcpy(
     dest: *mut c_void,
     src: *const c_void,

--- a/src/libs/libc_string/src/memmove.rs
+++ b/src/libs/libc_string/src/memmove.rs
@@ -56,7 +56,7 @@ use ::sysapi::{
 /// - `len` does not exceed `isize::MAX`.
 /// - `dest` and `src` are properly aligned for `c_uchar` access.
 ///
-#[unsafe(no_mangle)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn memmove(
     dest: *mut c_void,
     src: *const c_void,

--- a/src/libs/libc_string/src/memrchr.rs
+++ b/src/libs/libc_string/src/memrchr.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uchar,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Scans memory for a byte in reverse.
+///
+/// This function scans the initial `n` bytes of the memory area pointed to by `s` for the last
+/// instance of `c`. Both `c` and the bytes of the memory area are interpreted as unsigned chars.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the memory area to search.
+/// - `c`: Byte value to search for.
+/// - `n`: Number of bytes to search.
+///
+/// # Return Value
+///
+/// Returns a pointer to the last matching byte, or a null pointer if the byte is not found within
+/// the first `n` bytes.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory region pointed to by `s` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn memrchr(s: *const c_void, c: c_int, n: c_size_t) -> *mut c_void {
+    debug_assert!(!s.is_null(), "memrchr(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_uchar>()),
+        "memrchr(): pointer is not properly aligned"
+    );
+
+    let target: c_uchar = c.to_le_bytes()[0];
+    let p: *const c_uchar = s.cast::<c_uchar>();
+    let n: usize = n as usize;
+    let mut i: usize = n;
+    while i > 0 {
+        i -= 1;
+        if *p.add(i) == target {
+            return s.add(i).cast_mut();
+        }
+    }
+
+    core::ptr::null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::memrchr;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_int;
+
+    #[test]
+    fn test_memrchr_found_at_end() {
+        let buf: Vec<u8> = vec![1, 2, 3, 2, 5];
+        let ret: *mut core::ffi::c_void = unsafe { memrchr(buf.as_ptr().cast(), 2 as c_int, 5) };
+        assert!(!ret.is_null(), "memrchr should find the byte");
+        let offset: usize = (ret as usize) - (buf.as_ptr() as usize);
+        assert_eq!(offset, 3, "last 2 is at index 3");
+    }
+
+    #[test]
+    fn test_memrchr_found_at_start() {
+        let buf: Vec<u8> = vec![7, 1, 2, 3, 4];
+        let ret: *mut core::ffi::c_void = unsafe { memrchr(buf.as_ptr().cast(), 7 as c_int, 5) };
+        assert!(!ret.is_null(), "memrchr should find the byte");
+        let offset: usize = (ret as usize) - (buf.as_ptr() as usize);
+        assert_eq!(offset, 0, "7 is at index 0");
+    }
+
+    #[test]
+    fn test_memrchr_not_found() {
+        let buf: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let ret: *mut core::ffi::c_void = unsafe { memrchr(buf.as_ptr().cast(), 9 as c_int, 5) };
+        assert!(ret.is_null(), "memrchr should return null when byte not found");
+    }
+}

--- a/src/libs/libc_string/src/memset.rs
+++ b/src/libs/libc_string/src/memset.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use ::core::mem::align_of;
+use ::core::mem::{
+    align_of,
+    size_of,
+};
 use ::sysapi::{
     ffi::{
         c_int,
@@ -50,7 +53,7 @@ use ::sysapi::{
 ///
 /// Violating any of these conditions results in undefined behavior.
 ///
-#[unsafe(no_mangle)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn memset(ptr: *mut c_void, val: c_int, len: c_size_t) -> *mut c_void {
     debug_assert!(!ptr.is_null(), "memset(): null pointer");
     debug_assert!((len as usize) < isize::MAX as usize, "memset(): length too large");
@@ -62,7 +65,26 @@ pub unsafe extern "C" fn memset(ptr: *mut c_void, val: c_int, len: c_size_t) -> 
     let dst: *mut c_uchar = ptr.cast::<c_uchar>();
     let byte: c_uchar = (val & 0xFF) as c_uchar;
     let len: usize = len as usize;
-    let mut i: usize = 0;
+
+    const WORD_SIZE: usize = size_of::<usize>();
+    const WORD_ALIGN: usize = align_of::<usize>();
+    let d_addr: usize = dst as usize;
+    // Broadcast the fill byte across a full machine word (0x01010101... * byte).
+    let word: usize = (byte as usize).wrapping_mul(usize::MAX / 0xFF);
+
+    // Fill leading bytes until the destination is word-aligned.
+    let mut offset: usize = 0;
+    while ((d_addr + offset) & (WORD_ALIGN - 1)) != 0 && offset < len {
+        *dst.add(offset) = byte;
+        offset += 1;
+    }
+    // Bulk fill a word at a time.
+    let mut i: usize = offset;
+    while i + WORD_SIZE <= len {
+        *dst.add(i).cast::<usize>() = word;
+        i += WORD_SIZE;
+    }
+    // Fill the trailing bytes.
     while i < len {
         *dst.add(i) = byte;
         i += 1;

--- a/src/libs/libc_string/src/strcasecmp.rs
+++ b/src/libs/libc_string/src/strcasecmp.rs
@@ -1,0 +1,120 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Folds an ASCII upper-case byte to lower case.
+#[inline]
+fn to_lower(b: u8) -> u8 {
+    if b.is_ascii_uppercase() {
+        b + 32
+    } else {
+        b
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares the strings `s1` and `s2` ignoring the case of ASCII letters.
+///
+/// # Returns
+///
+/// A negative, zero, or positive value if `s1` is respectively less than, equal to, or greater
+/// than `s2` after case folding.
+///
+/// # Safety
+///
+/// Both `s1` and `s2` must point to valid, null-terminated strings.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcasecmp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcasecmp(s1: *const c_char, s2: *const c_char) -> c_int {
+    debug_assert!(!s1.is_null(), "strcasecmp(): null pointer");
+    debug_assert!(!s2.is_null(), "strcasecmp(): null pointer");
+
+    let mut a: *const c_char = s1;
+    let mut b: *const c_char = s2;
+    loop {
+        let ca: u8 = to_lower(*a as u8);
+        let cb: u8 = to_lower(*b as u8);
+        if ca != cb {
+            return c_int::from(ca) - c_int::from(cb);
+        }
+        if ca == 0 {
+            return 0;
+        }
+        a = a.add(1);
+        b = b.add(1);
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strcasecmp;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strcasecmp_equal_ignoring_case() {
+        let s1: Vec<c_char> = make_c_string(b"Hello");
+        let s2: Vec<c_char> = make_c_string(b"hELLO");
+        let ret: c_int = unsafe { strcasecmp(s1.as_ptr(), s2.as_ptr()) };
+        assert_eq!(ret, 0, "strcasecmp should ignore case for equal strings");
+    }
+
+    #[test]
+    fn test_strcasecmp_less() {
+        let s1: Vec<c_char> = make_c_string(b"abc");
+        let s2: Vec<c_char> = make_c_string(b"abz");
+        let ret: c_int = unsafe { strcasecmp(s1.as_ptr(), s2.as_ptr()) };
+        assert!(ret < 0, "strcasecmp should return negative when s1 < s2");
+    }
+
+    #[test]
+    fn test_strcasecmp_greater_case_insensitive() {
+        // Case-folded 'Z' (0x7A) is greater than 'c' (0x63).
+        let s1: Vec<c_char> = make_c_string(b"abZ");
+        let s2: Vec<c_char> = make_c_string(b"abc");
+        let ret: c_int = unsafe { strcasecmp(s1.as_ptr(), s2.as_ptr()) };
+        assert!(ret > 0, "strcasecmp should compare case-insensitively");
+    }
+
+    #[test]
+    fn test_strcasecmp_empty_strings() {
+        let s1: Vec<c_char> = make_c_string(b"");
+        let s2: Vec<c_char> = make_c_string(b"");
+        let ret: c_int = unsafe { strcasecmp(s1.as_ptr(), s2.as_ptr()) };
+        assert_eq!(ret, 0, "two empty strings should be equal");
+    }
+}

--- a/src/libs/libc_string/src/strcat.rs
+++ b/src/libs/libc_string/src/strcat.rs
@@ -1,0 +1,133 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Appends a null-terminated string to another.
+///
+/// This function appends the string pointed to by `src` to the end of the string pointed to by
+/// `dest`, overwriting the null terminator at the end of `dest`, and then adding a terminating null
+/// byte. The strings must not overlap, and the `dest` buffer must be large enough.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination null-terminated string.
+/// - `src`: Pointer to the source null-terminated string.
+///
+/// # Return Value
+///
+/// Returns the original destination pointer `dest`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcat(dest: *mut c_char, src: *const c_char) -> *mut c_char {
+    debug_assert!(!dest.is_null(), "strcat(): null destination pointer");
+    debug_assert!(!src.is_null(), "strcat(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strcat(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strcat(): source pointer is not properly aligned"
+    );
+
+    // Find the end of dest.
+    let mut d: usize = 0;
+    while *dest.add(d) != 0 {
+        d += 1;
+    }
+
+    // Copy src to end of dest.
+    let mut s: usize = 0;
+    loop {
+        let c: c_char = *src.add(s);
+        *dest.add(d) = c;
+        if c == 0 {
+            break;
+        }
+        d += 1;
+        s += 1;
+    }
+
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strcat;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strcat_basic() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 20];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        let world: Vec<c_char> = make_c_string(b" world");
+        // Copy "hello" into dest first.
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        unsafe { strcat(dest.as_mut_ptr(), world.as_ptr()) };
+        let expected: Vec<c_char> = make_c_string(b"hello world");
+        for (i, &c) in expected.iter().enumerate() {
+            assert_eq!(dest[i], c, "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_strcat_empty_src() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 10];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        let empty: Vec<c_char> = make_c_string(b"");
+        unsafe { strcat(dest.as_mut_ptr(), empty.as_ptr()) };
+        assert_eq!(dest[0], c_char::try_from(b'h').expect("ASCII fits in c_char"));
+        assert_eq!(dest[5], 0 as c_char);
+    }
+
+    #[test]
+    fn test_strcat_empty_dest() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 10];
+        let src: Vec<c_char> = make_c_string(b"abc");
+        unsafe { strcat(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dest[0], c_char::try_from(b'a').expect("ASCII fits in c_char"));
+        assert_eq!(dest[1], c_char::try_from(b'b').expect("ASCII fits in c_char"));
+        assert_eq!(dest[2], c_char::try_from(b'c').expect("ASCII fits in c_char"));
+        assert_eq!(dest[3], 0 as c_char);
+    }
+}

--- a/src/libs/libc_string/src/strchr.rs
+++ b/src/libs/libc_string/src/strchr.rs
@@ -1,0 +1,116 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_uchar,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates the first occurrence of a character in a string.
+///
+/// This function returns a pointer to the first occurrence of the character `c` (converted to a
+/// `c_char`) in the string pointed to by `s`. The terminating null byte is considered part of the
+/// string, so if `c` is `'\0'`, the function returns a pointer to the terminator.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to search.
+/// - `c`: Character to locate (converted to `c_char`).
+///
+/// # Return Value
+///
+/// Returns a pointer to the located character, or a null pointer if the character does not occur
+/// in the string.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory region pointed to by `s` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
+    debug_assert!(!s.is_null(), "strchr(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strchr(): pointer is not properly aligned"
+    );
+
+    let target: c_uchar = c.to_le_bytes()[0];
+    let p: *const c_uchar = s.cast::<c_uchar>();
+    let mut i: usize = 0;
+    loop {
+        let ch: c_uchar = *p.add(i);
+        if ch == target {
+            return s.add(i).cast_mut();
+        }
+        if ch == 0 {
+            return core::ptr::null_mut();
+        }
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strchr;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strchr_found() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strchr(s.as_ptr(), b'l' as c_int) };
+        assert!(!ret.is_null(), "strchr should find 'l'");
+        let offset: usize = unsafe { ret.offset_from(s.as_ptr()) } as usize;
+        assert_eq!(offset, 2, "first 'l' should be at index 2");
+    }
+
+    #[test]
+    fn test_strchr_not_found() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strchr(s.as_ptr(), b'z' as c_int) };
+        assert!(ret.is_null(), "strchr should return null for char not in string");
+    }
+
+    #[test]
+    fn test_strchr_find_null_terminator() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strchr(s.as_ptr(), 0) };
+        assert!(!ret.is_null(), "strchr should find null terminator");
+        let offset: usize = unsafe { ret.offset_from(s.as_ptr()) } as usize;
+        assert_eq!(offset, 5, "null terminator should be at index 5");
+    }
+
+    #[test]
+    fn test_strchr_empty_string() {
+        let s: Vec<c_char> = make_c_string(b"");
+        let ret: *mut c_char = unsafe { strchr(s.as_ptr(), b'a' as c_int) };
+        assert!(ret.is_null(), "strchr should return null for empty string");
+    }
+}

--- a/src/libs/libc_string/src/strcmp.rs
+++ b/src/libs/libc_string/src/strcmp.rs
@@ -1,0 +1,136 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_uchar,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares two null-terminated strings.
+///
+/// This function compares the strings pointed to by `s1` and `s2` byte by byte, interpreting each
+/// byte as an unsigned char (`c_uchar`). The comparison stops at the first differing byte or when
+/// a null terminator is reached.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated string.
+/// - `s2`: Pointer to the second null-terminated string.
+///
+/// # Return Value
+///
+/// Returns an integer less than, equal to, or greater than zero if `s1` is found, respectively, to
+/// be less than, to match, or be greater than `s2`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `s1` and `s2` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcmp(s1: *const c_char, s2: *const c_char) -> c_int {
+    debug_assert!(!s1.is_null(), "strcmp(): null pointer");
+    debug_assert!(!s2.is_null(), "strcmp(): null pointer");
+    debug_assert!(
+        (s1 as usize).is_multiple_of(align_of::<c_char>()),
+        "strcmp(): pointer is not properly aligned"
+    );
+    debug_assert!(
+        (s2 as usize).is_multiple_of(align_of::<c_char>()),
+        "strcmp(): pointer is not properly aligned"
+    );
+
+    let a: *const c_uchar = s1.cast::<c_uchar>();
+    let b: *const c_uchar = s2.cast::<c_uchar>();
+    let mut i: usize = 0;
+    loop {
+        let va: c_uchar = *a.add(i);
+        let vb: c_uchar = *b.add(i);
+        if va != vb {
+            return (va as c_int) - (vb as c_int);
+        }
+        if va == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strcmp;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strcmp_equal() {
+        let s1: Vec<c_char> = make_c_string(b"hello");
+        let s2: Vec<c_char> = make_c_string(b"hello");
+        let ret: c_int = unsafe { strcmp(s1.as_ptr(), s2.as_ptr()) };
+        assert_eq!(ret, 0, "strcmp should return 0 for equal strings");
+    }
+
+    #[test]
+    fn test_strcmp_first_less() {
+        let s1: Vec<c_char> = make_c_string(b"abc");
+        let s2: Vec<c_char> = make_c_string(b"abz");
+        let ret: c_int = unsafe { strcmp(s1.as_ptr(), s2.as_ptr()) };
+        assert!(ret < 0, "strcmp should return negative when s1 < s2");
+    }
+
+    #[test]
+    fn test_strcmp_first_greater() {
+        let s1: Vec<c_char> = make_c_string(b"abz");
+        let s2: Vec<c_char> = make_c_string(b"abc");
+        let ret: c_int = unsafe { strcmp(s1.as_ptr(), s2.as_ptr()) };
+        assert!(ret > 0, "strcmp should return positive when s1 > s2");
+    }
+
+    #[test]
+    fn test_strcmp_empty_strings() {
+        let s1: Vec<c_char> = make_c_string(b"");
+        let s2: Vec<c_char> = make_c_string(b"");
+        let ret: c_int = unsafe { strcmp(s1.as_ptr(), s2.as_ptr()) };
+        assert_eq!(ret, 0, "strcmp should return 0 for two empty strings");
+    }
+
+    #[test]
+    fn test_strcmp_one_empty() {
+        let s1: Vec<c_char> = make_c_string(b"");
+        let s2: Vec<c_char> = make_c_string(b"a");
+        let ret: c_int = unsafe { strcmp(s1.as_ptr(), s2.as_ptr()) };
+        assert!(ret < 0, "strcmp should return negative when s1 is empty and s2 is not");
+    }
+}

--- a/src/libs/libc_string/src/strcpy.rs
+++ b/src/libs/libc_string/src/strcpy.rs
@@ -1,0 +1,102 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies a null-terminated string.
+///
+/// This function copies the string pointed to by `src`, including the terminating null byte, to the
+/// buffer pointed to by `dest`. The strings must not overlap, and the destination buffer must be
+/// large enough to receive the copy.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination buffer.
+/// - `src`: Pointer to the source null-terminated string.
+///
+/// # Return Value
+///
+/// Returns the original destination pointer `dest`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char {
+    debug_assert!(!dest.is_null(), "strcpy(): null destination pointer");
+    debug_assert!(!src.is_null(), "strcpy(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strcpy(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strcpy(): source pointer is not properly aligned"
+    );
+
+    let mut i: usize = 0;
+    loop {
+        let c: c_char = *src.add(i);
+        *dest.add(i) = c;
+        if c == 0 {
+            break;
+        }
+        i += 1;
+    }
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strcpy;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strcpy_basic() {
+        let src: Vec<c_char> = make_c_string(b"hello");
+        let mut dest: Vec<c_char> = vec![0 as c_char; 10];
+        let ret: *mut c_char = unsafe { strcpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(ret, dest.as_mut_ptr(), "strcpy should return dest");
+        assert_eq!(dest[0], c_char::try_from(b'h').expect("ASCII fits in c_char"));
+        assert_eq!(dest[5], 0 as c_char);
+    }
+
+    #[test]
+    fn test_strcpy_empty() {
+        let src: Vec<c_char> = make_c_string(b"");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 5];
+        unsafe { strcpy(dest.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dest[0], 0 as c_char, "strcpy of empty string should write null terminator");
+    }
+}

--- a/src/libs/libc_string/src/strcspn.rs
+++ b/src/libs/libc_string/src/strcspn.rs
@@ -1,0 +1,122 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the length of a complementary substring.
+///
+/// This function calculates the length of the initial segment of the string `s` which consists
+/// entirely of bytes NOT in `reject`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to search.
+/// - `reject`: Pointer to a null-terminated string of rejected bytes.
+///
+/// # Return Value
+///
+/// Returns the number of bytes in the initial segment of `s` which are not in `reject`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `s` and `reject` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcspn(s: *const c_char, reject: *const c_char) -> c_size_t {
+    debug_assert!(!s.is_null(), "strcspn(): null pointer");
+    debug_assert!(!reject.is_null(), "strcspn(): null reject pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strcspn(): pointer is not properly aligned"
+    );
+    debug_assert!(
+        (reject as usize).is_multiple_of(align_of::<c_char>()),
+        "strcspn(): reject pointer is not properly aligned"
+    );
+
+    let mut count: c_size_t = 0;
+    while *s.add(count as usize) != 0 {
+        let ch: c_char = *s.add(count as usize);
+        let mut rejected: bool = false;
+        let mut r: usize = 0;
+        while *reject.add(r) != 0 {
+            if ch == *reject.add(r) {
+                rejected = true;
+                break;
+            }
+            r += 1;
+        }
+        if rejected {
+            break;
+        }
+        count += 1;
+    }
+
+    count
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strcspn;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        ffi::c_char,
+        sys_types::c_size_t,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strcspn_all_rejected() {
+        let s: Vec<c_char> = make_c_string(b"abc");
+        let reject: Vec<c_char> = make_c_string(b"abc");
+        let ret: c_size_t = unsafe { strcspn(s.as_ptr(), reject.as_ptr()) };
+        assert_eq!(ret as usize, 0, "first char is rejected");
+    }
+
+    #[test]
+    fn test_strcspn_none_rejected() {
+        let s: Vec<c_char> = make_c_string(b"abc");
+        let reject: Vec<c_char> = make_c_string(b"xyz");
+        let ret: c_size_t = unsafe { strcspn(s.as_ptr(), reject.as_ptr()) };
+        assert_eq!(ret as usize, 3, "no chars are rejected");
+    }
+
+    #[test]
+    fn test_strcspn_partial() {
+        let s: Vec<c_char> = make_c_string(b"abcxyz");
+        let reject: Vec<c_char> = make_c_string(b"xyz");
+        let ret: c_size_t = unsafe { strcspn(s.as_ptr(), reject.as_ptr()) };
+        assert_eq!(ret as usize, 3, "first 3 chars are not rejected");
+    }
+}

--- a/src/libs/libc_string/src/strdup.rs
+++ b/src/libs/libc_string/src/strdup.rs
@@ -1,0 +1,133 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn strlen(s: *const c_char) -> c_size_t;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Duplicates a string.
+///
+/// This function allocates sufficient memory for a copy of the string `s`, copies the string, and
+/// returns a pointer to it. The memory is obtained with `malloc` and can be freed with `free`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to duplicate.
+///
+/// # Return Value
+///
+/// Returns a pointer to the duplicated string, or a null pointer if allocation fails.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It allocates memory with `malloc`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strdup(s: *const c_char) -> *mut c_char {
+    debug_assert!(!s.is_null(), "strdup(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strdup(): pointer is not properly aligned"
+    );
+
+    let len: c_size_t = strlen(s);
+    let ptr: *mut c_void = malloc(len + 1);
+    if ptr.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let dest: *mut c_char = ptr.cast::<c_char>();
+    let mut i: usize = 0;
+    let total: usize = (len + 1) as usize;
+    while i < total {
+        *dest.add(i) = *s.add(i);
+        i += 1;
+    }
+
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strdup;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    extern "C" {
+        fn free(ptr: *mut core::ffi::c_void);
+    }
+
+    #[test]
+    fn test_strdup_basic() {
+        let src: Vec<c_char> = make_c_string(b"hello");
+        let dup: *mut c_char = unsafe { strdup(src.as_ptr()) };
+        assert!(!dup.is_null(), "strdup should not return null");
+        assert_eq!(c_str_to_bytes(dup), b"hello");
+        // Ensure it is a different allocation.
+        assert_ne!(dup as *const c_char, src.as_ptr());
+        unsafe { free(dup.cast()) };
+    }
+
+    #[test]
+    fn test_strdup_empty() {
+        let src: Vec<c_char> = make_c_string(b"");
+        let dup: *mut c_char = unsafe { strdup(src.as_ptr()) };
+        assert!(!dup.is_null(), "strdup should not return null for empty string");
+        assert_eq!(c_str_to_bytes(dup), b"");
+        unsafe { free(dup.cast()) };
+    }
+}

--- a/src/libs/libc_string/src/strerror.rs
+++ b/src/libs/libc_string/src/strerror.rs
@@ -1,0 +1,172 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    errno::{
+        E2BIG,
+        EACCES,
+        EAGAIN,
+        EBADF,
+        EBUSY,
+        ECHILD,
+        EDOM,
+        EEXIST,
+        EFAULT,
+        EFBIG,
+        EINTR,
+        EINVAL,
+        EIO,
+        EISDIR,
+        EMFILE,
+        ENFILE,
+        ENODEV,
+        ENOENT,
+        ENOEXEC,
+        ENOMEM,
+        ENOSPC,
+        ENOSYS,
+        ENOTDIR,
+        ENOTTY,
+        ENXIO,
+        EOPNOTSUPP,
+        EPERM,
+        EPIPE,
+        ERANGE,
+        EROFS,
+        ESPIPE,
+        ESRCH,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Maps an error number to a message string.
+///
+/// This function returns a pointer to a string that describes the error code passed in the argument
+/// `errnum`.
+///
+/// # Parameters
+///
+/// - `errnum`: Error number.
+///
+/// # Return Value
+///
+/// Returns a pointer to the appropriate error description string.
+///
+/// # Safety
+///
+/// This function is unsafe because it returns a raw pointer.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strerror(errnum: c_int) -> *mut c_char {
+    let msg: &[u8] = match errnum {
+        0 => b"Success\0",
+        EPERM => b"Operation not permitted\0",
+        ENOENT => b"No such file or directory\0",
+        ESRCH => b"No such process\0",
+        EINTR => b"Interrupted system call\0",
+        EIO => b"Input/output error\0",
+        ENXIO => b"No such device or address\0",
+        E2BIG => b"Argument list too long\0",
+        ENOEXEC => b"Exec format error\0",
+        EBADF => b"Bad file descriptor\0",
+        ECHILD => b"No child processes\0",
+        EAGAIN => b"Resource temporarily unavailable\0",
+        ENOMEM => b"Cannot allocate memory\0",
+        EACCES => b"Permission denied\0",
+        EFAULT => b"Bad address\0",
+        EBUSY => b"Device or resource busy\0",
+        EEXIST => b"File exists\0",
+        ENODEV => b"No such device\0",
+        ENOTDIR => b"Not a directory\0",
+        EISDIR => b"Is a directory\0",
+        EINVAL => b"Invalid argument\0",
+        ENFILE => b"Too many open files in system\0",
+        EMFILE => b"Too many open files\0",
+        ENOTTY => b"Inappropriate ioctl for device\0",
+        EFBIG => b"File too large\0",
+        ENOSPC => b"No space left on device\0",
+        ESPIPE => b"Illegal seek\0",
+        EROFS => b"Read-only file system\0",
+        EPIPE => b"Broken pipe\0",
+        EDOM => b"Numerical argument out of domain\0",
+        ERANGE => b"Numerical result out of range\0",
+        ENOSYS => b"Function not implemented\0",
+        EOPNOTSUPP => b"Operation not supported\0",
+        _ => b"Unknown error\0",
+    };
+    msg.as_ptr().cast::<c_char>().cast_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strerror;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        errno::{
+            EINVAL,
+            ENOSYS,
+        },
+        ffi::c_char,
+    };
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn test_strerror_known() {
+        let ret: *mut c_char = unsafe { strerror(EINVAL) };
+        assert!(!ret.is_null());
+        assert_eq!(c_str_to_bytes(ret), b"Invalid argument");
+    }
+
+    #[test]
+    fn test_strerror_zero() {
+        let ret: *mut c_char = unsafe { strerror(0) };
+        assert!(!ret.is_null());
+        assert_eq!(c_str_to_bytes(ret), b"Success");
+    }
+
+    #[test]
+    fn test_strerror_enosys() {
+        // ENOSYS is 88 on Nanvix (see sysapi::errno), not 38 as on Linux.
+        let ret: *mut c_char = unsafe { strerror(ENOSYS) };
+        assert!(!ret.is_null());
+        assert_eq!(c_str_to_bytes(ret), b"Function not implemented");
+    }
+
+    #[test]
+    fn test_strerror_unknown() {
+        let ret: *mut c_char = unsafe { strerror(999) };
+        assert!(!ret.is_null());
+        assert_eq!(c_str_to_bytes(ret), b"Unknown error");
+    }
+}

--- a/src/libs/libc_string/src/strerror_r.rs
+++ b/src/libs/libc_string/src/strerror_r.rs
@@ -1,0 +1,144 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    errno::{
+        EINVAL,
+        ERANGE,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Stores a textual description of the error number `errnum` in `buf`.
+///
+/// # Parameters
+///
+/// - `errnum`: Error number to describe.
+/// - `buf`: Buffer that receives the message.
+/// - `buflen`: Size of `buf` in bytes.
+///
+/// # Returns
+///
+/// Returns zero on success. Otherwise, returns an error number to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. `buf` must point to at least
+/// `buflen` writable bytes.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strerror_r.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: c_size_t) -> c_int {
+    if buf.is_null() {
+        return EINVAL;
+    }
+
+    // SAFETY: strerror returns a valid, null-terminated static string.
+    let src: *const c_char = unsafe { crate::strerror::strerror(errnum) };
+
+    // SAFETY: src is a valid, null-terminated string.
+    let len: usize = unsafe { crate::strlen::strlen(src) } as usize;
+    if buflen == 0 {
+        return ERANGE;
+    }
+
+    let cap: usize = buflen as usize - 1;
+    let copy_len: usize = if len < cap { len } else { cap };
+    // SAFETY: src has at least copy_len bytes; buf has room for copy_len + 1.
+    unsafe {
+        core::ptr::copy_nonoverlapping(src.cast::<u8>(), buf.cast::<u8>(), copy_len);
+        *buf.add(copy_len) = 0;
+    }
+
+    if len >= buflen as usize {
+        ERANGE
+    } else {
+        0
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strerror_r;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        errno::{
+            EINVAL,
+            ERANGE,
+        },
+        ffi::{
+            c_char,
+            c_int,
+        },
+    };
+
+    /// Computes the length of a null-terminated string.
+    fn c_strlen(p: *const c_char) -> usize {
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                i += 1;
+            }
+        }
+        i
+    }
+
+    #[test]
+    fn test_strerror_r_writes_buf_and_returns_zero() {
+        let mut buf: Vec<c_char> = vec![0x7F as c_char; 64];
+        let ret: c_int = unsafe { strerror_r(22 as c_int, buf.as_mut_ptr(), 64) };
+        assert_eq!(ret, 0, "strerror_r must return zero on success");
+        // The message must be null-terminated within the buffer.
+        assert!(c_strlen(buf.as_ptr()) < 64, "message must be null-terminated within buf");
+    }
+
+    #[test]
+    fn test_strerror_r_zero() {
+        let mut buf: Vec<c_char> = vec![0x7F as c_char; 64];
+        let ret: c_int = unsafe { strerror_r(0 as c_int, buf.as_mut_ptr(), 64) };
+        assert_eq!(ret, 0, "strerror_r(0) must succeed with a no-error message");
+        assert!(c_strlen(buf.as_ptr()) < 64, "message must be null-terminated within buf");
+    }
+
+    #[test]
+    fn test_strerror_r_truncates_and_returns_erange() {
+        let mut buf: Vec<c_char> = vec![0x7F as c_char; 4];
+        let ret: c_int = unsafe { strerror_r(22 as c_int, buf.as_mut_ptr(), 4) };
+        assert_eq!(ret, ERANGE, "strerror_r must fail with ERANGE when buf is too small");
+        // The buffer must always be null-terminated at size - 1 or earlier.
+        assert_eq!(buf[3], 0 as c_char, "buf must be null-terminated at size - 1");
+        assert!(c_strlen(buf.as_ptr()) <= 3, "truncated message fits within buf");
+    }
+
+    #[test]
+    fn test_strerror_r_zero_buflen_returns_erange() {
+        let mut buf: Vec<c_char> = vec![0x7F as c_char; 4];
+        let ret: c_int = unsafe { strerror_r(22 as c_int, buf.as_mut_ptr(), 0) };
+        assert_eq!(ret, ERANGE, "strerror_r must fail with ERANGE when buflen is zero");
+        assert_eq!(buf[0], 0x7F as c_char, "buf must be untouched when buflen is 0");
+    }
+
+    #[test]
+    fn test_strerror_r_null_buf_returns_einval() {
+        let ret: c_int = unsafe { strerror_r(22 as c_int, core::ptr::null_mut(), 16) };
+        assert_eq!(ret, EINVAL, "strerror_r returns EINVAL for a null buffer");
+    }
+}

--- a/src/libs/libc_string/src/strlcat.rs
+++ b/src/libs/libc_string/src/strlcat.rs
@@ -1,0 +1,147 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Size-bounded string concatenation.
+///
+/// This function appends the string `src` to the end of `dest`. It will append at most
+/// `size - strlen(dest) - 1` bytes, null-terminating the result.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination null-terminated string.
+/// - `src`: Pointer to the source null-terminated string.
+/// - `size`: Full size of the destination buffer.
+///
+/// # Return Value
+///
+/// Returns `strlen(dest) + strlen(src)` (initial lengths), representing the total length of the
+/// string it tried to create. If the return value is >= `size`, truncation occurred.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strlcat(
+    dest: *mut c_char,
+    src: *const c_char,
+    size: c_size_t,
+) -> c_size_t {
+    debug_assert!(!dest.is_null(), "strlcat(): null destination pointer");
+    debug_assert!(!src.is_null(), "strlcat(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strlcat(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strlcat(): source pointer is not properly aligned"
+    );
+
+    let size: usize = size as usize;
+
+    // Find current length of dest (up to size), using c_size_t to avoid truncation casts.
+    let mut dest_len: c_size_t = 0;
+    while (dest_len as usize) < size && *dest.add(dest_len as usize) != 0 {
+        dest_len += 1;
+    }
+
+    // Calculate strlen(src).
+    let mut src_len: c_size_t = 0;
+    while *src.add(src_len as usize) != 0 {
+        src_len += 1;
+    }
+
+    // If dest_len >= size, dest is not null-terminated within size.
+    if (dest_len as usize) >= size {
+        return dest_len + src_len;
+    }
+
+    // Append at most size - dest_len - 1 bytes from src.
+    let remaining: usize = size - (dest_len as usize) - 1;
+    let copy_len: usize = if (src_len as usize) < remaining {
+        src_len as usize
+    } else {
+        remaining
+    };
+    let mut i: usize = 0;
+    while i < copy_len {
+        *dest.add((dest_len as usize) + i) = *src.add(i);
+        i += 1;
+    }
+    *dest.add((dest_len as usize) + copy_len) = 0 as c_char;
+
+    dest_len + src_len
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strlcat;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        ffi::c_char,
+        sys_types::c_size_t,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strlcat_normal() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 20];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        let src: Vec<c_char> = make_c_string(b" world");
+        let ret: c_size_t = unsafe { strlcat(dest.as_mut_ptr(), src.as_ptr(), 20) };
+        assert_eq!(ret as usize, 11, "strlcat returns strlen(dest) + strlen(src)");
+        assert_eq!(dest[0], c_char::try_from(b'h').expect("ASCII fits in c_char"));
+        assert_eq!(dest[5], c_char::try_from(b' ').expect("ASCII fits in c_char"));
+        assert_eq!(dest[11], 0 as c_char);
+    }
+
+    #[test]
+    fn test_strlcat_truncation() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 8];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        let src: Vec<c_char> = make_c_string(b" world");
+        let ret: c_size_t = unsafe { strlcat(dest.as_mut_ptr(), src.as_ptr(), 8) };
+        assert_eq!(ret as usize, 11, "strlcat returns intended total length");
+        assert_eq!(dest[7], 0 as c_char, "dest should be null-terminated");
+    }
+}

--- a/src/libs/libc_string/src/strlcpy.rs
+++ b/src/libs/libc_string/src/strlcpy.rs
@@ -1,0 +1,139 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Size-bounded string copying.
+///
+/// This function copies up to `size - 1` characters from the string `src` to `dest`,
+/// null-terminating the result if `size` is not zero. Unlike `strncpy`, `strlcpy` always
+/// null-terminates the result (as long as `size > 0`).
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination buffer.
+/// - `src`: Pointer to the source null-terminated string.
+/// - `size`: Size of the destination buffer.
+///
+/// # Return Value
+///
+/// Returns the total length of the string that would have been created if there was unlimited
+/// space (i.e., `strlen(src)`). If the return value is >= `size`, truncation occurred.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strlcpy(
+    dest: *mut c_char,
+    src: *const c_char,
+    size: c_size_t,
+) -> c_size_t {
+    debug_assert!(!dest.is_null(), "strlcpy(): null destination pointer");
+    debug_assert!(!src.is_null(), "strlcpy(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strlcpy(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strlcpy(): source pointer is not properly aligned"
+    );
+
+    let size: usize = size as usize;
+
+    // Calculate strlen(src) using c_size_t to avoid usize->c_size_t cast.
+    let mut src_len: c_size_t = 0;
+    while *src.add(src_len as usize) != 0 {
+        src_len += 1;
+    }
+
+    if size > 0 {
+        let copy_len: usize = if (src_len as usize) < size {
+            src_len as usize
+        } else {
+            size - 1
+        };
+        let mut i: usize = 0;
+        while i < copy_len {
+            *dest.add(i) = *src.add(i);
+            i += 1;
+        }
+        *dest.add(copy_len) = 0 as c_char;
+    }
+
+    src_len
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strlcpy;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        ffi::c_char,
+        sys_types::c_size_t,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strlcpy_normal() {
+        let src: Vec<c_char> = make_c_string(b"hello");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 10];
+        let ret: c_size_t = unsafe { strlcpy(dest.as_mut_ptr(), src.as_ptr(), 10) };
+        assert_eq!(ret as usize, 5, "strlcpy should return strlen(src)");
+        assert_eq!(dest[0], c_char::try_from(b'h').expect("ASCII fits in c_char"));
+        assert_eq!(dest[5], 0 as c_char);
+    }
+
+    #[test]
+    fn test_strlcpy_truncation() {
+        let src: Vec<c_char> = make_c_string(b"hello world");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 6];
+        let ret: c_size_t = unsafe { strlcpy(dest.as_mut_ptr(), src.as_ptr(), 6) };
+        assert_eq!(ret as usize, 11, "strlcpy should return full strlen(src)");
+        assert_eq!(dest[5], 0 as c_char, "dest should be null-terminated");
+        assert_eq!(dest[0], c_char::try_from(b'h').expect("ASCII fits in c_char"));
+        assert_eq!(dest[4], c_char::try_from(b'o').expect("ASCII fits in c_char"));
+    }
+
+    #[test]
+    fn test_strlcpy_zero_size() {
+        let src: Vec<c_char> = make_c_string(b"hello");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 5];
+        let ret: c_size_t = unsafe { strlcpy(dest.as_mut_ptr(), src.as_ptr(), 0) };
+        assert_eq!(ret as usize, 5, "strlcpy should return strlen(src) even with size 0");
+        assert_eq!(dest[0], 0x7F as c_char, "dest should be unchanged with size 0");
+    }
+}

--- a/src/libs/libc_string/src/strlen.rs
+++ b/src/libs/libc_string/src/strlen.rs
@@ -11,9 +11,11 @@
 // Imports
 //==================================================================================================
 
-use ::core::mem::align_of;
 use ::sysapi::{
-    ffi::c_char,
+    ffi::{
+        c_char,
+        c_uchar,
+    },
     sys_types::c_size_t,
 };
 
@@ -44,20 +46,19 @@ use ::sysapi::{
 /// - It performs raw pointer dereferencing and arithmetic.
 /// - It reads from the memory region pointed to by `s` without bounds checking.
 ///
-#[unsafe(no_mangle)]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn strlen(s: *const c_char) -> c_size_t {
     debug_assert!(!s.is_null(), "strlen(): null pointer");
-    debug_assert!((s as usize) < isize::MAX as usize, "strlen(): pointer too large");
-    debug_assert!(
-        (s as usize).is_multiple_of(align_of::<c_char>()),
-        "strlen(): pointer is not properly aligned"
-    );
 
-    let mut i: c_size_t = 0;
-    while *s.add(i as usize) != 0 {
+    let bytes: *const c_uchar = s.cast::<c_uchar>();
+    let mut i: usize = 0;
+
+    // Scan one byte at a time so that no memory beyond the terminating null byte is ever read.
+    while *bytes.add(i) != 0 {
         i += 1;
     }
-    i
+
+    c_size_t::try_from(i).unwrap_or(c_size_t::MAX)
 }
 
 #[cfg(all(test, feature = "std"))]

--- a/src/libs/libc_string/src/strncasecmp.rs
+++ b/src/libs/libc_string/src/strncasecmp.rs
@@ -1,0 +1,122 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Folds an ASCII upper-case byte to lower case.
+#[inline]
+fn to_lower(b: u8) -> u8 {
+    if b.is_ascii_uppercase() {
+        b + 32
+    } else {
+        b
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares at most `n` bytes of the strings `s1` and `s2` ignoring the case of ASCII letters.
+///
+/// # Returns
+///
+/// A negative, zero, or positive value if `s1` is respectively less than, equal to, or greater
+/// than `s2` after case folding, considering at most `n` bytes.
+///
+/// # Safety
+///
+/// Both `s1` and `s2` must point to valid, null-terminated strings.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strncasecmp(s1: *const c_char, s2: *const c_char, n: c_size_t) -> c_int {
+    debug_assert!(!s1.is_null(), "strncasecmp(): null pointer");
+    debug_assert!(!s2.is_null(), "strncasecmp(): null pointer");
+
+    let mut i: c_size_t = 0;
+    while i < n {
+        let ca: u8 = to_lower(*s1.add(i as usize) as u8);
+        let cb: u8 = to_lower(*s2.add(i as usize) as u8);
+        if ca != cb {
+            return c_int::from(ca) - c_int::from(cb);
+        }
+        if ca == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+    0
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strncasecmp;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strncasecmp_equal_within_n() {
+        let s1: Vec<c_char> = make_c_string(b"Hello");
+        let s2: Vec<c_char> = make_c_string(b"hELLO");
+        let ret: c_int = unsafe { strncasecmp(s1.as_ptr(), s2.as_ptr(), 5) };
+        assert_eq!(ret, 0, "strncasecmp should ignore case within n bytes");
+    }
+
+    #[test]
+    fn test_strncasecmp_n_limits_comparison() {
+        // Strings differ only after the first three bytes; n=3 ignores the rest.
+        let s1: Vec<c_char> = make_c_string(b"abcXXX");
+        let s2: Vec<c_char> = make_c_string(b"abcYYY");
+        let ret: c_int = unsafe { strncasecmp(s1.as_ptr(), s2.as_ptr(), 3) };
+        assert_eq!(ret, 0, "strncasecmp should only compare the first n bytes");
+    }
+
+    #[test]
+    fn test_strncasecmp_differ_within_n() {
+        let s1: Vec<c_char> = make_c_string(b"abc");
+        let s2: Vec<c_char> = make_c_string(b"abz");
+        let ret: c_int = unsafe { strncasecmp(s1.as_ptr(), s2.as_ptr(), 3) };
+        assert!(ret < 0, "strncasecmp should return negative when s1 < s2 within n");
+    }
+
+    #[test]
+    fn test_strncasecmp_zero_n() {
+        let s1: Vec<c_char> = make_c_string(b"abc");
+        let s2: Vec<c_char> = make_c_string(b"xyz");
+        let ret: c_int = unsafe { strncasecmp(s1.as_ptr(), s2.as_ptr(), 0) };
+        assert_eq!(ret, 0, "strncasecmp should return 0 when n is 0");
+    }
+}

--- a/src/libs/libc_string/src/strncat.rs
+++ b/src/libs/libc_string/src/strncat.rs
@@ -1,0 +1,137 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Appends at most `n` bytes from a null-terminated string to another.
+///
+/// This function appends at most `n` bytes from the string pointed to by `src` to the end of the
+/// string pointed to by `dest`, overwriting the null terminator at the end of `dest`, and then
+/// adding a terminating null byte.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination null-terminated string.
+/// - `src`: Pointer to the source null-terminated string.
+/// - `n`: Maximum number of bytes to append from `src`.
+///
+/// # Return Value
+///
+/// Returns the original destination pointer `dest`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strncat(
+    dest: *mut c_char,
+    src: *const c_char,
+    n: c_size_t,
+) -> *mut c_char {
+    debug_assert!(!dest.is_null(), "strncat(): null destination pointer");
+    debug_assert!(!src.is_null(), "strncat(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strncat(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strncat(): source pointer is not properly aligned"
+    );
+
+    let n: usize = n as usize;
+
+    // Find the end of dest.
+    let mut d: usize = 0;
+    while *dest.add(d) != 0 {
+        d += 1;
+    }
+
+    // Append at most n bytes from src.
+    let mut s: usize = 0;
+    while s < n {
+        let c: c_char = *src.add(s);
+        if c == 0 {
+            break;
+        }
+        *dest.add(d) = c;
+        d += 1;
+        s += 1;
+    }
+
+    // Always null-terminate.
+    *dest.add(d) = 0 as c_char;
+
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strncat;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strncat_n_less_than_src() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 20];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        let src: Vec<c_char> = make_c_string(b" world");
+        unsafe { strncat(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        // Should append " wo" then null-terminate.
+        let expected: Vec<c_char> = make_c_string(b"hello wo");
+        for (i, &c) in expected.iter().enumerate() {
+            assert_eq!(dest[i], c, "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_strncat_n_greater_than_src() {
+        let mut dest: Vec<c_char> = vec![0 as c_char; 20];
+        let hello: Vec<c_char> = make_c_string(b"hello");
+        for (i, &c) in hello.iter().enumerate() {
+            dest[i] = c;
+        }
+        let src: Vec<c_char> = make_c_string(b" world");
+        unsafe { strncat(dest.as_mut_ptr(), src.as_ptr(), 100) };
+        let expected: Vec<c_char> = make_c_string(b"hello world");
+        for (i, &c) in expected.iter().enumerate() {
+            assert_eq!(dest[i], c, "mismatch at index {i}");
+        }
+    }
+}

--- a/src/libs/libc_string/src/strncmp.rs
+++ b/src/libs/libc_string/src/strncmp.rs
@@ -1,0 +1,134 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_uchar,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compares at most `n` bytes of two null-terminated strings.
+///
+/// This function compares the strings pointed to by `s1` and `s2` byte by byte, interpreting each
+/// byte as an unsigned char (`c_uchar`). The comparison stops at the first differing byte, when a
+/// null terminator is reached, or after `n` bytes have been compared.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated string.
+/// - `s2`: Pointer to the second null-terminated string.
+/// - `n`: Maximum number of bytes to compare.
+///
+/// # Return Value
+///
+/// Returns an integer less than, equal to, or greater than zero if the first `n` bytes of `s1` are
+/// found, respectively, to be less than, to match, or be greater than the first `n` bytes of `s2`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `s1` and `s2` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strncmp(s1: *const c_char, s2: *const c_char, n: c_size_t) -> c_int {
+    debug_assert!(!s1.is_null(), "strncmp(): null pointer");
+    debug_assert!(!s2.is_null(), "strncmp(): null pointer");
+    debug_assert!(
+        (s1 as usize).is_multiple_of(align_of::<c_char>()),
+        "strncmp(): pointer is not properly aligned"
+    );
+    debug_assert!(
+        (s2 as usize).is_multiple_of(align_of::<c_char>()),
+        "strncmp(): pointer is not properly aligned"
+    );
+
+    let a: *const c_uchar = s1.cast::<c_uchar>();
+    let b: *const c_uchar = s2.cast::<c_uchar>();
+    let n: usize = n as usize;
+    let mut i: usize = 0;
+    while i < n {
+        let va: c_uchar = *a.add(i);
+        let vb: c_uchar = *b.add(i);
+        if va != vb {
+            return (va as c_int) - (vb as c_int);
+        }
+        if va == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+    0
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strncmp;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strncmp_equal_within_n() {
+        let s1: Vec<c_char> = make_c_string(b"hello");
+        let s2: Vec<c_char> = make_c_string(b"hello");
+        let ret: c_int = unsafe { strncmp(s1.as_ptr(), s2.as_ptr(), 5) };
+        assert_eq!(ret, 0, "strncmp should return 0 for equal strings within n");
+    }
+
+    #[test]
+    fn test_strncmp_differ_within_n() {
+        let s1: Vec<c_char> = make_c_string(b"helly");
+        let s2: Vec<c_char> = make_c_string(b"hello");
+        let ret: c_int = unsafe { strncmp(s1.as_ptr(), s2.as_ptr(), 5) };
+        assert!(ret != 0, "strncmp should return non-zero when strings differ within n");
+    }
+
+    #[test]
+    fn test_strncmp_n_zero() {
+        let s1: Vec<c_char> = make_c_string(b"abc");
+        let s2: Vec<c_char> = make_c_string(b"xyz");
+        let ret: c_int = unsafe { strncmp(s1.as_ptr(), s2.as_ptr(), 0) };
+        assert_eq!(ret, 0, "strncmp should return 0 when n is 0");
+    }
+
+    #[test]
+    fn test_strncmp_n_greater_than_length() {
+        let s1: Vec<c_char> = make_c_string(b"ab");
+        let s2: Vec<c_char> = make_c_string(b"ab");
+        let ret: c_int = unsafe { strncmp(s1.as_ptr(), s2.as_ptr(), 100) };
+        assert_eq!(ret, 0, "strncmp should return 0 for equal strings even when n > length");
+    }
+}

--- a/src/libs/libc_string/src/strncpy.rs
+++ b/src/libs/libc_string/src/strncpy.rs
@@ -1,0 +1,140 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Copies at most `n` bytes from a null-terminated string.
+///
+/// This function copies at most `n` bytes from the string pointed to by `src` to the buffer
+/// pointed to by `dest`. If the length of `src` is less than `n`, the remainder of `dest` is
+/// padded with null bytes. If the length of `src` is greater than or equal to `n`, `dest` is NOT
+/// null-terminated.
+///
+/// # Parameters
+///
+/// - `dest`: Pointer to the destination buffer.
+/// - `src`: Pointer to the source null-terminated string.
+/// - `n`: Maximum number of bytes to copy.
+///
+/// # Return Value
+///
+/// Returns the original destination pointer `dest`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes to the memory region pointed to by `dest` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strncpy(
+    dest: *mut c_char,
+    src: *const c_char,
+    n: c_size_t,
+) -> *mut c_char {
+    debug_assert!(!dest.is_null(), "strncpy(): null destination pointer");
+    debug_assert!(!src.is_null(), "strncpy(): null source pointer");
+    debug_assert!(
+        (dest as usize).is_multiple_of(align_of::<c_char>()),
+        "strncpy(): destination pointer is not properly aligned"
+    );
+    debug_assert!(
+        (src as usize).is_multiple_of(align_of::<c_char>()),
+        "strncpy(): source pointer is not properly aligned"
+    );
+
+    let n: usize = n as usize;
+    let mut i: usize = 0;
+
+    // Copy bytes from src until null terminator or n bytes.
+    while i < n {
+        let c: c_char = *src.add(i);
+        *dest.add(i) = c;
+        if c == 0 {
+            i += 1;
+            break;
+        }
+        i += 1;
+    }
+
+    // Pad remainder with null bytes.
+    while i < n {
+        *dest.add(i) = 0 as c_char;
+        i += 1;
+    }
+
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strncpy;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strncpy_exact_fit() {
+        let src: Vec<c_char> = make_c_string(b"abc");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 4];
+        unsafe { strncpy(dest.as_mut_ptr(), src.as_ptr(), 4) };
+        assert_eq!(dest[0], c_char::try_from(b'a').expect("ASCII fits in c_char"));
+        assert_eq!(dest[1], c_char::try_from(b'b').expect("ASCII fits in c_char"));
+        assert_eq!(dest[2], c_char::try_from(b'c').expect("ASCII fits in c_char"));
+        assert_eq!(dest[3], 0 as c_char);
+    }
+
+    #[test]
+    fn test_strncpy_short_source() {
+        let src: Vec<c_char> = make_c_string(b"ab");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 6];
+        unsafe { strncpy(dest.as_mut_ptr(), src.as_ptr(), 6) };
+        assert_eq!(dest[0], c_char::try_from(b'a').expect("ASCII fits in c_char"));
+        assert_eq!(dest[1], c_char::try_from(b'b').expect("ASCII fits in c_char"));
+        // Remaining bytes should be null-padded.
+        for (j, &c) in dest[2..6].iter().enumerate() {
+            let idx: usize = j + 2;
+            assert_eq!(c, 0 as c_char, "byte at index {idx} should be null");
+        }
+    }
+
+    #[test]
+    fn test_strncpy_long_source() {
+        let src: Vec<c_char> = make_c_string(b"abcdef");
+        let mut dest: Vec<c_char> = vec![0x7F as c_char; 3];
+        unsafe { strncpy(dest.as_mut_ptr(), src.as_ptr(), 3) };
+        assert_eq!(dest[0], c_char::try_from(b'a').expect("ASCII fits in c_char"));
+        assert_eq!(dest[1], c_char::try_from(b'b').expect("ASCII fits in c_char"));
+        assert_eq!(dest[2], c_char::try_from(b'c').expect("ASCII fits in c_char"));
+        // Not null-terminated when source is longer than n.
+    }
+}

--- a/src/libs/libc_string/src/strndup.rs
+++ b/src/libs/libc_string/src/strndup.rs
@@ -1,0 +1,135 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn strlen(s: *const c_char) -> c_size_t;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Duplicates at most `n` bytes of a string.
+///
+/// This function is similar to `strdup`, but copies at most `n` bytes. If `s` is longer than `n`,
+/// only `n` bytes are copied, and a terminating null byte is added. The memory is obtained with
+/// `malloc` and can be freed with `free`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to duplicate.
+/// - `n`: Maximum number of bytes to copy.
+///
+/// # Return Value
+///
+/// Returns a pointer to the duplicated string, or a null pointer if allocation fails.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It allocates memory with `malloc`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strndup(s: *const c_char, n: c_size_t) -> *mut c_char {
+    debug_assert!(!s.is_null(), "strndup(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strndup(): pointer is not properly aligned"
+    );
+
+    let len: c_size_t = strlen(s);
+    let copy_len: c_size_t = if n < len { n } else { len };
+    let ptr: *mut c_void = malloc(copy_len + 1);
+    if ptr.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let dest: *mut c_char = ptr.cast::<c_char>();
+    let mut i: usize = 0;
+    let total: usize = copy_len as usize;
+    while i < total {
+        *dest.add(i) = *s.add(i);
+        i += 1;
+    }
+    *dest.add(total) = 0 as c_char;
+
+    dest
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strndup;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    extern "C" {
+        fn free(ptr: *mut core::ffi::c_void);
+    }
+
+    #[test]
+    fn test_strndup_n_less_than_length() {
+        let src: Vec<c_char> = make_c_string(b"hello world");
+        let dup: *mut c_char = unsafe { strndup(src.as_ptr(), 5) };
+        assert!(!dup.is_null(), "strndup should not return null");
+        assert_eq!(c_str_to_bytes(dup), b"hello");
+        unsafe { free(dup.cast()) };
+    }
+
+    #[test]
+    fn test_strndup_n_greater_than_length() {
+        let src: Vec<c_char> = make_c_string(b"hi");
+        let dup: *mut c_char = unsafe { strndup(src.as_ptr(), 100) };
+        assert!(!dup.is_null(), "strndup should not return null");
+        assert_eq!(c_str_to_bytes(dup), b"hi");
+        unsafe { free(dup.cast()) };
+    }
+}

--- a/src/libs/libc_string/src/strnlen.rs
+++ b/src/libs/libc_string/src/strnlen.rs
@@ -1,0 +1,112 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Calculates the length of a string, examining at most `maxlen` bytes.
+///
+/// This function computes the length of the string pointed to by `s`, excluding the terminating
+/// null byte (`'\0'`), but examines at most `maxlen` bytes.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string whose length is to be calculated.
+/// - `maxlen`: Maximum number of bytes to examine.
+///
+/// # Return Value
+///
+/// Returns the number of characters in the string pointed to by `s`, excluding the terminating
+/// null byte, or `maxlen` if no null byte is found within that many bytes.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory region pointed to by `s` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strnlen(s: *const c_char, maxlen: c_size_t) -> c_size_t {
+    debug_assert!(!s.is_null(), "strnlen(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strnlen(): pointer is not properly aligned"
+    );
+
+    let mut i: c_size_t = 0;
+    while i < maxlen && *s.add(i as usize) != 0 {
+        i += 1;
+    }
+    i
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strnlen;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strnlen_shorter_than_maxlen() {
+        let buf: Vec<c_char> = make_c_string(b"hello");
+        let len: usize = unsafe { strnlen(buf.as_ptr(), 100) as usize };
+        assert_eq!(len, 5, "strnlen should return actual length when shorter than maxlen");
+    }
+
+    #[test]
+    fn test_strnlen_longer_than_maxlen() {
+        let buf: Vec<c_char> = make_c_string(b"hello world");
+        let len: usize = unsafe { strnlen(buf.as_ptr(), 5) as usize };
+        assert_eq!(len, 5, "strnlen should return maxlen when string is longer");
+    }
+
+    #[test]
+    fn test_strnlen_empty_string() {
+        let buf: Vec<c_char> = make_c_string(b"");
+        let len: usize = unsafe { strnlen(buf.as_ptr(), 100) as usize };
+        assert_eq!(len, 0, "strnlen of empty string should be 0");
+    }
+
+    #[test]
+    fn test_strnlen_zero_maxlen() {
+        let buf: Vec<c_char> = make_c_string(b"hello");
+        let len: usize = unsafe { strnlen(buf.as_ptr(), 0) as usize };
+        assert_eq!(len, 0, "strnlen with maxlen 0 should return 0");
+    }
+
+    #[test]
+    fn test_strnlen_exact_maxlen() {
+        let buf: Vec<c_char> = make_c_string(b"hello");
+        let len: usize = unsafe { strnlen(buf.as_ptr(), 5) as usize };
+        assert_eq!(len, 5, "strnlen should return 5 when maxlen equals string length");
+    }
+}

--- a/src/libs/libc_string/src/strpbrk.rs
+++ b/src/libs/libc_string/src/strpbrk.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Searches a string for any of a set of bytes.
+///
+/// This function locates the first occurrence in the string `s` of any byte in the string `accept`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to search.
+/// - `accept`: Pointer to a null-terminated string of bytes to search for.
+///
+/// # Return Value
+///
+/// Returns a pointer to the byte in `s` that matches one of the bytes in `accept`, or a null
+/// pointer if no such byte is found.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `s` and `accept` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strpbrk(s: *const c_char, accept: *const c_char) -> *mut c_char {
+    debug_assert!(!s.is_null(), "strpbrk(): null pointer");
+    debug_assert!(!accept.is_null(), "strpbrk(): null accept pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strpbrk(): pointer is not properly aligned"
+    );
+    debug_assert!(
+        (accept as usize).is_multiple_of(align_of::<c_char>()),
+        "strpbrk(): accept pointer is not properly aligned"
+    );
+
+    let mut i: usize = 0;
+    while *s.add(i) != 0 {
+        let ch: c_char = *s.add(i);
+        let mut a: usize = 0;
+        while *accept.add(a) != 0 {
+            if ch == *accept.add(a) {
+                return s.add(i).cast_mut();
+            }
+            a += 1;
+        }
+        i += 1;
+    }
+
+    core::ptr::null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strpbrk;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strpbrk_found() {
+        let s: Vec<c_char> = make_c_string(b"hello world");
+        let accept: Vec<c_char> = make_c_string(b"ow");
+        let ret: *mut c_char = unsafe { strpbrk(s.as_ptr(), accept.as_ptr()) };
+        assert!(!ret.is_null(), "strpbrk should find a match");
+        let offset: usize = usize::try_from(unsafe { ret.offset_from(s.as_ptr()) })
+            .expect("offset is non-negative");
+        assert_eq!(offset, 4, "first 'o' is at index 4");
+    }
+
+    #[test]
+    fn test_strpbrk_not_found() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let accept: Vec<c_char> = make_c_string(b"xyz");
+        let ret: *mut c_char = unsafe { strpbrk(s.as_ptr(), accept.as_ptr()) };
+        assert!(ret.is_null(), "strpbrk should return null when no match");
+    }
+
+    #[test]
+    fn test_strpbrk_empty_accept() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let accept: Vec<c_char> = make_c_string(b"");
+        let ret: *mut c_char = unsafe { strpbrk(s.as_ptr(), accept.as_ptr()) };
+        assert!(ret.is_null(), "strpbrk should return null with empty accept");
+    }
+}

--- a/src/libs/libc_string/src/strrchr.rs
+++ b/src/libs/libc_string/src/strrchr.rs
@@ -1,0 +1,110 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_uchar,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates the last occurrence of a character in a string.
+///
+/// This function returns a pointer to the last occurrence of the character `c` (converted to a
+/// `c_char`) in the string pointed to by `s`. The terminating null byte is considered part of the
+/// string.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to search.
+/// - `c`: Character to locate (converted to `c_char`).
+///
+/// # Return Value
+///
+/// Returns a pointer to the last occurrence of the character, or a null pointer if the character
+/// does not occur in the string.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory region pointed to by `s` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strrchr(s: *const c_char, c: c_int) -> *mut c_char {
+    debug_assert!(!s.is_null(), "strrchr(): null pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strrchr(): pointer is not properly aligned"
+    );
+
+    let target: c_uchar = c.to_le_bytes()[0];
+    let p: *const c_uchar = s.cast::<c_uchar>();
+    let mut last: *mut c_char = core::ptr::null_mut();
+    let mut i: usize = 0;
+    loop {
+        let ch: c_uchar = *p.add(i);
+        if ch == target {
+            last = s.add(i).cast_mut();
+        }
+        if ch == 0 {
+            return last;
+        }
+        i += 1;
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strrchr;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strrchr_multiple_occurrences() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strrchr(s.as_ptr(), b'l' as c_int) };
+        assert!(!ret.is_null(), "strrchr should find 'l'");
+        let offset: usize = unsafe { ret.offset_from(s.as_ptr()) } as usize;
+        assert_eq!(offset, 3, "last 'l' should be at index 3");
+    }
+
+    #[test]
+    fn test_strrchr_single_occurrence() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strrchr(s.as_ptr(), b'h' as c_int) };
+        assert!(!ret.is_null(), "strrchr should find 'h'");
+        let offset: usize = unsafe { ret.offset_from(s.as_ptr()) } as usize;
+        assert_eq!(offset, 0, "'h' should be at index 0");
+    }
+
+    #[test]
+    fn test_strrchr_not_found() {
+        let s: Vec<c_char> = make_c_string(b"hello");
+        let ret: *mut c_char = unsafe { strrchr(s.as_ptr(), b'z' as c_int) };
+        assert!(ret.is_null(), "strrchr should return null for char not in string");
+    }
+}

--- a/src/libs/libc_string/src/strsep.rs
+++ b/src/libs/libc_string/src/strsep.rs
@@ -1,0 +1,156 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Checks whether `c` is one of the delimiter characters in `delim`.
+unsafe fn is_delim(c: c_char, delim: *const c_char) -> bool {
+    let mut d: usize = 0;
+    while *delim.add(d) != 0 {
+        if c == *delim.add(d) {
+            return true;
+        }
+        d += 1;
+    }
+    false
+}
+
+///
+/// # Description
+///
+/// Extracts tokens from strings.
+///
+/// This function locates in the null-terminated string referenced by `*stringp` the first
+/// occurrence of any character in the string `delim` and replaces it with a null byte. The
+/// location of the next character after the delimiter is stored in `*stringp`. The original
+/// value of `*stringp` is returned.
+///
+/// If no delimiter is found, `*stringp` is set to null and the token (the entire string) is
+/// returned. If `*stringp` is initially null, null is returned.
+///
+/// # Parameters
+///
+/// - `stringp`: Pointer to a pointer to the string being tokenized.
+/// - `delim`: Pointer to a null-terminated string of delimiter characters.
+///
+/// # Return Value
+///
+/// Returns a pointer to the original value of `*stringp` (the token), or a null pointer if
+/// `*stringp` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It modifies the string in place by writing null bytes.
+/// - It modifies `*stringp` to advance past the delimiter.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strsep(stringp: *mut *mut c_char, delim: *const c_char) -> *mut c_char {
+    debug_assert!(!stringp.is_null(), "strsep(): null stringp pointer");
+    debug_assert!(!delim.is_null(), "strsep(): null delimiter pointer");
+    debug_assert!(
+        (delim as usize).is_multiple_of(align_of::<c_char>()),
+        "strsep(): delimiter pointer is not properly aligned"
+    );
+
+    let s: *mut c_char = *stringp;
+    if s.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let token: *mut c_char = s;
+    let mut i: usize = 0;
+    while *s.add(i) != 0 {
+        if is_delim(*s.add(i), delim) {
+            *s.add(i) = 0 as c_char;
+            *stringp = s.add(i + 1);
+            return token;
+        }
+        i += 1;
+    }
+
+    // No delimiter found.
+    *stringp = core::ptr::null_mut();
+    token
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strsep;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn test_strsep_basic() {
+        let mut input: Vec<c_char> = make_c_string(b"hello,world");
+        let delim: Vec<c_char> = make_c_string(b",");
+        let mut ptr: *mut c_char = input.as_mut_ptr();
+
+        let t1: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert!(!t1.is_null());
+        assert_eq!(c_str_to_bytes(t1), b"hello");
+
+        let t2: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert!(!t2.is_null());
+        assert_eq!(c_str_to_bytes(t2), b"world");
+
+        let t3: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert!(t3.is_null(), "should return null when no more tokens");
+    }
+
+    #[test]
+    fn test_strsep_multiple_tokens() {
+        let mut input: Vec<c_char> = make_c_string(b"a;b;c");
+        let delim: Vec<c_char> = make_c_string(b";");
+        let mut ptr: *mut c_char = input.as_mut_ptr();
+
+        let t1: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert_eq!(c_str_to_bytes(t1), b"a");
+
+        let t2: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert_eq!(c_str_to_bytes(t2), b"b");
+
+        let t3: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert_eq!(c_str_to_bytes(t3), b"c");
+
+        let t4: *mut c_char = unsafe { strsep(&mut ptr, delim.as_ptr()) };
+        assert!(t4.is_null());
+    }
+}

--- a/src/libs/libc_string/src/strspn.rs
+++ b/src/libs/libc_string/src/strspn.rs
@@ -1,0 +1,123 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the length of a prefix substring.
+///
+/// This function calculates the length of the initial segment of the string `s` which consists
+/// entirely of bytes in `accept`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the null-terminated string to search.
+/// - `accept`: Pointer to a null-terminated string of accepted bytes.
+///
+/// # Return Value
+///
+/// Returns the number of bytes in the initial segment of `s` which consist only of bytes from
+/// `accept`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `s` and `accept` without bounds checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strspn(s: *const c_char, accept: *const c_char) -> c_size_t {
+    debug_assert!(!s.is_null(), "strspn(): null pointer");
+    debug_assert!(!accept.is_null(), "strspn(): null accept pointer");
+    debug_assert!(
+        (s as usize).is_multiple_of(align_of::<c_char>()),
+        "strspn(): pointer is not properly aligned"
+    );
+    debug_assert!(
+        (accept as usize).is_multiple_of(align_of::<c_char>()),
+        "strspn(): accept pointer is not properly aligned"
+    );
+
+    let mut count: c_size_t = 0;
+    while *s.add(count as usize) != 0 {
+        let ch: c_char = *s.add(count as usize);
+        let mut found: bool = false;
+        let mut a: usize = 0;
+        while *accept.add(a) != 0 {
+            if ch == *accept.add(a) {
+                found = true;
+                break;
+            }
+            a += 1;
+        }
+        if !found {
+            break;
+        }
+        count += 1;
+    }
+
+    count
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strspn;
+    use ::std::vec::Vec;
+    use ::sysapi::{
+        ffi::c_char,
+        sys_types::c_size_t,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strspn_all_match() {
+        let s: Vec<c_char> = make_c_string(b"aabbcc");
+        let accept: Vec<c_char> = make_c_string(b"abc");
+        let ret: c_size_t = unsafe { strspn(s.as_ptr(), accept.as_ptr()) };
+        assert_eq!(ret as usize, 6, "all chars are in accept");
+    }
+
+    #[test]
+    fn test_strspn_none_match() {
+        let s: Vec<c_char> = make_c_string(b"xyz");
+        let accept: Vec<c_char> = make_c_string(b"abc");
+        let ret: c_size_t = unsafe { strspn(s.as_ptr(), accept.as_ptr()) };
+        assert_eq!(ret as usize, 0, "no chars match");
+    }
+
+    #[test]
+    fn test_strspn_partial_match() {
+        let s: Vec<c_char> = make_c_string(b"aabxyz");
+        let accept: Vec<c_char> = make_c_string(b"ab");
+        let ret: c_size_t = unsafe { strspn(s.as_ptr(), accept.as_ptr()) };
+        assert_eq!(ret as usize, 3, "first 3 chars match");
+    }
+}

--- a/src/libs/libc_string/src/strstr.rs
+++ b/src/libs/libc_string/src/strstr.rs
@@ -1,0 +1,145 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates a substring.
+///
+/// This function finds the first occurrence of the substring `needle` in the string `haystack`.
+/// The terminating null bytes are not compared. If `needle` is an empty string, `haystack` is
+/// returned.
+///
+/// # Parameters
+///
+/// - `haystack`: Pointer to the null-terminated string to search in.
+/// - `needle`: Pointer to the null-terminated substring to search for.
+///
+/// # Return Value
+///
+/// Returns a pointer to the beginning of the located substring, or a null pointer if the substring
+/// is not found.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It reads from the memory regions pointed to by `haystack` and `needle` without bounds
+///   checking.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char {
+    debug_assert!(!haystack.is_null(), "strstr(): null haystack pointer");
+    debug_assert!(!needle.is_null(), "strstr(): null needle pointer");
+    debug_assert!(
+        (haystack as usize).is_multiple_of(align_of::<c_char>()),
+        "strstr(): haystack pointer is not properly aligned"
+    );
+    debug_assert!(
+        (needle as usize).is_multiple_of(align_of::<c_char>()),
+        "strstr(): needle pointer is not properly aligned"
+    );
+
+    // Empty needle: return haystack.
+    if *needle == 0 {
+        return haystack.cast_mut();
+    }
+
+    let mut h: usize = 0;
+    while *haystack.add(h) != 0 {
+        let mut hi: usize = h;
+        let mut ni: usize = 0;
+        while *needle.add(ni) != 0 && *haystack.add(hi) == *needle.add(ni) {
+            hi += 1;
+            ni += 1;
+        }
+        if *needle.add(ni) == 0 {
+            return haystack.add(h).cast_mut();
+        }
+        h += 1;
+    }
+
+    core::ptr::null_mut()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strstr;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    #[test]
+    fn test_strstr_found() {
+        let haystack: Vec<c_char> = make_c_string(b"hello world");
+        let needle: Vec<c_char> = make_c_string(b"world");
+        let ret: *mut c_char = unsafe { strstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert!(!ret.is_null(), "strstr should find 'world'");
+        let offset: usize = usize::try_from(unsafe { ret.offset_from(haystack.as_ptr()) })
+            .expect("offset is non-negative");
+        assert_eq!(offset, 6, "'world' starts at index 6");
+    }
+
+    #[test]
+    fn test_strstr_not_found() {
+        let haystack: Vec<c_char> = make_c_string(b"hello world");
+        let needle: Vec<c_char> = make_c_string(b"xyz");
+        let ret: *mut c_char = unsafe { strstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert!(ret.is_null(), "strstr should return null when needle not found");
+    }
+
+    #[test]
+    fn test_strstr_empty_needle() {
+        let haystack: Vec<c_char> = make_c_string(b"hello");
+        let needle: Vec<c_char> = make_c_string(b"");
+        let ret: *mut c_char = unsafe { strstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert_eq!(ret, haystack.as_ptr().cast_mut(), "empty needle returns haystack");
+    }
+
+    #[test]
+    fn test_strstr_at_start() {
+        let haystack: Vec<c_char> = make_c_string(b"hello");
+        let needle: Vec<c_char> = make_c_string(b"hell");
+        let ret: *mut c_char = unsafe { strstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert!(!ret.is_null(), "strstr should find needle at start");
+        let offset: usize = usize::try_from(unsafe { ret.offset_from(haystack.as_ptr()) })
+            .expect("offset is non-negative");
+        assert_eq!(offset, 0, "needle at start should be at index 0");
+    }
+
+    #[test]
+    fn test_strstr_at_end() {
+        let haystack: Vec<c_char> = make_c_string(b"hello");
+        let needle: Vec<c_char> = make_c_string(b"llo");
+        let ret: *mut c_char = unsafe { strstr(haystack.as_ptr(), needle.as_ptr()) };
+        assert!(!ret.is_null(), "strstr should find needle at end");
+        let offset: usize = usize::try_from(unsafe { ret.offset_from(haystack.as_ptr()) })
+            .expect("offset is non-negative");
+        assert_eq!(offset, 2, "'llo' starts at index 2");
+    }
+}

--- a/src/libs/libc_string/src/strtok.rs
+++ b/src/libs/libc_string/src/strtok.rs
@@ -1,0 +1,188 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// State
+//==================================================================================================
+
+static mut LAST: *mut c_char = core::ptr::null_mut();
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Checks whether `c` is one of the delimiter characters in `delim`.
+unsafe fn is_delim(c: c_char, delim: *const c_char) -> bool {
+    let mut d: usize = 0;
+    while *delim.add(d) != 0 {
+        if c == *delim.add(d) {
+            return true;
+        }
+        d += 1;
+    }
+    false
+}
+
+///
+/// # Description
+///
+/// Extracts tokens from strings.
+///
+/// This function breaks a string into a sequence of zero or more non-empty tokens. On the first
+/// call, `s` should point to the string to be parsed. On subsequent calls to obtain subsequent
+/// tokens, `s` should be null.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the string to tokenize, or null for subsequent calls.
+/// - `delim`: Pointer to a null-terminated string of delimiter characters.
+///
+/// # Return Value
+///
+/// Returns a pointer to the next token, or a null pointer if there are no more tokens.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It modifies a static mutable variable for state across calls.
+/// - It writes null bytes into the original string to terminate tokens.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtok(s: *mut c_char, delim: *const c_char) -> *mut c_char {
+    debug_assert!(!delim.is_null(), "strtok(): null delimiter pointer");
+    debug_assert!(
+        (delim as usize).is_multiple_of(align_of::<c_char>()),
+        "strtok(): delimiter pointer is not properly aligned"
+    );
+
+    let mut current: *mut c_char = if !s.is_null() { s } else { LAST };
+
+    if current.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Skip leading delimiters.
+    while *current != 0 && is_delim(*current, delim) {
+        current = current.add(1);
+    }
+
+    if *current == 0 {
+        LAST = core::ptr::null_mut();
+        return core::ptr::null_mut();
+    }
+
+    let token: *mut c_char = current;
+
+    // Find end of token.
+    while *current != 0 && !is_delim(*current, delim) {
+        current = current.add(1);
+    }
+
+    if *current != 0 {
+        *current = 0 as c_char;
+        LAST = current.add(1);
+    } else {
+        LAST = core::ptr::null_mut();
+    }
+
+    token
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strtok;
+    use ::std::{
+        sync::Mutex,
+        vec::Vec,
+    };
+    use ::sysapi::ffi::c_char;
+
+    // Serializes tests that exercise `strtok()`, which mutates the shared `static mut LAST`.
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn test_strtok_basic() {
+        let _guard = LOCK.lock().expect("lock poisoned");
+        let mut input: Vec<c_char> = make_c_string(b"hello world foo");
+        let delim: Vec<c_char> = make_c_string(b" ");
+
+        let t1: *mut c_char = unsafe { strtok(input.as_mut_ptr(), delim.as_ptr()) };
+        assert!(!t1.is_null());
+        assert_eq!(c_str_to_bytes(t1), b"hello");
+
+        let t2: *mut c_char = unsafe { strtok(core::ptr::null_mut(), delim.as_ptr()) };
+        assert!(!t2.is_null());
+        assert_eq!(c_str_to_bytes(t2), b"world");
+
+        let t3: *mut c_char = unsafe { strtok(core::ptr::null_mut(), delim.as_ptr()) };
+        assert!(!t3.is_null());
+        assert_eq!(c_str_to_bytes(t3), b"foo");
+
+        let t4: *mut c_char = unsafe { strtok(core::ptr::null_mut(), delim.as_ptr()) };
+        assert!(t4.is_null(), "should return null when no more tokens");
+    }
+
+    #[test]
+    fn test_strtok_multiple_delimiters() {
+        let _guard = LOCK.lock().expect("lock poisoned");
+        let mut input: Vec<c_char> = make_c_string(b"a,b;c");
+        let delim: Vec<c_char> = make_c_string(b",;");
+
+        let t1: *mut c_char = unsafe { strtok(input.as_mut_ptr(), delim.as_ptr()) };
+        assert!(!t1.is_null());
+        assert_eq!(c_str_to_bytes(t1), b"a");
+
+        let t2: *mut c_char = unsafe { strtok(core::ptr::null_mut(), delim.as_ptr()) };
+        assert!(!t2.is_null());
+        assert_eq!(c_str_to_bytes(t2), b"b");
+
+        let t3: *mut c_char = unsafe { strtok(core::ptr::null_mut(), delim.as_ptr()) };
+        assert!(!t3.is_null());
+        assert_eq!(c_str_to_bytes(t3), b"c");
+    }
+
+    #[test]
+    fn test_strtok_no_tokens() {
+        let _guard = LOCK.lock().expect("lock poisoned");
+        let mut input: Vec<c_char> = make_c_string(b",,,,");
+        let delim: Vec<c_char> = make_c_string(b",");
+
+        let t1: *mut c_char = unsafe { strtok(input.as_mut_ptr(), delim.as_ptr()) };
+        assert!(t1.is_null(), "string of only delimiters should yield no tokens");
+    }
+}

--- a/src/libs/libc_string/src/strtok_r.rs
+++ b/src/libs/libc_string/src/strtok_r.rs
@@ -1,0 +1,183 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem::align_of;
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Checks whether `c` is one of the delimiter characters in `delim`.
+unsafe fn is_delim(c: c_char, delim: *const c_char) -> bool {
+    let mut d: usize = 0;
+    while *delim.add(d) != 0 {
+        if c == *delim.add(d) {
+            return true;
+        }
+        d += 1;
+    }
+    false
+}
+
+///
+/// # Description
+///
+/// Extracts tokens from strings (reentrant version).
+///
+/// This function breaks a string into a sequence of zero or more non-empty tokens. On the first
+/// call, `s` should point to the string to be parsed. On subsequent calls to obtain subsequent
+/// tokens, `s` should be null. The `saveptr` argument is used to maintain context between
+/// successive calls that parse the same string.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the string to tokenize, or null for subsequent calls.
+/// - `delim`: Pointer to a null-terminated string of delimiter characters.
+/// - `saveptr`: Pointer to a `*mut c_char` variable used to maintain context.
+///
+/// # Return Value
+///
+/// Returns a pointer to the next token, or a null pointer if there are no more tokens.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It performs raw pointer dereferencing and arithmetic.
+/// - It writes null bytes into the original string to terminate tokens.
+/// - It writes the continuation pointer through `saveptr`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtok_r(
+    s: *mut c_char,
+    delim: *const c_char,
+    saveptr: *mut *mut c_char,
+) -> *mut c_char {
+    debug_assert!(!delim.is_null(), "strtok_r(): null delimiter pointer");
+    debug_assert!(!saveptr.is_null(), "strtok_r(): null saveptr");
+    debug_assert!(
+        (delim as usize).is_multiple_of(align_of::<c_char>()),
+        "strtok_r(): delimiter pointer is not properly aligned"
+    );
+
+    let mut current: *mut c_char = if !s.is_null() { s } else { *saveptr };
+
+    if current.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Skip leading delimiters.
+    while *current != 0 && is_delim(*current, delim) {
+        current = current.add(1);
+    }
+
+    if *current == 0 {
+        *saveptr = core::ptr::null_mut();
+        return core::ptr::null_mut();
+    }
+
+    let token: *mut c_char = current;
+
+    // Find end of token.
+    while *current != 0 && !is_delim(*current, delim) {
+        current = current.add(1);
+    }
+
+    if *current != 0 {
+        *current = 0 as c_char;
+        *saveptr = current.add(1);
+    } else {
+        *saveptr = core::ptr::null_mut();
+    }
+
+    token
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strtok_r;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::c_char;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0 as c_char);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn test_strtok_r_basic() {
+        let mut input: Vec<c_char> = make_c_string(b"hello world foo");
+        let delim: Vec<c_char> = make_c_string(b" ");
+        let mut save: *mut c_char = core::ptr::null_mut();
+
+        let t1: *mut c_char = unsafe { strtok_r(input.as_mut_ptr(), delim.as_ptr(), &mut save) };
+        assert!(!t1.is_null());
+        assert_eq!(c_str_to_bytes(t1), b"hello");
+
+        let t2: *mut c_char = unsafe { strtok_r(core::ptr::null_mut(), delim.as_ptr(), &mut save) };
+        assert!(!t2.is_null());
+        assert_eq!(c_str_to_bytes(t2), b"world");
+
+        let t3: *mut c_char = unsafe { strtok_r(core::ptr::null_mut(), delim.as_ptr(), &mut save) };
+        assert!(!t3.is_null());
+        assert_eq!(c_str_to_bytes(t3), b"foo");
+
+        let t4: *mut c_char = unsafe { strtok_r(core::ptr::null_mut(), delim.as_ptr(), &mut save) };
+        assert!(t4.is_null(), "should return null when no more tokens");
+    }
+
+    #[test]
+    fn test_strtok_r_continue_tokenization() {
+        let mut input: Vec<c_char> = make_c_string(b"a,b;c");
+        let delim: Vec<c_char> = make_c_string(b",;");
+        let mut save: *mut c_char = core::ptr::null_mut();
+
+        let t1: *mut c_char = unsafe { strtok_r(input.as_mut_ptr(), delim.as_ptr(), &mut save) };
+        assert!(!t1.is_null());
+        assert_eq!(c_str_to_bytes(t1), b"a");
+
+        let t2: *mut c_char = unsafe { strtok_r(core::ptr::null_mut(), delim.as_ptr(), &mut save) };
+        assert!(!t2.is_null());
+        assert_eq!(c_str_to_bytes(t2), b"b");
+
+        let t3: *mut c_char = unsafe { strtok_r(core::ptr::null_mut(), delim.as_ptr(), &mut save) };
+        assert!(!t3.is_null());
+        assert_eq!(c_str_to_bytes(t3), b"c");
+    }
+
+    #[test]
+    fn test_strtok_r_no_tokens() {
+        let mut input: Vec<c_char> = make_c_string(b",,,,");
+        let delim: Vec<c_char> = make_c_string(b",");
+        let mut save: *mut c_char = core::ptr::null_mut();
+
+        let t1: *mut c_char = unsafe { strtok_r(input.as_mut_ptr(), delim.as_ptr(), &mut save) };
+        assert!(t1.is_null(), "string of only delimiters should yield no tokens");
+    }
+}


### PR DESCRIPTION
Implement the remaining POSIX and common BSD byte-string and memory
routines in the libc_string crate, and regenerate the bundled C headers
to match.

New functions:
- Memory: memccpy, memchr, memrchr.
- String: strcat, strchr, strcmp, strcpy, strcspn, strdup, strerror,
  strerror_r, strlcat, strlcpy, strncat, strncmp, strncpy, strndup,
  strnlen, strpbrk, strrchr, strsep, strspn, strstr, strtok, strtok_r.
- BSD/legacy: bcmp, bcopy, bzero, ffs, strcasecmp, strncasecmp.

Details:
- strerror_r follows the POSIX prototype `int strerror_r(int, char *,
  size_t)`: returns 0 on success, ERANGE when the buffer is too small
  (including buflen 0), and EINVAL for a null buffer, rather than the
  GNU char* variant.
- strerror maps errno values using Nanvix's sysapi::errno table (which
  diverges from Linux for codes >= 35, e.g. ENOSYS = 88) and returns a
  message for errnum 0. The match arms use the sysapi::errno constants
  rather than raw numeric literals.
- Each extern "C" symbol is exported only in guest builds via
  `#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]`, mirroring the
  libc_assert convention so host std test builds do not collide with the
  host libc.
- include/string.h advertises the POSIX <string.h> symbols plus the
  widely-used extensions strndup (POSIX.1-2008) and the BSD
  strlcat/strlcpy, matching common libc layouts (musl/glibc). The
  non-POSIX memrchr and strsep remain implemented in the crate but are
  not declared there. Legacy BSD byte-string names (bcmp, bcopy, bzero,
  ffs, strcasecmp, strncasecmp) are exposed through strings.h.

Add host unit tests (`#[cfg(all(test, feature = "std"))]`) covering
success, not-found, truncation, boundary, and error paths for the new
functions. libc_string is already wired into ALL_GUEST_RUST_LIBS and
ALL_GUEST_RUST_LIBS_TEST_LIST in the Makefile.

Validated with libc_string unit tests, clippy (-D warnings), and
gen-headers-check.
