### PR TITLE
[tests] E: Add multi-threaded VFS attribution test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-vfs-test"
+version = "0.16.130"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "config",
+ "libc_string",
+ "nvx",
+ "nvx-crt0",
+ "sys",
+ "sysalloc",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
Adds a multi-threaded VFS attribution test.

Branch: `feature-tests-thread_vfs_test`