### PR TITLE
[libs] Add nanvix_libc/nanvix_libm staticlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanvix_libc"
+version = "0.17.2"
+dependencies = [
+ "libc_assert",
+ "libc_ctype",
+ "libc_inttypes",
+ "libc_langinfo",
+ "libc_locale",
+ "libc_setjmp",
+ "libc_signal",
+ "libc_stdio",
+ "libc_stdlib",
+ "libc_string",
+ "libc_time",
+ "libc_wchar",
+ "libc_wctype",
+ "nvx",
+ "posix",
+ "sys",
+ "sysalloc",
+ "sysapi",
+ "syslog",
+]
+
+[[package]]
+name = "nanvix_libm"
+version = "0.17.2"
+dependencies = [
+ "libc_math",
+ "nvx",
+]
+
+[[package]]
 name = "nanvixd"
 version = "0.17.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ members = [
         "src/libs/libc_time",
         "src/libs/libc_wchar",
         "src/libs/libc_wctype",
+        "src/libs/nanvix_libc",
+        "src/libs/nanvix_libm",
         "src/libs/cache",
         "src/libs/cmdline",
         "src/libs/koptions",
@@ -246,6 +248,8 @@ libc_string = { path = "src/libs/libc_string", default-features = false }
 libc_time = { path = "src/libs/libc_time", default-features = false }
 libc_wchar = { path = "src/libs/libc_wchar", default-features = false }
 libc_wctype = { path = "src/libs/libc_wctype", default-features = false }
+nanvix_libc = { path = "src/libs/nanvix_libc", default-features = false }
+nanvix_libm = { path = "src/libs/nanvix_libm", default-features = false }
 mmio-tag = { path = "src/libs/mmio-tag", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,10 @@ MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 
 # File format for guest executables (always ELF regardless of host OS).
 export EXEC_FORMAT := elf
-# Libraries
+# Libraries. `libposix.a` is the standalone Nanvix syscall backend, shipped for
+# out-of-tree C consumers that link it alongside their own libc. The in-tree
+# `libc.a` bundle additionally embeds the same backend (see
+# build/make/nanvix-libc-artifacts.mk); the two are independent archives.
 export LIBPOSIX := $(LIBRARIES_DIR)/libposix.a
 export LIBNVX_CRT0 := $(LIBRARIES_DIR)/libnvx_crt0.a
 
@@ -199,6 +202,34 @@ export NANVIX_NODENAME ?= localhost
 
 # Name of the machine on which the system is running.
 export NANVIX_MACHINE := $(MACHINE)
+
+#===================================================================================================
+# C Toolchain Configuration
+#===================================================================================================
+
+# SCCACHE integration for the host C/C++ compilers (optional).
+# Wrap the host C/C++ compiler entrypoints exactly once so build-script
+# (cc-crate) compilation benefits from the cache without re-prefixing a value
+# that already includes it.
+ifneq ($(SCCACHE),)
+
+# This helper ensures every compiler entrypoint picks up sccache exactly once.
+define wrap_with_sccache
+$(strip $(if $(filter $(SCCACHE),$(firstword $1)),$1,$(SCCACHE) $1))
+endef
+
+# Only wrap compilers that were explicitly configured by the environment,
+# command line, or makefile.  GNU Make's built-in defaults (`cc` / `g++`) are
+# not reliable on Windows and would prevent Rust `cc` build scripts from
+# auto-detecting the platform compiler.
+ifneq ($(filter environment command line file override,$(origin CC)),)
+export CC := $(call wrap_with_sccache,$(CC))
+endif
+ifneq ($(filter environment command line file override,$(origin CXX)),)
+export CXX := $(call wrap_with_sccache,$(CXX))
+endif
+undefine wrap_with_sccache
+endif
 
 #===================================================================================================
 # Rust Toolchain Configuration
@@ -332,7 +363,21 @@ export VERUS_KERNEL_FEATURES := microvm trace
 # Top-Level Targets
 #===================================================================================================
 
-ALL_GUEST_STATIC_LIBS := posix nvx-crt0
+# `posix` is built as the standalone `libposix.a` artifact (the Nanvix syscall
+# backend) AND compiled into `libc.a` as a `nanvix_libc` dependency (via its
+# `backend-nanvix` feature). `libposix.a` is shipped for out-of-tree C consumers
+# that link it alongside their own libc; the in-tree `libc.a` bundle embeds the
+# same backend compiled in a single cargo invocation (one unified `sysalloc`).
+# The two are independent archives — no link consumes both. `posix` takes a
+# feature override (see generic-guest-staticlibs.mk) so its standalone
+# `libposix.a` is built on its own and does NOT pick up `nanvix_libc`'s
+# `init-array` via cargo feature unification (which would impose a `.init_array`
+# linker-script contract on those consumers).
+#
+# `nanvix_libm` produces the standalone math archive `libm.a` (libc_math + the
+# nvx panic handler, no sysalloc). Together with `libc.a` and `libnvx_crt0.a` it
+# forms the full crt0 + libc + libm replacement for the GCC + newlib toolchain.
+ALL_GUEST_STATIC_LIBS := posix nvx-crt0 nanvix_libc nanvix_libm
 ALL_GUEST_RUST_LIBS := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi \
@@ -493,6 +538,9 @@ ifneq ($(strip $(filter $(MACHINE),microvm)),)
 clean: clean-nanvix-bench
 endif
 
+# The bundled libc artifacts are always built; clean them too.
+clean: clean-nanvix-libc-bundle
+
 distclean: clean
 ifeq ($(IS_WINDOWS),yes)
 	$(FORCE_RM_CMD) "$(OBJECTS_DIR)"
@@ -532,6 +580,7 @@ endif
 endif
 	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
 	@cp ${LIBNVX_CRT0} ${SYSROOT_DIR}/lib/
+	@cp ${NANVIX_LIBC_BUNDLE_INSTALL_ARTIFACTS} ${SYSROOT_DIR}/lib/
 	@mkdir -p ${SYSROOT_DIR}/etc/scripts/common
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/common/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
@@ -936,6 +985,9 @@ STANDALONE_NO_VFS_BINARIES := vfs-bench-nostd
 
 # List of standalone test binaries that need multibinary images with daemons.
 # Each image bundles procd, memd, vfsd, and the test binary itself.
+# NOTE: ALL_POSIX_TESTS are intentionally NOT bundled here. The ported POSIX C
+# test suites build their own standalone images (with custom argv[0]/env) in
+# build/make/posix-tests.mk.
 STANDALONE_TEST_BINARIES := $(filter-out $(STANDALONE_NO_DAEMON_TESTS) $(STANDALONE_NO_VFS_BINARIES) $(STANDALONE_RAMFS_ONLY_BINARIES),$(ALL_GUEST_TESTS)) $(filter-out $(STANDALONE_NO_VFS_BINARIES),$(ALL_GUEST_BENCHMARKS)) $(ALL_GUEST_APPLICATIONS)
 
 .PHONY: standalone-images standalone-images-clean
@@ -1132,6 +1184,12 @@ include build/make/snapshot.mk
 #===================================================================================================
 
 include build/make/generic-guest-staticlibs.mk
+
+#===================================================================================================
+# Build Rules for Bundled Nanvix C Library Artifacts (libc.a / libc.so)
+#===================================================================================================
+
+include build/make/nanvix-libc-artifacts.mk
 
 #===================================================================================================
 # Build Rules for Guest Rust Libraries

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -37,8 +37,46 @@ GUEST_STATICLIB_CARGO_FEATURES := $(if $(GUEST_STATICLIB_FEATURES),--features "$
 # `sysalloc` in transitively.  Cargo unifies all of these into a single
 # compilation per binary, so they do not consume the sysroot copy and
 # do not hit the duplicate-`sysalloc` scenario.
-GUEST_STATICLIB_FEATURES_nvx-crt0 := c-main forwarding-allocator $(LOG_LEVEL)
+# The `init-array` feature switches the `c-main` trampoline from the legacy
+# `_init` / `_fini` hooks to relying on `posix/init-array`
+# (`__nanvix_libc_start_main` walking `.init_array` / `.fini_array`).  Both
+# halves are enabled together for the bundle: `crt0.o` here and `libc.a` via
+# `nanvix_libc`'s `posix` dependency.
+GUEST_STATICLIB_FEATURES_nvx-crt0 := c-main forwarding-allocator init-array $(LOG_LEVEL)
 GUEST_STATICLIB_FEATURES_nvx-crt0 := $(strip $(GUEST_STATICLIB_FEATURES_nvx-crt0))
+
+# nanvix_libc is the C library aggregator that produces the deliverable libc.a.
+# It now ALSO pulls the POSIX syscall backend (`posix`) in via its
+# `backend-nanvix` feature, so a SINGLE `cargo build -p nanvix_libc` compiles the
+# complete C library + backend together. Cargo unifies every shared transitive
+# dependency (sysalloc, libc_stdlib, sys, nvx, syslog) to ONE instance, which
+# structurally prevents the duplicate-`sysalloc`/duplicate-`HEAP` bug the old
+# separate-build + `ar`-merge produced. It therefore takes the DEFAULT feature
+# set ($(LOG_LEVEL) [+ standalone]); its `standalone` feature forwards to
+# `posix/standalone`.
+#
+# (No `GUEST_STATICLIB_FEATURES_nanvix_libc` override: it must use the default
+# bundle so `standalone` reaches the embedded `posix` backend.)
+
+# nanvix_libm produces libm.a (libc_math + the nvx panic handler). It has no
+# standalone-specific behaviour and pulls no syscall backend, so it takes ONLY
+# the log level (never the `standalone` feature, which it does not define).
+GUEST_STATICLIB_FEATURES_nanvix_libm := $(LOG_LEVEL)
+GUEST_STATICLIB_FEATURES_nanvix_libm := $(strip $(GUEST_STATICLIB_FEATURES_nanvix_libm))
+
+# posix is the standalone Nanvix syscall backend (libposix.a), shipped for
+# out-of-tree C consumers that link it alongside their own libc. It takes an
+# EXPLICIT feature override — identical to the default `$(LOG_LEVEL) [+ standalone]`
+# set, and KEEPING posix's defaults (`syscall allocator c-main`; no
+# `--no-default-features`) — for ONE reason: to force posix into the per-package
+# build group so its `libposix.a` is compiled on its OWN, separately from
+# `nanvix_libc`. `nanvix_libc` depends on `posix` with `init-array`; a combined
+# `cargo build -p posix -p nanvix_libc` would unify features and bake
+# `init-array` into `libposix.a`, imposing a `.preinit/.init/.fini_array`
+# linker-script contract on those out-of-tree consumers. Building posix alone
+# keeps `libposix.a` on the legacy `_init`/`_fini` contract, exactly as before.
+GUEST_STATICLIB_FEATURES_posix := $(GUEST_STATICLIB_FEATURES)
+GUEST_STATICLIB_FEATURES_posix := $(strip $(GUEST_STATICLIB_FEATURES_posix))
 
 # Returns the cargo `--features "..."` arg for the given package, falling
 # back to the default $(GUEST_STATICLIB_CARGO_FEATURES) when no override is
@@ -49,6 +87,14 @@ GUEST_STATICLIB_PKG_FEATURES = $(if $(GUEST_STATICLIB_FEATURES_$(1)),--features 
 # `nvx-crt0` -> `libnvx_crt0.a`). This helper normalises the package name
 # for `cp` / `rm` paths against the cargo target dir.
 guest_staticlib_artifact = lib$(subst -,_,$(1)).a
+
+# Destination (staged) name in LIBRARIES_DIR. Defaults to the cargo output name,
+# EXCEPT the two aggregator staticlibs are staged under their conventional `-l`
+# names: `nanvix_libc` -> `libc.a` (embeds the POSIX backend) and `nanvix_libm`
+# -> `libm.a` (the math archive). There is no separate `libnanvix_libc.a` or
+# `libnanvix_libm.a`; `posix` still produces the standalone `libposix.a` for
+# out-of-tree consumers that link it with their own libc.
+guest_staticlib_staged = $(if $(filter nanvix_libc,$(1)),libc.a,$(if $(filter nanvix_libm,$(1)),libm.a,$(call guest_staticlib_artifact,$(1))))
 
 # Per-package crate-type override. Some packages keep `crate-type = ["lib"]`
 # only in `Cargo.toml` (so they can be used as a normal cargo dep without
@@ -68,7 +114,7 @@ GUEST_STATICLIB_CARGO_BUILD = $(if $(GUEST_STATICLIB_CRATE_TYPE_$(1)),$(subst ca
 define GUEST_STATICLIB_RULES
 all-guest-staticlib-$(1): init
 	$(call GUEST_STATICLIB_CARGO_BUILD,$(1)) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1))
-	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(call guest_staticlib_artifact,$(1)) $(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1))
+	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(call guest_staticlib_artifact,$(1)) $(LIBRARIES_DIR)/$(call guest_staticlib_staged,$(1))
 
 check-guest-staticlib-$(1):
 	@$(GUEST_CARGO_CHECK_CMD) -p $(1)
@@ -82,7 +128,7 @@ format-check-guest-staticlib-$(1):
 
 clean-guest-staticlib-$(1):
 	$(GUEST_CARGO_CLEAN_CMD) -p $(1)
-	$(RM_CMD) $(LIBRARIES_DIR)/$(call guest_staticlib_artifact,$(1))
+	$(RM_CMD) $(LIBRARIES_DIR)/$(call guest_staticlib_staged,$(1))
 
 rust-lint-guest-staticlib-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_STATICLIB_PKG_FEATURES,$(1)) --fix --allow-dirty --allow-no-vcs
@@ -124,7 +170,13 @@ all-guest-staticlibs: init
 	$(if $(_GUEST_STATICLIB_PKGS_DEFAULT),$(GUEST_CARGO_BUILD_CMD) $(_GUEST_STATICLIB_PKGS_DEFAULT) $(GUEST_STATICLIB_CARGO_FEATURES))
 	$(foreach pkg,$(_GUEST_STATICLIB_PKGS_OVERRIDE),$(call _OVERRIDE_BUILD_CMD,$(pkg)) &&) true
 	@for pkg in $(ALL_GUEST_STATIC_LIBS); do \
-		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$$(echo $$pkg | sed 's/-/_/g').a $(LIBRARIES_DIR)/lib$$(echo $$pkg | sed 's/-/_/g').a; \
+		src=lib$$(echo $$pkg | sed 's/-/_/g').a; \
+		case "$$pkg" in \
+			nanvix_libc) dst=libc.a;; \
+			nanvix_libm) dst=libm.a;; \
+			*) dst=$$src;; \
+		esac; \
+		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$$src $(LIBRARIES_DIR)/$$dst; \
 	done
 
 check-guest-staticlibs:

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -13,13 +13,22 @@ all-kernel: init
 ifeq ($(PROFILER),yes)
 	# Strip .debug_* but keep .symtab for guest profiler symbol resolution.
 	# See src/uservm/src/guest_profiler/README.md for setup prerequisites.
+	#
+	# Stripping is an optional size optimization (the profiler only needs
+	# .symtab, which is preserved regardless). Each strip tool is therefore
+	# invoked as part of the `if` condition so that a tool which is present but
+	# non-functional — e.g. `rust-objcopy` installed via cargo-binutils while the
+	# `llvm-tools` rustup component (the actual `llvm-objcopy`) is missing — falls
+	# through to the next candidate or the warning instead of failing the build.
 	$(CP_CMD) $(BINARIES_DIR)/kernel.elf $(BINARIES_DIR)/kernel.elf.debug
-	@if command -v rust-objcopy >/dev/null 2>&1; then \
-		rust-objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf"; \
-	elif command -v objcopy >/dev/null 2>&1; then \
-		objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf"; \
+	@if command -v rust-objcopy >/dev/null 2>&1 && rust-objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf" 2>/dev/null; then \
+		: ; \
+	elif command -v llvm-objcopy >/dev/null 2>&1 && llvm-objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf" 2>/dev/null; then \
+		: ; \
+	elif command -v objcopy >/dev/null 2>&1 && objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf" 2>/dev/null; then \
+		: ; \
 	else \
-		echo "WARNING: objcopy not found, kernel.elf retains debug sections (~1.4 MB extra)"; \
+		echo "WARNING: could not strip debug sections (no working objcopy); kernel.elf retains debug sections (~1.4 MB extra)"; \
 	fi
 endif
 

--- a/build/make/nanvix-libc-artifacts.mk
+++ b/build/make/nanvix-libc-artifacts.mk
@@ -1,0 +1,227 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===================================================================================================
+# Bundled Nanvix C Library Artifacts: libc.a, libm.a, libc.so, crt0.o, stub archives
+#===================================================================================================
+#
+# This fragment stages the complete newlib-free runtime surface the patched
+# gcc/clang toolchains link by default:
+#
+#   - libc.a   : static archive  (libc_* objects + syscall backend + runtime)
+#   - libm.a   : static archive  (the nanvix_libm math archive)
+#   - libc.so  : shared object   (the same exported symbol surface, for dlopen)
+#   - crt0.o   : startup object  (nvx-crt0 entry; crt1.o / Scrt1.o aliases)
+#   - libdl.a libpthread.a librt.a : empty stub archives so legacy `-ldl` /
+#                `-lpthread` / `-lrt` resolve with no spec drop-list
+#
+# libc.a embeds the Nanvix system-call backend (the same backend is also
+# shipped standalone as `libposix.a`, carrying `write`, `read`, `open`,
+# `__nanvix_libc_start_main`, and the typed kernel-call wrappers), while libm.a
+# carries the math routines. The startfile `crt0.o` provides `_do_start`
+# unconditionally, and the empty stub archives satisfy ports that still pass
+# `-ldl` / `-lpthread` / `-lrt`.
+#
+# Binutils: the bundle uses host `ld`/`ar`/`ranlib`. The shared object is linked
+# with the target's ELF emulation ($(NANVIX_LIBC_ELF_EMULATION)) and `-z notext`
+# because the libc objects are built with the target's
+# `relocation-model = static`; the resulting text relocations are exactly the
+# relocation types the Nanvix dynamic loader already handles for the dlfcn test
+# fixtures (libmul.so). `-z muldefs` on the libc.so link tolerates the Rust
+# allocator-shim duplicates (`__rust_alloc`, ...) that remain until the deeper
+# allocator work lands; the panic handler is already weak and
+# `__errno_location` already has a single owner.
+
+# Host binutils used to assemble the bundle (overridable).
+#
+# Windows has no GNU binutils. Rather than assume a separate LLVM install (the
+# benchmark runners have none), the bundle sources its binutils from the SAME
+# Rust toolchain that already links the guest (rust-lld, per
+# build/targets/$(TARGET)-user.json): the base toolchain ships the flavor-locked
+# `gcc-ld/ld.lld`, and the `llvm-tools` rustup component (declared in
+# rust-toolchain, so rustup auto-installs it) adds `llvm-ar`/`llvm-objcopy` under
+# `lib/rustlib/<host>/bin`. These accept the same flags this bundle uses
+# (-shared/-r/-m<emulation>, --whole-archive, -z notext/muldefs,
+# --localize-symbol). A standalone `C:/Program Files/LLVM` install and bare PATH
+# lookups remain as fallbacks.
+ifeq ($(IS_WINDOWS),yes)
+# Active Rust toolchain binutils directory: <sysroot>/lib/rustlib/<host>/bin.
+# Evaluated from the repo root so the rust-toolchain override (channel + the
+# auto-installed llvm-tools component) is in effect. `rustc --print sysroot`
+# emits a native (backslash) path, so normalize it to forward slashes.
+NANVIX_RUST_SYSROOT := $(subst \,/,$(shell "$(RUSTC)" --print sysroot 2>/dev/null))
+NANVIX_RUST_HOST    := $(shell "$(RUSTC)" -vV 2>/dev/null | sed -n 's/^host: //p')
+NANVIX_RUST_TC_BIN  := $(NANVIX_RUST_SYSROOT)/lib/rustlib/$(NANVIX_RUST_HOST)/bin
+# Legacy fallback: a standalone LLVM install (e.g. developer machines).
+NANVIX_DEFAULT_LLVM_BIN := $(shell if [ -d "C:/Program Files/LLVM/bin" ]; then printf '%s' "C:/Program Files/LLVM/bin"; fi)
+# `gcc-ld/ld.lld` ships with the base toolchain (no component needed), so its
+# presence is a reliable signal that the toolchain bin resolved correctly.
+ifneq ($(wildcard $(NANVIX_RUST_TC_BIN)/gcc-ld/ld.lld.exe),)
+NANVIX_LIBC_LD      ?= "$(NANVIX_RUST_TC_BIN)/gcc-ld/ld.lld.exe"
+NANVIX_LIBC_AR      ?= "$(NANVIX_RUST_TC_BIN)/llvm-ar.exe"
+NANVIX_LIBC_RANLIB  ?= "$(NANVIX_RUST_TC_BIN)/llvm-ar.exe"
+NANVIX_LIBC_OBJCOPY ?= "$(NANVIX_RUST_TC_BIN)/llvm-objcopy.exe"
+else ifneq ($(NANVIX_DEFAULT_LLVM_BIN),)
+NANVIX_LIBC_LD      ?= "$(NANVIX_DEFAULT_LLVM_BIN)/ld.lld.exe"
+NANVIX_LIBC_AR      ?= "$(NANVIX_DEFAULT_LLVM_BIN)/llvm-ar.exe"
+NANVIX_LIBC_RANLIB  ?= "$(NANVIX_DEFAULT_LLVM_BIN)/llvm-ranlib.exe"
+NANVIX_LIBC_OBJCOPY ?= "$(NANVIX_DEFAULT_LLVM_BIN)/llvm-objcopy.exe"
+else
+NANVIX_LIBC_LD      ?= ld.lld
+NANVIX_LIBC_AR      ?= llvm-ar
+NANVIX_LIBC_RANLIB  ?= llvm-ranlib
+NANVIX_LIBC_OBJCOPY ?= llvm-objcopy
+endif
+else
+NANVIX_LIBC_LD      ?= ld
+NANVIX_LIBC_AR      ?= ar
+NANVIX_LIBC_RANLIB  ?= ranlib
+NANVIX_LIBC_OBJCOPY ?= objcopy
+endif
+
+# ELF output emulation for the host linker, derived from the guest $(TARGET) so
+# the relocatable crt0.o and the libc.so link match the architecture of the
+# cargo-built objects (mirroring the `gnu-lld` `-melf_*` arg in
+# build/targets/$(TARGET)-user.json). Linking with the wrong emulation fails
+# with an architecture-mismatch error (notably folding the 64-bit libnvx_crt0.a
+# with elf_i386 on an x86_64 build).
+ifeq ($(TARGET),x86_64)
+NANVIX_LIBC_ELF_EMULATION := elf_x86_64
+else
+NANVIX_LIBC_ELF_EMULATION := elf_i386
+endif
+
+# Outputs. `libc.a` is now produced DIRECTLY by `all-guest-staticlibs`: a single
+# `cargo build -p nanvix_libc` compiles the C library together with the POSIX
+# syscall backend (pulled in via nanvix_libc's `backend-nanvix` feature →
+# `dep:posix`), so the staticlib already embeds `open`/`read`/`write`/
+# `__nanvix_libc_start_main` and a SINGLE unified `sysalloc`/`libc_stdlib`/`sys`/
+# `nvx`. It is staged straight under its conventional `-lc` name (`libc.a`) — no
+# `ar` merge and no separate `libnanvix_libc.a`. The standalone `libposix.a`
+# remains a separate out-of-tree-consumer artifact. The old two-archive libc
+# merge embedded DUPLICATE instances of those crates (each `sysalloc` with its
+# own `HEAP` static): exactly the duplicate-HEAP regression this restructure
+# structurally eliminates.
+NANVIX_LIBC_BUNDLE_AR := $(LIBRARIES_DIR)/libc.a
+NANVIX_LIBC_BUNDLE_SO := $(LIBRARIES_DIR)/libc.so
+# Standalone math archive (the `nanvix_libm` crate: libc_math + nvx panic
+# handler, no sysalloc). Staged directly by all-guest-staticlibs, exactly like
+# libc.a. Shipped alongside libc.a + libnvx_crt0.a as the newlib libc+libm
+# replacement.
+NANVIX_LIBM_BUNDLE_AR := $(LIBRARIES_DIR)/libm.a
+
+# Startup object (the `nvx-crt0` entry: `_do_start` / `_start` / `__nanvix_main`).
+#
+# Emitted as a single relocatable object. A startfile object is linked
+# UNCONDITIONALLY by the native gcc/clang specs and guarantees `_do_start` is
+# present — unlike an archive member, which is only pulled if a prior reference
+# is undefined. `crt1.o` /
+# `Scrt1.o` are glibc-style symlink aliases so build systems expecting those
+# names resolve. The existing `libnvx_crt0.a` archive remains for the Rust
+# no_std (cargo-lib) path.
+#
+# NOTE: the object is produced with `ld -r --whole-archive libnvx_crt0.a`, NOT
+# the literal relibc `cargo rustc -- --emit obj` recipe. `--emit obj` emits only
+# the `nvx-crt0` crate's own object, which leaves an UNDEFINED, crate-hashed
+# reference to `nvx::pie::relocate_pie_binary` (nvx-crt0 links `nvx` with
+# `default-features = false`; `libc.a` links it with `runtime`, so the v0-mangled
+# hashes differ and the symbol never resolves at the native link). Folding the
+# whole `libnvx_crt0.a` archive into one relocatable object makes `crt0.o`
+# self-contained: it then references only STABLE C-ABI symbols
+# (`__nanvix_libc_start_main`, the `__nanvix_rust_*` allocator bridges, `main`,
+# `memcpy`, ...) that `libc.a` provides. This guarantees a single startfile that
+# provides `_do_start`, and avoids the residual risk of the `--emit obj` path
+# leaving an unresolved crate-hashed reference.
+NANVIX_CRT0_ARCHIVE := $(LIBRARIES_DIR)/libnvx_crt0.a
+NANVIX_CRT0_OBJECT := $(LIBRARIES_DIR)/crt0.o
+NANVIX_CRT0_ALIAS_NAMES := crt1.o Scrt1.o
+NANVIX_CRT0_ALIAS_OBJECTS := $(foreach alias,$(NANVIX_CRT0_ALIAS_NAMES),$(LIBRARIES_DIR)/$(alias))
+
+# Empty stub archives so ports that still pass `-ldl` / `-lpthread` / `-lrt`
+# resolve with NO spec drop-list — every real symbol already lives in `libc.a`
+# (the relibc approach). `-lm` resolves to the real `libm.a` above, and `-lposix`
+# to the real `libposix.a` (the standalone Nanvix syscall backend, built by
+# `all-guest-staticlibs` and shipped for out-of-tree C consumers).
+NANVIX_LIBC_STUB_ARCHIVES := \
+	$(LIBRARIES_DIR)/libdl.a \
+	$(LIBRARIES_DIR)/libpthread.a \
+	$(LIBRARIES_DIR)/librt.a
+
+# Artifacts that must be installed into the sysroot/release lib directory for
+# native C/C++ toolchains: the libc/libm archives, shared libc surface,
+# startfile objects/aliases, and compatibility stub archives.
+NANVIX_LIBC_BUNDLE_INSTALL_ARTIFACTS := \
+	$(NANVIX_LIBC_BUNDLE_AR) \
+	$(NANVIX_LIBM_BUNDLE_AR) \
+	$(NANVIX_LIBC_BUNDLE_SO) \
+	$(NANVIX_CRT0_OBJECT) \
+	$(NANVIX_CRT0_ALIAS_OBJECTS) \
+	$(NANVIX_LIBC_STUB_ARCHIVES)
+
+.PHONY: nanvix-libc-bundle clean-nanvix-libc-bundle
+
+# Bridge: libc.a / libm.a / libnvx_crt0.a are created (with preserved mtimes) by
+# the phony all-guest-staticlibs target. These empty-recipe rules let the
+# libc.so / crt0.o targets and external dependents key off their mtimes for
+# incremental rebuilds, mirroring the guest-ELF bridge rule
+# (`$(BINARIES_DIR)/%.elf: all-guest-binaries ;`).
+$(NANVIX_LIBC_BUNDLE_AR): all-guest-staticlibs ;
+$(NANVIX_LIBM_BUNDLE_AR): all-guest-staticlibs ;
+$(NANVIX_CRT0_ARCHIVE): all-guest-staticlibs ;
+
+# libc.so: shared object (same exported surface, for dlopen), linked from libc.a.
+$(NANVIX_LIBC_BUNDLE_SO): $(NANVIX_LIBC_BUNDLE_AR)
+	@echo "[nanvix-libc] linking libc.so (shared)"
+	$(NANVIX_LIBC_LD) -shared -m $(NANVIX_LIBC_ELF_EMULATION) -z notext -z muldefs \
+		--whole-archive $(NANVIX_LIBC_BUNDLE_AR) --no-whole-archive \
+		-o $@
+
+# crt0.o: single relocatable startup object folded from libnvx_crt0.a (see the
+# NOTE above). The crt1.o / Scrt1.o aliases are regular object copies so the
+# sysroot/release bundle does not depend on symlink support.
+#
+# After folding, the Rust global-allocator shim symbols (`__rust_alloc`,
+# `__rust_dealloc`, `__rust_realloc`, `__rust_alloc_zeroed`,
+# `__rust_alloc_error_handler`) are demoted to LOCAL. `nvx-crt0` only carries a
+# *forwarding* `#[global_allocator]` (built with the `forwarding-allocator`
+# feature) — it has no allocation sites of its own and exists solely to satisfy
+# rustc's requirement that every `alloc`-linking staticlib declare a global
+# allocator (see nvx-crt0/src/lib.rs). The real allocator lives in `libc.a`'s
+# `sysalloc`, which exports the SAME shim symbols. As an ARCHIVE member the
+# forwarding shim is harmless (the linker skips it once `libc.a` satisfies the
+# reference), but `ld -r --whole-archive` folds it into `crt0.o` as an
+# UNCONDITIONAL global definition, so a default (no `-z muldefs`) static link of
+# `crt0.o + libc.a` fails with "multiple definition of `__rust_alloc'". Demoting
+# crt0's dead copies to local keeps `libc.a` the single owner and realizes the
+# "crt0 carries no #[global_allocator]" invariant — without a `-z muldefs`
+# reliance.
+$(NANVIX_CRT0_OBJECT): $(NANVIX_CRT0_ARCHIVE)
+	@echo "[nanvix-libc] emitting crt0.o (nvx-crt0 startup object)"
+	$(NANVIX_LIBC_LD) -r -m $(NANVIX_LIBC_ELF_EMULATION) \
+		--whole-archive $(NANVIX_CRT0_ARCHIVE) --no-whole-archive \
+		-o $@
+	$(NANVIX_LIBC_OBJCOPY) --wildcard \
+		-L '*__rust_alloc*' -L '*__rust_dealloc*' -L '*__rust_realloc*' \
+		$@
+	@for alias in $(NANVIX_CRT0_ALIAS_NAMES); do \
+		$(CP_CMD) $(NANVIX_CRT0_OBJECT) $(LIBRARIES_DIR)/$$alias; \
+	done
+
+# Empty -ldl/-lpthread/-lrt stub archives. `ar -rcs` on no members produces a
+# valid empty archive with an (empty) symbol index.
+$(NANVIX_LIBC_STUB_ARCHIVES):
+	@echo "[nanvix-libc] creating empty stub archive $(@F)"
+	$(NANVIX_LIBC_AR) -rcs $@
+
+# Convenience alias to build all artifacts (libc.a + libm.a + libc.so + crt0.o
+# [+ aliases] + the empty -ldl/-lpthread/-lrt stub archives).
+nanvix-libc-bundle: $(NANVIX_LIBC_BUNDLE_AR) $(NANVIX_LIBM_BUNDLE_AR) \
+	$(NANVIX_LIBC_BUNDLE_SO) $(NANVIX_CRT0_OBJECT) $(NANVIX_LIBC_STUB_ARCHIVES)
+
+clean-nanvix-libc-bundle:
+	$(RM_CMD) $(NANVIX_LIBC_BUNDLE_AR) $(NANVIX_LIBM_BUNDLE_AR) $(NANVIX_LIBC_BUNDLE_SO)
+	$(RM_CMD) $(NANVIX_CRT0_OBJECT) $(NANVIX_LIBC_STUB_ARCHIVES)
+	$(RM_CMD) $(NANVIX_CRT0_ALIAS_OBJECTS)
+
+# Produce the bundle as part of a full build.
+all-nanvix: nanvix-libc-bundle

--- a/build/targets/x86-user.json
+++ b/build/targets/x86-user.json
@@ -15,7 +15,9 @@
 		"gnu-lld": [
 			"-nostdlib",
 			"--entry=_do_start",
-			"-melf_i386"
+			"-melf_i386",
+			"-z",
+			"norelro"
 		]
 	},
 	"executables": true,

--- a/build/targets/x86_64-user.json
+++ b/build/targets/x86_64-user.json
@@ -17,7 +17,9 @@
 		"gnu-lld": [
 			"-nostdlib",
 			"--entry=_do_start",
-			"-melf_x86_64"
+			"-melf_x86_64",
+			"-z",
+			"norelro"
 		]
 	},
 	"executables": true,

--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -51,6 +51,40 @@ SECTIONS
 		KEEP(*crtend*.o(.dtors))
 	}
 
+	/*
+	 * Constructor / destructor arrays (the primary ctor/dtor mechanism).
+	 *
+	 * `__nanvix_libc_start_main` (libposix start.rs) walks `.preinit_array`
+	 * then `.init_array` before calling `main`, and `.fini_array` (in reverse)
+	 * after `main` returns.  The bound symbols below are provided HERE — not by
+	 * GCC crtbegin/crtend — because Nanvix ships no crti/crtn/crtbegin/crtend.
+	 * These sections hold relocated function pointers, so they must live in the
+	 * writable LOAD segment (with .data/.ctors/.dtors) where the PIE relocator
+	 * fixes them up.
+	 */
+	.preinit_array : ALIGN(4)
+	{
+		PROVIDE_HIDDEN(__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN(__preinit_array_end = .);
+	}
+
+	.init_array : ALIGN(4)
+	{
+		PROVIDE_HIDDEN(__init_array_start = .);
+		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN(__init_array_end = .);
+	}
+
+	.fini_array : ALIGN(4)
+	{
+		PROVIDE_HIDDEN(__fini_array_start = .);
+		KEEP(*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN(__fini_array_end = .);
+	}
+
 	/* Uninitialized data section. */
 	.bss :
 	{

--- a/build/user/linker/x86_64/user.ld
+++ b/build/user/linker/x86_64/user.ld
@@ -33,6 +33,39 @@ SECTIONS
 		*(.data*)
 	}
 
+	/*
+	 * Constructor / destructor arrays (the primary ctor/dtor mechanism).
+	 *
+	 * `__nanvix_libc_start_main` (libposix start.rs) walks `.preinit_array`
+	 * then `.init_array` before calling `main`, and `.fini_array` (in reverse)
+	 * after `main` returns.  The bound symbols below are provided HERE — not by
+	 * GCC crtbegin/crtend — because Nanvix ships no crti/crtn/crtbegin/crtend.
+	 * These sections hold relocated function pointers, so they must live in the
+	 * writable LOAD segment (with .data) where the PIE relocator fixes them up.
+	 */
+	.preinit_array : ALIGN(8)
+	{
+		PROVIDE_HIDDEN(__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN(__preinit_array_end = .);
+	}
+
+	.init_array : ALIGN(8)
+	{
+		PROVIDE_HIDDEN(__init_array_start = .);
+		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN(__init_array_end = .);
+	}
+
+	.fini_array : ALIGN(8)
+	{
+		PROVIDE_HIDDEN(__fini_array_start = .);
+		KEEP(*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN(__fini_array_end = .);
+	}
+
 	/* Uninitialized data section. */
 	.bss :
 	{

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -2,4 +2,5 @@
 channel = "nightly-2026-05-21"
 components = [
     "rust-src",
+    "llvm-tools",
 ]

--- a/src/libs/nanvix_libc/Cargo.toml
+++ b/src/libs/nanvix_libc/Cargo.toml
@@ -1,0 +1,89 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nanvix_libc"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Nanvix C Standard Library (combined staticlib)"
+homepage.workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+libc_assert = { workspace = true }
+libc_ctype = { workspace = true }
+libc_inttypes = { workspace = true }
+libc_langinfo = { workspace = true }
+libc_locale = { workspace = true }
+# NOTE: the math routines (`libc_math`) are deliberately NOT pulled in here — they
+# are shipped as the separate `libm.a` archive (the `nanvix_libm` crate), mirroring
+# the GCC + newlib split of `libc.a` / `libm.a`. `libc.a` references no math
+# symbols, so the two archives are independent.
+libc_setjmp = { workspace = true }
+libc_signal = { workspace = true }
+libc_stdio = { workspace = true }
+libc_stdlib = { workspace = true }
+libc_string = { workspace = true }
+libc_time = { workspace = true }
+libc_wchar = { workspace = true }
+libc_wctype = { workspace = true }
+# Backend runtime providers: the `#[panic_handler]` (nvx), the
+# `#[global_allocator]` (sysalloc), and the POSIX system-call backend (posix:
+# `open`/`read`/`write`/`__nanvix_libc_start_main` + the in-memory VFS). All are
+# gated behind the `backend-nanvix` feature so a consumer that supplies its own
+# backend can build with `--no-default-features`.
+#
+# `posix` is pulled in HERE (rather than merged as a separate `libposix.a` via
+# `ar`) so the entire C library + backend is compiled in ONE cargo invocation.
+# Cargo then unifies every shared transitive dependency (sysalloc, libc_stdlib,
+# sys, nvx, syslog) to a SINGLE instance each, which structurally prevents the
+# duplicate-`sysalloc`/duplicate-`HEAP` class of bugs that the previous
+# two-staticlib merge produced (crt0 initialised one `HEAP`, the global
+# allocator read another).
+nvx = { workspace = true, optional = true, features = ["weak-panic"] }
+sysalloc = { workspace = true, optional = true }
+posix = { workspace = true, optional = true, features = [
+    "syscall",
+    "allocator",
+    "c-main",
+    "init-array",
+] }
+sysapi = { workspace = true }
+syslog = { workspace = true, default-features = true }
+sys = { workspace = true }
+
+[features]
+default = ["staticlib", "backend-nanvix"]
+staticlib = []
+std = []
+
+# Default Nanvix runtime backend: pulls in the `#[panic_handler]` (nvx), the
+# `#[global_allocator]` (sysalloc), and the POSIX syscall backend (posix) so the
+# produced static archive is a complete, self-contained libc.a.
+backend-nanvix = ["dep:nvx", "dep:sysalloc", "dep:posix"]
+# Host/custom backend: the final link must supply panic + allocator + crt0.
+# Building a staticlib with this and without `backend-nanvix` requires the
+# consumer to provide the runtime trio at link time.
+backend-host = []
+
+# Standalone deployment: routes stdout/stderr to the debug kcall and file I/O to
+# the in-memory VFS. Forwarded to the `posix` backend (the libc functions
+# themselves have no standalone-specific behaviour).
+standalone = ["posix?/standalone"]
+
+# Logging — forwarded to the `posix` backend so the shared `syslog` (used by both
+# `posix` and `sysalloc` in the now-unified dependency graph) is compiled at the
+# same level it had under the previous separate `libposix.a` build.
+trace = ["posix?/trace"]
+debug = ["posix?/debug"]
+info = ["posix?/info"]
+warn = ["posix?/warn"]
+error = ["posix?/error"]
+panic = ["posix?/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -1,0 +1,467 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![no_std]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::expect_used)]
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+/// Pull in all libc_* crate symbols so the linker includes them in the static archive.
+extern crate libc_assert;
+extern crate libc_ctype;
+extern crate libc_inttypes;
+extern crate libc_langinfo;
+extern crate libc_locale;
+extern crate libc_setjmp;
+extern crate libc_signal;
+extern crate libc_stdio;
+extern crate libc_stdlib;
+extern crate libc_string;
+extern crate libc_time;
+extern crate libc_wchar;
+extern crate libc_wctype;
+
+/// Runtime support: panic handler, global allocator, and the POSIX syscall
+/// backend (`open`/`read`/`write`/`__nanvix_libc_start_main` + the in-memory
+/// VFS). The `extern crate posix` is REQUIRED (not just the Cargo dependency):
+/// it forces the linker to include posix's `#[no_mangle]` backend symbols in the
+/// static archive, exactly as the `extern crate libc_*` lines above do for the C
+/// library surface. Without it, rustc's staticlib reachability drops every
+/// posix symbol that this crate does not reference from Rust.
+///
+/// Gated behind the `backend-nanvix` feature so a consumer supplying its own
+/// backend (panic handler + global allocator + crt0 + syscalls) can build this
+/// archive with `--no-default-features`.
+#[cfg(feature = "backend-nanvix")]
+extern crate nvx;
+#[cfg(feature = "backend-nanvix")]
+extern crate posix;
+#[cfg(feature = "backend-nanvix")]
+extern crate sysalloc;
+
+/// Transitive dependencies required for staticlib resolution.
+extern crate sys;
+extern crate syslog;
+
+//==================================================================================================
+// errno support
+//==================================================================================================
+
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_long,
+        c_uint,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+/// Thread-local errno storage (single-threaded: a plain static suffices).
+#[allow(non_upper_case_globals)]
+static mut errno_val: c_int = 0;
+
+/// Returns a pointer to the per-thread `errno` variable.
+///
+/// # Safety
+///
+/// Returns a mutable pointer to a global variable.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __errno() -> *mut c_int {
+    &raw mut errno_val
+}
+
+//==================================================================================================
+// Stub symbols required by libc_signal (not available in the posix crate)
+//==================================================================================================
+
+/// Stub `sigaction` — returns -1 with `ENOSYS` since kernel signal support is not yet available.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigaction(
+    _signum: c_int,
+    _act: *const libc_signal::signal::sigaction_t,
+    _oldact: *mut libc_signal::signal::sigaction_t,
+) -> c_int {
+    *__errno() = ::sysapi::errno::ENOSYS;
+    -1
+}
+
+//==================================================================================================
+// Stub symbols required by libstdc++ but not yet implemented
+//==================================================================================================
+
+/// Stub `strxfrm` — copies at most `n` bytes of `src` to `dest` (C/POSIX locale identity).
+///
+/// # Safety
+///
+/// Caller must ensure `dest` has room for at least `n` bytes and `src` is null-terminated.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strxfrm(dest: *mut c_char, src: *const c_char, n: c_size_t) -> c_size_t {
+    let len: c_size_t = libc_string::strlen::strlen(src);
+    if n > 0 && !dest.is_null() {
+        let copy_len: c_size_t = if len < n { len } else { n - 1 };
+        core::ptr::copy_nonoverlapping(src, dest, copy_len as usize);
+        *dest.add(copy_len as usize) = 0;
+    }
+    len
+}
+
+/// Stub `strftime` — returns 0 (failure) since full locale-aware formatting is not implemented.
+///
+/// # Safety
+///
+/// Caller must ensure valid pointers.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strftime(
+    _s: *mut c_char,
+    _max: c_size_t,
+    _format: *const c_char,
+    _tm: *const c_void,
+) -> c_size_t {
+    0
+}
+
+/// Stub `wcsftime` — returns 0 (failure).
+///
+/// # Safety
+///
+/// Caller must ensure valid pointers.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsftime(
+    _s: *mut i32,
+    _max: c_size_t,
+    _format: *const i32,
+    _tm: *const c_void,
+) -> c_size_t {
+    0
+}
+
+/// C++ ABI: register a function to be called at exit or when a shared library is unloaded.
+///
+/// # Safety
+///
+/// This is a C++ runtime ABI function.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __cxa_atexit(
+    _func: Option<unsafe extern "C" fn(*mut c_void)>,
+    _arg: *mut c_void,
+    _dso_handle: *mut c_void,
+) -> c_int {
+    // Stub — atexit handlers are not supported in this environment.
+    0
+}
+
+/// Wrapper to make a raw pointer `Sync` for use as a static.
+#[allow(dead_code)]
+#[repr(transparent)]
+pub struct SyncPtr(*mut c_void);
+unsafe impl Sync for SyncPtr {}
+
+/// C++ ABI: DSO handle symbol required by __cxa_atexit.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub static __dso_handle: SyncPtr = SyncPtr(core::ptr::null_mut());
+
+//==================================================================================================
+// Terminal interface stubs (no interactive terminal in standalone mode)
+//==================================================================================================
+//
+// `tcgetattr`/`tcsetattr` are provided by the `posix` backend (src/libs/posix/
+// src/dummy.rs); the remaining terminal helpers below are not, so they live here.
+
+/// Stub `tcsendbreak` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcsendbreak(_fd: c_int, _duration: c_int) -> c_int {
+    0
+}
+
+/// Stub `tcdrain` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcdrain(_fd: c_int) -> c_int {
+    0
+}
+
+/// Stub `tcflush` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcflush(_fd: c_int, _queue_selector: c_int) -> c_int {
+    0
+}
+
+/// Stub `tcflow` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcflow(_fd: c_int, _action: c_int) -> c_int {
+    0
+}
+
+/// Stub `cfgetispeed` — returns the default `B9600` line speed.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cfgetispeed(_termios_p: *const c_void) -> c_uint {
+    13
+}
+
+/// Stub `cfgetospeed` — returns the default `B9600` line speed.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cfgetospeed(_termios_p: *const c_void) -> c_uint {
+    13
+}
+
+/// Stub `cfsetispeed` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cfsetispeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
+    0
+}
+
+/// Stub `cfsetospeed` — no terminal hardware, so this is a no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cfsetospeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
+    0
+}
+
+//==================================================================================================
+// Time zone globals (fixed UTC; Nanvix has no time-zone database)
+//==================================================================================================
+
+/// Backing storage for the `tzname` strings. Mutable so that any write a C
+/// consumer performs through `tzname` targets writable memory (writing through
+/// a pointer derived from an immutable `static` would be undefined behavior).
+static mut TZ_UTC: [c_char; 4] = [b'U' as c_char, b'T' as c_char, b'C' as c_char, 0];
+
+/// Standard/daylight time zone name strings. Always reports UTC.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub static mut tzname: [*mut c_char; 2] = [
+    (&raw mut TZ_UTC).cast::<c_char>(),
+    (&raw mut TZ_UTC).cast::<c_char>(),
+];
+
+/// Seconds west of UTC. Always zero (UTC).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub static mut timezone: c_long = 0;
+
+/// Daylight-saving flag. Always zero (no DST).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub static mut daylight: c_int = 0;
+
+/// `tzset` — initializes the time-zone globals. They are already fixed to UTC, so this is a no-op.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tzset() {}
+
+//==================================================================================================
+// System logging stubs (no system log daemon in standalone mode)
+//==================================================================================================
+
+/// Stub `openlog` — no system log daemon, so this is a no-op.
+///
+/// # Safety
+///
+/// `ident` may be null or a valid C string; it is not dereferenced.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn openlog(_ident: *const c_char, _option: c_int, _facility: c_int) {}
+
+/// Stub `closelog` — no-op.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn closelog() {}
+
+/// Stub `syslog` — discards the message (declared variadic in C; the extra
+/// arguments are ignored under the cdecl caller-cleanup ABI).
+///
+/// # Safety
+///
+/// `format` may be null or a valid C string; it is not dereferenced.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn syslog(_priority: c_int, _format: *const c_char) {}
+
+/// Stub `setlogmask` — tracks nothing and reports an empty previous mask.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn setlogmask(_mask: c_int) -> c_int {
+    0
+}
+
+//==================================================================================================
+// Generic C11/GCC atomic library routines
+//==================================================================================================
+//
+// Clang emits calls to these generic `__atomic_*` helpers for atomic operations
+// it cannot lower inline (arbitrary sizes / unknown alignment). The Nanvix guest
+// process is single-threaded for the purposes of these operations, so plain
+// (non-atomic) memory accesses are sufficient; the memory-order arguments are
+// ignored.
+
+/// Atomically loads `size` bytes from `mem` into `ret`.
+///
+/// # Safety
+///
+/// `mem` and `ret` must point to at least `size` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __atomic_load(
+    size: c_size_t,
+    mem: *const c_void,
+    ret: *mut c_void,
+    _model: c_int,
+) {
+    unsafe { core::ptr::copy_nonoverlapping(mem.cast::<u8>(), ret.cast::<u8>(), size as usize) };
+}
+
+/// Atomically stores `size` bytes from `val` into `mem`.
+///
+/// # Safety
+///
+/// `mem` and `val` must point to at least `size` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __atomic_store(
+    size: c_size_t,
+    mem: *mut c_void,
+    val: *const c_void,
+    _model: c_int,
+) {
+    unsafe { core::ptr::copy_nonoverlapping(val.cast::<u8>(), mem.cast::<u8>(), size as usize) };
+}
+
+/// Atomically exchanges `size` bytes: copies `mem` into `ret`, then `val` into `mem`.
+///
+/// # Safety
+///
+/// `mem`, `val`, and `ret` must point to at least `size` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __atomic_exchange(
+    size: c_size_t,
+    mem: *mut c_void,
+    val: *const c_void,
+    ret: *mut c_void,
+    _model: c_int,
+) {
+    let n: usize = size as usize;
+    unsafe {
+        core::ptr::copy_nonoverlapping(mem.cast::<u8>(), ret.cast::<u8>(), n);
+        core::ptr::copy_nonoverlapping(val.cast::<u8>(), mem.cast::<u8>(), n);
+    }
+}
+
+/// Atomic compare-and-exchange of `size` bytes.
+///
+/// Returns `true` and stores `desired` into `mem` when `mem` equals `expected`; otherwise updates
+/// `expected` with the current contents of `mem` and returns `false`.
+///
+/// # Safety
+///
+/// `mem`, `expected`, and `desired` must point to at least `size` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __atomic_compare_exchange(
+    size: c_size_t,
+    mem: *mut c_void,
+    expected: *mut c_void,
+    desired: *const c_void,
+    _success: c_int,
+    _failure: c_int,
+) -> bool {
+    let n: usize = size as usize;
+    let m: *const u8 = mem.cast::<u8>();
+    let e: *const u8 = expected.cast::<u8>();
+    let mut i: usize = 0;
+    while i < n {
+        if unsafe { *m.add(i) } != unsafe { *e.add(i) } {
+            // Mismatch: report the current value in `expected`.
+            unsafe { core::ptr::copy_nonoverlapping(m, expected.cast::<u8>(), n) };
+            return false;
+        }
+        i += 1;
+    }
+    unsafe { core::ptr::copy_nonoverlapping(desired.cast::<u8>(), mem.cast::<u8>(), n) };
+    true
+}
+
+/// Reports whether an atomic of the given `size` is lock-free.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn __atomic_is_lock_free(size: c_size_t, _ptr: *const c_void) -> bool {
+    matches!(size, 1 | 2 | 4 | 8)
+}
+
+//==================================================================================================
+// Codeset conversion (identity passthrough)
+//==================================================================================================
+
+/// Opens an identity codeset-conversion descriptor (no real conversion is performed).
+///
+/// # Safety
+///
+/// `tocode` and `frocode` may be null or valid C strings; they are not dereferenced.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn iconv_open(
+    _tocode: *const c_char,
+    _fromcode: *const c_char,
+) -> *mut c_void {
+    // A non-null, never-dereferenced sentinel handle. `iconv_open` reports
+    // failure as `(iconv_t)-1`, so any non-`-1`, non-null value signals success;
+    // `dangling_mut` yields such a pointer (address == align_of::<c_void>() == 1).
+    core::ptr::dangling_mut::<c_void>()
+}
+
+/// Copies bytes from the input to the output buffer unchanged (identity conversion).
+///
+/// # Safety
+///
+/// The buffer pointers and counters must be valid for the indicated lengths.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn iconv(
+    _cd: *mut c_void,
+    inbuf: *mut *mut c_char,
+    inbytesleft: *mut c_size_t,
+    outbuf: *mut *mut c_char,
+    outbytesleft: *mut c_size_t,
+) -> c_size_t {
+    // A null/!inbuf request resets state; nothing to do for identity.
+    if inbuf.is_null() || (*inbuf).is_null() {
+        return 0;
+    }
+
+    let in_left: c_size_t = if inbytesleft.is_null() {
+        0
+    } else {
+        *inbytesleft
+    };
+    let out_left: c_size_t = if outbytesleft.is_null() {
+        0
+    } else {
+        *outbytesleft
+    };
+    let n: c_size_t = core::cmp::min(in_left, out_left);
+
+    core::ptr::copy_nonoverlapping(*inbuf, *outbuf, n as usize);
+    *inbuf = (*inbuf).add(n as usize);
+    *outbuf = (*outbuf).add(n as usize);
+    if !inbytesleft.is_null() {
+        *inbytesleft = in_left - n;
+    }
+    if !outbytesleft.is_null() {
+        *outbytesleft = out_left - n;
+    }
+
+    // If input remains, the output buffer was too small.
+    if in_left > n {
+        *__errno() = ::sysapi::errno::E2BIG;
+        return c_size_t::MAX;
+    }
+    0
+}
+
+/// Closes an identity codeset-conversion descriptor.
+///
+/// # Safety
+///
+/// `cd` is the handle returned by [`iconv_open`]; it is not dereferenced.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn iconv_close(_cd: *mut c_void) -> c_int {
+    0
+}

--- a/src/libs/nanvix_libm/Cargo.toml
+++ b/src/libs/nanvix_libm/Cargo.toml
@@ -1,0 +1,45 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nanvix_libm"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Nanvix C Math Library (libm.a)"
+homepage.workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+# The pure-computational math routines (sin/cos/pow/sqrt/...). `libc_math` is
+# self-contained: it uses no heap, no syscalls and no errno, so `libm.a` shares
+# no runtime state with `libc.a`.
+libc_math = { workspace = true }
+# Runtime support: the `#[panic_handler]`. `nvx` is pinned to
+# `default-features = false` (workspace), so its `runtime` feature — and the
+# transitive `sysalloc`/`alloc` deps + `#[global_allocator]` it would pull in —
+# stay disabled. `libm.a` therefore carries NO `sysalloc`, which is what keeps it
+# free of the duplicate-allocator hazard when linked next to `libc.a`. The
+# `weak-panic` feature gives the panic handler weak linkage so its
+# `rust_begin_unwind` collapses with the copy in `libc.a` at the final link.
+nvx = { workspace = true, features = ["weak-panic"] }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+# Logging — forwarded to `nvx`/`syslog` so the panic handler logs at the same
+# level the rest of the build is compiled with.
+trace = ["nvx/trace"]
+debug = ["nvx/debug"]
+info = ["nvx/info"]
+warn = ["nvx/warn"]
+error = ["nvx/error"]
+panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix_libm/src/lib.rs
+++ b/src/libs/nanvix_libm/src/lib.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+//! Nanvix C math library (`libm.a`).
+//!
+//! This crate is a thin staticlib aggregator. It pulls in the pure-computational
+//! math routines from `libc_math` (`sin`, `cos`, `pow`, `sqrt`, `floor`, ...) and
+//! the Nanvix `#[panic_handler]` from `nvx`. Because `nvx` is built with
+//! `default-features = false`, its `runtime` feature is disabled and it brings in
+//! NO `sysalloc`/`#[global_allocator]` — `libm.a` is therefore self-contained and
+//! shares no mutable runtime state with `libc.a`.
+//!
+//! Together with `libc.a` and `libnvx_crt0.a`, `libm.a` forms a full replacement
+//! for the GCC + newlib `crt0` + `libc.a` + `libm.a` toolchain surface.
+
+// Attributes
+#![no_std]
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+/// Pull in all `libc_math` symbols so the linker includes them in the static
+/// archive (the same mechanism `nanvix_libc` uses for the `libc_*` crates).
+extern crate libc_math;
+
+/// Provides the `#[panic_handler]`. With `default-features = false`, `nvx` links
+/// in only the panic handler — its heap/TDA bring-up and the transitive
+/// `sysalloc`/`alloc` dependencies are gated behind the (disabled) `runtime`
+/// feature, so no `#[global_allocator]` is pulled into `libm.a`.
+extern crate nvx;
+
+//==================================================================================================
+// Global Allocator (forwarding)
+//==================================================================================================
+
+// The Rust `alloc` crate (pulled in unconditionally by `-Zbuild-std=core,alloc`)
+// requires every staticlib that links it to declare a `#[global_allocator]`,
+// even though the math routines never allocate. Declaring a real `sysalloc`
+// allocator here would embed a SECOND `sysalloc` instance (with its own `HEAP`
+// static) alongside the one in `libc.a` — the exact duplicate-allocator bug this
+// project fights. Instead we forward to `libc.a`'s allocator through the same
+// C-ABI bridges `nvx-crt0` uses; the symbols resolve at the final link and are
+// never actually called from `libm.a`.
+unsafe extern "C" {
+    fn __nanvix_rust_alloc_raw(size: usize, align: usize) -> *mut u8;
+    fn __nanvix_rust_dealloc_raw(ptr: *mut u8, size: usize, align: usize);
+}
+
+struct ForwardingAllocator;
+
+unsafe impl ::core::alloc::GlobalAlloc for ForwardingAllocator {
+    unsafe fn alloc(&self, layout: ::core::alloc::Layout) -> *mut u8 {
+        unsafe { __nanvix_rust_alloc_raw(layout.size(), layout.align()) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: ::core::alloc::Layout) {
+        unsafe { __nanvix_rust_dealloc_raw(ptr, layout.size(), layout.align()) };
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: ForwardingAllocator = ForwardingAllocator;

--- a/src/libs/nvx-crt0/Cargo.toml
+++ b/src/libs/nvx-crt0/Cargo.toml
@@ -47,7 +47,10 @@ sysalloc = { workspace = true, optional = true }
 # uses `--no-default-features`), so `libnvx_crt0.a` does NOT carry
 # `libposix` or `sysalloc` objects — `__nanvix_libc_start_main` is
 # resolved from the separately-built `libposix.a` at the cpython link.
-posix = { workspace = true, default-features = false, features = ["allocator", "syscall"], optional = true }
+posix = { workspace = true, default-features = false, features = [
+    "allocator",
+    "syscall",
+], optional = true }
 
 [features]
 # Default to `c-main` so a vanilla `cargo build -p nvx-crt0` succeeds without
@@ -57,6 +60,14 @@ posix = { workspace = true, default-features = false, features = ["allocator", "
 default = ["c-main"]
 c-main = []
 rust-main = []
+
+# `init-array` switches the `c-main` trampoline from the legacy GCC-style
+# `_init` / `_fini` constructor / destructor hooks to relying on
+# `__nanvix_libc_start_main` walking `.init_array` / `.fini_array`.  Off by
+# default so existing C consumers keep the `_init` / `_fini` contract; enabled
+# for the in-tree `nanvix_libc` bundle's `crt0.o`, which ships no
+# crti/crtn/crtbegin/crtend and pairs with `posix/init-array`.
+init-array = []
 
 # `provides-allocator` makes this crate force `sysalloc`'s
 # `#[global_allocator]` into the binary's link graph (via `extern crate

--- a/src/libs/nvx-crt0/src/lib.rs
+++ b/src/libs/nvx-crt0/src/lib.rs
@@ -298,8 +298,13 @@ pub unsafe extern "C" fn _start(argp: *mut c_char, envp: *mut c_char) -> ! {
 /// dispatch into the application's entry point.
 ///
 /// In `c-main` mode (cpython, hello-c, smoke, ...), this calls the
-/// standard `extern "C" fn main(int, char **)` plus the legacy `_init` /
-/// `_fini` constructor / destructor hooks expected by GCC-style toolchains.
+/// standard `extern "C" fn main(int, char **)`.  By default it also invokes
+/// the legacy GCC-style `_init` / `_fini` constructor / destructor hooks
+/// around `main`, preserving the historical contract that C consumers rely
+/// on.  When the `init-array` feature is enabled — as it is for the in-tree
+/// `nanvix_libc` bundle — those hooks are dropped and global constructors /
+/// destructors are instead run by `__nanvix_libc_start_main`, which walks
+/// `.init_array` / `.fini_array` around this trampoline.
 ///
 /// In `rust-main` mode (every Rust no_std binary in this workspace),
 /// this publishes the parsed `argc` / `argv` into [`ARGC`] / [`ARGV`]
@@ -317,9 +322,10 @@ pub unsafe extern "C" fn _start(argp: *mut c_char, envp: *mut c_char) -> ! {
 ///
 /// # Safety
 ///
-/// This function dereferences the foreign `argv` pointer and calls into
-/// foreign `main` / `_init` / `_fini` provided by the application
-/// (resolved at link time).
+/// This function dereferences the foreign `argv` pointer and calls into the
+/// foreign `main` (and, unless the `init-array` feature is enabled, the
+/// foreign `_init` / `_fini`) provided by the application (resolved at link
+/// time).
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __nanvix_main(argc: i32, argv: *const *const u8) -> i32 {
@@ -327,16 +333,35 @@ pub unsafe extern "C" fn __nanvix_main(argc: i32, argv: *const *const u8) -> i32
         if #[cfg(feature = "c-main")] {
             unsafe extern "C" {
                 fn main(argc: i32, argv: *const *const u8) -> i32;
-                fn _init();
-                fn _fini();
             }
-            let _ = argc;
-            let _ = argv;
-            unsafe {
-                _init();
-                let ret: i32 = main(argc, argv);
-                _fini();
-                ret
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "init-array")] {
+                    // Global constructors / destructors are run separately by
+                    // `__nanvix_libc_start_main` (libposix start.rs), which
+                    // walks `.init_array` / `.fini_array` around this
+                    // trampoline.  Matches the in-tree `nanvix_libc` bundle,
+                    // which ships no crti/crtn/crtbegin/crtend and therefore
+                    // provides no `_init` / `_fini`.
+                    unsafe { main(argc, argv) }
+                } else {
+                    // Default (backward-compatible) path: invoke the legacy
+                    // GCC-style `_init` / `_fini` constructor / destructor
+                    // hooks (provided by the application's crti/crtn) around
+                    // `main`, preserving the historical contract for C
+                    // consumers that depend on it.
+                    unsafe extern "C" {
+                        fn _init();
+                        fn _fini();
+                    }
+                    let _ = argc;
+                    let _ = argv;
+                    unsafe {
+                        _init();
+                        let ret: i32 = main(argc, argv);
+                        _fini();
+                        ret
+                    }
+                }
             }
         } else {
             unsafe extern "Rust" {

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -43,6 +43,12 @@ default = ["runtime"]
 # `sysalloc` transitive dep.  See the `Cargo.toml` of `nvx-crt0` for
 # the cpython staticlib build path that exercises this.
 runtime = ["dep:sysalloc"]
+# `weak-panic` gives the `#[panic_handler]` weak linkage.  Off by default so a
+# binary that links `nvx` once keeps a single strong `rust_begin_unwind`.
+# Enabled by the in-tree `nanvix_libc` / `nanvix_libm` staticlib bundle, where
+# `nvx` lands in more than one archive and the duplicate strong panic symbols
+# would otherwise have to be resolved with `-z muldefs` at the final link.
+weak-panic = []
 rustc-dep-of-std = [
     "alloc",
     "core",

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -8,6 +8,10 @@
 #![deny(clippy::all)]
 #![forbid(clippy::large_stack_frames)]
 #![forbid(clippy::large_stack_arrays)]
+// The `linkage` attribute is only needed when the `weak-panic` feature gives the
+// panic handler weak linkage (see `panic.rs`); gate the nightly feature on it so
+// default builds do not enable an otherwise-unused unstable feature.
+#![cfg_attr(feature = "weak-panic", feature(linkage))]
 #![no_std]
 
 //! Nanvix guest runtime helpers.

--- a/src/libs/nvx/src/panic.rs
+++ b/src/libs/nvx/src/panic.rs
@@ -19,7 +19,18 @@ use syslog::{
 // Standalone Functions
 //==================================================================================================
 
+// When built with the opt-in `weak-panic` feature, the panic handler is given
+// **weak** linkage so the `rust_begin_unwind` entry emitted into each separate
+// Nanvix static archive (`libc.a`, `libm.a`) collapses to a single definition
+// at the final guest link instead of colliding as multiple *strong* symbols
+// (which would otherwise force `-z muldefs` / `--allow-multiple-definition`).
+//
+// The feature is OFF by default: a regular guest binary links `nvx` exactly
+// once and therefore keeps a single strong panic handler, unchanged from the
+// historical behaviour.  Only the in-tree `nanvix_libc` / `nanvix_libm`
+// staticlib bundle (which links `nvx` into more than one archive) enables it.
 #[panic_handler]
+#[cfg_attr(feature = "weak-panic", linkage = "weak")]
 pub fn panic_implementation(info: &::core::panic::PanicInfo<'_>) -> ! {
     // Extract panic information.
     let (file, line) = match info.location() {

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -41,6 +41,16 @@ syscall = ["syslog", "syscall/dlfcn"]
 standalone = ["syscall/standalone"]
 std = []
 
+# `init-array` makes `__nanvix_libc_start_main` run global constructors /
+# destructors by walking the `.preinit_array` / `.init_array` / `.fini_array`
+# sections (bounded by the `__*_array_{start,end}` symbols from `user.ld`).
+# Off by default: a default `libposix` neither references those linker symbols
+# nor walks the arrays, so consumers with their own linker scripts keep linking
+# unchanged and rely on the `nvx-crt0` `c-main` trampoline's legacy `_init` /
+# `_fini` hooks.  Enabled (together with `nvx-crt0/init-array`) by the in-tree
+# `nanvix_libc` bundle.
+init-array = []
+
 # `c-main` gates the link-time errno wiring used by C executables (cpython,
 # numpy, ...).  When enabled, `syscall/staticlib` switches
 # `__errno_location()` from a self-contained local errno to an `extern fn

--- a/src/libs/posix/src/start.rs
+++ b/src/libs/posix/src/start.rs
@@ -71,6 +71,33 @@ unsafe extern "C" {
     fn __nanvix_env_init(envp: *const *const c_char);
 }
 
+// Constructor / destructor array bounds, provided by the guest linker script
+// (`build/user/linker/x86/user.ld`).  Only referenced when the `init-array`
+// feature is enabled (the in-tree `nanvix_libc` bundle); a default `libposix`
+// build neither walks these arrays nor requires the linker to define their
+// bound symbols, so consumers with their own linker scripts keep linking
+// unchanged.  Nanvix ships no crtbegin/crtend, so the `.preinit_array` /
+// `.init_array` / `.fini_array` bounds come from `user.ld`.  They are addressed
+// only via `&raw const` (their value is never read); each marks a section
+// boundary.
+#[cfg(feature = "init-array")]
+unsafe extern "C" {
+    static __preinit_array_start: u8;
+    static __preinit_array_end: u8;
+    static __init_array_start: u8;
+    static __init_array_end: u8;
+    static __fini_array_start: u8;
+    static __fini_array_end: u8;
+}
+
+/// Signature of a constructor / destructor entry stored in the
+/// `.preinit_array` / `.init_array` / `.fini_array` sections.  Modern
+/// toolchains (clang/gcc emitting `.init_array`) store `void (*)(void)`
+/// pointers; matching relibc's `relibc_start`, Nanvix invokes them with no
+/// arguments.
+#[cfg(feature = "init-array")]
+type InitArrayEntry = unsafe extern "C" fn();
+
 //==================================================================================================
 // Global Variables
 //==================================================================================================
@@ -188,11 +215,35 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
     // post-close-on-exec table. In run modes without a guest `vfsd`, this is a no-op.
     ::syscall::unistd::exec_startup_barrier();
 
+    // Run global constructors before entering `main`.  `.preinit_array` runs
+    // first, then `.init_array` (relibc's `relibc_start` pattern).  Done after
+    // the heap (runtime_init) and the environment table are up, because a
+    // constructor may allocate or read the environment.
+    //
+    // Gated on the `init-array` feature: only the in-tree `nanvix_libc` bundle
+    // (paired with `nvx-crt0/init-array`) walks these arrays.  A default
+    // `libposix` build keeps the historical behaviour where the `c-main`
+    // trampoline runs the GCC-style `_init` / `_fini` hooks instead.
+    #[cfg(feature = "init-array")]
+    unsafe {
+        run_init_array(&raw const __preinit_array_start, &raw const __preinit_array_end);
+        run_init_array(&raw const __init_array_start, &raw const __init_array_end);
+    }
+
     // Dispatch into the application's `main` via the binary-supplied
     // trampoline.  `__nanvix_main` is `nvx-crt0::__nanvix_main`, which
     // selects between the C and Rust trampoline at the binary's link
     // based on which crt0 feature is active.
     let status: i32 = unsafe { __nanvix_main(argc, argv_ptr) };
+
+    // Run global destructors after `main` returns, in REVERSE registration
+    // order, before the heap is torn down (a destructor may still allocate or
+    // free).  Mirrors the constructor walk above and is gated on the same
+    // `init-array` feature.
+    #[cfg(feature = "init-array")]
+    unsafe {
+        run_fini_array(&raw const __fini_array_start, &raw const __fini_array_end);
+    }
 
     // Tear down the runtime.  `argv` / `env` are leaked above (see the
     // comment at their declaration) so no Vec destructors run here
@@ -202,6 +253,64 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
     // Exit the process.  Never returns under normal circumstances.
     let Err(error) = ::sys::kcall::pm::__kcall_exit(status);
     panic!("__nanvix_libc_start_main(): exit kcall returned (error={error:?})");
+}
+
+//==================================================================================================
+// Constructor / Destructor Arrays
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Runs every function pointer in a `.preinit_array` / `.init_array` section,
+/// in ascending (registration) order.  Used for global constructors.
+///
+/// # Parameters
+///
+/// - `start`: Address of the first entry (the `__*_array_start` linker symbol).
+/// - `end`: Address one past the last entry (the `__*_array_end` linker symbol).
+///
+/// # Safety
+///
+/// `start` and `end` must bound a contiguous, properly-aligned array of
+/// `InitArrayEntry` function pointers (guaranteed by `user.ld`), and each entry
+/// must be a valid, relocated function pointer safe to call with no arguments.
+///
+#[cfg(feature = "init-array")]
+unsafe fn run_init_array(start: *const u8, end: *const u8) {
+    let mut entry: *const InitArrayEntry = start as *const InitArrayEntry;
+    let end: *const InitArrayEntry = end as *const InitArrayEntry;
+    while entry < end {
+        let func: InitArrayEntry = unsafe { *entry };
+        unsafe { func() };
+        entry = unsafe { entry.add(1) };
+    }
+}
+
+///
+/// # Description
+///
+/// Runs every function pointer in a `.fini_array` section, in DESCENDING order
+/// (the reverse of registration), as required for global destructors.
+///
+/// # Parameters
+///
+/// - `start`: Address of the first entry (the `__fini_array_start` linker symbol).
+/// - `end`: Address one past the last entry (the `__fini_array_end` linker symbol).
+///
+/// # Safety
+///
+/// Same invariants as [`run_init_array`].
+///
+#[cfg(feature = "init-array")]
+unsafe fn run_fini_array(start: *const u8, end: *const u8) {
+    let start: *const InitArrayEntry = start as *const InitArrayEntry;
+    let mut entry: *const InitArrayEntry = end as *const InitArrayEntry;
+    while entry > start {
+        entry = unsafe { entry.sub(1) };
+        let func: InitArrayEntry = unsafe { *entry };
+        unsafe { func() };
+    }
 }
 
 //==================================================================================================


### PR DESCRIPTION
Introduce two aggregator staticlib crates that produce the newlib-free
C-library surface (`libc.a` and `libm.a`) the patched gcc/clang guest
toolchains link by default, replacing the previous two-archive merge that
embedded duplicate `sysalloc`/`HEAP` instances.

New crates:
- Add `nanvix_libc` (-> `libc.a`): pulls in every `libc_*` crate (except
  `libc_math`) plus the POSIX syscall backend (`posix`), panic handler
  (`nvx`), and global allocator (`sysalloc`) via the `backend-nanvix`
  feature, so the whole C library and backend compile in a single cargo
  invocation. Cargo unifies the shared transitive deps (`sysalloc`,
  `libc_stdlib`, `sys`, `nvx`, `syslog`) to one instance each, which
  structurally prevents the duplicate-`sysalloc`/duplicate-`HEAP` bug.
  Provide the `__errno()` storage plus libstdc++/C++ ABI, terminal,
  time-zone, syslog, generic `__atomic_*`, and iconv stubs not supplied
  by the backend crates. Symbols use `cfg_attr(not(std), no_mangle)` so
  host `std` test builds do not collide with the host libc.
- Add `nanvix_libm` (-> `libm.a`): aggregates `libc_math` and the `nvx`
  panic handler with `default-features = false`, so it carries no
  `sysalloc` and shares no mutable runtime state with `libc.a`. Declares
  a forwarding `#[global_allocator]` that bridges to `libc.a`'s allocator
  (never actually called) to satisfy rustc's alloc-linking requirement.

Backward-compatible runtime features (all opt-in, default off):
- `nvx/weak-panic`: gives `#[panic_handler]` weak linkage (gating the
  nightly `linkage` feature on it) so the `rust_begin_unwind` copies in
  `libc.a` and `libm.a` collapse at the final link instead of colliding.
- `posix/init-array` + `nvx-crt0/init-array`: switch the `c-main`
  trampoline from the legacy GCC `_init`/`_fini` hooks to
  `__nanvix_libc_start_main` walking `.preinit_array`/`.init_array`/
  `.fini_array`. Default builds keep the `_init`/`_fini` contract and
  emit no linker-symbol references, so out-of-tree consumers with their
  own linker scripts are unaffected.

Linker and target support:
- Add `.preinit_array`/`.init_array`/`.fini_array` output sections
  (with `PROVIDE_HIDDEN` bound symbols) to the x86 and x86_64 user
  linker scripts, placed in the writable LOAD segment so the PIE
  relocator fixes up the function pointers. Nanvix ships no
  crtbegin/crtend, so these bounds come from `user.ld`.
- Add `-z norelro` to the x86/x86_64 user target link args.

Build system:
- Add `build/make/nanvix-libc-artifacts.mk` to stage the bundle:
  `libc.a`, `libm.a`, `libc.so` (shared, for dlopen), `crt0.o`
  (folded from `libnvx_crt0.a` via `ld -r --whole-archive`, with the
  Rust allocator-shim symbols localized) plus `crt1.o`/`Scrt1.o`
  aliases, and empty `libdl.a`/`libpthread.a`/`librt.a` stub archives.
- Wire `nanvix_libc`/`nanvix_libm` into `ALL_GUEST_STATIC_LIBS`, stage
  them under their conventional `libc.a`/`libm.a` names, and add the
  per-package feature overrides. `posix` keeps building its standalone
  `libposix.a` separately so it does not pick up `init-array` via
  feature unification.
- Add an optional sccache wrapper for the host `CC`/`CXX` entrypoints.
- Register both crates in the workspace `Cargo.toml`/`Cargo.lock`.

