### PR TITLE
[tests] Add ported POSIX C test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,14 @@ endif
 ALL_GUEST_BINARIES := $(ALL_GUEST_DAEMONS) $(ALL_GUEST_BENCHMARKS) $(ALL_GUEST_APPLICATIONS)
 ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
+# Ported POSIX C test suites (src/posix-tests/<suite>/), compiled against the
+# bundled libc by build/make/posix-tests.mk and booted by `run-posix-tests`.
+# `common/` holds shared crt0 scaffolding and is not a suite of its own. The
+# guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
+# (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
+# is gated on TARGET=x86 accordingly.
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-global-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
+
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
 ALL_HOST_RUST_LIBS := \
@@ -541,6 +549,9 @@ endif
 # The bundled libc artifacts are always built; clean them too.
 clean: clean-nanvix-libc-bundle
 
+# The ported POSIX C test suites and their bootable/RAMFS images.
+clean: clean-posix-tests
+
 distclean: clean
 ifeq ($(IS_WINDOWS),yes)
 	$(FORCE_RM_CMD) "$(OBJECTS_DIR)"
@@ -627,6 +638,7 @@ help:
 	@echo "Testing Targets"
 	@echo "  run-unit-tests       Run unit tests for libraries and components"
 	@echo "  run-nanvix-tests     Run system integration tests using nanvix-test"
+	@echo "  run-posix-tests      Run the ported POSIX C test suites (standalone, Linux/x86)"
 	@echo ""
 	@echo "Execution Targets"
 	@echo "  debug    Run system in debug mode"
@@ -1071,6 +1083,7 @@ ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	@$(MAKE) run-kernel-tests
 	@$(MAKE) run-smoke-test
 	@$(MAKE) run-nanvix-tests
+	@$(MAKE) run-posix-tests
 endif
 
 run-unit-tests: all-nanvix test-guest-rlibs
@@ -1190,6 +1203,16 @@ include build/make/generic-guest-staticlibs.mk
 #===================================================================================================
 
 include build/make/nanvix-libc-artifacts.mk
+
+#===================================================================================================
+# Build Rules for the Guest C Toolchain and Ported POSIX C Test Suites
+#===================================================================================================
+
+# guest-c-apps.mk must come after nanvix-libc-artifacts.mk (it references
+# NANVIX_LIBC_BUNDLE_AR) and posix-tests.mk after guest-c-apps.mk (it reuses the
+# GUEST_C_APP_* toolchain definitions and ALL_POSIX_TESTS).
+include build/make/guest-c-apps.mk
+include build/make/posix-tests.mk
 
 #===================================================================================================
 # Build Rules for Guest Rust Libraries

--- a/build/make/guest-c-apps.mk
+++ b/build/make/guest-c-apps.mk
@@ -1,0 +1,75 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===================================================================================================
+# Shared Guest C Toolchain (build guest C sources against the bundled libc)
+#===================================================================================================
+#
+# Defines the host C toolchain and link flags used to build guest C sources
+# against the merged `libc.a` (the C library + the Nanvix system-call backend,
+# produced by `nanvix-libc-bundle`). These definitions are consumed by
+# `build/make/posix-tests.mk`, which compiles the ported POSIX C test suites with
+# them. The resulting binaries exercise the bundled libc and are never shipped in
+# releases: `install`/`release` copy only the kernel, daemons, libraries, and
+# host tools.
+#
+# C toolchain: guest C sources are cross-compiled with the host `clang`
+# (targeting the i686 guest ABI), so they build on developer machines and CI
+# without a dedicated cross toolchain.
+
+#---------------------------------------------------------------------------------------------------
+# C compiler.
+#---------------------------------------------------------------------------------------------------
+
+# Host clang, cross-compiling to the i686 guest ABI.
+GUEST_C_APP_CC := clang --target=i686-unknown-none
+
+#---------------------------------------------------------------------------------------------------
+# Flags and inputs.
+#---------------------------------------------------------------------------------------------------
+
+# Compile flags: freestanding i686, project headers only. Clang supplies the
+# freestanding headers (stddef.h/stdarg.h) from its builtin resource dir.
+#
+# On GNU/Linux, -nostdinc maximally isolates from host headers while clang still
+# resolves its builtin freestanding headers. On Windows this clang drops the
+# builtin resource dir under -nostdinc, so use -nostdlibinc there: it still
+# excludes the host C library headers but keeps the compiler's builtin
+# freestanding headers (stdarg.h, stddef.h, ...).
+ifeq ($(IS_WINDOWS),yes)
+GUEST_C_APP_CFLAGS := -m32 -march=pentiumpro -ffreestanding -nostdlibinc -std=c17
+else
+GUEST_C_APP_CFLAGS := -m32 -march=pentiumpro -ffreestanding -nostdinc -std=c17
+endif
+GUEST_C_APP_CFLAGS += -isystem $(ROOT_DIR)/include
+ifeq ($(RELEASE),yes)
+GUEST_C_APP_CFLAGS += -O3
+else
+GUEST_C_APP_CFLAGS += -O0 -g
+endif
+
+# Link: host ld over the merged libc.a + crt0 + the guest user linker script.
+# Mirrors the proven guest link (-z muldefs == the guest build's
+# -Wl,--allow-multiple-definition: both libc and the backend define __errno_location).
+#
+# Windows has no GNU ld. The LLVM toolchain that already supplies the guest
+# `clang` also ships `ld.lld`, which performs the same ELF i386 link
+# (-melf_i386, -z muldefs, -T script, --entry), so default to it there.
+ifeq ($(IS_WINDOWS),yes)
+GUEST_C_APP_LD ?= ld.lld
+else
+GUEST_C_APP_LD ?= ld
+endif
+GUEST_C_APP_LIBC := $(NANVIX_LIBC_BUNDLE_AR)
+# Standalone math archive (newlib-style libc.a / libm.a split). Produced by
+# `all-guest-staticlibs` from the `nanvix_libm` crate (libc_math + nvx panic
+# handler, no sysalloc).
+GUEST_C_APP_LIBM := $(LIBRARIES_DIR)/libm.a
+GUEST_C_APP_LD_SCRIPT := $(BUILD_DIR)/user/linker/$(TARGET)/user.ld
+GUEST_C_APP_LDFLAGS := -melf_i386 -z noexecstack -z muldefs
+# --no-warn-rwx-segments silences a GNU ld >= 2.39 diagnostic. ld.lld neither
+# emits that warning nor recognizes the flag, so pass it only to GNU ld.
+ifneq ($(IS_WINDOWS),yes)
+GUEST_C_APP_LDFLAGS += --no-warn-rwx-segments
+endif
+GUEST_C_APP_LDFLAGS += -T $(GUEST_C_APP_LD_SCRIPT) --entry=_do_start

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -1,0 +1,361 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===================================================================================================
+# Ported POSIX C Test Suites (built against the bundled Nanvix libc)
+#===================================================================================================
+#
+# Builds the C test suites ported from `nanvix/posix-tests` and runs them under
+# nanvixd in standalone mode (nanvixd drives the UserVM). Each suite lives at
+# `src/posix-tests/<suite>/` (one or
+# more `*.c` files), is compiled with the host C toolchain against the in-tree
+# headers in `include/`, and linked against the merged `libc.a` (the C library +
+# the Nanvix system-call backend, produced by `nanvix-libc-bundle`) — exactly
+# like `build/make/guest-c-apps.mk`, whose compiler/flag definitions this fragment
+# reuses.
+#
+# The suites build against the bundled libc; the boot runner
+# (`run-posix-tests`) is gated on DEPLOYMENT_MODE=standalone, the only mode it
+# supports.
+#
+# Like the other guest test binaries, the suites are never shipped in releases:
+# `install`/`release` copy only the kernel, daemons, libraries, and host tools.
+#
+# Pass/fail convention (matches the test-kernel exit-code signal): a suite passes
+# when its `main()` returns 0, which nanvixd propagates as its own exit code.
+# A failed `assert()` aborts (SIGABRT -> exit 134) or a non-zero return marks a
+# failure. Guest stdout is discarded in standalone mode, so the exit code
+# is authoritative.
+
+#---------------------------------------------------------------------------------------------------
+# Inputs and flags (reused from guest-c-apps.mk).
+#---------------------------------------------------------------------------------------------------
+
+POSIX_TESTS_SRCDIR := $(SOURCES_DIR)/posix-tests
+POSIX_TESTS_OBJDIR := $(OBJECTS_DIR)/posix-tests
+
+# Shared, weak `_init`/`_fini` glue, retained only as harmless legacy scaffolding.
+# After doc/toolchain-migration.md §4.5 (decision 1), the c-main startup
+# (nvx-crt0's __nanvix_main) NO LONGER calls `_init`/`_fini`: constructors and
+# destructors run via `.init_array`/`.fini_array`, walked by
+# `__nanvix_libc_start_main` (see src/libs/posix/src/start.rs) using the bounds
+# the guest `user.ld` provides. These weak stubs therefore resolve nothing and
+# are unreferenced; they are kept so any not-yet-updated port object that still
+# references `_init`/`_fini` links cleanly, and disappear with the native
+# toolchains.
+POSIX_TEST_CRT_OBJ := $(POSIX_TESTS_OBJDIR)/common/crt0-stubs.o
+
+# Compile flags: the freestanding guest C flags, plus the upstream suite defines
+# (mirroring nanvix/posix-tests' src/Makefile) so the ported sources behave the
+# same as upstream — standalone build, microvm platform, and the system/node
+# name strings that misc-c compares against.
+POSIX_TEST_CFLAGS := $(GUEST_C_APP_CFLAGS)
+POSIX_TEST_CFLAGS += -D__NANVIX_STANDALONE__ -D__microvm__
+POSIX_TEST_CFLAGS += -D__NANVIX_SYSNAME__=\"nanvix\" -D__NANVIX_NODENAME__=\"localhost\"
+
+#---------------------------------------------------------------------------------------------------
+# Per-suite build rule.
+#---------------------------------------------------------------------------------------------------
+
+# Object compile rule: one object per source file, mirroring the suite tree under
+# the objects directory. Kept out of the per-suite `define` so it is parsed once
+# (a shell loop inside an `$(eval $(call ...))` body would have its `$var`
+# references eaten by the extra expansion pass). PIE suites add `-fPIE` through
+# the per-object `POSIX_TEST_EXTRA_CFLAGS` target-specific variable.
+$(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_SRCDIR)/%.c
+	@command -v $(firstword $(GUEST_C_APP_CC)) >/dev/null 2>&1 || { \
+		echo "ERROR: posix-tests need '$(firstword $(GUEST_C_APP_CC))' on PATH to cross-compile the guest C sources."; \
+		exit 1; \
+	}
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] compiling $< (CC=$(firstword $(GUEST_C_APP_CC)))"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_CFLAGS) $(POSIX_TEST_EXTRA_CFLAGS) -c $< -o $@
+
+# $(1) = suite name (directory under src/posix-tests/ and resulting <suite>.elf).
+#
+# All `*.c` under the suite directory are compiled and linked together. The
+# explicit `.elf` rule overrides the generic `$(BINARIES_DIR)/%.elf:
+# all-guest-binaries ;` pattern bridge for these specific files (explicit rules
+# win over pattern rules), so the standalone-images machinery bundles the
+# resulting ELF into `<suite>.initrd` without any custom mkimage recipe.
+#
+# A suite may restrict the compiled set via POSIX_TEST_FILES_<suite> (a list of
+# file names under the suite directory) — used by file-c, whose link-only and
+# guarded sub-tests need features absent from the standalone VFS (FAT32 has no
+# links/permissions; poll/select have no standalone backend).
+
+# file-c: only the sub-tests that main.c runs under __NANVIX_STANDALONE__. The
+# remaining files exercise links, permissions/ownership, timestamps, and
+# poll/select, which the standalone FAT32 VFS does not support.
+POSIX_TEST_FILES_file-c := \
+	main.c open_close.c create_unlink.c write_read.c posix_fadvise.c lseek.c \
+	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
+	fdatasync.c stat.c ftruncate.c renameat.c unlinkat.c mkdirat.c mkdir.c \
+	dirent.c getcwd.c chdir.c fchdir.c
+
+# Extra link flags for position-independent executables. The dlfcn PIE variants
+# build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's
+# own symbols are resolvable via dlopen(NULL)/RTLD_DEFAULT. Mirrors the proven
+# dlfcn-rust PIE link (src/tests/dlfcn-rust/build.rs): -z notext for the static
+# libc's text relocations, -z norelro to keep .dynamic in the data segment (the
+# kernel maps pages per-segment), SysV hashing, and no PT_INTERP (Nanvix has no
+# system dynamic linker; nvx-crt0 self-relocates the PIE at startup).
+POSIX_TEST_PIE_LDFLAGS := -pie --export-dynamic --no-dynamic-linker -z notext -z norelro --hash-style=sysv
+
+# Suites linked as position-independent executables (PIE).
+POSIX_TEST_PIE_dlfcn-pie-c := yes
+POSIX_TEST_PIE_dlfcn-global-c := yes
+POSIX_TEST_PIE_dlfcn-needed-c := yes
+
+define POSIX_TEST_RULE
+POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TESTS_SRCDIR)/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TESTS_SRCDIR)/$(1)/*.c))
+POSIX_TEST_OBJS_$(1) := $$(patsubst $$(POSIX_TESTS_SRCDIR)/%.c,$$(POSIX_TESTS_OBJDIR)/%.o,$$(POSIX_TEST_SRCS_$(1)))
+# PIE suites compile their objects with -fPIE and link with the PIE flags.
+ifeq ($$(POSIX_TEST_PIE_$(1)),yes)
+$$(POSIX_TEST_OBJS_$(1)): POSIX_TEST_EXTRA_CFLAGS := -fPIE
+endif
+$$(BINARIES_DIR)/$(1).$$(EXEC_FORMAT): $$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
+		$$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) $$(LIBNVX_CRT0) $$(GUEST_C_APP_LD_SCRIPT)
+	@echo "[posix-test] linking $(1) against libc.a + libm.a$$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))), (PIE))"
+	$$(GUEST_C_APP_LD) $$(GUEST_C_APP_LDFLAGS) $$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))),$$(POSIX_TEST_PIE_LDFLAGS)) \
+		$$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
+		--start-group $$(LIBNVX_CRT0) $$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) --end-group -o $$@
+	@echo "[posix-test] built $$@"
+endef
+
+$(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_RULE,$(suite))))
+
+#---------------------------------------------------------------------------------------------------
+# Per-suite standalone image rule.
+#---------------------------------------------------------------------------------------------------
+
+# Each suite is bundled into its own `<suite>.initrd` (procd + memd + vfsd + the
+# suite ELF) with a custom command line, rather than going through the generic
+# `standalone-images` machinery, so that:
+#   * argv[0] is "<suite>.elf" — the upstream convention some suites assert on
+#     (e.g. misc-c checks `strcmp(argv[0], "misc-c.elf") == 0`);
+#   * suites that need environment variables (e.g. misc-c needs NANVIX_TEST=1)
+#     can inject them via POSIX_TEST_ENV_<suite>.
+#
+# Command-line wire format (see src/libs/cmdline + src/utils/mkimage): the mkimage
+# entry is `<path>;<cmdline>` and mkimage splits the path off on the first `;`;
+# the kernel's split_cmdline() then splits the cmdline into `<args>;<env>` on the
+# next `;`. Every `;` is written `\;` so the shell passes a literal `;` to mkimage.
+
+# Per-suite environment variables (space-separated KEY=VALUE entries). Empty unless set.
+POSIX_TEST_ENV_misc-c := NANVIX_TEST=1
+
+# $(1) = suite name.
+define POSIX_TEST_IMAGE_RULE
+$$(BINARIES_DIR)/$(1).initrd: $$(BINARIES_DIR)/$(1).$$(EXEC_FORMAT) \
+		$$(BINARIES_DIR)/procd.$$(EXEC_FORMAT) \
+		$$(BINARIES_DIR)/memd.$$(EXEC_FORMAT) \
+		$$(BINARIES_DIR)/vfsd.$$(EXEC_FORMAT) \
+		$$(MKIMAGE)
+	$$(MKIMAGE) -o $$@ \
+		$$(BINARIES_DIR)/procd.$$(EXEC_FORMAT)\;procd \
+		$$(BINARIES_DIR)/memd.$$(EXEC_FORMAT)\;memd \
+		$$(BINARIES_DIR)/vfsd.$$(EXEC_FORMAT)\;vfsd \
+		$$(BINARIES_DIR)/$(1).$$(EXEC_FORMAT)\;$(1).$$(EXEC_FORMAT)$$(if $$(strip $$(POSIX_TEST_ENV_$(1))),\;$$(POSIX_TEST_ENV_$(1)))
+endef
+
+$(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_IMAGE_RULE,$(suite))))
+
+#---------------------------------------------------------------------------------------------------
+# Aggregate and clean targets.
+#---------------------------------------------------------------------------------------------------
+
+.PHONY: all-posix-tests clean-posix-tests
+
+all-posix-tests: $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).$(EXEC_FORMAT))
+
+clean-posix-tests:
+	$(RM_CMD) $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).$(EXEC_FORMAT))
+	$(RM_CMD) $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).initrd)
+	$(RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs.img
+	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
+	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
+	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
+	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
+
+#---------------------------------------------------------------------------------------------------
+# Boot runner: build + boot each ported suite under nanvixd in standalone mode
+# (nanvixd drives the UserVM) and assert the propagated exit code is 0.
+#---------------------------------------------------------------------------------------------------
+
+POSIX_TEST_INITRDS := $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).initrd)
+POSIX_TEST_LOGDIR  := $(LOGS_DIR)/posix-tests
+
+# Writable FAT32 RAMFS image for suites that exercise the file system (file-c)
+# or load a shared library at runtime (dlfcn-c). Built from a tiny seed directory
+# with mkramfs and handed to the UserVM via `-ramfs`; without it the standalone
+# guest has no writable file system and open(O_CREAT) fails. The seed also
+# carries lib/libmul.so (the prebuilt dlopen fixture that dlfcn-rust installs
+# into lib/) so dlfcn-c can dlopen("lib/libmul.so"). Suites that need the image
+# are listed in POSIX_TEST_RAMFS_SUITES. Suites with their own fixtures (the
+# dlfcn global/needed variants, below) override the image with a per-suite one.
+POSIX_TEST_RAMFS_SUITES := file-c dlfcn-c dlfcn-pie-c dlfcn-global-c dlfcn-needed-c
+POSIX_TEST_RAMFS_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-seed
+POSIX_TEST_RAMFS_IMG    := $(BINARIES_DIR)/posix-tests-ramfs.img
+
+$(POSIX_TEST_RAMFS_SEED)/marker.txt:
+	@$(MKDIR_CMD) $(POSIX_TEST_RAMFS_SEED)
+	@echo "posix-tests ramfs marker" > $@
+
+# Depends on dlfcn-rust's ELF so that its build script has installed
+# lib/libmul.so and lib/libmul-pie.so before we stage them into the RAMFS seed.
+$(POSIX_TEST_RAMFS_IMG): $(POSIX_TEST_RAMFS_SEED)/marker.txt \
+		$(BINARIES_DIR)/dlfcn-rust.$(EXEC_FORMAT) all-host-binaries-mkramfs
+	@$(MKDIR_CMD) $(POSIX_TEST_RAMFS_SEED)/lib
+	$(CP_CMD) $(LIBRARIES_DIR)/libmul.so $(POSIX_TEST_RAMFS_SEED)/lib/
+	$(CP_CMD) $(LIBRARIES_DIR)/libmul-pie.so $(POSIX_TEST_RAMFS_SEED)/lib/
+	$(MKRAMFS) -o $(POSIX_TEST_RAMFS_IMG) $(POSIX_TEST_RAMFS_SEED)
+
+#---------------------------------------------------------------------------------------------------
+# Suites that build their own shared-library fixtures (a `libs/` subdirectory).
+#---------------------------------------------------------------------------------------------------
+#
+# dlfcn-global-c and dlfcn-needed-c each ship a libprovider.so and a
+# libconsumer.so, but with *different* linkage of the same file names:
+#   * global-c: libconsumer.so has the provider symbols UNDEFINED (no DT_NEEDED);
+#     they are resolved at dlopen time from the global scope (RTLD_GLOBAL).
+#   * needed-c: libconsumer.so is linked against libprovider.so (DT_NEEDED), so
+#     the loader auto-loads the provider.
+# Because the names collide, each suite gets its own RAMFS image.
+#
+# The `.so` are built with the same host toolchain as the guest C apps:
+# position-independent, freestanding objects linked with `ld -shared` and
+# `-z notext` (the inline-asm-free fixtures still need text relocations allowed
+# for R_386_* against local symbols), mirroring the prebuilt libmul.so recipe.
+
+POSIX_TEST_SOLIB_SUITES := dlfcn-global-c dlfcn-needed-c
+POSIX_TEST_SOLIB_CFLAGS := -m32 -march=pentiumpro -nostdlib -ffreestanding -fPIC -O2
+POSIX_TEST_SOLIB_LDFLAGS := -shared -melf_i386 -z notext
+
+# Consumer libraries that should carry a DT_NEEDED entry on libprovider.so.
+POSIX_TEST_SOLIB_NEEDED_dlfcn-needed-c := yes
+
+# $(1) = suite name with a libs/ subdir (provider.c + consumer.c).
+define POSIX_TEST_SOLIB_RULE
+POSIX_TEST_SOLIB_DIR_$(1) := $$(POSIX_TESTS_OBJDIR)/$(1)/libs
+POSIX_TEST_RAMFS_SEED_$(1) := $$(BINARIES_DIR)/posix-tests-ramfs-$(1)-seed
+POSIX_TEST_RAMFS_IMG_$(1)  := $$(BINARIES_DIR)/posix-tests-ramfs-$(1).img
+
+# Provider: self-contained (zero undefined symbols).
+$$(POSIX_TEST_SOLIB_DIR_$(1))/libprovider.so: $$(POSIX_TESTS_SRCDIR)/$(1)/libs/provider.c
+	@$$(MKDIR_CMD) $$(dir $$@)
+	@echo "[posix-test] building $(1)/libprovider.so"
+	$$(GUEST_C_APP_CC) $$(POSIX_TEST_SOLIB_CFLAGS) -c $$< -o $$@.o
+	$$(GUEST_C_APP_LD) $$(POSIX_TEST_SOLIB_LDFLAGS) $$@.o -o $$@
+
+# Consumer: references the provider's symbols. With DT_NEEDED for needed-c
+# (linked against libprovider.so); with the symbols left UNDEFINED for global-c.
+$$(POSIX_TEST_SOLIB_DIR_$(1))/libconsumer.so: $$(POSIX_TESTS_SRCDIR)/$(1)/libs/consumer.c \
+		$$(POSIX_TEST_SOLIB_DIR_$(1))/libprovider.so
+	@$$(MKDIR_CMD) $$(dir $$@)
+	@echo "[posix-test] building $(1)/libconsumer.so$$(if $$(POSIX_TEST_SOLIB_NEEDED_$(1)), (DT_NEEDED libprovider.so))"
+	$$(GUEST_C_APP_CC) $$(POSIX_TEST_SOLIB_CFLAGS) -c $$< -o $$@.o
+	$$(GUEST_C_APP_LD) $$(POSIX_TEST_SOLIB_LDFLAGS) $$@.o \
+		$$(if $$(POSIX_TEST_SOLIB_NEEDED_$(1)),-L$$(POSIX_TEST_SOLIB_DIR_$(1)) -lprovider) -o $$@
+
+# Per-suite RAMFS image carrying the two fixtures under lib/.
+$$(POSIX_TEST_RAMFS_IMG_$(1)): $$(POSIX_TEST_SOLIB_DIR_$(1))/libprovider.so \
+		$$(POSIX_TEST_SOLIB_DIR_$(1))/libconsumer.so all-host-binaries-mkramfs
+	@$$(MKDIR_CMD) $$(POSIX_TEST_RAMFS_SEED_$(1))/lib
+	$$(CP_CMD) $$(POSIX_TEST_SOLIB_DIR_$(1))/libprovider.so $$(POSIX_TEST_RAMFS_SEED_$(1))/lib/
+	$$(CP_CMD) $$(POSIX_TEST_SOLIB_DIR_$(1))/libconsumer.so $$(POSIX_TEST_RAMFS_SEED_$(1))/lib/
+	$$(MKRAMFS) -o $$@ $$(POSIX_TEST_RAMFS_SEED_$(1))
+endef
+
+$(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(eval $(call POSIX_TEST_SOLIB_RULE,$(suite))))
+
+# All per-suite RAMFS images (built on demand by the runner).
+POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite)))
+
+# Maps each RAMFS suite to the image it boots with: a suite with its own
+# fixtures uses its per-suite image (POSIX_TEST_RAMFS_IMG_<suite>, defined by the
+# solib rule above), otherwise the shared image. The runner looks the suite up in
+# this `suite:image` list.
+POSIX_TEST_RAMFS_MAP := $(foreach s,$(POSIX_TEST_RAMFS_SUITES),$(s):$(or $(POSIX_TEST_RAMFS_IMG_$(s)),$(POSIX_TEST_RAMFS_IMG)))
+
+# Suites that need host networking (AF_INET sockets bridged to the host). The
+# runner boots these with nanvixd's `-allow-host-networking` flag, which enables
+# the in-VMM network daemon in standalone mode.
+POSIX_TEST_NET_SUITES := network-c
+
+#---------------------------------------------------------------------------------------------------
+# Aggregate image target.
+#---------------------------------------------------------------------------------------------------
+
+# Builds every suite's bootable `<suite>.initrd` plus the RAMFS images the
+# file-system and dlopen suites need (the shared image and the per-suite
+# global/needed fixtures). This is the build-side entry point used wherever
+# `run-posix-tests` is skipped — notably Windows, where suites are booted
+# manually under WHP (see the repo notes). `run-posix-tests` depends on the same
+# set, so this also pre-stages everything the Linux runner consumes.
+.PHONY: all-posix-test-images
+all-posix-test-images: $(POSIX_TEST_INITRDS) \
+		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
+		$(POSIX_TEST_SOLIB_IMGS)
+	@echo "All POSIX C test-suite images built."
+
+.PHONY: run-posix-tests
+
+# The boot runner is Linux- and i686-only: it relies on coreutils `timeout`,
+# `/dev/null`, and a cloud-hypervisor-style nanvixd invocation (Linux), and the
+# guest C toolchain is pinned to the i686 ABI (TARGET=x86). On Windows or other
+# targets the suites can still be built (`all-posix-tests`); on Windows they boot
+# manually under WHP (see doc + repo notes).
+ifeq ($(IS_WINDOWS),yes)
+run-posix-tests:
+	@echo "Skipping POSIX C test suites (run-posix-tests is Linux-only; build with 'all-posix-tests' and boot manually under WHP)."
+else ifneq ($(TARGET),x86)
+run-posix-tests:
+	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
+else ifeq ($(DEPLOYMENT_MODE),standalone)
+run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS)
+	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
+	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }
+	@test -f $(USERVM) || { echo "ERROR: $(USERVM) missing; run './z build -- all' first."; exit 1; }
+	@$(MKDIR_CMD) $(POSIX_TEST_LOGDIR)
+	@echo "================================================================================"
+	@echo "Running ported POSIX C test suites under nanvixd (standalone)"
+	@echo "================================================================================"
+	@failures=""; \
+	for suite in $(ALL_POSIX_TESTS); do \
+		initrd="$(BINARIES_DIR)/$$suite.initrd"; \
+		log="$(POSIX_TEST_LOGDIR)/$$suite.log"; \
+		console="$(POSIX_TEST_LOGDIR)/$$suite.console.log"; \
+		ramfs=""; \
+		for entry in $(POSIX_TEST_RAMFS_MAP); do \
+			case "$$entry" in \
+				$$suite:*) ramfs="-ramfs $${entry#*:}" ;; \
+			esac; \
+		done; \
+		net=""; \
+		case " $(POSIX_TEST_NET_SUITES) " in \
+			*" $$suite "*) net="-allow-host-networking" ;; \
+		esac; \
+		printf '%-24s ... ' "$$suite"; \
+		rc=0; \
+		timeout -k 5 $(TIMEOUT) $(NANVIXD) -console-file $$console -log-dir $(POSIX_TEST_LOGDIR) \
+			$$ramfs $$net -- $$initrd \
+			< /dev/null > $$log 2>&1 || rc=$$?; \
+		if [ "$$rc" -eq 0 ]; then \
+			echo "PASS (exit 0)"; \
+		else \
+			echo "FAIL (exit $$rc)"; \
+			failures="$$failures $$suite"; \
+		fi; \
+	done; \
+	echo "--------------------------------------------------------------------------------"; \
+	if [ -n "$$failures" ]; then \
+		echo "FAILED suites:$$failures"; \
+		echo "(logs in $(POSIX_TEST_LOGDIR))"; \
+		exit 1; \
+	fi; \
+	echo "All ported POSIX C test suites passed."
+else
+run-posix-tests:
+	@echo "Skipping POSIX C test suites (DEPLOYMENT_MODE=$(DEPLOYMENT_MODE), requires standalone)."
+endif

--- a/src/posix-tests/c-bindings/main.c
+++ b/src/posix-tests/c-bindings/main.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+/**
+ * @brief Performs static assertions on C bindings.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. This function performs static assertions on the
+ * C bindings. If any assertion fails, compilation will fail.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert size of signed primitive types.
+    STATIC_ASSERT_SIZE(char, 1);
+    STATIC_ASSERT_SIZE(short, 2);
+    STATIC_ASSERT_SIZE(int, 4);
+    STATIC_ASSERT_SIZE(long, 4);
+    STATIC_ASSERT_SIZE(long long, 8);
+    STATIC_ASSERT_SIZE(float, 4);
+    STATIC_ASSERT_SIZE(double, 8);
+
+    // Assert size of unsigned primitive types.
+    STATIC_ASSERT_SIZE(unsigned char, 1);
+    STATIC_ASSERT_SIZE(unsigned short, 2);
+    STATIC_ASSERT_SIZE(unsigned int, 4);
+    STATIC_ASSERT_SIZE(unsigned long, 4);
+    STATIC_ASSERT_SIZE(unsigned long long, 8);
+
+    // Assert size of types in <stdint.h>.
+    STATIC_ASSERT_SIZE(int8_t, 1);
+    STATIC_ASSERT_SIZE(int16_t, 2);
+    STATIC_ASSERT_SIZE(int32_t, 4);
+    STATIC_ASSERT_SIZE(int64_t, 8);
+    STATIC_ASSERT_SIZE(uint8_t, 1);
+    STATIC_ASSERT_SIZE(uint16_t, 2);
+    STATIC_ASSERT_SIZE(uint32_t, 4);
+    STATIC_ASSERT_SIZE(uint64_t, 8);
+
+    // Assert size of types int <sys/types.h>.
+    STATIC_ASSERT_SIZE(blkcnt_t, sizeof(long long));
+    STATIC_ASSERT_SIZE(blksize_t, sizeof(long long));
+    STATIC_ASSERT_SIZE(clock_t, (sizeof(long long)));
+    STATIC_ASSERT_SIZE(clockid_t, sizeof(int));
+    STATIC_ASSERT_SIZE(dev_t, sizeof(unsigned long long));
+    STATIC_ASSERT_SIZE(gid_t, sizeof(unsigned int));
+    STATIC_ASSERT_SIZE(ino_t, sizeof(unsigned long long));
+    STATIC_ASSERT_SIZE(mode_t, sizeof(unsigned int));
+    STATIC_ASSERT_SIZE(nlink_t, sizeof(unsigned long long));
+    STATIC_ASSERT_SIZE(off_t, sizeof(long long));
+    STATIC_ASSERT_SIZE(pid_t, sizeof(int));
+    STATIC_ASSERT_SIZE(reclen_t, sizeof(unsigned short));
+    STATIC_ASSERT_SIZE(size_t, sizeof(unsigned int));
+    STATIC_ASSERT_SIZE(ssize_t, sizeof(int));
+    STATIC_ASSERT_SIZE(time_t, sizeof(long long));
+    STATIC_ASSERT_SIZE(uid_t, sizeof(unsigned int));
+
+    // Assert size of types in <time.h>.
+    STATIC_ASSERT_SIZE(struct timespec, sizeof(time_t) + sizeof(long));
+
+    // Assert types in <sched.h>.
+    STATIC_ASSERT_SIZE(struct sched_param, sizeof(int));
+
+    return (0);
+}

--- a/src/posix-tests/common/crt0-stubs.c
+++ b/src/posix-tests/common/crt0-stubs.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Minimal `_init`/`_fini` glue shared by every ported POSIX C test suite.
+ *
+ * The `c-main` startup driver (nvx-crt0's `__nanvix_main`) NO LONGER calls
+ * `_init()`/`_fini()`: with the in-tree `nanvix_libc` bundle (which enables the
+ * `init-array` feature) global constructors and destructors instead run via
+ * `.init_array`/`.fini_array`, walked by `__nanvix_libc_start_main` (see
+ * src/libs/posix/src/start.rs). These empty stubs therefore resolve nothing and
+ * are normally unreferenced; they are kept only as harmless legacy scaffolding
+ * so any not-yet-updated port object that still references `_init`/`_fini`
+ * links cleanly (the host-clang posix-tests link path pulls in no
+ * `crti.o`/`crtn.o`). It is compiled once and linked into each suite ELF (it is
+ * not a suite of its own).
+ */
+
+void _init(void)
+{
+}
+
+void _fini(void)
+{
+}

--- a/src/posix-tests/ctor-c/main.c
+++ b/src/posix-tests/ctor-c/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Validates the `.init_array` constructor framing walked by
+ * `__nanvix_libc_start_main` (doc/toolchain-migration.md §4.5, decision 1).
+ *
+ * Nanvix ships no GCC `crtbegin`/`crtend`; instead the libc-side start-of-day
+ * driver walks `.preinit_array` and `.init_array` (whose bounds come from the
+ * guest `user.ld`) before calling `main`. This suite asserts that:
+ *
+ *   1. a default-priority global constructor runs before `main`, and
+ *   2. prioritized constructors run in ascending-priority order
+ *      (exercising the `SORT_BY_INIT_PRIORITY` collection in `user.ld`).
+ *
+ * The suite passes (returns 0) only when both hold.
+ */
+
+static int ctor_default_ran = 0;
+static int ctor_prio_seq[2] = {0, 0};
+static int ctor_prio_pos = 0;
+
+__attribute__((constructor)) static void ctor_default(void)
+{
+    ctor_default_ran = 1;
+}
+
+__attribute__((constructor(101))) static void ctor_first(void)
+{
+    if (ctor_prio_pos < 2)
+    {
+        ctor_prio_seq[ctor_prio_pos++] = 101;
+    }
+}
+
+__attribute__((constructor(102))) static void ctor_second(void)
+{
+    if (ctor_prio_pos < 2)
+    {
+        ctor_prio_seq[ctor_prio_pos++] = 102;
+    }
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* The default-priority constructor must have run before main. */
+    if (!ctor_default_ran)
+    {
+        return (1);
+    }
+
+    /* Prioritized constructors must have run, lower priority first. */
+    if (ctor_prio_seq[0] != 101 || ctor_prio_seq[1] != 102)
+    {
+        return (2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/dlfcn-c/main.c
+++ b/src/posix-tests/dlfcn-c/main.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Opens a dynamic load library.
+void *open_library(const char *path)
+{
+    void *handle = dlopen(path, RTLD_LAZY);
+    assert(handle != NULL);
+    return (handle);
+}
+
+// Closes a dynamic load library.
+void close_library(void *handle)
+{
+    assert(dlclose(handle) == 0);
+}
+
+// Resolves a symbol in a dynamic load library.
+void *resolve_symbol(void *handle, const char *symbol)
+{
+    void *sym = dlsym(handle, symbol);
+    assert(sym != NULL);
+    return (sym);
+}
+
+// Tests if dlopen() and dlclose() work.
+void test_dlopen_dlclose(const char *path)
+{
+    void *handle = open_library(path);
+    close_library(handle);
+}
+
+// Tests if dlsym() works.
+void test_dlsym(const char *path)
+{
+    void *handle = open_library(path);
+
+    int (*add)(int, int) = NULL;
+    *(void **)(&add) = resolve_symbol(handle, "add");
+    assert(add != NULL);
+    assert(add(1, 2) == 3);
+
+    int (*fast_mul)(int, int) = NULL;
+    *(void **)(&fast_mul) = resolve_symbol(handle, "fast_mul");
+    assert(fast_mul != NULL);
+    assert(fast_mul(7, 2) == 14);
+
+    int (*slow_mul)(int, int) = NULL;
+    *(void **)(&slow_mul) = resolve_symbol(handle, "slow_mul");
+    assert(slow_mul != NULL);
+    assert(slow_mul(3, 4) == 12);
+
+    int (*multiply)(int, int) = NULL;
+    *(void **)(&multiply) = resolve_symbol(handle, "multiply");
+    assert(multiply != NULL);
+    assert(multiply(7, 6) == 42);
+
+    const char **version = resolve_symbol(handle, "VERSION");
+    assert(version != NULL);
+    assert(!strcmp(*version, "0.0.1"));
+
+    const char *(*get_version)(void) = NULL;
+    *(void **)(&get_version) = resolve_symbol(handle, "get_version");
+    assert(get_version != NULL);
+    assert(!strcmp(get_version(), "0.0.1"));
+
+    close_library(handle);
+}
+
+// Tests if dladdr() works.
+void test_dladdr(const char *path)
+{
+    void *handle = open_library(path);
+
+    int (*add)(int, int) = NULL;
+    *(void **)(&add) = resolve_symbol(handle, "add");
+    assert(add != NULL);
+
+    void *add_addr = *(void **)(&add);
+
+    Dl_info_t info;
+    assert(dladdr(add_addr, &info) == 0);
+    assert(!strcmp(info.dli_fname, path));
+    assert(info.dli_fbase != NULL);
+    assert(!strcmp(info.dli_sname, "add"));
+    assert(info.dli_saddr == add_addr);
+
+    close_library(handle);
+}
+
+/**
+ * @brief Tests system calls to operate on dynamic load libraries.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert types in <dlfcn.h>.
+    STATIC_ASSERT_SIZE(Dl_info_t,
+                       sizeof(char *)             // dli_fname
+                           + sizeof(void *)       // dli_fbase
+                           + sizeof(const char *) // dli_sname
+                           + sizeof(void *)       // dli_saddr
+    );
+
+    test_dlopen_dlclose("lib/libmul.so");
+    test_dlsym("lib/libmul.so");
+    test_dladdr("lib/libmul.so");
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/dlfcn-global-c/libs/consumer.c
+++ b/src/posix-tests/dlfcn-global-c/libs/consumer.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libconsumer.so - Shared library that depends on libprovider.so
+ *                  WITHOUT a DT_NEEDED entry.
+ *
+ * This library calls provider_add(), provider_mul(), provider_isqrt()
+ * but is NOT linked against libprovider.so at build time.  The symbols
+ * must be resolved at dlopen time from the global scope (RTLD_GLOBAL).
+ *
+ * This pattern occurs in plugin architectures where a host loads a
+ * provider library with RTLD_GLOBAL before loading plugin modules.
+ */
+
+extern int provider_add(int a, int b);
+extern int provider_mul(int a, int b);
+extern int provider_isqrt(int x);
+
+int consumer_add(int a, int b)
+{
+    return provider_add(a, b);
+}
+
+int consumer_mul(int a, int b)
+{
+    return provider_mul(a, b);
+}
+
+int consumer_isqrt(int x)
+{
+    return provider_isqrt(x);
+}
+
+/* Function with no cross-library dependency (control case). */
+int consumer_noop(int x)
+{
+    return x + 1;
+}

--- a/src/posix-tests/dlfcn-global-c/libs/provider.c
+++ b/src/posix-tests/dlfcn-global-c/libs/provider.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libprovider.so - Self-contained shared library that exports functions.
+ *
+ * All functions are implemented inline with no external dependencies,
+ * so this library has ZERO undefined symbols and always loads successfully.
+ */
+
+int provider_add(int a, int b)
+{
+    return a + b;
+}
+
+int provider_mul(int a, int b)
+{
+    return a * b;
+}
+
+/* Integer square root via Newton's method. */
+int provider_isqrt(int x)
+{
+    if (x <= 0)
+        return 0;
+    int r = x;
+    while (r > x / r)
+        r = (r + x / r) / 2;
+    return r;
+}

--- a/src/posix-tests/dlfcn-global-c/main.c
+++ b/src/posix-tests/dlfcn-global-c/main.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-global-c: Test RTLD_GLOBAL cross-.so symbol resolution.
+ *
+ * This tests the plugin pattern where a host pre-loads a provider
+ * library with RTLD_GLOBAL, then loads consumer plugins that reference
+ * the provider's symbols without DT_NEEDED linkage.
+ *
+ * Per POSIX, RTLD_GLOBAL should make a library's symbols available
+ * for symbol resolution of subsequently loaded libraries.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 1: Load libconsumer.so WITHOUT loading libprovider.so first.
+ * Expected: FAIL — provider_add/mul/isqrt are unresolved.
+ */
+static void test_consumer_alone_fails(void)
+{
+    void *h = dlopen("lib/libconsumer.so", RTLD_NOW);
+    if (h == NULL) {
+        pass("consumer alone fails");
+        return;
+    }
+
+    fail("consumer alone fails",
+         "dlopen should have returned NULL for unresolved symbols");
+    dlclose(h);
+}
+
+/*
+ * Test 2: Load libprovider.so with RTLD_GLOBAL, then libconsumer.so.
+ *
+ * Per POSIX, RTLD_GLOBAL should make libprovider.so's exports
+ * available to subsequently loaded libraries.
+ */
+static void test_global_provides_symbols(void)
+{
+    printf("  [2a] loading provider with RTLD_GLOBAL...\n");
+    fflush(stdout);
+
+    void *prov = dlopen("lib/libprovider.so", RTLD_GLOBAL);
+    if (prov == NULL) {
+        fail("RTLD_GLOBAL cross-lib", dlerror());
+        return;
+    }
+    printf("  [2b] provider loaded, loading consumer...\n");
+    fflush(stdout);
+
+    void *cons = dlopen("lib/libconsumer.so", RTLD_NOW);
+    printf("  [2c] consumer dlopen returned %p\n", (void *)cons);
+    fflush(stdout);
+
+    if (cons == NULL) {
+        fail("RTLD_GLOBAL cross-lib", dlerror());
+        dlclose(prov);
+        return;
+    }
+
+    int (*cadd)(int, int) = NULL;
+    *(void **)(&cadd) = dlsym(cons, "consumer_add");
+    if (cadd == NULL || cadd(10, 20) != 30) {
+        fail("RTLD_GLOBAL cross-lib", "consumer_add() failed");
+        dlclose(cons);
+        dlclose(prov);
+        return;
+    }
+
+    dlclose(cons);
+    dlclose(prov);
+    pass("RTLD_GLOBAL cross-lib");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn RTLD_GLOBAL tests ===\n");
+    fflush(stdout);
+
+    test_consumer_alone_fails();
+    test_global_provides_symbols();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/src/posix-tests/dlfcn-needed-c/libs/consumer.c
+++ b/src/posix-tests/dlfcn-needed-c/libs/consumer.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libconsumer.so - Shared library that depends on libprovider.so.
+ *
+ * Calls provider_add(), provider_mul(), provider_isqrt() which are
+ * defined in libprovider.so.  This library is linked against
+ * libprovider.so at build time, creating a DT_NEEDED entry.
+ *
+ * When the dynamic loader opens this library, it should automatically
+ * load libprovider.so (via DT_NEEDED) and resolve the symbols.
+ * This is the standard mechanism for shared library dependencies
+ * (e.g., a Python C extension depending on libm.so or libc.so).
+ */
+
+extern int provider_add(int a, int b);
+extern int provider_mul(int a, int b);
+extern int provider_isqrt(int x);
+
+int consumer_add(int a, int b)
+{
+    return provider_add(a, b);
+}
+
+int consumer_mul(int a, int b)
+{
+    return provider_mul(a, b);
+}
+
+int consumer_isqrt(int x)
+{
+    return provider_isqrt(x);
+}
+
+/* Function with no cross-library dependency (control case). */
+int consumer_noop(int x)
+{
+    return x + 1;
+}

--- a/src/posix-tests/dlfcn-needed-c/libs/provider.c
+++ b/src/posix-tests/dlfcn-needed-c/libs/provider.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libprovider.so - Self-contained shared library that exports functions.
+ *
+ * All functions are implemented inline with no external dependencies,
+ * so this library has ZERO undefined symbols and always loads successfully.
+ */
+
+int provider_add(int a, int b)
+{
+    return a + b;
+}
+
+int provider_mul(int a, int b)
+{
+    return a * b;
+}
+
+/* Integer square root via Newton's method. */
+int provider_isqrt(int x)
+{
+    if (x <= 0)
+        return 0;
+    int r = x;
+    while (r > x / r)
+        r = (r + x / r) / 2;
+    return r;
+}

--- a/src/posix-tests/dlfcn-needed-c/main.c
+++ b/src/posix-tests/dlfcn-needed-c/main.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-needed-c: Test DT_NEEDED automatic dependency loading.
+ *
+ * This is the most common shared library pattern: libconsumer.so is
+ * linked against libprovider.so at build time, creating a DT_NEEDED
+ * entry.  When the loader opens libconsumer.so, it should automatically
+ * load libprovider.so and resolve all symbols.
+ *
+ * This is how real-world dependencies work:
+ *   - CPython C extensions have DT_NEEDED entries for libm.so, libc.so
+ *   - The dynamic linker loads those automatically
+ *   - No RTLD_GLOBAL or manual pre-loading is needed
+ *
+ * On Nanvix, this tests whether the ELF loader follows DT_NEEDED
+ * entries and loads transitive dependencies.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 1: Load libprovider.so directly.
+ * Expected: PASS (no undefined symbols).
+ */
+static void test_provider_loads(void)
+{
+    void *h = dlopen("lib/libprovider.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("provider loads", dlerror());
+        return;
+    }
+
+    int (*fn)(int, int) = NULL;
+    *(void **)(&fn) = dlsym(h, "provider_add");
+    if (fn == NULL || fn(2, 3) != 5) {
+        fail("provider loads", "provider_add() wrong result");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("provider loads");
+}
+
+/*
+ * Test 2: Load libconsumer.so (which has DT_NEEDED: libprovider.so).
+ *
+ * The loader should automatically load libprovider.so via DT_NEEDED,
+ * resolve provider_add/mul/isqrt, and make consumer functions work.
+ *
+ * This is the standard pattern for how shared libraries depend on
+ * each other (e.g., a .so depending on libc.so or libm.so).
+ */
+static void test_consumer_with_needed(void)
+{
+    printf("  [2a] loading consumer (has DT_NEEDED: libprovider.so)...\n");
+    fflush(stdout);
+
+    void *h = dlopen("lib/libconsumer.so", RTLD_NOW);
+
+    printf("  [2b] dlopen returned %p\n", (void *)h);
+    fflush(stdout);
+
+    if (h == NULL) {
+        fail("DT_NEEDED auto-load", dlerror());
+        return;
+    }
+
+    /* Verify consumer functions work (they delegate to provider) */
+    int (*cadd)(int, int) = NULL;
+    *(void **)(&cadd) = dlsym(h, "consumer_add");
+    if (cadd == NULL || cadd(10, 20) != 30) {
+        fail("DT_NEEDED auto-load", "consumer_add() failed");
+        dlclose(h);
+        return;
+    }
+
+    int (*cmul)(int, int) = NULL;
+    *(void **)(&cmul) = dlsym(h, "consumer_mul");
+    if (cmul == NULL || cmul(6, 7) != 42) {
+        fail("DT_NEEDED auto-load", "consumer_mul() failed");
+        dlclose(h);
+        return;
+    }
+
+    int (*cisqrt)(int) = NULL;
+    *(void **)(&cisqrt) = dlsym(h, "consumer_isqrt");
+    if (cisqrt == NULL || cisqrt(9) != 3) {
+        fail("DT_NEEDED auto-load", "consumer_isqrt() failed");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("DT_NEEDED auto-load");
+}
+
+/*
+ * Test 3: consumer_noop() has no cross-lib dependency (control test).
+ */
+static void test_consumer_noop(void)
+{
+    void *h = dlopen("lib/libconsumer.so", RTLD_LAZY);
+    if (h == NULL) {
+        fail("consumer_noop (no cross-lib dep)", dlerror());
+        return;
+    }
+
+    int (*fn)(int) = NULL;
+    *(void **)(&fn) = dlsym(h, "consumer_noop");
+    if (fn == NULL || fn(41) != 42) {
+        fail("consumer_noop (no cross-lib dep)", "wrong result");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("consumer_noop (no cross-lib dep)");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn DT_NEEDED tests ===\n");
+    fflush(stdout);
+
+    test_provider_loads();
+    test_consumer_with_needed();
+    test_consumer_noop();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/src/posix-tests/dlfcn-pie-c/main.c
+++ b/src/posix-tests/dlfcn-pie-c/main.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Opens a dynamic load library.
+void *open_library(const char *path)
+{
+    void *handle = dlopen(path, RTLD_LAZY);
+    assert(handle != NULL);
+    return (handle);
+}
+
+// Closes a dynamic load library.
+void close_library(void *handle)
+{
+    assert(dlclose(handle) == 0);
+}
+
+// Resolves a symbol in a dynamic load library.
+void *resolve_symbol(void *handle, const char *symbol)
+{
+    void *sym = dlsym(handle, symbol);
+    assert(sym != NULL);
+    return (sym);
+}
+
+// A global variable exported by the main executable (via -rdynamic).
+int exe_global_value = 42;
+
+// Tests if dlopen(NULL) returns a handle to the global symbol scope and
+// dlsym() can resolve symbols exported by the main executable.
+void test_dlopen_null(void)
+{
+    // dlopen(NULL) should return a valid handle per POSIX.
+    void *handle = dlopen(NULL, RTLD_NOW);
+    assert(handle != NULL);
+
+    // Resolve a symbol that the main executable exports.
+    int *value = (int *)dlsym(handle, "exe_global_value");
+    assert(value != NULL);
+    assert(*value == 42);
+
+    // RTLD_DEFAULT (NULL handle) should also resolve the same symbol.
+    int *value2 = (int *)dlsym(RTLD_DEFAULT, "exe_global_value");
+    assert(value2 != NULL);
+    assert(*value2 == 42);
+    assert(value == value2);
+
+    // Closing the global handle should be a no-op.
+    assert(dlclose(handle) == 0);
+}
+
+// Tests if dlsym() works on a shared library loaded from a PIE executable.
+void test_dlsym(const char *path)
+{
+    void *handle = open_library(path);
+
+    int (*add)(int, int) = NULL;
+    *(void **)(&add) = resolve_symbol(handle, "add");
+    assert(add != NULL);
+    assert(add(1, 2) == 3);
+
+    int (*multiply)(int, int) = NULL;
+    *(void **)(&multiply) = resolve_symbol(handle, "multiply");
+    assert(multiply != NULL);
+    assert(multiply(7, 6) == 42);
+
+    const char **version = resolve_symbol(handle, "VERSION");
+    assert(version != NULL);
+    assert(!strcmp(*version, "0.0.1"));
+
+    close_library(handle);
+}
+
+/**
+ * @brief Tests dynamic loading from a PIE executable with exported symbols.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_dlopen_null();
+    test_dlsym("lib/libmul-pie.so");
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/echo-c/main.c
+++ b/src/posix-tests/echo-c/main.c
@@ -1,0 +1,43 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#include <stddef.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#define MAX_REQUEST_SIZE 4096
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+char buffer[MAX_REQUEST_SIZE];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+int main(void)
+{
+    ssize_t nread = 0;
+
+    while (1) {
+        nread = read(STDIN_FILENO, buffer, MAX_REQUEST_SIZE);
+        if (nread < 0) {
+            break; // Error encountered.
+        } else if (nread == 0) {
+            break; // End of file reached.
+        }
+
+        if (nread > 0) {
+            write(STDOUT_FILENO, buffer, nread);
+        }
+    }
+
+    return 0;
+}

--- a/src/posix-tests/file-c/access.c
+++ b/src/posix-tests/file-c/access.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // For POSIX compliance
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can check access permissions of a file using access().
+void test_access(void)
+{
+    fprintf(stderr, "testing access() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Check read and write access.
+    assert(access(filename, R_OK | W_OK) == 0);
+
+    // Remove write access and check again.
+    assert(chmod(filename, S_IRUSR) == 0);
+    assert(access(filename, W_OK) == -1);
+
+    // Restore write access and check again.
+    assert(chmod(filename, S_IRUSR | S_IWUSR) == 0);
+    assert(access(filename, W_OK) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/chdir.c
+++ b/src/posix-tests/file-c/chdir.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the current working directory.
+void test_chdir(void)
+{
+    fprintf(stderr, "testing chdir() ... ");
+
+    const char *dirname = "testdir_chdir";
+    assert(strlen(dirname) <= NAME_MAX);
+
+    // Create a temporary directory.
+    assert(mkdir(dirname, S_IRUSR | S_IWUSR | S_IXUSR) == 0);
+
+    char original_cwd[PATH_MAX];
+    char new_cwd[PATH_MAX];
+
+    // Get the current working directory.
+    assert(getcwd(original_cwd, sizeof(original_cwd)) != NULL);
+
+    // Change to the target directory.
+    assert(chdir(dirname) == 0);
+
+    // Verify the current working directory has changed.
+    assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
+    assert(strcmp(new_cwd, original_cwd) != 0);
+
+    // Restore the original working directory.
+    assert(chdir(original_cwd) == 0);
+
+    // Verify the current working directory is restored.
+    assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
+    assert(strcmp(new_cwd, original_cwd) == 0);
+
+    // Clean up.
+    assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/chmod.c
+++ b/src/posix-tests/file-c/chmod.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change access permissions of a file.
+void test_chmod(void)
+{
+    fprintf(stderr, "testing chmod() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    struct stat st = {0};
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Save current access permissions.
+    assert(stat(filename, &st) == 0);
+    mode_t original_mode = st.st_mode;
+
+    // Change access permissions and assert result.
+    assert(chmod(filename, st.st_mode & ~(S_IRGRP | S_IROTH)) == 0);
+    assert(stat(filename, &st) == 0);
+    assert((st.st_mode & S_IRGRP) == 0);
+    assert((st.st_mode & S_IROTH) == 0);
+
+    // Restore the original access permissions.
+    assert(chmod(filename, original_mode) == 0);
+    assert(stat(filename, &st) == 0);
+    assert(st.st_mode == original_mode);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/chown.c
+++ b/src/posix-tests/file-c/chown.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the ownership of a file.
+void test_chown(void)
+{
+    fprintf(stderr, "testing chown() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Touch file without changing ownership and assert result.
+    assert(chown(filename, -1, -1) == 0);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/common.h
+++ b/src/posix-tests/file-c/common.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+// Tests whether we can check access permissions of a file using access().
+extern void test_access(void);
+
+// Tests whether we can change the current working directory.
+extern void test_chdir(void);
+
+// Tests system calls on directory entries.
+extern void test_dirent(void);
+
+// Tests whether we can open and close a file.
+extern void test_open_close(void);
+
+// Tests whether we can create and unlink a file.
+extern void test_create_unlink(void);
+
+// Tests whether we can get the current working directory.
+extern void test_getcwd(void);
+
+// Tests whether we can check access permissions of a file.
+extern void test_faccessat(void);
+
+// Tests whether we can change the current working directory.
+extern void test_fchdir(void);
+
+// Tests whether we can change access permissions of a file.
+extern void test_chmod(void);
+
+// Tests whether we can change the ownership of a file.
+extern void test_chown(void);
+
+// Tests whether we can change access permissions of a file.
+extern void test_fchmod(void);
+
+// Tests whether we can change access permissions of a file.
+extern void test_fchmodat(void);
+
+// Tests whether we can change the ownership of a file descriptor.
+extern void test_fchown(void);
+
+// Tests whether we can change the ownership of a file.
+extern void test_fchownat(void);
+
+// Tests whether we can synchronize file data to disk.
+extern void test_fdatasync(void);
+
+// Tests whether we can truncate a file descriptor.
+extern void test_ftruncate(void);
+
+// Tests whether we can change access permissions of a file.
+extern void test_lchmod(void);
+
+// Tests whether we can change the ownership of a file.
+extern void test_lchown(void);
+
+// Tests whether we can create a hard link to a file.
+extern void test_link(void);
+
+// Tests whether we can create a hard link to a file.
+extern void test_linkat(void);
+
+// Tests whether we can manipulate file offsets using lseek.
+extern void test_lseek(void);
+
+// Tests whether we can update file timestamps with `futimens()`.
+extern void test_futimens(void);
+
+// Tests whether we can create a directory.
+extern void test_mkdirat(void);
+
+// Tests whether we can create a directory.
+extern void test_mkdir(void);
+
+// Tests whether we can use posix_fadvise on a file.
+extern void test_posix_fadvise(void);
+
+// Tests whether we can use posix_fallocate on a file.
+extern void test_posix_fallocate(void);
+
+// Tests whether we can read from a file using pread.
+extern void test_pread(void);
+
+// Tests whether we can read from a file using preadv.
+extern void test_preadv(void);
+
+// Tests whether we can write to a file using pwrite.
+extern void test_pwrite(void);
+
+// Tests whether we can write to a file using pwritev.
+extern void test_pwritev(void);
+
+// Tests whether we can read a symbolic link.
+extern void test_readlink(void);
+
+// Tests whether we can read a symbolic link.
+extern void test_readlinkat(void);
+
+// Tests whether we can read from a file using vectorized I/O.
+extern void test_readv(void);
+
+// Tests whether we can rename a file.
+extern void test_renameat(void);
+
+// Tests whether we can get file status information.
+extern void test_stat(void);
+
+// Tests whether we can create a symbolic link to a file.
+extern void test_symlinkat(void);
+
+// Tests whether we can remove a file.
+extern void test_unlinkat(void);
+
+// Tests whether we can change file access and modification times.
+extern void test_utimensat(void);
+
+// Tests whether we can update file timestamps with `utimes()`.
+extern void test_utimes(void);
+
+// Tests whether we can update file timestamps with `utime()`.
+extern void test_utime(void);
+
+// Tests whether we can write and read to/from a file.
+extern void test_write_read(void);
+
+// Tests whether we can write to a file using vectorized I/O.
+extern void test_writev(void);
+
+// Tests whether we can poll a file descriptor for read/write readiness.
+extern void test_poll(void);
+
+// Tests whether we can use select() to check read/write readiness on a file descriptor.
+extern void test_select(void);
+
+#endif

--- a/src/posix-tests/file-c/create_unlink.c
+++ b/src/posix-tests/file-c/create_unlink.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create and unlink a file.
+void test_create_unlink(void)
+{
+    fprintf(stderr, "testing create()/unlink() ... ");
+
+    const char *filename = "testfile.txt";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Remove test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/dirent.c
+++ b/src/posix-tests/file-c/dirent.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if we can open/close a directory stream.
+static void test_opendir_closedir(const char *dirname)
+{
+    DIR *dirp = NULL;
+
+    dirp = opendir(dirname);
+    assert(dirp != NULL);
+
+    assert(closedir(dirp) == 0);
+}
+
+// Tests if we can read a directory stream.
+static void test_readdir(const char *dirname)
+{
+    fprintf(stderr, "testing readdir() ... ");
+
+    DIR *dirp = NULL;
+    struct dirent *entry = NULL;
+
+    dirp = opendir(dirname);
+    assert(dirp != NULL);
+
+    assert(errno == 0);
+    while ((entry = readdir(dirp)) != NULL) {
+        assert(strlen(entry->d_name) > 0);
+        assert(entry->d_ino != 0);
+    }
+    assert(errno == 0);
+
+    assert(closedir(dirp) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests system calls on directory entries.
+void test_dirent(void)
+{
+    const char *dirname = ".";
+
+    test_opendir_closedir(dirname);
+    test_readdir(dirname);
+}

--- a/src/posix-tests/file-c/faccessat.c
+++ b/src/posix-tests/file-c/faccessat.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can check access permissions of a file.
+void test_faccessat(void)
+{
+    fprintf(stderr, "testing faccessat() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDONLY, S_IRUSR | S_IRGRP | S_IROTH);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Check read and write access.
+    assert(faccessat(AT_FDCWD, filename, R_OK, 0) == 0);
+    assert(faccessat(AT_FDCWD, filename, W_OK, 0) == -1);
+
+    // Add write access and check again.
+    assert(fchmodat(AT_FDCWD, filename, S_IWUSR | S_IRUSR, 0) == 0);
+    assert(faccessat(AT_FDCWD, filename, R_OK, 0) == 0);
+    assert(faccessat(AT_FDCWD, filename, W_OK, 0) == 0);
+
+    // Remove write access and check again.
+    assert(fchmodat(AT_FDCWD, filename, S_IRUSR, 0) == 0);
+    assert(faccessat(AT_FDCWD, filename, R_OK, 0) == 0);
+    assert(faccessat(AT_FDCWD, filename, W_OK, 0) == -1);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fchdir.c
+++ b/src/posix-tests/file-c/fchdir.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // strnlen()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the current working directory.
+void test_fchdir(void)
+{
+    fprintf(stderr, "testing fchdir() ... ");
+
+    const char *TARGET_DIRECTORY = "testdir_fchdir";
+
+    // Create a temporary directory.
+    assert(mkdir(TARGET_DIRECTORY, S_IRUSR | S_IWUSR | S_IXUSR) == 0);
+
+    char initial_working_directory[PATH_MAX] = {0};
+
+    // Open initial directory.
+    int initial_directory_fd = open(".", O_RDONLY);
+    assert(initial_directory_fd != -1);
+
+    // Store initial working directory.
+    char *initial_cwd = getcwd(initial_working_directory, sizeof(initial_working_directory));
+    assert(initial_cwd != NULL);
+    assert(initial_cwd == initial_working_directory);
+    size_t initial_cwd_length = strnlen(initial_cwd, PATH_MAX);
+    assert((initial_cwd_length > 0) && (initial_cwd_length < PATH_MAX));
+
+    // Open target directory.
+    int target_directory_fd = open(TARGET_DIRECTORY, O_RDONLY);
+    assert(target_directory_fd != -1);
+
+    // Change working directory.
+    int ret = fchdir(target_directory_fd);
+    assert(ret == 0);
+
+    // Get current working directory and assert result.
+    char target_working_directory[PATH_MAX] = {0};
+    char *target_cwd = getcwd(target_working_directory, sizeof(target_working_directory));
+    assert(target_cwd != NULL);
+    assert(target_cwd == target_working_directory);
+    size_t target_cwd_length = strnlen(target_cwd, PATH_MAX);
+    assert((target_cwd_length > 0) && (target_cwd_length < PATH_MAX));
+    assert(strcmp(target_cwd, initial_cwd) != 0);
+
+    // Move back to initial working directory.
+    ret = fchdir(initial_directory_fd);
+    assert(ret == 0);
+
+    // Get current working directory and assert result.
+    char restored_working_directory[PATH_MAX] = {0};
+    char *restored_cwd = getcwd(restored_working_directory, sizeof(restored_working_directory));
+    assert(restored_cwd != NULL);
+    assert(restored_cwd == restored_working_directory);
+    size_t restored_cwd_length = strnlen(restored_cwd, PATH_MAX);
+    assert((restored_cwd_length > 0) && (restored_cwd_length < PATH_MAX));
+    assert(strcmp(restored_cwd, initial_cwd) == 0);
+
+    // Close target directory.
+    ret = close(target_directory_fd);
+    assert(ret == 0);
+
+    // Close initial directory.
+    ret = close(initial_directory_fd);
+    assert(ret == 0);
+
+    // Clean up.
+    assert(unlinkat(AT_FDCWD, TARGET_DIRECTORY, AT_REMOVEDIR) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fchmod.c
+++ b/src/posix-tests/file-c/fchmod.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change access permissions of a file.
+void test_fchmod(void)
+{
+    fprintf(stderr, "testing fchmod() ... ");
+
+    struct stat st = {0};
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Save current access permissions.
+    assert(fstat(fd, &st) == 0);
+    mode_t original_mode = st.st_mode;
+
+    // Change access permissions and assert result.
+    assert(fchmod(fd, st.st_mode & ~(S_IRGRP | S_IROTH)) == 0);
+    assert(fstat(fd, &st) == 0);
+    assert((st.st_mode & S_IRGRP) == 0);
+    assert((st.st_mode & S_IROTH) == 0);
+
+    // Restore the original access permissions.
+    assert(fchmod(fd, original_mode) == 0);
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_mode == original_mode);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fchmodat.c
+++ b/src/posix-tests/file-c/fchmodat.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change access permissions of a file.
+void test_fchmodat(void)
+{
+    fprintf(stderr, "testing fchmodat() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    struct stat st = {0};
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Save current access permissions.
+    assert(stat(filename, &st) == 0);
+    mode_t original_mode = st.st_mode;
+
+    // Change access permissions and assert result.
+    assert(fchmodat(AT_FDCWD, filename, st.st_mode & ~(S_IRGRP | S_IROTH), 0) == 0);
+    assert(stat(filename, &st) == 0);
+    assert((st.st_mode & S_IRGRP) == 0);
+    assert((st.st_mode & S_IROTH) == 0);
+
+    // Restore the original access permissions.
+    assert(fchmodat(AT_FDCWD, filename, original_mode, 0) == 0);
+    assert(stat(filename, &st) == 0);
+    assert(st.st_mode == original_mode);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fchown.c
+++ b/src/posix-tests/file-c/fchown.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the ownership of a file descriptor.
+void test_fchown(void)
+{
+    fprintf(stderr, "testing fchown() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Touch file without changing ownership and assert result.
+    assert(fchown(fd, -1, -1) == 0);
+
+    // Close and remove the test file.
+    assert(close(fd) == 0);
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fchownat.c
+++ b/src/posix-tests/file-c/fchownat.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the ownership of a file.
+void test_fchownat(void)
+{
+    fprintf(stderr, "testing fchownat() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Touch file without changing ownership and assert result.
+    assert(fchownat(AT_FDCWD, filename, -1, -1, 0) == 0);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/fdatasync.c
+++ b/src/posix-tests/file-c/fdatasync.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 199309 // fdatasync()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can synchronize file data to disk.
+void test_fdatasync(void)
+{
+    fprintf(stderr, "testing fdatasync() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= DATA_LEN_MAX);
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write some data to the file.
+    ssize_t bytes_written = write(fd, data, strlen(data));
+    assert(bytes_written == (ssize_t)strlen(data));
+
+    // Synchronize file data to disk.
+    assert(fdatasync(fd) == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, bytes_written);
+    assert(bytes_read == bytes_written);
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/ftruncate.c
+++ b/src/posix-tests/file-c/ftruncate.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can truncate a file descriptor.
+void test_ftruncate(void)
+{
+    fprintf(stderr, "testing ftruncate() ... ");
+
+    const size_t SIZE = 1024;
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    assert(ftruncate(fd, SIZE) == 0);
+
+    // Get file size and assert result.
+    struct stat st = {0};
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_size == SIZE);
+
+    // Close and remove the test file.
+    assert(close(fd) == 0);
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/futimens.c
+++ b/src/posix-tests/file-c/futimens.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // futimens()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can update file timestamps with `futimens()`.
+void test_futimens(void)
+{
+    fprintf(stderr, "testing futimens() ... ");
+
+    const char *filename = "testfile.tmp";
+
+    // Create a temporary file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+
+    struct stat st = {0};
+    struct timespec times[2] = {0};
+
+    // Get the current file timestamps.
+    assert(fstat(fd, &st) == 0);
+
+    // Set new timestamps.
+    times[0].tv_sec = st.st_atime + 20; // Access time.
+    times[0].tv_nsec = 0;
+    times[1].tv_sec = st.st_mtime + 10; // Modification time.
+    times[1].tv_nsec = 0;
+
+    // Update the file timestamps and check the result.
+    assert(futimens(fd, times) == 0);
+
+    // Verify the updated timestamps.
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_atime == times[0].tv_sec);
+    assert(st.st_mtime == times[1].tv_sec);
+
+    // Clean up.
+    assert(close(fd) == 0);
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/getcwd.c
+++ b/src/posix-tests/file-c/getcwd.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // strnlen()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the current working directory.
+void test_getcwd(void)
+{
+    fprintf(stderr, "testing getcwd() ... ");
+
+    char pathbuf[PATH_MAX] = {0};
+
+    // Get current working directory and assert result.
+    char *cwd = getcwd(pathbuf, sizeof(pathbuf));
+    assert(cwd != NULL);
+    assert(cwd == pathbuf);
+    size_t len = strnlen(cwd, PATH_MAX);
+    assert((len > 0) && (len < PATH_MAX));
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/lchmod.c
+++ b/src/posix-tests/file-c/lchmod.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change access permissions of a file.
+void test_lchmod(void)
+{
+    fprintf(stderr, "testing lchmod() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+    const char *linkname = "testfile.link";
+
+    struct stat st = {0};
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Save current access permissions.
+    assert(stat(filename, &st) == 0);
+    mode_t original_mode = st.st_mode;
+
+    // Create a link to the test file.
+    assert(link(filename, linkname) == 0);
+
+    // Change access permissions and assert result.
+    assert(lchmod(linkname, st.st_mode & ~(S_IRGRP | S_IROTH)) == 0);
+    assert(stat(linkname, &st) == 0);
+    assert((st.st_mode & S_IRGRP) == 0);
+    assert((st.st_mode & S_IROTH) == 0);
+
+    // Restore the original access permissions.
+    assert(lchmod(linkname, original_mode) == 0);
+    assert(stat(linkname, &st) == 0);
+    assert(st.st_mode == original_mode);
+
+    // Remove the link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    // Remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/lchown.c
+++ b/src/posix-tests/file-c/lchown.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can change the ownership of a file.
+void test_lchown(void)
+{
+    fprintf(stderr, "testing lchown() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Touch file without changing ownership and assert result.
+    assert(lchown(filename, -1, -1) == 0);
+
+    // Close and remove the test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/link.c
+++ b/src/posix-tests/file-c/link.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a hard link to a file.
+void test_link(void)
+{
+    fprintf(stderr, "testing link() ... ");
+
+    const char *filename = "README.md";
+    const char *linkname = "README.link";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a hard link.
+    assert(link(filename, linkname) == 0);
+
+    // Get information from the original file.
+    struct stat st = {0};
+    assert(stat(filename, &st) == 0);
+
+    // Get information from the hard link.
+    struct stat st_link = {0};
+    assert(stat(linkname, &st_link) == 0);
+
+    // Check if the hard link points to the same inode as the original file.
+    assert(st.st_ino == st_link.st_ino);
+    assert(st.st_dev == st_link.st_dev);
+    assert(st.st_nlink == st_link.st_nlink); // Link count should be the same.
+    assert(st.st_mode == st_link.st_mode);   // Mode should be the same.
+    assert(st.st_size == st_link.st_size);   // Size should be the same.
+    assert(st.st_mtime == st_link.st_mtime); // Modification time should be the same.
+    assert(st.st_ctime == st_link.st_ctime); // Change time should be the same.
+    assert(st.st_atime != 0);                // Access time should not be zero.
+    assert(st.st_mtime != 0);                // Modification time should not be zero.
+    assert(st.st_ctime != 0);                // Change time should not be zero.
+
+    // Remove the hard link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/linkat.c
+++ b/src/posix-tests/file-c/linkat.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a hard link to a file.
+void test_linkat(void)
+{
+    fprintf(stderr, "testing linkat() ... ");
+
+    const char *filename = "README.md";
+    const char *linkname = "README.link";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a hard link.
+    assert(linkat(AT_FDCWD, filename, AT_FDCWD, linkname, 0) == 0);
+
+    // Get information from the original file.
+    struct stat st = {0};
+    assert(stat(filename, &st) == 0);
+
+    // Get information from the hard link.
+    struct stat st_link = {0};
+    assert(stat(linkname, &st_link) == 0);
+
+    // Check if the hard link points to the same inode as the original file.
+    assert(st.st_ino == st_link.st_ino);
+    assert(st.st_dev == st_link.st_dev);
+    assert(st.st_nlink == st_link.st_nlink); // Link count should be the same.
+    assert(st.st_mode == st_link.st_mode);   // Mode should be the same.
+    assert(st.st_size == st_link.st_size);   // Size should be the same.
+    assert(st.st_mtime == st_link.st_mtime); // Modification time should be the same.
+    assert(st.st_ctime == st_link.st_ctime); // Change time should be the same.
+    assert(st.st_atime != 0);                // Access time should not be zero.
+    assert(st.st_mtime != 0);                // Modification time should not be zero.
+    assert(st.st_ctime != 0);                // Change time should not be zero.
+
+    // Remove the hard link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/lseek.c
+++ b/src/posix-tests/file-c/lseek.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can manipulate file offsets using lseek.
+void test_lseek(void)
+{
+    fprintf(stderr, "testing lseek() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write using write.
+    const char *data1 = "Hello ";
+    const char *data2 = "Nanvix!";
+    size_t data1_len = strlen(data1);
+    size_t data2_len = strlen(data2);
+    assert(data1_len + data2_len <= DATA_LEN_MAX);
+
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write data1 to the file.
+    ssize_t bytes_written = write(fd, data1, data1_len);
+    assert(bytes_written == (ssize_t)data1_len);
+
+    // Use lseek to move the file offset to the end of data1.
+    off_t offset = lseek(fd, 0, SEEK_END);
+    assert(offset == (off_t)data1_len);
+
+    // Write data2 at the current offset.
+    bytes_written = write(fd, data2, data2_len);
+    assert(bytes_written == (ssize_t)data2_len);
+
+    // Use lseek to move the file offset back to the beginning.
+    offset = lseek(fd, 0, SEEK_SET);
+    assert(offset == 0);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, data1_len + data2_len);
+    assert(bytes_read == (ssize_t)(data1_len + data2_len));
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, "Hello Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/main.c
+++ b/src/posix-tests/file-c/main.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests file system system calls.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert types in <sys/stat.h>.
+    STATIC_ASSERT_SIZE(struct stat,
+                       sizeof(dev_t) +               // st_dev
+                           sizeof(ino_t) +           // st_ino
+                           sizeof(mode_t) +          // st_mode
+                           sizeof(nlink_t) +         // st_nlink
+                           sizeof(uid_t) +           // st_uid
+                           sizeof(gid_t) +           // st_gid
+                           sizeof(dev_t) +           // st_rdev
+                           sizeof(off_t) +           // st_size
+                           sizeof(struct timespec) + // st_atim
+                           sizeof(struct timespec) + // st_mtim
+                           sizeof(struct timespec) + // st_ctim
+                           sizeof(blksize_t) +       // st_blksize
+                           sizeof(blkcnt_t)          // st_blocks
+    );
+
+    // Assert types in <dirent.h>.
+    STATIC_ASSERT_SIZE(struct dirent,
+                       sizeof(ino_t) +                     // d_ino
+                           (NAME_MAX + 1) * (sizeof(char)) // d_name
+    );
+    STATIC_ASSERT_SIZE(struct posix_dent,
+                       sizeof(ino_t) +                       // d_ino
+                           sizeof(reclen_t) +                // d_reclen
+                           sizeof(unsigned char) +           // d_type
+                           (NAME_MAX + 1) * (sizeof(char)) + // d_name
+                           1 * sizeof(char)                  // d_pad
+    );
+
+    // Run tests.
+    test_open_close();
+    test_create_unlink(); // tests open() and unlink().
+    test_write_read();    // tests open(), close() and unlink.
+#ifndef __NANVIX_STANDALONE__
+    // poll() and select() have no VFS implementation in standalone mode.
+    test_poll();            // tests open(), close(), write(), read(), poll() and unlink().
+    test_select();          // tests open(), close(), write(), read(), select() and unlink().
+#endif                      // __NANVIX_STANDALONE__
+    test_posix_fadvise();   // requires open(), close() and unlink().
+    test_lseek();           // requires open(), close(), read(), write() and unlink().
+    test_posix_fallocate(); // requires open(), close(), lseek and unlink().
+    test_readv();           // requires open(), close(), write() and unlink().
+    test_preadv();          // requires open(), close(), read() and unlink().
+    test_writev();          // requires open(), close(), read() and unlink().
+    test_pwritev();         // requires open(), close(), read(), lseek() and unlink().
+    test_pread();           // requires open(), close(), read() and unlink().
+    test_pwrite();          // requires open(), close(), read(), lseek() and unlink().
+    test_fdatasync();       // requires open(), close(), read(), write(), and unlink().
+    test_stat();
+    test_ftruncate(); // requires open(), close(), fstat() and unlink().
+#ifndef __NANVIX_STANDALONE__
+    // FAT32 does not support hard links or symbolic links.
+    test_linkat();     // requires open(), stat() and unlinkat().
+    test_link();       // requires open(), stat() and unlinkat().
+    test_symlinkat();  // requires open(), stat() and unlinkat().
+    test_readlinkat(); // requires symlinkat() and unlinkat().
+    test_readlink();   // requires symlinkat() and unlink().
+#endif                 // __NANVIX_STANDALONE__
+    test_renameat();   // requires open(), close() and unlink().
+    test_unlinkat();   // requires open() and close().
+    test_mkdirat();    // requires stat() and unlinkat().
+    test_mkdir();      // requires stat() and unlinkat().
+    test_dirent();
+    test_getcwd();
+    test_chdir(); // requires getcwd().
+    test_fchdir();
+#ifndef __NANVIX_STANDALONE__
+    // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
+    test_utimensat();
+    test_utimes();    // requires open(), close(), stat() and unlinkat().
+    test_utime();     // requires open(), close(), stat() and unlinkat().
+    test_chmod();     // requires open(), close(), stat() and unlinkat().
+    test_fchmodat();  // requires open(), close(), stat() and unlinkat().
+    test_fchmod();    // requires open(), close(), fstat() and unlink().
+    test_lchmod();    // requires open(), close(), stat(), link() and unlinkat().
+    test_fchownat();  // requires open(), close() and unlinkat().
+    test_faccessat(); // requires open(), close(), chmodat() and unlinkat().
+    test_access();    // requires open(), close(), chmodat() and unlinkat().
+    test_chown();     // requires open(), close(), and unlinkat().
+    test_fchown();    // requires open(), close() and unlink().
+    test_lchown();    // requires open(), close() and unlinkat().
+    test_futimens();  // Requires open(), fstat(), close() and unlink().
+#endif                // __NANVIX_STANDALONE__
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/file-c/mkdir.c
+++ b/src/posix-tests/file-c/mkdir.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a directory.
+void test_mkdir(void)
+{
+    fprintf(stderr, "testing mkdir() ... ");
+
+    const char *dirname = "testdir";
+    assert(strlen(dirname) <= NAME_MAX);
+
+    // Create a test directory.
+    assert(mkdir(dirname, S_IRUSR | S_IWUSR | S_IXUSR) == 0);
+
+    // Check if test directory exists.
+    struct stat st = {0};
+    assert(stat(dirname, &st) == 0);
+    assert(S_ISDIR(st.st_mode) != 0);
+    assert(st.st_mode & S_IRUSR);
+    assert(st.st_mode & S_IWUSR);
+    assert(st.st_mode & S_IXUSR);
+    assert(st.st_nlink == 2); // Newly-created empty directory has 2 links: "." and "..".
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
+    // TODO: Uncomment the following lines when user/group ID checks are supported.
+    // assert(st.st_uid == getuid()); // User ID of the owner.
+    // assert(st.st_gid == getgid()); // Group ID of the owner.
+
+    // Remove test directory.
+    assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/mkdirat.c
+++ b/src/posix-tests/file-c/mkdirat.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a directory.
+void test_mkdirat(void)
+{
+    fprintf(stderr, "testing mkdirat() ... ");
+
+    const char *dirname = "testdir";
+    assert(strlen(dirname) <= NAME_MAX);
+
+    // Create a test directory.
+    assert(mkdirat(AT_FDCWD, dirname, S_IRUSR | S_IWUSR | S_IXUSR) == 0);
+
+    // Check if test directory exists.
+    struct stat st = {0};
+    assert(stat(dirname, &st) == 0);
+    assert(S_ISDIR(st.st_mode) != 0);
+    assert(st.st_mode & S_IRUSR);
+    assert(st.st_mode & S_IWUSR);
+    assert(st.st_mode & S_IXUSR);
+    assert(st.st_nlink == 2); // Newly created directory typically has 2 links: "." and "..".
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
+    // TODO: Uncomment the following lines when user/group ID checks are supported.
+    // assert(st.st_uid == getuid()); // User ID of the owner.
+    // assert(st.st_gid == getgid()); // Group ID of the owner.
+
+    // Remove test directory.
+    assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/open_close.c
+++ b/src/posix-tests/file-c/open_close.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can open and close a file.
+void test_open_close(void)
+{
+    const char *filename = "testfile_open_close.tmp";
+
+    // Create a file.
+    int fd = open(filename, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Open the file read-only.
+    fd = open(filename, O_RDONLY, 0);
+    assert(fd != -1);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Clean up.
+    assert(unlink(filename) == 0);
+}

--- a/src/posix-tests/file-c/poll.c
+++ b/src/posix-tests/file-c/poll.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define POLL_TEST_DATA_MAX 256
+
+// Timeout for poll() system call.
+#define POLL_TIMEOUT 1000
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can poll a file descriptor for read/write readiness.
+void test_poll(void)
+{
+    fprintf(stderr, "testing poll() ... ");
+
+    const char *filename = "poll_testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= POLL_TEST_DATA_MAX);
+    char buffer[POLL_TEST_DATA_MAX + 1];
+
+    // Open file with O_NONBLOCK so that readiness semantics are exercised.
+    int fd = open(filename, O_CREAT | O_EXCL | O_RDWR | O_NONBLOCK, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Prepare pollfd for write readiness (POLLOUT).
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLOUT;
+    pfd.revents = 0;
+
+    // Poll for write readiness. Should be ready immediately.
+    int ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 1);
+    assert((pfd.revents & POLLOUT) != 0);
+
+    // Write data.
+    ssize_t bytes_written = write(fd, data, data_len);
+    assert(bytes_written == (ssize_t)data_len);
+
+    // Rewind to begin of the file.
+    assert(lseek(fd, 0, SEEK_SET) == 0);
+
+    // Reset pollfd for read readiness.
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    // Poll for read readiness. Should be ready immediately.
+    ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 1);
+    assert((pfd.revents & POLLIN) != 0);
+
+    // Read data and sanity check.
+    ssize_t bytes_read = read(fd, buffer, (size_t)bytes_written);
+    assert(bytes_read == bytes_written);
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    // Re-open read-only non-blocking and poll for read.
+    fd = open(filename, O_RDONLY | O_NONBLOCK);
+    assert(fd != -1);
+
+    // Seek to end so that no data is available.
+    assert(lseek(fd, 0, SEEK_END) != -1);
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    // Poll for read readiness. It should either timeout, or return readiness with POLLHUP.
+    ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 0 || ((ret == 1) && ((pfd.revents & (POLLIN | POLLHUP)) != 0)));
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    // Remove test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/posix_fadvise.c
+++ b/src/posix-tests/file-c/posix_fadvise.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200112L // posix_fadvise()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can use posix_fadvise on a file.
+void test_posix_fadvise(void)
+{
+    fprintf(stderr, "testing posix_fadvise() ... ");
+
+    const char *filename = "testfile.tmp";
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write some data to the file.
+    const char *data = "Hello Nanvix!";
+    ssize_t bytes_written = write(fd, data, strlen(data));
+    assert(bytes_written == (ssize_t)strlen(data));
+
+    // Use posix_fadvise to give advice about file access.
+    int ret = posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+    assert(ret == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/posix_fallocate.c
+++ b/src/posix-tests/file-c/posix_fallocate.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200112L // posix_fadvise()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can use posix_fallocate on a file.
+void test_posix_fallocate(void)
+{
+    fprintf(stderr, "testing posix_fallocate() ... ");
+
+    const char *filename = "testfile.tmp";
+    const off_t file_length = 1024;
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Allocate space for the file.
+    int ret = posix_fallocate(fd, 0, file_length);
+    assert(ret == 0);
+
+    // Verify the file size.
+    off_t file_size = lseek(fd, 0, SEEK_END);
+    assert(file_size == file_length);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/pread.c
+++ b/src/posix-tests/file-c/pread.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // pread()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can read from a file using pread.
+void test_pread(void)
+{
+    fprintf(stderr, "testing pread() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write to the file.
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= DATA_LEN_MAX);
+
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Define a constant for the read offset.
+    const off_t DATA_OFFSET = 0;
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write data to the file.
+    ssize_t bytes_written = write(fd, data, data_len);
+    assert(bytes_written == (ssize_t)data_len);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Read data using pread.
+    ssize_t bytes_read = pread(fd, buffer, data_len, DATA_OFFSET);
+    assert(bytes_read == (ssize_t)data_len);
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/preadv.c
+++ b/src/posix-tests/file-c/preadv.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _BSD_SOURCE // preadv()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can read from a file using preadv.
+void test_preadv(void)
+{
+    fprintf(stderr, "testing preadv() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write to the file.
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= DATA_LEN_MAX);
+
+    // Define a constant for the write offset.
+    const off_t DATA_OFFSET = 10;
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Move the file offset to the specified position.
+    assert(lseek(fd, DATA_OFFSET, SEEK_SET) == DATA_OFFSET);
+
+    // Write data to the file at the current offset.
+    assert(write(fd, data, data_len) == (ssize_t)data_len);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Prepare buffers for preadv.
+    char buffer1[7]; // "Hello "
+    char buffer2[8]; // "Nanvix!"
+    struct iovec iov[2];
+    iov[0].iov_base = buffer1;
+    iov[0].iov_len = 6; // Length of "Hello "
+    iov[1].iov_base = buffer2;
+    iov[1].iov_len = 7; // Length of "Nanvix!"
+
+    // Read data using preadv at the specified offset.
+    ssize_t bytes_read = preadv(fd, iov, 2, DATA_OFFSET);
+    assert(bytes_read == (ssize_t)data_len);
+
+    // Null-terminate the buffers.
+    buffer1[6] = '\0';
+    buffer2[7] = '\0';
+
+    // Assert contents.
+    assert(strcmp(buffer1, "Hello ") == 0);
+    assert(strcmp(buffer2, "Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/pwrite.c
+++ b/src/posix-tests/file-c/pwrite.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // pwrite()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can write to a file using pwrite.
+void test_pwrite(void)
+{
+    fprintf(stderr, "testing pwrite() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write using pwrite.
+    const char *data1 = "Hello ";
+    const char *data2 = "Nanvix!";
+    size_t data1_len = strlen(data1);
+    size_t data2_len = strlen(data2);
+    assert(data1_len + data2_len <= DATA_LEN_MAX);
+
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Define a constant for the read offset.
+    const off_t DATA_OFFSET = 0;
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write data1 at an offset of 10 using pwrite.
+    ssize_t bytes_written = pwrite(fd, data1, data1_len, DATA_OFFSET);
+    assert(bytes_written == (ssize_t)data1_len);
+
+    // Write data2 at the end of data1 using pwrite.
+    bytes_written = pwrite(fd, data2, data2_len, DATA_OFFSET + data1_len);
+    assert(bytes_written == (ssize_t)data2_len);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Use lseek to set the read offset.
+    assert(lseek(fd, DATA_OFFSET, SEEK_SET) == DATA_OFFSET);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, data1_len + data2_len);
+    assert(bytes_read == (ssize_t)(data1_len + data2_len));
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, "Hello Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/pwritev.c
+++ b/src/posix-tests/file-c/pwritev.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _BSD_SOURCE // pwritev()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can write to a file using pwritev.
+void test_pwritev(void)
+{
+    fprintf(stderr, "testing pwritev() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write using pwritev.
+    const char *data1 = "Hello ";
+    const char *data2 = "Nanvix!";
+    size_t data1_len = strlen(data1);
+    size_t data2_len = strlen(data2);
+    assert(data1_len + data2_len <= DATA_LEN_MAX);
+
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Define a constant for the read offset.
+    const off_t DATA_OFFSET = 10;
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Prepare iovec structures for pwritev.
+    struct iovec iov[2];
+    iov[0].iov_base = (void *)data1;
+    iov[0].iov_len = data1_len;
+    iov[1].iov_base = (void *)data2;
+    iov[1].iov_len = data2_len;
+
+    // Write data1 and data2 using pwritev at the specified offset.
+    ssize_t bytes_written = pwritev(fd, iov, 2, DATA_OFFSET);
+    assert(bytes_written == (ssize_t)(data1_len + data2_len));
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Use lseek to set the read offset.
+    assert(lseek(fd, DATA_OFFSET, SEEK_SET) == DATA_OFFSET);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, data1_len + data2_len);
+    assert(bytes_read == (ssize_t)(data1_len + data2_len));
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, "Hello Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/readlink.c
+++ b/src/posix-tests/file-c/readlink.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can read a symbolic link.
+void test_readlink(void)
+{
+    fprintf(stderr, "testing readlink() ... ");
+
+    const char *filename = "README.md";
+    const char *linkname = "README.link";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a symbolic link.
+    assert(symlinkat(filename, AT_FDCWD, linkname) == 0);
+
+    // Read the symbolic link.
+    char buffer[PATH_MAX + 1];
+    ssize_t len = readlink(linkname, buffer, sizeof(buffer) - 1);
+    assert(len >= 0);
+    assert(len < (ssize_t)sizeof(buffer));
+    buffer[len] = '\0'; // Conforming applications should not assume that the returned contents of
+                        // the symbolic link are null-terminated.
+
+    // Check if the readlink was successful.
+    assert(strcmp(buffer, filename) == 0); // Check if the link points to the original file.
+
+    // Remove the symbolic link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/readlinkat.c
+++ b/src/posix-tests/file-c/readlinkat.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can read a symbolic link.
+void test_readlinkat(void)
+{
+    fprintf(stderr, "testing readlinkat() ... ");
+
+    const char *filename = "README.md";
+    const char *linkname = "README.link";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a symbolic link.
+    assert(symlinkat(filename, AT_FDCWD, linkname) == 0);
+
+    // Read the symbolic link.
+    char buffer[PATH_MAX + 1];
+    ssize_t len = readlinkat(AT_FDCWD, linkname, buffer, sizeof(buffer) - 1);
+    assert(len >= 0);
+    assert(len < (ssize_t)sizeof(buffer));
+    buffer[len] = '\0'; // Conforming applications should not assume that the returned contents of
+                        // the symbolic link are null-terminated.
+
+    // Check if the readlinkat was successful.
+    assert(strcmp(buffer, filename) == 0); // Check if the link points to the original file.
+
+    // Remove the symbolic link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/readv.c
+++ b/src/posix-tests/file-c/readv.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can read from a file using vectorized I/O.
+void test_readv(void)
+{
+    fprintf(stderr, "testing readv() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write to the file.
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= DATA_LEN_MAX);
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write data to the file.
+    ssize_t bytes_written = write(fd, data, data_len);
+    assert(bytes_written == (ssize_t)data_len);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Prepare iovec structures for reading.
+    char buffer1[7]; // To read "Hello "
+    char buffer2[8]; // To read "Nanvix!"
+    struct iovec iov[2];
+    iov[0].iov_base = buffer1;
+    iov[0].iov_len = sizeof(buffer1) - 1;
+    iov[1].iov_base = buffer2;
+    iov[1].iov_len = sizeof(buffer2) - 1;
+
+    // Read data from the file using readv.
+    ssize_t bytes_read = readv(fd, iov, 2);
+    assert(bytes_read == (ssize_t)data_len);
+
+    // Null-terminate the buffers.
+    buffer1[sizeof(buffer1) - 1] = '\0';
+    buffer2[sizeof(buffer2) - 1] = '\0';
+
+    // Assert contents.
+    assert(strcmp(buffer1, "Hello ") == 0);
+    assert(strcmp(buffer2, "Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/renameat.c
+++ b/src/posix-tests/file-c/renameat.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can rename a file.
+void test_renameat(void)
+{
+    fprintf(stderr, "testing renameat() ... ");
+
+    const char *filename = "test.txt";
+    assert(strlen(filename) < PATH_MAX);
+
+    const char *renamed_filename = "renamed.txt";
+    assert(strlen(renamed_filename) < PATH_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Rename test file and check result.
+    assert(renameat(AT_FDCWD, filename, AT_FDCWD, renamed_filename) == 0);
+
+    // Remove renamed test file.
+    assert(unlink(renamed_filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/select.c
+++ b/src/posix-tests/file-c/select.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define SELECT_TEST_DATA_MAX 256
+
+// Timeout (in seconds) for select() system call.
+#define SELECT_TIMEOUT_SECS 1
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can use select() to check read/write readiness on a file descriptor.
+void test_select(void)
+{
+    fprintf(stderr, "testing select() ... ");
+
+    const char *filename = "select_testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= SELECT_TEST_DATA_MAX);
+    char buffer[SELECT_TEST_DATA_MAX + 1];
+
+    // Open file with O_NONBLOCK so that readiness semantics are exercised.
+    int fd = open(filename, O_CREAT | O_EXCL | O_RDWR | O_NONBLOCK, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    //----------------------------------------------------------------------------------------------
+    // Write readiness (select on writefds).
+    //----------------------------------------------------------------------------------------------
+    fd_set writefds;
+    FD_ZERO(&writefds);
+    FD_SET(fd, &writefds);
+    struct timeval tvw;
+    tvw.tv_sec = SELECT_TIMEOUT_SECS;
+    tvw.tv_usec = 0;
+
+    int ret = select(fd + 1, NULL, &writefds, NULL, &tvw);
+    assert(ret == 1);
+    assert(FD_ISSET(fd, &writefds));
+
+    // Write data.
+    ssize_t bytes_written = write(fd, data, data_len);
+    assert(bytes_written == (ssize_t)data_len);
+
+    // Rewind to beginning of file.
+    assert(lseek(fd, 0, SEEK_SET) == 0);
+
+    //----------------------------------------------------------------------------------------------
+    // Read readiness (select on readfds).
+    //----------------------------------------------------------------------------------------------
+    fd_set readfds;
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
+    struct timeval tvr;
+    tvr.tv_sec = SELECT_TIMEOUT_SECS;
+    tvr.tv_usec = 0;
+
+    ret = select(fd + 1, &readfds, NULL, NULL, &tvr);
+    assert(ret == 1);
+    assert(FD_ISSET(fd, &readfds));
+
+    // Read data and sanity check.
+    ssize_t bytes_read = read(fd, buffer, (size_t)bytes_written);
+    assert(bytes_read == bytes_written);
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    //----------------------------------------------------------------------------------------------
+    // Re-open read-only non-blocking; seek to end and attempt a read readiness check.
+    //----------------------------------------------------------------------------------------------
+    fd = open(filename, O_RDONLY | O_NONBLOCK);
+    assert(fd != -1);
+
+    // Seek to end so that no data is left to read.
+    assert(lseek(fd, 0, SEEK_END) != -1);
+
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
+    struct timeval tve;
+    tve.tv_sec = SELECT_TIMEOUT_SECS;
+    tve.tv_usec = 0;
+
+    // For regular files POSIX specifies they are always ready; but we tolerate a timeout for
+    // implementation-specific behavior while still asserting correctness when ready.
+    ret = select(fd + 1, &readfds, NULL, NULL, &tve);
+    assert(ret == 0 || (ret == 1 && FD_ISSET(fd, &readfds)));
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    // Remove test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/stat.c
+++ b/src/posix-tests/file-c/stat.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get file status information.
+void test_stat(void)
+{
+    fprintf(stderr, "testing stat() ... ");
+
+    const char *filename = "testfile_stat.tmp";
+
+    // Create a file with some content so st_size > 0.
+    int fd = open(filename, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(write(fd, "hello", 5) == 5);
+    assert(close(fd) == 0);
+
+    struct stat st = {0};
+
+    // Get file status information and assert result.
+    assert(stat(filename, &st) == 0);
+    assert(st.st_mode & S_IFREG);
+    assert(st.st_size > 0);
+    assert(st.st_nlink > 0);
+    assert(st.st_blocks > 0);
+    assert(st.st_dev != 0);
+    assert(st.st_ino != 0);
+
+    // Clean up.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/symlinkat.c
+++ b/src/posix-tests/file-c/symlinkat.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a symbolic link to a file.
+void test_symlinkat(void)
+{
+    fprintf(stderr, "testing symlinkat() ... ");
+
+    const char *filename = "README.md";
+    const char *linkname = "README.link";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a symbolic link.
+    assert(symlinkat(filename, AT_FDCWD, linkname) == 0);
+
+    // Verify the symbolic link itself via lstat().
+    struct stat st_link = {0};
+    assert(lstat(linkname, &st_link) == 0);
+    assert(S_ISLNK(st_link.st_mode));
+
+    // Verify the stored path via readlink().
+    char buf[PATH_MAX] = {0};
+    ssize_t len = readlink(linkname, buf, sizeof(buf) - 1);
+    assert(len > 0);
+    buf[len] = '\0';
+    assert(strcmp(buf, filename) == 0);
+
+    // Verify the symbolic link resolves to the original file.
+    struct stat st = {0};
+    assert(stat(filename, &st) == 0);
+    struct stat st_resolved = {0};
+    assert(stat(linkname, &st_resolved) == 0);
+    assert(st.st_ino == st_resolved.st_ino);
+    assert(st.st_dev == st_resolved.st_dev);
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
+
+    // Remove the symbolic link.
+    assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/unlinkat.c
+++ b/src/posix-tests/file-c/unlinkat.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // AT_FDCWD
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can remove a file.
+void test_unlinkat(void)
+{
+    fprintf(stderr, "testing unlinkat() ... ");
+
+    const char *filename = "test.txt";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Create a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+
+    // Remove test file.
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/utime.c
+++ b/src/posix-tests/file-c/utime.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/utime.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can update file timestamps with `utime()`.
+void test_utime(void)
+{
+    fprintf(stderr, "testing utime() ... ");
+
+    struct stat st = {0};
+    const char *filename = "testfile.tmp";
+
+    // Create a temporary file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+
+    // Get the current file timestamps.
+    assert(stat(filename, &st) == 0);
+
+    // Set new timestamps.
+    struct utimbuf times = {
+        .actime = st.st_atime + 20, // Access time.
+        .modtime = st.st_mtime + 10 // Modification time.
+    };
+
+    // Update the file timestamps using utime and check the result.
+    assert(utime(filename, &times) == 0);
+
+    // Verify the updated timestamps.
+    assert(stat(filename, &st) == 0);
+    assert(st.st_atime == times.actime);
+    assert(st.st_mtime == times.modtime);
+
+    // Clean up.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/utimensat.c
+++ b/src/posix-tests/file-c/utimensat.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809 // utimensat()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can update file timestamps with `utimensat()`.
+void test_utimensat(void)
+{
+    fprintf(stderr, "testing utimensat() ... ");
+
+    const char *filename = "testfile.tmp";
+
+    // Create a temporary file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+
+    struct stat st = {0};
+    struct timespec times[2] = {0};
+
+    // Get the current file timestamps.
+    assert(fstat(fd, &st) == 0);
+
+    // Set new timestamps.
+    times[0].tv_sec = st.st_atime + 20; // Access time.
+    times[0].tv_nsec = 0;
+    times[1].tv_sec = st.st_mtime + 10; // Modification time.
+    times[1].tv_nsec = 0;
+
+    // Update the file timestamps using utimensat and check the result.
+    assert(utimensat(AT_FDCWD, filename, times, 0) == 0);
+
+    // Verify the updated timestamps.
+    assert(stat(filename, &st) == 0);
+    assert(st.st_atime == times[0].tv_sec);
+    assert(st.st_mtime == times[1].tv_sec);
+
+    // Clean up.
+    assert(close(fd) == 0);
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/utimes.c
+++ b/src/posix-tests/file-c/utimes.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can update file timestamps with `utimes()`.
+void test_utimes(void)
+{
+    fprintf(stderr, "testing utimes() ... ");
+
+    struct stat st = {0};
+    const char *filename = "testfile.tmp";
+
+    // Create a temporary file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+
+    // Get the current file timestamps.
+    assert(stat(filename, &st) == 0);
+
+    // Set new timestamps.
+    struct timeval times[2] = {{
+                                   .tv_sec = st.st_atime + 20, // Access time.
+                                   .tv_usec = 0,
+                               },
+                               {
+                                   .tv_sec = st.st_mtime + 10, // Modification time.
+                                   .tv_usec = 0,
+                               }};
+
+    // Update the file timestamps using futimes and check the result.
+    assert(utimes(filename, times) == 0);
+
+    // Verify the updated timestamps.
+    assert(stat(filename, &st) == 0);
+    assert(st.st_atime == times[0].tv_sec);
+    assert(st.st_mtime == times[1].tv_sec);
+
+    // Clean up.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/write_read.c
+++ b/src/posix-tests/file-c/write_read.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can write and read to/from a file.
+void test_write_read(void)
+{
+    fprintf(stderr, "testing write()/read() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= DATA_LEN_MAX);
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write some data to the file.
+    ssize_t bytes_written = write(fd, data, strlen(data));
+    assert(bytes_written == (ssize_t)strlen(data));
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, bytes_written);
+    assert(bytes_read == bytes_written);
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/file-c/writev.c
+++ b/src/posix-tests/file-c/writev.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define DATA_LEN_MAX 256
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can write to a file using vectorized I/O.
+void test_writev(void)
+{
+    fprintf(stderr, "testing writev() ... ");
+
+    const char *filename = "testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    // Data to write using writev.
+    const char *data1 = "Hello ";
+    const char *data2 = "Nanvix!";
+    size_t data1_len = strlen(data1);
+    size_t data2_len = strlen(data2);
+    assert(data1_len + data2_len <= DATA_LEN_MAX);
+
+    struct iovec iov[2];
+    iov[0].iov_base = (void *)data1;
+    iov[0].iov_len = data1_len;
+    iov[1].iov_base = (void *)data2;
+    iov[1].iov_len = data2_len;
+
+    char buffer[DATA_LEN_MAX + 1];
+
+    // Create and open a test file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Write data to the file using writev.
+    ssize_t bytes_written = writev(fd, iov, 2);
+    assert(bytes_written == (ssize_t)(data1_len + data2_len));
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Reopen the file for reading.
+    fd = open(filename, O_RDONLY);
+    assert(fd != -1);
+
+    // Read the data back.
+    ssize_t bytes_read = read(fd, buffer, bytes_written);
+    assert(bytes_read == bytes_written);
+
+    // Null-terminate the buffer and assert contents.
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, "Hello Nanvix!") == 0);
+
+    // Close the file.
+    assert(close(fd) == 0);
+
+    // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/hello-c/main.c
+++ b/src/posix-tests/hello-c/main.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <stdio.h>
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Hello, world from C!\n");
+
+    return (0);
+}

--- a/src/posix-tests/memory-c/aligned_alloc_free.c
+++ b/src/posix-tests/memory-c/aligned_alloc_free.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdint.h> // uintptr_t
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * Tests whether we can allocate and free memory using `aligned_alloc()` and `free()`.
+ * Validates that returned pointers satisfy the requested alignment, memory is writable,
+ * and multiple allocation patterns work without failure.
+ */
+void test_aligned_alloc_free(void)
+{
+    fprintf(stderr, "testing aligned_alloc() and free() ... ");
+
+    // A selection of alignment/size pairs. According to C11, alignment must be a power of two
+    // and a multiple of sizeof(void*). Sizes must be a multiple of alignment.
+    struct test_case {
+        size_t alignment;
+        size_t size; // Multiple of alignment.
+    };
+
+    const struct test_case cases[] = {
+        {.alignment = 4u, .size = 4u}, // Assuming 32-bit (sizeof(void*) == 4).
+        {.alignment = 8u, .size = 16u},
+        {.alignment = 16u, .size = 32u},
+        {.alignment = 32u, .size = 64u},
+        {.alignment = 64u, .size = 128u},
+        {.alignment = 128u, .size = 256u},
+        {.alignment = 256u, .size = 512u},
+        {.alignment = 512u, .size = 512u},
+        {.alignment = 1024u, .size = 2048u},
+    };
+
+    const size_t ncases = sizeof(cases) / sizeof(cases[0]);
+
+    for (size_t i = 0; i < ncases; ++i) {
+        size_t alignment = cases[i].alignment;
+        size_t size = cases[i].size;
+
+        assert((alignment & (alignment - 1u)) == 0u); // Power of two.
+        assert((alignment % sizeof(void *)) == 0u);   // Multiple of sizeof(void*).
+        assert((size % alignment) == 0u);             // Required by aligned_alloc().
+
+        void *ptr = aligned_alloc(alignment, size);
+        assert(ptr != NULL);
+        assert(((uintptr_t)ptr % alignment) == 0u);
+
+        // Fill memory with a pattern and verify it was written.
+        memset(ptr, (int)0x5Au, size);
+        unsigned char *bytes = (unsigned char *)ptr;
+        for (size_t j = 0; j < size; ++j) {
+            assert(bytes[j] == 0x5Au);
+        }
+
+        free(ptr);
+    }
+
+    // Stress: allocate and free many aligned blocks of the same alignment.
+    for (size_t iter = 0; iter < 64u; ++iter) {
+        void *p = aligned_alloc(64u, 64u); // size multiple of alignment.
+        assert(p != NULL);
+        assert(((uintptr_t)p % 64u) == 0u);
+        ((unsigned char *)p)[0] = (unsigned char)iter; // Touch.
+        free(p);
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/common.h
+++ b/src/posix-tests/memory-c/common.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+// Tests whether we can map and unmap memory using `mmap()` and `munmap()`.
+extern void test_mmap_munmap(void);
+
+// Tests whether we can allocate and free memory using `malloc()` and `free()`.
+extern void test_malloc_free(void);
+
+// Tests whether we can allocate and free aligned memory using `aligned_alloc()` and `free()`.
+extern void test_aligned_alloc_free(void);
+
+// Tests whether we can query the usable size of allocated blocks using `malloc_usable_size()`.
+extern void test_malloc_usable_size(void);
+
+// Stresses the heap allocator with alloc/free cycles under fragmentation pressure.
+extern void test_heap_reclaim(void);
+
+// Tests the allocator by attempting to consume the maximum allowed heap capacity.
+extern void test_heap_max_capacity(void);
+
+// Exercises the heap shrink path through bulk-free, shrink-to-minimum, anchor-pinned,
+// repeated cycles, and small-heap scenarios.
+extern void test_heap_shrink(void);
+
+// Tests realloc growth, shrink, NULL-ptr, data preservation, and alignment boundary sizes.
+extern void test_realloc(void);
+
+#endif

--- a/src/posix-tests/memory-c/heap_shrink.c
+++ b/src/posix-tests/memory-c/heap_shrink.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Integration tests for the heap shrink path (Heap::shrink / try_reclaim).
+ *
+ * All scenarios exercise shrink() indirectly through malloc()/free(). The allocator triggers
+ * try_reclaim() when the heap is at capacity (heap_size >= capacity), which calls
+ * Heap::shrink() to unmap tail pages no longer containing live allocations.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// 1 KB.
+#define KB (1024u)
+
+// 1 MB.
+#define MB (1024u * KB)
+
+// Block size used in bulk-free, anchor, and cycle scenarios.
+#define LARGE_BLOCK_SIZE MB
+
+// Number of large blocks in bulk-free and anchor scenarios.
+#define NUM_LARGE_BLOCKS 4u
+
+// Size of small anchor allocations.
+#define ANCHOR_SIZE 64u
+
+// Number of shrink-grow iterations.
+#define SHRINK_GROW_CYCLES 16u
+
+// Number of small allocations in the small-heap scenario.
+#define NUM_SMALL_ALLOCS 8u
+
+// Size of each small allocation (well below one page).
+#define SMALL_ALLOC_SIZE 128u
+
+// Number of regrowth blocks after shrink-to-minimum.
+#define REGROWTH_BLOCKS 4u
+
+// Size of each regrowth block (64 KB).
+#define REGROWTH_BLOCK_SIZE (64u * KB)
+
+//==================================================================================================
+// Private Functions — Scenarios
+//==================================================================================================
+
+// Scenario 1: Bulk-free triggers shrink.
+//
+// Allocate several large blocks so the heap grows well beyond one page, then free them all.
+// Each free at capacity triggers try_reclaim() → Heap::shrink() to unmap tail pages.
+// Re-allocate the same total to confirm pages were reclaimed and can be re-mapped.
+static void scenario_bulk_free(void)
+{
+    unsigned char *blocks[NUM_LARGE_BLOCKS];
+
+    // Allocate large blocks.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks[i] != NULL);
+        memset(blocks[i], 0, LARGE_BLOCK_SIZE);
+        blocks[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Free all — each free at capacity triggers try_reclaim() → shrink.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks[i]);
+    }
+
+    // Re-allocate to confirm reclaimed pages are re-mappable.
+    unsigned char *blocks2[NUM_LARGE_BLOCKS];
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks2[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks2[i] != NULL);
+        memset(blocks2[i], 0, LARGE_BLOCK_SIZE);
+        blocks2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks2[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks2[i]);
+    }
+}
+
+// Scenario 2: All-freed shrinks to minimum.
+//
+// Allocate a single large block (2 MB) to force heap growth, free it. With no live allocations,
+// try_reclaim() sees an empty span and shrinks the heap to PAGE_SIZE. Then allocate multiple
+// medium blocks to verify the heap grows back from minimum.
+static void scenario_shrink_to_minimum(void)
+{
+    // Grow the heap with a 2 MB allocation.
+    unsigned char *block = (unsigned char *)malloc(2 * MB);
+    assert(block != NULL);
+    memset(block, 0, 2 * MB);
+    block[0] = 0xAA;
+    free(block);
+    // Heap should now be at PAGE_SIZE (empty span → minimum).
+
+    // Verify regrowth from minimum.
+    unsigned char *regrowth[REGROWTH_BLOCKS];
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        regrowth[i] = (unsigned char *)malloc(REGROWTH_BLOCK_SIZE);
+        assert(regrowth[i] != NULL);
+        memset(regrowth[i], 0, REGROWTH_BLOCK_SIZE);
+        regrowth[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        assert(regrowth[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        free(regrowth[i]);
+    }
+}
+
+// Scenario 3: Anchors prevent full shrink.
+//
+// Allocate large blocks interleaved with small persistent anchors. Free the large blocks.
+// try_reclaim() can only reclaim tail pages above the highest live anchor. Then free anchors
+// and reallocate large blocks to verify full reclaimability.
+static void scenario_anchors_prevent_full_shrink(void)
+{
+    unsigned char *blocks[NUM_LARGE_BLOCKS];
+    unsigned char *anchors[NUM_LARGE_BLOCKS];
+
+    // Interleave: large block, anchor, large block, anchor, ...
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks[i] != NULL);
+        memset(blocks[i], 0, LARGE_BLOCK_SIZE);
+        blocks[i][0] = (unsigned char)(i & 0xFFu);
+
+        anchors[i] = (unsigned char *)malloc(ANCHOR_SIZE);
+        assert(anchors[i] != NULL);
+        memset(anchors[i], 0, ANCHOR_SIZE);
+        anchors[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Free large blocks; anchors persist and pin the heap above minimum.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks[i]);
+    }
+
+    // Free anchors — now the heap can fully reclaim.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(anchors[i]);
+    }
+
+    // Verify full reclaimability by re-allocating large blocks.
+    unsigned char *blocks2[NUM_LARGE_BLOCKS];
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks2[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks2[i] != NULL);
+        memset(blocks2[i], 0, LARGE_BLOCK_SIZE);
+        blocks2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks2[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks2[i]);
+    }
+}
+
+// Scenario 4: Repeated shrink-grow cycles.
+//
+// In a tight loop, allocate a large block then immediately free it. Each free triggers
+// try_reclaim() → shrink(), and the next allocation triggers the OOM handler → grow().
+// This exercises the self-healing path repeatedly.
+static void scenario_shrink_grow_cycles(void)
+{
+    for (size_t i = 0; i < SHRINK_GROW_CYCLES; ++i) {
+        unsigned char *block = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(block != NULL);
+        memset(block, 0, LARGE_BLOCK_SIZE);
+        unsigned char tag = (unsigned char)(i & 0xFFu);
+        block[0] = tag;
+        assert(block[0] == tag);
+        free(block);
+    }
+}
+
+// Scenario 5: Small heap stays at minimum.
+//
+// Allocate only small blocks whose total is well below a single page. Free them. The heap
+// should remain at PAGE_SIZE because try_reclaim() returns early when heap.size() <= PAGE_SIZE.
+// Verify stability by allocating and freeing small blocks again.
+static void scenario_small_heap_minimum(void)
+{
+    unsigned char *small[NUM_SMALL_ALLOCS];
+
+    // Allocate small blocks that fit within the initial page.
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        small[i] = (unsigned char *)malloc(SMALL_ALLOC_SIZE);
+        assert(small[i] != NULL);
+        memset(small[i], 0, SMALL_ALLOC_SIZE);
+        small[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Free all — heap remains at PAGE_SIZE (no shrink below minimum).
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        free(small[i]);
+    }
+
+    // Reallocate to verify stability.
+    unsigned char *small2[NUM_SMALL_ALLOCS];
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        small2[i] = (unsigned char *)malloc(SMALL_ALLOC_SIZE);
+        assert(small2[i] != NULL);
+        memset(small2[i], 0, SMALL_ALLOC_SIZE);
+        small2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        free(small2[i]);
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Exercises the heap shrink path through five scenarios that cover bulk-free, shrink-to-minimum,
+// anchor-pinned partial shrink, repeated shrink-grow cycles, and small-heap early-return.
+void test_heap_shrink(void)
+{
+    fprintf(stderr, "testing heap shrink ... ");
+
+    scenario_bulk_free();
+    scenario_shrink_to_minimum();
+    scenario_anchors_prevent_full_shrink();
+    scenario_shrink_grow_cycles();
+    scenario_small_heap_minimum();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/heap_stress.c
+++ b/src/posix-tests/memory-c/heap_stress.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// 1 KB.
+#define KB (1024u)
+
+// 1 MB.
+#define MB (1024u * KB)
+
+// Number of alloc/free rounds for the reclaim test.
+#define RECLAIM_ROUNDS 32u
+
+// Number of allocations per round.
+#define ALLOCS_PER_ROUND 8u
+
+// Block sizes to cycle through.
+#define NUM_BLOCK_SIZES 4u
+static const size_t BLOCK_SIZES[NUM_BLOCK_SIZES] = {
+    512u * KB,
+    256u * KB,
+    128u * KB,
+    64u * KB,
+};
+
+// Size of small anchor allocations placed between freed blocks.
+#define ANCHOR_SIZE 64u
+
+// xorshift PRNG seed.
+#define XORSHIFT_SEED 0xDEADBEEFu
+
+// Size of each large block used to fill the heap.
+#define FILL_BLOCK_SIZE MB
+
+// Maximum number of large blocks to attempt (32 MB / 1 MB).
+#define MAX_FILL_BLOCKS 32u
+
+// Size of medium blocks used in the fragmentation phase.
+#define MEDIUM_BLOCK_SIZE (256u * KB)
+
+// Maximum number of medium blocks (32 MB / 256 KB).
+#define MAX_MEDIUM_BLOCKS 128u
+
+// Number of allocations in the reuse-after-drain validation.
+#define REUSE_ROUNDS 8u
+
+// Size of blocks allocated in the reuse-after-drain phase.
+#define REUSE_BLOCK_SIZE (512u * KB)
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Simple 32-bit xorshift PRNG.
+static unsigned xorshift32(unsigned state)
+{
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    return state;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Stresses the heap allocator with many alloc/free cycles of varying sizes under fragmentation
+// pressure. Each round allocates blocks of pseudo-random sizes, interleaves them with small
+// persistent anchors, and frees the large blocks while keeping the anchors.
+void test_heap_reclaim(void)
+{
+    fprintf(stderr, "testing heap reclaim ... ");
+
+    // Anchors survive across rounds to create fragmentation.
+    unsigned char *anchors[RECLAIM_ROUNDS * ALLOCS_PER_ROUND];
+    size_t num_anchors = 0;
+    unsigned rng = XORSHIFT_SEED;
+
+    for (size_t round = 0; round < RECLAIM_ROUNDS; ++round) {
+        unsigned char *blocks[ALLOCS_PER_ROUND];
+
+        for (size_t slot = 0; slot < ALLOCS_PER_ROUND; ++slot) {
+            // Pick a block size pseudo-randomly.
+            rng = xorshift32(rng);
+            size_t size_index = rng % NUM_BLOCK_SIZES;
+            size_t sz = BLOCK_SIZES[size_index];
+
+            blocks[slot] = (unsigned char *)malloc(sz);
+            assert(blocks[slot] != NULL);
+
+            // Tag the first byte so the allocation is not optimized away.
+            unsigned char tag = (unsigned char)((round * ALLOCS_PER_ROUND + slot) & 0xFFu);
+            blocks[slot][0] = tag;
+            assert(blocks[slot][0] == tag);
+
+            // Place an anchor after every second block.
+            if (slot % 2 == 1) {
+                anchors[num_anchors] = (unsigned char *)malloc(ANCHOR_SIZE);
+                assert(anchors[num_anchors] != NULL);
+                anchors[num_anchors][0] = (unsigned char)((round + slot) & 0xFFu);
+                num_anchors++;
+            }
+        }
+
+        // Free all large blocks from this round; anchors persist.
+        for (size_t slot = 0; slot < ALLOCS_PER_ROUND; ++slot) {
+            free(blocks[slot]);
+        }
+    }
+
+    // Clean up all anchors.
+    for (size_t i = 0; i < num_anchors; ++i) {
+        free(anchors[i]);
+    }
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests the allocator by attempting to consume the maximum allowed heap capacity. Proceeds in
+// four phases: fill, drain, fragmentation, and reuse-after-drain.
+void test_heap_max_capacity(void)
+{
+    fprintf(stderr, "testing heap max capacity ... ");
+
+    //==============================================================================================
+    // Phase 1: Fill the heap to near-capacity with large blocks.
+    //==============================================================================================
+
+    unsigned char *large_blocks[MAX_FILL_BLOCKS];
+    size_t num_large = 0;
+    size_t total_allocated = 0;
+
+    for (size_t i = 0; i < MAX_FILL_BLOCKS; ++i) {
+        unsigned char *p = (unsigned char *)malloc(FILL_BLOCK_SIZE);
+        if (p == NULL) {
+            break; // OOM — heap is full.
+        }
+        unsigned char tag = (unsigned char)(i & 0xFFu);
+        memset(p, 0, FILL_BLOCK_SIZE);
+        p[0] = tag;
+        large_blocks[num_large] = p;
+        num_large++;
+        total_allocated += FILL_BLOCK_SIZE;
+    }
+
+    // We should have allocated at least one block.
+    assert(total_allocated >= FILL_BLOCK_SIZE);
+
+    // Verify data integrity on all blocks.
+    for (size_t i = 0; i < num_large; ++i) {
+        unsigned char expected = (unsigned char)(i & 0xFFu);
+        assert(large_blocks[i][0] == expected);
+    }
+
+    //==============================================================================================
+    // Phase 2: Drain and verify reclaimability.
+    //==============================================================================================
+
+    for (size_t i = 0; i < num_large; ++i) {
+        free(large_blocks[i]);
+    }
+
+    // Verify reclaimability with a multi-block allocation.
+    size_t reclaim_size = (num_large >= 2) ? (2 * FILL_BLOCK_SIZE) : FILL_BLOCK_SIZE;
+    unsigned char *reclaim = (unsigned char *)malloc(reclaim_size);
+    assert(reclaim != NULL);
+    memset(reclaim, 0xAA, reclaim_size);
+    free(reclaim);
+
+    //==============================================================================================
+    // Phase 3: Fragmentation near capacity.
+    //==============================================================================================
+
+    unsigned char *medium_blocks[MAX_MEDIUM_BLOCKS];
+    size_t num_medium = 0;
+
+    for (size_t i = 0; i < MAX_MEDIUM_BLOCKS; ++i) {
+        unsigned char *p = (unsigned char *)malloc(MEDIUM_BLOCK_SIZE);
+        if (p == NULL) {
+            break; // OOM — heap is full.
+        }
+        unsigned char tag = (unsigned char)(i & 0xFFu);
+        memset(p, 0, MEDIUM_BLOCK_SIZE);
+        p[0] = tag;
+        medium_blocks[num_medium] = p;
+        num_medium++;
+    }
+
+    // Retain odd-indexed blocks as anchors, free even-indexed ones.
+    size_t anchor_count = 0;
+    unsigned char *frag_anchors[MAX_MEDIUM_BLOCKS / 2];
+    for (size_t i = 0; i < num_medium; ++i) {
+        if (i % 2 == 1) {
+            frag_anchors[anchor_count] = medium_blocks[i];
+            anchor_count++;
+        } else {
+            free(medium_blocks[i]);
+        }
+    }
+
+    // Allocate into the freed gaps.
+    size_t num_gap = 0;
+    unsigned char *gap_blocks[MAX_MEDIUM_BLOCKS / 2];
+    for (size_t i = 0; i < anchor_count; ++i) {
+        unsigned char *p = (unsigned char *)malloc(MEDIUM_BLOCK_SIZE);
+        if (p == NULL) {
+            break; // No more room.
+        }
+        unsigned char tag = (unsigned char)(i & 0xFFu);
+        p[0] = tag;
+        gap_blocks[num_gap] = p;
+        num_gap++;
+    }
+
+    // We should have been able to fit at least some blocks into the gaps.
+    if (anchor_count > 0) {
+        assert(num_gap > 0);
+    }
+
+    // Verify gap block integrity.
+    for (size_t i = 0; i < num_gap; ++i) {
+        unsigned char expected = (unsigned char)(i & 0xFFu);
+        assert(gap_blocks[i][0] == expected);
+    }
+
+    // Free all gap and anchor blocks.
+    for (size_t i = 0; i < num_gap; ++i) {
+        free(gap_blocks[i]);
+    }
+    for (size_t i = 0; i < anchor_count; ++i) {
+        free(frag_anchors[i]);
+    }
+
+    //==============================================================================================
+    // Phase 4: Reuse after full drain.
+    //==============================================================================================
+
+    for (size_t round = 0; round < REUSE_ROUNDS; ++round) {
+        unsigned char *p = (unsigned char *)malloc(REUSE_BLOCK_SIZE);
+        assert(p != NULL);
+        unsigned char tag = (unsigned char)(round & 0xFFu);
+        p[0] = tag;
+        assert(p[0] == tag);
+        free(p);
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/main.c
+++ b/src/posix-tests/memory-c/main.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests memory management system calls.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_mmap_munmap();
+    test_malloc_free();
+    test_aligned_alloc_free();
+    test_malloc_usable_size();
+    test_heap_reclaim();
+    test_heap_max_capacity();
+    test_heap_shrink();
+    test_realloc();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/memory-c/malloc_free.c
+++ b/src/posix-tests/memory-c/malloc_free.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can allocate and free memory using `malloc()` and `free()`.
+void test_malloc_free(void)
+{
+    fprintf(stderr, "testing malloc() and free() ... ");
+
+    // A small collection of allocation sizes (bytes) to exercise allocator paths.
+    const size_t sizes[] = {1u, 8u, 32u, 128u, 511u, 512u, 1024u, 4096u};
+    const size_t nsizes = sizeof(sizes) / sizeof(sizes[0]);
+
+    // Allocate, touch, and free each block individually.
+    for (size_t i = 0; i < nsizes; ++i) {
+        size_t sz = sizes[i];
+        void *ptr = malloc(sz);
+        assert(ptr != NULL);
+
+        // Fill memory with a pattern and verify it was written.
+        memset(ptr, (int)(0xA5u), sz);
+        unsigned char *bytes = (unsigned char *)ptr;
+        for (size_t j = 0; j < sz; ++j) {
+            assert(bytes[j] == 0xA5u);
+        }
+
+        free(ptr);
+    }
+
+    // Repeated allocate/free cycle to check for simple leaks or reuse issues.
+    for (size_t iter = 0; iter < 100u; ++iter) {
+        void *p = malloc(64u);
+        assert(p != NULL);
+        ((unsigned char *)p)[0] = (unsigned char)iter; // Touch.
+        free(p);
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/malloc_usable_size.c
+++ b/src/posix-tests/memory-c/malloc_usable_size.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <malloc.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can query the usable size of allocated blocks using `malloc_usable_size()`.
+void test_malloc_usable_size(void)
+{
+    fprintf(stderr, "testing malloc_usable_size() ... ");
+
+    // Null pointer must yield zero.
+    {
+        size_t sz = malloc_usable_size(NULL);
+        assert(sz == 0u);
+    }
+
+    // Exercise a range of allocation sizes and verify reported usable size.
+    {
+        const size_t sizes[] = {1u, 8u, 32u, 64u, 127u, 128u, 255u, 256u, 511u, 512u, 1024u};
+        const size_t nsizes = sizeof(sizes) / sizeof(sizes[0]);
+        for (size_t i = 0; i < nsizes; ++i) {
+            size_t req = sizes[i];
+            void *p = malloc(req);
+            assert(p != NULL);
+            size_t usable = malloc_usable_size(p);
+            // Current allocator promises exact size; enforce so regressions are caught.
+            assert(usable >= req);
+            assert(usable == req);
+            // Touch within requested bounds (never rely on any extra capacity).
+            memset(p, 0xA5, req);
+            unsigned char *bytes = (unsigned char *)p;
+            for (size_t j = 0; j < req; ++j) {
+                assert(bytes[j] == 0xA5u);
+            }
+            free(p);
+        }
+    }
+
+    // Realloc growth path: ensure updated usable size reflects new request.
+    {
+        void *p = malloc(64u);
+        assert(p != NULL);
+        assert(malloc_usable_size(p) == 64u);
+        void *p2 = realloc(p, 200u);
+        assert(p2 != NULL);
+        assert(malloc_usable_size(p2) == 200u);
+        memset(p2, 0x5A, 200u);
+        free(p2);
+    }
+
+    // Aligned allocation path.
+    {
+        void *pa = aligned_alloc(128u, 256u); // size is a multiple of alignment.
+        assert(pa != NULL);
+        // Alignment validation (platform is 32-bit, so pointer fits in uintptr_t).
+        assert(((uintptr_t)pa % 128u) == 0u);
+        assert(malloc_usable_size(pa) == 256u);
+        free(pa);
+    }
+
+    // Stress: allocate/free and query usable size repeatedly to reveal metadata issues.
+    for (size_t iter = 0; iter < 100u; ++iter) {
+        void *p = malloc(96u);
+        assert(p != NULL);
+        assert(malloc_usable_size(p) == 96u);
+        ((unsigned char *)p)[0] = (unsigned char)iter; // Touch.
+        free(p);
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/mmap_munmap.c
+++ b/src/posix-tests/memory-c/mmap_munmap.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can map and unmap memory using `mmap()` and `munmap()`.
+void test_mmap_munmap(void)
+{
+    fprintf(stderr, "testing mmap() and munmap() with anonymous memory ... ");
+
+    // Get the page size from the system.
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    assert(page_size > 0);
+
+    // Map a page of anonymous memory.
+    void *ptr = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    assert(ptr != MAP_FAILED);
+
+    // Attempt to write to the mapped memory.
+    *((char *)ptr) = 'A';
+
+    // Unmap the page.
+    assert(munmap(ptr, page_size) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/memory-c/realloc.c
+++ b/src/posix-tests/memory-c/realloc.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Pattern byte used to fill memory before realloc.
+#define FILL_BYTE 0xA5u
+
+// Number of grow/shrink cycles in the stress test.
+#define STRESS_CYCLES 64u
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests realloc growth, shrink, NULL-ptr, data preservation, alignment boundary sizes, and
+// repeated grow/shrink cycles. Exercises the BlockHeader alignment rounding and free-path
+// header validation introduced by the libc_stdlib fix.
+void test_realloc(void)
+{
+    fprintf(stderr, "testing realloc() ... ");
+
+    //==============================================================================================
+    // Growth path: malloc then realloc to a larger size.
+    //==============================================================================================
+
+    {
+        void *ptr = malloc(64u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 64u);
+
+        void *ptr2 = realloc(ptr, 256u);
+        assert(ptr2 != NULL);
+
+        // Verify original data is preserved in the first 64 bytes.
+        unsigned char *bytes = (unsigned char *)ptr2;
+        for (size_t i = 0; i < 64u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr2);
+    }
+
+    //==============================================================================================
+    // Shrink path: malloc a large block then realloc to a smaller size.
+    //==============================================================================================
+
+    {
+        void *ptr = malloc(512u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 512u);
+
+        void *ptr2 = realloc(ptr, 64u);
+        assert(ptr2 != NULL);
+
+        // Verify data preserved in the smaller region.
+        unsigned char *bytes = (unsigned char *)ptr2;
+        for (size_t i = 0; i < 64u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr2);
+    }
+
+    //==============================================================================================
+    // NULL-ptr realloc: behaves like malloc.
+    //==============================================================================================
+
+    {
+        void *ptr = realloc(NULL, 128u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 128u);
+
+        unsigned char *bytes = (unsigned char *)ptr;
+        for (size_t i = 0; i < 128u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr);
+    }
+
+    //==============================================================================================
+    // Alignment boundary sizes: exercise UNDERLYING_ALIGNMENT (8-byte) rounding.
+    //==============================================================================================
+
+    {
+        const size_t sizes[] = {1u, 7u, 8u, 9u, 15u, 16u, 17u, 31u, 32u, 33u};
+        const size_t nsizes = sizeof(sizes) / sizeof(sizes[0]);
+
+        for (size_t i = 0; i < nsizes; ++i) {
+            size_t sz = sizes[i];
+            void *ptr = malloc(sz);
+            assert(ptr != NULL);
+            memset(ptr, FILL_BYTE, sz);
+
+            // Grow to double size.
+            size_t new_sz = sz * 2;
+            void *ptr2 = realloc(ptr, new_sz);
+            assert(ptr2 != NULL);
+
+            // Verify original data preserved.
+            unsigned char *bytes = (unsigned char *)ptr2;
+            for (size_t j = 0; j < sz; ++j) {
+                assert(bytes[j] == FILL_BYTE);
+            }
+
+            free(ptr2);
+        }
+    }
+
+    //==============================================================================================
+    // Repeated grow/shrink cycles: stress alignment and header validation.
+    //==============================================================================================
+
+    {
+        size_t cur_size = 32u;
+        void *ptr = malloc(cur_size);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, cur_size);
+
+        for (size_t cycle = 0; cycle < STRESS_CYCLES; ++cycle) {
+            // Alternate: grow on even cycles, shrink on odd.
+            size_t new_size = (cycle % 2 == 0) ? cur_size * 2 : cur_size / 2;
+            if (new_size == 0) {
+                new_size = 1;
+            }
+
+            size_t check_size = (new_size < cur_size) ? new_size : cur_size;
+            void *ptr2 = realloc(ptr, new_size);
+            assert(ptr2 != NULL);
+
+            // Verify data preserved up to the smaller of old/new sizes.
+            unsigned char *bytes = (unsigned char *)ptr2;
+            for (size_t j = 0; j < check_size; ++j) {
+                assert(bytes[j] == FILL_BYTE);
+            }
+
+            // Fill the new region with the pattern.
+            memset(ptr2, FILL_BYTE, new_size);
+
+            ptr = ptr2;
+            cur_size = new_size;
+        }
+
+        free(ptr);
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/clock_getres.c
+++ b/src/posix-tests/misc-c/clock_getres.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the resolution of a clock with `clock_getres()`.
+void test_clock_getres(void)
+{
+    fprintf(stderr, "testing clock_getres() ... ");
+
+    // Assert size of `timespec` structure.
+    STATIC_ASSERT_SIZE(struct timespec, sizeof(time_t) + sizeof(long));
+
+    struct timespec res = {0};
+
+    // Get the resolution of the monotonic clock and check the result.
+    memset(&res, 0, sizeof(res));
+    assert(clock_getres(CLOCK_MONOTONIC, &res) == 0);
+    assert(res.tv_sec >= 0);
+    assert(res.tv_nsec >= 0);
+
+    // Get the resolution of the real-time clock and check the result.
+    memset(&res, 0, sizeof(res));
+    assert(clock_getres(CLOCK_REALTIME, &res) == 0);
+    assert(res.tv_sec >= 0);
+    assert(res.tv_nsec >= 0);
+
+    // Get the resolution of the process CPU-time clock and check the result.
+    memset(&res, 0, sizeof(res));
+    assert(clock_getres(CLOCK_PROCESS_CPUTIME_ID, &res) == -1);
+    assert(errno == ENOTSUP);
+    errno = 0;
+
+    // Get the resolution of the thread CPU-time clock and check the result.
+    memset(&res, 0, sizeof(res));
+    assert(clock_getres(CLOCK_THREAD_CPUTIME_ID, &res) == -1);
+    assert(errno == ENOTSUP);
+    errno = 0;
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/clock_gettime.c
+++ b/src/posix-tests/misc-c/clock_gettime.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the current time of a clock with `clock_gettime()`.
+void test_clock_gettime(void)
+{
+    fprintf(stderr, "testing clock_gettime() ... ");
+
+    struct timespec ts = {0};
+
+    // Get the current time of the monotonic clock and check the result.
+    memset(&ts, 0, sizeof(ts));
+    assert(clock_gettime(CLOCK_MONOTONIC, &ts) == 0);
+    assert(ts.tv_sec >= 0);
+    assert(ts.tv_nsec >= 0);
+
+    // Get the current time of the real-time clock and check the result.
+    memset(&ts, 0, sizeof(ts));
+    assert(clock_gettime(CLOCK_REALTIME, &ts) == 0);
+    assert(ts.tv_sec >= 0);
+    assert(ts.tv_nsec >= 0);
+
+    // Get the current time of the process CPU-time clock and check the result.
+    memset(&ts, 0, sizeof(ts));
+    assert(clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == -1);
+    assert(errno == ENOTSUP);
+    errno = 0;
+
+    // Get the current time of the thread CPU-time clock and check the result.
+    memset(&ts, 0, sizeof(ts));
+    assert(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == -1);
+    assert(errno == ENOTSUP);
+    errno = 0;
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/common.h
+++ b/src/posix-tests/misc-c/common.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Functions
+//==================================================================================================
+
+// Tests whether we can get the resolution of a clock with `clock_getres()`.
+extern void test_clock_getres(void);
+
+// Tests if `getenv()` works.
+extern void test_getenv(void);
+
+// Tests whether we can get the effective group ID of the calling process with `getegid()`.
+extern void test_getegid(void);
+
+// Tests whether we can get the effective user ID of the calling process with `geteuid()`.
+extern void test_geteuid(void);
+
+// Tests whether we can get the group ID of the calling process with `getgid()`.
+extern void test_getgid(void);
+
+// Tests whether `gethostname()` works.
+extern void test_gethostname(void);
+
+// Tests whether we can the user ID of the calling process with `getuid()`.
+extern void test_getuid(void);
+
+// Tests whether we can get the current time of a clock with `clock_gettime()`.
+extern void test_clock_gettime(void);
+
+// Tests whether we can sleep for a given amount of time with `nanosleep()`.
+extern void test_nanosleep(void);
+
+// Tests whether `setegid()` can be used to set the effective group ID of the calling process.
+extern void test_setegid(void);
+
+// Tests whether `setgid()` can be used to set the real group ID of the calling process.
+extern void test_setgid(void);
+
+// Tests whether `seteuid()` can be used to set the effective user ID of the calling process.
+extern void test_seteuid(void);
+
+// Tests whether `setuid()` can be used to set the real user ID of the calling process.
+extern void test_setuid(void);
+
+// Tests whether we can retrieve process times with `times()`.
+extern void test_times(void);
+
+// Tests whether we can get system information with `uname()`.
+extern void test_uname(void);
+
+#endif

--- a/src/posix-tests/misc-c/getegid.c
+++ b/src/posix-tests/misc-c/getegid.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the effective group ID of the calling process with `getegid()`.
+void test_getegid(void)
+{
+    fprintf(stderr, "testing getegid() ... ");
+
+    assert(getegid() != (gid_t)-1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/getenv.c
+++ b/src/posix-tests/misc-c/getenv.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests whether `getenv()` correctly retrieves a set environment variable.
+ */
+static void test_getenv_set(void)
+{
+    fprintf(stderr, "testing getenv() set ... ");
+
+    const char *value = getenv("NANVIX_TEST");
+    assert(value != NULL);
+    assert(strcmp(value, "1") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+/**
+ * @brief Tests whether `getenv()` returns NULL for an unset environment variable.
+ */
+static void test_getenv_unset(void)
+{
+    fprintf(stderr, "testing getenv() unset ... ");
+
+    const char *value = getenv("NANVIX_UNSET_VAR");
+    assert(value == NULL);
+
+    fprintf(stderr, "passed\n");
+}
+
+/**
+ * @brief Tests if `getenv()` works.
+ */
+void test_getenv(void)
+{
+    test_getenv_set();
+    test_getenv_unset();
+}

--- a/src/posix-tests/misc-c/geteuid.c
+++ b/src/posix-tests/misc-c/geteuid.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the effective user ID of the calling process with `geteuid()`.
+void test_geteuid(void)
+{
+    fprintf(stderr, "testing geteuid() ... ");
+
+    assert(geteuid() != (uid_t)-1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/getgid.c
+++ b/src/posix-tests/misc-c/getgid.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the group ID of the calling process with `getgid()`.
+void test_getgid(void)
+{
+    fprintf(stderr, "testing getgid() ... ");
+
+    assert(getgid() != (gid_t)-1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/gethostname.c
+++ b/src/posix-tests/misc-c/gethostname.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#define _POSIX_C_SOURCE 200112L // gethostname().
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+// TODO: Remove this constant when it exported by Newlib.
+#define HOSTNAME_MAX 255
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `gethostname()` works.
+void test_gethostname(void)
+{
+    fprintf(stderr, "testing gethostname() ... ");
+
+    char hostname[HOSTNAME_MAX + 1];
+    const char *HOSTNAME = __NANVIX_NODENAME__;
+
+    // Get host name and assert result.
+    assert(gethostname(hostname, sizeof(hostname)) != -1);
+    assert(strncmp(hostname, HOSTNAME, sizeof(hostname)) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/getuid.c
+++ b/src/posix-tests/misc-c/getuid.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get the user ID of the calling process with `getuid()`.
+void test_getuid(void)
+{
+    fprintf(stderr, "testing getuid() ... ");
+
+    assert(getuid() != (uid_t)-1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/main.c
+++ b/src/posix-tests/misc-c/main.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests miscellaneous system calls.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert command-line arguments.
+    assert(argc == 1);
+    assert(argv[0] != NULL);
+    assert(argv[1] == NULL);
+    assert(strcmp(argv[0], "misc-c.elf") == 0);
+
+    test_getuid();
+    test_getgid();
+    test_geteuid();
+    test_getegid();
+    test_setuid();
+    test_seteuid();
+    test_setgid();
+    test_setegid();
+    test_clock_getres();
+    test_clock_gettime();
+#ifndef __hyperlight__
+    test_nanosleep();
+#endif
+    test_times();
+    test_uname();
+    test_gethostname();
+    test_getenv();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/misc-c/nanosleep.c
+++ b/src/posix-tests/misc-c/nanosleep.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can sleep for a given amount of time with `nanosleep()`.
+void test_nanosleep(void)
+{
+    fprintf(stderr, "testing nanosleep() ... ");
+
+    struct timespec req = {
+        .tv_sec = 1,
+        .tv_nsec = 0,
+    };
+
+    assert(nanosleep(&req, NULL) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/setegid.c
+++ b/src/posix-tests/misc-c/setegid.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#define _POSIX_C_SOURCE 200112
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setegid()` can be used to set the effective group ID of the calling process.
+void test_setegid(void)
+{
+    fprintf(stderr, "testing setegid() ... ");
+
+    gid_t gid = getgid();
+    assert(setegid(gid) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/seteuid.c
+++ b/src/posix-tests/misc-c/seteuid.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#define _POSIX_C_SOURCE 200112
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `seteuid()` can be used to set the effective user ID of the calling process.
+void test_seteuid(void)
+{
+    fprintf(stderr, "testing seteuid() ... ");
+
+    uid_t uid = getuid();
+    assert(seteuid(uid) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/setgid.c
+++ b/src/posix-tests/misc-c/setgid.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setgid()` can be used to set the real group ID of the calling process.
+void test_setgid(void)
+{
+    fprintf(stderr, "testing setgid() ... ");
+
+    gid_t gid = getgid();
+    assert(setgid(gid) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/setuid.c
+++ b/src/posix-tests/misc-c/setuid.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setuid()` can be used to set the real user ID of the calling process.
+void test_setuid(void)
+{
+    fprintf(stderr, "testing setuid() ... ");
+
+    uid_t uid = getuid();
+    assert(setuid(uid) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/times.c
+++ b/src/posix-tests/misc-c/times.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/times.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can retrieve process times with `times()`.
+void test_times(void)
+{
+    fprintf(stderr, "testing times() ... ");
+
+    struct tms buf = {0};
+
+    // Call `times()` and check the result.
+    memset(&buf, 0, sizeof(buf));
+    assert(times(&buf) != (clock_t)-1);
+
+    // Validate the values returned in the `tms` structure.
+    // TODO: Investigate why `tms` is filled with zeroes and uncomment the assertions.
+#if 0
+    assert(buf.tms_utime > 0);
+    assert(buf.tms_stime > 0);
+    assert(buf.tms_cutime > 0);
+    assert(buf.tms_cstime > 0);
+#endif
+
+    // Call `times()` and check the result.
+    assert(times(NULL) != (clock_t)-1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/misc-c/uname.c
+++ b/src/posix-tests/misc-c/uname.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can get system information with `uname()`.
+void test_uname(void)
+{
+    fprintf(stderr, "testing uname() ... ");
+
+    // Sanity check size of `utsname` structure.
+    STATIC_ASSERT_SIZE(struct utsname,
+                       _UTSNAME_LENGTH * sizeof(char) +     // sysname
+                           _UTSNAME_LENGTH * sizeof(char) + // nodename
+                           _UTSNAME_LENGTH * sizeof(char) + // release
+                           _UTSNAME_LENGTH * sizeof(char) + // version
+                           _UTSNAME_LENGTH * sizeof(char)   // machine
+    );
+
+    // Get system information.
+    struct utsname utsname = {0};
+    assert(uname(&utsname) == 0);
+
+    // Check if the system information structure is not empty.
+    assert(utsname.sysname[0] != '\0');
+    assert(utsname.nodename[0] != '\0');
+    assert(utsname.release[0] != '\0');
+    assert(utsname.version[0] != '\0');
+    assert(utsname.machine[0] != '\0');
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/network-c/common.c
+++ b/src/posix-tests/network-c/common.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Creates a new unbound socket.
+static int new_unbound_socket(int domain, int type, int protocol)
+{
+    int sockfd = socket(domain, type, protocol);
+    assert(sockfd >= 0);
+    return sockfd;
+}
+
+// Creates a new bound socket.
+static int new_bound_socket(int domain,
+                            int type,
+                            int protocol,
+                            const struct sockaddr *addr,
+                            socklen_t addrlen)
+{
+    int sockfd = new_unbound_socket(domain, type, protocol);
+    int ret = bind(sockfd, addr, addrlen);
+    assert(ret == 0);
+    return sockfd;
+}
+
+// Creates a listening socket.
+static int new_listening_socket(int domain,
+                                int type,
+                                int protocol,
+                                const struct sockaddr *addr,
+                                socklen_t addrlen)
+{
+    int sockfd = new_bound_socket(domain, type, protocol, addr, addrlen);
+    int ret = listen(sockfd, 5);
+    assert(ret == 0);
+    return sockfd;
+}
+
+// Creates a pair of connected sockets.
+void new_socket_pair(int domain, int type, int protocol, int sockfds[2])
+{
+    int ret = socketpair(domain, type, protocol, sockfds);
+    assert(ret == 0);
+}
+
+// Tests if we succeed to create a socket.
+void test_create_socket(int domain, int type, int protocol)
+{
+    int sockfd = new_unbound_socket(domain, type, protocol);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+}
+
+// Tests if we succeed to bind a socket.
+void test_bind_socket(int domain,
+                      int type,
+                      int protocol,
+                      const struct sockaddr *addr,
+                      socklen_t addrlen)
+{
+    int sockfd = new_bound_socket(domain, type, protocol, addr, addrlen);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+
+    if (addr->sa_family == AF_UNIX) {
+        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
+        assert(ret == 0);
+    }
+}
+
+// Tests if we succeed to create a listening socket.
+void test_listen_socket(int domain,
+                        int type,
+                        int protocol,
+                        const struct sockaddr *addr,
+                        socklen_t addrlen)
+{
+    int sockfd = new_listening_socket(domain, type, protocol, addr, addrlen);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+
+    if (addr->sa_family == AF_UNIX) {
+        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
+        assert(ret == 0);
+    }
+}
+
+// Tests if we succeed to get the name of a bound socket.
+void test_getsockname_bound_socket(int domain,
+                                   int type,
+                                   int protocol,
+                                   const struct sockaddr *addr,
+                                   socklen_t addrlen)
+{
+    int sockfd = new_bound_socket(domain, type, protocol, addr, addrlen);
+
+    struct sockaddr addrbuf;
+    socklen_t addrlenbuf = sizeof(addrbuf);
+
+    int ret = getsockname(sockfd, &addrbuf, &addrlenbuf);
+    assert(ret == 0);
+
+    // Check if the address family and the port are what we expect.
+    assert(memcmp(&addr->sa_len, &addrbuf.sa_len, sizeof(addr->sa_len)) == 0);
+    assert(memcmp(&addr->sa_family, &addrbuf.sa_family, sizeof(addr->sa_family)) == 0);
+    assert(memcmp(&addr->sa_data, &addrbuf.sa_data, sizeof(addr->sa_data)) == 0);
+
+    ret = close(sockfd);
+    assert(ret == 0);
+
+    if (addr->sa_family == AF_UNIX) {
+        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
+        assert(ret == 0);
+    }
+}
+
+// Tests if we succeed to get the name of a listening socket.
+void test_getsockname_listening_socket(int domain,
+                                       int type,
+                                       int protocol,
+                                       const struct sockaddr *addr,
+                                       socklen_t addrlen)
+{
+    int sockfd = new_listening_socket(domain, type, protocol, addr, addrlen);
+
+    struct sockaddr addrbuf;
+    socklen_t addrlenbuf = sizeof(addrbuf);
+
+    int ret = getsockname(sockfd, &addrbuf, &addrlenbuf);
+    assert(ret == 0);
+
+    // Check if the address family and the port are what we expect.
+    assert(memcmp(&addr->sa_len, &addrbuf.sa_len, sizeof(addr->sa_len)) == 0);
+    assert(memcmp(&addr->sa_family, &addrbuf.sa_family, sizeof(addr->sa_family)) == 0);
+    assert(memcmp(&addr->sa_data, &addrbuf.sa_data, sizeof(addr->sa_data)) == 0);
+
+    ret = close(sockfd);
+    assert(ret == 0);
+
+    if (addr->sa_family == AF_UNIX) {
+        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
+        assert(ret == 0);
+    }
+}
+
+// Tests if we succeed to get the name of a socket.
+void test_get_sockname(int domain,
+                       int type,
+                       int protocol,
+                       const struct sockaddr *sockaddr,
+                       socklen_t addrlen)
+{
+    test_getsockname_bound_socket(domain, type, protocol, sockaddr, addrlen);
+    test_getsockname_listening_socket(domain, type, protocol, sockaddr, addrlen);
+}

--- a/src/posix-tests/network-c/common.h
+++ b/src/posix-tests/network-c/common.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+// Creates a pair of connected sockets.
+extern void new_socket_pair(int domain, int type, int protocol, int sockfds[2]);
+
+// Tests if we succeed to create a socket.
+extern void test_create_socket(int domain, int type, int protocol);
+
+// Tests if we succeed to bind a socket.
+extern void test_bind_socket(int domain,
+                             int type,
+                             int protocol,
+                             const struct sockaddr *addr,
+                             socklen_t addrlen);
+
+// Tests if we succeed to create a listening socket.
+extern void test_listen_socket(int domain,
+                               int type,
+                               int protocol,
+                               const struct sockaddr *addr,
+                               socklen_t addrlen);
+
+// Tests if we succeed to get the name of a bound socket.
+extern void test_getsockname_bound_socket(int domain,
+                                          int type,
+                                          int protocol,
+                                          const struct sockaddr *addr,
+                                          socklen_t addrlen);
+
+// Tests if we succeed to get the name of a listening socket.
+extern void test_getsockname_listening_socket(int domain,
+                                              int type,
+                                              int protocol,
+                                              const struct sockaddr *addr,
+                                              socklen_t addrlen);
+
+// Tests if we succeed to get the name of a socket.
+extern void test_get_sockname(int domain,
+                              int type,
+                              int protocol,
+                              const struct sockaddr *sockaddr,
+                              socklen_t addrlen);
+
+extern void test_unix_sockets(char sun_path[]);
+extern void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr);
+
+#endif

--- a/src/posix-tests/network-c/inet.c
+++ b/src/posix-tests/network-c/inet.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests operations in INET sockets.
+void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr)
+{
+    // Test configuration.
+    int domain = AF_INET;
+    int type = SOCK_STREAM;
+    int protocol = IPPROTO_TCP;
+
+    struct sockaddr_in sockaddr = {
+        .sin_len = sizeof(sockaddr),
+        .sin_family = domain,
+        .sin_port = sin_port,
+        .sin_addr = sin_addr,
+    };
+
+    test_create_socket(domain, type, protocol);
+    test_bind_socket(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    test_listen_socket(
+        domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    test_get_sockname(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+}

--- a/src/posix-tests/network-c/main.c
+++ b/src/posix-tests/network-c/main.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#ifndef __NANVIX_STANDALONE__
+#include <sys/un.h>
+#endif
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Seed for random number generation.
+#ifndef __RELEASE
+#define SEED 0
+#else
+#define SEED 42
+#endif
+
+// Length of the UNIX socket name (including the null terminator).
+// We set this so it fits on socaddr.sa_data.
+#define UNIX_SOCKET_NAME_LEN 9
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests networking system calls.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Sanity check size of `sa_family_t` type.
+    STATIC_ASSERT_SIZE(sa_family_t, sizeof(uint8_t));
+
+    // Sanity check size of `in_port_t` type.
+    STATIC_ASSERT_SIZE(in_port_t, sizeof(uint16_t));
+
+    // Sanity check size of `in_addr_t` type.
+    STATIC_ASSERT_SIZE(in_addr_t, sizeof(uint32_t));
+
+    // Sanity check size of `sockaddr_storage` structure.
+    STATIC_ASSERT_SIZE(struct sockaddr_storage,
+                       sizeof(unsigned char) +        // ss_len
+                           sizeof(sa_family_t) +      // ss_family
+                           _SS_PADSIZE * sizeof(char) // __ss_pad1
+    );
+
+    // Sanity check size of `sockaddr` structure.
+    STATIC_ASSERT_SIZE(struct sockaddr,
+                       sizeof(unsigned char) +   // sa_len
+                           sizeof(sa_family_t) + // sa_family
+                           14 * sizeof(char)     // sa_data
+    );
+    STATIC_ASSERT_SIZE(struct sockaddr, sizeof(struct sockaddr_storage));
+
+    // Sanity check size of `in_addr` structure.
+    STATIC_ASSERT_SIZE(struct in_addr, sizeof(in_addr_t));
+
+    // Sanity check size of `sockaddr_in` structure.
+    STATIC_ASSERT_SIZE(struct sockaddr_in,
+                       sizeof(uint8_t) +            // sin_len
+                           sizeof(sa_family_t) +    // sin_family
+                           sizeof(in_port_t) +      // sin_port
+                           sizeof(struct in_addr) + // sin_addr
+                           8 * sizeof(char)         // sin_zero
+    );
+    STATIC_ASSERT_SIZE(struct sockaddr_in, sizeof(struct sockaddr_storage));
+
+#ifndef __NANVIX_STANDALONE__
+    // Sanity check size of `sockaddr_un` structure.
+    STATIC_ASSERT_SIZE(struct sockaddr_un,
+                       sizeof(unsigned char) +       // sun_len
+                           sizeof(sa_family_t) +     // sun_family
+                           SUNPATHLEN * sizeof(char) // sun_path
+    );
+    STATIC_ASSERT_SIZE(struct sockaddr_un, sizeof(struct sockaddr_storage));
+#endif
+
+    srand(SEED);
+
+    in_port_t sin_port = htons(1992);
+    struct in_addr sin_addr = {.s_addr = htonl(0x7f000001)};
+
+    test_inet_sockets(sin_port, sin_addr);
+
+    // Unix-domain sockets require linuxd; networkd only supports AF_INET sockets.
+#ifndef __NANVIX_STANDALONE__
+    {
+        char sun_path[UNIX_SOCKET_NAME_LEN];
+        for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
+            sun_path[i] = 'a' + (rand() % 26);
+        }
+        sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
+        test_unix_sockets(sun_path);
+    }
+#endif
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/noop-c/main.c
+++ b/src/posix-tests/noop-c/main.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    return (0);
+}

--- a/src/posix-tests/thread-c/attr_init_destroy.c
+++ b/src/posix-tests/thread-c/attr_init_destroy.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread attributes can be initialized and destroyed.
+void test_pthread_attr_init_destroy(void)
+{
+    fprintf(stderr, "testing pthread_attr_init() and pthread_attr_destroy() ... ");
+
+    // Initialize the thread attributes object and assert operation.
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    // Destroy the thread attributes object and assert operation.
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/common.h
+++ b/src/posix-tests/thread-c/common.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+// Tests if threads can get their own identifiers.
+extern void test_pthread_self(void);
+
+// Tests if `pthread_mutex_cond_timedwait()` can be used for synchronization.
+extern void test_pthread_cond_timedwait(void);
+
+// Tests if threads can be created and joined.
+extern void test_pthread_create_join(void);
+
+// Tests if statically initialized mutexes can be used for synchronization.
+extern void test_pthread_mutex_static_init(void);
+
+// Tests if dynamically initialized mutexes can be used for synchronization.
+extern void test_pthread_mutex_dynamic_init(void);
+
+// Tests if calling exit() causes the program to exit even if there are other threads running.
+extern void test_pthread_nowait(void);
+
+// Tests if statically initialized condition variables can be used for synchronization.
+extern void test_pthread_cond_static_init(void);
+
+// Tests if thread interface for operating on thread-specific data works.
+extern void test_pthread_tda(void);
+
+// Tests if calling `test_pthread_mutex_timedlock() works.
+extern void test_pthread_mutex_timedlock(void);
+
+// Tests if calling `pthread_mutex_trylock() works.
+extern void test_pthread_mutex_trylock(void);
+
+// Tests if thread local storage works.
+extern void test_thread_local(void);
+
+// Tests if pthread attributes can be initialized and destroyed.
+extern void test_pthread_attr_init_destroy(void);
+
+// Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
+extern void test_pthread_getattr_np_destroy(void);
+
+// Tests if pthread_attr_getstack() can retrieve stack attributes and they can be destroyed.
+extern void test_pthread_attr_getstack(void);
+
+// Tests if statically initialized read-write locks can synchronize multiple readers.
+extern void test_pthread_rwlock_static_init(void);
+
+// Tests if dynamically initialized read-write locks work (init/destroy + exclusion semantics).
+extern void test_pthread_rwlock_dynamic_init(void);
+
+#endif

--- a/src/posix-tests/thread-c/cond_static_init.c
+++ b/src/posix-tests/thread-c/cond_static_init.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Global condition variable used for synchronization.
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+// Global mutex used to synchronize access to the `initialized` variable.
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Global variable used to signal that the worker thread is initialized.
+static volatile int initialized = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Wait for the main thread to signal the condition variable.
+    assert(pthread_mutex_lock(&mutex) == 0);
+    while (!initialized) {
+        assert(pthread_cond_wait(&cond, &mutex) == 0);
+    }
+    assert(pthread_mutex_unlock(&mutex) == 0);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+
+    // Signal the worker thread to proceed.
+    assert(pthread_mutex_lock(&mutex) == 0);
+    initialized = 1;
+    assert(pthread_cond_signal(&cond) == 0);
+    assert(pthread_mutex_unlock(&mutex) == 0);
+
+    // Wait for the worker thread to finish and check its exit status.
+    void *exit_status;
+    ret = pthread_join(worker_tid, &exit_status);
+    assert(ret == 0);
+    assert((size_t)exit_status == EXPECTED_EXIT_STATUS);
+}
+
+// Tests if statically initialized condition variables can be used for synchronization.
+void test_pthread_cond_static_init(void)
+{
+    fprintf(stderr, "testing pthread_cond_static_init() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/cond_timedwait.c
+++ b/src/posix-tests/thread-c/cond_timedwait.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <time.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Global condition variable used for synchronization.
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+// Global mutex used to synchronize access to the `initialized` variable.
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Global variable used to signal that the worker thread is initialized.
+static volatile int initialized = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    struct timespec ts = {0};
+    assert(clock_gettime(CLOCK_MONOTONIC, &ts) == 0);
+    ts.tv_sec += 1;
+
+    // Wait for the main thread to signal the condition variable.
+    assert(pthread_mutex_lock(&mutex) == 0);
+    assert(pthread_cond_timedwait(&cond, &mutex, &ts) == ETIMEDOUT);
+    assert(pthread_mutex_unlock(&mutex) == 0);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+
+    // Never Signal the worker thread.
+
+    // Wait for the worker thread to finish and check its exit status.
+    void *exit_status;
+    ret = pthread_join(worker_tid, &exit_status);
+    assert(ret == 0);
+    assert((size_t)exit_status == EXPECTED_EXIT_STATUS);
+}
+
+// Tests if `pthread_mutex_cond_timedwait()` can be used for synchronization.
+void test_pthread_cond_timedwait(void)
+{
+    fprintf(stderr, "testing pthread_cond_timedwait() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/create_join.c
+++ b/src/posix-tests/thread-c/create_join.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+}
+
+// Tests if threads can be created and joined.
+void test_pthread_create_join(void)
+{
+    fprintf(stderr, "testing pthread_create() and pthread_join() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/getattr.c
+++ b/src/posix-tests/thread-c/getattr.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
+void test_pthread_getattr_np_destroy(void)
+{
+    fprintf(stderr, "testing pthread_getattr_np() and pthread_attr_destroy() ... ");
+
+    // Get attributes of the calling thread.
+    pthread_attr_t attr = {0};
+    int ret = pthread_getattr_np(pthread_self(), &attr);
+    assert(ret == 0);
+
+    // Sanity check a couple of fields via accessors; values are implementation-defined,
+    // so we only verify that getters succeed and return something sensible.
+    size_t stacksize = 0;
+    void *stackaddr = NULL;
+    ret = pthread_attr_getstack(&attr, &stackaddr, &stacksize);
+    assert(ret == 0);
+    assert(stacksize > 0);
+
+    int detachstate = 0;
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_JOINABLE || detachstate == PTHREAD_CREATE_DETACHED);
+
+    // Destroy the attributes object.
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/getstack.c
+++ b/src/posix-tests/thread-c/getstack.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread_attr_getstack() retrieves stack attributes and they can be destroyed.
+void test_pthread_attr_getstack(void)
+{
+    fprintf(stderr, "testing pthread_attr_getstack() and pthread_attr_destroy() ... ");
+
+    // Initialize the thread attributes object.
+    pthread_attr_t attr = {0};
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    // Retrieve stack attributes.
+    size_t stacksize = 0;
+    void *stackaddr = NULL;
+    ret = pthread_attr_getstack(&attr, &stackaddr, &stacksize);
+    assert(ret == 0);
+
+    // Sanity check returned values.
+    assert(stacksize > 0);
+    assert(stackaddr != NULL);
+
+    // Destroy the attributes object.
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/main.c
+++ b/src/posix-tests/thread-c/main.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <pthread.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+/**
+ * @brief Performs a static assertion.
+ *
+ * @param a Expression to assert.
+ * @param b Expected value.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT(a, b) ((void)sizeof(char[(((a) == (b)) ? 1 : -1)]))
+
+/**
+ * @brief Performs a static assertion on the size of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected size.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_SIZE(a, b) STATIC_ASSERT(sizeof(a), b)
+
+/**
+ * @brief Performs a static assertion on the alignment of a type.
+ *
+ * @param a Type to assert.
+ * @param b Expected alignment.
+ *
+ * @returns Nothing. If the assertion fails, compilation will fail.
+ */
+#define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests pthreads system calls.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Sanity check size of `pthread_t` type.
+    STATIC_ASSERT_SIZE(pthread_t, sizeof(uint32_t));
+
+    // Sanity check size of `pthread_key_t` type.
+    STATIC_ASSERT_SIZE(pthread_key_t, sizeof(uint32_t));
+
+    // Sanity check size of `pthread_attr_t` type.
+    STATIC_ASSERT_SIZE(pthread_attr_t,
+                       sizeof(int) +                    // is_initialized
+                           sizeof(void *) +             // stackaddr
+                           sizeof(size_t) +             // stacksize
+                           sizeof(int) +                // contentionscope
+                           sizeof(int) +                // inheritsched
+                           sizeof(int) +                // schedpolicy
+                           sizeof(struct sched_param) + // schedparam
+                           sizeof(int) +                // cputime_clock_allowed
+                           sizeof(int)                  // detachstate
+
+    );
+
+    // Sanity check size of `pthread_cond_t` type.
+    STATIC_ASSERT_SIZE(pthread_cond_t, sizeof(uint32_t));
+
+    // Sanity check size of `pthread_condattr_t` type.
+    STATIC_ASSERT_SIZE(pthread_condattr_t,
+                       sizeof(int) +       // is_initialized
+                           sizeof(clock_t) // clock
+    );
+
+    // Sanity check size of `pthread_mutex_t` type.
+    STATIC_ASSERT_SIZE(pthread_mutex_t, sizeof(uint32_t));
+
+    // Sanity check size of `pthread_mutexattr_t` type.
+    STATIC_ASSERT_SIZE(pthread_mutexattr_t,
+                       sizeof(int) +     // is_initialized
+                           sizeof(int) + // type
+                           sizeof(int)   // recursive
+    );
+
+    // Sanity check size of `pthread_rwlock_t` type.
+    STATIC_ASSERT_SIZE(pthread_rwlock_t, sizeof(uint32_t));
+
+    // Sanity check size of `pthread_rwlockattr_t` type.
+    STATIC_ASSERT_SIZE(pthread_rwlockattr_t, sizeof(int));
+
+    test_pthread_self();
+    test_pthread_attr_init_destroy();
+    test_pthread_attr_getstack();
+    test_pthread_getattr_np_destroy();
+    test_pthread_create_join();
+    test_pthread_mutex_static_init();
+    test_pthread_mutex_dynamic_init();
+    test_pthread_mutex_trylock();
+    test_pthread_mutex_timedlock();
+    test_pthread_rwlock_static_init();
+    test_pthread_rwlock_dynamic_init();
+    test_pthread_cond_static_init();
+    test_pthread_cond_timedwait();
+    test_pthread_tda();
+    test_thread_local();
+
+    // Must be last test.
+    test_pthread_nowait();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/thread-c/mutex_dynamic_init.c
+++ b/src/posix-tests/thread-c/mutex_dynamic_init.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Global mutex used to synchronize access to the `initialized` variable.
+static pthread_mutex_t mutex = {0};
+
+// Global variable used to signal that the worker thread is initialized.
+static volatile int initialized = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Signal that the worker thread is initialized.
+    assert(pthread_mutex_lock(&mutex) == 0);
+    initialized = 1;
+    assert(pthread_mutex_unlock(&mutex) == 0);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Initialize mutex.
+    assert(pthread_mutex_init(&mutex, NULL) == 0);
+
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to complete.
+    while (1) {
+        // Obtain a cached copy of the initialized variable.
+        assert(pthread_mutex_lock(&mutex) == 0);
+        int initialized_copy = initialized;
+        assert(pthread_mutex_unlock(&mutex) == 0);
+
+        if (initialized_copy) {
+            break;
+        }
+
+        sched_yield();
+    }
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+
+    // Destroy mutex.
+    assert(pthread_mutex_destroy(&mutex) == 0);
+}
+
+// Tests if dynamically initialized mutexes can be used for synchronization.
+void test_pthread_mutex_dynamic_init(void)
+{
+    fprintf(stderr, "testing pthread_mutex_dynamic_init() ... ");
+
+    for (int i = 0; i < 2; i++) {
+        main_thread();
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/mutex_static_init.c
+++ b/src/posix-tests/thread-c/mutex_static_init.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Global mutex used to synchronize access to the `initialized` variable.
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Global variable used to signal that the worker thread is initialized.
+static volatile int initialized = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Signal that the worker thread is initialized.
+    assert(pthread_mutex_lock(&mutex) == 0);
+    initialized = 1;
+    assert(pthread_mutex_unlock(&mutex) == 0);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to complete.
+    while (1) {
+        // Obtain a cached copy of the initialized variable.
+        assert(pthread_mutex_lock(&mutex) == 0);
+        int initialized_copy = initialized;
+        assert(pthread_mutex_unlock(&mutex) == 0);
+
+        if (initialized_copy) {
+            break;
+        }
+
+        sched_yield();
+    }
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+}
+
+// Tests if statically initialized mutexes can be used for synchronization.
+void test_pthread_mutex_static_init(void)
+{
+    fprintf(stderr, "testing pthread_mutex_static_init() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/mutex_timedlock.c
+++ b/src/posix-tests/thread-c/mutex_timedlock.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#define _POSIX_TIMEOUTS 1 // pthread_mutex_timedlock()
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <time.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+// Dead mutex locked by main thread.
+static pthread_mutex_t mutex_main_thread = PTHREAD_MUTEX_INITIALIZER;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    struct timespec ts = {0};
+    assert(clock_gettime(CLOCK_MONOTONIC, &ts) == 0);
+    ts.tv_sec += 1;
+
+    // Try to lock a mutex that is already locked by the main thread.
+    assert(pthread_mutex_timedlock(&mutex_main_thread, &ts) == ETIMEDOUT);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Get the master thread identifier and check if it is valid.
+    pthread_t master_tid = pthread_self();
+    assert(master_tid != PTHREAD_NULL);
+
+    // Lock some resources.
+    assert(pthread_mutex_lock(&mutex_main_thread) == 0);
+
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+
+    assert(pthread_mutex_unlock(&mutex_main_thread) == 0);
+}
+
+// Tests if calling `test_pthread_mutex_timedlock() works.
+void test_pthread_mutex_timedlock(void)
+{
+    fprintf(stderr, "testing pthread_mutex_timedlock() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/mutex_trylock.c
+++ b/src/posix-tests/thread-c/mutex_trylock.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+// Dead mutex locked by main thread.
+static pthread_mutex_t mutex_main_thread = PTHREAD_MUTEX_INITIALIZER;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Try to lock a mutex that is already locked by the main thread.
+    assert(pthread_mutex_trylock(&mutex_main_thread) == EBUSY);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Get the master thread identifier and check if it is valid.
+    pthread_t master_tid = pthread_self();
+    assert(master_tid != PTHREAD_NULL);
+
+    // Lock some resources.
+    assert(pthread_mutex_lock(&mutex_main_thread) == 0);
+
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+
+    assert(pthread_mutex_unlock(&mutex_main_thread) == 0);
+}
+
+// Tests if calling `pthread_mutex_trylock() works.
+void test_pthread_mutex_trylock(void)
+{
+    fprintf(stderr, "testing pthread_mutex_trylock() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/nowait.c
+++ b/src/posix-tests/thread-c/nowait.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+// Dead mutex locked by main thread.
+static pthread_mutex_t dead_mutex_main_thread = PTHREAD_MUTEX_INITIALIZER;
+
+// Dead mutex locked by worker thread.
+static pthread_mutex_t dead_mutex_worker_thread = PTHREAD_MUTEX_INITIALIZER;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Lock some resources.
+    assert(pthread_mutex_lock(&dead_mutex_worker_thread) == 0);
+
+    // Block forever.
+    assert(pthread_mutex_lock(&dead_mutex_main_thread) == 0);
+
+    while (true) {
+        sched_yield();
+    }
+
+    // NOTE: We never get here.
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    // Get the master thread identifier and check if it is valid.
+    pthread_t master_tid = pthread_self();
+    assert(master_tid != PTHREAD_NULL);
+
+    // Lock some resources.
+    assert(pthread_mutex_lock(&dead_mutex_main_thread) == 0);
+
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Don't wait for the worker thread to exit, if something goes wrong this test will hang.
+}
+
+// Tests if calling exit() causes the program to exit even if there are other threads running.
+void test_pthread_nowait(void)
+{
+    fprintf(stderr, "testing exit() with a running thread ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/rwlock_dynamic_init.c
+++ b/src/posix-tests/thread-c/rwlock_dynamic_init.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+// Enable rwlock API in toolchain headers.
+#define _POSIX_READER_WRITER_LOCKS 1
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Flags for synchronization validation.
+static volatile int writer_inside = 0;
+static volatile int reader_inside = 0;
+static volatile int reader_started_after_writer = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Writer thread: acquires write lock, holds briefly, then releases.
+static void *writer_thread(void *arg)
+{
+    pthread_rwlock_t *rwlock = (pthread_rwlock_t *)arg;
+
+    assert(pthread_rwlock_wrlock(rwlock) == 0);
+    writer_inside = 1;
+    for (int i = 0; i < 4000; i++) {
+        sched_yield();
+    }
+    writer_inside = 0;
+    assert(pthread_rwlock_unlock(rwlock) == 0);
+    return (void *)0;
+}
+
+// Reader thread: should observe writer has left before entering.
+static void *reader_thread(void *arg)
+{
+    pthread_rwlock_t *rwlock = (pthread_rwlock_t *)arg;
+    assert(pthread_rwlock_rdlock(rwlock) == 0);
+    // By contract of scheduling in the test, writer should no longer be inside.
+    if (!writer_inside) {
+        reader_started_after_writer = 1;
+    }
+    reader_inside = 1;
+    for (int i = 0; i < 2000; i++) {
+        sched_yield();
+    }
+    reader_inside = 0;
+    assert(pthread_rwlock_unlock(rwlock) == 0);
+    return (void *)0;
+}
+
+// Tests dynamic initialization, lock exclusion between writer and reader, and destroy semantics.
+void test_pthread_rwlock_dynamic_init(void)
+{
+    fprintf(stderr, "testing pthread_rwlock_dynamic_init() ... ");
+
+    pthread_rwlock_t rwlock = 0; // Uninitialized object.
+    assert(pthread_rwlock_init(&rwlock, NULL) == 0);
+
+    // Test that destroying while locked fails.
+    assert(pthread_rwlock_wrlock(&rwlock) == 0);
+    int destroy_ret = pthread_rwlock_destroy(&rwlock);
+    assert(destroy_ret != 0); // Should fail because lock is busy.
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+
+    // Launch writer first so that reader blocks until writer releases.
+    pthread_t writer_tid = 0;
+    assert(pthread_create(&writer_tid, NULL, writer_thread, (void *)&rwlock) == 0);
+
+    // Wait until writer holds the lock.
+    while (!writer_inside) {
+        sched_yield();
+    }
+
+    // Launch reader which must block until writer releases the lock.
+    pthread_t reader_tid = 0;
+    assert(pthread_create(&reader_tid, NULL, reader_thread, (void *)&rwlock) == 0);
+
+    // While writer is inside, reader must not have entered.
+    while (writer_inside) {
+        assert(reader_inside == 0);
+        sched_yield();
+    }
+
+    // Join threads.
+    void *retval = (void *)1;
+    assert(pthread_join(writer_tid, &retval) == 0);
+    assert(retval == 0);
+    assert(pthread_join(reader_tid, &retval) == 0);
+    assert(retval == 0);
+
+    // Reader must have started only after writer exited.
+    assert(reader_started_after_writer == 1);
+
+    // Now destroy must succeed.
+    assert(pthread_rwlock_destroy(&rwlock) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/rwlock_static_init.c
+++ b/src/posix-tests/thread-c/rwlock_static_init.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+// Enable rwlock API in toolchain headers.
+#define _POSIX_READER_WRITER_LOCKS 1
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Statically initialized read-write lock under test.
+static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+// Test state machine:
+// 0 -> initial
+// 1 -> reader A acquired lock
+// 2 -> reader B acquired lock while A still holds (concurrency proven)
+// 3 -> reader A released
+// 4 -> reader B released
+static volatile int stage = 0;
+static volatile int concurrency_observed = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Reader thread routine.
+static void *reader_a(void *arg)
+{
+    (void)arg;
+    assert(pthread_rwlock_rdlock(&rwlock) == 0);
+    stage = 1; // acquired
+    // Wait until reader B also acquires (stage moves to 2).
+    while (stage < 2) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+    stage = 3;
+    return (void *)0;
+}
+
+static void *reader_b(void *arg)
+{
+    (void)arg;
+    // Wait until reader A has acquired (stage==1).
+    while (stage < 1) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_rdlock(&rwlock) == 0);
+    if (stage == 1) {
+        // A still holds lock, so concurrency achieved.
+        concurrency_observed = 1;
+    }
+    stage = 2; // mark that B acquired
+    // Wait until A releases (stage>=3) before B releases so ordering predictable.
+    while (stage < 3) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+    stage = 4;
+    return (void *)0;
+}
+
+// Tests if statically initialized read-write locks support multiple concurrent readers.
+void test_pthread_rwlock_static_init(void)
+{
+    fprintf(stderr, "testing pthread_rwlock_static_init() ... ");
+
+    pthread_t a = 0, b = 0;
+    assert(pthread_create(&a, NULL, reader_a, NULL) == 0);
+    assert(pthread_create(&b, NULL, reader_b, NULL) == 0);
+
+    void *rv = (void *)1;
+    assert(pthread_join(a, &rv) == 0 && rv == 0);
+    assert(pthread_join(b, &rv) == 0 && rv == 0);
+
+    assert(stage == 4);
+    assert(concurrency_observed == 1);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/self.c
+++ b/src/posix-tests/thread-c/self.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Main thread.
+static void main_thread(void)
+{
+    // Get the master thread identifier and check if it is valid.
+    pthread_t master_tid = pthread_self();
+    assert(master_tid != PTHREAD_NULL);
+}
+
+// Tests if threads can get their own identifiers.
+void test_pthread_self(void)
+{
+    fprintf(stderr, "testing pthread_self() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/tda.c
+++ b/src/posix-tests/thread-c/tda.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected argument passed to the worker thread.
+static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
+
+// Expected exit status of the worker thread.
+static const size_t EXPECTED_EXIT_STATUS = 0xdeadbeef;
+
+// Expected thread-specific data for the worker thread.
+static const size_t EXPECTED_WORKER_TDA = 0xcafebabe;
+
+// Expected thread-specific data for the main thread.
+static const size_t EXPECTED_MAIN_TDA = 0xfeedface;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Create a key for thread-specific data.
+pthread_key_t key;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    int ret = -1;
+
+    // Check if worker argument matches the expected value.
+    assert((size_t)arg == EXPECTED_WORKER_ARG);
+
+    // Set thread-specific data.
+    ret = pthread_setspecific(key, (void *)EXPECTED_WORKER_TDA);
+    assert(ret == 0);
+
+    // Get thread-specific data and check if it matches the expected value.
+    void *value = pthread_getspecific(key);
+    assert(value == (void *)EXPECTED_WORKER_TDA);
+
+    // Exit the worker thread and make sure it returns the expected value.
+    return ((void *)EXPECTED_EXIT_STATUS);
+}
+
+// Main thread.
+static void main_thread(void)
+{
+    int ret = -1;
+
+    ret = pthread_key_create(&key, NULL);
+    assert(ret == 0);
+
+    // Set thread-specific data.
+    ret = pthread_setspecific(key, (void *)EXPECTED_MAIN_TDA);
+    assert(ret == 0);
+
+    // Get thread-specific data and check if it matches the expected value.
+    void *value = pthread_getspecific(key);
+    assert(value == (void *)EXPECTED_MAIN_TDA);
+
+    // Create a worker thread and check if its identifier matches the expected value.
+    pthread_t worker_tid = PTHREAD_NULL;
+    ret = pthread_create(&worker_tid, NULL, worker_thread, (void *)EXPECTED_WORKER_ARG);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to exit and check if it returns the expected value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == (void *)EXPECTED_EXIT_STATUS);
+
+    // Check if thread-specific data for the main thread is still the expected value.
+    value = pthread_getspecific(key);
+    assert(value == (void *)EXPECTED_MAIN_TDA);
+
+    // Delete the key for thread-specific data.
+    ret = pthread_key_delete(key);
+    assert(ret == 0);
+}
+
+// Tests if thread interface for operating on thread-specific data works.
+void test_pthread_tda(void)
+{
+    fprintf(stderr, "testing pthread_tda() ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/thread-c/thread_local.c
+++ b/src/posix-tests/thread-c/thread_local.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Expected value for the main thread's thread-local variable.
+static const int EXPECTED_MAIN_THREAD_THREAD_LOCAL_VARIABLE_VALUE = 0x1234;
+
+// Expected value for the worker thread's thread-local variable.
+static const int EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE = 0xabcd;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/*
+ * A thread-local variable used for testing.
+ *
+ * Notes:
+ *
+ * - This variable is declared as `_Thread_local` to ensure that each thread has its own instance.
+ * - This variable is declared as non-static and `volatile` to prevent the compiler from optimizing
+ *   it away.
+ */
+_Thread_local volatile int thread_local_var = 0;
+
+/*
+ * Zero-initialized thread-local variable for regression testing of overlapping TLS.
+ *
+ * NOTE: Do NOT add an explicit `= 0` initializer. Without one, the compiler places this variable in
+ * .tbss (NOBITS); adding `= 0` would move it to .tdata (PROGBITS), which would mask the overlap bug
+ * this test is designed to catch.
+ */
+_Thread_local volatile int thread_local_zero_init_var;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread for thread-local storage test.
+static void *worker_thread(void *arg)
+{
+    (void)arg;
+
+    // Verify that zero-initialized thread-local variable starts at zero (GitHub issue #1486).
+    assert(thread_local_zero_init_var == 0);
+
+    // Set thread-local variable.
+    thread_local_var = EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE;
+
+    // Verify that the thread-local variable was set correctly.
+    assert(thread_local_var == EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE);
+
+    // Return the value that was set for verification.
+    return ((void *)(uintptr_t)thread_local_var);
+}
+
+// Main thread for thread-local storage test.
+static void main_thread(void)
+{
+    // Verify that zero-initialized thread-local variable starts at zero (GitHub issue #1486).
+    assert(thread_local_zero_init_var == 0);
+
+    // Set thread-local variable.
+    thread_local_var = EXPECTED_MAIN_THREAD_THREAD_LOCAL_VARIABLE_VALUE;
+
+    // Verify that the main thread's thread-local variable is still unchanged.
+    assert(thread_local_var == EXPECTED_MAIN_THREAD_THREAD_LOCAL_VARIABLE_VALUE);
+
+    // Create a worker thread.
+    pthread_t worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&worker_tid, NULL, worker_thread, NULL);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    // Wait for the worker thread to exit and get its return value.
+    void *retval = NULL;
+    ret = pthread_join(worker_tid, &retval);
+    assert(ret == 0);
+    assert((uintptr_t)retval == (uintptr_t)EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE);
+
+    // Verify that the main thread's thread-local variable is still unchanged.
+    assert(thread_local_var == EXPECTED_MAIN_THREAD_THREAD_LOCAL_VARIABLE_VALUE);
+}
+
+/**
+ * @brief Tests thread local storage.
+ *
+ * @returns Nothing. If the test fails, the program will abort.
+ */
+void test_thread_local(void)
+{
+    fprintf(stderr, "testing thread local storage ... ");
+
+    main_thread();
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Ports the C test suites from `nanvix/posix-tests` into `src/posix-tests/` and wires
them into the build so they can be cross-compiled against the bundled in-tree libc and
booted under `nanvixd` in standalone mode.

## Test suites (`src/posix-tests/<suite>/`)

- **c-bindings, ctor-c, echo-c, hello-c, noop-c** — basic runtime, constructor ordering,
  C ABI binding, and I/O smoke tests.
- **file-c** — file-system syscalls (open/close, read/write, lseek, stat, ftruncate,
  dirent, mkdir/mkdirat, renameat, unlinkat, chdir/fchdir, getcwd, pread/pwrite,
  readv/writev, preadv/pwritev, posix_fadvise, posix_fallocate, fdatasync) plus
  link/permission/timestamp/poll/select cases gated out of the standalone subset.
- **memory-c** — malloc/free, realloc, aligned_alloc, malloc_usable_size, mmap/munmap,
  and heap stress/shrink/reclaim.
- **misc-c** — id and clock syscalls (uid/gid/euid/egid, clock_getres, clock_gettime,
  nanosleep, times, uname, gethostname, getenv).
- **network-c** — AF_INET socket and inet helper tests.
- **thread-c** — pthread create/join, mutex/rwlock/cond, thread-local storage, and
  detached threads.
- **dlfcn-c, dlfcn-pie-c, dlfcn-global-c, dlfcn-needed-c** — dlopen/dlsym coverage
  including PIE executables, RTLD_GLOBAL scope resolution, and DT_NEEDED auto-loading,
  with per-suite provider/consumer `.so` fixtures.
- **common/crt0-stubs.c** — shared weak `_init`/`_fini` scaffolding.

## Build integration

- `build/make/guest-c-apps.mk` — freestanding guest C toolchain definitions shared by
  the suites.
- `build/make/posix-tests.mk` — per-suite compile/link rules against `libc.a` + `libm.a`,
  per-suite bootable `<suite>.initrd` images, writable FAT32 RAMFS images, shared-library
  fixtures, and the `run-posix-tests` boot runner.
- `Makefile` — register `ALL_POSIX_TESTS`, include the new fragments, hook
  `run-posix-tests` into `test`, and add `clean-posix-tests` to `clean`.

## Notes

- The suites are never shipped in releases.
- The boot runner is gated to `DEPLOYMENT_MODE=standalone` on Linux/i686; on Windows the
  images are built with `all-posix-test-images` and booted manually under WHP.
- Pass/fail is signaled by `main()`'s return code, which `nanvixd` propagates as its exit
  code.

---

Rebased onto `dev` (Nanvix 0.17.3). A superseded `nanvix_libc`/`nanvix_libm` commit was
dropped during the rebase because that work already landed via #2659.
