### PR TITLE
[libs] Align generated C headers with implemented libc surface

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -29,6 +29,7 @@ extern void free(void *ptr);
 extern void *calloc(size_t nmemb, size_t size);
 extern void *realloc(void *ptr, size_t size);
 extern void *aligned_alloc(size_t alignment, size_t size);
+extern void *memalign(size_t alignment, size_t size);
 extern size_t malloc_usable_size(void *ptr);
 
 #ifdef __cplusplus

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -128,7 +128,6 @@ extern char *secure_getenv(const char *name);
 extern int setenv(const char *name, const char *value, int overwrite);
 extern int unsetenv(const char *name);
 extern int putenv(char *string);
-extern int getsubopt(char **restrict optionp, char *const *restrict tokens, char **restrict valuep);
 
 /*==================================================================================================
  * Process Control
@@ -153,17 +152,10 @@ extern int wctomb(char *s, wchar_t wc);
 extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n);
 
 /*==================================================================================================
- * Temporary Files and Terminals
+ * Temporary Files
  *==================================================================================================*/
 
-extern char *mkdtemp(char *template);
-extern int mkostemp(char *template, int flags);
 extern int mkstemp(char *template);
-extern int posix_openpt(int flags);
-extern char *ptsname(int fildes);
-extern int ptsname_r(int fildes, char *name, size_t namesize);
-extern int unlockpt(int fildes);
-extern int grantpt(int fildes);
 
 /*==================================================================================================
  * Path Utilities

--- a/include/string.h
+++ b/include/string.h
@@ -29,6 +29,7 @@ extern void *memchr(const void *s, int c, size_t n);
 extern int memcmp(const void *ptr1, const void *ptr2, size_t len);
 extern void *memcpy(void *dest, const void *src, size_t len);
 extern void *memmove(void *dest, const void *src, size_t len);
+extern void *memrchr(const void *s, int c, size_t n);
 extern void *memset(void *ptr, int val, size_t len);
 
 /*==================================================================================================
@@ -53,6 +54,7 @@ extern char *strndup(const char *s, size_t n);
 extern size_t strnlen(const char *s, size_t maxlen);
 extern char *strpbrk(const char *s, const char *accept);
 extern char *strrchr(const char *s, int c);
+extern char *strsep(char **stringp, const char *delim);
 extern size_t strspn(const char *s, const char *accept);
 extern char *strstr(const char *haystack, const char *needle);
 extern char *strtok(char *s, const char *delim);

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -118,14 +118,7 @@ functions = ["rand", "srand"]
 
 [[sections]]
 title = "Environment"
-functions = [
-    "getenv",
-    "secure_getenv",
-    "setenv",
-    "unsetenv",
-    "putenv",
-    "getsubopt",
-]
+functions = ["getenv", "secure_getenv", "setenv", "unsetenv", "putenv"]
 
 [[sections]]
 title = "Process Control"
@@ -144,17 +137,8 @@ title = "Multibyte Conversion"
 functions = ["mblen", "mbtowc", "mbstowcs", "wctomb", "wcstombs"]
 
 [[sections]]
-title = "Temporary Files and Terminals"
-functions = [
-    "mkdtemp",
-    "mkostemp",
-    "mkstemp",
-    "posix_openpt",
-    "ptsname",
-    "ptsname_r",
-    "unlockpt",
-    "grantpt",
-]
+title = "Temporary Files"
+functions = ["mkstemp"]
 
 [[sections]]
 title = "Path Utilities"
@@ -183,8 +167,6 @@ strtoul = '''
 extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);'''
 strtoull = '''
 extern unsigned long long strtoull(const char *restrict nptr, char **restrict endptr, int base);'''
-getsubopt = '''
-extern int getsubopt(char **restrict optionp, char *const *restrict tokens, char **restrict valuep);'''
 qsort_r = '''
 extern void qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *arg);'''
 mbtowc = '''
@@ -197,21 +179,7 @@ mbstowcs = '''
 extern size_t mbstowcs(wchar_t *restrict dst, const char *restrict src, size_t n);'''
 wcstombs = '''
 extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n);'''
-mkdtemp = '''
-extern char *mkdtemp(char *template);'''
-mkostemp = '''
-extern int mkostemp(char *template, int flags);'''
 mkstemp = '''
 extern int mkstemp(char *template);'''
-posix_openpt = '''
-extern int posix_openpt(int flags);'''
-ptsname = '''
-extern char *ptsname(int fildes);'''
-ptsname_r = '''
-extern int ptsname_r(int fildes, char *name, size_t namesize);'''
-unlockpt = '''
-extern int unlockpt(int fildes);'''
-grantpt = '''
-extern int grantpt(int fildes);'''
 realpath = '''
 extern char *realpath(const char *restrict path, char *restrict resolved_path);'''

--- a/src/libs/libc_string/header.toml
+++ b/src/libs/libc_string/header.toml
@@ -15,7 +15,15 @@ guard = "_NANVIX_STRING_H"
 
 [[sections]]
 title = "Memory Operations"
-functions = ["memccpy", "memchr", "memcmp", "memcpy", "memmove", "memset"]
+functions = [
+    "memccpy",
+    "memchr",
+    "memcmp",
+    "memcpy",
+    "memmove",
+    "memrchr",
+    "memset",
+]
 
 [[sections]]
 title = "String Operations"
@@ -38,6 +46,7 @@ functions = [
     "strnlen",
     "strpbrk",
     "strrchr",
+    "strsep",
     "strspn",
     "strstr",
     "strtok",

--- a/src/libs/sysapi/headers/malloc.toml
+++ b/src/libs/sysapi/headers/malloc.toml
@@ -23,5 +23,6 @@ functions = [
     "calloc",
     "realloc",
     "aligned_alloc",
+    "memalign",
     "malloc_usable_size",
 ]


### PR DESCRIPTION
## Description

Under `-nostdinc` a standalone C program sees only the sysroot's generated
headers, which described the `libc_*` Rust crate surface rather than the libc
the program actually links. This caused two opposite build failures: headers
omitted standard prototypes that the linked libc implements (pointer-returning
functions used without a declaration are a hard error on i386), and headers
declared functions the standalone libc does not implement (their plain
prototypes clash with the attributed fallback prototypes portable programs
emit, e.g. BusyBox's "conflicting types for 'mkdtemp'").

## Changes

Align the generated surface with the implemented one:

- `string.h`: declare `memrchr()` and `strsep()`, which are implemented as
  `extern "C"` functions in the `libc_string` crate but were missing from the
  header spec.
- `malloc.h`: declare `memalign()`, implemented in `libc_stdlib` and required
  to resolve libstdc++'s aligned `operator new` against the embedded runtime.
- `stdlib.h`: drop `getsubopt()`, `mkdtemp()`, `mkostemp()`, `posix_openpt()`,
  `ptsname()`, `ptsname_r()`, `unlockpt()`, and `grantpt()`, which were
  declared via `header.toml` overrides despite having no implementation in
  `libposix` or newlib. Rename the "Temporary Files and Terminals" section to
  "Temporary Files" (`mkstemp()` is retained; it is newlib-provided).

The `include/*.h` files are regenerated from the updated `header.toml` specs.

## Validation

- `./z.ps1 build -- gen-headers-check` — all headers up to date.
- `./z.ps1 build -- run-unit-tests` — passed.
- `./z.ps1 build -- run-nanvix-tests` — passed (standalone, microvm).

Fixes #2649
Supersedes #2653 