### PR TITLE
[syscall] Close console fd aliases

### DIFF
--- a/src/libs/syscall/src/close_route.rs
+++ b/src/libs/syscall/src/close_route.rs
@@ -1,0 +1,108 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Backend selection for resolved `close()` requests.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::fdtable::{
+    Resolution,
+    Route,
+};
+use ::sys::{
+    ipc::MessageType,
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// IPC target selected for a resolved `close()` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CloseTarget {
+    /// Descriptor number the selected backend must close.
+    pub(crate) fd: i32,
+    /// Backend process that serves the close request.
+    pub(crate) destination: ProcessIdentifier,
+    /// Message type expected by the backend.
+    pub(crate) message_type: MessageType,
+    /// Whether a missing backend is treated as success.
+    pub(crate) tolerate_missing_backend: bool,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Chooses the backend and descriptor number for a resolved standalone `close()` request.
+pub(crate) fn close_target(fd: i32, resolution: Resolution) -> CloseTarget {
+    match resolution.route {
+        // VFS-backed descriptors are closed by vfsd using the backend descriptor it reported.
+        Route::Vfs => CloseTarget {
+            fd: resolution.backend_fd,
+            destination: crate::VFS_DESTINATION,
+            message_type: crate::VFS_MESSAGE_TYPE,
+            tolerate_missing_backend: false,
+        },
+        // When a guest vfsd exists, a console descriptor also occupies a slot in vfsd's flat table;
+        // closing one must release that slot so the descriptor number can be reused. The slot is
+        // addressed by the caller-facing flat descriptor, not by the console stream number carried
+        // in `backend_fd`. A console alias minted by `fcntl(F_DUPFD)` (e.g. a shell parking stdout
+        // at fd 10 while it redirects) shares stream number 1 but lives in slot 10, so closing it
+        // must free slot 10. Closing `backend_fd` (1) would instead drop the live console and leave
+        // the alias dangling. When no guest vfsd exists (direct-ELF standalone), there is no slot
+        // to free, so delivery failure is tolerated and the close is a no-op.
+        Route::Console => CloseTarget {
+            fd,
+            destination: crate::VFS_DESTINATION,
+            message_type: crate::VFS_MESSAGE_TYPE,
+            tolerate_missing_backend: true,
+        },
+        // A socket occupies a flat slot owned by vfsd: closing it releases that slot, and vfsd
+        // forwards the endpoint close to networkd when the last reference is dropped. The slot is
+        // addressed by the caller-facing flat descriptor, not the networkd descriptor `backend_fd`
+        // routes I/O to.
+        Route::Socket => CloseTarget {
+            fd,
+            destination: crate::VFS_DESTINATION,
+            message_type: crate::VFS_MESSAGE_TYPE,
+            tolerate_missing_backend: false,
+        },
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::sysapi::unistd::STDOUT_FILENO;
+
+    /// Tests that closing a duplicated console descriptor addresses vfsd's flat slot, not the
+    /// console stream number returned as `backend_fd`.
+    #[test]
+    fn console_alias_close_targets_flat_slot() {
+        const ALIAS_FD: i32 = 10;
+
+        let target: CloseTarget = close_target(
+            ALIAS_FD,
+            Resolution {
+                route: Route::Console,
+                backend_fd: STDOUT_FILENO,
+            },
+        );
+
+        assert_eq!(target.fd, ALIAS_FD, "console aliases must close their flat slot");
+        assert_eq!(target.destination, crate::VFS_DESTINATION, "console slots live in vfsd");
+        assert_eq!(target.message_type, crate::VFS_MESSAGE_TYPE, "vfsd uses its message type");
+        assert!(
+            target.tolerate_missing_backend,
+            "direct-ELF console close must tolerate the absence of guest vfsd"
+        );
+    }
+}

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -507,6 +507,45 @@ mod tests {
         clear();
     }
 
+    /// Tests the descriptor distinction the console `close` path depends on. A console alias minted
+    /// by `fcntl(F_DUPFD)` — e.g. a shell parking stdout at fd 10 while it redirects — resolves to
+    /// the console route but reports the *stream number* (`1`) as its `backend_fd`, not its flat
+    /// slot (`10`). Because that stream number is also the live console's own flat slot, closing
+    /// the alias by `backend_fd` would free the live console and orphan the alias, so `close` must
+    /// address vfsd's slot by the caller-facing flat descriptor, never by `backend_fd`.
+    #[test]
+    fn console_alias_resolves_by_stream_number_not_slot() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        const ALIAS_FD: i32 = 10;
+        // The live console stdout: its flat slot and stream number coincide at 1.
+        mock_vfsd(STDOUT_FILENO, Route::Console, STDOUT_FILENO, 1);
+        // The alias parked at fd 10 by fcntl(F_DUPFD): a distinct slot that still streams to
+        // stdout.
+        mock_vfsd(ALIAS_FD, Route::Console, STDOUT_FILENO, 1);
+
+        let alias: Resolution = resolve(ALIAS_FD).expect("the alias must resolve");
+        assert_eq!(alias.route, Route::Console, "an alias of a console stream is still a console");
+        assert_eq!(
+            alias.backend_fd, STDOUT_FILENO,
+            "a console alias reports its stream number as backend_fd, not its flat slot"
+        );
+        // The crux of the close fix: backend_fd (the stream number) is the live console's own slot,
+        // so it must not be used as the slot key when closing the alias.
+        assert_ne!(
+            alias.backend_fd, ALIAS_FD,
+            "the alias's stream number must differ from its flat slot"
+        );
+        assert_eq!(
+            resolve(STDOUT_FILENO).map(|r| r.backend_fd),
+            Some(STDOUT_FILENO),
+            "backend_fd collides with the live console's own flat slot"
+        );
+
+        clear();
+    }
+
     /// Tests that hosted builds leave VFS descriptor interpretation to linuxd.
     #[test]
     fn hosted_resolve_vfs_returns_raw_fd() {

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -97,6 +97,10 @@ pub(crate) mod path;
 #[cfg(any(feature = "syscall", feature = "standalone", test))]
 pub(crate) mod fdtable;
 
+/// Backend selection for resolved `close()` requests.
+#[cfg(any(feature = "standalone", test))]
+pub(crate) mod close_route;
+
 // Safe wrappers.
 #[cfg(feature = "syscall")]
 pub mod safe;

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -36,34 +36,22 @@ pub fn close(fd: i32) -> Result<(), Error> {
     // In standalone mode, route based on the descriptor's resolved backend.
     #[cfg(feature = "standalone")]
     {
-        use crate::fdtable::{
-            resolve,
-            Route,
+        use crate::{
+            close_route::{
+                close_target,
+                CloseTarget,
+            },
+            fdtable::resolve,
         };
         let result: Result<(), Error> = match resolve(fd) {
-            Some(res) => match res.route {
-                // VFS-backed descriptors are closed by vfsd.
-                Route::Vfs => close_ipc(
-                    res.backend_fd,
-                    crate::VFS_DESTINATION,
-                    crate::VFS_MESSAGE_TYPE,
-                    false,
-                ),
-                // When a guest vfsd exists, a console descriptor also occupies a slot in vfsd's
-                // flat table; closing one must release that slot so the descriptor number can be
-                // reused. When no guest vfsd exists (direct-ELF standalone), resolve() routes the
-                // stream to the console by number and there is no slot to free, so the close is a
-                // no-op: the request cannot be delivered and that delivery failure is tolerated.
-                Route::Console => {
-                    close_ipc(res.backend_fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE, true)
-                },
-                // A socket occupies a flat slot owned by vfsd: closing it releases that slot, and
-                // vfsd forwards the endpoint close to networkd when the last reference is dropped.
-                // The slot is addressed by the caller-facing flat descriptor, not the networkd
-                // descriptor `backend_fd` routes I/O to.
-                Route::Socket => {
-                    close_ipc(fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE, false)
-                },
+            Some(res) => {
+                let target: CloseTarget = close_target(fd, res);
+                close_ipc(
+                    target.fd,
+                    target.destination,
+                    target.message_type,
+                    target.tolerate_missing_backend,
+                )
             },
             // Unknown fd: no handler available.
             None => {
@@ -85,7 +73,6 @@ pub fn close(fd: i32) -> Result<(), Error> {
         close_ipc(fd, crate::LINUXD, MessageType::Ikc, false)
     }
 }
-
 /// Forwards a `close` request via IPC to the given destination.
 ///
 /// When `tolerate_missing_backend` is set, a failure to deliver the request (no such backend
@@ -141,7 +128,6 @@ fn close_ipc(
         }
     }
 }
-
 pub mod bindings {
     use crate::errno::__errno_location;
     use ::sysapi::ffi::c_int;

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -4341,6 +4341,63 @@ mod tests {
         forget_processes(&[pid]);
     }
 
+    /// Reproduces the ash I/O-redirection save/restore dance on the console:
+    ///   savedfd = fcntl(1, F_DUPFD, 10);  // park the console stdout
+    ///   dup2(file, 1);                    // redirect stdout to a file
+    ///   dup2(savedfd, 1);                 // restore stdout to the console
+    ///   close(savedfd);                   // drop the parked alias
+    /// After the dance, fd 1 must resolve back to the console.
+    #[test]
+    fn dup2_console_save_restore_dance_restores_console() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7506);
+        set_current_process(pid);
+
+        // Seed console stdin/stdout so stdout lands on fd 1 (the lowest free numbers).
+        let stdin_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdin)))
+                .expect("stdin alloc");
+        assert_eq!(stdin_fd, STDIN_FILENO);
+        let stdout_fd: c_int =
+            alloc_fd(VfsFileHandle::Console(ConsoleHandle::new(ConsoleStream::Stdout)))
+                .expect("stdout alloc");
+        assert_eq!(stdout_fd, STDOUT_FILENO, "console stdout must be fd 1");
+
+        // A file to redirect into.
+        let file_fd: c_int = vfs_alloc_hostfs(70, false, None).expect("file alloc");
+
+        // savedfd = fcntl(1, F_DUPFD, 10): park the console stdout above the low range.
+        let saved_fd: c_int = vfs_dup_from(stdout_fd, 10).expect("savefd");
+        assert_eq!(saved_fd, 10);
+        assert_eq!(
+            vfs_resolve(saved_fd),
+            Some((VfsRoute::Console, STDOUT_FILENO)),
+            "the parked fd must alias the console"
+        );
+
+        // dup2(file, 1): redirect stdout to the file.
+        vfs_dup2(file_fd, stdout_fd).expect("redirect");
+        assert_eq!(
+            vfs_resolve(stdout_fd).map(|(r, _)| r),
+            Some(VfsRoute::Vfs),
+            "fd 1 must route to the file while redirected"
+        );
+
+        // dup2(savedfd, 1): restore stdout to the console.
+        vfs_dup2(saved_fd, stdout_fd).expect("restore");
+        // close(savedfd): drop the parked alias.
+        vfs_close(saved_fd).expect("close saved");
+
+        // fd 1 must once again route to the console.
+        assert_eq!(
+            vfs_resolve(stdout_fd),
+            Some((VfsRoute::Console, STDOUT_FILENO)),
+            "after restore+close, fd 1 must resolve back to the console"
+        );
+
+        forget_processes(&[pid]);
+    }
+
     // -- console fstat tests ------------------------------------------------------
 
     /// Tests that `vfs_fstat` reports a console descriptor as a character device with a stable


### PR DESCRIPTION
## Summary

In standalone mode `close()` routed a console-backed descriptor to vfsd using `Resolution::backend_fd`. For a console route `backend_fd` is the standard stream number (`0`/`1`/`2`), not the caller-facing flat slot. A console alias minted by `fcntl(F_DUPFD)` — e.g. the ash redirection dance that parks stdout at fd 10 (`savedfd = fcntl(1, F_DUPFD, 10)`), redirects fd 1 to a file, restores it, then `close(savedfd)` — shares stream number 1 but lives in slot 10. Closing it by `backend_fd` (1) freed the live console's own slot and left the alias dangling, so fd 1 no longer resolved back to the console after the restore.

## Changes

- Close console descriptors by the caller-facing flat descriptor instead, so vfsd releases the correct slot. VFS-backed and socket descriptors continue to be addressed by `backend_fd`, and the direct-ELF standalone no-op (tolerated missing backend) is preserved.
- Extract the per-route backend/descriptor selection into a new `close_route::close_target` helper so the dispatch decision is unit testable without IPC, and route `close()` through it.

## Tests

- `close_route`: console alias resolves to its flat slot, targets vfsd, and tolerates a missing backend.
- `fdtable`: a console alias resolves to the console route while reporting the stream number as `backend_fd`, distinct from its flat slot.
- `vfs::fd`: the ash save/restore/close dance leaves fd 1 resolving back to the console.

Validated with `./z build -- run-unit-tests` and `./z build -- run-nanvix-tests`.

## Issues

Closes #2646 