### PR TITLE
[kernel] Document and assert scheduling-event FIFO-by-id invariant

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -216,20 +216,21 @@ struct EventManagerInner {
     pending_exceptions:
         [LinkedList<(EventDescriptor, ExceptionEventInformation, Condvar)>; usize::BITS as usize],
     scheduling_owner: Option<ProcessIdentifier>,
-    /// Pending scheduling-event notifications delivered in strict FIFO order. A single
+    /// Pending scheduling-event notifications delivered in FIFO order by global event id. A single
     /// totally-ordered queue (rather than per-event-type sub-queues drained round-robin) guarantees
     /// that a process's creation event is delivered before its termination event: the kernel main
     /// loop publishes a process's creation ahead of its termination, and a process is always created
-    /// before it terminates, so the creation is enqueued before the termination and FIFO delivery
-    /// preserves that order. This per-process creation-before-termination invariant lets the
+    /// before it terminates, so the creation is enqueued before the termination and carries the
+    /// smaller event id. This per-process creation-before-termination invariant lets the
     /// scheduling-event owner (`procd`) record a child's lineage from its creation before handling
     /// its termination, with no out-of-order reconciliation.
     ///
-    /// Each entry also carries the global [`EventDescriptor`] stamped at generation time. Delivery
-    /// does not consult it today, because this single FIFO queue already yields insertion order
-    /// (hence event-id order); it is retained for uniformity with the interrupt and exception
-    /// queues, which likewise stamp every entry, and for the planned unified FIFO-by-event-id
-    /// delivery tracked in #2558.
+    /// Each entry carries the global [`EventDescriptor`] stamped at generation time. The queue is
+    /// maintained in event-id order: notifications are appended with monotonically increasing ids
+    /// (`notify_scheduling()`) and removals preserve relative order, so the smallest id is always at
+    /// the front and delivery (`try_wait()`) pops the front in O(1). A debug assertion guards that
+    /// id-order invariant. Broadening explicit FIFO-by-event-id delivery across the interrupt and
+    /// exception queues is tracked in #2558.
     pending_scheduling: LinkedList<(EventDescriptor, SchedulingNotification)>,
 }
 
@@ -513,17 +514,25 @@ impl EventManagerInner {
 
             // Check if any scheduling events were triggered.
             if ((self.nevents + i) % Self::NUMBER_EVENTS) == 2 {
-                // Deliver scheduling events in strict FIFO order from a single totally-ordered
-                // queue. Because the kernel main loop publishes a process's creation event before
-                // its termination event, and a process is always created before it terminates, the
-                // creation is enqueued ahead of the termination; FIFO delivery therefore guarantees
-                // that the owner (`procd`) observes a process's creation before its termination, so
-                // it can record the child's lineage before handling the termination with no
-                // out-of-order reconciliation. The non-zero `scheduling` mask means the calling
-                // process owns the scheduling-event class. The scan returns on the first entry, so
-                // at most one scheduling event is delivered per call.
+                // Deliver scheduling events in FIFO order by global event id. Every pending entry
+                // is stamped with a monotonically increasing `EventDescriptor` id at generation time
+                // (`notify_scheduling()`) and appended to the queue, and removals preserve relative
+                // order, so the queue is always sorted by id and the smallest id sits at the front.
+                // Delivering the front entry therefore honors the true arrival order of events in
+                // O(1). Because the kernel main loop publishes a process's creation event before its
+                // termination event, and a process is always created before it terminates, the
+                // creation carries the smaller id and is enqueued ahead of the termination; the
+                // owner (`procd`) thus observes a process's creation before its termination and can
+                // record the child's lineage before handling the termination with no out-of-order
+                // reconciliation. The non-zero `scheduling` mask means the calling process owns the
+                // scheduling-event class. At most one scheduling event is delivered per call.
                 if scheduling != 0 {
-                    if let Some((_ev, notification)) = self.pending_scheduling.pop_front() {
+                    debug_assert!(
+                        self.pending_scheduling_is_ordered(),
+                        "scheduling-event queue is not ordered by event id"
+                    );
+
+                    if let Some((_eventid, notification)) = self.pending_scheduling.pop_front() {
                         // Serialize the notification into the head of the message payload. The
                         // two notification variants have different serialized sizes, so each is
                         // copied using its own length.
@@ -565,6 +574,22 @@ impl EventManagerInner {
             Ok(None) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    fn pending_scheduling_is_ordered(&self) -> bool {
+        let mut previous: Option<usize> = None;
+
+        for (eventid, _) in self.pending_scheduling.iter() {
+            let current: usize = eventid.id();
+            if let Some(previous_id) = previous {
+                if previous_id > current {
+                    return false;
+                }
+            }
+            previous = Some(current);
+        }
+
+        true
     }
 
     ///


### PR DESCRIPTION
## Summary

Clarify and enforce that the event manager's single `pending_scheduling` queue delivers scheduling-event notifications in **FIFO order by global event id**, rather than relying on the looser "strict FIFO / insertion order" framing.

`notify_scheduling()` stamps every entry with a strictly increasing `EventDescriptor` id and appends it, while the only removals are `pop_front()` (delivery) and `pop_back()` (error-path undo). The queue is therefore always sorted by id with the smallest id at the front, so `try_wait()` can keep delivering the front entry in O(1) and still honor the true arrival order of events.

## Changes

- Rewrite the `pending_scheduling` field doc and the `try_wait()` scheduling branch comment to describe delivery as FIFO ordered by global event id, and to spell out why front-of-queue delivery preserves the per-process creation-before-termination invariant relied on by `procd`.
- Add a `pending_scheduling_is_ordered()` helper that verifies the entire pending queue is non-decreasing by event id, and guard delivery with a `debug_assert!` on it before `pop_front()`, so any future code path that violates the ordering invariant is caught in debug builds.
- Cross-reference #2558 for broadening explicit FIFO-by-event-id delivery to the interrupt and exception queues.

This is behavior-preserving in release builds (the assertion is a debug guard); the front entry already carried the smallest id.

## Validation

- `./z build -- format-check-kernel`
- `./z build -- check-kernel`
- `./z build -- rust-lint-check-kernel`
- `./z build -- run-unit-tests`
- `./z build -- run-nanvix-tests`
- `./z build -- run-smoke-test` (passed `test_duplicate_burst`)

Closes #2557