### PR TITLE
[kernel] Order events by sequence number

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -215,24 +215,29 @@ impl Drop for EventOwnership {
 
 struct EventManagerInner {
     interrupt_capable: bool,
-    nevents: usize,
+    /// Full-width monotonic counter incremented once per generated event. Its value at generation
+    /// time is the event's sequence number, stamped alongside the [`EventDescriptor`] in each
+    /// pending queue and used as the FIFO ordering key in `try_wait()`. It is `u64` so that ordering
+    /// never wraps on the kernel's 32-bit target, where the truncated [`EventDescriptor`] id would
+    /// otherwise overflow its narrow field (see issue #2674).
+    nevents: u64,
     wait: Option<Condvar>,
     waiting_threads: VecDeque<(ProcessIdentifier, ThreadIdentifier)>,
     interrupt_ownership: [Option<ProcessIdentifier>; usize::BITS as usize],
-    pending_interrupts: [LinkedList<EventDescriptor>; usize::BITS as usize],
+    pending_interrupts: [LinkedList<(u64, EventDescriptor)>; usize::BITS as usize],
     exception_ownership: [Option<ProcessIdentifier>; usize::BITS as usize],
-    pending_exceptions:
-        [LinkedList<(EventDescriptor, ExceptionEventInformation, Condvar)>; usize::BITS as usize],
+    pending_exceptions: [LinkedList<(u64, EventDescriptor, ExceptionEventInformation, Condvar)>;
+        usize::BITS as usize],
     scheduling_owner: Option<ProcessIdentifier>,
-    /// Pending scheduling-event notifications delivered in FIFO order by global event id. The
+    /// Pending scheduling-event notifications delivered in FIFO order by event sequence number. The
     /// kernel main loop publishes a process's creation before its termination, so FIFO delivery lets
     /// the owner observe the child's lineage before handling its exit.
     ///
-    /// Each entry carries the global [`EventDescriptor`] stamped at generation time. The queue is
-    /// maintained in event-id order: notifications are appended with monotonically increasing ids
-    /// (`notify_scheduling()`) and removals preserve relative order, so delivery (`try_wait()`) pops
-    /// the smallest id in O(1).
-    pending_scheduling: LinkedList<(EventDescriptor, SchedulingNotification)>,
+    /// Each entry pairs the full-width sequence number stamped at generation time with its
+    /// [`EventDescriptor`]. The queue is maintained in sequence order: notifications are appended
+    /// with monotonically increasing sequence numbers (`notify_scheduling()`) and removals preserve
+    /// relative order, so delivery (`try_wait()`) pops the smallest sequence number in O(1).
+    pending_scheduling: LinkedList<(u64, EventDescriptor, SchedulingNotification)>,
 }
 
 impl EventManagerInner {
@@ -464,13 +469,11 @@ impl EventManagerInner {
     ) -> Result<Option<Message>, Error> {
         for i in 0..Self::NUMBER_EVENTS {
             // Check if any interrupts were triggered.
-            if (self.nevents + i).is_multiple_of(Self::NUMBER_EVENTS) {
+            if (self.nevents + i as u64).is_multiple_of(Self::NUMBER_EVENTS as u64) {
                 // Deliver the oldest eligible interrupt first. This prevents a continuously
                 // refilled low-numbered bit from starving an older high-numbered one.
                 let selected: Option<usize> = Self::smallest_pending_front(interrupts, |bit| {
-                    self.pending_interrupts[bit]
-                        .front()
-                        .map(EventDescriptor::id)
+                    self.pending_interrupts[bit].front().map(|(seq, _)| *seq)
                 });
                 if let Some(idx) = selected {
                     if let Some(_event) = self.pending_interrupts[idx].pop_front() {
@@ -486,23 +489,23 @@ impl EventManagerInner {
             }
 
             // Check if any exceptions were triggered.
-            if ((self.nevents + i) % Self::NUMBER_EVENTS) == 1 {
-                // Deliver the oldest eligible exception first, using the same FIFO-by-event-id rule
+            if ((self.nevents + i as u64) % Self::NUMBER_EVENTS as u64) == 1 {
+                // Deliver the oldest eligible exception first, using the same FIFO-by-sequence rule
                 // as interrupts.
                 let selected: Option<usize> = Self::smallest_pending_front(exceptions, |bit| {
                     self.pending_exceptions[bit]
                         .front()
-                        .map(|(evdesc, _, _)| evdesc.id())
+                        .map(|(seq, _, _, _)| *seq)
                 });
                 if let Some(idx) = selected {
                     if let Some(entry) = self.pending_exceptions[idx].pop_front() {
                         let mut info: EventInformation = EventInformation::default();
-                        info.id = entry.0.clone();
-                        info.pid = entry.1.pid;
-                        info.number = Some(entry.1.info.num() as usize);
-                        info.code = Some(entry.1.info.code() as usize);
-                        info.address = Some(entry.1.info.addr() as usize);
-                        info.instruction = Some(entry.1.info.instruction() as usize);
+                        info.id = entry.1.clone();
+                        info.pid = entry.2.pid;
+                        info.number = Some(entry.2.info.num() as usize);
+                        info.code = Some(entry.2.info.code() as usize);
+                        info.address = Some(entry.2.info.addr() as usize);
+                        info.instruction = Some(entry.2.info.instruction() as usize);
 
                         let mut message: Message = Message::from(info);
                         message.destination = MessageReceiver::from(pid);
@@ -516,16 +519,18 @@ impl EventManagerInner {
             }
 
             // Check if any scheduling events were triggered.
-            if ((self.nevents + i) % Self::NUMBER_EVENTS) == 2 {
-                // Scheduling events are already kept in FIFO-by-event-id order. The non-zero
+            if ((self.nevents + i as u64) % Self::NUMBER_EVENTS as u64) == 2 {
+                // Scheduling events are already kept in FIFO-by-sequence order. The non-zero
                 // `scheduling` mask means the caller owns the scheduling-event class.
                 if scheduling != 0 {
                     debug_assert!(
                         self.pending_scheduling_is_ordered(),
-                        "scheduling-event queue is not ordered by event id"
+                        "scheduling-event queue is not ordered by sequence number"
                     );
 
-                    if let Some((_eventid, notification)) = self.pending_scheduling.pop_front() {
+                    if let Some((_seq, _descriptor, notification)) =
+                        self.pending_scheduling.pop_front()
+                    {
                         // Serialize the notification into the head of the message payload. The
                         // two notification variants have different serialized sizes, so each is
                         // copied using its own length.
@@ -558,7 +563,8 @@ impl EventManagerInner {
         }
 
         // FIXME(#2558): IPC can still starve under a sustained exception / interrupt rate. The
-        // in-class scans above are FIFO by event id, but IPC is only checked after event classes.
+        // in-class scans above are FIFO by sequence number, but IPC is only checked after event
+        // classes.
 
         // Check if any messages were delivered.
         match ProcessManager::try_recv(tid) {
@@ -569,12 +575,12 @@ impl EventManagerInner {
     }
 
     fn pending_scheduling_is_ordered(&self) -> bool {
-        let mut previous: Option<usize> = None;
+        let mut previous: Option<u64> = None;
 
-        for (eventid, _) in self.pending_scheduling.iter() {
-            let current: usize = eventid.id();
-            if let Some(previous_id) = previous {
-                if previous_id > current {
+        for (seq, _descriptor, _) in self.pending_scheduling.iter() {
+            let current: u64 = *seq;
+            if let Some(previous_seq) = previous {
+                if previous_seq > current {
                     return false;
                 }
             }
@@ -587,19 +593,20 @@ impl EventManagerInner {
     ///
     /// # Description
     ///
-    /// Selects the queue that should deliver next under FIFO-by-event-id ordering: among the bits
-    /// set in `mask`, returns the index whose pending-queue head carries the smallest global event
-    /// id, or [`None`] when no selected bit has a pending entry.
+    /// Selects the queue that should deliver next under FIFO-by-sequence ordering: among the bits
+    /// set in `mask`, returns the index whose pending-queue head carries the smallest event
+    /// sequence number, or [`None`] when no selected bit has a pending entry.
     ///
-    /// Delivering the smallest-id head first makes per-class delivery starvation-free: every queued
-    /// event has a fixed position in the global id order and is therefore served within a bounded
-    /// number of calls, regardless of which bit it occupies. This replaces the previous bit-0-first
-    /// scan, in which a continuously refilled low-numbered bit could starve a higher-numbered one.
+    /// Delivering the smallest-sequence head first makes per-class delivery starvation-free: every
+    /// queued event has a fixed position in the global sequence order and is therefore served within
+    /// a bounded number of calls, regardless of which bit it occupies. The sequence number is the
+    /// full-width `nevents` value stamped at generation time, so ordering is stable even where the
+    /// truncated [`EventDescriptor`] id would wrap on the kernel's 32-bit target (see issue #2674).
     ///
     /// # Parameters
     ///
     /// - `mask`: Bit mask of queues eligible for delivery.
-    /// - `front_id`: Returns the global event id at the head of the queue for a given bit, or
+    /// - `front_seq`: Returns the event sequence number at the head of the queue for a given bit, or
     ///   [`None`] when that queue is empty.
     ///
     /// # Returns
@@ -607,14 +614,14 @@ impl EventManagerInner {
     /// The index of the queue to deliver from, or [`None`] when no eligible queue has a pending
     /// entry.
     ///
-    fn smallest_pending_front<F>(mask: usize, mut front_id: F) -> Option<usize>
+    fn smallest_pending_front<F>(mask: usize, mut front_seq: F) -> Option<usize>
     where
-        F: FnMut(usize) -> Option<usize>,
+        F: FnMut(usize) -> Option<u64>,
     {
         (0..usize::BITS as usize)
             .filter(|&bit| (mask & (1usize << bit)) != 0)
-            .filter_map(|bit| front_id(bit).map(|id| (bit, id)))
-            .min_by_key(|&(_, id)| id)
+            .filter_map(|bit| front_seq(bit).map(|seq| (bit, seq)))
+            .min_by_key(|&(_, seq)| seq)
             .map(|(bit, _)| bit)
     }
 
@@ -659,9 +666,9 @@ impl EventManagerInner {
         // Search and remove event from pending exceptions by full descriptor (id + event).
         if let Some(entry) = self.pending_exceptions[idx]
             .iter()
-            .position(|(pending_evdesc, _info, _resume)| *pending_evdesc == evdesc)
+            .position(|(_seq, pending_evdesc, _info, _resume)| *pending_evdesc == evdesc)
         {
-            let (_eventinfo, excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
+            let (_seq, _eventinfo, excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
 
             if let Err(error) = resume.notify_thread(excpinfo.tid) {
                 // The faulting thread may have already been terminated by the exception owner .
@@ -705,8 +712,8 @@ impl EventManagerInner {
         self.nevents += 1;
         let idx: usize = interrupts.trailing_zeros() as usize;
         let ev = Event::from(sys::event::InterruptEvent::try_from(idx)?);
-        let eventid: EventDescriptor = EventDescriptor::new(self.nevents, ev);
-        self.pending_interrupts[idx].push_back(eventid);
+        let descriptor: EventDescriptor = EventDescriptor::new(self.nevents as usize, ev);
+        self.pending_interrupts[idx].push_back((self.nevents, descriptor));
 
         // Get interrupt owner.
         let pid: ProcessIdentifier = match self.interrupt_ownership[idx] {
@@ -759,10 +766,11 @@ impl EventManagerInner {
         self.nevents += 1;
         let idx: usize = exceptions.trailing_zeros() as usize;
         let ev: Event = Event::from(ExceptionEvent::try_from(idx)?);
-        let eventid: EventDescriptor = EventDescriptor::new(self.nevents, ev);
+        let descriptor: EventDescriptor = EventDescriptor::new(self.nevents as usize, ev);
         let resume: Condvar = Condvar::new();
         self.pending_exceptions[idx].push_back((
-            eventid,
+            self.nevents,
+            descriptor,
             ExceptionEventInformation {
                 pid,
                 tid,
@@ -849,8 +857,10 @@ impl EventManagerInner {
         }
 
         self.nevents += 1;
-        let eventid: EventDescriptor = EventDescriptor::new(self.nevents, Event::from(event));
-        self.pending_scheduling.push_back((eventid, notification));
+        let descriptor: EventDescriptor =
+            EventDescriptor::new(self.nevents as usize, Event::from(event));
+        self.pending_scheduling
+            .push_back((self.nevents, descriptor, notification));
 
         // Wake the owning process if the scheduling-event class is currently owned. When there is
         // no owner yet, the notification stays buffered and is delivered once a subscriber
@@ -1348,7 +1358,7 @@ fn exception_handler(info: &ExceptionInformation, ctx: &ContextInformation) {
 }
 
 pub fn init() -> Result<(), Error> {
-    let mut pending_interrupts: [LinkedList<EventDescriptor>; usize::BITS as usize] =
+    let mut pending_interrupts: [LinkedList<(u64, EventDescriptor)>; usize::BITS as usize] =
         unsafe { mem::zeroed() };
     for list in pending_interrupts.iter_mut() {
         *list = LinkedList::default();
@@ -1360,8 +1370,12 @@ pub fn init() -> Result<(), Error> {
         *entry = None;
     }
 
-    let mut pending_exceptions: [LinkedList<(EventDescriptor, ExceptionEventInformation, Condvar)>;
-        usize::BITS as usize] = unsafe { mem::zeroed() };
+    let mut pending_exceptions: [LinkedList<(
+        u64,
+        EventDescriptor,
+        ExceptionEventInformation,
+        Condvar,
+    )>; usize::BITS as usize] = unsafe { mem::zeroed() };
     for list in pending_exceptions.iter_mut() {
         *list = LinkedList::default();
     }
@@ -1372,7 +1386,7 @@ pub fn init() -> Result<(), Error> {
         *entry = None;
     }
 
-    let pending_scheduling: LinkedList<(EventDescriptor, SchedulingNotification)> =
+    let pending_scheduling: LinkedList<(u64, EventDescriptor, SchedulingNotification)> =
         LinkedList::default();
 
     let scheduling_owner: Option<ProcessIdentifier> = None;

--- a/src/kernel/src/event/manager/test.rs
+++ b/src/kernel/src/event/manager/test.rs
@@ -90,21 +90,22 @@ fn make_inner() -> EventManagerInner {
 ///
 /// # Description
 ///
-/// Enqueues a pending interrupt event on `bit`, stamping it with the next global event id.
+/// Enqueues a pending interrupt event on `bit`, stamping it with the next event sequence number.
 ///
 fn push_interrupt(inner: &mut EventManagerInner, bit: usize) {
     inner.nevents += 1;
     let event: Event = Event::Interrupt(InterruptEvent::VALUES[bit]);
-    inner.pending_interrupts[bit].push_back(EventDescriptor::new(inner.nevents, event));
+    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents as usize, event);
+    inner.pending_interrupts[bit].push_back((inner.nevents, descriptor));
 }
 
 ///
 /// # Description
 ///
-/// Enqueues a pending exception event on `bit`, owned by `pid`, stamping it with the next global
-/// event id. The event manager re-queues exceptions on each delivery until the owner resumes from
-/// them, so a test that does not want continuous re-delivery must clear the slot once observed (see
-/// [`resume_exception`]).
+/// Enqueues a pending exception event on `bit`, owned by `pid`, stamping it with the next event
+/// sequence number. The event manager re-queues exceptions on each delivery until the owner resumes
+/// from them, so a test that does not want continuous re-delivery must clear the slot once observed
+/// (see [`resume_exception`]).
 ///
 fn push_exception(
     inner: &mut EventManagerInner,
@@ -115,12 +116,13 @@ fn push_exception(
     inner.nevents += 1;
     inner.exception_ownership[bit] = Some(pid);
     let event: Event = Event::Exception(ExceptionEvent::VALUES[bit]);
-    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents, event);
+    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents as usize, event);
     // SAFETY: `ExceptionInformation` is plain-old-data: a register snapshot of fixed-width integer
     // fields (`u32` on 32-bit x86, `u64` on x86_64) for which the all-zero bit pattern is a valid
     // value on every supported architecture. The tests only need a placeholder to exercise delivery.
     let info: ExceptionInformation = unsafe { core::mem::zeroed() };
     inner.pending_exceptions[bit].push_back((
+        inner.nevents,
         descriptor,
         ExceptionEventInformation { pid, tid, info },
         Condvar::new(),
@@ -141,38 +143,43 @@ fn resume_exception(inner: &mut EventManagerInner, bit: usize) {
 ///
 /// # Description
 ///
-/// Enqueues a pending process-creation scheduling event, stamping it with the next global event id.
+/// Enqueues a pending process-creation scheduling event, stamping it with the next event sequence
+/// number.
 ///
 fn push_creation(inner: &mut EventManagerInner, pid: ProcessIdentifier) {
     inner.nevents += 1;
     let event: Event = Event::Scheduling(SchedulingEvent::ProcessCreation);
-    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents, event);
+    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents as usize, event);
     let info: ProcessCreationInfo =
         ProcessCreationInfo::new(pid, ProcessIdentifier::KERNEL, ProcessRole::User);
-    inner
-        .pending_scheduling
-        .push_back((descriptor, SchedulingNotification::Creation(info)));
+    inner.pending_scheduling.push_back((
+        inner.nevents,
+        descriptor,
+        SchedulingNotification::Creation(info),
+    ));
 }
 
 ///
 /// # Description
 ///
-/// Enqueues a pending process-termination scheduling event, stamping it with the next global event
-/// id.
+/// Enqueues a pending process-termination scheduling event, stamping it with the next event
+/// sequence number.
 ///
 fn push_termination(inner: &mut EventManagerInner, pid: ProcessIdentifier) {
     inner.nevents += 1;
     let event: Event = Event::Scheduling(SchedulingEvent::ProcessTermination);
-    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents, event);
+    let descriptor: EventDescriptor = EventDescriptor::new(inner.nevents as usize, event);
     let info: ProcessTerminationInfo = ProcessTerminationInfo::new(
         pid,
         ExitStatus::ok(),
         ProcessIdentifier::KERNEL,
         ProcessRole::User,
     );
-    inner
-        .pending_scheduling
-        .push_back((descriptor, SchedulingNotification::Termination(info)));
+    inner.pending_scheduling.push_back((
+        inner.nevents,
+        descriptor,
+        SchedulingNotification::Termination(info),
+    ));
 }
 
 ///
@@ -281,7 +288,7 @@ fn test_each_call_delivers_a_single_interrupt() -> bool {
 ///
 /// # Description
 ///
-/// Verifies that scheduling events are delivered in FIFO order by global event id: a process's
+/// Verifies that scheduling events are delivered in FIFO order by event sequence number: a process's
 /// creation event, enqueued before its termination event, is delivered first. This per-process
 /// creation-before-termination invariant is the cross-event ordering guarantee preserved while
 /// making delivery starvation-free.
@@ -457,18 +464,18 @@ fn test_standing_scheduling_event_not_starved_under_interrupt_load() -> bool {
 ///
 /// # Description
 ///
-/// Verifies the FIFO-by-event-id selection rule that underlies starvation-free interrupt and
+/// Verifies the FIFO-by-sequence selection rule that underlies starvation-free interrupt and
 /// exception delivery: among the eligible bits, [`EventManagerInner::smallest_pending_front`] picks
-/// the queue head with the smallest global event id rather than the lowest-numbered bit. This is
-/// the structural property that makes delivery starvation-free, exercised here directly and
+/// the queue head with the smallest event sequence number rather than the lowest-numbered bit. This
+/// is the structural property that makes delivery starvation-free, exercised here directly and
 /// independently of the surrounding `try_wait` machinery (and shared verbatim by both the interrupt
 /// and exception delivery paths).
 ///
-fn test_smallest_pending_front_selects_oldest_id() -> bool {
-    // Bit 1 (low) holds a newer event (id 20); bit 5 (high) holds an older one (id 10). Selection
-    // must pick bit 5, proving a lower-numbered bit does not win merely by being scanned first, the
-    // previous bit-0-first bias.
-    let front_id = |bit: usize| -> Option<usize> {
+fn test_smallest_pending_front_selects_oldest_sequence() -> bool {
+    // Bit 1 (low) holds a newer event (sequence 20); bit 5 (high) holds an older one (sequence
+    // 10). Selection must pick bit 5, proving a lower-numbered bit does not win merely by being
+    // scanned first, the previous bit-0-first bias.
+    let front_seq = |bit: usize| -> Option<u64> {
         match bit {
             1 => Some(20),
             5 => Some(10),
@@ -477,13 +484,13 @@ fn test_smallest_pending_front_selects_oldest_id() -> bool {
     };
 
     let both: usize = (1usize << 1) | (1usize << 5);
-    if EventManagerInner::smallest_pending_front(both, front_id) != Some(5) {
+    if EventManagerInner::smallest_pending_front(both, front_seq) != Some(5) {
         error!("oldest event (bit 5) must be selected ahead of the lower-numbered bit 1");
         return false;
     }
 
     // When only the lower bit is eligible, it is selected.
-    if EventManagerInner::smallest_pending_front(1usize << 1, front_id) != Some(1) {
+    if EventManagerInner::smallest_pending_front(1usize << 1, front_seq) != Some(1) {
         error!("bit 1 must be selected when it is the only eligible bit");
         return false;
     }
@@ -511,12 +518,12 @@ fn test_smallest_pending_front_selects_oldest_id() -> bool {
 ///
 /// # Description
 ///
-/// Verifies that interrupt delivery follows FIFO order by global event id end-to-end: an older
+/// Verifies that interrupt delivery follows FIFO order by event sequence number end-to-end: an older
 /// interrupt enqueued on a high-numbered bit is delivered before a newer interrupt on a
 /// low-numbered bit. The previous bit-0-first scan delivered the low-numbered bit regardless of
-/// age; FIFO-by-id delivers the oldest first.
+/// age; FIFO-by-sequence delivers the oldest first.
 ///
-fn test_interrupt_delivery_is_fifo_by_id() -> bool {
+fn test_interrupt_delivery_is_fifo_by_sequence() -> bool {
     const OLDER_HIGH_BIT: usize = 5;
     const NEWER_LOW_BIT: usize = 1;
 
@@ -557,10 +564,10 @@ fn test_interrupt_delivery_is_fifo_by_id() -> bool {
 /// # Description
 ///
 /// Verifies that an interrupt is not starved by a continuous stream of lower-numbered interrupts: an
-/// interrupt on a high-numbered bit is enqueued first (oldest id), then a lower-numbered interrupt
-/// is enqueued before every delivery. Under the previous bit-0-first scan the low bit would win on
-/// every call and the older interrupt would never be delivered; FIFO-by-id delivers the oldest
-/// within a bounded number of calls.
+/// interrupt on a high-numbered bit is enqueued first (oldest sequence number), then a
+/// lower-numbered interrupt is enqueued before every delivery. Under the previous bit-0-first scan
+/// the low bit would win on every call and the older interrupt would never be delivered;
+/// FIFO-by-sequence delivers the oldest within a bounded number of calls.
 ///
 fn test_oldest_interrupt_not_starved_by_low_bit_load() -> bool {
     const VICTIM_HIGH_BIT: usize = 7;
@@ -596,11 +603,11 @@ fn test_oldest_interrupt_not_starved_by_low_bit_load() -> bool {
 ///
 /// # Description
 ///
-/// Verifies that exception delivery follows FIFO order by global event id end-to-end: an older
+/// Verifies that exception delivery follows FIFO order by event sequence number end-to-end: an older
 /// exception enqueued on a high-numbered bit is delivered before a newer exception on a
 /// low-numbered bit.
 ///
-fn test_exception_delivery_is_fifo_by_id() -> bool {
+fn test_exception_delivery_is_fifo_by_sequence() -> bool {
     const OLDER_HIGH_BIT: usize = 5;
     const NEWER_LOW_BIT: usize = 1;
 
@@ -653,6 +660,71 @@ fn test_oldest_exception_not_starved_by_low_bit_load() -> bool {
     false
 }
 
+///
+/// # Description
+///
+/// Verifies that delivery ordering follows the full-width event sequence number rather than the
+/// truncated [`EventDescriptor`] id, so FIFO order is preserved across the descriptor's id wrap
+/// boundary (issue #2674). [`EventDescriptor`] stores its id in a narrow field (24 bits on the
+/// kernel's 32-bit target), so an event generated just past the wrap reads back a *smaller* id than
+/// an older one generated just before it. Ordering by the descriptor id would deliver the newer
+/// event first; ordering by the `u64` sequence number delivers the older one first, as it must.
+///
+fn test_delivery_orders_by_sequence_across_id_wrap() -> bool {
+    const OLDER_HIGH_BIT: usize = 7;
+    const NEWER_LOW_BIT: usize = 1;
+
+    // Width of the `EventDescriptor` id field: the top bit is reserved and the low `BIT_LENGTH` bits
+    // hold the event tag, leaving the rest for the id. The id read back from a descriptor is the
+    // generation sequence number truncated to this many bits.
+    let id_bits: u32 = usize::BITS - 1 - Event::BIT_LENGTH as u32;
+    let wrap: u64 = 1u64 << id_bits;
+
+    let mut inner: EventManagerInner = make_inner();
+
+    // Arrange for the next two generated events to straddle the id wrap: the older event lands on
+    // the last id before the wrap (`wrap - 1`) and the newer event on the wrapped id (`0`).
+    inner.nevents = wrap - 2;
+
+    // Older event (high bit): sequence `wrap - 1`, descriptor id `wrap - 1` (the maximum).
+    push_interrupt(&mut inner, OLDER_HIGH_BIT);
+    // Newer event (low bit): sequence `wrap`, descriptor id `0` (wrapped).
+    push_interrupt(&mut inner, NEWER_LOW_BIT);
+
+    // Confirm the wrap actually occurred, otherwise the test would not exercise the regression.
+    let older_id: usize = inner.pending_interrupts[OLDER_HIGH_BIT]
+        .front()
+        .map(|(_, descriptor)| descriptor.id())
+        .unwrap_or(0);
+    let newer_id: usize = inner.pending_interrupts[NEWER_LOW_BIT]
+        .front()
+        .map(|(_, descriptor)| descriptor.id())
+        .unwrap_or(0);
+    if older_id <= newer_id {
+        error!(
+            "test setup did not straddle the id wrap (older_id={}, newer_id={})",
+            older_id, newer_id
+        );
+        return false;
+    }
+
+    // The older event must be delivered first even though its descriptor id is larger.
+    if deliver_once(&mut inner) != Some(MessageType::Interrupt) {
+        error!("expected an interrupt to be delivered");
+        return false;
+    }
+    if !inner.pending_interrupts[OLDER_HIGH_BIT].is_empty() {
+        error!("the older interrupt must be delivered first across the id wrap");
+        return false;
+    }
+    if inner.pending_interrupts[NEWER_LOW_BIT].is_empty() {
+        error!("the newer interrupt was delivered out of order across the id wrap");
+        return false;
+    }
+
+    true
+}
+
 //==================================================================================================
 // Test Runner
 //==================================================================================================
@@ -669,10 +741,11 @@ pub fn test() -> bool {
     passed &= run_test!(test_cross_class_drainable_events_all_delivered);
     passed &= run_test!(test_all_three_event_classes_make_progress);
     passed &= run_test!(test_standing_scheduling_event_not_starved_under_interrupt_load);
-    passed &= run_test!(test_smallest_pending_front_selects_oldest_id);
-    passed &= run_test!(test_interrupt_delivery_is_fifo_by_id);
+    passed &= run_test!(test_smallest_pending_front_selects_oldest_sequence);
+    passed &= run_test!(test_interrupt_delivery_is_fifo_by_sequence);
     passed &= run_test!(test_oldest_interrupt_not_starved_by_low_bit_load);
-    passed &= run_test!(test_exception_delivery_is_fifo_by_id);
+    passed &= run_test!(test_exception_delivery_is_fifo_by_sequence);
     passed &= run_test!(test_oldest_exception_not_starved_by_low_bit_load);
+    passed &= run_test!(test_delivery_orders_by_sequence_across_id_wrap);
     passed
 }


### PR DESCRIPTION
## Summary

`EventManagerInner::try_wait()` ordered interrupt, exception, and scheduling
delivery by `EventDescriptor::id()`, which the shared descriptor encoding
truncates to a 24-bit field on the kernel's 32-bit target. After `2^24`
generated events the id wraps, so `min_by_key(id)` in `smallest_pending_front()`
could select a newer (wrapped-low) event ahead of an older (high-id) one,
transiently misordering delivery until the wrapped entries drain.

This makes in-class FIFO ordering independent of the truncated descriptor id by
stamping each pending entry with the full-width `u64` `nevents` value at
generation time and ordering delivery by that sequence number.

## Changes

- Widen `nevents` to `u64` so the ordering key never wraps.
- Pair the sequence number with the descriptor in `pending_interrupts`,
  `pending_exceptions`, and `pending_scheduling`.
- Select interrupt/exception queues via `smallest_pending_front()` keyed on the
  sequence number, and check the scheduling FIFO invariant
  (`pending_scheduling_is_ordered`) against it.
- Leave the `EventDescriptor` encoding and its `Message` wire format unchanged,
  so the fix is local to the event manager and preserves serialized-descriptor
  compatibility.

## Tests

- Add `test_delivery_orders_by_sequence_across_id_wrap`, which arranges two
  events straddling the id wrap and asserts the older one is delivered first.
- Rename the existing FIFO-by-id tests and helpers to FIFO-by-sequence to match
  the new ordering key.

Validated with `run-unit-tests`, `run-kernel-tests`, `run-nanvix-tests`,
`format-check`, and `rust-lint-check-kernel KERNEL_FEATURES='microvm trace test'`.

Closes: #2674