### PR TITLE
[tests] Gate integration tests by build mode

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -60,6 +60,9 @@ runs:
       shell: bash
       env:
         RUST_LOG: info
+        # Forwarded to the harness so it can gate build-mode-restricted tests (e.g. heavy tests
+        # marked release-only via `build_modes`, which are too slow under a debug/trace build).
+        BUILD_MODE: ${{ inputs.build-type }}
       run: |
         set -Eeuo pipefail
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,15 +389,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PRs run debug only (fast feedback); merge queue and dev pushes run
-        # release only (final validation + release archives); manual dispatch
-        # runs both.
-        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' ||
+        # PRs run debug AND release (so release-gated integration tests run on
+        # PRs too); merge queue and dev pushes run release only (final validation
+        # + release archives); manual dispatch runs both.
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug","release"]' ||
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
         deployment-type: [ standalone, single-process, multi-process ]
-        memory-size: [ 128, 256 ]
+        memory-size: ${{ fromJSON(github.event_name == 'pull_request' && '[128]' || '[128, 256]') }}
         # 256MB images are release-only; exclude them from debug builds.
         exclude:
           - build-type: debug
@@ -494,7 +494,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' ||
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug","release"]' ||
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
@@ -711,11 +711,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' ||
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug","release"]' ||
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
-        memory-size: [ 128, 256 ]
+        memory-size: ${{ fromJSON(github.event_name == 'pull_request' && '[128]' || '[128, 256]') }}
         # 256MB images are release-only; exclude them from debug builds.
         exclude:
           - build-type: debug
@@ -792,7 +792,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' ||
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug","release"]' ||
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
@@ -887,6 +887,9 @@ jobs:
         shell: pwsh
         env:
           RUST_LOG: trace
+          # Forwarded to the harness so it can gate build-mode-restricted tests (e.g. heavy tests
+          # marked release-only via `build_modes`, which are too slow under a debug/trace build).
+          BUILD_MODE: ${{ matrix.build-type }}
         run: |
           & .\bin\nanvix-test.exe .\test\test-standalone-windows.toml
 

--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -576,6 +576,12 @@ pub struct TestCaseConfig {
     pub expected_exit_code: Option<i32>,
     /// Optional list of machine types on which this test should run.
     pub runs_on: Option<Vec<String>>,
+    /// Required, non-empty list of build modes (`debug`, `release`) in which this test should run.
+    /// The test is skipped in any build mode not listed. This gates heavy tests to builds where
+    /// they are tractable: a test that loads a large image many times is prohibitively slow under a
+    /// `debug` (trace-enabled) build, where the kernel emits per-page trace over a byte-at-a-time
+    /// UART, but completes quickly under a `release` (trace-disabled) build.
+    pub build_modes: Vec<String>,
     /// Optional environment variables forwarded to the workload under test.
     /// Formatted as space-separated `KEY=VALUE` pairs (e.g., `"FOO=bar BAZ=qux"`).
     pub program_env: Option<String>,
@@ -586,6 +592,9 @@ pub struct TestCaseConfig {
 }
 
 impl TestCaseConfig {
+    /// Build modes recognized by the `build_modes` gate and by the active `BUILD_MODE` selector.
+    pub const KNOWN_BUILD_MODES: [&'static str; 2] = ["debug", "release"];
+
     ///
     /// # Description
     ///
@@ -615,6 +624,7 @@ impl TestCaseConfig {
         let extra_nanvixd_args_field: String = format!("{entry_prefix}.extra_nanvixd_args");
         let expected_exit_code_field: String = format!("{entry_prefix}.expected_exit_code");
         let runs_on_field: String = format!("{entry_prefix}.runs_on");
+        let build_modes_field: String = format!("{entry_prefix}.build_modes");
         let program_env_field: String = format!("{entry_prefix}.program_env");
         let program_args_padding_len_field: String =
             format!("{entry_prefix}.program_args_padding_len");
@@ -653,6 +663,12 @@ impl TestCaseConfig {
                 expected_exit_code_field.as_str(),
             )?,
             runs_on: read_optional_string_array(table, "runs_on", runs_on_field.as_str())?,
+            build_modes: read_optional_string_array(
+                table,
+                "build_modes",
+                build_modes_field.as_str(),
+            )?
+            .ok_or_else(|| ::anyhow::anyhow!("{build_modes_field} is a required field"))?,
             program_env: read_optional_string(table, "program_env", program_env_field.as_str())?,
             program_args_padding_len: read_optional_usize(
                 table,
@@ -710,6 +726,29 @@ impl TestCaseConfig {
         if self.program_args.is_some() && self.program_args_padding_len.is_some() {
             let reason: String = format!(
                 "tests[{index}] cannot set both 'program_args' and 'program_args_padding_len'"
+            );
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        // `build_modes` must list at least one mode: an empty list would match no build mode and
+        // silently disable the test in every run.
+        if self.build_modes.is_empty() {
+            let reason: String =
+                format!("tests[{index}] must specify a non-empty 'build_modes' list");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        // Reject unknown build-mode filters early: a typo (e.g. "Release") would otherwise match no
+        // build mode and silently exclude the test from every run.
+        if let Some(unknown_mode) = self
+            .build_modes
+            .iter()
+            .find(|mode| !Self::KNOWN_BUILD_MODES.contains(&mode.as_str()))
+        {
+            let reason: String = format!(
+                "tests[{index}] has an unknown build mode '{unknown_mode}' in 'build_modes' \
+                 (known modes: {})",
+                Self::KNOWN_BUILD_MODES.join(", ")
             );
             return Err(::anyhow::anyhow!(reason));
         }
@@ -788,6 +827,24 @@ impl TestCaseConfig {
             // Filter specified - check if machine is in the list.
             Some(allowed_machines) => allowed_machines.iter().any(|m| m == machine),
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether this test case should run in the specified build mode.
+    ///
+    /// # Parameters
+    ///
+    /// - `build_mode`: Build mode to check against (`debug` or `release`).
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` when the test lists the given build mode in its `build_modes` filter; returns
+    /// `false` otherwise.
+    ///
+    pub fn should_run_in_build_mode(&self, build_mode: &str) -> bool {
+        self.build_modes.iter().any(|m| m == build_mode)
     }
 
     ///
@@ -1788,6 +1845,10 @@ mod tests {
         let mut table: Table = Table::new();
         table.insert("executor".to_string(), Value::String(executor.to_string()));
         table.insert("iterations".to_string(), Value::Integer(1));
+        table.insert(
+            "build_modes".to_string(),
+            Value::Array(vec![Value::String("debug".to_string())]),
+        );
         if let Some(exit_code) = expected_exit_code {
             table.insert("expected_exit_code".to_string(), exit_code);
         }
@@ -1861,6 +1922,7 @@ mod tests {
             extra_nanvixd_args: None,
             expected_exit_code: Some(0),
             runs_on: None,
+            build_modes: vec!["debug".to_string()],
             program_env: None,
             program_args_padding_len: None,
         };
@@ -1882,6 +1944,7 @@ mod tests {
             extra_nanvixd_args: None,
             expected_exit_code: None,
             runs_on: None,
+            build_modes: vec!["debug".to_string()],
             program_env: None,
             program_args_padding_len: None,
         };
@@ -1977,6 +2040,7 @@ mod tests {
             extra_nanvixd_args: None,
             expected_exit_code: None,
             runs_on: None,
+            build_modes: vec!["debug".to_string()],
             program_env: None,
             program_args_padding_len: Some(100),
         };
@@ -1986,5 +2050,81 @@ mod tests {
             "validate() must reject configs with both 'program_args' and \
              'program_args_padding_len'"
         );
+    }
+
+    /// Builds a minimal `empty` test case configuration with the given `build_modes` filter.
+    fn config_with_build_modes(build_modes: Vec<String>) -> TestCaseConfig {
+        TestCaseConfig {
+            executor: "empty".to_string(),
+            name: "empty/build_mode_gate".to_string(),
+            iterations: 1,
+            program: None,
+            program_args: None,
+            input: None,
+            expected_output: None,
+            expect_empty_output: false,
+            extra_nanvixd_args: None,
+            expected_exit_code: None,
+            runs_on: None,
+            build_modes,
+            program_env: None,
+            program_args_padding_len: None,
+        }
+    }
+
+    #[test]
+    fn should_run_in_build_mode_respects_listed_modes() {
+        let config: TestCaseConfig = config_with_build_modes(vec!["release".to_string()]);
+        assert!(
+            config.should_run_in_build_mode("release"),
+            "a release-gated test must run under release"
+        );
+        assert!(
+            !config.should_run_in_build_mode("debug"),
+            "a release-gated test must not run under debug"
+        );
+    }
+
+    #[test]
+    fn should_run_in_build_mode_matches_any_listed_mode() {
+        let config: TestCaseConfig =
+            config_with_build_modes(vec!["debug".to_string(), "release".to_string()]);
+        assert!(config.should_run_in_build_mode("debug"), "must run under a listed mode (debug)");
+        assert!(
+            config.should_run_in_build_mode("release"),
+            "must run under a listed mode (release)"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_known_build_modes() -> Result<()> {
+        let config: TestCaseConfig =
+            config_with_build_modes(vec!["debug".to_string(), "release".to_string()]);
+        config.validate(0)?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_rejects_empty_build_modes() {
+        let config: TestCaseConfig = config_with_build_modes(Vec::new());
+        let result = config.validate(0);
+        assert!(result.is_err(), "validate() must reject an empty 'build_modes' list");
+    }
+
+    #[test]
+    fn validate_rejects_unknown_build_mode() {
+        let config: TestCaseConfig = config_with_build_modes(vec!["release-profiling".to_string()]);
+        let result = config.validate(0);
+        assert!(result.is_err(), "validate() must reject an unknown build mode in 'build_modes'");
+    }
+
+    #[test]
+    fn from_table_requires_build_modes() {
+        // A table without `build_modes` must fail to parse, since the field is required.
+        let mut table: Table = Table::new();
+        table.insert("executor".to_string(), Value::String("empty".to_string()));
+        table.insert("iterations".to_string(), Value::Integer(1));
+        let result: Result<TestCaseConfig> = TestCaseConfig::from_table(&table, 0);
+        assert!(result.is_err(), "from_table() must reject a test entry missing 'build_modes'");
     }
 }

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -368,6 +368,26 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
     // Machine type used for filtering tests.
     let machine: &str = "microvm";
 
+    // Build mode used for filtering tests. The Makefile exports the guest `BUILD_MODE` (`debug` or
+    // `release`) into the environment. A missing or unrecognized value is a hard error rather than
+    // a silent default, so a misconfigured run fails fast instead of quietly skipping every
+    // build-mode-gated test.
+    let build_mode: String = match ::std::env::var("BUILD_MODE") {
+        Ok(value) => value.trim().to_string(),
+        Err(_) => {
+            return Err(::anyhow::anyhow!(
+                "BUILD_MODE environment variable is required (expected one of: {})",
+                TestCaseConfig::KNOWN_BUILD_MODES.join(", ")
+            ));
+        },
+    };
+    if !TestCaseConfig::KNOWN_BUILD_MODES.contains(&build_mode.as_str()) {
+        return Err(::anyhow::anyhow!(
+            "unknown BUILD_MODE '{build_mode}' (expected one of: {})",
+            TestCaseConfig::KNOWN_BUILD_MODES.join(", ")
+        ));
+    }
+
     for test_config in selected_tests {
         // Skip tests that are not applicable to the current machine.
         if !test_config.should_run_on(machine) {
@@ -379,6 +399,23 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
                 test_config.program,
                 machine,
                 test_config.runs_on
+            );
+            continue;
+        }
+
+        // Skip tests that are not applicable to the current build mode. This keeps heavy tests
+        // (e.g. those that load a large image many times) off the debug/trace builds, where the
+        // per-page kernel trace over a byte-at-a-time UART makes them too slow, while still running
+        // them in release builds where tracing is disabled.
+        if !test_config.should_run_in_build_mode(&build_mode) {
+            info!(
+                "main(): skipping test not applicable to build mode (executor={}, name={}, \
+                 program={:?}, build_mode={}, build_modes={:?})",
+                test_config.executor,
+                test_config.name,
+                test_config.program,
+                build_mode,
+                test_config.build_modes
             );
             continue;
         }
@@ -401,6 +438,7 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
             extra_nanvixd_args,
             expected_exit_code,
             runs_on: _,
+            build_modes: _,
             program_env,
             program_args_padding_len,
         } = test_config;

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -26,11 +26,13 @@ gateway_connect_max_backoff_ms = 500
 gateway_connect_timeout_ms = 15000
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -40,6 +42,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -48,6 +51,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -57,42 +61,49 @@ expected_exit_code = 3
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.elf"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/memory-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/misc-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.elf"
 input = "[]"

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -26,11 +26,13 @@ gateway_connect_max_backoff_ms = 500
 gateway_connect_timeout_ms = 15000
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -40,6 +42,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -48,6 +51,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -56,54 +60,63 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.elf"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/file-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/misc-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/memory-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.elf"
 extra_nanvixd_args = "-allow-host-networking"
@@ -111,6 +124,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
@@ -121,6 +135,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -129,6 +144,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -137,58 +153,69 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/echo-rust-nostd.elf"
 input = "hello world"
 expected_output = "hello world"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/linux-app.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/file-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/arch-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/misc-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/memory-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/network-rust.elf"
 extra_nanvixd_args = "-allow-host-networking"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -201,6 +228,7 @@ expected_output = "ok"
 
 # Single environment variable.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -208,6 +236,7 @@ input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -215,6 +244,7 @@ expected_output = "TEST_VAR=hello\nok"
 
 # Multiple environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -222,6 +252,7 @@ input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -229,6 +260,7 @@ expected_output = "FOO=bar\nBAZ=qux\nok"
 
 # Environment variable with special characters in value.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -236,6 +268,7 @@ input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -247,6 +280,7 @@ expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 # Program with args and environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -255,6 +289,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -263,6 +298,7 @@ expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 # Program with args and no environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -270,6 +306,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -277,6 +314,7 @@ expected_output = "ARGS:hello world\nENV:\nok"
 
 # Program with no args and with environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -284,6 +322,7 @@ input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -291,6 +330,7 @@ expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 # Program with escaped args (literal semicolon in arguments).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -299,6 +339,7 @@ input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -307,6 +348,7 @@ expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 # Program with escaped environment variables (literal semicolon in env value).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"
@@ -315,6 +357,7 @@ input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -25,11 +25,13 @@ gateway_connect_max_backoff_ms = 500
 gateway_connect_timeout_ms = 15000
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -39,6 +41,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -47,6 +50,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -55,54 +59,63 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.elf"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/file-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/misc-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/memory-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.elf"
 extra_nanvixd_args = "-allow-host-networking"
@@ -110,6 +123,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
@@ -120,6 +134,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -128,6 +143,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -136,58 +152,69 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/echo-rust-nostd.elf"
 input = "hello world"
 expected_output = "hello world"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/linux-app.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/file-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/arch-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/misc-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/memory-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/network-rust.elf"
 extra_nanvixd_args = "-allow-host-networking"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -200,6 +227,7 @@ expected_output = "ok"
 
 # Single environment variable.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -207,6 +235,7 @@ input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -214,6 +243,7 @@ expected_output = "TEST_VAR=hello\nok"
 
 # Multiple environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -221,6 +251,7 @@ input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -228,6 +259,7 @@ expected_output = "FOO=bar\nBAZ=qux\nok"
 
 # Environment variable with special characters in value.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -235,6 +267,7 @@ input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -246,6 +279,7 @@ expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 # Program with args and environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -254,6 +288,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -262,6 +297,7 @@ expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 # Program with args and no environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -269,6 +305,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -276,6 +313,7 @@ expected_output = "ARGS:hello world\nENV:\nok"
 
 # Program with no args and with environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -283,6 +321,7 @@ input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -290,6 +329,7 @@ expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 # Program with escaped args (literal semicolon in arguments).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -298,6 +338,7 @@ input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -306,6 +347,7 @@ expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 # Program with escaped environment variables (literal semicolon in env value).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"
@@ -314,6 +356,7 @@ input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -37,11 +37,13 @@ gateway_connect_timeout_ms = 15000
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -51,6 +53,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -60,6 +63,7 @@ expected_exit_code = 13
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -69,6 +73,7 @@ expected_exit_code = 3
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
@@ -77,11 +82,13 @@ expect_empty_output = true
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/arch-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 name = "execv-small"
 program = "./bin/execv-test.initrd"
@@ -92,6 +99,7 @@ expected_exit_code = 0
 # execv() of a large binary (target inflated to MEMORY_SIZE/8). Reuses the same caller, pointed at
 # a ramfs whose `/target` is the large program, to exercise loading a big image with no size cap.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 name = "execv-big"
 program = "./bin/execv-test.initrd"
@@ -100,38 +108,45 @@ expected_output = "ok"
 expected_exit_code = 0
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/echo-rust-nostd.initrd"
 input = '["hello"]'
 expected_output = "hello"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/waitpid-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/setenv-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/stress-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -150,6 +165,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -159,6 +175,7 @@ expected_exit_code = 13
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -168,6 +185,7 @@ expected_exit_code = 3
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
@@ -176,42 +194,49 @@ expect_empty_output = true
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.initrd"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/waitpid-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/setenv-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/stress-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
@@ -219,6 +244,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -231,6 +257,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/mount-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img -mount ./bin/mount-test-data"
@@ -240,6 +267,7 @@ expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-fork-hostfs.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img -mount ./bin/test-fork-hostfs-data"
@@ -249,6 +277,7 @@ expected_exit_code = 13
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/mount-multipart-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
@@ -262,6 +291,7 @@ runs_on = ["microvm"]
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -269,18 +299,21 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/network-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/pipe-dup2-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-vfsd-test.img"
@@ -288,6 +321,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
@@ -299,6 +333,7 @@ expected_output = "ok"
 # execv()s. FAILS while the exec'd image does not receive the parent's cloned
 # descriptor table (the inherited fd is unknown and the child's read fails).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
@@ -306,6 +341,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
@@ -316,6 +352,7 @@ expected_output = "ok"
 # while vfsd derives the caller PID by casting the request's TID: the non-main thread's distinct
 # TID maps to a phantom process whose descriptor table is empty, so the I/O returns EBADF.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
@@ -323,12 +360,14 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
@@ -338,6 +377,7 @@ expected_output = "ok"
 # FAILS until sockets are reference-counted across fork(): a child closing its
 # inherited copy currently destroys the parent's socket.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/socket-fork-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -345,17 +385,20 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/pipe-dup2-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-vfsd-test.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/socket-fork-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -366,6 +409,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "snapshot-restore"
 program = "./bin/snapshot-test.elf"
 iterations = 1

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -25,11 +25,13 @@ gateway_connect_max_backoff_ms = 500
 gateway_connect_timeout_ms = 15000
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -39,6 +41,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -47,6 +50,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -55,6 +59,7 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
@@ -63,18 +68,21 @@ expect_empty_output = true
 expected_exit_code = 0
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.initrd"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-fork-kcall.initrd"
 input = "[]"
@@ -82,6 +90,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-fork-guestfs.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-fork-guestfs.img"
@@ -90,30 +99,35 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/waitpid-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/setenv-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/stress-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
@@ -125,6 +139,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -133,6 +148,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -141,6 +157,7 @@ expect_empty_output = true
 expected_exit_code = 3
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
@@ -149,23 +166,27 @@ expect_empty_output = true
 expected_exit_code = 0
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/echo-rust-nostd.initrd"
 input = "hello world"
 expected_output = "hello world"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-fork-kcall.initrd"
 expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-fork-guestfs.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-fork-guestfs.img"
@@ -173,26 +194,31 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/waitpid-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/setenv-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/stress-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/arch-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 name = "execv-small"
 program = "./bin/execv-test.initrd"
@@ -203,6 +229,7 @@ expected_exit_code = 0
 # execv() of a large binary (target inflated to MEMORY_SIZE/8). Reuses the same caller, pointed at
 # a ramfs whose `/target` is the large program, to exercise loading a big image with no size cap.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 name = "execv-big"
 program = "./bin/execv-test.initrd"
@@ -211,12 +238,14 @@ expected_output = "ok"
 expected_exit_code = 0
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -225,6 +254,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-len-rust.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 20 (filename) - 1 (space separator) = 4071.
@@ -237,6 +267,7 @@ expected_output = "ok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/mount-test.initrd"
 extra_nanvixd_args = "-mount ./bin/mount-test-data"
@@ -246,6 +277,7 @@ expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-fork-hostfs.initrd"
 extra_nanvixd_args = "-mount ./bin/test-fork-hostfs-data"
@@ -255,6 +287,7 @@ expected_exit_code = 13
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/mount-multipart-test.initrd"
 input = "[]"
@@ -267,6 +300,7 @@ runs_on = ["microvm"]
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -274,18 +308,21 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/network-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/pipe-dup2-rust.initrd"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-vfsd-test.img"
@@ -293,6 +330,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
@@ -304,6 +342,7 @@ expected_output = "ok"
 # execv()s. FAILS while the exec'd image does not receive the parent's cloned
 # descriptor table (the inherited fd is unknown and the child's read fails).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
@@ -311,6 +350,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-write-test.img"
@@ -321,6 +361,7 @@ expected_output = "ok"
 # while vfsd derives the caller PID by casting the request's TID: the non-main thread's distinct
 # TID maps to a phantom process whose descriptor table is empty, so the I/O returns EBADF.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
@@ -328,12 +369,14 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/thread-vfs-test.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-loop-test.img"
@@ -343,6 +386,7 @@ expected_output = "ok"
 # FAILS until sockets are reference-counted across fork(): a child closing its
 # inherited copy currently destroys the parent's socket.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/socket-fork-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -350,17 +394,20 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/pipe-dup2-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/fork-exec-vfsd-test.img"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/socket-fork-rust.initrd"
 extra_nanvixd_args = "-allow-host-networking"
@@ -372,6 +419,7 @@ expected_output = "ok"
 
 # Single environment variable.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -379,6 +427,7 @@ input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "TEST_VAR=hello"
@@ -386,6 +435,7 @@ expected_output = "TEST_VAR=hello\nok"
 
 # Multiple environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -393,6 +443,7 @@ input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
@@ -400,6 +451,7 @@ expected_output = "FOO=bar\nBAZ=qux\nok"
 
 # Environment variable with special characters in value.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -407,6 +459,7 @@ input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/env-rust-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
@@ -418,6 +471,7 @@ expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 # Program with args and environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -426,6 +480,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -434,6 +489,7 @@ expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 # Program with args and no environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -441,6 +497,7 @@ input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello world"
@@ -448,6 +505,7 @@ expected_output = "ARGS:hello world\nENV:\nok"
 
 # Program with no args and with environment variables.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -455,6 +513,7 @@ input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_env = "FOO=bar"
@@ -462,6 +521,7 @@ expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 # Program with escaped args (literal semicolon in arguments).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -470,6 +530,7 @@ input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "a;b"
@@ -478,6 +539,7 @@ expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 # Program with escaped environment variables (literal semicolon in env value).
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"
@@ -486,6 +548,7 @@ input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/cmdline-env-rust-nostd.elf"
 program_args = "hello"
@@ -497,6 +560,7 @@ expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "snapshot-restore"
 program = "./bin/snapshot-test.elf"
 iterations = 1
@@ -506,6 +570,7 @@ expected_exit_code = 32
 # written to disk. The guest workload spins forever after taking the snapshot, so the only
 # path to a clean nanvixd exit is the host-side snapshot-completion tear-down.
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "snapshot-save-exit"
 program = "./bin/snapshot-test.elf"
 iterations = 1

--- a/test/test.toml
+++ b/test/test.toml
@@ -25,11 +25,13 @@ gateway_connect_max_backoff_ms = 500
 gateway_connect_timeout_ms = 15000
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/1"
 iterations = 1
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "empty"
 name = "empty/2"
 iterations = 2
@@ -39,6 +41,7 @@ iterations = 2
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -47,6 +50,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -56,60 +60,70 @@ expected_exit_code = 3
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/echo-rust-nostd.elf"
 input = '["hello world!"]'
 expected_output = "hello world!"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/linux-app.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/file-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/thread-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/arch-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/misc-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/memory-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/network-rust.elf"
 input = "[]"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
@@ -121,6 +135,7 @@ runs_on = ["microvm"]
 #===================================================================================================
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -129,6 +144,7 @@ expect_empty_output = true
 expected_exit_code = 13
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
@@ -138,52 +154,62 @@ expected_exit_code = 3
 runs_on = ["microvm"]
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/echo-rust-nostd.elf"
 input = "hello world"
 expected_output = "hello world"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/linux-app.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/file-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/arch-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/misc-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/memory-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/network-rust.elf"
 expected_output = "ok"
 
 [[tests]]
+build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"


### PR DESCRIPTION
## Summary

Adds an optional per-test **build-mode gate** to the `nanvix-test` integration harness and wires CI to use it, so heavy integration tests can be restricted to the build modes where they are tractable.

A test that loads a large image many times is prohibitively slow under a `debug` (trace-enabled) build — the kernel emits per-page trace over a byte-at-a-time UART — but completes quickly under a `release` (trace-disabled) build. The gate lets such tests opt out of slow builds without affecting the rest of the suite.

## Changes

**Harness (`[tests] E`)**
- New optional `build_modes` field on `[[tests]]` entries. When set, the test is skipped in any build mode not listed; tests without it run in every mode (unchanged behavior).
- The harness selects the active mode from the `BUILD_MODE` environment variable (already exported by the Makefile), defaulting to `debug` when unset so a direct invocation never accidentally runs a gated heavy test under a slow trace build.
- A profiling build satisfies a filter that lists its base mode: `release-profiling` matches `["release"]` (both disable kernel tracing); the `-profiling` suffix is stripped before matching. An explicit `["release-profiling"]` still gates to profiling only.
- Unknown `build_modes` entries are rejected at config-load time (known modes: `debug`, `release`, `release-profiling`) so a typo cannot silently exclude a test everywhere.
- Adds unit tests for the no-filter, listed-mode match/exclude, release→release-profiling family, explicit-profiling exclusion, and validate accept/reject paths.

**CI (`[ci] E`)**
- Forwards `BUILD_MODE` to the harness in the Linux integration-test action step and the Windows "Run Integration Tests" step.
- Runs pull requests in **debug AND release** (previously debug only) for the ci-build/ci-test matrices and the Windows build matrix, so release-gated tests are exercised on PRs. Merge-queue/dev pushes remain release-only; `workflow_dispatch` still runs both.
- Caps the PR `memory-size` axis to `[128]` to offset the added release jobs; 256MB images stay release-only and are still built on merge-queue, dev, and manual runs.

## Notes / trade-offs

- No test currently sets `build_modes`, so the existing suite's behavior is unchanged; this lands the plumbing.
- PR integration jobs roughly double (debug + release). 256MB release images are no longer built on PRs, so a 256MB-only regression would surface in the merge queue rather than on the PR.

## Validation

- `cargo fmt -p nanvix-test --check` and `cargo test -p nanvix-test` (62 passed) pass.