### PR TITLE
[kernel] Add scatter-gather IKC bulk transfers

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -83,6 +83,19 @@ ipc_message_size = 64
 ikc_poll_batch_size = 8
 
 #==================================================================================================
+# Kernel Heap
+#==================================================================================================
+
+# Maximum allocation size (in bytes) served by the kernel heap's slab allocator.
+# Allocations whose size or alignment exceed this value are rejected. Components outside the kernel
+# (such as the scatter/gather IKC limits in the `sys` crate) size their buffers against this budget.
+# Constraints:
+# - Must be a power of two.
+# - Must match the largest slab tier in `src/kernel/src/mm/kheap.rs` (currently 512). The
+#   compile-time assertion in that module fails the build if the two ever diverge.
+max_slab_size = 512
+
+#==================================================================================================
 # Thread Limits
 #==================================================================================================
 

--- a/src/kernel/src/ipc/mod.rs
+++ b/src/kernel/src/ipc/mod.rs
@@ -13,6 +13,8 @@ mod push;
 mod recv;
 pub(crate) mod rendezvous;
 mod send;
+#[cfg(feature = "stdio")]
+mod sg;
 
 //==================================================================================================
 //  Exports

--- a/src/kernel/src/ipc/pull.rs
+++ b/src/kernel/src/ipc/pull.rs
@@ -5,14 +5,18 @@
 // Imports
 //==================================================================================================
 
+use crate::pm::SleepError;
 #[cfg(feature = "stdio")]
-use crate::mm::{
-    KernelPage,
-    VirtMemoryManager,
+use crate::{
+    hal::mem::VirtualAddress,
+    pm::ProcessManager,
 };
 #[cfg(feature = "stdio")]
-use crate::pm::ProcessManager;
-use crate::pm::SleepError;
+use ::sys::ipc::{
+    GuestSgBulkKind,
+    GuestSgSegment,
+    SG_BULK_MAX_BYTES,
+};
 use ::sys::{
     error::{
         Error,
@@ -33,12 +37,8 @@ use ::sys::{
 ///
 /// Pulls data from a sender process using rendezvous synchronization.
 ///
-/// When the sender is the kernel (linuxd), data is transferred via the vmbus data chunk transfer
-/// path. The vmbus translates a single virtual address into one guest physical address and treats
-/// the payload as physically contiguous. A buffer that lies within a single page is therefore
-/// handed to the VMM directly (fast path), while a buffer that crosses a page boundary is only
-/// *virtually* contiguous and is staged through a physically-contiguous kernel bounce page (slow
-/// path). Either way the payload must fit within a single page.
+/// When the sender is the kernel (linuxd), data is transferred via the vmbus scatter/gather data
+/// chunk transfer path.
 ///
 /// # Parameters
 ///
@@ -111,109 +111,45 @@ pub fn pull(
     // intermediate kernel buffer copy. After the transfer completes the data is already in place.
     #[cfg(feature = "stdio")]
     if sender_pid == ProcessIdentifier::KERNEL {
+        if transfer_len == 0 || transfer_len > SG_BULK_MAX_BYTES {
+            let reason: &str = "invalid scatter/gather bulk pull length";
+            error!(
+                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
+                 buffer={buffer_raw:#x}, len={transfer_len})"
+            );
+            return Err(SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason)));
+        }
+
         trace!(
             "pull(): data chunk transfer via vmbus (caller_pid={caller_pid:?}, \
              caller_tid={caller_tid:?}, len={transfer_len})"
         );
 
-        // The vmbus data chunk transfer path writes `transfer_len` physically-contiguous bytes
-        // starting at a single translated guest-physical address. A user buffer is only
-        // *virtually* contiguous, so one whose bytes spill past its first page cannot be handed to
-        // the VMM directly: only the first page would be translated and the VMM would write into an
-        // unrelated physical frame. Detect that case up front.
-        let page_offset: usize = buffer_raw & (::arch::mem::PAGE_SIZE - 1);
-        let crosses_page: bool =
-            transfer_len > 0 && page_offset.saturating_add(transfer_len) > ::arch::mem::PAGE_SIZE;
-
-        if !crosses_page {
-            // Fast path: the buffer lies within a single page, so the VMM writes directly into the
-            // guest physical page backing it and no post-wake copy is needed.
-            let pm: &ProcessManager = unsafe { ProcessManager::get() };
-            let vaddr: crate::hal::mem::VirtualAddress =
-                crate::hal::mem::VirtualAddress::from_raw_value(buffer_raw);
-            let paddr: usize = pm
-                .user_vaddr_to_paddr(caller_pid, vaddr)
-                .map_err(SleepError::Generic)?;
-            let gpa: u32 = u32::try_from(paddr).map_err(|_| {
-                let reason: &str = "guest physical address exceeds u32";
-                error!(
-                    "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                     paddr={paddr:#x})"
-                );
-                SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
-            })?;
-
-            crate::stdio::write_bulk(
-                caller_pid,
-                caller_tid,
-                sender_pid,
-                sender_tid,
-                gpa,
-                transfer_len_raw,
-            )
-            .map_err(SleepError::Generic)?;
-
-            // Register a pending bulk pull and sleep until the completion arrives.
-            return super::bulk_pull::register_and_sleep(caller_tid);
-        }
-
-        // Slow path: the buffer straddles a page boundary. Receive into a physically-contiguous
-        // kernel bounce page so the VMM still sees a single contiguous region, then scatter the
-        // delivered bytes back into the page-straddling user buffer. The payload itself must fit
-        // within one page (every kernel-peer caller transfers at most a page of data).
-        if transfer_len > ::arch::mem::PAGE_SIZE {
-            let reason: &str = "bulk pull payload exceeds one page";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 len={transfer_len})"
-            );
-            return Err(SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason)));
-        }
-
-        // Allocate the bounce page. A kernel frame is a single physical frame: contiguous and
-        // identity-mapped, so its guest-physical address can be handed to the VMM directly.
-        let bounce: KernelPage = unsafe { VirtMemoryManager::get_mut() }
-            .alloc_kpage(true)
-            .map_err(SleepError::Generic)?;
-        let bounce_vaddr: crate::hal::mem::VirtualAddress =
-            crate::hal::mem::VirtualAddress::from_raw_value(bounce.base().into_raw_value());
-        let gpa: u32 = u32::try_from(bounce.frame_address().into_raw_value()).map_err(|_| {
-            let reason: &str = "bounce page guest physical address exceeds u32";
-            error!("{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?})");
-            SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
-        })?;
+        // SAFETY: IPC runs after the process manager is initialized, and the process manager
+        // provides the synchronization needed for address translation.
+        let pm: &ProcessManager = unsafe { ProcessManager::get() };
+        let segments: ::alloc::vec::Vec<GuestSgSegment> = super::sg::build_user_segments(
+            pm,
+            caller_pid,
+            VirtualAddress::from_raw_value(buffer_raw),
+            transfer_len,
+        )
+        .map_err(SleepError::Generic)?;
 
         crate::stdio::write_bulk(
             caller_pid,
             caller_tid,
             sender_pid,
             sender_tid,
-            gpa,
+            GuestSgBulkKind::Pull,
+            &segments,
             transfer_len_raw,
         )
         .map_err(SleepError::Generic)?;
 
-        // Sleep until the VMM has written the payload into the bounce page. `bounce` lives on this
-        // thread's kernel stack across the sleep, so it is still valid on wake.
-        // Clamp the completion length to what the caller actually requested: never copy out or
-        // report more bytes than the user buffer holds, even if the completion claims a larger
-        // transfer (e.g. a buggy or malicious peer).
-        let actual_len: usize = super::bulk_pull::register_and_sleep(caller_tid)?.min(transfer_len);
-
-        // Scatter the delivered bytes from the contiguous bounce page back into the user buffer.
-        if actual_len > 0 {
-            unsafe { ProcessManager::get_mut() }
-                .vmcopy_to_user(
-                    caller_pid,
-                    crate::hal::mem::VirtualAddress::from_raw_value(buffer_raw),
-                    bounce_vaddr,
-                    actual_len,
-                )
-                .map_err(SleepError::Generic)?;
-        }
-
-        // `bounce` is dropped here, freeing the kernel frame.
-        return Ok(actual_len);
+        // Register a pending bulk pull and sleep until the completion arrives. UserVM scatters the
+        // response into the guest physical segments before waking this thread.
+        return super::bulk_pull::register_and_sleep(caller_tid);
     }
 
     super::rendezvous::do_pull(

--- a/src/kernel/src/ipc/push.rs
+++ b/src/kernel/src/ipc/push.rs
@@ -5,14 +5,18 @@
 // Imports
 //==================================================================================================
 
+use crate::pm::SleepError;
 #[cfg(feature = "stdio")]
-use crate::mm::{
-    KernelPage,
-    VirtMemoryManager,
+use crate::{
+    hal::mem::VirtualAddress,
+    pm::ProcessManager,
 };
 #[cfg(feature = "stdio")]
-use crate::pm::ProcessManager;
-use crate::pm::SleepError;
+use ::sys::ipc::{
+    GuestSgBulkKind,
+    GuestSgSegment,
+    SG_BULK_MAX_BYTES,
+};
 use ::sys::{
     error::{
         Error,
@@ -33,12 +37,8 @@ use ::sys::{
 ///
 /// Pushes data to a destination process using rendezvous synchronization.
 ///
-/// When the destination is the kernel (linuxd), data is transferred via the vmbus data chunk
-/// transfer path. The vmbus translates a single virtual address into one guest physical address and
-/// treats the payload as physically contiguous. A buffer that lies within a single page is
-/// therefore handed to the VMM directly (fast path), while a buffer that crosses a page boundary is
-/// only *virtually* contiguous and is staged through a physically-contiguous kernel bounce page
-/// (slow path). Either way the payload must fit within a single page.
+/// When the destination is the kernel (linuxd), data is transferred via the vmbus scatter/gather
+/// data chunk transfer path.
 ///
 /// # Parameters
 ///
@@ -108,98 +108,41 @@ pub fn push(
     // buffer copy.
     #[cfg(feature = "stdio")]
     if destination_pid == ProcessIdentifier::KERNEL {
+        if transfer_len == 0 || transfer_len > SG_BULK_MAX_BYTES {
+            let reason: &str = "invalid scatter/gather bulk push length";
+            error!(
+                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
+                 buffer={buffer_raw:#x}, len={transfer_len})"
+            );
+            return Err(SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason)));
+        }
+
         trace!(
             "push(): data chunk transfer via vmbus (caller_pid={caller_pid:?}, \
              caller_tid={caller_tid:?}, len={transfer_len})"
         );
 
-        // The vmbus data chunk transfer path reads `transfer_len` physically-contiguous bytes
-        // starting at a single translated guest-physical address. A user buffer is only
-        // *virtually* contiguous, so one whose bytes spill past its first page cannot be handed to
-        // the VMM directly: only the first page would be translated and the VMM would read into an
-        // unrelated physical frame. Detect that case up front.
-        let page_offset: usize = buffer_raw & (::arch::mem::PAGE_SIZE - 1);
-        let crosses_page: bool =
-            transfer_len > 0 && page_offset.saturating_add(transfer_len) > ::arch::mem::PAGE_SIZE;
+        // SAFETY: IPC runs after the process manager is initialized, and the process manager
+        // provides the synchronization needed for address translation.
+        let pm: &ProcessManager = unsafe { ProcessManager::get() };
+        let segments: ::alloc::vec::Vec<GuestSgSegment> = super::sg::build_user_segments(
+            pm,
+            caller_pid,
+            VirtualAddress::from_raw_value(buffer_raw),
+            transfer_len,
+        )
+        .map_err(SleepError::Generic)?;
 
-        if !crosses_page {
-            // Fast path: the buffer lies within a single page, so translate its address and let the
-            // VMM read it in place with no intermediate copy.
-            let pm: &ProcessManager = unsafe { ProcessManager::get() };
-            let vaddr: crate::hal::mem::VirtualAddress =
-                crate::hal::mem::VirtualAddress::from_raw_value(buffer_raw);
-            let paddr: usize = pm
-                .user_vaddr_to_paddr(caller_pid, vaddr)
-                .map_err(SleepError::Generic)?;
-            let gpa: u32 = u32::try_from(paddr).map_err(|_| {
-                let reason: &str = "guest physical address exceeds u32";
-                error!(
-                    "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                     paddr={paddr:#x})"
-                );
-                SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
-            })?;
-
-            return crate::stdio::write_bulk(
-                caller_pid,
-                caller_tid,
-                destination_pid,
-                destination_tid,
-                gpa,
-                transfer_len_raw,
-            )
-            .map_err(SleepError::Generic);
-        }
-
-        // Slow path: the buffer straddles a page boundary. Stage it through a physically-contiguous
-        // kernel bounce page so the VMM still sees a single contiguous region. The payload itself
-        // must fit within one page (every kernel-peer caller transfers at most a page of data).
-        if transfer_len > ::arch::mem::PAGE_SIZE {
-            let reason: &str = "bulk push payload exceeds one page";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 len={transfer_len})"
-            );
-            return Err(SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason)));
-        }
-
-        // Allocate the bounce page. A kernel frame is a single physical frame: contiguous and
-        // identity-mapped, so its guest-physical address can be handed to the VMM directly.
-        let bounce: KernelPage = unsafe { VirtMemoryManager::get_mut() }
-            .alloc_kpage(true)
-            .map_err(SleepError::Generic)?;
-        let bounce_vaddr: crate::hal::mem::VirtualAddress =
-            crate::hal::mem::VirtualAddress::from_raw_value(bounce.base().into_raw_value());
-        let gpa: u32 = u32::try_from(bounce.frame_address().into_raw_value()).map_err(|_| {
-            let reason: &str = "bounce page guest physical address exceeds u32";
-            error!("{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?})");
-            SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
-        })?;
-
-        // Copy the page-straddling user buffer into the contiguous bounce page.
-        unsafe { ProcessManager::get_mut() }
-            .vmcopy_from_user(
-                caller_pid,
-                bounce_vaddr,
-                crate::hal::mem::VirtualAddress::from_raw_value(buffer_raw),
-                transfer_len,
-            )
-            .map_err(SleepError::Generic)?;
-
-        // Hand the bounce page to the VMM. The port write traps synchronously into the VMM, which
-        // reads the page before this call returns, so the bounce page may be released right after.
-        crate::stdio::write_bulk(
+        return crate::stdio::write_bulk(
             caller_pid,
             caller_tid,
             destination_pid,
             destination_tid,
-            gpa,
+            GuestSgBulkKind::Push,
+            &segments,
             transfer_len_raw,
         )
-        .map_err(SleepError::Generic)?;
-
-        // `bounce` is dropped here, freeing the kernel frame.
-        return Ok(());
+        .map_err(SleepError::Generic);
     }
 
     super::rendezvous::do_push(

--- a/src/kernel/src/ipc/sg.rs
+++ b/src/kernel/src/ipc/sg.rs
@@ -1,0 +1,228 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::mem::{
+        PhysicalAddress,
+        VirtualAddress,
+    },
+    pm::ProcessManager,
+};
+use ::alloc::vec::Vec;
+use ::arch::mem::PAGE_SIZE;
+use ::core::cmp;
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        GuestSgSegment,
+        SG_BULK_MAX_BYTES,
+        SG_BULK_MAX_SEGMENTS,
+    },
+    mm::Address,
+    pm::ProcessIdentifier,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Builds a scatter/gather segment list for a user-space buffer.
+///
+/// The returned descriptors are fully chained: each non-final descriptor records the guest virtual
+/// address of the descriptor that follows it, and the final descriptor terminates the chain.
+///
+/// # Parameters
+///
+/// - `pm`: Process manager used to translate user virtual addresses.
+/// - `pid`: Identifier of the process that owns the buffer.
+/// - `buffer`: Start virtual address of the user-space buffer.
+/// - `transfer_len`: Number of bytes to transfer.
+///
+/// # Returns
+///
+/// Upon success, the scatter/gather segment list is returned. Upon failure, an error is returned
+/// instead.
+///
+/// # Errors
+///
+/// This function returns an error if the transfer length is invalid, if a user virtual address
+/// cannot be translated, if a segment field does not fit the wire format, or if the segment chain
+/// would exceed the scatter/gather limits.
+///
+pub fn build_user_segments(
+    pm: &ProcessManager,
+    pid: ProcessIdentifier,
+    buffer: VirtualAddress,
+    transfer_len: usize,
+) -> Result<Vec<GuestSgSegment>, Error> {
+    let buffer_raw: usize = buffer.into_raw_value();
+    if transfer_len == 0 {
+        let reason: &str = "scatter/gather transfer length is zero";
+        error!("{reason} (pid={pid:?}, buffer={buffer_raw:#x})");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    if transfer_len > SG_BULK_MAX_BYTES {
+        let reason: &str = "scatter/gather transfer exceeds maximum byte count";
+        error!(
+            "{reason} (pid={pid:?}, buffer={buffer_raw:#x}, len={transfer_len}, \
+             max={SG_BULK_MAX_BYTES})"
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    // Bound the allocation up front: a transfer needs at most one segment per page it spans, capped
+    // by the scatter/gather segment limit. Reserving that exact capacity keeps the kernel-heap
+    // allocation bounded and avoids reallocation while the chain is built. Use fallible reservation
+    // so a kernel-heap exhaustion is reported as an error instead of aborting.
+    let first_page_offset: usize = buffer_raw & (PAGE_SIZE - 1);
+    let span_pages: usize = (first_page_offset + transfer_len).div_ceil(PAGE_SIZE);
+    let capacity: usize = cmp::min(span_pages, SG_BULK_MAX_SEGMENTS as usize);
+    let mut segments: Vec<GuestSgSegment> = Vec::new();
+    segments.try_reserve_exact(capacity).map_err(|_| {
+        let reason: &str = "failed to allocate scatter/gather segment list";
+        error!("{reason} (pid={pid:?}, buffer={buffer_raw:#x}, capacity={capacity})");
+        Error::new(ErrorCode::OutOfMemory, reason)
+    })?;
+
+    let mut current: usize = buffer_raw;
+    let mut remaining: usize = transfer_len;
+
+    while remaining > 0 {
+        let page_offset: usize = current & (PAGE_SIZE - 1);
+        let chunk_len: usize = cmp::min(PAGE_SIZE - page_offset, remaining);
+        let vaddr: VirtualAddress = VirtualAddress::from_raw_value(current);
+
+        // Translate the user virtual address and keep the result strongly typed so the contiguity
+        // check below operates on real physical addresses rather than raw integers.
+        let paddr_raw: usize = pm.user_vaddr_to_paddr(pid, vaddr).inspect_err(|error| {
+            error!(
+                "failed to translate scatter/gather segment (pid={pid:?}, vaddr={current:#x}, \
+                 error={error:?})"
+            );
+        })?;
+        let paddr: PhysicalAddress =
+            PhysicalAddress::from_raw_value(paddr_raw).inspect_err(|error| {
+                error!(
+                    "scatter/gather segment is not a valid physical address (pid={pid:?}, \
+                     vaddr={current:#x}, paddr={paddr_raw:#x}, error={error:?})"
+                );
+            })?;
+        let paddr_u32: u32 = u32::try_from(paddr.into_raw_value()).map_err(|_| {
+            let reason: &str = "guest physical address exceeds u32";
+            error!("{reason} (pid={pid:?}, paddr={paddr_raw:#x})");
+            Error::new(ErrorCode::InvalidArgument, reason)
+        })?;
+        let chunk_len_u32: u32 = u32::try_from(chunk_len).map_err(|_| {
+            let reason: &str = "scatter/gather segment length exceeds u32";
+            error!("{reason} (pid={pid:?}, chunk_len={chunk_len})");
+            Error::new(ErrorCode::InvalidArgument, reason)
+        })?;
+
+        if let Some(last) = segments.last_mut() {
+            let last_gpa: PhysicalAddress =
+                PhysicalAddress::from_raw_value(last.data_gpa() as usize).map_err(|error| {
+                    let reason: &str = "segment is not a valid physical address";
+                    error!(
+                        "{reason} (pid={pid:?}, data_gpa={:#x}, error={error:?})",
+                        last.data_gpa()
+                    );
+                    Error::new(ErrorCode::InvalidArgument, reason)
+                })?;
+            // The segments are contiguous when the previous one ends exactly where this one starts.
+            // `checked_add` returns `None` when the previous segment ends at the top of physical
+            // memory, in which case the two cannot be contiguous.
+            let contiguous: bool = last_gpa.checked_add(last.data_len() as usize) == Some(paddr);
+            if contiguous {
+                let new_len: u32 = last.data_len().checked_add(chunk_len_u32).ok_or_else(|| {
+                    let reason: &str = "segment length overflow";
+                    error!(
+                        "{reason} (pid={pid:?}, data_len={}, chunk_len={chunk_len_u32})",
+                        last.data_len()
+                    );
+                    Error::new(ErrorCode::InvalidArgument, reason)
+                })?;
+                last.set_data_len(new_len);
+            } else {
+                if segments.len() == SG_BULK_MAX_SEGMENTS as usize {
+                    let reason: &str = "scatter/gather transfer has too many segments";
+                    error!(
+                        "{reason} (pid={pid:?}, buffer={buffer_raw:#x}, len={transfer_len}, \
+                         max={SG_BULK_MAX_SEGMENTS})"
+                    );
+                    return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                }
+                segments.push(GuestSgSegment::new(
+                    VirtualAddress::from_raw_value(0),
+                    paddr_u32,
+                    chunk_len_u32,
+                ));
+            }
+        } else {
+            segments.push(GuestSgSegment::new(
+                VirtualAddress::from_raw_value(0),
+                paddr_u32,
+                chunk_len_u32,
+            ));
+        }
+
+        current = current.checked_add(chunk_len).ok_or_else(|| {
+            let reason: &str = "buffer address overflow";
+            error!("{reason} (pid={pid:?}, current={current:#x}, chunk_len={chunk_len})");
+            Error::new(ErrorCode::InvalidArgument, reason)
+        })?;
+        remaining -= chunk_len;
+    }
+
+    // Now that the segment vector has reached its final size and heap location, link each
+    // descriptor to the next. Performing the chaining here, rather than in the stdio transport,
+    // keeps all scatter/gather chain construction within the ipc subsystem.
+    chain_segments(&mut segments)?;
+
+    Ok(segments)
+}
+
+///
+/// # Description
+///
+/// Links scatter/gather descriptors together in place.
+///
+/// Each non-final descriptor is updated to record the guest virtual address of the descriptor that
+/// follows it; the final descriptor is terminated with a zero link. The descriptors must already
+/// reside at their final memory location, as their addresses are captured into the chain.
+///
+/// # Parameters
+///
+/// - `segments`: Scatter/gather descriptors to link.
+///
+/// # Returns
+///
+/// Upon success, empty is returned. Upon failure, an error is returned instead.
+///
+/// # Errors
+///
+/// This function returns an error if a descriptor address does not fit the guest/host wire format.
+///
+fn chain_segments(segments: &mut [GuestSgSegment]) -> Result<(), Error> {
+    for i in 0..segments.len() {
+        let next: VirtualAddress = if i + 1 < segments.len() {
+            VirtualAddress::try_from_ptr(
+                &segments[i + 1] as *const GuestSgSegment,
+                "scatter/gather segment descriptor address exceeds u32",
+            )?
+        } else {
+            VirtualAddress::from_raw_value(0)
+        };
+        segments[i].set_next(next);
+    }
+    Ok(())
+}

--- a/src/kernel/src/mm/kheap.rs
+++ b/src/kernel/src/mm/kheap.rs
@@ -47,10 +47,19 @@ const MIN_SLAB_SIZE: usize = SLAB_COUNT * mem::PAGE_SIZE;
 /// provided to initialize the heap.
 pub(crate) closed const MIN_HEAP_SIZE: usize = NUM_OF_SLABS * MIN_SLAB_SIZE;
 /// Maximum slab size in bytes. Allocations whose size or alignment exceed this are rejected.
-/// Use `512` directly because Verus does not yet support enum discriminants in const expressions:
-/// https://github.com/verus-lang/verus/issues/1107.
+///
+/// This must mirror [`config::kernel::MAX_SLAB_SIZE`], the shared kernel-heap budget. It is
+/// duplicated as the literal `512` here because Verus cannot evaluate cross-crate constants in
+/// specification contexts (and, separately, does not yet support enum discriminants in const
+/// expressions: https://github.com/verus-lang/verus/issues/1107). The `assert_eq!` below makes this
+/// a genuine dependency on the `config` crate: the kernel fails to compile if the two diverge.
 const MAX_SLAB_SIZE: usize = 512;
 }
+
+// Bind the Verus-visible literal above to the shared budget defined in the `config` crate. This
+// turns the duplicated literal into a compile-time dependency: if `config::kernel::MAX_SLAB_SIZE`
+// ever changes, this assertion forces the kernel-heap constant to be updated in lockstep.
+::static_assert::assert_eq!(MAX_SLAB_SIZE == ::config::kernel::MAX_SLAB_SIZE);
 
 //==================================================================================================
 //  Structures

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -20,10 +20,18 @@ use ::sys::{
         ErrorCode,
     },
     ipc::{
-        DataChunkHeader,
+        GuestSgBulkHeader,
+        GuestSgBulkKind,
+        GuestSgSegment,
         Message,
         MessageType,
+        SegmentCount,
         VmBusMessage,
+        VmBusMessageKind,
+    },
+    mm::{
+        Address,
+        VirtualAddress,
     },
     pm::{
         ProcessIdentifier,
@@ -57,10 +65,13 @@ pub fn write(message: Message) -> Result<(), Error> {
     }
 
     let bytes: [u8; mem::size_of::<Message>()] = message.to_bytes();
+    let message_addr: u32 =
+        VirtualAddress::try_from_ptr(bytes.as_ptr(), "message address exceeds u32")?
+            .into_raw_value() as u32;
 
     // Build vmbus message wrapping the message address.
     let vmbus_msg: VmBusMessage =
-        VmBusMessage::new(mem::size_of::<Message>() as u32, true, &bytes as *const u8 as u32);
+        VmBusMessage::new(mem::size_of::<Message>() as u32, VmBusMessageKind::Ikc, message_addr);
 
     // Write vmbus message to the kernel's standard output.
     // SAFETY: The standard output is present, initialized and thread-safe to write.
@@ -107,8 +118,11 @@ pub fn read() -> Result<Option<Message>, Error> {
     }
 
     // Build vmbus message wrapping the message buffer address.
+    let message_addr: u32 =
+        VirtualAddress::try_from_ptr(message.as_mut_ptr(), "message buffer address exceeds u32")?
+            .into_raw_value() as u32;
     let vmbus_msg: VmBusMessage =
-        VmBusMessage::new(NBYTES as u32, true, &mut message as *mut u8 as u32);
+        VmBusMessage::new(NBYTES as u32, VmBusMessageKind::Ikc, message_addr);
 
     // Read message from the kernel's standard input via the vmbus message.
     // SAFETY: The standard input is present, initialized and thread-safe to read.
@@ -151,8 +165,8 @@ pub fn read() -> Result<Option<Message>, Error> {
 /// # Description
 ///
 /// Writes a data chunk transfer envelope to the kernel's standard output. This sends the
-/// [`DataChunkHeader`] metadata to the VMM via the vmbus, which then reads the bulk payload
-/// directly from guest memory. This function is only available for the microvm machine type.
+/// [`GuestSgBulkHeader`] metadata to the VMM via the vmbus. This function is only available for
+/// the microvm machine type.
 ///
 /// # Parameters
 ///
@@ -160,7 +174,9 @@ pub fn read() -> Result<Option<Message>, Error> {
 /// - `source_tid`: Thread identifier of the source (sender).
 /// - `destination_pid`: Process identifier of the destination (receiver).
 /// - `destination_tid`: Thread identifier of the destination (receiver).
-/// - `buffer_addr`: Guest physical address of the bulk data buffer.
+/// - `kind`: Type of scatter/gather transfer.
+/// - `segments`: Scatter/gather segment list. The first segment is embedded in the header and the
+///   remaining segments are chained through guest memory addresses.
 /// - `data_len`: Number of bytes in the bulk payload.
 ///
 /// # Returns
@@ -172,23 +188,47 @@ pub fn write_bulk(
     source_tid: ThreadIdentifier,
     destination_pid: ProcessIdentifier,
     destination_tid: ThreadIdentifier,
-    buffer_addr: u32,
+    kind: GuestSgBulkKind,
+    segments: &[GuestSgSegment],
     data_len: u32,
 ) -> Result<(), Error> {
-    // Build data chunk transfer header in the caller's stack.
-    let header: DataChunkHeader = DataChunkHeader::new(
-        source_pid,
-        source_tid,
-        destination_pid,
-        destination_tid,
-        buffer_addr,
-        data_len,
-    );
+    if segments.is_empty() {
+        let reason: &str = "scatter/gather transfer has no segments";
+        error!("{reason} (source_pid={source_pid:?}, source_tid={source_tid:?})");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    let segment_count: SegmentCount = SegmentCount::try_from(segments.len()).inspect_err(|_| {
+        error!(
+            "too many scatter/gather segments (source_pid={source_pid:?}, \
+             source_tid={source_tid:?}, segments={})",
+            segments.len()
+        );
+    })?;
 
-    // Build a vmbus message referencing the header. The vmbus message signals a data chunk transfer by
-    // setting `is_ikc` to `false` and `size` to the bulk payload length.
+    // Build scatter/gather transfer header in the caller's stack. The descriptor chain (the `next`
+    // links between segments) is wired up by the ipc subsystem that built `segments`.
+    let header: GuestSgBulkHeader = GuestSgBulkHeader::new(
+        (source_pid, source_tid),
+        (destination_pid, destination_tid),
+        kind,
+        segment_count,
+        data_len,
+        segments[0],
+    );
+    let reason: &str = "scatter/gather header address exceeds u32";
+    let header_addr: u32 = VirtualAddress::try_from_ptr(&header as *const GuestSgBulkHeader, reason)
+        .inspect_err(|_| {
+            let header_addr: usize = &header as *const GuestSgBulkHeader as usize;
+            error!(
+                "{reason} (source_pid={source_pid:?}, source_tid={source_tid:?}, \
+                 header_addr={header_addr:#x})"
+            );
+        })?
+        .into_raw_value() as u32;
+
+    // Build a vmbus message referencing the scatter/gather header.
     let vmbus_msg: VmBusMessage =
-        VmBusMessage::new(data_len, false, &header as *const DataChunkHeader as u32);
+        VmBusMessage::new(data_len, VmBusMessageKind::GuestSgBulk, header_addr);
 
     // Write vmbus message to the kernel's standard output.
     // SAFETY: The standard output is present, initialized and thread-safe to write.

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -166,6 +166,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     constants.push_str(&format!("pub const IKC_POLL_BATCH_SIZE: usize = {val};\n"));
 
     let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "max_slab_size"),
+        "max_slab_size",
+    );
+    constants.push_str(&format!("pub const MAX_SLAB_SIZE: usize = {val};\n"));
+
+    let val: usize = parse_hex_or_decimal_usize(
         required_key(&kernel_config_toml, "debug_buffer_size"),
         "debug_buffer_size",
     );
@@ -262,6 +268,17 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         "max_processes ({}) must not exceed u8::MAX ({})",
         max_processes,
         u8::MAX,
+    );
+
+    // max_slab_size must be a power of two so it lines up with the kernel heap's slab tiers.
+    let max_slab_size: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "max_slab_size"),
+        "max_slab_size",
+    );
+    assert!(
+        max_slab_size.is_power_of_two(),
+        "max_slab_size ({}) must be a power of two",
+        max_slab_size,
     );
 
     // Write the generated file.

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -11,12 +11,60 @@ use crate::{
         ErrorCode,
     },
     ipc::typ::MessageType,
+    mm::{
+        Address,
+        Alignment,
+        VirtualAddress,
+    },
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
     },
 };
 use ::core::mem;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Page size, in bytes, used to reason about scatter/gather bulk transfer limits.
+///
+/// Scatter/gather chains describe guest memory at page granularity, so the limits below are
+/// expressed as multiples of this value rather than as opaque byte counts. Sourced from
+/// [`Alignment`] (the same canonical definition that the `arch` crate's page alignment resolves to)
+/// because the `sys` crate cannot depend on the `arch` crate: `arch` already depends on `sys`, so
+/// the reverse dependency would form a cycle.
+const PAGE_SIZE: usize = Alignment::Align4096 as usize;
+
+/// Largest single allocation, in bytes, that the guest kernel's slab heap allocator can satisfy.
+///
+/// The kernel assembles the scatter/gather descriptor list for a transfer as one contiguous heap
+/// allocation, and its slab allocator rejects any request larger than this. Sourced from the shared
+/// [`config::kernel::MAX_SLAB_SIZE`] budget (the same value the kernel heap enforces in
+/// `kernel::mm::kheap`) so the kernel can always build the descriptor chain without overflowing the
+/// heap; reading the same constant keeps the two in sync.
+const SG_BULK_MAX_DESCRIPTOR_BYTES: usize = config::kernel::MAX_SLAB_SIZE;
+
+/// Maximum number of segments in a scatter/gather bulk transfer.
+///
+/// In the worst case every page of a transfer is physically discontiguous and needs its own segment
+/// descriptor, so the kernel builds up to this many [`GuestSgSegment`] descriptors in a single
+/// heap allocation. The limit is therefore the number of fixed-size descriptors that fit within
+/// [`SG_BULK_MAX_DESCRIPTOR_BYTES`]; raising that heap budget is required before this can grow.
+///
+/// Typed as `u16` to match the wire representation of a segment count, so call sites do not need a
+/// narrowing `as` cast. The single narrowing cast below is a compile-time constant that is
+/// provably lossless (the descriptor budget is far smaller than `u16::MAX`).
+pub const SG_BULK_MAX_SEGMENTS: u16 = (SG_BULK_MAX_DESCRIPTOR_BYTES / GuestSgSegment::SIZE) as u16;
+
+/// Maximum number of bytes in a scatter/gather bulk transfer.
+///
+/// Guideline: this is derived from [`SG_BULK_MAX_SEGMENTS`] assuming the worst case of one page per
+/// segment, so the byte ceiling is the segment ceiling times the page size. Keeping it a multiple
+/// of [`PAGE_SIZE`] ensures the two limits stay consistent. Larger user transfers are split
+/// into several bulk transfers by the read/write chunking path, so this bounds a single transfer
+/// rather than the total amount a caller may move.
+pub const SG_BULK_MAX_BYTES: usize = SG_BULK_MAX_SEGMENTS as usize * PAGE_SIZE;
 
 //==================================================================================================
 // Structures
@@ -253,12 +301,43 @@ impl Default for Message {
 pub struct VmBusMessage {
     /// Size of the message in bytes (stored as `u64`, logical type is `u32`).
     size: u64,
-    /// Whether this is an IKC message (stored as `u64`, logical type is `bool`).
-    is_ikc: u64,
+    /// Type of message carried by this envelope (stored as `u64`).
+    kind: u64,
     /// Guest virtual address of the message (stored as `u64`, logical type is `u32`).
     message_addr: u64,
 }
 ::static_assert::assert_eq_size!(VmBusMessage, 3 * mem::size_of::<u64>());
+
+///
+/// # Description
+///
+/// Message kind carried by a [`VmBusMessage`].
+///
+#[repr(u64)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmBusMessageKind {
+    /// Legacy contiguous bulk transfer descriptor.
+    LegacyBulk = 0,
+    /// Standard IKC message.
+    Ikc = 1,
+    /// Guest scatter/gather bulk transfer descriptor.
+    GuestSgBulk = 2,
+}
+
+impl TryFrom<u64> for VmBusMessageKind {
+    type Error = Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        // Match against the enum discriminants themselves so the wire values have a single source
+        // of truth and are not duplicated as literals here.
+        match value {
+            value if value == Self::LegacyBulk as u64 => Ok(Self::LegacyBulk),
+            value if value == Self::Ikc as u64 => Ok(Self::Ikc),
+            value if value == Self::GuestSgBulk as u64 => Ok(Self::GuestSgBulk),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid vmbus message kind")),
+        }
+    }
+}
 
 //==================================================================================================
 // Implementations
@@ -276,17 +355,17 @@ impl VmBusMessage {
     /// # Parameters
     ///
     /// - `size`: Size of the message in bytes.
-    /// - `is_ikc`: Whether this is an IKC message.
+    /// - `kind`: Type of message carried by this envelope.
     /// - `message_addr`: Guest virtual address of the message.
     ///
     /// # Returns
     ///
     /// The new message envelope.
     ///
-    pub fn new(size: u32, is_ikc: bool, message_addr: u32) -> Self {
+    pub fn new(size: u32, kind: VmBusMessageKind, message_addr: u32) -> Self {
         Self {
             size: size as u64,
-            is_ikc: is_ikc as u64,
+            kind: kind as u64,
             message_addr: message_addr as u64,
         }
     }
@@ -316,23 +395,40 @@ impl VmBusMessage {
     ///
     /// # Description
     ///
-    /// Returns whether this is an IKC message.
+    /// Returns the type of message carried by this envelope.
     ///
-    pub fn is_ikc(&self) -> bool {
-        self.is_ikc != 0
+    /// # Returns
+    ///
+    /// Upon success, the message kind is returned. Upon failure, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the envelope contains an unknown message kind.
+    ///
+    pub fn kind(&self) -> Result<VmBusMessageKind, Error> {
+        VmBusMessageKind::try_from(self.kind)
     }
 
     ///
     /// # Description
     ///
-    /// Sets whether this is an IKC message.
+    /// Returns whether this is an IKC message.
+    ///
+    pub fn is_ikc(&self) -> bool {
+        self.kind == VmBusMessageKind::Ikc as u64
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the type of message carried by this envelope.
     ///
     /// # Parameters
     ///
-    /// - `is_ikc`: Whether this is an IKC message.
+    /// - `kind`: Type of message carried by this envelope.
     ///
-    pub fn set_is_ikc(&mut self, is_ikc: bool) {
-        self.is_ikc = is_ikc as u64;
+    pub fn set_kind(&mut self, kind: VmBusMessageKind) {
+        self.kind = kind as u64;
     }
 
     ///
@@ -367,6 +463,8 @@ impl VmBusMessage {
     /// A byte array that represents the target message envelope.
     ///
     pub fn to_bytes(self) -> [u8; Self::SIZE] {
+        // SAFETY: The header is `repr(C)` and contains only fixed-width integer fields, so its
+        // in-memory representation is exactly `Self::SIZE` bytes.
         unsafe { mem::transmute(self) }
     }
 
@@ -395,26 +493,23 @@ impl VmBusMessage {
 }
 
 //==================================================================================================
-// DataChunkHeader
+// HostBulkTransferHeader
 //==================================================================================================
 
 ///
 /// # Description
 ///
-/// Header structure describing a data chunk transfer between a user process and the kernel
-/// (linuxd). This header is placed in guest memory and referenced by a [`VmBusMessage`] with
-/// `is_ikc` set to `false`. The `message_addr` field of the envelope points to this header, and
-/// the envelope's `size` field holds the byte count of the bulk payload.
+/// Header structure describing a contiguous data chunk transfer between UserVM and linuxd.
 ///
 /// # Notes
 ///
 /// - All fields use fixed-width types for ABI stability across the guest/host boundary.
-/// - The `data_addr` field stores a guest physical address pointing to the bulk payload buffer.
-/// - This structure is `no_std`-compatible so it can be used inside the kernel.
+/// - The `data_addr` field stores an opaque UserVM value. It may be a guest physical address on
+///   legacy paths, or a UserVM transfer identifier for scatter/gather pull responses.
 ///
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct DataChunkHeader {
+pub struct HostBulkTransferHeader {
     /// Process identifier of the source (sender), stored as a fixed-width `i32`.
     source_pid: i32,
     /// Thread identifier of the source (sender), stored as a fixed-width `i32`.
@@ -423,18 +518,21 @@ pub struct DataChunkHeader {
     destination_pid: i32,
     /// Thread identifier of the destination (receiver), stored as a fixed-width `i32`.
     destination_tid: i32,
-    /// Guest physical address of the bulk data buffer.
+    /// Opaque bulk payload location.
+    ///
+    /// This is a guest physical address on legacy contiguous paths and a UserVM transfer identifier
+    /// on scatter/gather pull responses.
     data_addr: u32,
     /// Number of bytes in the bulk payload.
     data_len: u32,
 }
-::static_assert::assert_eq_size!(DataChunkHeader, 6 * mem::size_of::<u32>());
+::static_assert::assert_eq_size!(HostBulkTransferHeader, 6 * mem::size_of::<u32>());
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl DataChunkHeader {
+impl HostBulkTransferHeader {
     /// Size of the header in bytes.
     pub const SIZE: usize = mem::size_of::<Self>();
 
@@ -449,7 +547,7 @@ impl DataChunkHeader {
     /// - `source_tid`: Thread identifier of the source.
     /// - `destination_pid`: Process identifier of the destination.
     /// - `destination_tid`: Thread identifier of the destination.
-    /// - `data_addr`: Guest physical address of the bulk data buffer.
+    /// - `data_addr`: Guest physical address or opaque UserVM transfer identifier.
     /// - `data_len`: Number of bytes in the bulk payload.
     ///
     /// # Returns
@@ -517,7 +615,7 @@ impl DataChunkHeader {
     ///
     /// # Description
     ///
-    /// Returns the guest physical address of the bulk data buffer.
+    /// Returns the guest physical address or opaque UserVM transfer identifier.
     ///
     pub fn data_addr(&self) -> u32 {
         self.data_addr
@@ -566,6 +664,380 @@ impl DataChunkHeader {
     /// validation is added in the future.
     ///
     pub fn try_from_bytes(bytes: [u8; Self::SIZE]) -> Result<Self, Error> {
-        Ok(unsafe { mem::transmute::<[u8; Self::SIZE], DataChunkHeader>(bytes) })
+        // SAFETY: All bit patterns are valid because the header contains only fixed-width integer
+        // fields.
+        Ok(unsafe { mem::transmute::<[u8; Self::SIZE], HostBulkTransferHeader>(bytes) })
+    }
+}
+
+/// Backwards-compatible name for the contiguous UserVM/linuxd bulk header.
+pub type DataChunkHeader = HostBulkTransferHeader;
+
+///
+/// # Description
+///
+/// Kind of guest scatter/gather bulk transfer.
+///
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestSgBulkKind {
+    /// UserVM should gather guest memory and send it to linuxd.
+    Push = 1,
+    /// UserVM should register guest memory as the destination for a later linuxd response.
+    Pull = 2,
+}
+
+impl TryFrom<u16> for GuestSgBulkKind {
+    type Error = Error;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        // Match against the enum discriminants themselves so the wire values have a single source
+        // of truth and are not duplicated as literals here.
+        match value {
+            value if value == Self::Push as u16 => Ok(Self::Push),
+            value if value == Self::Pull as u16 => Ok(Self::Pull),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid scatter/gather kind")),
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// A guest physical memory segment in a scatter/gather bulk transfer.
+///
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct GuestSgSegment {
+    /// Guest virtual address of the next segment descriptor, or zero if this is the last segment.
+    ///
+    /// Stored as a fixed-width `u32` for ABI stability across the guest/host boundary; the typed
+    /// [`VirtualAddress`] accessors convert to and from this representation.
+    next: u32,
+    /// Guest physical address of this segment's data.
+    data_gpa: u32,
+    /// Number of bytes in this segment.
+    data_len: u32,
+}
+::static_assert::assert_eq_size!(GuestSgSegment, 3 * mem::size_of::<u32>());
+
+impl GuestSgSegment {
+    /// Size of the segment descriptor in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new guest scatter/gather segment.
+    ///
+    /// # Parameters
+    ///
+    /// - `next`: Guest virtual address of the next segment descriptor, or zero for the last
+    ///   segment.
+    /// - `data_gpa`: Guest physical address of this segment's data.
+    /// - `data_len`: Number of bytes in this segment.
+    ///
+    /// # Returns
+    ///
+    /// The new guest scatter/gather segment.
+    ///
+    pub fn new(next: VirtualAddress, data_gpa: u32, data_len: u32) -> Self {
+        Self {
+            next: next.into_raw_value() as u32,
+            data_gpa,
+            data_len,
+        }
+    }
+
+    /// Returns the guest virtual address of the next descriptor.
+    pub fn next(&self) -> VirtualAddress {
+        VirtualAddress::from_raw_value(self.next as usize)
+    }
+
+    /// Sets the guest virtual address of the next descriptor.
+    pub fn set_next(&mut self, next: VirtualAddress) {
+        self.next = next.into_raw_value() as u32;
+    }
+
+    /// Returns the guest physical address of this segment's data.
+    pub fn data_gpa(&self) -> u32 {
+        self.data_gpa
+    }
+
+    /// Returns the number of bytes in this segment.
+    pub fn data_len(&self) -> u32 {
+        self.data_len
+    }
+
+    /// Sets the number of bytes in this segment.
+    pub fn set_data_len(&mut self, data_len: u32) {
+        self.data_len = data_len;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts the segment descriptor to a byte array.
+    ///
+    /// # Returns
+    ///
+    /// A byte array that represents the segment descriptor.
+    ///
+    pub fn to_bytes(self) -> [u8; Self::SIZE] {
+        // SAFETY: The segment is `repr(C)` and contains only fixed-width integer fields, so its
+        // in-memory representation is exactly `Self::SIZE` bytes.
+        unsafe { mem::transmute(self) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a byte array to a segment descriptor.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: The byte array to convert.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the segment descriptor is returned. Upon failure, an error is returned
+    /// instead.
+    ///
+    /// # Errors
+    ///
+    /// This function currently cannot fail because all bit patterns are valid for the `repr(C)`
+    /// layout. The `Result` return type is retained for forward compatibility in case field
+    /// validation is added in the future.
+    ///
+    pub fn try_from_bytes(bytes: [u8; Self::SIZE]) -> Result<Self, Error> {
+        // SAFETY: All bit patterns are valid because the segment contains only fixed-width integer
+        // fields.
+        Ok(unsafe { mem::transmute::<[u8; Self::SIZE], GuestSgSegment>(bytes) })
+    }
+}
+
+///
+/// # Description
+///
+/// Number of segments in a scatter/gather bulk transfer.
+///
+/// This is a thin newtype over `u16` (the wire representation) that provides stronger type safety
+/// than a bare integer when describing the length of a scatter/gather segment chain.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SegmentCount(u16);
+
+impl SegmentCount {
+    /// Maximum number of segments a scatter/gather bulk transfer may contain.
+    pub const MAX: Self = Self(SG_BULK_MAX_SEGMENTS);
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new [`SegmentCount`] from a raw count.
+    ///
+    /// # Parameters
+    ///
+    /// - `count`: Number of segments.
+    ///
+    /// # Returns
+    ///
+    /// The new segment count.
+    ///
+    pub fn new(count: u16) -> Self {
+        Self(count)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the raw number of segments.
+    ///
+    pub fn get(self) -> u16 {
+        self.0
+    }
+}
+
+impl TryFrom<usize> for SegmentCount {
+    type Error = Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value == 0 || value > SG_BULK_MAX_SEGMENTS as usize {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "invalid scatter/gather segment count",
+            ));
+        }
+        let count: u16 = u16::try_from(value).map_err(|_| {
+            Error::new(ErrorCode::InvalidArgument, "too many scatter/gather segments")
+        })?;
+        Ok(Self(count))
+    }
+}
+
+///
+/// # Description
+///
+/// Guest scatter/gather bulk transfer descriptor consumed by UserVM.
+///
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct GuestSgBulkHeader {
+    /// Process identifier of the source.
+    source_pid: i32,
+    /// Thread identifier of the source.
+    source_tid: i32,
+    /// Process identifier of the destination.
+    destination_pid: i32,
+    /// Thread identifier of the destination.
+    destination_tid: i32,
+    /// Scatter/gather transfer kind.
+    kind: u16,
+    /// Number of segments in the chain, including `first`.
+    segment_count: u16,
+    /// Total number of bytes in the transfer.
+    total_len: u32,
+    /// First segment descriptor.
+    first: GuestSgSegment,
+}
+::static_assert::assert_eq_size!(GuestSgBulkHeader, 9 * mem::size_of::<u32>());
+
+impl GuestSgBulkHeader {
+    /// Size of the scatter/gather bulk header in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new guest scatter/gather bulk header.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Process and thread identifiers of the source.
+    /// - `destination`: Process and thread identifiers of the destination.
+    /// - `kind`: Type of scatter/gather transfer.
+    /// - `segment_count`: Number of segments in the chain, including `first`.
+    /// - `total_len`: Total number of bytes in the transfer.
+    /// - `first`: First segment descriptor.
+    ///
+    /// # Returns
+    ///
+    /// The new guest scatter/gather bulk header.
+    ///
+    pub fn new(
+        source: (ProcessIdentifier, ThreadIdentifier),
+        destination: (ProcessIdentifier, ThreadIdentifier),
+        kind: GuestSgBulkKind,
+        segment_count: SegmentCount,
+        total_len: u32,
+        first: GuestSgSegment,
+    ) -> Self {
+        let (source_pid, source_tid) = source;
+        let (destination_pid, destination_tid) = destination;
+        Self {
+            source_pid: source_pid.into(),
+            source_tid: source_tid.into(),
+            destination_pid: destination_pid.into(),
+            destination_tid: destination_tid.into(),
+            kind: kind as u16,
+            segment_count: segment_count.get(),
+            total_len,
+            first,
+        }
+    }
+
+    /// Returns the process identifier of the source.
+    pub fn source_pid(&self) -> ProcessIdentifier {
+        ProcessIdentifier::from(self.source_pid)
+    }
+
+    /// Returns the thread identifier of the source.
+    pub fn source_tid(&self) -> ThreadIdentifier {
+        ThreadIdentifier::from(self.source_tid)
+    }
+
+    /// Returns the process identifier of the destination.
+    pub fn destination_pid(&self) -> ProcessIdentifier {
+        ProcessIdentifier::from(self.destination_pid)
+    }
+
+    /// Returns the thread identifier of the destination.
+    pub fn destination_tid(&self) -> ThreadIdentifier {
+        ThreadIdentifier::from(self.destination_tid)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the scatter/gather transfer kind.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the scatter/gather transfer kind is returned. Upon failure, an error is
+    /// returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the header contains an unknown scatter/gather transfer
+    /// kind.
+    ///
+    pub fn kind(&self) -> Result<GuestSgBulkKind, Error> {
+        GuestSgBulkKind::try_from(self.kind)
+    }
+
+    /// Returns the number of segments in the chain.
+    pub fn segment_count(&self) -> SegmentCount {
+        SegmentCount::new(self.segment_count)
+    }
+
+    /// Returns the total number of bytes in the transfer.
+    pub fn total_len(&self) -> u32 {
+        self.total_len
+    }
+
+    /// Returns the first segment descriptor.
+    pub fn first(&self) -> GuestSgSegment {
+        self.first
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts the scatter/gather bulk header to a byte array.
+    ///
+    /// # Returns
+    ///
+    /// A byte array that represents the scatter/gather bulk header.
+    ///
+    pub fn to_bytes(self) -> [u8; Self::SIZE] {
+        // SAFETY: The header is `repr(C)` and contains only fixed-width integer fields plus a
+        // fixed-layout segment, so its in-memory representation is exactly `Self::SIZE` bytes.
+        unsafe { mem::transmute(self) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a byte array to a scatter/gather bulk header.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: The byte array to convert.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the scatter/gather bulk header is returned. Upon failure, an error is returned
+    /// instead.
+    ///
+    /// # Errors
+    ///
+    /// This function currently cannot fail because all bit patterns are valid for the `repr(C)`
+    /// layout. The `Result` return type is retained for forward compatibility in case field
+    /// validation is added in the future.
+    ///
+    pub fn try_from_bytes(bytes: [u8; Self::SIZE]) -> Result<Self, Error> {
+        // SAFETY: All bit patterns are valid because the header contains only fixed-width integer
+        // fields and a segment whose bit patterns are all valid.
+        Ok(unsafe { mem::transmute::<[u8; Self::SIZE], GuestSgBulkHeader>(bytes) })
     }
 }

--- a/src/libs/sys/src/sys/ipc/message/mod.rs
+++ b/src/libs/sys/src/sys/ipc/message/mod.rs
@@ -16,10 +16,18 @@ mod transfer;
 
 pub use kernel::{
     DataChunkHeader,
+    GuestSgBulkHeader,
+    GuestSgBulkKind,
+    GuestSgSegment,
+    HostBulkTransferHeader,
     Message,
     MessageReceiver,
     MessageSender,
+    SegmentCount,
     VmBusMessage,
+    VmBusMessageKind,
+    SG_BULK_MAX_BYTES,
+    SG_BULK_MAX_SEGMENTS,
 };
 pub use system::{
     SystemMessage,

--- a/src/libs/sys/src/sys/ipc/message/transfer.rs
+++ b/src/libs/sys/src/sys/ipc/message/transfer.rs
@@ -17,9 +17,9 @@ use crate::ipc::{
 ///
 /// # Description
 ///
-/// Represents a data chunk transfer between a user process and the kernel (linuxd). This structure
-/// pairs the fixed-size [`DataChunkHeader`] with a variable-length data buffer that holds the
-/// actual payload bytes.
+/// Represents a contiguous bulk transfer between UserVM and linuxd. This structure pairs the
+/// fixed-size [`DataChunkHeader`] with a variable-length data buffer that holds the actual payload
+/// bytes.
 ///
 /// # Notes
 ///

--- a/src/libs/sys/src/sys/mm/address/virt.rs
+++ b/src/libs/sys/src/sys/mm/address/virt.rs
@@ -57,6 +57,35 @@ impl VirtualAddress {
     ///
     /// # Description
     ///
+    /// Converts a pointer into a [`VirtualAddress`], validating that it fits the 32-bit guest/host
+    /// wire format used to locate the referenced bytes over the vmbus.
+    ///
+    /// # Parameters
+    ///
+    /// - `ptr`: Pointer to convert.
+    /// - `reason`: Human-readable reason carried by the returned error if the pointer does not fit
+    ///   the guest/host wire format.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the [`VirtualAddress`] is returned. Upon failure, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the pointer does not fit the 32-bit guest/host address
+    /// width.
+    ///
+    pub fn try_from_ptr<T>(ptr: *const T, reason: &'static str) -> Result<Self, Error> {
+        let addr: usize = ptr as usize;
+        if u32::try_from(addr).is_err() {
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        Ok(VirtualAddress::new(addr))
+    }
+
+    ///
+    /// # Description
+    ///
     /// Aligns the target [`VirtualAddress`] to the provided `alignment`. If the address is already
     /// aligned, it is returned as is.
     ///

--- a/src/libs/syscall/src/unistd/syscall/mod.rs
+++ b/src/libs/syscall/src/unistd/syscall/mod.rs
@@ -11,6 +11,12 @@
 #[cfg(any(feature = "syscall", feature = "std", test))]
 mod getopt;
 
+// The scatter/gather chunking helper in `util` is pure Rust and host-testable, so it is also
+// compiled under `test`. Its only non-test consumers (`read`/`write`) are gated behind the
+// `syscall` feature, which keeps `util` available there too.
+#[cfg(any(feature = "syscall", test))]
+mod util;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {
         mod _exit;
@@ -46,7 +52,6 @@ cfg_if::cfg_if! {
         mod symlink;
         mod symlinkat;
         mod unlink;
-        mod util;
         mod write;
     }
 }

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -41,7 +41,7 @@ use ::sysapi::{
 ///
 /// # Description
 ///
-/// Reads a single page-aligned chunk from a file descriptor via IKC. Sends a ReadRequest,
+/// Reads a single page-bounded chunk from a file descriptor via IKC. Sends a ReadRequest,
 /// pulls the chunk data, and receives the ReadResponse.
 ///
 /// # Parameters
@@ -269,7 +269,13 @@ fn read_ipc(
         total_read += count;
         offset += count as usize;
 
-        // Short read: fewer bytes returned than the chunk size.
+        // A short reply ends the read. Because the chunk never spans more than one page (see
+        // `page_chunk_size`) and the IKC backends deliver up to a full page per request, receiving
+        // fewer bytes than requested means the input is exhausted: end-of-file for a regular file,
+        // or no more bytes currently available for a stream. Continuing here would truncate neither
+        // a multi-page file (the next page is fetched on the following iteration) nor block a
+        // partially-filled stream. Do not switch this loop to multi-page chunks without revisiting
+        // this guard: a capped multi-page reply is indistinguishable from genuine end-of-input.
         if (count as usize) < chunk_size {
             break;
         }

--- a/src/libs/syscall/src/unistd/syscall/util.rs
+++ b/src/libs/syscall/src/unistd/syscall/util.rs
@@ -7,6 +7,10 @@
 
 use ::arch::mem::PAGE_SIZE;
 use ::core::cmp;
+use ::sys::ipc::{
+    SG_BULK_MAX_BYTES,
+    SG_BULK_MAX_SEGMENTS,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -15,10 +19,48 @@ use ::core::cmp;
 ///
 /// # Description
 ///
+/// Computes the number of bytes that can be represented by a single scatter/gather bulk transfer.
+///
+/// # Parameters
+///
+/// - `ptr`: Start address of the buffer.
+/// - `remaining`: Total number of bytes remaining to transfer.
+///
+/// # Returns
+///
+/// The number of bytes that fit within the scatter/gather limits.
+///
+pub fn sg_chunk_size(ptr: usize, remaining: usize) -> usize {
+    if remaining == 0 {
+        return 0;
+    }
+
+    let page_offset: usize = ptr & (PAGE_SIZE - 1);
+    let first_page_bytes: usize = PAGE_SIZE - page_offset;
+    let max_by_segments: usize = if SG_BULK_MAX_SEGMENTS == 0 {
+        0
+    } else {
+        first_page_bytes + (SG_BULK_MAX_SEGMENTS as usize - 1) * PAGE_SIZE
+    };
+
+    cmp::min(remaining, cmp::min(SG_BULK_MAX_BYTES, max_by_segments))
+}
+
+///
+/// # Description
+///
 /// Computes the number of bytes that can be transferred starting at `ptr` without crossing a page
-/// boundary. The kernel's data chunk transfer path can stage page-crossing buffers through a
-/// bounce page, but chunking callers at page boundaries keeps the common path on the direct
-/// single-page transfer.
+/// boundary.
+///
+/// Unlike [`sg_chunk_size`], this caps a chunk at a single page. The read path uses it because the
+/// IKC backends deliver at most one page per request: vfsd reads into a one-page bulk buffer, and
+/// the standalone stdin bridge returns only the bytes currently available. With page-sized requests
+/// a short reply unambiguously signals end-of-input -- true EOF for files, "no more bytes ready"
+/// for streams -- so the read loop can stop without truncating a multi-page file or blocking a
+/// partially-filled stream. A multi-page request would instead be capped by the backend, and the
+/// resulting short reply would be indistinguishable from EOF. The write path has no such ambiguity
+/// (the whole source buffer is already available, so it loops until no forward progress is made)
+/// and therefore keeps using [`sg_chunk_size`].
 ///
 /// # Parameters
 ///
@@ -33,4 +75,164 @@ pub fn page_chunk_size(ptr: usize, remaining: usize) -> usize {
     let page_offset: usize = ptr & (PAGE_SIZE - 1);
     let available: usize = PAGE_SIZE - page_offset;
     cmp::min(available, remaining)
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Number of distinct pages a `len`-byte buffer starting at `ptr` touches. This is the upper
+    /// bound on the number of scatter/gather segment descriptors the kernel builds for the chunk,
+    /// because the kernel emits at most one descriptor per page it spans (contiguous physical pages
+    /// are merged, so the real count is never larger).
+    fn pages_spanned(ptr: usize, len: usize) -> usize {
+        if len == 0 {
+            return 0;
+        }
+        let page_offset: usize = ptr & (PAGE_SIZE - 1);
+        (page_offset + len).div_ceil(PAGE_SIZE)
+    }
+
+    /// A zero-length request transfers nothing.
+    #[test]
+    fn zero_remaining_yields_zero() {
+        assert_eq!(sg_chunk_size(0, 0), 0, "an empty request must produce an empty chunk");
+        assert_eq!(
+            sg_chunk_size(PAGE_SIZE - 1, 0),
+            0,
+            "an empty request must produce an empty chunk regardless of alignment"
+        );
+    }
+
+    /// A buffer that already fits within the limits is transferred whole.
+    #[test]
+    fn small_buffer_is_not_split() {
+        assert_eq!(sg_chunk_size(0, 100), 100, "a small page-aligned buffer must not be split");
+        assert_eq!(
+            sg_chunk_size(PAGE_SIZE - 10, 5),
+            5,
+            "a small buffer within a single page must not be split"
+        );
+    }
+
+    /// A page-aligned buffer larger than the limit is capped at the maximum transfer size.
+    #[test]
+    fn page_aligned_large_buffer_caps_at_max_bytes() {
+        assert_eq!(
+            sg_chunk_size(0, SG_BULK_MAX_BYTES * 4),
+            SG_BULK_MAX_BYTES,
+            "a page-aligned buffer must be capped at the maximum scatter/gather transfer size"
+        );
+    }
+
+    /// The chunk size must never describe more pages than the kernel can turn into descriptors in a
+    /// single bounded heap allocation. This is the invariant that keeps the kernel's descriptor
+    /// list within one heap slab; violating it reintroduces an unbounded allocation that the
+    /// kernel-heap allocator rejects.
+    #[test]
+    fn chunk_never_exceeds_segment_budget() {
+        let offsets: [usize; 6] = [0, 1, 37, PAGE_SIZE / 2, PAGE_SIZE - 100, PAGE_SIZE - 1];
+        let remainings: [usize; 5] = [
+            1,
+            PAGE_SIZE,
+            SG_BULK_MAX_BYTES - 1,
+            SG_BULK_MAX_BYTES,
+            SG_BULK_MAX_BYTES * 3,
+        ];
+
+        for &offset in &offsets {
+            for &remaining in &remainings {
+                let chunk: usize = sg_chunk_size(offset, remaining);
+
+                assert!(
+                    chunk > 0,
+                    "a non-empty request must make progress (offset={offset}, \
+                     remaining={remaining})"
+                );
+                assert!(
+                    chunk <= remaining,
+                    "a chunk must never exceed the requested length (offset={offset}, \
+                     remaining={remaining}, chunk={chunk})"
+                );
+                assert!(
+                    chunk <= SG_BULK_MAX_BYTES,
+                    "a chunk must never exceed the maximum transfer size (offset={offset}, \
+                     remaining={remaining}, chunk={chunk})"
+                );
+                assert!(
+                    pages_spanned(offset, chunk) <= SG_BULK_MAX_SEGMENTS as usize,
+                    "a chunk must never span more pages than the segment budget (offset={offset}, \
+                     remaining={remaining}, chunk={chunk}, pages={}, max={SG_BULK_MAX_SEGMENTS})",
+                    pages_spanned(offset, chunk)
+                );
+            }
+        }
+    }
+
+    /// A `page_chunk_size` request that stays within a single page is transferred whole.
+    #[test]
+    fn page_chunk_within_single_page_is_not_split() {
+        assert_eq!(
+            page_chunk_size(0, 100),
+            100,
+            "a small page-aligned buffer must be transferred whole"
+        );
+        assert_eq!(
+            page_chunk_size(PAGE_SIZE - 10, 5),
+            5,
+            "a small buffer that stays within one page must be transferred whole"
+        );
+    }
+
+    /// A `page_chunk_size` request is capped at the end of the page that holds its first byte, so a
+    /// chunk never crosses a page boundary. This is the property that lets the read loop treat a
+    /// short reply as end-of-input rather than truncating a multi-page transfer.
+    #[test]
+    fn page_chunk_stops_at_page_boundary() {
+        assert_eq!(
+            page_chunk_size(0, PAGE_SIZE * 4),
+            PAGE_SIZE,
+            "a page-aligned multi-page request must be capped at a single page"
+        );
+        assert_eq!(
+            page_chunk_size(PAGE_SIZE - 100, PAGE_SIZE * 4),
+            100,
+            "an unaligned request must be capped at the bytes left in its first page"
+        );
+    }
+
+    /// Whatever the alignment and length, a `page_chunk_size` chunk must make forward progress and
+    /// must never straddle a page boundary.
+    #[test]
+    fn page_chunk_never_crosses_a_page() {
+        let offsets: [usize; 6] = [0, 1, 37, PAGE_SIZE / 2, PAGE_SIZE - 100, PAGE_SIZE - 1];
+        let remainings: [usize; 5] = [1, 100, PAGE_SIZE - 1, PAGE_SIZE, PAGE_SIZE * 3 + 7];
+
+        for &offset in &offsets {
+            for &remaining in &remainings {
+                let chunk: usize = page_chunk_size(offset, remaining);
+
+                assert!(
+                    chunk > 0,
+                    "a non-empty request must make progress (offset={offset}, \
+                     remaining={remaining})"
+                );
+                assert!(
+                    chunk <= remaining,
+                    "a chunk must never exceed the requested length (offset={offset}, \
+                     remaining={remaining}, chunk={chunk})"
+                );
+                let page_offset: usize = offset & (PAGE_SIZE - 1);
+                assert!(
+                    page_offset + chunk <= PAGE_SIZE,
+                    "a chunk must never cross a page boundary (offset={offset}, \
+                     remaining={remaining}, chunk={chunk})"
+                );
+            }
+        }
+    }
 }

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -5,7 +5,7 @@
 // Imports
 //==================================================================================================
 
-use super::util::page_chunk_size;
+use super::util::sg_chunk_size;
 use crate::{
     safe::RawFileDescriptor,
     unistd::message::{
@@ -44,14 +44,14 @@ use ::sysapi::{
 ///
 /// # Description
 ///
-/// Writes a single page-aligned chunk to a file descriptor via IKC. Sends a WriteRequest,
+/// Writes a single scatter/gather chunk to a file descriptor via IKC. Sends a WriteRequest,
 /// pushes the chunk data, and receives the WriteResponse.
 ///
 /// # Parameters
 ///
 /// - `tid`: Thread identifier of the calling thread.
 /// - `fd`: File descriptor.
-/// - `chunk`: Byte slice to write (must not cross a page boundary).
+/// - `chunk`: Byte slice to write.
 ///
 /// # Returns
 ///
@@ -102,6 +102,34 @@ fn write_chunk(
     match message.header {
         SystemCallMessageHeader::WriteResponse => {
             let response: WriteResponse = WriteResponse::from_bytes(message.payload);
+            let count: i32 = response.count;
+
+            if count < 0 {
+                ::syslog::warn!(
+                    "write_chunk(): linuxd returned negative count (fd={:?}, count={:?})",
+                    fd,
+                    count
+                );
+                return Err(Error::new(
+                    ErrorCode::InvalidMessage,
+                    "write response count is negative",
+                ));
+            }
+
+            if (count as usize) > chunk.len() {
+                ::syslog::warn!(
+                    "write_chunk(): linuxd returned oversized count (fd={:?}, count={:?}, \
+                     chunk.len={:?})",
+                    fd,
+                    count,
+                    chunk.len()
+                );
+                return Err(Error::new(
+                    ErrorCode::InvalidMessage,
+                    "write response count exceeds requested chunk length",
+                ));
+            }
+
             Ok(response.count as c_size_t)
         },
         header => {
@@ -188,7 +216,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
     )
 }
 
-/// Forwards a write request via IPC, splitting the buffer into page-aligned chunks.
+/// Forwards a write request via IPC, splitting the buffer into scatter/gather chunks.
 fn write_ipc(
     fd: RawFileDescriptor,
     buffer: &[u8],
@@ -204,7 +232,7 @@ fn write_ipc(
 
     while offset < buffer.len() {
         let chunk_size: usize =
-            page_chunk_size(buffer[offset..].as_ptr() as usize, buffer.len() - offset);
+            sg_chunk_size(buffer[offset..].as_ptr() as usize, buffer.len() - offset);
         let chunk: &[u8] = &buffer[offset..offset + chunk_size];
 
         let written: c_size_t =

--- a/src/tests/test-fork-kcall/src/tests/bulk_unaligned.rs
+++ b/src/tests/test-fork-kcall/src/tests/bulk_unaligned.rs
@@ -15,13 +15,12 @@
 //!    to the parent and child, and verifies the received bytes against a known pattern.
 //!
 //! 2. **Kernel-peer bulk transfer** (`push()`/`pull()` with [`ProcessIdentifier::KERNEL`]). This
-//!    path hands the buffer to the VMM as a single guest-physical address and lets it read/write
-//!    `data_len` **physically contiguous** bytes from there. Because a user buffer is only
-//!    *virtually* contiguous, a buffer that crosses a page boundary would make the VMM touch an
-//!    unrelated physical frame, so the kernel stages such a buffer through a physically-contiguous
-//!    bounce page before the transfer. [`test_kernel_bulk_push_page_crossing`] pushes a
-//!    page-crossing buffer to the kernel and confirms the call now succeeds — it was previously
-//!    rejected with an `InvalidArgument` error because only the first page was translated.
+//!    path hands the buffer to the VMM as a scatter/gather list of guest-physical segments.
+//!    Because a user buffer is only *virtually* contiguous, a buffer that crosses a page boundary
+//!    spans multiple physical frames, so the kernel describes each physically-contiguous run as
+//!    its own segment. [`test_kernel_bulk_push_page_crossing`] pushes a page-crossing buffer to
+//!    the kernel and confirms the call succeeds — it was previously rejected with an
+//!    `InvalidArgument` error because only the first page was translated.
 //!
 //! `push()` does not wait for a reply, so the kernel-peer test is deterministic and does not block
 //! even in standalone deployments where no Linux daemon completes the transfer.
@@ -178,12 +177,13 @@ fn assert_straddles_page(offset: usize, len: usize) {
 
 /// Verifies that a page-crossing buffer is accepted on the kernel-peer bulk transfer path.
 ///
-/// A `push()` whose peer is [`ProcessIdentifier::KERNEL`] is serviced via the vmbus data chunk
-/// transfer, which hands the VMM a single guest-physical address. A buffer that crosses a page
-/// boundary is only *virtually* contiguous, so the kernel stages it through a physically-contiguous
-/// bounce page before handing it to the VMM. On the unfixed kernel the buffer was rejected with an
+/// A `push()` whose peer is [`ProcessIdentifier::KERNEL`] is serviced via the vmbus scatter/gather
+/// data chunk transfer, which hands the VMM a list of guest-physical segments. A buffer that
+/// crosses a page boundary is only *virtually* contiguous, so the kernel describes it as one
+/// segment per physically-contiguous run. On the unfixed kernel the buffer was rejected with an
 /// `InvalidArgument` error because only its first page was translated, so this call is the
-/// regression trigger: it fails on the unfixed kernel and succeeds once the bounce page is staged.
+/// regression trigger: it fails on the unfixed kernel and succeeds once the buffer is described
+/// as scatter/gather segments.
 ///
 /// `pull()` is intentionally not exercised here: it would block waiting for a completion that no
 /// Linux daemon supplies in this standalone test. `push()` does not wait, so it stays
@@ -193,21 +193,21 @@ fn test_kernel_bulk_push_page_crossing() -> Result<(), Error> {
     let buffer: &mut [u8] = unsafe { arena_region(ptr::addr_of_mut!(SRC_ARENA), SRC_OFFSET) };
 
     // Fill the page-straddling buffer with a recognizable pattern and confirm it really does cross
-    // a page boundary — the exact shape the kernel-peer bulk path must stage through a bounce page.
+    // a page boundary — the exact shape the kernel-peer bulk path maps to scatter/gather segments.
     for (i, byte) in buffer.iter_mut().enumerate() {
         *byte = pattern_byte(i);
     }
     assert_straddles_page(SRC_OFFSET, PAYLOAD_LEN);
 
     // push(): writing a page-crossing buffer to the kernel must succeed. On the unfixed kernel this
-    // returns InvalidArgument (the VMM could translate only the first page); with the bounce-page
-    // staging in place it must be accepted and complete without blocking.
+    // returns InvalidArgument (the VMM could translate only the first page); with scatter/gather
+    // segment staging in place it must be accepted and complete without blocking.
     let push_result: Result<(), Error> =
         ipc::__kcall_push(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buffer);
     assert!(
         push_result.is_ok(),
-        "push() to the kernel with a page-crossing buffer must succeed once it is staged through \
-         a bounce page (got {push_result:?})"
+        "push() to the kernel with a page-crossing buffer must succeed once it is described as \
+         scatter/gather segments (got {push_result:?})"
     );
 
     Ok(())

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -93,7 +93,13 @@ async fn forward_bulk_to_system_vm(
     frame_type: u8,
 ) -> Result<()> {
     // Label: uservm::io_thread::system_vm::write()
-    profiler::timestamp_message!(bulk.data_mut(), 0);
+    // Scatter/gather pull requests forward an empty payload (the data is filled in by the
+    // response that arrives later), so there is nothing to timestamp. The timestamp macro
+    // indexes byte 0 of the payload as its step header, which would panic on an empty buffer
+    // when message timestamping is enabled. Skip injection when there is no payload to carry it.
+    if !bulk.data().is_empty() {
+        profiler::timestamp_message!(bulk.data_mut(), 0);
+    }
     let payload: Vec<u8> = bulk.to_bytes();
     let len_prefix: [u8; BULK_TRANSFER_LENGTH_PREFIX_SIZE] =
         u32::to_le_bytes(u32::try_from(payload.len()).map_err(|e| {

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -103,19 +103,34 @@ use ::log::{
 #[cfg(feature = "profile-time")]
 use ::std::time::Instant;
 use ::std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
     fs::File,
     io::Write,
     sync::Arc,
     time::Duration,
 };
-use ::sys::ipc::{
-    DataChunk,
-    DataChunkHeader,
-    IkcFrame,
-    Message,
-    MessageReceiver,
-    MessageSender,
-    MessageType,
+use ::sys::{
+    ipc::{
+        DataChunk,
+        DataChunkHeader,
+        GuestSgBulkHeader,
+        GuestSgBulkKind,
+        GuestSgSegment,
+        HostBulkTransferHeader,
+        IkcFrame,
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+        SG_BULK_MAX_BYTES,
+        SG_BULK_MAX_SEGMENTS,
+        VmBusMessage,
+        VmBusMessageKind,
+    },
+    mm::Address,
 };
 use ::tokio::{
     sync::{
@@ -168,6 +183,59 @@ pub const CHANNEL_CAPACITY: usize = 1024;
 /// `nanvixd` hung with no stdout and no exit (the rare standalone interactive boot/teardown wedge).
 ///
 const TEARDOWN_JOIN_GRACE: Duration = Duration::from_secs(5);
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+#[derive(Clone)]
+struct SgSegmentRange {
+    data_gpa: u32,
+    data_len: u32,
+}
+
+struct PendingSgPull {
+    total_len: usize,
+    segments: Vec<SgSegmentRange>,
+}
+
+#[derive(Default)]
+struct SgBulkRegistry {
+    next_transfer_id: u32,
+    pending: BTreeMap<u32, PendingSgPull>,
+}
+
+impl SgBulkRegistry {
+    fn insert(&mut self, pending: PendingSgPull, first_valid_transfer_id: u32) -> Result<u32> {
+        let first_valid_transfer_id: u32 = first_valid_transfer_id.max(1);
+        let mut transfer_id: u32 = if self.next_transfer_id < first_valid_transfer_id
+            || self.next_transfer_id == u32::MAX
+        {
+            first_valid_transfer_id
+        } else {
+            self.next_transfer_id + 1
+        };
+
+        for _ in first_valid_transfer_id..=u32::MAX {
+            if !self.pending.contains_key(&transfer_id) {
+                self.next_transfer_id = transfer_id;
+                self.pending.insert(transfer_id, pending);
+                return Ok(transfer_id);
+            }
+            transfer_id = if transfer_id == u32::MAX {
+                first_valid_transfer_id
+            } else {
+                transfer_id + 1
+            };
+        }
+
+        anyhow::bail!("scatter/gather transfer id space exhausted")
+    }
+
+    fn remove(&mut self, transfer_id: u32) -> Option<PendingSgPull> {
+        self.pending.remove(&transfer_id)
+    }
+}
 
 //==================================================================================================
 // UserVmArgs
@@ -285,16 +353,24 @@ impl UserVm {
             },
         };
 
+        let sg_bulk_registry: Arc<Mutex<SgBulkRegistry>> =
+            Arc::new(Mutex::new(SgBulkRegistry::default()));
+
         // Move the stdout sender out of args so no extra clone keeps the
         // data_rx channel alive after the VMM thread finishes.
         // Output function used for emulating I/O port writes.
-        let vmm_stdout_fn: Box<StdoutFn> = output_fn(args.vcpu_thread_stdout_tx);
+        let vmm_stdout_fn: Box<StdoutFn> =
+            output_fn(args.vcpu_thread_stdout_tx, sg_bulk_registry.clone());
 
         // Input function used for emulating I/O port reads.
         let ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool> =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let vmm_stdin_fn: Box<StdinFn> =
-            build_input_fn(vcpu_thread_stdin_rx, args.counters.clone(), ikc_pending.clone());
+        let vmm_stdin_fn: Box<StdinFn> = build_input_fn(
+            vcpu_thread_stdin_rx,
+            args.counters.clone(),
+            ikc_pending.clone(),
+            sg_bulk_registry,
+        );
 
         #[cfg(feature = "profile-time")]
         #[allow(clippy::cast_possible_truncation)]
@@ -587,6 +663,153 @@ fn add_credit_fn(
     })
 }
 
+struct ValidatedSgBulk {
+    source_pid: ::sys::pm::ProcessIdentifier,
+    source_tid: ::sys::pm::ThreadIdentifier,
+    destination_pid: ::sys::pm::ProcessIdentifier,
+    destination_tid: ::sys::pm::ThreadIdentifier,
+    kind: GuestSgBulkKind,
+    total_len: usize,
+    segments: Vec<SgSegmentRange>,
+}
+
+fn validate_guest_range(vmem: &VirtualMemory, addr: u64, len: usize) -> Result<()> {
+    let addr: usize = usize::try_from(addr).map_err(|e| {
+        let reason: String = format!("guest address does not fit usize: {e}");
+        error!("{reason}");
+        anyhow::Error::msg(reason)
+    })?;
+    match addr.checked_add(len) {
+        Some(end) if end <= vmem.get_size() => Ok(()),
+        _ => {
+            let reason: String =
+                format!("invalid guest physical range (addr={addr:#x}, len={len:#x})");
+            error!("{reason}");
+            anyhow::bail!(reason)
+        },
+    }
+}
+
+fn read_guest_sg_segment(vmem: &VirtualMemory, addr: u64) -> Result<GuestSgSegment> {
+    validate_guest_range(vmem, addr, GuestSgSegment::SIZE)?;
+    let mut bytes: [u8; GuestSgSegment::SIZE] = [0u8; GuestSgSegment::SIZE];
+    vmem.read_bytes(addr, &mut bytes)?;
+    GuestSgSegment::try_from_bytes(bytes).map_err(|e| {
+        let reason: String = format!("failed to parse scatter/gather segment: {e:?}");
+        error!("{reason}");
+        anyhow::Error::msg(reason)
+    })
+}
+
+fn read_guest_sg_header(vmem: &VirtualMemory, addr: u64) -> Result<GuestSgBulkHeader> {
+    validate_guest_range(vmem, addr, GuestSgBulkHeader::SIZE)?;
+    let mut bytes: [u8; GuestSgBulkHeader::SIZE] = [0u8; GuestSgBulkHeader::SIZE];
+    vmem.read_bytes(addr, &mut bytes)?;
+    GuestSgBulkHeader::try_from_bytes(bytes).map_err(|e| {
+        let reason: String = format!("failed to parse scatter/gather header: {e:?}");
+        error!("{reason}");
+        anyhow::Error::msg(reason)
+    })
+}
+
+fn parse_guest_sg_bulk(vmem: &VirtualMemory, header_addr: u64) -> Result<ValidatedSgBulk> {
+    let header: GuestSgBulkHeader = read_guest_sg_header(vmem, header_addr)?;
+    let kind: GuestSgBulkKind = header.kind().map_err(|e| {
+        let reason: String = format!("invalid scatter/gather transfer kind: {e:?}");
+        error!("{reason}");
+        anyhow::Error::msg(reason)
+    })?;
+    let segment_count: usize = header.segment_count().get() as usize;
+    let total_len: usize = header.total_len() as usize;
+
+    if total_len == 0 || total_len > SG_BULK_MAX_BYTES {
+        let reason: String = format!("invalid scatter/gather length (len={total_len})");
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+    if segment_count == 0 || segment_count > SG_BULK_MAX_SEGMENTS as usize {
+        let reason: String =
+            format!("invalid scatter/gather segment count (count={segment_count})");
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+
+    let mut segments: Vec<SgSegmentRange> = Vec::with_capacity(segment_count);
+    let mut seen_descriptors: BTreeSet<u32> = BTreeSet::new();
+    let mut cumulative_len: usize = 0;
+    let mut segment: GuestSgSegment = header.first();
+
+    for index in 0..segment_count {
+        let data_len: usize = segment.data_len() as usize;
+        if data_len == 0 {
+            let reason: String = format!("zero-length scatter/gather segment (index={index})");
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+        cumulative_len = cumulative_len.checked_add(data_len).ok_or_else(|| {
+            let reason: String = "scatter/gather cumulative length overflow".to_string();
+            error!("{reason}");
+            anyhow::Error::msg(reason)
+        })?;
+        if cumulative_len > total_len || cumulative_len > SG_BULK_MAX_BYTES {
+            let reason: String =
+                format!("scatter/gather segment lengths exceed declared length (index={index})");
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+        validate_guest_range(vmem, segment.data_gpa() as u64, data_len)?;
+        segments.push(SgSegmentRange {
+            data_gpa: segment.data_gpa(),
+            data_len: segment.data_len(),
+        });
+
+        let next: u32 = u32::try_from(segment.next().into_raw_value()).map_err(|e| {
+            let reason: String =
+                format!("scatter/gather next descriptor address does not fit u32: {e}");
+            error!("{reason}");
+            anyhow::Error::msg(reason)
+        })?;
+        if index + 1 == segment_count {
+            if next != 0 {
+                let reason: String = "scatter/gather chain has extra descriptors".to_string();
+                error!("{reason}");
+                anyhow::bail!(reason)
+            }
+        } else {
+            if next == 0 {
+                let reason: String = "scatter/gather chain ended early".to_string();
+                error!("{reason}");
+                anyhow::bail!(reason)
+            }
+            if !seen_descriptors.insert(next) {
+                let reason: String =
+                    format!("scatter/gather descriptor cycle detected (addr={next:#x})");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            }
+            segment = read_guest_sg_segment(vmem, next as u64)?;
+        }
+    }
+
+    if cumulative_len != total_len {
+        let reason: String = format!(
+            "scatter/gather length mismatch (declared={total_len}, actual={cumulative_len})"
+        );
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+
+    Ok(ValidatedSgBulk {
+        source_pid: header.source_pid(),
+        source_tid: header.source_tid(),
+        destination_pid: header.destination_pid(),
+        destination_tid: header.destination_tid(),
+        kind,
+        total_len,
+        segments,
+    })
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -693,10 +916,11 @@ fn is_windows_named_pipe(path: &str) -> bool {
 ///
 /// A boxed closure compatible with the VMM's stdin handler implementation.
 ///
-pub fn build_input_fn(
+fn build_input_fn(
     mut input_queue: Receiver<IkcFrame>,
     counters: MessageCounters,
     ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    sg_bulk_registry: Arc<Mutex<SgBulkRegistry>>,
 ) -> Box<StdinFn> {
     // Input function used for emulating I/O port reads.
     let input = move |guest: &Arc<Mutex<Guest>>,
@@ -704,7 +928,7 @@ pub fn build_input_fn(
                       data,
                       size|
           -> Result<()> {
-        use std::mem;
+        use ::std::mem;
         on_input_function_called(&counters);
 
         // Check for invalid operand size.
@@ -757,14 +981,68 @@ pub fn build_input_fn(
                         let mut locked_guest: MutexGuard<'_, Guest> = guest.blocking_lock();
                         let mut locked_vm: MutexGuard<'_, VirtualMemory> = vmem.blocking_lock();
 
-                        let dest_addr: u64 = bulk.header().data_addr() as u64;
                         let actual_len: usize = bulk.data().len();
-                        trace!(
-                            "input(): writing {actual_len} bulk bytes to guest at {dest_addr:#x}"
-                        );
-                        // Label: uservm::lib::vm_input::vm_write_bytes()
-                        profiler::timestamp_message!(bulk.data_mut(), 0);
-                        locked_vm.write_bytes(dest_addr, bulk.data())?;
+                        let transfer_id: u32 = bulk.header().data_addr();
+                        let pending_pull: Option<PendingSgPull> =
+                            sg_bulk_registry.blocking_lock().remove(transfer_id);
+                        if let Some(pending_pull) = pending_pull {
+                            if actual_len > pending_pull.total_len {
+                                let reason: String = format!(
+                                    "bulk response exceeds pending scatter/gather pull length \
+                                     (actual={actual_len}, max={})",
+                                    pending_pull.total_len
+                                );
+                                error!("{reason}");
+                                anyhow::bail!(reason);
+                            }
+                            trace!(
+                                "input(): scattering {actual_len} bulk bytes to guest \
+                                 (transfer_id={transfer_id})"
+                            );
+                            // Label: uservm::lib::vm_input::vm_write_bytes()
+                            profiler::timestamp_message!(bulk.data_mut(), 0);
+                            let mut copied: usize = 0;
+                            for segment in &pending_pull.segments {
+                                if copied == actual_len {
+                                    break;
+                                }
+                                let segment_len: usize = segment.data_len as usize;
+                                let bytes_to_copy: usize =
+                                    core::cmp::min(segment_len, actual_len - copied);
+                                locked_vm.write_bytes(
+                                    segment.data_gpa as u64,
+                                    &bulk.data()[copied..copied + bytes_to_copy],
+                                )?;
+                                copied += bytes_to_copy;
+                            }
+                        } else {
+                            let dest_addr: u64 = transfer_id as u64;
+                            let guest_size: usize = locked_vm.get_size();
+                            let dest_addr_usize: usize =
+                                usize::try_from(dest_addr).map_err(|e| {
+                                    let reason: String =
+                                        format!("bulk response address does not fit usize: {e}");
+                                    error!("input(): {reason}");
+                                    anyhow::Error::msg(reason)
+                                })?;
+                            if dest_addr_usize >= guest_size {
+                                let reason: String = format!(
+                                    "bulk response references unknown scatter/gather transfer id \
+                                     or invalid legacy address (data_addr={dest_addr:#x}, \
+                                     guest_size={guest_size:#x})"
+                                );
+                                error!("input(): {reason}");
+                                anyhow::bail!(reason);
+                            }
+                            validate_guest_range(&locked_vm, dest_addr, actual_len)?;
+                            trace!(
+                                "input(): writing {actual_len} legacy bulk bytes to guest at \
+                                 {dest_addr:#x}"
+                            );
+                            // Label: uservm::lib::vm_input::vm_write_bytes()
+                            profiler::timestamp_message!(bulk.data_mut(), 0);
+                            locked_vm.write_bytes(dest_addr, bulk.data())?;
+                        }
 
                         // Construct a PullResponse notification message. The kernel's
                         // main loop reads this from the regular message buffer, detects the
@@ -816,8 +1094,7 @@ pub fn build_input_fn(
 ///
 /// Builds an output callback that forwards messages and data chunk transfers emitted by the virtual
 /// machine. The callback inspects the [`VmBusMessage`] to determine whether the guest is
-/// sending a standard IKC message or a data chunk transfer and constructs the appropriate
-/// [`Transfer`] variant.
+/// sending a standard IKC message or a bulk transfer and constructs the appropriate [`IkcFrame`].
 ///
 /// # Parameters
 ///
@@ -828,7 +1105,10 @@ pub fn build_input_fn(
 ///
 /// A boxed closure compatible with the VMM's stdout handler implementation.
 ///
-pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
+fn output_fn(
+    queue: Sender<IkcFrame>,
+    sg_bulk_registry: Arc<Mutex<SgBulkRegistry>>,
+) -> Box<StdoutFn> {
     // On Windows/WHP the closure below runs on the vCPU thread while it holds the WHP partition
     // lock (held across `Emulator::handle_pmio_access()`). Sending directly on the bounded channel
     // there would block the vCPU thread under the lock whenever the asynchronous consumer is
@@ -838,11 +1118,16 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
     let sink: crate::pal::IkcStdoutSink = crate::pal::IkcStdoutSink::new(queue);
 
     // Output function used for emulating I/O port writes.
-    let output =
-        move |vm: &Arc<Mutex<VirtualMemory>>, envelope: &::sys::ipc::VmBusMessage| -> Result<()> {
-            use std::mem;
+    let output = move |vm: &Arc<Mutex<VirtualMemory>>, envelope: &VmBusMessage| -> Result<()> {
+        use ::std::mem;
 
-            if envelope.is_ikc() {
+        let envelope_kind: VmBusMessageKind = envelope.kind().map_err(|e| {
+            let reason: String = format!("invalid vmbus message kind: {e:?}");
+            error!("output(): {reason}");
+            anyhow::Error::msg(reason)
+        })?;
+        match envelope_kind {
+            VmBusMessageKind::Ikc => {
                 // Standard IKC message: read the message from guest memory.
                 let mut bytes: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
                 trace!("output(): reading message from user VM");
@@ -873,7 +1158,8 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
                 }
 
                 trace!("output(): message forwarded to system VM");
-            } else {
+            },
+            VmBusMessageKind::LegacyBulk => {
                 // Data chunk transfer: `message_addr` points to a DataChunkHeader.
                 let mut header_bytes: [u8; DataChunkHeader::SIZE] = [0; DataChunkHeader::SIZE];
                 vm.blocking_lock()
@@ -905,10 +1191,110 @@ pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
                     error!("output(): {reason}");
                     anyhow::bail!(reason);
                 }
-            }
+            },
+            VmBusMessageKind::GuestSgBulk => {
+                let (sg_bulk, first_valid_transfer_id): (ValidatedSgBulk, u32) = {
+                    let locked_vm: MutexGuard<'_, VirtualMemory> = vm.blocking_lock();
+                    let sg_bulk: ValidatedSgBulk =
+                        parse_guest_sg_bulk(&locked_vm, envelope.message_addr() as u64)?;
+                    let first_valid_transfer_id: u32 = u32::try_from(locked_vm.get_size())
+                        .map_err(|e| {
+                            let reason: String =
+                                format!("guest memory size exceeds transfer id space: {e}");
+                            error!("{reason}");
+                            anyhow::Error::msg(reason)
+                        })?;
+                    (sg_bulk, first_valid_transfer_id)
+                };
 
-            Ok(())
-        };
+                match sg_bulk.kind {
+                    GuestSgBulkKind::Push => {
+                        let mut data: Vec<u8> = vec![0u8; sg_bulk.total_len];
+                        {
+                            let locked_vm: MutexGuard<'_, VirtualMemory> = vm.blocking_lock();
+                            let mut offset: usize = 0;
+                            for segment in &sg_bulk.segments {
+                                let segment_len: usize = segment.data_len as usize;
+                                locked_vm.read_bytes(
+                                    segment.data_gpa as u64,
+                                    &mut data[offset..offset + segment_len],
+                                )?;
+                                offset += segment_len;
+                            }
+                        }
+
+                        // Label: uservm::lib::vm_output::send()
+                        profiler::timestamp_message!(&mut data, 0);
+
+                        let header: HostBulkTransferHeader = HostBulkTransferHeader::new(
+                            sg_bulk.source_pid,
+                            sg_bulk.source_tid,
+                            sg_bulk.destination_pid,
+                            sg_bulk.destination_tid,
+                            0,
+                            u32::try_from(sg_bulk.total_len).map_err(|e| {
+                                let reason: String =
+                                    format!("scatter/gather length exceeds u32: {e}");
+                                error!("{reason}");
+                                anyhow::Error::msg(reason)
+                            })?,
+                        );
+                        let bulk: DataChunk = DataChunk::new(header, data);
+
+                        trace!(
+                            "output(): forwarding scatter/gather push ({} bytes, {} segments)",
+                            sg_bulk.total_len,
+                            sg_bulk.segments.len()
+                        );
+                        if let Err(e) = sink.send(IkcFrame::Bulk(bulk)) {
+                            let reason: String =
+                                format!("failed to send scatter/gather transfer: {e:?}");
+                            error!("output(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                    },
+                    GuestSgBulkKind::Pull => {
+                        let pending: PendingSgPull = PendingSgPull {
+                            total_len: sg_bulk.total_len,
+                            segments: sg_bulk.segments,
+                        };
+                        let transfer_id: u32 = sg_bulk_registry
+                            .blocking_lock()
+                            .insert(pending, first_valid_transfer_id)?;
+                        let header: HostBulkTransferHeader = HostBulkTransferHeader::new(
+                            sg_bulk.source_pid,
+                            sg_bulk.source_tid,
+                            sg_bulk.destination_pid,
+                            sg_bulk.destination_tid,
+                            transfer_id,
+                            u32::try_from(sg_bulk.total_len).map_err(|e| {
+                                let reason: String =
+                                    format!("scatter/gather length exceeds u32: {e}");
+                                error!("{reason}");
+                                anyhow::Error::msg(reason)
+                            })?,
+                        );
+                        let bulk: DataChunk = DataChunk::new(header, Vec::new());
+
+                        trace!(
+                            "output(): forwarding scatter/gather pull request \
+                             (transfer_id={transfer_id}, len={})",
+                            sg_bulk.total_len
+                        );
+                        if let Err(e) = sink.send(IkcFrame::Bulk(bulk)) {
+                            sg_bulk_registry.blocking_lock().remove(transfer_id);
+                            let reason: String =
+                                format!("failed to send scatter/gather pull request: {e:?}");
+                            error!("output(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                    },
+                }
+            },
+        }
+
+        Ok(())
+    };
 
     Box::new(output)
 }

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -1088,7 +1088,8 @@ async fn handle_read_request(
     trace!("standalone io_handler: handling ReadRequest (fd={fd}, tid={tid:?})");
 
     // Wait for the pull-header bulk frame. The kernel emits this when the guest calls
-    // ipc::pull(). The header contains the guest buffer address and maximum byte count.
+    // ipc::pull(). The header carries an opaque bulk location and maximum byte count; the location
+    // is a guest buffer address on legacy paths or a UserVM transfer id for scatter/gather pulls.
     let pull_header: DataChunkHeader = match vm_stdout_rx.recv().await {
         Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
         other => {


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                               

- Add scatter/gather IKC bulk transfers for guest↔UserVM bulk push/pull paths.                                                                                                                                                                                       
- Keep UserVM↔linuxd bulk transfers contiguous while UserVM gathers/scatters guest SG segments.                                                                                                                                                                           
- Fix `warm-start-vmm` benchmark chunk handling so it honors actual push/pull request sizes.                                                                                                                                                                              
- Add `nanvix-bench -payload-size <bytes>` for warm-start benchmarks.                                                                                                                                                                                                      
- Add CI support for the payload-size option and a `warm-start-vmm-32kb` benchmark run.                                                                                                                                                                                   

 ## Validation

- `.\z.ps1 build -- format-check lint-check spellcheck verify test`                                                                                                                                                                                                       

## Benchmark Notes
                                                                                                                                                                                                                                                        
Local `warm-start-vmm` comparisons against `dev` showed the SG path significantly improves large payload latency, especially at 32 KiB, while preserving small-payload behavior.