### PR TITLE
[ci] Build and run ported POSIX C suites

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -80,3 +80,27 @@ runs:
 
         echo "Running: ./bin/nanvix-test.elf ${TEST_CONFIG}"
         ./bin/nanvix-test.elf "${TEST_CONFIG}"
+
+    # Ported POSIX C test suites. Standalone-only: the runner boots each suite
+    # under nanvixd in standalone mode and uses the guest exit code as the
+    # pass/fail signal. This also exercises the freestanding guest C toolchain
+    # (build/make/guest-c-apps.mk) that no other CI step compiles.
+    - name: "POSIX C Suites (${{ inputs.machine-type }})"
+      if: inputs.deployment-type == 'standalone'
+      shell: bash
+      # No RUST_LOG here (unlike the direct-invocation steps above): this step
+      # drives the harness through `./z build -- run-posix-tests`, whose recipe
+      # sets RUST_LOG=$(LOG_LEVEL) on the harness command line, so a step-level
+      # RUST_LOG would be overridden and have no effect.
+      run: |
+        set -Eeuo pipefail
+
+        RELEASE_FLAG=""
+        if [[ "${{ inputs.build-type }}" == "release" ]]; then
+          RELEASE_FLAG="--release"
+        fi
+
+        ./z build ${RELEASE_FLAG} -- run-posix-tests \
+            "MACHINE=${{ inputs.machine-type }}" \
+            TARGET=x86 \
+            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,7 +770,7 @@ jobs:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- all run-unit-tests $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL MEMORY_SIZE=${{ matrix.memory-size }}
+          .\z.ps1 build -- all run-unit-tests all-posix-test-images $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL MEMORY_SIZE=${{ matrix.memory-size }}
 
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7
@@ -892,6 +892,20 @@ jobs:
           BUILD_MODE: ${{ matrix.build-type }}
         run: |
           & .\bin\nanvix-test.exe .\test\test-standalone-windows.toml
+
+      # Ported POSIX C test suites. Boots the prebuilt <suite>.initrd images
+      # (built by the Windows build job via all-posix-test-images and downloaded
+      # with the artifact) directly under WHP through the nanvix-test harness,
+      # asserting each guest exit code is 0. No rebuild is needed here.
+      - name: "POSIX C Suites (${{ matrix.machine-type }})"
+        if: steps.whp-check.outputs.whp_available == 'true'
+        shell: pwsh
+        env:
+          RUST_LOG: info
+          # Forwarded to the harness so it can gate build-mode-restricted tests.
+          BUILD_MODE: ${{ matrix.build-type }}
+        run: |
+          & .\bin\nanvix-test.exe .\test\test-posix-windows.toml
 
       - name: "Upload logs in case of failures"
         if: failure() || cancelled()

--- a/build/make/guest-c-apps.mk
+++ b/build/make/guest-c-apps.mk
@@ -28,19 +28,15 @@ GUEST_C_APP_CC := clang --target=i686-unknown-none
 # Flags and inputs.
 #---------------------------------------------------------------------------------------------------
 
-# Compile flags: freestanding i686, project headers only. Clang supplies the
-# freestanding headers (stddef.h/stdarg.h) from its builtin resource dir.
+# Compile flags: freestanding i686, project headers only.
 #
-# On GNU/Linux, -nostdinc maximally isolates from host headers while clang still
-# resolves its builtin freestanding headers. On Windows this clang drops the
-# builtin resource dir under -nostdinc, so use -nostdlibinc there: it still
-# excludes the host C library headers but keeps the compiler's builtin
-# freestanding headers (stdarg.h, stddef.h, ...).
-ifeq ($(IS_WINDOWS),yes)
-GUEST_C_APP_CFLAGS := -m32 -march=pentiumpro -ffreestanding -nostdlibinc -std=c17
-else
+# Use -nostdinc for maximal isolation: it drops BOTH the host system include
+# paths and the compiler's builtin resource-directory headers. The freestanding
+# headers normally supplied by the compiler (stddef.h, stdarg.h, stdint.h,
+# stdbool.h) are vendored in-tree under include/, so the build is hermetic and
+# does not depend on the compiler's resource directory (which clang 18 omits
+# under -nostdinc on both Linux and Windows).
 GUEST_C_APP_CFLAGS := -m32 -march=pentiumpro -ffreestanding -nostdinc -std=c17
-endif
 GUEST_C_APP_CFLAGS += -isystem $(ROOT_DIR)/include
 ifeq ($(RELEASE),yes)
 GUEST_C_APP_CFLAGS += -O3

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -184,7 +184,6 @@ clean-posix-tests:
 #---------------------------------------------------------------------------------------------------
 
 POSIX_TEST_INITRDS := $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).initrd)
-POSIX_TEST_LOGDIR  := $(LOGS_DIR)/posix-tests
 
 # Writable FAT32 RAMFS image for suites that exercise the file system (file-c)
 # or load a shared library at runtime (dlfcn-c). Built from a tiny seed directory
@@ -272,16 +271,11 @@ $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(eval $(call POSIX_TEST_SOLIB_RULE,$
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite)))
 
-# Maps each RAMFS suite to the image it boots with: a suite with its own
-# fixtures uses its per-suite image (POSIX_TEST_RAMFS_IMG_<suite>, defined by the
-# solib rule above), otherwise the shared image. The runner looks the suite up in
-# this `suite:image` list.
-POSIX_TEST_RAMFS_MAP := $(foreach s,$(POSIX_TEST_RAMFS_SUITES),$(s):$(or $(POSIX_TEST_RAMFS_IMG_$(s)),$(POSIX_TEST_RAMFS_IMG)))
-
-# Suites that need host networking (AF_INET sockets bridged to the host). The
-# runner boots these with nanvixd's `-allow-host-networking` flag, which enables
-# the in-VMM network daemon in standalone mode.
-POSIX_TEST_NET_SUITES := network-c
+# The per-suite boot arguments that pair each suite with its RAMFS image
+# (`-ramfs <img>`) or enable host networking (`-allow-host-networking`) now live
+# in the nanvix-test harness configs (test/test-posix.toml and
+# test/test-posix-windows.toml) as `extra_nanvixd_args`, since the harness — not
+# this makefile — boots the suites. This makefile only builds the images above.
 
 #---------------------------------------------------------------------------------------------------
 # Aggregate image target.
@@ -301,60 +295,33 @@ all-posix-test-images: $(POSIX_TEST_INITRDS) \
 
 .PHONY: run-posix-tests
 
-# The boot runner is Linux- and i686-only: it relies on coreutils `timeout`,
-# `/dev/null`, and a cloud-hypervisor-style nanvixd invocation (Linux), and the
-# guest C toolchain is pinned to the i686 ABI (TARGET=x86). On Windows or other
-# targets the suites can still be built (`all-posix-tests`); on Windows they boot
-# manually under WHP (see doc + repo notes).
+# The boot runner drives the suites through the nanvix-test harness, which boots
+# each <suite>.initrd under nanvixd in standalone mode (the `terminal` executor)
+# and asserts a guest exit code of 0. The harness is cross-platform: on Linux it
+# launches nanvixd against cloud-hypervisor; on Windows it launches nanvixd.exe
+# under WHP. The suites are i686-only (the guest C toolchain is pinned to the
+# i686 ABI, TARGET=x86) and standalone-only (they bundle the guest daemons). On
+# other targets or deployment modes the suites can still be built with
+# `all-posix-tests`.
+
+# Harness configuration: Windows uses the .exe nanvixd and a `.`-rooted temp dir.
 ifeq ($(IS_WINDOWS),yes)
-run-posix-tests:
-	@echo "Skipping POSIX C test suites (run-posix-tests is Linux-only; build with 'all-posix-tests' and boot manually under WHP)."
-else ifneq ($(TARGET),x86)
+POSIX_TEST_CONFIG := test/test-posix-windows.toml
+else
+POSIX_TEST_CONFIG := test/test-posix.toml
+endif
+
+ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
 else ifeq ($(DEPLOYMENT_MODE),standalone)
 run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS)
+	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(USERVM) || { echo "ERROR: $(USERVM) missing; run './z build -- all' first."; exit 1; }
-	@$(MKDIR_CMD) $(POSIX_TEST_LOGDIR)
-	@echo "================================================================================"
-	@echo "Running ported POSIX C test suites under nanvixd (standalone)"
-	@echo "================================================================================"
-	@failures=""; \
-	for suite in $(ALL_POSIX_TESTS); do \
-		initrd="$(BINARIES_DIR)/$$suite.initrd"; \
-		log="$(POSIX_TEST_LOGDIR)/$$suite.log"; \
-		console="$(POSIX_TEST_LOGDIR)/$$suite.console.log"; \
-		ramfs=""; \
-		for entry in $(POSIX_TEST_RAMFS_MAP); do \
-			case "$$entry" in \
-				$$suite:*) ramfs="-ramfs $${entry#*:}" ;; \
-			esac; \
-		done; \
-		net=""; \
-		case " $(POSIX_TEST_NET_SUITES) " in \
-			*" $$suite "*) net="-allow-host-networking" ;; \
-		esac; \
-		printf '%-24s ... ' "$$suite"; \
-		rc=0; \
-		timeout -k 5 $(TIMEOUT) $(NANVIXD) -console-file $$console -log-dir $(POSIX_TEST_LOGDIR) \
-			$$ramfs $$net -- $$initrd \
-			< /dev/null > $$log 2>&1 || rc=$$?; \
-		if [ "$$rc" -eq 0 ]; then \
-			echo "PASS (exit 0)"; \
-		else \
-			echo "FAIL (exit $$rc)"; \
-			failures="$$failures $$suite"; \
-		fi; \
-	done; \
-	echo "--------------------------------------------------------------------------------"; \
-	if [ -n "$$failures" ]; then \
-		echo "FAILED suites:$$failures"; \
-		echo "(logs in $(POSIX_TEST_LOGDIR))"; \
-		exit 1; \
-	fi; \
-	echo "All ported POSIX C test suites passed."
+	@echo "Running ported POSIX C test suites with configuration: $(POSIX_TEST_CONFIG)"
+	RUST_LOG=$(LOG_LEVEL) $(NANVIX_TEST_BIN) $(POSIX_TEST_CONFIG)
 else
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (DEPLOYMENT_MODE=$(DEPLOYMENT_MODE), requires standalone)."

--- a/include/stdarg.h
+++ b/include/stdarg.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDARG_H
+#define _NANVIX_STDARG_H
+
+/**
+ * @file stdarg.h
+ * @brief Variable argument lists.
+ *
+ * Freestanding header vendored in-tree so the guest C toolchain does not depend
+ * on the compiler's builtin resource-directory headers. The machinery maps onto
+ * the compiler's `__builtin_va_*` primitives, which both clang and gcc provide
+ * for the active target ABI.
+ */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/*
+ * Guarded with `_VA_LIST_DEFINED` so other headers that need `va_list` in scope
+ * (for example <stdio.h> and <wchar.h>) share this single definition instead of
+ * emitting a competing typedef.
+ */
+#ifndef _VA_LIST_DEFINED
+#define _VA_LIST_DEFINED
+
+/** @brief Type for iterating over a function's variable arguments. */
+typedef __builtin_va_list va_list;
+
+/** @brief Legacy GNU spelling of `va_list`, kept for ported sources. */
+typedef __builtin_va_list __gnuc_va_list;
+
+#endif
+
+/*==================================================================================================
+ * Macros
+ *==================================================================================================*/
+
+/** @brief Initializes @p ap to retrieve the arguments following @p param. */
+#define va_start(ap, param) __builtin_va_start(ap, param)
+
+/** @brief Releases @p ap once argument retrieval is complete. */
+#define va_end(ap) __builtin_va_end(ap)
+
+/** @brief Returns the next argument of the given @p type. */
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+
+/** @brief Copies the state of @p src into @p dst. */
+#define va_copy(dst, src) __builtin_va_copy(dst, src)
+
+/** @brief Legacy GNU spelling of `va_copy`, kept for ported sources. */
+#define __va_copy(dst, src) __builtin_va_copy(dst, src)
+
+#endif /* _NANVIX_STDARG_H */

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDBOOL_H
+#define _NANVIX_STDBOOL_H
+
+/**
+ * @file stdbool.h
+ * @brief Boolean type and values.
+ *
+ * Freestanding header vendored in-tree so the guest C toolchain does not depend
+ * on the compiler's builtin resource-directory headers.
+ */
+
+#ifndef __cplusplus
+
+/** @brief Boolean type. */
+#define bool _Bool
+
+/** @brief Boolean true. */
+#define true 1
+
+/** @brief Boolean false. */
+#define false 0
+
+#endif /* !__cplusplus */
+
+/** @brief Indicates that `bool`, `true`, and `false` are defined. */
+#define __bool_true_false_are_defined 1
+
+#endif /* _NANVIX_STDBOOL_H */

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDDEF_H
+#define _NANVIX_STDDEF_H
+
+/**
+ * @file stddef.h
+ * @brief Common definitions.
+ *
+ * Freestanding header vendored in-tree so the guest C toolchain does not depend
+ * on the compiler's builtin resource-directory headers. The underlying types
+ * are obtained from compiler-predefined macros (`__SIZE_TYPE__`, ...), which
+ * both clang and gcc supply for the active target, so the layouts always match
+ * the selected ABI.
+ */
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+/** @brief Null pointer constant. */
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL 0
+#else
+#define NULL ((void *)0)
+#endif
+#endif
+
+/*==================================================================================================
+ * Macros
+ *==================================================================================================*/
+
+/** @brief Offset (in bytes) of a member within a structure. */
+#define offsetof(type, member) __builtin_offsetof(type, member)
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Signed result of subtracting two pointers. */
+#ifndef _PTRDIFF_T_DEFINED
+#define _PTRDIFF_T_DEFINED
+typedef __PTRDIFF_TYPE__ ptrdiff_t;
+#endif
+
+/** @brief Unsigned result of the `sizeof` operator. */
+#ifndef _SIZE_T_DEFINED
+#define _SIZE_T_DEFINED
+typedef __SIZE_TYPE__ size_t;
+#endif
+
+/** @brief Wide-character type (C only; C++ has a built-in `wchar_t`). */
+#ifndef __cplusplus
+#ifndef _WCHAR_T_DEFINED
+#define _WCHAR_T_DEFINED
+typedef __WCHAR_TYPE__ wchar_t;
+#endif
+#endif
+
+/** @brief Type with the greatest fundamental alignment. */
+#ifndef _MAX_ALIGN_T_DEFINED
+#define _MAX_ALIGN_T_DEFINED
+typedef struct {
+    long long __max_align_ll;
+    long double __max_align_ld;
+} max_align_t;
+#endif
+
+#endif /* _NANVIX_STDDEF_H */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDINT_H
+#define _NANVIX_STDINT_H
+
+/**
+ * @file stdint.h
+ * @brief Fixed-width integer types.
+ *
+ * Freestanding header vendored in-tree so the guest C toolchain does not depend
+ * on the compiler's builtin resource-directory headers. Every type and limit is
+ * derived from compiler-predefined macros (`__INT32_TYPE__`, `__INT32_MAX__`,
+ * ...), which both clang and gcc supply for the active target, so the widths and
+ * ranges always match the selected ABI.
+ */
+
+/*==================================================================================================
+ * Exact-width integer types
+ *==================================================================================================*/
+
+typedef __INT8_TYPE__ int8_t;
+typedef __INT16_TYPE__ int16_t;
+typedef __INT32_TYPE__ int32_t;
+typedef __INT64_TYPE__ int64_t;
+
+typedef __UINT8_TYPE__ uint8_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __UINT32_TYPE__ uint32_t;
+typedef __UINT64_TYPE__ uint64_t;
+
+/*==================================================================================================
+ * Minimum-width integer types
+ *==================================================================================================*/
+
+typedef __INT_LEAST8_TYPE__ int_least8_t;
+typedef __INT_LEAST16_TYPE__ int_least16_t;
+typedef __INT_LEAST32_TYPE__ int_least32_t;
+typedef __INT_LEAST64_TYPE__ int_least64_t;
+
+typedef __UINT_LEAST8_TYPE__ uint_least8_t;
+typedef __UINT_LEAST16_TYPE__ uint_least16_t;
+typedef __UINT_LEAST32_TYPE__ uint_least32_t;
+typedef __UINT_LEAST64_TYPE__ uint_least64_t;
+
+/*==================================================================================================
+ * Fastest minimum-width integer types
+ *==================================================================================================*/
+
+typedef __INT_FAST8_TYPE__ int_fast8_t;
+typedef __INT_FAST16_TYPE__ int_fast16_t;
+typedef __INT_FAST32_TYPE__ int_fast32_t;
+typedef __INT_FAST64_TYPE__ int_fast64_t;
+
+typedef __UINT_FAST8_TYPE__ uint_fast8_t;
+typedef __UINT_FAST16_TYPE__ uint_fast16_t;
+typedef __UINT_FAST32_TYPE__ uint_fast32_t;
+typedef __UINT_FAST64_TYPE__ uint_fast64_t;
+
+/*==================================================================================================
+ * Integer types capable of holding object pointers
+ *==================================================================================================*/
+
+typedef __INTPTR_TYPE__ intptr_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+
+/*==================================================================================================
+ * Greatest-width integer types
+ *==================================================================================================*/
+
+#ifndef _INTMAX_T_DEFINED
+#define _INTMAX_T_DEFINED
+typedef __INTMAX_TYPE__ intmax_t;
+typedef __UINTMAX_TYPE__ uintmax_t;
+#endif
+
+/*==================================================================================================
+ * Limits of exact-width integer types
+ *==================================================================================================*/
+
+#define INT8_MAX __INT8_MAX__
+#define INT16_MAX __INT16_MAX__
+#define INT32_MAX __INT32_MAX__
+#define INT64_MAX __INT64_MAX__
+
+#define INT8_MIN (-__INT8_MAX__ - 1)
+#define INT16_MIN (-__INT16_MAX__ - 1)
+#define INT32_MIN (-__INT32_MAX__ - 1)
+#define INT64_MIN (-__INT64_MAX__ - 1)
+
+#define UINT8_MAX __UINT8_MAX__
+#define UINT16_MAX __UINT16_MAX__
+#define UINT32_MAX __UINT32_MAX__
+#define UINT64_MAX __UINT64_MAX__
+
+/*==================================================================================================
+ * Limits of minimum-width integer types
+ *==================================================================================================*/
+
+#define INT_LEAST8_MAX __INT_LEAST8_MAX__
+#define INT_LEAST16_MAX __INT_LEAST16_MAX__
+#define INT_LEAST32_MAX __INT_LEAST32_MAX__
+#define INT_LEAST64_MAX __INT_LEAST64_MAX__
+
+#define INT_LEAST8_MIN (-__INT_LEAST8_MAX__ - 1)
+#define INT_LEAST16_MIN (-__INT_LEAST16_MAX__ - 1)
+#define INT_LEAST32_MIN (-__INT_LEAST32_MAX__ - 1)
+#define INT_LEAST64_MIN (-__INT_LEAST64_MAX__ - 1)
+
+#define UINT_LEAST8_MAX __UINT_LEAST8_MAX__
+#define UINT_LEAST16_MAX __UINT_LEAST16_MAX__
+#define UINT_LEAST32_MAX __UINT_LEAST32_MAX__
+#define UINT_LEAST64_MAX __UINT_LEAST64_MAX__
+
+/*==================================================================================================
+ * Limits of fastest minimum-width integer types
+ *==================================================================================================*/
+
+#define INT_FAST8_MAX __INT_FAST8_MAX__
+#define INT_FAST16_MAX __INT_FAST16_MAX__
+#define INT_FAST32_MAX __INT_FAST32_MAX__
+#define INT_FAST64_MAX __INT_FAST64_MAX__
+
+#define INT_FAST8_MIN (-__INT_FAST8_MAX__ - 1)
+#define INT_FAST16_MIN (-__INT_FAST16_MAX__ - 1)
+#define INT_FAST32_MIN (-__INT_FAST32_MAX__ - 1)
+#define INT_FAST64_MIN (-__INT_FAST64_MAX__ - 1)
+
+#define UINT_FAST8_MAX __UINT_FAST8_MAX__
+#define UINT_FAST16_MAX __UINT_FAST16_MAX__
+#define UINT_FAST32_MAX __UINT_FAST32_MAX__
+#define UINT_FAST64_MAX __UINT_FAST64_MAX__
+
+/*==================================================================================================
+ * Limits of pointer-holding and greatest-width integer types
+ *==================================================================================================*/
+
+#define INTPTR_MAX __INTPTR_MAX__
+#define INTPTR_MIN (-__INTPTR_MAX__ - 1)
+#define UINTPTR_MAX __UINTPTR_MAX__
+
+#define INTMAX_MAX __INTMAX_MAX__
+#define INTMAX_MIN (-__INTMAX_MAX__ - 1)
+#define UINTMAX_MAX __UINTMAX_MAX__
+
+/*==================================================================================================
+ * Limits of other integer types
+ *==================================================================================================*/
+
+#define PTRDIFF_MAX __PTRDIFF_MAX__
+#define PTRDIFF_MIN (-__PTRDIFF_MAX__ - 1)
+
+#define SIZE_MAX __SIZE_MAX__
+
+#define SIG_ATOMIC_MAX __SIG_ATOMIC_MAX__
+#define SIG_ATOMIC_MIN __SIG_ATOMIC_MIN__
+
+#ifndef WCHAR_MAX
+#define WCHAR_MAX __WCHAR_MAX__
+#endif
+#ifndef WCHAR_MIN
+#define WCHAR_MIN __WCHAR_MIN__
+#endif
+
+#define WINT_MAX __WINT_MAX__
+#define WINT_MIN __WINT_MIN__
+
+/*==================================================================================================
+ * Macros for integer constants
+ *==================================================================================================*/
+
+#define INT8_C(c) __INT8_C(c)
+#define INT16_C(c) __INT16_C(c)
+#define INT32_C(c) __INT32_C(c)
+#define INT64_C(c) __INT64_C(c)
+
+#define UINT8_C(c) __UINT8_C(c)
+#define UINT16_C(c) __UINT16_C(c)
+#define UINT32_C(c) __UINT32_C(c)
+#define UINT64_C(c) __UINT64_C(c)
+
+#define INTMAX_C(c) __INTMAX_C(c)
+#define UINTMAX_C(c) __UINTMAX_C(c)
+
+#endif /* _NANVIX_STDINT_H */

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -31,7 +31,7 @@ extern "C" {
 #ifndef _WCHAR_T_DEFINED
 #define _WCHAR_T_DEFINED
 #ifndef __cplusplus
-typedef int wchar_t;
+typedef __WCHAR_TYPE__ wchar_t;
 #endif
 #endif
 

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -29,7 +29,7 @@ text = '''
 #ifndef _WCHAR_T_DEFINED
 #define _WCHAR_T_DEFINED
 #ifndef __cplusplus
-typedef int wchar_t;
+typedef __WCHAR_TYPE__ wchar_t;
 #endif
 #endif
 

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -1,0 +1,146 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Ported POSIX C test-suite configuration (Windows).
+#
+# Mirrors test-posix.toml adapted for Windows (WHP backend, `.exe` binary, and a
+# `.`-rooted tmp_directory).
+# Each `<suite>.initrd` is booted under nanvixd in standalone mode (the `terminal`
+# executor) and the propagated guest exit code must be 0. Guest stdout is discarded
+# in standalone mode, so the exit code is authoritative and no output assertion is made.
+#
+# Usage: nanvix-test.exe test/test-posix-windows.toml
+
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.exe"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "."
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 600000
+tcp_cleanup_max_wait_seconds = 0
+tcp_cleanup_poll_interval_seconds = 1
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+#===================================================================================================
+# Ported POSIX C Test Suites (standalone, exit-code-only)
+#===================================================================================================
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/c-bindings"
+program = "./bin/c-bindings.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/ctor-c"
+program = "./bin/ctor-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-c"
+program = "./bin/dlfcn-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-global-c"
+program = "./bin/dlfcn-global-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-global-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-needed-c"
+program = "./bin/dlfcn-needed-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-needed-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-pie-c"
+program = "./bin/dlfcn-pie-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/echo-c"
+program = "./bin/echo-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/file-c"
+program = "./bin/file-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/hello-c"
+program = "./bin/hello-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/memory-c"
+program = "./bin/memory-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/misc-c"
+program = "./bin/misc-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/network-c"
+program = "./bin/network-c.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/noop-c"
+program = "./bin/noop-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/thread-c"
+program = "./bin/thread-c.initrd"
+expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -1,0 +1,146 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Ported POSIX C test-suite configuration (Linux).
+#
+# Drives the suites built by build/make/posix-tests.mk through the nanvix-test
+# harness: each `<suite>.initrd` is booted under nanvixd in standalone mode (the
+# `terminal` executor) and the propagated guest exit code must be 0. Guest stdout
+# is discarded in standalone mode, so the exit code is authoritative and no output
+# assertion is made.
+#
+# Usage: nanvix-test.elf test/test-posix.toml
+
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+#===================================================================================================
+# Ported POSIX C Test Suites (standalone, exit-code-only)
+#===================================================================================================
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/c-bindings"
+program = "./bin/c-bindings.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/ctor-c"
+program = "./bin/ctor-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-c"
+program = "./bin/dlfcn-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-global-c"
+program = "./bin/dlfcn-global-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-global-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-needed-c"
+program = "./bin/dlfcn-needed-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-needed-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/dlfcn-pie-c"
+program = "./bin/dlfcn-pie-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/echo-c"
+program = "./bin/echo-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/file-c"
+program = "./bin/file-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/hello-c"
+program = "./bin/hello-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/memory-c"
+program = "./bin/memory-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/misc-c"
+program = "./bin/misc-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/network-c"
+program = "./bin/network-c.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/noop-c"
+program = "./bin/noop-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/thread-c"
+program = "./bin/thread-c.initrd"
+expected_exit_code = 0


### PR DESCRIPTION
## Summary

Gets the ported POSIX C test suites building and running in CI on **both Linux and Windows**, by migrating the runner to the `nanvix-test` harness and provisioning the freestanding guest C toolchain on each platform.

## Changes

- **[libc] Vendor freestanding C headers** — bundle `stddef.h`/`stdarg.h`/`stdint.h`/`stdbool.h` under `include/` so the guest C build is hermetic under `-nostdinc` (clang 18 omits its resource-dir headers there on both Linux and Windows).
- **[tests] Migrate POSIX runner to nanvix-test** — replace the hand-rolled shell loop in `run-posix-tests` with the cross-platform `nanvix-test` harness, driven by `test/test-posix.toml` (Linux) and `test/test-posix-windows.toml` (Windows). Per-suite `-ramfs`/`-allow-host-networking` boot args move into the TOML as `extra_nanvixd_args`.
- **[build] Auto-detect clang on Windows** — add `find_clang()` to probe the LLVM install locations and prepend to PATH (the Windows LLVM installer does not update PATH), and have `z.ps1 setup` install LLVM/Clang.
- **[build] Install clang in Linux core setup** — add `clang` to `scripts/setup/ubuntu-core.sh`; Linux still links with GNU `ld` from `build-essential`, so no `lld` is needed and no PATH probing is required.
- **[ci] Run POSIX C suites in integration tests** — wire the suites into CI: Linux via the integration-test composite action (`./z build -- run-posix-tests`, standalone only), Windows via a WHP-gated test step that boots prebuilt `<suite>.initrd` images with `nanvix-test.exe` (build job now also produces `all-posix-test-images`).

## Notes

- Suites are i686-only (guest C toolchain pinned to the i686 ABI) and standalone-only; non-`x86` targets / non-standalone modes skip the runner but can still build the images.
- Pass/fail signal is the propagated guest exit code (0 = pass), matching the existing convention.