### PR TITLE
[vfs] Add console line discipline

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -449,6 +449,16 @@ pub(crate) fn handle_read_with_hostfs(
     let req: ReadRequest = ReadRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
 
+    if let Ok(stream) = ::vfs::fd::vfs_console_stream(fd) {
+        return Some(super::readwrite::handle_console_read(
+            source_pid,
+            source_tid,
+            fd,
+            stream,
+            req.count as usize,
+        ));
+    }
+
     // Pipe read end: served by the pipe handler (which may park the caller).
     if let Some((pipe_id, is_write)) = ::vfs::fd::vfs_pipe_id(fd) {
         return super::pipe::handle_pipe_read(

--- a/src/daemons/vfsd/src/handler/readwrite.rs
+++ b/src/daemons/vfsd/src/handler/readwrite.rs
@@ -9,9 +9,13 @@ use crate::error::{
     build_error,
     fat32_to_error_code,
 };
+use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_SIZE;
 use ::sys::{
-    error::ErrorCode,
+    error::{
+        Error,
+        ErrorCode,
+    },
     ipc::{
         Message,
         MessageType,
@@ -22,6 +26,7 @@ use ::sys::{
     },
 };
 use ::sysapi::{
+    fcntl::file_status_flags,
     sys_ioctl::{
         Winsize,
         TCGETS,
@@ -29,7 +34,12 @@ use ::sysapi::{
         TIOCGWINSZ,
         TIOCSWINSZ,
     },
+    sys_types::c_size_t,
     termios::Termios,
+    unistd::{
+        STDIN_FILENO,
+        STDOUT_FILENO,
+    },
 };
 use ::syscall::{
     sys::ioctl::message::{
@@ -48,7 +58,13 @@ use ::syscall::{
     },
     SystemCallMessage,
 };
-use ::vfs::fd::TtyError;
+use ::vfs::{
+    fd::{
+        ConsoleStream,
+        TtyError,
+    },
+    line_discipline::ConsoleReadOutcome,
+};
 
 //==================================================================================================
 // Constants
@@ -62,6 +78,15 @@ const MAX_BULK_TRANSFER_SIZE: usize = PAGE_SIZE;
 /// Safety: vfsd processes one request at a time (single-threaded message loop),
 /// so there is no concurrent access to this buffer.
 static mut BULK_BUFFER: [u8; MAX_BULK_TRANSFER_SIZE] = [0u8; MAX_BULK_TRANSFER_SIZE];
+
+/// Number of raw host-console bytes fetched from the kernel per blocking fetch.
+///
+/// Reading a small chunk (rather than a single byte) per round-trip lets a burst of buffered or
+/// pasted input — and piped input in tests — be cooked in one kernel exchange. Interactive,
+/// per-keystroke input still arrives one byte at a time regardless, since the host delivers each
+/// keystroke as it is typed. Over-reading is safe: surplus bytes are buffered by the line
+/// discipline and served to later reads.
+const CONSOLE_RAW_READ_SIZE: usize = 256;
 
 //==================================================================================================
 // Read/Write Handlers (with push/pull bulk data transfer)
@@ -115,6 +140,79 @@ pub(crate) fn handle_read(
     }
 }
 
+/// Handles a `read()` on a console descriptor.
+///
+/// Cooked input already buffered in the line discipline is served without blocking. When none is
+/// available and the descriptor is blocking, this fetches raw input from the host console and feeds
+/// it through the line discipline until a readable unit (a canonical line, a raw byte, or EOF)
+/// becomes available.
+///
+/// The host console protocol is synchronous and demand-driven — the host blocks until input arrives
+/// and delivers it only in response to an explicit request — and vfsd is single-threaded, so this
+/// fetch necessarily blocks the event loop while waiting for the user. Requests from other clients
+/// that arrive meanwhile are queued (never lost) and are serviced as soon as the read completes.
+/// Crucially, the raw fetch does not consume the kernel's acknowledgement with a nested
+/// `__kcall_recv()` (which could dequeue an unrelated request from the shared mailbox); those
+/// acknowledgements are drained by the main event loop instead.
+pub(crate) fn handle_console_read(
+    source_pid: ProcessIdentifier,
+    source_tid: ThreadIdentifier,
+    fd: i32,
+    stream: ConsoleStream,
+    count: usize,
+) -> Message {
+    if stream != ConsoleStream::Stdin {
+        let _ = push_to_reader(source_pid, source_tid, &[], "console read");
+        return build_error(source_tid, ErrorCode::BadFile);
+    }
+
+    let buf_size: usize = count.min(MAX_BULK_TRANSFER_SIZE);
+    // Safety: vfsd is single-threaded; no concurrent access to BULK_BUFFER.
+    let buf: &mut [u8] = unsafe { &mut BULK_BUFFER[..buf_size] };
+
+    loop {
+        match ::vfs::fd::vfs_console_read(fd, buf) {
+            Ok(ConsoleReadOutcome::Read(n)) => {
+                if let Err(code) = push_to_reader(source_pid, source_tid, &buf[..n], "console read")
+                {
+                    return build_error(source_tid, code);
+                }
+                return ReadResponse::build(
+                    source_tid,
+                    n as i32,
+                    [0u8; ReadResponse::BUFFER_SIZE],
+                    ProcessIdentifier::VFSD,
+                    MessageType::Ipc,
+                );
+            },
+            Ok(ConsoleReadOutcome::Eof) => {
+                let _ = push_to_reader(source_pid, source_tid, &[], "console read");
+                return ReadResponse::build(
+                    source_tid,
+                    0,
+                    [0u8; ReadResponse::BUFFER_SIZE],
+                    ProcessIdentifier::VFSD,
+                    MessageType::Ipc,
+                );
+            },
+            Ok(ConsoleReadOutcome::WouldBlock) => {
+                if is_nonblocking(fd) {
+                    let _ = push_to_reader(source_pid, source_tid, &[], "console read");
+                    return build_error(source_tid, ErrorCode::TryAgain);
+                }
+                if let Err(code) = feed_console_input(fd) {
+                    let _ = push_to_reader(source_pid, source_tid, &[], "console read");
+                    return build_error(source_tid, code);
+                }
+            },
+            Err(error) => {
+                let _ = push_to_reader(source_pid, source_tid, &[], "console read");
+                return build_error(source_tid, tty_error_code(error));
+            },
+        }
+    }
+}
+
 pub(crate) fn handle_write(
     source_pid: ProcessIdentifier,
     source_tid: ThreadIdentifier,
@@ -153,6 +251,94 @@ pub(crate) fn handle_write(
             build_error(source_tid, ErrorCode::IoErr)
         },
     }
+}
+
+/// Returns `true` if the open file description for `fd` has `O_NONBLOCK` set.
+fn is_nonblocking(fd: i32) -> bool {
+    ::vfs::fd::vfs_get_status_flags(fd) & file_status_flags::O_NONBLOCK != 0
+}
+
+/// Pushes data to a reader blocked in `__kcall_pull`.
+fn push_to_reader(
+    pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
+    data: &[u8],
+    context: &'static str,
+) -> Result<(), ErrorCode> {
+    if let Err(error) = ::sys::kcall::ipc::__kcall_push(pid, tid, data) {
+        ::syslog::error!("{context}: push failed (error={:?})", error);
+        return Err(ErrorCode::IoErr);
+    }
+    Ok(())
+}
+
+/// Feeds a chunk of raw host-console input through the line discipline.
+///
+/// Fetches up to [`CONSOLE_RAW_READ_SIZE`] raw bytes from the kernel console, cooks them through the
+/// line discipline, and writes back any bytes the discipline wants echoed. A zero-length fetch means
+/// end-of-file, which is signalled to the discipline. Echo failures are non-fatal and only logged.
+fn feed_console_input(fd: i32) -> Result<(), ErrorCode> {
+    let mut raw: [u8; CONSOLE_RAW_READ_SIZE] = [0u8; CONSOLE_RAW_READ_SIZE];
+    let n: usize = kernel_read_stdin(&mut raw).map_err(|error| error.code)?;
+    if n == 0 {
+        return ::vfs::fd::vfs_console_push_eof(fd).map_err(tty_error_code);
+    }
+
+    let echo: Vec<u8> = ::vfs::fd::vfs_console_push_input(fd, &raw[..n]).map_err(tty_error_code)?;
+    if !echo.is_empty() {
+        if let Err(error) = kernel_write_console(STDOUT_FILENO, &echo) {
+            ::syslog::warn!("console read: failed to echo input (error={:?})", error);
+        }
+    }
+
+    Ok(())
+}
+
+/// Reads raw input from the kernel console stdin stream.
+///
+/// Sends a `ReadRequest` to the kernel console and pulls the delivered bytes. The pulled byte count
+/// is authoritative: the host always completes the pull (with `0` bytes on end-of-file). The
+/// kernel's matching `ReadResponse` acknowledgement is intentionally left in vfsd's mailbox for the
+/// main event loop to discard, rather than consumed here with a nested `__kcall_recv()` that could
+/// instead dequeue an unrelated guest request (the mailbox is shared by the whole process).
+fn kernel_read_stdin(buf: &mut [u8]) -> Result<usize, Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let request: Message = ReadRequest::build(
+        tid,
+        STDIN_FILENO,
+        buf.len() as c_size_t,
+        ProcessIdentifier::KERNEL,
+        MessageType::Ikc,
+    );
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+    let bytes_pulled: usize =
+        ::sys::kcall::ipc::__kcall_pull(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buf)?;
+    Ok(bytes_pulled)
+}
+
+/// Writes bytes to the kernel console output stream (used to echo cooked input).
+///
+/// Like [`kernel_read_stdin`], the kernel's `WriteResponse` acknowledgement is left in vfsd's
+/// mailbox for the main event loop to discard rather than consumed with a nested `__kcall_recv()`,
+/// which could otherwise dequeue an unrelated guest request from the shared mailbox.
+fn kernel_write_console(fd: i32, buf: &[u8]) -> Result<(), Error> {
+    if buf.is_empty() {
+        return Ok(());
+    }
+
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let empty_buf: [u8; WriteRequest::BUFFER_SIZE] = [0u8; WriteRequest::BUFFER_SIZE];
+    let request: Message = WriteRequest::build(
+        tid,
+        fd,
+        buf.len() as c_size_t,
+        empty_buf,
+        ProcessIdentifier::KERNEL,
+        MessageType::Ikc,
+    );
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+    ::sys::kcall::ipc::__kcall_push(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buf)?;
+    Ok(())
 }
 
 //==================================================================================================

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -201,6 +201,17 @@ pub fn main() {
                         if header == SystemCallMessageHeader::CloseResponse {
                             continue;
                         }
+                        // The console line-discipline backend fetches raw input and echoes output
+                        // through synchronous kernel-console exchanges (see vfsd's
+                        // `handle_console_read`). It deliberately does not consume the kernel's
+                        // `ReadResponse`/`WriteResponse` acknowledgement inline — a nested
+                        // `__kcall_recv()` there could dequeue an unrelated guest request from the
+                        // shared mailbox — so those acknowledgements surface here and are discarded.
+                        if header == SystemCallMessageHeader::ReadResponse
+                            || header == SystemCallMessageHeader::WriteResponse
+                        {
+                            continue;
+                        }
                         // Multi-part response stream: assemble parts before dispatch.
                         // The op_id is *not* at the standard payload[2..6] offset for
                         // these messages (those bytes carry SystemCallMessagePart

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -50,6 +50,103 @@ const IO_BUFFER_SIZE: usize = 4096;
 const STDIN_CHANNEL_CAPACITY: usize = 4096;
 
 //==================================================================================================
+// Host Raw Mode
+//==================================================================================================
+
+/// Guard that places the host terminal in raw input mode while the guest runs.
+///
+/// In standalone mode the guest's vfsd console backend owns the terminal line discipline (canonical
+/// editing, echo, special characters). For that to be authoritative, the host terminal must stop
+/// cooking input: canonical mode, echo, signal generation, and input CR/NL translation are disabled
+/// so keystrokes reach the guest verbatim. Output post-processing (e.g. `ONLCR`) is intentionally
+/// left enabled, because guest *program* output bypasses the guest line discipline and still relies
+/// on the host to render newlines.
+///
+/// The switch is a no-op unless host stdin is a real terminal, so piped or redirected input (tests,
+/// scripts, HTTP mode) is forwarded byte-for-byte and unaffected. The previous attributes are
+/// restored when the guard drops, i.e. when the guest exits.
+struct RawModeGuard {
+    /// The terminal attributes to restore on drop; `None` when no switch was performed.
+    #[cfg(unix)]
+    saved: Option<::libc::termios>,
+}
+
+impl RawModeGuard {
+    /// Switches host stdin to raw input mode when it is a terminal, returning a restoring guard.
+    #[cfg(unix)]
+    fn new() -> Self {
+        // Only switch a real terminal; leave piped/redirected stdin untouched.
+        // SAFETY: `isatty` only inspects the descriptor and is always safe to call.
+        if unsafe { ::libc::isatty(::libc::STDIN_FILENO) } != 1 {
+            return Self { saved: None };
+        }
+        // SAFETY: `termios` is a plain C struct; a zeroed value is a valid initial state that
+        // `tcgetattr` fully overwrites.
+        let mut termios: ::libc::termios = unsafe { ::std::mem::zeroed() };
+        // SAFETY: `termios` points to a valid, owned structure for the duration of the call.
+        if unsafe { ::libc::tcgetattr(::libc::STDIN_FILENO, &mut termios) } != 0 {
+            warn!("standalone: failed to read host terminal attributes; leaving cooked mode");
+            return Self { saved: None };
+        }
+        let saved: ::libc::termios = termios;
+        Self::make_raw_input(&mut termios);
+        // SAFETY: `termios` points to a valid, owned structure for the duration of the call.
+        if unsafe { ::libc::tcsetattr(::libc::STDIN_FILENO, ::libc::TCSANOW, &termios) } != 0 {
+            warn!("standalone: failed to set host terminal to raw mode; leaving cooked mode");
+            return Self { saved: None };
+        }
+        info!("standalone: host terminal switched to raw input mode");
+        Self { saved: Some(saved) }
+    }
+
+    /// Non-Unix hosts do not expose POSIX termios; the switch is a no-op there.
+    #[cfg(not(unix))]
+    fn new() -> Self {
+        Self {}
+    }
+
+    /// Clears the input-cooking, echo, and signal flags, leaving output post-processing intact.
+    #[cfg(unix)]
+    fn make_raw_input(termios: &mut ::libc::termios) {
+        // Disable canonical mode, echo, signal generation (`^C`/`^Z`), and extended input
+        // processing so the guest line discipline is authoritative for editing, echo, and special
+        // characters.
+        termios.c_lflag &= !(::libc::ICANON
+            | ::libc::ECHO
+            | ::libc::ECHOE
+            | ::libc::ECHOK
+            | ::libc::ECHONL
+            | ::libc::ISIG
+            | ::libc::IEXTEN);
+        // Disable input CR/NL translation, flow control, and break handling so bytes reach the
+        // guest verbatim; the guest maps CR to NL itself (`ICRNL` in its own termios).
+        termios.c_iflag &= !(::libc::ICRNL
+            | ::libc::INLCR
+            | ::libc::IGNCR
+            | ::libc::IXON
+            | ::libc::IXOFF
+            | ::libc::BRKINT
+            | ::libc::ISTRIP
+            | ::libc::INPCK);
+        // Deliver each byte as soon as it is typed.
+        termios.c_cc[::libc::VMIN] = 1;
+        termios.c_cc[::libc::VTIME] = 0;
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(saved) = self.saved {
+            // SAFETY: `saved` is a valid termios previously read from this same terminal.
+            unsafe {
+                ::libc::tcsetattr(::libc::STDIN_FILENO, ::libc::TCSANOW, &saved);
+            }
+        }
+    }
+}
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -109,6 +206,12 @@ impl Terminal {
         guest_binary_args: &str,
     ) -> Result<i32> {
         info!("spawning VM in standalone terminal mode");
+
+        // Put the host terminal in raw mode for the lifetime of the guest so its in-vfsd line
+        // discipline is authoritative for canonical editing, echo, and special characters. The
+        // guard restores the previous attributes on drop (guest exit). It is a no-op unless host
+        // stdin is a terminal, so piped/redirected input (tests, scripts) is forwarded verbatim.
+        let _raw_mode: RawModeGuard = RawModeGuard::new();
 
         let initrd_args: Option<String> = if guest_binary_args.is_empty() {
             None

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -71,6 +71,22 @@ pub(crate) struct Resolution {
     pub backend_fd: i32,
 }
 
+/// Result of resolving a descriptor specifically for console I/O.
+#[cfg(feature = "standalone")]
+pub(crate) enum ConsoleLookup {
+    /// The descriptor is a console stream.
+    Console {
+        /// The standard stream number (`0`/`1`/`2`) represented by the descriptor.
+        backend_fd: i32,
+        /// Whether the descriptor is backed by an authoritative vfsd slot.
+        via_vfsd: bool,
+    },
+    /// The descriptor exists, but is not a console stream.
+    Other,
+    /// The descriptor does not exist.
+    BadFile,
+}
+
 /// A cached resolution together with the `vfsd` table generation it was learned at.
 #[cfg(any(feature = "standalone", test))]
 #[derive(Debug, Clone, Copy)]
@@ -176,6 +192,44 @@ pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
         VfsdResolution::Hit(resolution) => Some(resolution),
         VfsdResolution::BadFile => None,
         VfsdResolution::Unavailable => derive_console(fd),
+    }
+}
+
+/// Resolves `fd` for console I/O and reports whether vfsd owns the descriptor slot.
+#[cfg(feature = "standalone")]
+pub(crate) fn resolve_console(fd: i32) -> ConsoleLookup {
+    {
+        let cache: ::spin::MutexGuard<'_, BTreeMap<i32, CacheEntry>> = CACHE.lock();
+        if let Some(entry) = cache.get(&fd) {
+            if is_coherent(entry.epoch) {
+                return if entry.route == Route::Console {
+                    ConsoleLookup::Console {
+                        backend_fd: entry.backend_fd,
+                        via_vfsd: true,
+                    }
+                } else {
+                    ConsoleLookup::Other
+                };
+            }
+        }
+    }
+
+    match resolve_via_vfsd(fd) {
+        VfsdResolution::Hit(resolution) if resolution.route == Route::Console => {
+            ConsoleLookup::Console {
+                backend_fd: resolution.backend_fd,
+                via_vfsd: true,
+            }
+        },
+        VfsdResolution::Hit(_) => ConsoleLookup::Other,
+        VfsdResolution::BadFile => ConsoleLookup::BadFile,
+        VfsdResolution::Unavailable => match derive_console(fd) {
+            Some(resolution) => ConsoleLookup::Console {
+                backend_fd: resolution.backend_fd,
+                via_vfsd: false,
+            },
+            None => ConsoleLookup::BadFile,
+        },
     }
 }
 

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -173,31 +173,57 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
     {
         use crate::fdtable::{
             resolve,
+            resolve_console,
+            ConsoleLookup,
             Route,
         };
-        match resolve(fd) {
-            // stdin reads flow directly to the kernel over IKC.
-            Some(res) if res.route == Route::Console && res.backend_fd == STDIN_FILENO => read_ipc(
-                res.backend_fd,
-                buffer,
-                crate::LINUXD,
-                MessageType::Ikc,
-                ProcessIdentifier::KERNEL,
-                ThreadIdentifier::KERNEL,
-            ),
-            // VFS-backed descriptors go to vfsd.
-            Some(res) if res.route == Route::Vfs => read_ipc(
-                res.backend_fd,
-                buffer,
-                crate::VFS_DESTINATION,
-                crate::VFS_MESSAGE_TYPE,
-                crate::VFS_PUSH_PULL_PID,
-                crate::VFS_PUSH_PULL_TID,
-            ),
-            // stdout/stderr, sockets, and unroutable descriptors are not readable here.
-            _ => {
+        match resolve_console(fd) {
+            // When vfsd owns the console slot, use the flat descriptor so vfsd can apply the
+            // shared terminal line discipline. In direct-ELF standalone runs without vfsd, keep the
+            // historical direct kernel-console path.
+            ConsoleLookup::Console {
+                backend_fd: STDIN_FILENO,
+                via_vfsd,
+            } => {
+                if via_vfsd {
+                    read_ipc(
+                        fd,
+                        buffer,
+                        crate::VFS_DESTINATION,
+                        crate::VFS_MESSAGE_TYPE,
+                        crate::VFS_PUSH_PULL_PID,
+                        crate::VFS_PUSH_PULL_TID,
+                    )
+                } else {
+                    read_ipc(
+                        STDIN_FILENO,
+                        buffer,
+                        crate::LINUXD,
+                        MessageType::Ikc,
+                        ProcessIdentifier::KERNEL,
+                        ThreadIdentifier::KERNEL,
+                    )
+                }
+            },
+            ConsoleLookup::Console { .. } | ConsoleLookup::BadFile => {
                 ::syslog::warn!("read(): bad file descriptor fd={fd} in standalone mode");
-                Err(Error::new(ErrorCode::BadFile, "read: fd is not a VFS fd in standalone mode"))
+                Err(Error::new(ErrorCode::BadFile, "read: bad file descriptor"))
+            },
+            ConsoleLookup::Other => match resolve(fd) {
+                // VFS-backed descriptors go to vfsd.
+                Some(res) if res.route == Route::Vfs => read_ipc(
+                    res.backend_fd,
+                    buffer,
+                    crate::VFS_DESTINATION,
+                    crate::VFS_MESSAGE_TYPE,
+                    crate::VFS_PUSH_PULL_PID,
+                    crate::VFS_PUSH_PULL_TID,
+                ),
+                // stdout/stderr, sockets, and unroutable descriptors are not readable here.
+                _ => {
+                    ::syslog::warn!("read(): bad file descriptor fd={fd} in standalone mode");
+                    Err(Error::new(ErrorCode::BadFile, "read: bad file descriptor"))
+                },
             },
         }
     }

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -20,7 +20,13 @@
 // Imports
 //==================================================================================================
 
-use crate::fat32_backend;
+use crate::{
+    fat32_backend,
+    line_discipline::{
+        ConsoleReadOutcome,
+        LineDiscipline,
+    },
+};
 use ::alloc::{
     collections::{
         BTreeMap,
@@ -209,9 +215,8 @@ pub enum VfsFileHandle {
     Pipe(crate::pipe::PipeEnd),
     /// Routing token for a console stream (stdin/stdout/stderr).
     ///
-    /// This is not a real handle: it carries no buffer and performs no I/O. It only lets vfsd own
-    /// the descriptor slot and its per-descriptor flags while console I/O is routed elsewhere. No
-    /// production path constructs this variant yet (that lands in a later plan).
+    /// The handle lets vfsd own the descriptor slot, its per-descriptor flags, and the shared
+    /// console line discipline. The daemon still drives host I/O around this token.
     Console(ConsoleHandle),
     /// Routing token for a socket, holding the descriptor assigned by `networkd`.
     ///
@@ -299,57 +304,34 @@ pub enum ConsoleStream {
     Stderr,
 }
 
-/// Shared terminal device state backing the console streams.
-///
-/// Terminal attributes belong to the console *device*, not to an individual descriptor: the three
-/// standard streams (and every descriptor duplicated or forked from them) observe one consistent
-/// `termios`/`winsize`. This object is therefore held behind an [`Arc`] that all console handles
-/// share, so a `tcsetattr` through one console descriptor is visible through another and is
-/// inherited across `fork`/`dup`.
-#[derive(Clone, Copy, Debug)]
-pub struct TerminalState {
-    /// Terminal attributes (`tcgetattr`/`tcsetattr`, `TCGETS`/`TCSETS`).
-    pub termios: Termios,
-    /// Terminal window size (`TIOCGWINSZ`/`TIOCSWINSZ`).
-    pub winsize: Winsize,
-}
-
-impl Default for TerminalState {
-    fn default() -> Self {
-        Self {
-            termios: Termios::console_default(),
-            winsize: Winsize::console_default(),
-        }
-    }
-}
-
 /// Routing token for a console-backed descriptor.
 ///
 /// A console handle records which standard stream the descriptor represents and a reference to the
-/// shared terminal device state, but holds no buffer and performs no I/O. It exists so that vfsd can
-/// own the descriptor slot, its per-descriptor flags, and the terminal attributes while the actual
-/// console I/O is routed elsewhere.
+/// shared line discipline (terminal attributes plus cooked input), but performs no I/O of its own.
+/// It exists so that vfsd can own the descriptor slot, its per-descriptor flags, and the terminal
+/// device state while the actual console I/O is driven from the daemon.
 pub struct ConsoleHandle {
     /// Which standard stream this descriptor represents.
     stream: ConsoleStream,
-    /// Shared terminal device state, referenced by every console descriptor.
-    terminal: Arc<Mutex<TerminalState>>,
+    /// Shared line discipline (terminal attributes and cooked input), referenced by every console
+    /// descriptor of the device.
+    terminal: Arc<Mutex<LineDiscipline>>,
 }
 
 impl ConsoleHandle {
-    /// Creates a console handle for the given standard stream with its own fresh terminal state.
+    /// Creates a console handle for the given standard stream with its own fresh line discipline.
     ///
     /// Use [`ConsoleHandle::with_terminal`] when several handles must share one terminal device, as
     /// the standard streams do.
     pub fn new(stream: ConsoleStream) -> Self {
-        Self::with_terminal(stream, Arc::new(Mutex::new(TerminalState::default())))
+        Self::with_terminal(stream, Arc::new(Mutex::new(LineDiscipline::default())))
     }
 
     /// Creates a console handle for the given standard stream that references `terminal`.
     ///
-    /// The three standard streams are created this way from a single shared terminal object so that
-    /// they observe one consistent `termios`/`winsize`.
-    pub fn with_terminal(stream: ConsoleStream, terminal: Arc<Mutex<TerminalState>>) -> Self {
+    /// The three standard streams are created this way from a single shared line discipline so that
+    /// they observe one consistent `termios`/`winsize` and one shared input buffer.
+    pub fn with_terminal(stream: ConsoleStream, terminal: Arc<Mutex<LineDiscipline>>) -> Self {
         Self { stream, terminal }
     }
 
@@ -358,8 +340,8 @@ impl ConsoleHandle {
         self.stream
     }
 
-    /// Returns a reference to the shared terminal device state.
-    pub fn terminal(&self) -> &Arc<Mutex<TerminalState>> {
+    /// Returns a reference to the shared line discipline backing this console descriptor.
+    pub fn terminal(&self) -> &Arc<Mutex<LineDiscipline>> {
         &self.terminal
     }
 }
@@ -989,7 +971,7 @@ pub fn vfs_seed_root_console(pid: ProcessIdentifier) {
     // The three standard streams share one terminal device, so they reference a single shared
     // terminal-state object. A `tcsetattr` through any of them is therefore visible through the
     // others, and the shared object flows down every `fork`/`dup` with the descriptor slots.
-    let terminal: Arc<Mutex<TerminalState>> = Arc::new(Mutex::new(TerminalState::default()));
+    let terminal: Arc<Mutex<LineDiscipline>> = Arc::new(Mutex::new(LineDiscipline::default()));
     for (fd, stream) in [
         (STDIN_FILENO, ConsoleStream::Stdin),
         (STDOUT_FILENO, ConsoleStream::Stdout),
@@ -2278,7 +2260,7 @@ pub enum TtyError {
 /// before it is returned, so the caller may lock the terminal without nesting registry or entry
 /// locks. A descriptor with no slot yields [`TtyError::BadFd`]; a non-console descriptor yields
 /// [`TtyError::NotTty`].
-fn console_terminal(fd: c_int) -> Result<Arc<Mutex<TerminalState>>, TtyError> {
+fn console_handle(fd: c_int) -> Result<(ConsoleStream, Arc<Mutex<LineDiscipline>>), TtyError> {
     let file: OpenFile = {
         let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
             PROCESSES.lock();
@@ -2293,14 +2275,23 @@ fn console_terminal(fd: c_int) -> Result<Arc<Mutex<TerminalState>>, TtyError> {
     };
     let guard = file.lock();
     match &guard.handle {
-        VfsFileHandle::Console(h) => Ok(h.terminal().clone()),
+        VfsFileHandle::Console(h) => Ok((h.stream(), h.terminal().clone())),
         _ => Err(TtyError::NotTty),
     }
 }
 
+/// Returns the console stream represented by descriptor `fd`.
+pub fn vfs_console_stream(fd: c_int) -> Result<ConsoleStream, TtyError> {
+    console_handle(fd).map(|(stream, _)| stream)
+}
+
+fn console_terminal(fd: c_int) -> Result<Arc<Mutex<LineDiscipline>>, TtyError> {
+    console_handle(fd).map(|(_, terminal)| terminal)
+}
+
 /// Reads the terminal attributes of the console descriptor `fd` (`TCGETS`/`tcgetattr`).
 pub fn vfs_tty_get_termios(fd: c_int) -> Result<Termios, TtyError> {
-    let terminal: Arc<Mutex<TerminalState>> = console_terminal(fd)?;
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
     let termios: Termios = terminal.lock().termios;
     Ok(termios)
 }
@@ -2310,23 +2301,44 @@ pub fn vfs_tty_get_termios(fd: c_int) -> Result<Termios, TtyError> {
 /// The new attributes are stored on the shared terminal object, so the change is observed by every
 /// console descriptor that references it, including descriptors in forked children.
 pub fn vfs_tty_set_termios(fd: c_int, termios: Termios) -> Result<(), TtyError> {
-    let terminal: Arc<Mutex<TerminalState>> = console_terminal(fd)?;
-    terminal.lock().termios = termios;
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
+    terminal.lock().set_termios(termios);
     Ok(())
 }
 
 /// Reads the window size of the console descriptor `fd` (`TIOCGWINSZ`).
 pub fn vfs_tty_get_winsize(fd: c_int) -> Result<Winsize, TtyError> {
-    let terminal: Arc<Mutex<TerminalState>> = console_terminal(fd)?;
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
     let winsize: Winsize = terminal.lock().winsize;
     Ok(winsize)
 }
 
 /// Replaces the window size of the console descriptor `fd` (`TIOCSWINSZ`).
 pub fn vfs_tty_set_winsize(fd: c_int, winsize: Winsize) -> Result<(), TtyError> {
-    let terminal: Arc<Mutex<TerminalState>> = console_terminal(fd)?;
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
     terminal.lock().winsize = winsize;
     Ok(())
+}
+
+/// Feeds raw input bytes into the console line discipline and returns bytes to echo.
+pub fn vfs_console_push_input(fd: c_int, input: &[u8]) -> Result<Vec<u8>, TtyError> {
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
+    let echo: Vec<u8> = terminal.lock().push_input(input);
+    Ok(echo)
+}
+
+/// Signals end-of-input on the raw console stream.
+pub fn vfs_console_push_eof(fd: c_int) -> Result<(), TtyError> {
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
+    terminal.lock().push_eof();
+    Ok(())
+}
+
+/// Attempts a non-blocking read from the console line discipline.
+pub fn vfs_console_read(fd: c_int, buf: &mut [u8]) -> Result<ConsoleReadOutcome, TtyError> {
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
+    let outcome: ConsoleReadOutcome = terminal.lock().read(buf);
+    Ok(outcome)
 }
 
 /// Reads from a VFS file descriptor at a given offset without changing position.
@@ -3632,6 +3644,29 @@ mod tests {
             Ok(attrs),
             "stderr observes a change made through stdout"
         );
+
+        forget_processes(&[root]);
+    }
+
+    /// Tests that the shared console line discipline is reachable through console descriptors.
+    #[test]
+    fn console_line_discipline_is_shared_across_standard_streams() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let root: ProcessIdentifier = root_process_identifier();
+        vfs_seed_root_console(root);
+        set_current_process(root);
+
+        let echo: Vec<u8> =
+            vfs_console_push_input(STDIN_FILENO, b"ab\n").expect("push console input");
+        assert_eq!(echo, b"ab\r\n", "canonical input is echoed through the discipline");
+
+        let mut buf: [u8; 8] = [0u8; 8];
+        assert_eq!(
+            vfs_console_read(STDERR_FILENO, &mut buf),
+            Ok(ConsoleReadOutcome::Read(3)),
+            "all standard streams share one console input queue"
+        );
+        assert_eq!(&buf[..3], b"ab\n");
 
         forget_processes(&[root]);
     }

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -68,6 +68,9 @@ pub mod fd;
 /// High-level file handle and OpenOptions builder.
 pub mod file;
 
+/// Terminal line discipline backing the vfsd console device.
+pub mod line_discipline;
+
 /// Mount table and path resolution.
 pub mod mount;
 

--- a/src/libs/vfs/src/line_discipline.rs
+++ b/src/libs/vfs/src/line_discipline.rs
@@ -1,0 +1,585 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! In-guest terminal line discipline for the vfsd console backend.
+//!
+//! This is the cooked side of the console device. It owns the terminal attributes
+//! ([`Termios`]/[`Winsize`]) introduced by the TTY-probing plan and promotes them into a real line
+//! discipline: it turns the raw byte stream arriving from the host into the bytes a guest `read`
+//! observes, honoring the `termios` flags.
+//!
+//! # Model
+//!
+//! Raw input bytes are fed in with [`LineDiscipline::push_input`], which returns the bytes that must
+//! be echoed back to the terminal. A guest read consumes cooked bytes with [`LineDiscipline::read`].
+//! The two operations are decoupled by an internal queue of [`Segment`]s so that the daemon can
+//! buffer input that arrives before a reader is waiting and serve a reader from already-buffered
+//! input.
+//!
+//! vfsd owns one `LineDiscipline` per console device behind a shared lock and drives it: it calls
+//! [`LineDiscipline::push_input`] as host bytes arrive and serves guest console reads through
+//! [`LineDiscipline::read`], parking the reader or returning `EAGAIN` on
+//! [`ConsoleReadOutcome::WouldBlock`]. The discipline itself performs no I/O and never blocks;
+//! routing host and guest bytes to these calls is the daemon's responsibility.
+//!
+//! ## Canonical mode (`ICANON`)
+//!
+//! Input is assembled into a *line*: ordinary bytes accumulate in a pending-line buffer, `VERASE`
+//! deletes the last byte, `VKILL` deletes the whole line, and a newline (or a carriage return when
+//! `ICRNL` is set) commits the line — including its terminating newline — as one readable unit. A
+//! read returns at most one line and never crosses a line boundary, so a complete line becomes
+//! available exactly when the user presses Enter. `VEOF` (`^D`) commits the pending bytes
+//! immediately without a newline; on an empty line it instead yields an end-of-file marker so the
+//! reader observes a zero-length read.
+//!
+//! ## Raw mode (`ICANON` cleared)
+//!
+//! There is no line editing: every byte becomes readable as soon as it arrives, so a reader is
+//! served immediately. This is the mode used by `readline`, editors, and the REPL.
+//!
+//! ## Echo (`ECHO`)
+//!
+//! When `ECHO` is set, ordinary input is echoed verbatim, an erased byte is echoed as a
+//! backspace-space-backspace sequence, and a committed line is echoed as a carriage-return/newline
+//! pair so the host cursor advances correctly while the host terminal is in raw mode. `VEOF` is
+//! never echoed. When `ECHO` is cleared, no bytes are echoed.
+//!
+//! ## Limitations
+//!
+//! The discipline implements the cooked-input behavior the console needs and deliberately omits the
+//! rest of the `termios` machinery:
+//!
+//! - **Signals.** `ISIG` is not acted upon: `VINTR` (`^C`), `VQUIT`, and `VSUSP` (`^Z`) are treated
+//!   as ordinary input rather than raising signals.
+//! - **Flow control.** `IXON`/`IXOFF` are ignored: `VSTART` (`^Q`) and `VSTOP` (`^S`) do not gate
+//!   output.
+//! - **Input translation.** Among the input-mode flags only `ICRNL` is honored; `IGNCR`, `INLCR`,
+//!   and `ISTRIP` are not.
+//! - **Output processing.** Output post-processing (`OPOST`/`ONLCR`) is not modeled here; the echo
+//!   path emits a `CR`-`LF` pair directly, and the console write path is handled separately.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::{
+    collections::VecDeque,
+    vec::Vec,
+};
+use ::sysapi::{
+    sys_ioctl::Winsize,
+    termios::{
+        self,
+        Termios,
+    },
+};
+
+//==================================================================================================
+// Outcomes
+//==================================================================================================
+
+/// Outcome of a non-blocking console read attempt.
+///
+/// The discipline itself never blocks: it reports whether data was available, and the daemon
+/// decides whether to park the reader (blocking) or return `EAGAIN` (`O_NONBLOCK`) on
+/// [`ConsoleReadOutcome::WouldBlock`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum ConsoleReadOutcome {
+    /// Copied `N` bytes out of the cooked queue. `N` is `0` only for a zero-length request.
+    Read(usize),
+    /// No cooked input is available — the caller must block (or receive `EAGAIN`).
+    WouldBlock,
+    /// A `VEOF` (`^D`) on an empty line — the caller must receive end-of-file (`0`).
+    Eof,
+}
+
+//==================================================================================================
+// Segments
+//==================================================================================================
+
+/// One committed, readable unit in the cooked queue.
+///
+/// In canonical mode every committed line is one [`Segment::Data`]; in raw mode incoming bytes are
+/// coalesced into a single trailing [`Segment::Data`]. A `VEOF` on an empty line produces a
+/// [`Segment::Eof`] so the end-of-file is delivered in order with the surrounding input.
+enum Segment {
+    /// Readable bytes belonging to one canonical line (or a coalesced run of raw bytes).
+    Data(VecDeque<u8>),
+    /// A soft end-of-file produced by `VEOF` (`^D`) on an empty line.
+    Eof,
+}
+
+//==================================================================================================
+// Line Discipline
+//==================================================================================================
+
+/// The cooked state of the console device: terminal attributes plus the line-discipline buffers.
+///
+/// Terminal attributes belong to the console *device*, not to an individual descriptor: the three
+/// standard streams (and every descriptor duplicated or forked from them) observe one consistent
+/// `termios`/`winsize`. This object is therefore held behind a shared lock by every console handle,
+/// so a `tcsetattr` through one console descriptor is visible through another and is inherited
+/// across `fork`/`dup`, and the input buffered here is shared by every reader of the console.
+pub struct LineDiscipline {
+    /// Terminal attributes (`tcgetattr`/`tcsetattr`, `TCGETS`/`TCSETS`).
+    pub termios: Termios,
+    /// Terminal window size (`TIOCGWINSZ`/`TIOCSWINSZ`).
+    pub winsize: Winsize,
+    /// Bytes of the canonical line currently being edited (no terminator yet). Always empty in raw
+    /// mode.
+    pending: Vec<u8>,
+    /// Committed, readable segments in FIFO order.
+    ready: VecDeque<Segment>,
+    /// Whether the trailing `ready` segment is an open raw-mode run that new raw bytes may extend.
+    ///
+    /// Raw bytes coalesce only onto another raw run, never onto a committed canonical line or an
+    /// end-of-file marker. This keeps a canonical line one self-contained segment, so a canonical
+    /// read never crosses a line boundary even if `ICANON` is cleared and later restored while that
+    /// line is still queued unread.
+    raw_run_open: bool,
+}
+
+impl Default for LineDiscipline {
+    fn default() -> Self {
+        Self {
+            termios: Termios::console_default(),
+            winsize: Winsize::console_default(),
+            pending: Vec::new(),
+            ready: VecDeque::new(),
+            raw_run_open: false,
+        }
+    }
+}
+
+impl LineDiscipline {
+    /// Replaces the terminal attributes and applies line-discipline state transitions.
+    pub fn set_termios(&mut self, termios: Termios) {
+        let was_canonical: bool = self.canonical();
+        self.termios = termios;
+
+        if was_canonical && !self.canonical() && !self.pending.is_empty() {
+            self.commit_pending_line();
+        }
+    }
+
+    /// Returns `true` when canonical-mode line editing is enabled (`ICANON`).
+    fn canonical(&self) -> bool {
+        self.termios.c_lflag & termios::ICANON != 0
+    }
+
+    /// Returns `true` when input echo is enabled (`ECHO`).
+    fn echo_enabled(&self) -> bool {
+        self.termios.c_lflag & termios::ECHO != 0
+    }
+
+    /// Returns `true` when carriage returns are mapped to newlines on input (`ICRNL`).
+    fn map_cr_to_nl(&self) -> bool {
+        self.termios.c_iflag & termios::ICRNL != 0
+    }
+
+    /// Returns the control character at `index`, or `None` when it is disabled (`0`).
+    ///
+    /// POSIX disables a control character by setting its `c_cc` slot to `_POSIX_VDISABLE` (`0`); a
+    /// disabled character must never match an input byte, so it is reported as absent here.
+    fn control_char(&self, index: usize) -> Option<u8> {
+        match self.termios.c_cc[index] {
+            0 => None,
+            value => Some(value),
+        }
+    }
+
+    /// Feeds raw input bytes through the discipline and returns the bytes to echo.
+    ///
+    /// The returned vector is empty when `ECHO` is cleared. Cooked bytes produced here become
+    /// available to [`LineDiscipline::read`].
+    pub fn push_input(&mut self, input: &[u8]) -> Vec<u8> {
+        let mut echo: Vec<u8> = Vec::new();
+        let canonical: bool = self.canonical();
+        let echo_on: bool = self.echo_enabled();
+        let map_cr_to_nl: bool = self.map_cr_to_nl();
+        let erase: Option<u8> = self.control_char(termios::VERASE);
+        let kill: Option<u8> = self.control_char(termios::VKILL);
+        let eof: Option<u8> = self.control_char(termios::VEOF);
+
+        for &raw in input {
+            // Input translation: map carriage return to newline when ICRNL is set. The host
+            // terminal is in raw mode, so Enter arrives as a carriage return.
+            let byte: u8 = if map_cr_to_nl && raw == b'\r' {
+                b'\n'
+            } else {
+                raw
+            };
+
+            if !canonical {
+                // Raw mode: the byte becomes readable immediately and is echoed verbatim.
+                self.push_raw_byte(byte);
+                if echo_on {
+                    echo.push(byte);
+                }
+                continue;
+            }
+
+            // Canonical mode: assemble and edit the pending line.
+            if byte == b'\n' {
+                self.pending.push(b'\n');
+                self.commit_pending_line();
+                if echo_on {
+                    echo.extend_from_slice(b"\r\n");
+                }
+            } else if Some(byte) == erase {
+                if self.pending.pop().is_some() && echo_on {
+                    echo.extend_from_slice(b"\x08 \x08");
+                }
+            } else if Some(byte) == kill {
+                let erased: usize = self.pending.len();
+                self.pending.clear();
+                if echo_on {
+                    for _ in 0..erased {
+                        echo.extend_from_slice(b"\x08 \x08");
+                    }
+                }
+            } else if Some(byte) == eof {
+                // VEOF delivers the pending bytes immediately without a newline; on an empty line it
+                // is an end-of-file. It is never echoed.
+                if self.pending.is_empty() {
+                    self.ready.push_back(Segment::Eof);
+                    self.raw_run_open = false;
+                } else {
+                    self.commit_pending_line();
+                }
+            } else {
+                self.pending.push(byte);
+                if echo_on {
+                    echo.push(byte);
+                }
+            }
+        }
+
+        echo
+    }
+
+    /// Signals end-of-input from the raw console stream.
+    pub fn push_eof(&mut self) {
+        if !self.pending.is_empty() {
+            self.commit_pending_line();
+        }
+        self.ready.push_back(Segment::Eof);
+        self.raw_run_open = false;
+    }
+
+    /// Reads cooked bytes into `buf`, returning the outcome of the attempt.
+    ///
+    /// In canonical mode a read returns at most one line and never crosses a line boundary; a line
+    /// shorter than `buf` is returned whole, while a line longer than `buf` is returned in pieces
+    /// across successive reads. In raw mode as many buffered bytes as fit are returned. A read of a
+    /// zero-length buffer transfers nothing and never blocks.
+    pub fn read(&mut self, buf: &mut [u8]) -> ConsoleReadOutcome {
+        // A zero-length read transfers nothing and never blocks, even on empty input.
+        if buf.is_empty() {
+            return ConsoleReadOutcome::Read(0);
+        }
+
+        loop {
+            match self.ready.front_mut() {
+                // No cooked input is available.
+                None => return ConsoleReadOutcome::WouldBlock,
+                // An end-of-file marker: consume it and report EOF.
+                Some(Segment::Eof) => {
+                    self.ready.pop_front();
+                    return ConsoleReadOutcome::Eof;
+                },
+                Some(Segment::Data(data)) => {
+                    // A committed segment always holds at least one byte, so this guards an
+                    // invariant rather than a reachable state: were an empty segment ever queued,
+                    // skipping it prevents returning `Read(0)`, which a blocking reader would
+                    // misinterpret as end-of-file.
+                    if data.is_empty() {
+                        self.ready.pop_front();
+                        continue;
+                    }
+                    let n: usize = buf.len().min(data.len());
+                    // `n <= data.len()`, so the drain yields exactly `n` bytes in order.
+                    for (dst, src) in buf.iter_mut().zip(data.drain(..n)) {
+                        *dst = src;
+                    }
+                    if data.is_empty() {
+                        self.ready.pop_front();
+                    }
+                    return ConsoleReadOutcome::Read(n);
+                },
+            }
+        }
+    }
+
+    /// Commits the pending line to the cooked queue as a single readable segment.
+    fn commit_pending_line(&mut self) {
+        let line: VecDeque<u8> = ::core::mem::take(&mut self.pending).into();
+        self.ready.push_back(Segment::Data(line));
+        // A canonical line is a closed unit: a following raw byte must start its own segment rather
+        // than extend this line, or a canonical read could later cross the line boundary.
+        self.raw_run_open = false;
+    }
+
+    /// Appends a raw-mode byte, coalescing it into an open raw run when one is at the tail.
+    ///
+    /// Coalescing groups a burst of raw bytes into one segment so a single read can drain them
+    /// together; it never reorders bytes and never merges onto a committed canonical line or an
+    /// end-of-file marker (tracked by `raw_run_open`). A canonical line therefore stays one
+    /// self-contained segment, so a canonical read never crosses a line boundary even when `ICANON`
+    /// is cleared and later restored while that line is still queued unread.
+    fn push_raw_byte(&mut self, byte: u8) {
+        if self.raw_run_open {
+            if let Some(Segment::Data(data)) = self.ready.back_mut() {
+                data.push_back(byte);
+                return;
+            }
+        }
+        let mut data: VecDeque<u8> = VecDeque::new();
+        data.push_back(byte);
+        self.ready.push_back(Segment::Data(data));
+        self.raw_run_open = true;
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ::sysapi::termios::{
+        ECHO,
+        ICANON,
+    };
+
+    /// Reads all immediately-available bytes into a freshly allocated vector of length `max`.
+    fn read_bytes(ld: &mut LineDiscipline, max: usize) -> Vec<u8> {
+        let mut buf: Vec<u8> = ::alloc::vec![0u8; max];
+        match ld.read(&mut buf) {
+            ConsoleReadOutcome::Read(n) => {
+                buf.truncate(n);
+                buf
+            },
+            _ => Vec::new(),
+        }
+    }
+
+    /// Clears the given local-mode flags on the discipline's terminal attributes.
+    fn clear_lflag(ld: &mut LineDiscipline, flags: u32) {
+        ld.termios.c_lflag &= !flags;
+    }
+
+    /// Tests that a canonical line becomes readable, whole, only once Enter is pressed.
+    #[test]
+    fn canonical_line_assembly_on_enter() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        // Without a newline the line is incomplete and a read would block.
+        let echo: Vec<u8> = ld.push_input(b"hello");
+        assert_eq!(echo, b"hello", "ordinary bytes are echoed verbatim");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+        // The newline commits the line, which is then read back in full including the newline.
+        let echo: Vec<u8> = ld.push_input(b"\n");
+        assert_eq!(echo, b"\r\n", "a committed line echoes CR-LF");
+        assert_eq!(read_bytes(&mut ld, 16), b"hello\n");
+        // After the line is consumed there is nothing left to read.
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that echo is suppressed when the `ECHO` flag is cleared.
+    #[test]
+    fn echo_off_when_flag_cleared() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        clear_lflag(&mut ld, ECHO);
+        let echo: Vec<u8> = ld.push_input(b"abc\n");
+        assert!(echo.is_empty(), "no bytes are echoed when ECHO is cleared");
+        assert_eq!(read_bytes(&mut ld, 16), b"abc\n", "the line is still assembled and readable");
+    }
+
+    /// Tests that raw mode delivers bytes immediately and, by default here, without echo.
+    #[test]
+    fn raw_mode_delivers_immediately() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        clear_lflag(&mut ld, ICANON | ECHO);
+        // No newline is needed: the bytes are readable as soon as they arrive.
+        let echo: Vec<u8> = ld.push_input(b"ab");
+        assert!(echo.is_empty(), "ECHO is cleared, so nothing is echoed");
+        assert_eq!(read_bytes(&mut ld, 16), b"ab");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that raw mode echoes bytes verbatim when `ECHO` remains set.
+    #[test]
+    fn raw_mode_echoes_when_enabled() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        clear_lflag(&mut ld, ICANON);
+        let echo: Vec<u8> = ld.push_input(b"xy");
+        assert_eq!(echo, b"xy", "raw bytes are echoed verbatim when ECHO is set");
+        assert_eq!(read_bytes(&mut ld, 16), b"xy");
+    }
+
+    /// Tests that `^D` on an empty line yields a zero-length read (EOF).
+    #[test]
+    fn ctrl_d_on_empty_line_is_eof() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        let echo: Vec<u8> = ld.push_input(b"\x04");
+        assert!(echo.is_empty(), "VEOF is never echoed");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::Eof);
+        // The EOF marker is consumed: a subsequent read blocks rather than repeating EOF.
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that `^D` with pending bytes delivers them as a partial line without a newline.
+    #[test]
+    fn ctrl_d_with_data_delivers_partial_line() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.push_input(b"ab\x04");
+        assert_eq!(
+            read_bytes(&mut ld, 16),
+            b"ab",
+            "VEOF delivers the pending bytes without a newline"
+        );
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+        // A following lone ^D is then an end-of-file.
+        ld.push_input(b"\x04");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::Eof);
+    }
+
+    /// Tests that `VERASE` deletes the last pending byte before the line is committed.
+    #[test]
+    fn verase_deletes_last_byte() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        // DEL (0x7f) is the default VERASE.
+        let echo: Vec<u8> = ld.push_input(b"ab\x7fc\n");
+        assert_eq!(read_bytes(&mut ld, 16), b"ac\n", "the erased byte is dropped from the line");
+        // The erase echoes a destructive backspace; the surrounding bytes echo verbatim.
+        assert_eq!(echo, b"ab\x08 \x08c\r\n");
+    }
+
+    /// Tests that `VKILL` discards the entire pending line.
+    #[test]
+    fn vkill_discards_pending_line() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        // ^U (0x15) is the default VKILL.
+        ld.push_input(b"abc\x15xy\n");
+        assert_eq!(read_bytes(&mut ld, 16), b"xy\n", "everything before VKILL is discarded");
+    }
+
+    /// Tests that a carriage return terminates a canonical line when `ICRNL` is set.
+    #[test]
+    fn icrnl_maps_cr_to_nl() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        // The default attributes set ICRNL, so Enter (CR) terminates the line as a newline.
+        ld.push_input(b"hi\r");
+        assert_eq!(read_bytes(&mut ld, 16), b"hi\n", "CR is translated to NL and commits the line");
+    }
+
+    /// Tests that a zero-length read transfers nothing and never blocks.
+    #[test]
+    fn zero_length_read_returns_zero() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        assert_eq!(ld.read(&mut []), ConsoleReadOutcome::Read(0));
+    }
+
+    /// Tests that an empty console blocks (the `EAGAIN`/park decision point for the daemon).
+    #[test]
+    fn empty_console_would_block() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        assert_eq!(ld.read(&mut [0u8; 8]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that canonical reads return exactly one line at a time.
+    #[test]
+    fn canonical_returns_one_line_per_read() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.push_input(b"a\nbc\n");
+        assert_eq!(
+            read_bytes(&mut ld, 16),
+            b"a\n",
+            "the first read stops at the first line boundary"
+        );
+        assert_eq!(read_bytes(&mut ld, 16), b"bc\n", "the second read returns the next line");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that a line longer than the read buffer is returned across successive reads.
+    #[test]
+    fn canonical_line_split_across_reads() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.push_input(b"abcde\n");
+        assert_eq!(read_bytes(&mut ld, 3), b"abc", "only as much as fits is returned");
+        assert_eq!(read_bytes(&mut ld, 3), b"de\n", "the remainder of the same line follows");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that clearing `ICANON` switches subsequent input to immediate raw delivery.
+    #[test]
+    fn switching_to_raw_delivers_subsequent_bytes() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        clear_lflag(&mut ld, ICANON);
+        ld.push_input(b"z");
+        assert_eq!(read_bytes(&mut ld, 16), b"z", "raw input is readable without a newline");
+    }
+
+    /// Tests that pending canonical bytes are not stranded when `ICANON` is cleared.
+    #[test]
+    fn switching_to_raw_releases_pending_canonical_bytes() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.push_input(b"abc");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+
+        let mut termios: Termios = ld.termios;
+        termios.c_lflag &= !ICANON;
+        ld.set_termios(termios);
+
+        assert_eq!(read_bytes(&mut ld, 16), b"abc");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that raw stream EOF delivers pending canonical bytes before reporting EOF.
+    #[test]
+    fn raw_stream_eof_releases_pending_canonical_bytes() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.push_input(b"abc");
+        ld.push_eof();
+
+        assert_eq!(read_bytes(&mut ld, 16), b"abc");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::Eof);
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that raw bytes do not merge into an unread, already-committed canonical line.
+    ///
+    /// A committed line stays one self-contained segment, so after `ICANON` is cleared and later
+    /// restored a canonical read still returns the original line whole, never crossing its boundary
+    /// into the raw bytes that arrived in between.
+    #[test]
+    fn raw_bytes_do_not_extend_a_committed_canonical_line() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+
+        // A full canonical line is committed but left unread.
+        ld.push_input(b"abc\n");
+
+        // ICANON is cleared and raw bytes arrive while the line is still queued.
+        let mut termios: Termios = ld.termios;
+        termios.c_lflag &= !ICANON;
+        ld.set_termios(termios);
+        ld.push_input(b"xy");
+
+        // ICANON is restored before the queued line is drained.
+        let mut termios: Termios = ld.termios;
+        termios.c_lflag |= ICANON;
+        ld.set_termios(termios);
+
+        // The canonical read returns the original line whole, not "abc\nxy".
+        assert_eq!(
+            read_bytes(&mut ld, 16),
+            b"abc\n",
+            "a canonical read stops at the committed line boundary"
+        );
+        // The raw bytes that arrived in between remain their own readable segment.
+        assert_eq!(read_bytes(&mut ld, 16), b"xy", "the raw bytes are a separate segment");
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #2644 (`feature-libs-syscall`). This PR is based on
> `feature-libs-syscall`, so its diff is just the console line-discipline
> commit. Re-target to `dev` once #2644 merges.

Promote the vfsd console's terminal-attribute snapshot into a real line
discipline that cooks host input into the bytes a guest read observes,
honoring the termios flags. This makes the console behave like a TTY:
canonical line editing, echo, and special characters now work, while raw
mode (readline, editors, REPLs) gets immediate byte delivery.

### vfs — line discipline

- Add the `line_discipline` module. `LineDiscipline` owns the termios and
  winsize (moved off the old `TerminalState`) and the cooked-input buffers.
  `push_input()` cooks raw bytes and returns the bytes to echo; `read()`
  returns a `ConsoleReadOutcome` (`Read`/`WouldBlock`/`Eof`); `push_eof()`
  signals end of input.
- The two sides are decoupled by an internal queue of committed segments, so
  input that arrives before a reader is buffered and served later.
- Canonical mode (`ICANON`) assembles a line, honors `VERASE`/`VKILL`/`VEOF`
  and `ICRNL`, and commits a whole line on newline; raw mode delivers each
  byte immediately; `ECHO` emits verbatim bytes, backspace-space-backspace on
  erase, and CR-LF on commit. `set_termios()` flushes the pending line on a
  canonical→raw switch.
- Signals (`ISIG`), flow control (`IXON`/`IXOFF`), most input translation, and
  output post-processing are deliberately out of scope.

### vfs — fd.rs

- Back every console descriptor with a shared `Arc<Mutex<LineDiscipline>>`
  (replacing `TerminalState`), so one cooked input queue and one
  termios/winsize are shared across the standard streams and inherited across
  fork/dup.
- Add `vfs_console_stream()`, `vfs_console_read()`, `vfs_console_push_input()`,
  and `vfs_console_push_eof()`; route `vfs_tty_set_termios()` through the
  discipline's `set_termios()`.

### syscall

- Add `resolve_console()`/`ConsoleLookup` to classify a descriptor as a console
  owned by vfsd, a console served directly by the kernel (direct-ELF runs
  without vfsd), a non-console, or a bad fd.
- `read()` now sends stdin console reads to vfsd over the flat descriptor so the
  shared line discipline applies, falling back to the historical direct
  kernel-console path only when no vfsd is present.

### vfsd

- Add `handle_console_read()`. It serves already-cooked input without blocking;
  when none is available on a blocking descriptor it fetches a chunk of raw host
  input, feeds it through the line discipline, echoes any cooked-echo bytes, and
  repeats until a readable unit (line, raw byte, or EOF) is available, returning
  `EAGAIN` for `O_NONBLOCK`.
- The raw fetch (`kernel_read_stdin`/`kernel_write_console`) deliberately does
  not consume the kernel's `ReadResponse`/`WriteResponse` acknowledgement with a
  nested `__kcall_recv()` — that could dequeue an unrelated guest request from
  the shared mailbox — so the main event loop discards those acks instead.
- hostfs_handlers routes console-stream reads to this handler.

### nanvix-terminal

- Add `RawModeGuard`, which switches the host terminal to raw input mode for the
  guest's lifetime so the in-vfsd discipline is authoritative (clears
  `ICANON`/`ECHO`/`ISIG`/`IEXTEN`, input CR/NL translation, and flow control;
  leaves output post-processing such as `ONLCR` intact). It is a no-op unless
  host stdin is a TTY, so piped or redirected input (tests, scripts, HTTP mode)
  is forwarded verbatim, and the previous attributes are restored on drop
  (guest exit).

### tests

- Line-discipline unit tests for canonical line assembly on Enter, erase/kill/
  EOF editing, echo on/off, and raw-mode immediate delivery and echo.
- A vfs test that the cooked input queue is shared across the standard streams.

## Issues

Closes #2641
