### PR TITLE
[sys] Test ProcessRole serialization round trip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ export VERUS_KERNEL_FEATURES := microvm trace
 
 ALL_GUEST_STATIC_LIBS := posix nvx-crt0
 ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype syslog-macros syslog mmio-tag syscall vfs
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe koptions proc raw-array nanvix-slab sorted-vec static_assert libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time libc_wchar libc_wctype syslog-macros syslog sys mmio-tag syscall vfs
 
 ALL_GUEST_DAEMONS := memd procd vfsd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/sys/src/sys/event/scheduling/creation.rs
+++ b/src/libs/sys/src/sys/event/scheduling/creation.rs
@@ -145,4 +145,16 @@ mod tests {
         );
         assert_eq!(ProcessCreationInfo::from_ne_bytes(info.to_ne_bytes()), info);
     }
+
+    #[test]
+    fn creation_info_round_trip_preserves_roles() {
+        for role in [ProcessRole::Init, ProcessRole::Daemon, ProcessRole::User] {
+            let info: ProcessCreationInfo = ProcessCreationInfo::new(
+                ProcessIdentifier::from(5),
+                ProcessIdentifier::KERNEL,
+                role,
+            );
+            assert_eq!(ProcessCreationInfo::from_ne_bytes(info.to_ne_bytes()), info);
+        }
+    }
 }

--- a/src/libs/sys/src/sys/event/scheduling/termination.rs
+++ b/src/libs/sys/src/sys/event/scheduling/termination.rs
@@ -41,8 +41,8 @@ impl ProcessRole {
     ///
     /// Classifies a process from the identifier of its parent and whether the kernel spawned it as
     /// a system daemon. This is the authoritative classification owned by the kernel, which spawns
-    /// the init process and the daemons directly and therefore knows which is which — independent of
-    /// the process identifiers they happen to receive.
+    /// the init process and the daemons directly and therefore knows which is which — independent
+    /// of the process identifiers they happen to receive.
     ///
     /// # Parameters
     ///
@@ -267,5 +267,45 @@ mod tests {
             ProcessRole::User,
         );
         assert_eq!(ProcessTerminationInfo::from_ne_bytes(info.to_ne_bytes()), info);
+    }
+
+    #[test]
+    fn termination_info_round_trip_preserves_kernel_spawned_roles() {
+        // procd routes a termination on the role carried in this event: an `Init` termination
+        // triggers system shutdown and a `Daemon` termination triggers deregistration (and a crash
+        // shutdown on a non-zero status). The role must therefore survive the native-endian round
+        // trip intact. If a kernel-spawned process's role decoded as `User`, procd would silently
+        // reap it as an ordinary forked child and never bring the system down — the regression
+        // tracked in issue #2541.
+        for role in [ProcessRole::Init, ProcessRole::Daemon] {
+            let info: ProcessTerminationInfo = ProcessTerminationInfo::new(
+                ProcessIdentifier::from(4),
+                ExitStatus::ok(),
+                ProcessIdentifier::KERNEL,
+                role,
+            );
+            assert_eq!(ProcessTerminationInfo::from_ne_bytes(info.to_ne_bytes()), info);
+        }
+    }
+
+    #[test]
+    fn process_role_round_trips_through_raw_u32() {
+        // The kernel encodes the role as a raw `u32` and procd decodes it; both sides must agree on
+        // each value so the role that drives the shutdown / deregistration / reap decision is the
+        // one the kernel assigned.
+        assert_eq!(ProcessRole::Init.to_u32(), 0);
+        assert_eq!(ProcessRole::Daemon.to_u32(), 1);
+        assert_eq!(ProcessRole::User.to_u32(), 2);
+        assert_eq!(ProcessRole::from_u32(ProcessRole::Init.to_u32()), ProcessRole::Init);
+        assert_eq!(ProcessRole::from_u32(ProcessRole::Daemon.to_u32()), ProcessRole::Daemon);
+        assert_eq!(ProcessRole::from_u32(ProcessRole::User.to_u32()), ProcessRole::User);
+    }
+
+    #[test]
+    fn process_role_unknown_value_decodes_to_user() {
+        // An unrecognized raw value decodes to `User` — the only role that triggers no system-wide
+        // action — so a malformed event cannot spuriously shut the system down.
+        assert_eq!(ProcessRole::from_u32(3), ProcessRole::User);
+        assert_eq!(ProcessRole::from_u32(u32::MAX), ProcessRole::User);
     }
 }


### PR DESCRIPTION
## Summary

The kernel stamps every process-creation and process-termination event with an
authoritative `ProcessRole` and procd routes on it: an `Init` termination triggers system
shutdown, a `Daemon` termination triggers deregistration (and a crash shutdown on non-zero
status), and a `User` termination is reaped. The role crosses the kernel/procd boundary as
a raw `u32`, so a mismatch in its native-endian encoding would silently misroute a
kernel-spawned process as an ordinary forked child and never bring the system down
(issue #2541). This path had no direct coverage.

## Changes

- Add unit tests for the `ProcessRole` encoding contract:
  - `ProcessCreationInfo` and `ProcessTerminationInfo` preserve every role
    (`Init`, `Daemon`, `User`) across a `to_ne_bytes`/`from_ne_bytes` round trip.
  - `to_u32`/`from_u32` agree on each discriminant (`Init=0`, `Daemon=1`, `User=2`).
  - Unknown raw values decode to `User`, the only role that triggers no system-wide
    action, so a malformed event cannot spuriously shut the system down.
- Register the `sys` crate in `ALL_GUEST_RUST_LIBS_TEST_LIST` so these tests run under
  `run-unit-tests`; the crate was built but its unit tests were never executed.
- Rewrap an over-length doc comment on `ProcessRole::classify` to satisfy the 100-column
  limit.

## Validation

- `./z build -- run-unit-tests` passes.
- `./z build -- run-nanvix-tests` passes.

Closes: #2541
