### PR TITLE
[sys] Add `ProcessIdentifier::INIT` and derive the VFS root pid from it

### DIFF
--- a/src/libs/sys/src/sys/pm/pid.rs
+++ b/src/libs/sys/src/sys/pm/pid.rs
@@ -84,6 +84,21 @@ impl ProcessIdentifier {
     /// Identifier of the VFS daemon process.
     pub const VFSD: ProcessIdentifier = ProcessIdentifier(Self::VFSD_RAW);
 
+    /// Raw identifier for the init process.
+    ///
+    /// The kernel spawns the fixed daemon set (`procd`, `memd`, `vfsd`) before the boot workload,
+    /// so the init/root process — the first process not born from a fork — is assigned the pid that
+    /// immediately follows [`Self::VFSD_RAW`].
+    pub const INIT_RAW: i32 = Self::VFSD_RAW + 1;
+
+    /// Identifier of the init process.
+    ///
+    /// This is the root of the process tree: the one process the kernel creates directly rather
+    /// than through a fork, and therefore the authoritative source for the root identity. It is
+    /// named `INIT` (not `INITD`) to avoid colliding with the `ThreadIdentifier::INITD` thread
+    /// identifier, which holds a different value.
+    pub const INIT: ProcessIdentifier = ProcessIdentifier(Self::INIT_RAW);
+
     /// Error message for conversion failures.
     const PARSE_ERROR_MESSAGE: &'static str = "invalid process identifier";
 

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -124,6 +124,43 @@ use ::sys::{
 };
 
 //==================================================================================================
+// Boot-Order Invariants
+//==================================================================================================
+
+// Boot-order invariant for the init/root process identifier.
+//
+// The kernel spawns the guest daemon set (`procd`, `memd`, `vfsd`) on a contiguous pid block
+// immediately after the kernel process, then assigns the init/root workload the pid that follows
+// the daemon set. The VFS derives the root identity from `ProcessIdentifier::INIT` on that basis,
+// so pin the layout with a compile-time check: a daemon renumbering, or a change to the guest
+// daemon set, becomes a build error instead of silently re-pointing the root at the wrong process.
+//
+// This lives in `syscall` (rather than nearer the kernel or VFS) because `syscall` already carries
+// the `standalone` deployment feature, and the fixed three-daemon layout pinned below is the
+// standalone deployment's boot contract — other deployment modes spawn a different guest set.
+#[cfg(feature = "standalone")]
+mod boot_order_invariants {
+    use ::sys::pm::ProcessIdentifier;
+
+    ::static_assert::assert_eq!(ProcessIdentifier::PROCD_RAW == ProcessIdentifier::KERNEL_RAW + 1);
+    ::static_assert::assert_eq!(ProcessIdentifier::MEMD_RAW == ProcessIdentifier::PROCD_RAW + 1);
+    ::static_assert::assert_eq!(ProcessIdentifier::VFSD_RAW == ProcessIdentifier::MEMD_RAW + 1);
+    ::static_assert::assert_eq!(ProcessIdentifier::INIT_RAW == ProcessIdentifier::VFSD_RAW + 1);
+    // The init workload follows the *entire* guest daemon set, so the number of guest daemon names
+    // must equal the number of guest daemon pids reserved above. Adding a daemon to
+    // `GUEST_DAEMON_NAMES` without reserving a pid here (or vice versa) is a compile error.
+    ::static_assert::assert_eq!(
+        ::config::daemons::GUEST_DAEMON_NAMES.len()
+            == [
+                ProcessIdentifier::PROCD_RAW,
+                ProcessIdentifier::MEMD_RAW,
+                ProcessIdentifier::VFSD_RAW,
+            ]
+            .len()
+    );
+}
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -716,16 +716,14 @@ fn current_pid() -> ProcessIdentifier {
 
 /// Returns the identifier assigned to the root/init process.
 ///
-/// The kernel creates the fixed daemon set first (`procd`, `memd`, then `vfsd`) and assigns the
-/// boot workload the next pid. Keeping this derivation local avoids treating whichever process
-/// happens to issue the first VFS request as the root, which would break the fork-race placeholder
-/// path that [`vfs_fork_clone`] preserves.
-///
-/// TODO(#2610): replace this positional derivation with an authoritative root pid — a dedicated
-/// `ProcessIdentifier::INIT` constant or a value supplied by `procd` — instead of hardcoding
-/// `VFSD_RAW + 1`, which silently breaks if the daemon spawn order changes.
+/// The root identity comes from a single authoritative definition, [`ProcessIdentifier::INIT`]:
+/// the kernel creates the fixed daemon set first (`procd`, `memd`, then `vfsd`) and assigns the
+/// boot workload the next pid. Deriving the root from that constant — rather than recomputing
+/// `VFSD_RAW + 1` here — keeps the boot-order assumption in one place and avoids treating whichever
+/// process happens to issue the first VFS request as the root, which would break the fork-race
+/// placeholder path that [`vfs_fork_clone`] preserves.
 fn root_process_identifier() -> ProcessIdentifier {
-    ProcessIdentifier::from(ProcessIdentifier::VFSD_RAW + 1)
+    ProcessIdentifier::INIT
 }
 
 /// Selects the process on whose behalf subsequent VFS operations are performed.


### PR DESCRIPTION
## Summary

Introduce a single authoritative definition of the init/root process identifier (`ProcessIdentifier::INIT`) and use it where the VFS resolves the root, replacing a hardcoded positional derivation. A compile-time guard pins the daemon/init pid layout so a future daemon-set change cannot silently mis-point the VFS root.

## Changes

- **`sys`**: add `ProcessIdentifier::INIT` / `INIT_RAW`. The kernel spawns the fixed guest daemon set (`procd`, `memd`, `vfsd`) before the boot workload, so the init/root process (the first process not born from a fork) takes the pid immediately following `VFSD_RAW`. Named `INIT` (not `INITD`) to avoid colliding with the unrelated `ThreadIdentifier::INITD`.
- **`vfs`**: derive `root_process_identifier()` from `ProcessIdentifier::INIT` instead of recomputing `VFSD_RAW + 1` locally. This keeps the boot-order assumption in one place and avoids treating whichever process happens to issue the first VFS request as the root, which would break the fork-race placeholder path that `vfs_fork_clone` preserves.
- **`syscall`**: add a `standalone`-gated compile-time guard (`boot_order_invariants`) asserting the guest daemons occupy a contiguous pid block immediately after the kernel, and that the number of `config::daemons::GUEST_DAEMON_NAMES` matches the reserved daemon pids. Adding or renumbering a guest daemon without updating the layout becomes a build error. It lives in `syscall` because that crate already carries the `standalone` deployment feature, and the fixed three-daemon layout is the standalone deployment boot contract; other deployment modes spawn a different guest set.

## Validation

- `rust-lint-check-guest-rlib-syscall` (standalone off): clean, module stripped.
- `rust-lint-check-guest-binaries-arch-rust` (compiles `syscall` with `standalone`): asserts compiled and held under `-D warnings`.
- `rust-lint-check-kernel`: clean.
- `run-unit-tests`: all passed.
- `run-nanvix-tests` (standalone): 36/36 passed.

Closes #2610
