### PR TITLE
[kernel] Quiet benign thread-not-found logs

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1187,10 +1187,10 @@ impl ProcessManager {
         if self.try_wakeup_thread(tid) {
             Ok(())
         } else {
-            // The target thread may have legitimately exited while an IPC wakeup was still in
-            // flight (e.g. a short-lived forked applet that was already reaped). This is an
-            // expected, benign race, so it is logged at TRACE rather than ERROR while still
-            // returning NoSuchEntry for callers to handle.
+            // The wakeup target may legitimately no longer be sleeping by the time we deliver the
+            // notification (e.g., it already woke/timed out, or it exited and was reaped while an
+            // IPC wakeup was still in flight). This is an expected race, so it is logged at TRACE
+            // rather than ERROR while still returning NoSuchEntry for callers to handle.
             let reason: &str = "thread not found";
             trace!("{reason} (tid={tid:?})");
             Err(Error::new(ErrorCode::NoSuchEntry, reason))

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1187,8 +1187,12 @@ impl ProcessManager {
         if self.try_wakeup_thread(tid) {
             Ok(())
         } else {
+            // The target thread may have legitimately exited while an IPC wakeup was still in
+            // flight (e.g. a short-lived forked applet that was already reaped). This is an
+            // expected, benign race, so it is logged at TRACE rather than ERROR while still
+            // returning NoSuchEntry for callers to handle.
             let reason: &str = "thread not found";
-            error!("{reason} (tid={tid:?})");
+            trace!("{reason} (tid={tid:?})");
             Err(Error::new(ErrorCode::NoSuchEntry, reason))
         }
     }
@@ -2322,8 +2326,11 @@ impl ProcessManager {
             }
         }
 
+        // The thread may have already been reaped while a lookup was in flight (e.g. an FPU-owner
+        // lookup after the owning thread exited). This is an expected, benign race, so it is logged
+        // at TRACE rather than ERROR while still returning NoSuchEntry for callers to handle.
         let reason: &str = "thread not found";
-        error!("{reason} (tid={tid:?})");
+        trace!("{reason} (tid={tid:?})");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 


### PR DESCRIPTION
## Summary

`do_wakeup()` and the manager's `find_thread_mut()` logged at `ERROR` whenever a
target thread was already gone. This fires routinely when a short-lived forked
applet exits while an in-flight IPC wakeup (via `ipc/rendezvous.rs`) or FPU-owner
lookup (in `handle_fpu_exception()`) still targets one of its threads — flooding
`LOG_LEVEL=error` with benign races that have no functional effect.

The kernel log macros prepend the enclosing function name via
`extract_function_name!()`, which is why the reported symptom appears as
`find_thread_mut(): thread not found (tid=N)`.

## Changes

- Downgrade the "thread not found" log in `do_wakeup()` from `error!` to `trace!`.
- Downgrade the "thread not found" log in `find_thread_mut()` from `error!` to `trace!`.
- Both paths still return `ErrorCode::NoSuchEntry`; only the log level changed, so
  behavior is unchanged. Added brief comments explaining the benign race at each site.

## Validation

- `.\z.ps1 build -- rust-lint-check-kernel` passes (clippy `-D warnings`).

Closes #2651
