### PR TITLE
[sys] Unify per-image getpid() cache

### DIFF
--- a/src/libs/sys/src/lib.rs
+++ b/src/libs/sys/src/lib.rs
@@ -10,6 +10,7 @@
 #![forbid(clippy::large_stack_arrays)]
 #![cfg_attr(feature = "kcall", feature(never_type))] // exit() uses this.
 #![cfg_attr(feature = "kcall", feature(likely_unlikely))] // Branch hints for unlikely error paths.
+#![cfg_attr(feature = "kcall", feature(linkage))] // Unified per-image getpid() cache (CACHED_PID).
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //==================================================================================================

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -53,6 +53,18 @@ const PID_UNCACHED: i32 = -1;
 /// duplicated into a child by `fork()`; the child half of `__kcall_fork()` invalidates it (see
 /// [`invalidate_cached_pid`]) so the child re-queries its own identity rather than reusing the
 /// parent's.
+///
+/// The cache is a single, per-process-image instance. A C-linked guest image links several
+/// independently-compiled static archives (e.g. `libposix.a` and `libnvx_crt0.a`), each embedding
+/// its own compilation of this crate; without a shared symbol every archive would carry a private
+/// `CACHED_PID`, and a `fork()` invalidation in one archive would not refresh the copy another
+/// archive reads (it could still serve the parent's pid inherited through copy-on-write memory).
+/// Giving the storage a stable export name with `weak` linkage collapses those per-archive copies
+/// into one instance at link time, so a single invalidation reliably refreshes every reader. The
+/// `weak` linkage lets the duplicate definitions merge instead of colliding, and is harmless for a
+/// single-compilation Rust binary, where only one definition exists.
+#[unsafe(export_name = "__nanvix_sys_cached_pid")]
+#[linkage = "weak"]
 static CACHED_PID: AtomicI32 = AtomicI32::new(PID_UNCACHED);
 
 ///

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -70,20 +70,12 @@ impl Heap {
 
         // Map initial pages.
         //
-        // Resolve the owning pid with an UNCACHED kernel query. The kernel rejects an mmap whose
-        // target pid differs from the calling process (its memory-management capability check), so a
-        // mapping must always name the current process. The cached getpid() offers no guarantee
-        // here: the pid cache is a per-link-unit `static`, and a C-linked image ends up with several
-        // independent copies of it (cpython, for example, links libposix.a and libnvx_crt0.a, each
-        // compiled with its own `sys` crate and therefore its own cache). fork() can invalidate only
-        // the copy in its own link unit, so it cannot guarantee that the copy this mapping consults
-        // was refreshed; that copy may still hold the parent's pid inherited through copy-on-write
-        // memory. Querying the kernel directly is independent of every cached copy.
-        //
-        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a process image is
-        // guaranteed to carry a single, unified pid cache that fork() invalidates, restore the
-        // cached getpid() here.
-        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
+        // Resolve the owning pid. The kernel rejects an mmap whose target pid differs from the
+        // calling process (its memory-management capability check), so the mapping must name the
+        // current process. The cached getpid() is correct here: CACHED_PID is a single per-image
+        // instance, and every fork path invalidates it, so a forked child re-resolves to its own
+        // identity before mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
         let start: VirtualAddress = base;
         let end: VirtualAddress = VirtualAddress::from_raw_value(base.into_raw_value() + size);
         map_range(pid, start, end)?;
@@ -135,9 +127,9 @@ impl Heap {
 
         // Map pages.
         //
-        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
-        // getpid() cannot be trusted for a capability-sensitive mapping.
-        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
+        // Resolve the owning pid; see new() for why the cached getpid() is correct for a
+        // capability-sensitive mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
         let end: VirtualAddress = self.base + self.size;
         let new_end: VirtualAddress = end + increment;
         map_range(pid, end, new_end)?;
@@ -176,9 +168,9 @@ impl Heap {
             return Ok(());
         }
 
-        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
-        // getpid() cannot be trusted for a capability-sensitive unmapping.
-        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
+        // Resolve the owning pid; see new() for why the cached getpid() is correct for a
+        // capability-sensitive unmapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
 
         // Unmap tail pages from the end backwards, stopping at the first failure so that
         // self.size always reflects the actual contiguous mapped extent.
@@ -296,9 +288,9 @@ impl Drop for Heap {
             self.capacity
         );
 
-        // Resolve the owning pid with an UNCACHED kernel query; see new() for the rationale. Drop
-        // cannot propagate errors, so skip unmapping if the pid cannot be determined.
-        let pid: ProcessIdentifier = match kcall::pm::getpid_uncached() {
+        // Resolve the owning pid; see new() for the rationale. Drop cannot propagate errors, so
+        // skip unmapping if the pid cannot be determined.
+        let pid: ProcessIdentifier = match kcall::pm::getpid() {
             Ok(pid) => pid,
             Err(_error) => {
                 ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -98,20 +98,12 @@ impl MemorySegment {
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
-        // Resolve the owning pid with an UNCACHED kernel query. The kernel rejects an mmap whose
-        // target pid differs from the calling process (its memory-management capability check), so a
-        // mapping must always name the current process. The cached getpid() offers no guarantee
-        // here: the pid cache is a per-link-unit `static`, and a C-linked image ends up with several
-        // independent copies of it (cpython, for example, links libposix.a and libnvx_crt0.a, each
-        // compiled with its own `sys` crate and therefore its own cache). fork() can invalidate only
-        // the copy in its own link unit, so it cannot guarantee that the copy this mapping consults
-        // was refreshed; that copy may still hold the parent's pid inherited through copy-on-write
-        // memory. Querying the kernel directly is independent of every cached copy.
-        //
-        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a process image is
-        // guaranteed to carry a single, unified pid cache that fork() invalidates, restore the
-        // cached getpid() here.
-        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
+        // Resolve the owning pid. The kernel rejects an mmap whose target pid differs from the
+        // calling process (its memory-management capability check), so the mapping must name the
+        // current process. The cached getpid() is correct here: CACHED_PID is a single per-image
+        // instance, and every fork path invalidates it, so a forked child re-resolves to its own
+        // identity before mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
 
         map_range(
             pid,
@@ -218,9 +210,9 @@ impl MemorySegment {
             prot
         );
 
-        // Resolve the owning pid with an UNCACHED kernel query; see new() for why the cached
-        // getpid() cannot be trusted for a capability-sensitive mapping.
-        let pid: ProcessIdentifier = kcall::pm::getpid_uncached()?;
+        // Resolve the owning pid; see new() for why the cached getpid() is correct for a
+        // capability-sensitive mapping.
+        let pid: ProcessIdentifier = kcall::pm::getpid()?;
 
         protect_range(
             pid,
@@ -235,9 +227,9 @@ impl Drop for MemorySegment {
     fn drop(&mut self) {
         ::syslog::trace!("drop(): base={:X?}, capacity={:X?}", self.base, self.capacity);
 
-        // Resolve the owning pid with an UNCACHED kernel query; see new() for the rationale. Drop
-        // cannot propagate errors, so skip unmapping if the pid cannot be determined.
-        let pid: ProcessIdentifier = match kcall::pm::getpid_uncached() {
+        // Resolve the owning pid; see new() for the rationale. Drop cannot propagate errors, so
+        // skip unmapping if the pid cannot be determined.
+        let pid: ProcessIdentifier = match kcall::pm::getpid() {
             Ok(pid) => pid,
             Err(_error) => {
                 ::syslog::warn!("drop(): failed to query pid, skipping unmap (error={:?})", _error);

--- a/src/libs/syscall/src/unistd/fork/mod.rs
+++ b/src/libs/syscall/src/unistd/fork/mod.rs
@@ -242,26 +242,12 @@ pub fn do_fork() -> Result<pid_t, ErrorCode> {
             panic!("do_fork(): child exit kcall returned (error={exit_error:?})");
         }
 
-        // Defensively refresh the child's cached process identifier.
-        //
-        // The child inherits `CACHED_PID` (holding the *parent's* pid) through copy-on-write
-        // memory. `__kcall_fork()` already clears this crate instance's copy at the start of the
-        // child path, and the kernel always reports the child's own identity — there is no window
-        // in which `getpid()` returns the parent's pid — so the next cached query re-resolves to
-        // the child regardless. This post-handshake clear is a low-cost safety net for the
-        // libc-side identity cache; it adds at most one kernel transition per fork.
-        //
-        // It is NOT the capability fix. `CACHED_PID` is a per-link-unit static, so a process image
-        // that links several independently-compiled copies of this crate (e.g. a C program linking
-        // `libposix.a` and `libnvx_crt0.a`) carries multiple instances that no single invalidation
-        // can reach. The capability-sensitive callers — `mmap`/`mprotect`/`munmap` in
-        // `MemorySegment` and the heap allocator — therefore resolve the owning pid with
-        // `getpid_uncached()` and never trust this cache for the kernel's `pid != caller_pid` check.
-        //
-        // Tracked by https://github.com/nanvix/nanvix/issues/2622: once a single unified pid cache
-        // is guaranteed per image, this defensive re-invalidation can be dropped.
-        ::sys::kcall::pm::invalidate_cached_pid();
-
+        // No cache refresh is needed here: the child inherited the parent's `CACHED_PID` through
+        // copy-on-write memory, but `__kcall_fork()` already invalidated it on the child path — at
+        // the single, lowest-level choke point common to every fork caller — before returning here.
+        // `CACHED_PID` is one unified per-image instance, so that single invalidation reaches every
+        // reader (including the capability-sensitive `mmap`/`mprotect`/`munmap` callers), and the
+        // next `getpid()` re-resolves to the child's own identity.
         Ok(0)
     } else {
         // Parent: ask the daemon to duplicate our descriptors onto the child, and block until it

--- a/src/tests/c-bindings-rust/src/main.rs
+++ b/src/tests/c-bindings-rust/src/main.rs
@@ -143,6 +143,7 @@ const _: () = assert!(size_of::<sched_param>() == size_of::<c_int>());
 // could trigger LLVM LTO type-mismatch failures. The linker only needs to resolve the symbol
 // address; the actual calling convention is irrelevant here.
 unsafe extern "C" {
+    static __nanvix_sys_cached_pid: u8;
     static __errno_location: u8;
     static _exit: u8;
     static accept: u8;
@@ -283,7 +284,8 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 129] = [
+static SYSCALL_SYMBOLS: [SymAddr; 130] = [
+    SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
     SymAddr(&raw const accept),


### PR DESCRIPTION
## Summary

Unifies the per-image `getpid()` cache so that C-linked guest images no longer carry multiple independent copies of `CACHED_PID`.

`CACHED_PID` is now exported under a stable name with `weak` linkage. A C-linked guest image links several independently-compiled static archives (e.g. `libposix.a` and `libnvx_crt0.a`), each embedding its own compilation of the `sys` crate. Previously every archive carried a private `CACHED_PID`, so a `fork()` invalidation in one archive could not refresh the copy another archive read — which could still serve the parent's pid inherited through copy-on-write memory. The weak export collapses those per-archive copies into a single per-process-image instance at link time.

## Changes

- **`sys`**: export `CACHED_PID` as `__nanvix_sys_cached_pid` with `weak` linkage; enable the unstable `linkage` feature (gated behind `feature = "kcall"`).
- **`sysalloc`**: restore cached `getpid()` in `Heap::new`/`grow`/`shrink`/`Drop`, replacing the `getpid_uncached()` workaround.
- **`syscall`**: restore cached `getpid()` in `MemorySegment::new`/`set_protection`/`Drop`.
- **`syscall`**: drop the defensive post-handshake `invalidate_cached_pid()` in `do_fork()`; `__kcall_fork()` already invalidates the unified cache on the child path at the single lowest-level choke point common to every fork caller.

## Validation

- `z.ps1 build -- check-guest-rlib-sys check-guest-rlib-sysalloc check-guest-rlib-syscall check-guest-staticlib-posix check-guest-staticlib-nvx-crt0`
- `z.ps1 build -- run-unit-tests`
- `z.ps1 build -- run-nanvix-tests`

Closes #2622
