### PR TITLE
[tests] Add fd-inheritance across fork+exec acceptance test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fork-exec-loop-target"
+version = "0.16.134"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc_string",
+ "nvx",
+ "nvx-crt0",
+ "sys",
+ "sysalloc",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
+name = "fork-exec-loop-test"
+version = "0.16.134"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc_string",
+ "nvx",
+ "nvx-crt0",
+ "sys",
+ "sysalloc",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
 name = "fork-exec-vfsd-target"
 version = "0.16.139"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ members = [
         "src/tests/fork-exec-write-test",
         "src/tests/fork-exec-write-target",
         "src/tests/thread-vfs-test",
+        "src/tests/fork-exec-loop-test",
+        "src/tests/fork-exec-loop-target",
         "src/tests/socket-fork-rust",
         "src/tests/setenv-rust",
         "src/tests/snapshot-test",

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,8 @@ ALL_GUEST_TESTS := \
 	c-bindings-rust mount-test mount-multipart-test cmdline-len-rust \
 	env-rust-nostd cmdline-env-rust-nostd snapshot-test execv-test execv-target \
 	execv-big-target pipe-dup2-rust fork-exec-vfsd-test fork-exec-vfsd-target \
-	fork-exec-write-test fork-exec-write-target thread-vfs-test socket-fork-rust
+	fork-exec-write-test fork-exec-write-target thread-vfs-test \
+	fork-exec-loop-test fork-exec-loop-target socket-fork-rust
 # dlfcn-rust requires PIE linking for dlopen/dlsym; the x86_64 static
 # relocation model produces R_X86_64_32 relocations incompatible with PIE.
 ifneq ($(TARGET),x86_64)
@@ -927,7 +928,7 @@ STANDALONE_NO_DAEMON_TESTS := test-kernel
 # not have a standalone .initrd of their own. The execv targets are loaded at runtime by
 # execv-test (the small target as `/target` in execv-test.img, the large target as `/target` in
 # execv-big-test.img).
-STANDALONE_RAMFS_ONLY_BINARIES := execv-target execv-big-target fork-exec-vfsd-target fork-exec-write-target
+STANDALONE_RAMFS_ONLY_BINARIES := execv-target execv-big-target fork-exec-vfsd-target fork-exec-write-target fork-exec-loop-target
 
 # Standalone binaries that manage VFS locally and must NOT include vfsd in their
 # .initrd image (vfsd would claim the RAMFS MMIO region before the benchmark).

--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -22,7 +22,7 @@ STANDALONE_GUEST_BINARIES := \
 	mount-multipart-test mount-bench-nostd cmdline-len-rust network-rust \
 	execv-test execv-target execv-big-target pipe-dup2-rust fork-exec-vfsd-test \
 	fork-exec-vfsd-target fork-exec-write-test fork-exec-write-target \
-	thread-vfs-test socket-fork-rust
+	thread-vfs-test fork-exec-loop-test fork-exec-loop-target socket-fork-rust
 
 # Computes the cargo features string for a guest binary package.
 # test-kernel has its own overrides. When DEPLOYMENT_MODE=standalone, packages

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -72,6 +72,13 @@ ifeq ($(DEPLOYMENT_MODE),standalone)
 	@mkdir -p $(BINARIES_DIR)/thread-vfs-test-seed
 	@printf 'THREAD-VFS-2529-PAYLOAD' > $(BINARIES_DIR)/thread-vfs-test-seed/input.dat
 	$(BINARIES_DIR)/mkramfs.$(HOST_BIN_EXT) -o $(BINARIES_DIR)/thread-vfs-test.img $(BINARIES_DIR)/thread-vfs-test-seed/
+	# Build the ramfs image for the repeated fork()+execv() test. It contains the target at the
+	# filesystem root as "target" and a seeded file "coldfile.dat" that the parent opens before each
+	# fork; the child reads it through the inherited descriptor passed in argv.
+	@mkdir -p $(BINARIES_DIR)/fork-exec-loop-test-seed
+	@cp -f $(BINARIES_DIR)/fork-exec-loop-target.$(EXEC_FORMAT) $(BINARIES_DIR)/fork-exec-loop-test-seed/target
+	@printf 'COLD-READ-PAYLOAD-OK' > $(BINARIES_DIR)/fork-exec-loop-test-seed/coldfile.dat
+	$(BINARIES_DIR)/mkramfs.$(HOST_BIN_EXT) -o $(BINARIES_DIR)/fork-exec-loop-test.img $(BINARIES_DIR)/fork-exec-loop-test-seed/
 endif
 	# Only give nanvixd CAP_SYS_ADMIN and CAP_NET_ADMIN if we need to manage
 	# network namespaces. This is only the case in L2 deployments (Linux only).

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -22,7 +22,9 @@ use crate::{
 };
 use ::proc::{
     exec_ack,
+    fork_clone_ack,
     ExecMessage,
+    ForkCloneAckMessage,
     ForkCloneMessage,
     ProcessExitMessage,
     ProcessManagementMessage,
@@ -154,20 +156,46 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                     // descriptors (sharing the underlying open file descriptions, and therefore
                     // file offsets, as POSIX requires) together with a private copy of its current
                     // working directory.
-                    if let Err(e) = ::vfs::fd::vfs_fork_clone(parent, child) {
-                        ::syslog::error!(
-                            "failed to clone filesystem state (parent={:?}, child={:?}, \
-                             error={:?})",
-                            parent,
+                    let status: i32 = match ::vfs::fd::vfs_fork_clone(parent, child) {
+                        Ok(()) => {
+                            ::syslog::info!(
+                                "cloned filesystem state (parent={:?}, child={:?})",
+                                parent,
+                                child
+                            );
+                            ForkCloneAckMessage::STATUS_SUCCESS
+                        },
+                        Err(e) => {
+                            ::syslog::error!(
+                                "failed to clone filesystem state (parent={:?}, child={:?}, \
+                                 error={:?})",
+                                parent,
+                                child,
+                                e
+                            );
+                            ErrorCode::TryAgain.get()
+                        },
+                    };
+                    // Acknowledge the process manager daemon that the clone has been processed, so
+                    // it releases the parent and child held at the fork-synchronization barrier only
+                    // now that the snapshot has actually been taken. Releasing on dispatch alone
+                    // would let the child run its first filesystem operation (e.g. the `execv()`
+                    // image load) before this clone, so that operation would make the child's table
+                    // active and the clone would be refused, dropping the inherited descriptors. A
+                    // non-zero status reports a failed clone so the fork is aborted rather than
+                    // proceeding with a half-cloned child.
+                    match fork_clone_ack(
+                        ProcessIdentifier::VFSD,
+                        ProcessIdentifier::PROCD,
+                        child,
+                        status,
+                    ) {
+                        Ok(ack) => send_response(&ack),
+                        Err(e) => ::syslog::error!(
+                            "failed to build fork-clone acknowledgement (child={:?}, error={:?})",
                             child,
                             e
-                        );
-                    } else {
-                        ::syslog::info!(
-                            "cloned filesystem state (parent={:?}, child={:?})",
-                            parent,
-                            child
-                        );
+                        ),
                     }
                     Ok(false)
                 },

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     identity::ProcessIdentity,
     message,
     ExecAckMessage,
+    ForkCloneAckMessage,
     ForkSyncAckMessage,
     ForkSyncMessage,
     LookupMessage,
@@ -78,14 +79,16 @@ struct ProcessRecord {
     parent: Option<ProcessIdentifier>,
     /// Process identifiers of the live children.
     children: Vec<ProcessIdentifier>,
-    /// Whether the fork-clone of this process has already been dispatched to the filesystem daemon.
-    /// Used to acknowledge a fork-sync request regardless of whether it races ahead of the
-    /// process-creation event.
+    /// Whether the fork-clone of this process has been acknowledged by the filesystem daemon, i.e.
+    /// the parent's filesystem state has actually been duplicated onto this child. Used to release a
+    /// fork-sync request regardless of whether it races ahead of the process-creation event or of
+    /// the clone acknowledgement.
     fork_clone_done: bool,
-    /// Whether the fork-clone of this process could not be dispatched to the filesystem daemon (the
-    /// notification failed to build or send). Used to release a blocked fork-sync waiter with a
-    /// failure acknowledgement instead of leaving it deadlocked on a snapshot that will never be
-    /// taken.
+    /// Whether the fork-clone of this process failed: either it could not be dispatched to the
+    /// filesystem daemon (the notification failed to build or send) or the filesystem daemon
+    /// acknowledged that it could not take the snapshot. Used to release a blocked fork-sync waiter
+    /// with a failure acknowledgement instead of leaving it deadlocked on a snapshot that will never
+    /// be taken.
     fork_clone_failed: bool,
     /// Termination status once the process has terminated and is awaiting reap by `waitpid()`.
     /// `Some(status)` marks a zombie; `None` marks a live (or not-yet-terminated) process.
@@ -152,9 +155,12 @@ pub struct ProcessDaemon {
     /// process-creation event. Used only to re-parent orphaned children; the shutdown decision is
     /// made authoritatively from the role carried in the termination event, not from this field.
     init_proc: Option<ProcessIdentifier>,
-    /// Fork-sync requests awaiting the fork-clone dispatch, stored as `(child, parent)` pairs that
-    /// map a child to the blocked parent. Populated when a fork-sync request arrives before the
-    /// child's process-creation event; drained when that event dispatches the clone. A `Vec` is
+    /// Fork-sync requests awaiting the filesystem daemon's acknowledgement that the child's
+    /// fork-clone snapshot has been taken, stored as `(child, parent)` pairs that map a child to the
+    /// blocked parent. Populated when a fork-sync request cannot be answered immediately -- either
+    /// the child's process-creation event has not yet been observed, or the clone has been
+    /// dispatched but not yet acknowledged; drained when the filesystem daemon acknowledges the
+    /// clone (releasing or failing the waiter) or when the clone could not be dispatched. A `Vec` is
     /// used rather than a map because only a handful of fork operations are ever pending
     /// concurrently, so a linear scan is cheaper than the overhead of an ordered map.
     pending_fork_syncs: Vec<(ProcessIdentifier, ProcessIdentifier)>,
@@ -287,22 +293,27 @@ impl ProcessDaemon {
         // there is no parent filesystem state to inherit: skip the fork-clone notification for
         // them. This avoids needless boot-time traffic to the filesystem daemon and a phantom
         // per-process state keyed by the kernel. Only genuine user-space forks (parent is another
-        // process) require duplication. The clone is remembered as dispatched only if the
-        // notification was actually delivered to the filesystem daemon: marking it done on a failed
-        // send would let a later fork-sync request be acknowledged without a snapshot ever having
-        // been taken, letting parent and child proceed past unduplicated filesystem state.
+        // process) require duplication. A failed dispatch is recorded so that a later fork-sync
+        // request fails the fork instead of being acknowledged on the basis of a snapshot that will
+        // never be taken, which would let parent and child proceed past unduplicated filesystem
+        // state; a successful dispatch is confirmed separately by the filesystem daemon's
+        // acknowledgement (see below).
         if parent != ProcessIdentifier::KERNEL {
             let clone_dispatched: bool = self.notify_fork_clone(parent, child);
-            if let Some(record) = self.processes.get_mut(&child) {
-                if clone_dispatched {
-                    record.fork_clone_done = true;
-                } else {
-                    // The fork-clone notification could not be dispatched. Mark the failure so that
-                    // a fork-sync waiter (whether already pending below or arriving later) is
-                    // released with a failure acknowledgement rather than left blocked forever.
+            if !clone_dispatched {
+                // The fork-clone notification could not be dispatched. Mark the failure so that a
+                // fork-sync waiter (whether already pending below or arriving later) is released
+                // with a failure acknowledgement rather than left blocked forever.
+                if let Some(record) = self.processes.get_mut(&child) {
                     record.fork_clone_failed = true;
                 }
             }
+            // On a successful dispatch `fork_clone_done` stays false: it is set only when the
+            // filesystem daemon acknowledges that it has actually taken the snapshot (see
+            // `handle_fork_clone_ack`). Gating the fork-sync release on that acknowledgement keeps
+            // the freshly forked child from issuing its first filesystem operation -- such as the
+            // `execv()` image load, which opens a descriptor and makes its table active -- ahead of
+            // the clone, which would otherwise refuse the clone and drop the inherited descriptors.
         }
 
         // Release a parent (and its child) that is already blocked awaiting fork synchronization.
@@ -313,12 +324,12 @@ impl ProcessDaemon {
         //    actually its own (the `child` field of a fork-sync request is untrusted): drop it
         //    without acknowledging, so it cannot inject a spurious acknowledgement into a victim's
         //    mailbox or displace the genuine waiter.
-        // 2. The fork-clone must have actually been dispatched to the filesystem daemon, tracked by
-        //    `fork_clone_done`. If the notification failed to send, the waiter is instead released
-        //    with a failure acknowledgement so that `fork()` aborts rather than acknowledged with
-        //    success: a success acknowledgement would let parent and child proceed past a filesystem
-        //    snapshot that was never taken, mirroring the `fork_clone_done` gating on the fork-sync
-        //    fast path in `handle_fork_sync()`.
+        // 2. The fork-clone must have actually been *taken* by the filesystem daemon, tracked by
+        //    `fork_clone_done` (set when its acknowledgement arrives). If the clone could not even
+        //    be dispatched, the waiter is released with a failure acknowledgement so that `fork()`
+        //    aborts. If the clone was dispatched but is not yet acknowledged, the waiter is left
+        //    pending here and released later by `handle_fork_clone_ack`, so neither process resumes
+        //    before the snapshot is actually in place.
         if let Some(pos) = self
             .pending_fork_syncs
             .iter()
@@ -340,14 +351,19 @@ impl ProcessDaemon {
                 .map(|record| record.fork_clone_done)
                 .unwrap_or(false)
             {
-                // Genuine waiter and the fork-clone has been dispatched: acknowledge it.
+                // Genuine waiter and the fork-clone has been acknowledged: release it.
                 self.pending_fork_syncs.swap_remove(pos);
                 self.release_fork_sync(waiting_parent, child);
-            } else {
-                // Genuine waiter but the fork-clone was not dispatched (the notification failed to
-                // build or send). Release it with a failure acknowledgement so that `fork()` aborts
-                // in both parent and child instead of deadlocking forever on a snapshot that was
-                // never taken.
+            } else if self
+                .processes
+                .get(&child)
+                .map(|record| record.fork_clone_failed)
+                .unwrap_or(false)
+            {
+                // Genuine waiter but the fork-clone could not be dispatched (the notification failed
+                // to build or send). Release it with a failure acknowledgement so that `fork()`
+                // aborts in both parent and child instead of deadlocking forever on a snapshot that
+                // was never taken.
                 self.pending_fork_syncs.swap_remove(pos);
                 ::syslog::warn!(
                     "fork-clone not dispatched, failing fork-sync waiter (parent={:?}, child={:?})",
@@ -356,6 +372,8 @@ impl ProcessDaemon {
                 );
                 self.fail_fork_sync(waiting_parent, child);
             }
+            // Otherwise the clone was dispatched but not yet acknowledged: leave the waiter pending;
+            // `handle_fork_clone_ack` releases it once the filesystem daemon confirms the snapshot.
         }
 
         Ok(())
@@ -744,6 +762,23 @@ impl ProcessDaemon {
                         ::syslog::warn!("dropping forged exec-ack (source={:?})", destination);
                     }
                 },
+                ProcessManagementMessageHeader::ForkCloneAck => {
+                    // The filesystem daemon confirms whether it has duplicated the parent's
+                    // filesystem state onto the freshly forked child. Only it may drive this
+                    // acknowledgement; one from any other source is a forgery that could release a
+                    // fork-sync waiter before the snapshot was taken, so it is dropped without
+                    // effect.
+                    if destination == ProcessIdentifier::VFSD {
+                        let ack: ForkCloneAckMessage =
+                            ForkCloneAckMessage::from_bytes(message.payload);
+                        self.handle_fork_clone_ack(ack.child, ack.status);
+                    } else {
+                        ::syslog::warn!(
+                            "dropping forged fork-clone-ack (source={:?})",
+                            destination
+                        );
+                    }
+                },
                 ProcessManagementMessageHeader::Wait => {
                     let message: WaitMessage = WaitMessage::from_bytes(message.payload);
                     // The reply is deferred (no send here) when the waiter blocks; it is produced
@@ -840,13 +875,14 @@ impl ProcessDaemon {
     }
 
     /// Notifies the filesystem daemon that the filesystem resources of `parent` must be cloned onto
-    /// the freshly forked `child`. The notification is sent in a fire-and-forget fashion: the
-    /// process manager daemon does not block waiting for an acknowledgement, so that it never risks
-    /// swallowing an unrelated message (such as a process-termination event) on its receive path.
+    /// the freshly forked `child`. The notification is sent asynchronously: the process manager
+    /// daemon does not block waiting for the acknowledgement, so that it never risks swallowing an
+    /// unrelated message (such as a process-termination event) on its receive path.
     ///
     /// Returns `true` if the fork-clone request was successfully handed to the kernel for delivery
-    /// to the filesystem daemon, and `false` if it could not be built or sent. The caller uses this
-    /// to decide whether to mark the child's fork-clone as dispatched: a fork-sync request must not
+    /// to the filesystem daemon, and `false` if it could not be built or sent. The caller uses a
+    /// `false` return to mark the child's fork-clone as failed (a successful dispatch is instead
+    /// confirmed later by the filesystem daemon's acknowledgement): a fork-sync request must not
     /// be acknowledged on the basis of a clone that was never delivered.
     fn notify_fork_clone(&self, parent: ProcessIdentifier, child: ProcessIdentifier) -> bool {
         match message::fork_clone_request(parent, child) {
@@ -879,13 +915,16 @@ impl ProcessDaemon {
     /// Handles a fork-sync request from a freshly forked `parent` awaiting confirmation that the
     /// filesystem state of `child` has been duplicated.
     ///
-    /// If the child's fork-clone has already been dispatched to the filesystem daemon, the parent
-    /// and child are released immediately with a success acknowledgement. If the fork-clone could
-    /// not be dispatched, they are released with a failure acknowledgement so that `fork()` aborts
-    /// instead of hanging. Otherwise the request is recorded and resolved once the child's
-    /// process-creation event dispatches (or fails to dispatch) the clone. A success release is
-    /// always ordered after the fork-clone on the filesystem daemon's receive path, so neither
-    /// process can race ahead of the snapshot.
+    /// If the child's fork-clone has already been acknowledged by the filesystem daemon, the parent
+    /// and child are released immediately with a success acknowledgement. If the fork-clone failed
+    /// (it could not be dispatched, or the filesystem daemon reported it could not take the
+    /// snapshot), they are released with a failure acknowledgement so that `fork()` aborts instead
+    /// of hanging. Otherwise the request is recorded and resolved once the filesystem daemon
+    /// acknowledges the clone (see [`handle_fork_clone_ack`]). Because the release is ordered after
+    /// the filesystem daemon has actually taken the snapshot, neither process can issue a filesystem
+    /// operation that races ahead of -- and is therefore dropped by -- the clone.
+    ///
+    /// [`handle_fork_clone_ack`]: Self::handle_fork_clone_ack
     fn handle_fork_sync(&mut self, parent: ProcessIdentifier, child: ProcessIdentifier) {
         ::syslog::info!("fork-sync request (parent={:?}, child={:?})", parent, child);
 
@@ -932,17 +971,18 @@ impl ProcessDaemon {
     }
 
     /// Releases a parent and its freshly forked child that are blocked awaiting fork
-    /// synchronization, by acknowledging both with success. The fork-clone has already been
-    /// dispatched to the filesystem daemon, so these acknowledgements are necessarily ordered after
-    /// it.
+    /// synchronization, by acknowledging both with success. The filesystem daemon has already
+    /// acknowledged that it took the fork-clone snapshot, so these acknowledgements are necessarily
+    /// ordered after it.
     fn release_fork_sync(&self, parent: ProcessIdentifier, child: ProcessIdentifier) {
         self.send_fork_sync_ack(parent, child, ForkSyncAckMessage::STATUS_SUCCESS);
     }
 
     /// Releases a parent and its freshly forked child that are blocked awaiting fork
-    /// synchronization, by acknowledging both with a failure status. Used when the fork-clone could
-    /// not be dispatched to the filesystem daemon, so that `fork()` aborts in both processes instead
-    /// of deadlocking on a snapshot that will never be taken.
+    /// synchronization, by acknowledging both with a failure status. Used when the fork-clone
+    /// failed -- either it could not be dispatched to the filesystem daemon, or the filesystem
+    /// daemon acknowledged that it could not take the snapshot -- so that `fork()` aborts in both
+    /// processes instead of deadlocking on a snapshot that will never be taken.
     fn fail_fork_sync(&self, parent: ProcessIdentifier, child: ProcessIdentifier) {
         self.send_fork_sync_ack(parent, child, ErrorCode::TryAgain.get());
     }
@@ -971,6 +1011,62 @@ impl ProcessDaemon {
                         e
                     );
                 },
+            }
+        }
+    }
+
+    /// Handles a fork-clone acknowledgement from the filesystem daemon, recording the outcome for
+    /// `child` and releasing a parent and child blocked at the fork-synchronization barrier.
+    ///
+    /// The acknowledgement arrives once the filesystem daemon has actually duplicated (or failed to
+    /// duplicate) the parent's filesystem state onto `child`. Recording the outcome lets a fork-sync
+    /// request that arrives after this point be answered immediately (see [`handle_fork_sync`]),
+    /// while any waiter already blocked is released here: with success when the snapshot is in
+    /// place, or with a failure status so that `fork()` aborts rather than proceeding with a child
+    /// whose descriptor table was never cloned. The blocked waiter's parent must match `child`'s
+    /// recorded real parent; a mismatch is a forged entry and is dropped without acknowledging.
+    ///
+    /// [`handle_fork_sync`]: Self::handle_fork_sync
+    fn handle_fork_clone_ack(&mut self, child: ProcessIdentifier, status: i32) {
+        let success: bool = status == ForkCloneAckMessage::STATUS_SUCCESS;
+
+        // Record the outcome so a fork-sync request that races ahead of this acknowledgement is
+        // answered on its fast path.
+        if let Some(record) = self.processes.get_mut(&child) {
+            if success {
+                record.fork_clone_done = true;
+            } else {
+                record.fork_clone_failed = true;
+            }
+        }
+
+        // Release any waiter already blocked on this child.
+        if let Some(pos) = self
+            .pending_fork_syncs
+            .iter()
+            .position(|(c, _)| *c == child)
+        {
+            let (_, waiting_parent) = self.pending_fork_syncs[pos];
+            let real_parent: Option<ProcessIdentifier> =
+                self.processes.get(&child).and_then(|record| record.parent);
+            self.pending_fork_syncs.swap_remove(pos);
+            if real_parent != Some(waiting_parent) {
+                ::syslog::warn!(
+                    "dropping forged fork-sync on clone ack (waiter={:?}, child={:?}, \
+                     real_parent={:?})",
+                    waiting_parent,
+                    child,
+                    real_parent
+                );
+            } else if success {
+                self.release_fork_sync(waiting_parent, child);
+            } else {
+                ::syslog::warn!(
+                    "fork-clone failed, failing fork-sync waiter (parent={:?}, child={:?})",
+                    waiting_parent,
+                    child
+                );
+                self.fail_fork_sync(waiting_parent, child);
             }
         }
     }

--- a/src/libs/proc/src/lib.rs
+++ b/src/libs/proc/src/lib.rs
@@ -33,6 +33,7 @@ extern crate alloc;
 pub use message::{
     exec_ack,
     exec_request,
+    fork_clone_ack,
     fork_clone_request,
     fork_sync_ack,
     fork_sync_request,
@@ -46,6 +47,7 @@ pub use message::{
     wait_response,
     ExecAckMessage,
     ExecMessage,
+    ForkCloneAckMessage,
     ForkCloneMessage,
     ForkSyncAckMessage,
     ForkSyncMessage,

--- a/src/libs/proc/src/message/fork_clone.rs
+++ b/src/libs/proc/src/message/fork_clone.rs
@@ -47,6 +47,33 @@ pub struct ForkCloneMessage {
 // NOTE: The size of a fork-clone message must match the size of a process management message payload.
 ::static_assert::assert_eq_size!(ForkCloneMessage, ProcessManagementMessage::PAYLOAD_SIZE);
 
+///
+/// # Description
+///
+/// A message that acknowledges a fork-clone. It is sent by the filesystem daemon to the process
+/// manager daemon once it has finished duplicating (or has failed to duplicate) the parent's
+/// filesystem state onto the freshly forked `child`. The process manager daemon uses it to release
+/// the parent and child blocked at the fork-synchronization barrier only after the snapshot has
+/// actually been taken, rather than merely dispatched, so that neither process can issue a
+/// filesystem operation that races ahead of (and is therefore dropped by) the clone.
+///
+/// The `status` field conveys the outcome: `0` when the clone was applied, or a non-zero error code
+/// when it could not be (for example, the child already held an active descriptor table). A
+/// non-zero status fails the fork so that a half-cloned child is never allowed to proceed.
+///
+#[repr(C, packed)]
+pub struct ForkCloneAckMessage {
+    /// Process identifier of the freshly forked child the acknowledgement concerns.
+    pub child: ProcessIdentifier,
+    /// Outcome of the clone: `0` on success, or a non-zero error code on failure.
+    pub status: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+
+// NOTE: The size of a fork-clone acknowledgement message must match the size of a process
+// management message payload.
+::static_assert::assert_eq_size!(ForkCloneAckMessage, ProcessManagementMessage::PAYLOAD_SIZE);
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -106,6 +133,64 @@ impl ForkCloneMessage {
     }
 }
 
+impl ForkCloneAckMessage {
+    /// Status value that marks a successful fork-clone.
+    pub const STATUS_SUCCESS: i32 = 0;
+
+    /// Size of padding.
+    pub const PADDING_SIZE: usize = ProcessManagementMessage::PAYLOAD_SIZE
+        - mem::size_of::<ProcessIdentifier>()
+        - mem::size_of::<i32>();
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new fork-clone acknowledgement message.
+    ///
+    /// # Parameters
+    ///
+    /// - `child`: Process identifier of the freshly forked child.
+    /// - `status`: Outcome of the clone (`0` on success, a non-zero error code on failure).
+    ///
+    pub fn new(child: ProcessIdentifier, status: i32) -> Self {
+        Self {
+            child,
+            status,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a byte array into a fork-clone acknowledgement message.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Byte array.
+    ///
+    /// # Returns
+    ///
+    /// A fork-clone acknowledgement message.
+    ///
+    pub fn from_bytes(bytes: [u8; ProcessManagementMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts a fork-clone acknowledgement message into a byte array.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding byte array.
+    ///
+    pub fn into_bytes(self) -> [u8; ProcessManagementMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -147,6 +232,51 @@ pub fn fork_clone_request(
     let ipc_message: Message = Message::new(
         MessageSender::from(ProcessIdentifier::PROCD),
         MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    );
+
+    Ok(ipc_message)
+}
+
+///
+/// # Description
+///
+/// Builds a fork-clone acknowledgement message.
+///
+/// # Parameters
+///
+/// - `source`: Process identifier of the sender (the filesystem daemon when confirming to the
+///   process manager daemon).
+/// - `destination`: Process identifier of the recipient (the process manager daemon).
+/// - `child`: Process identifier of the freshly forked child the acknowledgement concerns.
+/// - `status`: Outcome of the clone (`0` on success, a non-zero error code on failure).
+///
+/// # Returns
+///
+/// Upon successful completion, a fork-clone acknowledgement message is returned. Otherwise, an error
+/// is returned instead.
+///
+pub fn fork_clone_ack(
+    source: ProcessIdentifier,
+    destination: ProcessIdentifier,
+    child: ProcessIdentifier,
+    status: i32,
+) -> Result<Message, Error> {
+    let ack_message: ForkCloneAckMessage = ForkCloneAckMessage::new(child, status);
+
+    let pm_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::ForkCloneAck,
+        ack_message.into_bytes(),
+    );
+
+    let system_message: SystemMessage =
+        SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
+
+    let ipc_message: Message = Message::new(
+        MessageSender::from(source),
+        MessageReceiver::from(destination),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/fork_sync.rs
+++ b/src/libs/proc/src/message/fork_sync.rs
@@ -50,9 +50,9 @@ pub struct ForkSyncMessage {
 ///
 /// A message sent by the process manager daemon to release a parent or child blocked on a fork-sync
 /// request. The `status` field conveys the outcome of the fork synchronization: `0` when the
-/// fork-clone was successfully dispatched to the filesystem daemon, or a non-zero error code when it
-/// could not be dispatched. A non-zero status lets a blocked `fork()` abort instead of hanging
-/// forever on a snapshot that will never be taken.
+/// fork-clone was acknowledged by the filesystem daemon after the snapshot was taken, or a non-zero
+/// error code when the snapshot failed. A non-zero status lets a blocked `fork()` abort instead of
+/// hanging forever on a snapshot that will never be taken.
 ///
 #[repr(C, packed)]
 pub struct ForkSyncAckMessage {

--- a/src/libs/proc/src/message/mod.rs
+++ b/src/libs/proc/src/message/mod.rs
@@ -75,7 +75,7 @@ pub enum ProcessManagementMessageHeader {
     /// the child's filesystem state has been duplicated before either process proceeds).
     ForkSync = 11,
     /// Fork-sync acknowledgement (the process manager daemon releases a parent and its child once
-    /// the fork-clone has been dispatched to the filesystem daemon).
+    /// the filesystem daemon has acknowledged the fork-clone snapshot).
     ForkSyncAck = 12,
     /// Process-exit notification (used to notify other daemons to reclaim a terminated process's
     /// per-process state).
@@ -87,6 +87,11 @@ pub enum ProcessManagementMessageHeader {
     /// Exec acknowledgement (the filesystem daemon confirms close-on-exec was applied, and the
     /// process manager daemon releases the held process).
     ExecAck = 15,
+    /// Fork-clone acknowledgement (the filesystem daemon confirms it has duplicated the parent's
+    /// filesystem state onto the freshly forked child, allowing the process manager daemon to
+    /// release the held parent and child only once the snapshot has actually been taken rather than
+    /// merely dispatched).
+    ForkCloneAck = 16,
 }
 
 impl TryFrom<u8> for ProcessManagementMessageHeader {
@@ -107,6 +112,7 @@ impl TryFrom<u8> for ProcessManagementMessageHeader {
             13 => Ok(ProcessManagementMessageHeader::ProcessExit),
             14 => Ok(ProcessManagementMessageHeader::Exec),
             15 => Ok(ProcessManagementMessageHeader::ExecAck),
+            16 => Ok(ProcessManagementMessageHeader::ForkCloneAck),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid process management message")),
         }
     }
@@ -128,6 +134,7 @@ impl From<&ProcessManagementMessageHeader> for u8 {
             ProcessManagementMessageHeader::ProcessExit => 13,
             ProcessManagementMessageHeader::Exec => 14,
             ProcessManagementMessageHeader::ExecAck => 15,
+            ProcessManagementMessageHeader::ForkCloneAck => 16,
         }
     }
 }

--- a/src/libs/syscall/src/unistd/fork/mod.rs
+++ b/src/libs/syscall/src/unistd/fork/mod.rs
@@ -66,8 +66,8 @@ fn map_duplicate_error(code: ErrorCode) -> ErrorCode {
 /// state (open file descriptors and current working directory) is duplicated asynchronously by the
 /// filesystem daemon. To honor POSIX semantics, the parent must not mutate its descriptor table
 /// before that snapshot is taken. This function blocks the parent until the process manager daemon
-/// confirms that the fork-clone has been dispatched to the filesystem daemon, after which the
-/// parent's subsequent filesystem operations are correctly ordered after the snapshot.
+/// confirms that the filesystem daemon has taken the fork-clone snapshot, after which the parent's
+/// subsequent filesystem operations are correctly ordered after that snapshot.
 ///
 /// # Parameters
 ///
@@ -94,13 +94,13 @@ fn sync_parent_after_fork(child: ProcessIdentifier) -> Result<(), Error> {
 ///
 /// # Description
 ///
-/// Blocks until the process manager daemon acknowledges that the fork-clone of the calling process
-/// has been dispatched to the filesystem daemon.
+/// Blocks until the process manager daemon acknowledges that the filesystem daemon has taken the
+/// fork-clone snapshot for the calling process.
 ///
 /// This is the child's half of the fork synchronization: a freshly forked child must not use its
 /// inherited descriptors before the filesystem daemon has duplicated them. The parent triggers the
 /// duplication (see [`sync_parent_after_fork`]); the daemon releases the parent and the child
-/// together once the fork-clone has been dispatched.
+/// together once the filesystem daemon acknowledges that the snapshot has been taken.
 ///
 /// # Returns
 ///
@@ -125,9 +125,8 @@ fn sync_child_after_fork() -> Result<(), Error> {
                     match message.header {
                         ProcessManagementMessageHeader::ForkSyncAck => {
                             // The acknowledgement carries the outcome of the fork synchronization. A
-                            // non-zero status means the process manager daemon could not dispatch the
-                            // fork-clone to the filesystem daemon, so `fork()` should fail rather than
-                            // proceed past a snapshot that was never taken.
+                            // non-zero status means the fork-clone snapshot failed, so `fork()`
+                            // should fail rather than proceed past a snapshot that was never taken.
                             let ack: ForkSyncAckMessage =
                                 ForkSyncAckMessage::from_bytes(message.payload);
                             let status: i32 = ack.status;
@@ -194,7 +193,7 @@ fn sync_child_after_fork() -> Result<(), Error> {
 /// manager daemon before returning. The kernel duplicates memory eagerly, but the child's
 /// filesystem state (open file descriptors and current working directory) is duplicated by the
 /// filesystem daemon out of band. The synchronization guarantees that this duplication has been
-/// dispatched before either process resumes, so that the parent cannot mutate its descriptor table
+/// acknowledged before either process resumes, so that the parent cannot mutate its descriptor table
 /// before the snapshot is taken and the child observes valid, offset-sharing descriptors the
 /// instant `fork()` returns — as POSIX requires.
 ///
@@ -217,9 +216,9 @@ pub fn do_fork() -> Result<pid_t, ErrorCode> {
         // Child: block until the daemon confirms that the inherited descriptors have been
         // duplicated into the filesystem daemon.
         if let Err(error) = sync_child_after_fork() {
-            // The fork synchronization failed: either the process manager daemon could not dispatch
-            // the fork-clone to the filesystem daemon (and released the child with a failure
-            // acknowledgement), or an unexpected message was observed in the synchronization window.
+            // The fork synchronization failed: either the fork-clone snapshot failed (and the
+            // process manager daemon released the child with a failure acknowledgement), or an
+            // unexpected message was observed in the synchronization window.
             // Either way the child's inherited descriptors are not in a well-defined state, and
             // POSIX forbids `fork()` from returning -1 in the child. Self-terminate rather than
             // surface the failure to the application, honoring the contract that no child survives a

--- a/src/tests/fork-exec-loop-target/Cargo.toml
+++ b/src/tests/fork-exec-loop-target/Cargo.toml
@@ -1,0 +1,41 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "fork-exec-loop-target"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "execv() target performing a filesystem read, loaded repeatedly by fork-exec-loop-test"
+homepage.workspace = true
+
+[[bin]]
+name = "fork-exec-loop-target"
+
+[dependencies]
+nvx = { workspace = true }
+nvx-crt0 = { workspace = true, features = ["rust-main", "provides-allocator"] }
+sysalloc = { workspace = true }
+libc_string = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
+syslog = { workspace = true, default-features = true }
+
+[build-dependencies]
+cc = { workspace = true }
+cfg-if = { workspace = true }
+
+[features]
+default = ["panic"]
+standalone = ["syscall/standalone"]
+trace = ["nvx/trace", "syscall/trace", "syslog/trace", "nvx-crt0/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug", "nvx-crt0/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info", "nvx-crt0/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn", "nvx-crt0/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error", "nvx-crt0/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic", "nvx-crt0/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/fork-exec-loop-target/build.rs
+++ b/src/tests/fork-exec-loop-target/build.rs
@@ -1,0 +1,18 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#![deny(clippy::all)]
+
+use std::env;
+
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
+
+    // Strip all symbols and debug information at link time. fork-exec-loop-test execv()s this image
+    // ITERATIONS times, and execv() stages the whole on-disk image into the guest page-by-page over
+    // IPC; an unstripped debug build carries megabytes of debug info, so loading it repeatedly is
+    // slow enough to exceed the integration-test timeout. Stripping keeps the image small (matching
+    // execv-target) without depending on an external objcopy/llvm-tools being installed.
+    println!("cargo::rustc-link-arg=-s");
+}

--- a/src/tests/fork-exec-loop-target/src/main.rs
+++ b/src/tests/fork-exec-loop-target/src/main.rs
@@ -1,0 +1,143 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![no_main]
+#![deny(clippy::all)]
+#![deny(clippy::as_conversions)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+//! # `execv()` Target That Reads From an Inherited File Descriptor
+//!
+//! Loaded into the guest ramfs at `/target` and `execv()`'d by each iteration of
+//! `fork-exec-loop-test`. The parent opened a file before forking and passes that descriptor's
+//! number as `argv[1]`; after exec the target reads from that INHERITED descriptor and verifies the
+//! contents, exiting 0 on success or with a distinct non-zero status identifying the failing step.
+//!
+//! Reading the inherited descriptor only works if the child received the parent's vfsd-side file
+//! descriptor table through the fork-clone. That is exactly the state the repeated `fork()`+`execv()`
+//! race drops (vfsd: `failed to clone filesystem state (... error=AlreadyExists)`), so this is the
+//! per-iteration check whose reliability the caller exercises.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+extern crate alloc;
+extern crate libc_string;
+extern crate nvx;
+extern crate nvx_crt0;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::sync::atomic::Ordering;
+use ::sysapi::ffi::c_int;
+use ::syscall::unistd::{
+    bindings,
+    read,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Expected contents of the inherited file. Must match the seed written by the test harness.
+const EXPECTED: &[u8] = b"COLD-READ-PAYLOAD-OK";
+
+/// Exit status: argv did not carry the inherited descriptor number.
+const ST_NO_ARGV: c_int = 40;
+
+/// Exit status: read() from the inherited descriptor failed or returned the wrong contents.
+const ST_READ_MISMATCH: c_int = 42;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Parses a non-negative decimal integer from the leading ASCII digits of `bytes`, stopping at the
+/// end of the slice or at the first NUL byte (whichever comes first; the input need not be
+/// NUL-terminated). Returns `None` if a non-digit byte precedes any NUL, or if no digits are present.
+fn parse_fd(bytes: &[u8]) -> Option<c_int> {
+    let mut acc: i32 = 0;
+    let mut seen: bool = false;
+    for &b in bytes {
+        if b == 0 {
+            break;
+        }
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        let digit: i32 = i32::from(b - b'0');
+        acc = acc.checked_mul(10)?.checked_add(digit)?;
+        seen = true;
+    }
+    if seen { Some(acc) } else { None }
+}
+
+/// Returns `argv[1]` as a byte slice borrowing the bytes up to (but excluding) the terminating NUL,
+/// bounded to 32 bytes, or `None` if absent.
+fn argv1() -> Option<&'static [u8]> {
+    let argc: usize = usize::try_from(nvx_crt0::ARGC.load(Ordering::SeqCst)).unwrap_or(0);
+    if argc < 2 {
+        return None;
+    }
+    let argv: *mut *const u8 = nvx_crt0::ARGV.load(Ordering::SeqCst);
+    if argv.is_null() {
+        return None;
+    }
+    // SAFETY: argc >= 2 guarantees argv[1] is a valid NUL-terminated C string pointer.
+    let ptr: *const u8 = unsafe { *argv.add(1) };
+    if ptr.is_null() {
+        return None;
+    }
+    let mut len: usize = 0;
+    // SAFETY: the string is NUL-terminated; stop at the first NUL (bounded for safety).
+    while len < 32 && unsafe { *ptr.add(len) } != 0 {
+        len += 1;
+    }
+    // SAFETY: `ptr` points to `len` initialized bytes.
+    Some(unsafe { ::core::slice::from_raw_parts(ptr, len) })
+}
+
+//==================================================================================================
+// Entry Point
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn main() -> Result<(), ::sys::error::Error> {
+    let fd: c_int = match argv1().and_then(parse_fd) {
+        Some(fd) => fd,
+        // SAFETY: the process holds no resources requiring cleanup; terminate immediately.
+        None => unsafe { bindings::_exit::_exit(ST_NO_ARGV) },
+    };
+
+    // Read from the INHERITED descriptor. This requires the parent's vfsd fd table to have been
+    // cloned onto this child during fork; if the clone was refused, the descriptor is unknown here.
+    let mut buf: [u8; EXPECTED.len()] = [0u8; EXPECTED.len()];
+    let n: usize = match read(fd, &mut buf) {
+        // read() never returns more than buf.len() bytes, so narrowing to usize cannot fail in
+        // practice; route any unexpected value through the read-failure path rather than masking
+        // it as 0.
+        Ok(bytes) => match usize::try_from(bytes) {
+            Ok(n) => n,
+            // SAFETY: the process holds no resources requiring cleanup; terminate immediately.
+            Err(_) => unsafe { bindings::_exit::_exit(ST_READ_MISMATCH) },
+        },
+        // SAFETY: the process holds no resources requiring cleanup; terminate immediately.
+        Err(_) => unsafe { bindings::_exit::_exit(ST_READ_MISMATCH) },
+    };
+
+    if n != EXPECTED.len() || buf != *EXPECTED {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(ST_READ_MISMATCH) };
+    }
+
+    Ok(())
+}

--- a/src/tests/fork-exec-loop-test/Cargo.toml
+++ b/src/tests/fork-exec-loop-test/Cargo.toml
@@ -1,0 +1,41 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "fork-exec-loop-test"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "Regression test for repeated fork() + execv() from the same parent"
+homepage.workspace = true
+
+[[bin]]
+name = "fork-exec-loop-test"
+
+[dependencies]
+nvx = { workspace = true }
+nvx-crt0 = { workspace = true, features = ["rust-main", "provides-allocator"] }
+sysalloc = { workspace = true }
+libc_string = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
+syslog = { workspace = true, default-features = true }
+
+[build-dependencies]
+cc = { workspace = true }
+cfg-if = { workspace = true }
+
+[features]
+default = ["panic"]
+standalone = ["syscall/standalone"]
+trace = ["nvx/trace", "syscall/trace", "syslog/trace", "nvx-crt0/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug", "nvx-crt0/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info", "nvx-crt0/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn", "nvx-crt0/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error", "nvx-crt0/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic", "nvx-crt0/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/fork-exec-loop-test/build.rs
+++ b/src/tests/fork-exec-loop-test/build.rs
@@ -1,0 +1,11 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#![deny(clippy::all)]
+
+use std::env;
+
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
+}

--- a/src/tests/fork-exec-loop-test/src/main.rs
+++ b/src/tests/fork-exec-loop-test/src/main.rs
@@ -1,0 +1,200 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![no_main]
+#![deny(clippy::all)]
+#![deny(clippy::as_conversions)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+//! # File-Descriptor Inheritance Across `fork()` + `execv()` Regression Test (caller)
+//!
+//! Acceptance test: a file descriptor opened by the parent before `fork()` must remain usable by the
+//! child after it `execv()`s a new image -- POSIX requires open descriptors to survive `execv()`
+//! unless they are marked `FD_CLOEXEC`. Each iteration the parent opens `/coldfile.dat`, forks, and
+//! the child `execv()`s `/target` (`fork-exec-loop-target`) passing the descriptor number as
+//! `argv[1]`; the target reads `/coldfile.dat`'s contents through that INHERITED descriptor.
+//!
+//! On Nanvix a freshly opened (non-`CLOEXEC`) descriptor is NOT usable by a `fork()`+`execv()`'d
+//! child: although a plain `fork()` correctly shares the parent's descriptors (see
+//! `test-fork-guestfs`), the descriptor table is not carried onto the child once it `execv()`s, so
+//! the inherited descriptor is unknown in the exec'd image and the read fails. vfsd clones the
+//! parent's per-process descriptor table onto the child asynchronously (in response to a
+//! fire-and-forget notification from procd); the exec'd image races ahead of -- or otherwise does
+//! not receive -- that clone, sometimes accompanied by the log line `failed to clone filesystem
+//! state (... error=AlreadyExists)`.
+//!
+//! This is a concrete, deterministic facet of the broader fork+exec filesystem-state handling that
+//! also makes a `fork()`+`execv()`'d CPython abort during interpreter initialization (e.g.
+//! "init_import_site: Failed to import the site module") when a long-running parent (such as an HTTP
+//! server) spawns interpreter subprocesses. The test loops [`ITERATIONS`] times so a partial fix
+//! that only works occasionally still fails it.
+//!
+//! The caller requires EVERY child to exit 0. The first child that does not (including an `execv()`
+//! failure surfaced as [`CHILD_EXECV_FAILED`]) fails the test. While the bug is present the test
+//! FAILS; once a descriptor opened before `fork()` survives the child's `execv()`, it passes and
+//! guards the behavior.
+//!
+//! `/coldfile.dat` and `/target` are bundled into the test ramfs by the harness.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+extern crate alloc;
+extern crate libc_string;
+extern crate nvx;
+extern crate nvx_crt0;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::Error;
+use ::sysapi::{
+    fcntl::file_access_mode::O_RDONLY,
+    ffi::c_int,
+    sys_types::{
+        mode_t,
+        pid_t,
+    },
+    sys_wait::{
+        wexitstatus,
+        wifexited,
+    },
+    unistd::STDOUT_FILENO,
+};
+use ::syscall::{
+    fcntl::open,
+    unistd::{
+        bindings,
+        close,
+        do_execv,
+        write,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Path of the execv() target in the mounted ramfs (mounted at the filesystem root).
+const TARGET_PATH: &str = "/target";
+
+/// File the parent opens before each fork; the child reads it through the inherited descriptor.
+const COLD_PATH: &str = "/coldfile.dat";
+
+/// Number of fork()+execv() cycles to perform. The bug reproduces on the first cycle; the loop
+/// guards against a partial fix that only preserves the inherited descriptor some of the time.
+const ITERATIONS: usize = 32;
+
+/// Exit status reported by the child if execv() returned (i.e. failed).
+const CHILD_EXECV_FAILED: c_int = 127;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Formats `value` as decimal into `buf` and returns a `&str` borrowing the digit bytes for use as
+/// an argv entry. A trailing NUL is also written into `buf` so the buffer holds a C string, but it
+/// is not part of the returned slice. `buf` must be large enough for the digits plus a trailing NUL
+/// (12 bytes suffices for any non-negative `i32`).
+fn format_fd(value: c_int, buf: &mut [u8; 12]) -> &str {
+    let mut tmp: [u8; 11] = [0u8; 11];
+    let mut i: usize = tmp.len();
+    let mut v: u32 = u32::try_from(value).unwrap_or(0);
+    loop {
+        i -= 1;
+        tmp[i] = b'0' + u8::try_from(v % 10).unwrap_or(0);
+        v /= 10;
+        if v == 0 {
+            break;
+        }
+    }
+    let digits: &[u8] = &tmp[i..];
+    buf[..digits.len()].copy_from_slice(digits);
+    buf[digits.len()] = 0;
+    // The bytes are ASCII digits followed by a NUL, hence valid UTF-8.
+    ::core::str::from_utf8(&buf[..digits.len()]).unwrap_or("0")
+}
+
+//==================================================================================================
+// Test
+//==================================================================================================
+
+/// Verifies that the parent can fork()+execv() a child that reads an inherited descriptor,
+/// repeatedly.
+fn test_fork_exec_loop() -> Result<(), Error> {
+    let mode: mode_t = 0;
+
+    for i in 0..ITERATIONS {
+        // Open the data file in the parent. The child must inherit this descriptor across
+        // fork()+execv() and read the file through it.
+        let fd: c_int = open(COLD_PATH, O_RDONLY, mode)?;
+
+        let mut fd_buf: [u8; 12] = [0u8; 12];
+        let fd_arg: &str = format_fd(fd, &mut fd_buf);
+
+        let ret: pid_t = bindings::fork::fork();
+        if ret == 0 {
+            // Child: exec the target, handing it the inherited descriptor number.
+            let _error: Error = do_execv(TARGET_PATH, &["target", fd_arg], &[]);
+            // Only reached if execv() itself failed (e.g. the loader could not read the target).
+            // SAFETY: the child holds no resources requiring cleanup; terminate immediately.
+            unsafe { bindings::_exit::_exit(CHILD_EXECV_FAILED) };
+        }
+        if ret < 0 {
+            // fork() failed: release the descriptor opened above before aborting so a failing
+            // fork() (e.g. EMFILE) does not leak descriptors across iterations.
+            close(fd)?;
+            panic!("fork() failed at iteration {} (ret={})", i, ret);
+        }
+
+        let mut wstatus: c_int = 0;
+        // SAFETY: `wstatus` is a valid `c_int`.
+        let reaped: pid_t = unsafe { bindings::waitpid::waitpid(ret, &raw mut wstatus, 0) };
+        assert!(
+            reaped == ret,
+            "waitpid() must reap the child at iteration {} (ret={}, child={})",
+            i,
+            reaped,
+            ret
+        );
+
+        // Close the parent's copy of the descriptor before checking the result.
+        close(fd)?;
+
+        assert!(
+            wifexited(wstatus) && wexitstatus(wstatus) == 0,
+            "fork()+execv()'d child failed at iteration {} (status={:#x}); a descriptor opened \
+             before fork() did not survive the child's execv()",
+            i,
+            wstatus
+        );
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Entry Point
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn main() -> Result<(), Error> {
+    ::syslog::info!("fork-exec-loop-test: starting fork()+execv() fd-inheritance test");
+
+    test_fork_exec_loop()?;
+    ::syslog::info!("fork-exec-loop-test: PASS - fork_exec_loop");
+
+    // Magic string consumed by the CI harness to mark a successful run.
+    let magic_string: &[u8] = b"ok";
+    write(STDOUT_FILENO, magic_string)?;
+
+    Ok(())
+}

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -294,6 +294,17 @@ extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
 input = "[]"
 expected_output = "ok"
 
+# Acceptance test for file-descriptor inheritance across fork()+execv(): a
+# descriptor opened before fork() must remain usable by the child after it
+# execv()s. FAILS while the exec'd image does not receive the parent's cloned
+# descriptor table (the inherited fd is unknown and the child's read fails).
+[[tests]]
+executor = "http"
+program = "./bin/fork-exec-loop-test.initrd"
+extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
+input = "[]"
+expected_output = "ok"
+
 [[tests]]
 executor = "terminal"
 program = "./bin/fork-exec-write-test.initrd"
@@ -315,6 +326,12 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/fork-exec-loop-test.initrd"
+extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
 expected_output = "ok"
 
 # Acceptance test for socket reference-counting across fork() (nanvix/nanvix#2609).

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -299,6 +299,17 @@ extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
 input = "[]"
 expected_output = "ok"
 
+# Acceptance test for file-descriptor inheritance across fork()+execv(): a
+# descriptor opened before fork() must remain usable by the child after it
+# execv()s. FAILS while the exec'd image does not receive the parent's cloned
+# descriptor table (the inherited fd is unknown and the child's read fails).
+[[tests]]
+executor = "http"
+program = "./bin/fork-exec-loop-test.initrd"
+extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
+input = "[]"
+expected_output = "ok"
+
 [[tests]]
 executor = "terminal"
 program = "./bin/fork-exec-write-test.initrd"
@@ -320,6 +331,12 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/fork-exec-loop-test.initrd"
+extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
 expected_output = "ok"
 
 # Acceptance test for socket reference-counting across fork() (nanvix/nanvix#2609).


### PR DESCRIPTION
## Summary

Adds `fork-exec-loop-test` and its `execv()` target `fork-exec-loop-target`, standalone Rust
**acceptance tests** for file-descriptor inheritance across `fork()` + `execv()`.

> Red by design today — opened as a draft. It asserts the **correct** (POSIX) behavior, so it fails
> until a descriptor opened before `fork()` survives the child's `execv()`, after which it passes
> and guards the behavior.

## What it reproduces (the deterministic test in this PR)

Each iteration the parent opens `/coldfile.dat`, `fork()`s, and the child `execv()`s `/target`
passing the descriptor number in `argv[1]`; the target reads `/coldfile.dat` through that
**inherited** descriptor. POSIX requires open descriptors to survive `execv()` unless marked
`FD_CLOEXEC`.

On Nanvix a freshly opened (non-`CLOEXEC`) descriptor is **not** usable by a `fork()`+`execv()`'d
child: a plain `fork()` correctly shares the parent's descriptors (see `test-fork-guestfs`), but the
descriptor table is not carried onto the child once it `execv()`s, so the inherited descriptor is
unknown in the exec'd image and the read fails (the child exits `42`). The test fails deterministically
at the first iteration:

```
PANIC ... fork()+execv()'d child failed at iteration 0 (status=0x2a00);
a descriptor opened before fork() did not survive the child's execv()
```

## Background: the CPython failure that led here (the nondeterministic variant)

A CPython interpreter running on Nanvix that `fork()`s and `execv()`s a **fresh** interpreter
(e.g. an HTTP server spawning a subprocess, or `os.execve("/bin/python3.12", ...)`) aborts during
interpreter initialization:

```
Fatal Python error: init_import_site: Failed to import the site module
```

The fresh interpreter imports `site` (from `/lib/python3.12/site.py`) by absolute path, and the
**identical** import succeeds a moment later once initialization has finished — so the failure is
timing-dependent, not a missing file.

### Evidence that it is nondeterministic and rooted in vfsd fork-clone

Instrumenting CPython and probing the primitives produced:

- **It is not `site.main()`**: wrapping the module-level `main()` call in `site.py` in a
  `try/except` never triggers — the interpreter still aborts the same way.
- **It is not `site.py`'s content**: replacing `site.py` with an *empty* file still aborts during
  init. So the failure is in the import machinery *loading* `site` during the earliest filesystem
  import in init, not in running its body.
- **The same import works post-init**: launching with `-S` (skip auto-site) and then `import site`
  manually succeeds every time.
- **Determinism probe** — fork+exec a fresh interpreter 10× in a row and record each child's exit
  code:

  | invocation | exit codes across 10 runs |
  |---|---|
  | `python -B -c pass` (init imports `site`) | `[1, 127, 0, 127, 127, 0, 0, 127, 127, 127]` |
  | `python -S -B -c "import site"` (manual, after many prior fork+execs) | `[127, 127, 127, 127, 127, 127, 127, 127, 127, 127]` |

  `1` = the `init_import_site` fatal error, `127` = `execve()` itself failed (the loader could not
  read `/bin/python3.12`), `0` = success. The mix proves the failure is **nondeterministic**.

- **The smoking gun** in the vfsd log during these runs:

  ```
  [ERROR][vfsd::ipc] failed to clone filesystem state (parent=4, child=N, error=AlreadyExists)
  ```

### Likely mechanism

`vfs_fork_clone` (`src/libs/vfs/src/fd.rs`) clones the parent's per-process filesystem state
(open descriptors + cwd) onto the child in response to a fire-and-forget notification from procd.
If the freshly `execv()`'d child issues its first vfsd request before that notification is
processed, `set_current_process` has already inserted an *active* state for the child, so the clone
is refused with `AlreadyExists` and the child never receives the parent's filesystem state. The
exec'd image is then left with a degraded state, and its earliest filesystem accesses (loading
`site.py`, or even the loader reading the binary) fail nondeterministically.

The deterministic test in this PR isolates the **inherited file descriptor** facet of that same
fork+exec filesystem-state handling into a minimal, reliable reproducer.

## How to reproduce the CPython failure

1. Build Nanvix (standalone, with networking) and build CPython against that local Nanvix tree.
2. Run, on the guest, a Python program that forks and execs a fresh interpreter, e.g.:

   ```python
   import os
   pid = os.fork()
   if pid == 0:
       # -v traces imports at the C level (visible on the console); -c pass is space-free
       # because Nanvix execv rejects argv tokens containing spaces.
       os.execve("/bin/python3.12", ["/bin/python3.12", "-B", "-v", "-c", "pass"], os.environ)
   else:
       _, status = os.waitpid(pid, 0)
       print("child exit:", os.waitstatus_to_exitcode(status))
   ```

3. Observe (nondeterministically across runs) the `-v` import trace ending in
   `Fatal Python error: init_import_site: Failed to import the site module`, a child exit code of
   `1` or `127`, and vfsd logging `failed to clone filesystem state (... error=AlreadyExists)`.
   Wrapping the fork+exec in a loop makes the nondeterministic failures appear reliably within a few
   iterations.

## Wiring

Mirrors `fork-exec-vfsd-test`:
- Workspace members (`Cargo.toml` + `Cargo.lock`).
- `ALL_GUEST_TESTS` and `STANDALONE_GUEST_BINARIES`; the target is added to
  `STANDALONE_RAMFS_ONLY_BINARIES` and bundled as `/target` alongside the seeded `/coldfile.dat` in
  `fork-exec-loop-test.img` (`build/make/nanvixd.mk`).
- Registered in `test/test-standalone.toml` and `test/test-standalone-windows.toml` with
  `-ramfs ./bin/fork-exec-loop-test.img`.

## Validation

- `cargo check`, `clippy -D warnings` (incl. `as_conversions`/`unwrap_used`/`expect_used`), and
  `rustfmt --check` pass.
- A full standalone build produces the `.elf`, `.initrd`, and `fork-exec-loop-test.img` artifacts.
- Run on standalone Nanvix it fails at the intended assertion (child exit `42` — the inherited
  descriptor is unreadable after `execv()`).
