### PR TITLE
[syscall] Fix diamond DT_NEEDED resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -106,6 +106,7 @@ POSIX_TEST_PIE_LDFLAGS := -pie --export-dynamic --no-dynamic-linker -z notext -z
 POSIX_TEST_PIE_dlfcn-pie-c := yes
 POSIX_TEST_PIE_dlfcn-global-c := yes
 POSIX_TEST_PIE_dlfcn-needed-c := yes
+POSIX_TEST_PIE_dlfcn-diamond-c := yes
 # dlfcn-init-runpath-c links PIE with --export-dynamic so the main executable's
 # `g_dtor_ran` global lands in `.dynsym`; the loader's global symbol table then
 # satisfies libctor.so's `extern volatile int g_dtor_ran` reference at load time.
@@ -179,9 +180,11 @@ clean-posix-tests:
 	$(RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs.img
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_dlfcn-diamond-c)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
 
 #---------------------------------------------------------------------------------------------------
@@ -199,7 +202,7 @@ POSIX_TEST_INITRDS := $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite
 # into lib/) so dlfcn-c can dlopen("lib/libmul.so"). Suites that need the image
 # are listed in POSIX_TEST_RAMFS_SUITES. Suites with their own fixtures (the
 # dlfcn global/needed variants, below) override the image with a per-suite one.
-POSIX_TEST_RAMFS_SUITES := file-c dlfcn-c dlfcn-pie-c dlfcn-global-c dlfcn-needed-c
+POSIX_TEST_RAMFS_SUITES := file-c dlfcn-c dlfcn-pie-c dlfcn-global-c dlfcn-needed-c dlfcn-diamond-c
 POSIX_TEST_RAMFS_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-seed
 POSIX_TEST_RAMFS_IMG    := $(BINARIES_DIR)/posix-tests-ramfs.img
 
@@ -274,8 +277,83 @@ endef
 
 $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(eval $(call POSIX_TEST_SOLIB_RULE,$(suite))))
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-diamond-c: four-library diamond DT_NEEDED fixture.
+#---------------------------------------------------------------------------------------------------
+#
+#   libdiamond.so -> libleft.so  -> libbase.so
+#                 -> libright.so -> libbase.so
+#                 -> libbase.so                (direct edge)
+#
+# The two arms (libleft.so, libright.so) each carry a DT_NEEDED on libbase.so;
+# libdiamond.so carries DT_NEEDED on both arms AND a direct DT_NEEDED on
+# libbase.so. A correct loader consolidates all three libbase.so edges onto a
+# single in-memory instance instead of opening it more than once (or
+# dead-locking on the recursive load). The two arm edges are consolidated by
+# the per-frame registry scan; libdiamond.so's own direct edge is consolidated
+# by the loader's load-loop re-check (libbase.so is loaded by an arm after
+# libdiamond's entry scan already ran). Built with the same i686 freestanding
+# toolchain as the provider/consumer fixtures above; each DT_NEEDED edge is
+# produced by linking the dependent against its dependencies with `-L<dir>
+# -l<name>` (the linker records each found `lib<name>.so` as a bare DT_NEEDED
+# entry, which the loader resolves through its default `lib/` search path —
+# exactly like dlfcn-needed-c).
+POSIX_TEST_DIAMOND_DIR  := $(POSIX_TESTS_OBJDIR)/dlfcn-diamond-c/libs
+POSIX_TEST_DIAMOND_SEED := $(BINARIES_DIR)/posix-tests-ramfs-dlfcn-diamond-c-seed
+POSIX_TEST_RAMFS_IMG_dlfcn-diamond-c := $(BINARIES_DIR)/posix-tests-ramfs-dlfcn-diamond-c.img
+
+# Leaf: libbase.so (no dependencies).
+$(POSIX_TEST_DIAMOND_DIR)/libbase.so: $(POSIX_TESTS_SRCDIR)/dlfcn-diamond-c/libs/base.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-diamond-c/libbase.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Left arm: DT_NEEDED libbase.so.
+$(POSIX_TEST_DIAMOND_DIR)/libleft.so: $(POSIX_TESTS_SRCDIR)/dlfcn-diamond-c/libs/left.c \
+		$(POSIX_TEST_DIAMOND_DIR)/libbase.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-diamond-c/libleft.so (DT_NEEDED libbase.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -L$(POSIX_TEST_DIAMOND_DIR) -lbase -o $@
+
+# Right arm: DT_NEEDED libbase.so.
+$(POSIX_TEST_DIAMOND_DIR)/libright.so: $(POSIX_TESTS_SRCDIR)/dlfcn-diamond-c/libs/right.c \
+		$(POSIX_TEST_DIAMOND_DIR)/libbase.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-diamond-c/libright.so (DT_NEEDED libbase.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -L$(POSIX_TEST_DIAMOND_DIR) -lbase -o $@
+
+# Root: DT_NEEDED libleft.so + libright.so + libbase.so. The direct libbase.so
+# edge (alongside the two arms that also pull it in) is what exercises the
+# load-loop re-check in load_all_dependencies(): an arm loads libbase.so first,
+# then libdiamond.so's own libbase.so edge must bind to that existing instance
+# instead of re-opening it.
+$(POSIX_TEST_DIAMOND_DIR)/libdiamond.so: $(POSIX_TESTS_SRCDIR)/dlfcn-diamond-c/libs/diamond.c \
+		$(POSIX_TEST_DIAMOND_DIR)/libleft.so $(POSIX_TEST_DIAMOND_DIR)/libright.so \
+		$(POSIX_TEST_DIAMOND_DIR)/libbase.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-diamond-c/libdiamond.so (DT_NEEDED libleft.so libright.so libbase.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o \
+		-L$(POSIX_TEST_DIAMOND_DIR) -lleft -lright -lbase -o $@
+
+# Per-suite RAMFS image carrying all four fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_dlfcn-diamond-c): $(POSIX_TEST_DIAMOND_DIR)/libbase.so \
+		$(POSIX_TEST_DIAMOND_DIR)/libleft.so \
+		$(POSIX_TEST_DIAMOND_DIR)/libright.so \
+		$(POSIX_TEST_DIAMOND_DIR)/libdiamond.so all-host-binaries-mkramfs
+	@$(MKDIR_CMD) $(POSIX_TEST_DIAMOND_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libbase.so $(POSIX_TEST_DIAMOND_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libleft.so $(POSIX_TEST_DIAMOND_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libright.so $(POSIX_TEST_DIAMOND_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libdiamond.so $(POSIX_TEST_DIAMOND_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_DIAMOND_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
-POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite)))
+POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
+	$(POSIX_TEST_RAMFS_IMG_dlfcn-diamond-c)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-init-runpath-c: constructor/destructor + DT_RUNPATH fixtures.

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -26,7 +26,10 @@ use ::spin::{
     Mutex,
     MutexGuard,
 };
-use ::sys::error::Error;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 //===================================================================================================
 // dlopen()
@@ -167,12 +170,19 @@ fn load_all_dependencies(
         dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
         new_dlhandle: &DlHandle,
         new_dlfile: &mut MutexGuard<'_, DynamicLibrary>,
+        ancestors: &mut BTreeMap<DlHandle, String>,
     ) -> Result<(), Error> {
         // Snapshot the loader's `DT_RUNPATH` entries so they are visible to
         // `resolve_library_path` while probing every dependency below. The
         // `DynamicLibrary` mutex is borrowed throughout, so this avoids
         // re-borrowing it per call.
         let runpaths: Vec<String> = new_dlfile.runpaths().to_vec();
+
+        // Snapshot the current library's own name so it can be (a) recorded as
+        // an ancestor for the recursive frames below and (b) compared against
+        // each dependency to detect a `DT_NEEDED` self-cycle, both without
+        // re-locking the (already held) `DynamicLibrary` mutex.
+        let self_name: String = new_dlfile.name().to_string();
 
         // Collect the name of all dependencies.
         let mut dependencies: Vec<String> = new_dlfile
@@ -182,13 +192,46 @@ fn load_all_dependencies(
             .collect();
 
         // Bind to already loaded dependencies and remove them from the list.
+        //
+        // The closure below calls `dlfile.lock()` on every other entry in the
+        // registry while looking for a matching name. Those locks must skip
+        // BOTH the current library (`new_dlhandle`) AND every ancestor still
+        // held by an outer recursive frame — otherwise any non-trivial
+        // recursive load (e.g. `libA → libB`, and especially diamond graphs
+        // like the one below) deadlocks:
+        //
+        //   dlopen(libdiamond.so)                  // holds libdiamond lock
+        //     -> recurse into libright.so          // also holds libright lock
+        //          -> retain() iterates dlfiles    // tries to lock libdiamond
+        //             ^ blocks forever, libdiamond is still held by the
+        //               outer frame.
+        //
+        // What this `retain` legitimately consolidates is a dependency that a
+        // PRIOR, already-finished iteration of an OUTER frame loaded. In the
+        // classic diamond
+        //
+        //   libdiamond.so -> libleft.so  -> libbase.so
+        //                 -> libright.so -> libbase.so
+        //
+        // libdiamond finishes libleft first (recursing in and loading
+        // libbase), then starts libright's frame; libright's `retain` then
+        // sees libbase already resident and binds libright's `libbase` edge to
+        // that single shared instance here. (The other shape — a sibling
+        // pulled in LATER within the *same* frame's own dependency list — is
+        // caught by the re-check in the load loop below, not here.)
+        //
+        // Skipping ancestors by handle is safe: the only dependency that can
+        // legitimately resolve to an ancestor is a `DT_NEEDED` cycle, which is
+        // detected and rejected explicitly in the load loop below (see the
+        // `self_name`/`ancestors` cycle check), so it never reaches this scan.
         dependencies.retain(|dependency| {
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
             let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
             for (dlhandle, dlfile) in dlfiles.iter() {
-                // Check if need to skip the dynamic library itself.
-                if dlhandle == new_dlhandle {
+                // Skip the dynamic library itself and any ancestor held by
+                // an outer frame's lock — locking them would deadlock.
+                if dlhandle == new_dlhandle || ancestors.contains_key(dlhandle) {
                     continue;
                 }
 
@@ -223,6 +266,73 @@ fn load_all_dependencies(
             // Resolve bare library names to full paths using search directories.
             let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));
 
+            // Reject `DT_NEEDED` cycles before they recurse without bound. A
+            // dependency that resolves to the current library or to any
+            // ancestor still being loaded by an outer recursive frame cannot be
+            // followed: the ancestor's mutex is held, so we can neither recurse
+            // into it nor lock it to consolidate onto it, and skipping it by
+            // handle (as `retain` and the re-check do) would just open a fresh
+            // copy on a new handle and recurse forever. Cycles in `DT_NEEDED`
+            // are pathological — no sane toolchain emits them — so reject the
+            // load cleanly; `dlopen` then rolls back every entry added during
+            // this call.
+            if self_name == dependency
+                || self_name == resolved_dep
+                || ancestors
+                    .values()
+                    .any(|name| name == &dependency || name == &resolved_dep)
+            {
+                let reason: &str = "cyclic DT_NEEDED dependency";
+                ::syslog::warn!(
+                    "load_all_dependencies_recursive(): {} (dependency '{}')",
+                    reason,
+                    dependency
+                );
+                return Err(Error::new(ErrorCode::BadFile, reason));
+            }
+
+            // Re-check the registry before opening: an EARLIER iteration of
+            // THIS frame's own load loop may have already loaded this exact
+            // dependency transitively. `retain` above runs only once, at frame
+            // entry, before any sibling is processed, so it cannot see a
+            // sibling that a later-processed sibling pulls in. Concretely, when
+            // a parent directly `DT_NEEDED`s both `libX` and `libbase` and
+            // `libX -> libbase`:
+            //
+            //   libdiamond.so -> libright.so -> libbase.so   (processed first)
+            //                 -> libbase.so                  (direct edge)
+            //
+            // processing `libright` loads `libbase`; when the loop reaches
+            // libdiamond's own direct `libbase` edge it is already resident and
+            // must be bound here, not re-opened. (dlfcn-diamond-c builds
+            // libdiamond with exactly this direct `libbase` edge to exercise
+            // this path.) Without this check the loader would open `libbase` a
+            // second time — two distinct in-memory copies with two private
+            // `unique_counter`s — or trip the `unreachable!()` below if the VFS
+            // recycles the underlying file descriptor.
+            let already_loaded: Option<Arc<Mutex<DynamicLibrary>>> =
+                dlfiles.iter().find_map(|(dlhandle, dlfile)| {
+                    if dlhandle == new_dlhandle || ancestors.contains_key(dlhandle) {
+                        return None;
+                    }
+                    let loaded_file: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+                    let loaded_name: &str = loaded_file.name();
+                    if loaded_name == dependency.as_str() || loaded_name == resolved_dep {
+                        Some(dlfile.clone())
+                    } else {
+                        None
+                    }
+                });
+            if let Some(existing) = already_loaded {
+                ::syslog::debug!(
+                    "load_all_dependencies_recursive(): dependency '{}' loaded transitively \
+                     during this dlopen call; binding to existing copy",
+                    dependency
+                );
+                new_dlfile.bind_dependency(dependency, existing)?;
+                continue;
+            }
+
             // Open and pre-load the dynamic library file.
             let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&resolved_dep)?;
             let handle: DlHandle = dep_dlfile.handle();
@@ -235,9 +345,16 @@ fn load_all_dependencies(
 
             new_dlfile.bind_dependency(dependency.clone(), dep_dlfile.clone())?;
 
-            // Load dependencies of the new dynamic library file.
+            // Load dependencies of the new dynamic library file. Record the
+            // current library as an ancestor (keyed by handle, valued by its
+            // name) so the recursive frame neither tries to lock our still-held
+            // mutex (would deadlock on diamond DT_NEEDED graphs) nor mistakes a
+            // cycle back to us for a brand-new library.
+            ancestors.insert(*new_dlhandle, self_name.clone());
             let mut dlfile: MutexGuard<'_, DynamicLibrary> = dep_dlfile.lock();
-            load_all_dependencies_recursive(dlfiles, &handle, &mut dlfile)?;
+            let result = load_all_dependencies_recursive(dlfiles, &handle, &mut dlfile, ancestors);
+            ancestors.remove(new_dlhandle);
+            result?;
         }
 
         Ok(())
@@ -245,7 +362,8 @@ fn load_all_dependencies(
 
     let mut new_dlfile = new_dlfile.lock();
     let new_dlhandle = new_dlfile.handle();
-    load_all_dependencies_recursive(dlfiles, &new_dlhandle, &mut new_dlfile)?;
+    let mut ancestors: BTreeMap<DlHandle, String> = BTreeMap::new();
+    load_all_dependencies_recursive(dlfiles, &new_dlhandle, &mut new_dlfile, &mut ancestors)?;
 
     Ok(())
 }

--- a/src/posix-tests/dlfcn-diamond-c/libs/base.c
+++ b/src/posix-tests/dlfcn-diamond-c/libs/base.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libbase.so - shared leaf of the diamond DT_NEEDED graph.
+ *
+ *   libdiamond.so
+ *     +-- DT_NEEDED libleft.so   --+
+ *     +-- DT_NEEDED libright.so  --+-- DT_NEEDED libbase.so
+ *
+ * Both libleft.so and libright.so declare DT_NEEDED libbase.so. When the
+ * loader walks libdiamond.so's dependencies, it must NOT load libbase.so
+ * twice -- exactly one copy should appear in the registry. Otherwise the
+ * `unique_counter` global below would be visible at two distinct
+ * addresses to libleft.so and libright.so, and the assertion in
+ * dlfcn-diamond-c/main.c would fire.
+ */
+
+/* Process-lifetime counter. Bumped by every call to `base_bump()`. */
+static int unique_counter = 0;
+
+int base_bump(void)
+{
+    unique_counter += 1;
+    return unique_counter;
+}
+
+int base_get(void)
+{
+    return unique_counter;
+}

--- a/src/posix-tests/dlfcn-diamond-c/libs/diamond.c
+++ b/src/posix-tests/dlfcn-diamond-c/libs/diamond.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libdiamond.so - root of the diamond. Pulls in libleft.so and
+ * libright.so via DT_NEEDED, AND carries a direct DT_NEEDED on
+ * libbase.so as well. Both arms transitively depend on libbase.so,
+ * so a correct loader must consolidate all three "DT_NEEDED
+ * libbase.so" edges (the two arms' plus libdiamond's own direct edge)
+ * onto a single libbase.so instance. The direct edge is what exercises
+ * the loader's load-loop re-check: an arm loads libbase.so first, then
+ * libdiamond's own libbase.so edge must bind to that existing instance
+ * instead of re-opening it.
+ */
+
+extern int left_bump(void);
+extern int right_bump(void);
+extern int right_get(void);
+extern int base_get(void);
+
+int diamond_left(void)
+{
+    return left_bump();
+}
+
+int diamond_right(void)
+{
+    return right_bump();
+}
+
+int diamond_observe(void)
+{
+    return right_get();
+}
+
+/*
+ * Reads the shared counter through libdiamond's OWN direct DT_NEEDED
+ * edge on libbase.so (not through an arm). If the loader re-opened
+ * libbase.so for this direct edge instead of consolidating, this would
+ * observe a separate counter than the arms bumped.
+ */
+int diamond_base_get(void)
+{
+    return base_get();
+}

--- a/src/posix-tests/dlfcn-diamond-c/libs/left.c
+++ b/src/posix-tests/dlfcn-diamond-c/libs/left.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libleft.so - left arm of the diamond. Calls base_bump() so the test
+ * can observe whether libleft and libright share the same libbase.so
+ * instance (single counter) or each got their own (independent counters).
+ */
+
+extern int base_bump(void);
+
+int left_bump(void)
+{
+    return base_bump();
+}

--- a/src/posix-tests/dlfcn-diamond-c/libs/right.c
+++ b/src/posix-tests/dlfcn-diamond-c/libs/right.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libright.so - right arm of the diamond. Symmetric to libleft.so.
+ */
+
+extern int base_bump(void);
+extern int base_get(void);
+
+int right_bump(void)
+{
+    return base_bump();
+}
+
+int right_get(void)
+{
+    return base_get();
+}

--- a/src/posix-tests/dlfcn-diamond-c/main.c
+++ b/src/posix-tests/dlfcn-diamond-c/main.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * dlfcn-diamond-c: Exercises diamond DT_NEEDED graph resolution.
+ *
+ *   libdiamond.so
+ *     +-- DT_NEEDED libleft.so   --+
+ *     +-- DT_NEEDED libright.so  --+-- DT_NEEDED libbase.so
+ *     +-- DT_NEEDED libbase.so  ---/   (direct edge)
+ *
+ * libdiamond.so also carries a DIRECT DT_NEEDED on libbase.so (in
+ * addition to the two arms that pull it in transitively). This shape
+ * exercises both loader consolidation paths in one graph:
+ *   * the two arms' libbase.so edges are consolidated by the registry
+ *     scan run at each frame's entry (one arm loads libbase.so, the
+ *     other binds to it);
+ *   * libdiamond.so's own direct libbase.so edge is consolidated by the
+ *     loader's load-loop re-check, because libbase.so is loaded by an
+ *     arm AFTER libdiamond's entry scan already ran.
+ *
+ * A correct loader walks libdiamond.so's dependencies, opens libleft.so,
+ * recurses into its DT_NEEDED list and opens libbase.so, then resumes
+ * the outer loop for libright.so and its own direct libbase.so edge --
+ * at which point libbase.so is already in the registry and must be
+ * bound, NOT re-opened. A broken loader either:
+ *   (a) deadlocks: while recursing into libleft.so it scans the registry
+ *       and tries to lock libdiamond.so, whose mutex is still held by the
+ *       outer recursive frame -- the guest hangs forever (the test
+ *       harness catches this via its watchdog timeout), OR
+ *   (b) re-opens libbase.so, ending up with two copies and two distinct
+ *       `unique_counter` instances, OR
+ *   (c) trips an internal `unreachable!()` / panics because the same
+ *       file descriptor is now mapped to two registry entries.
+ *
+ * All three failure modes are caught by the assertions below (the
+ * deadlock by the external watchdog, the duplication and panic by the
+ * delta checks).
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 0 (control): dlopen libright.so directly. libright has a single
+ * DT_NEEDED edge to libbase.so, so this exercises the depth-2 chain
+ * without involving the diamond shape. If this hangs, the issue is
+ * not specific to diamond resolution.
+ */
+static void test_chain_dlopen(void)
+{
+    void *h = dlopen("lib/libright.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("dlopen(libright.so) [depth-2]", dlerror());
+        return;
+    }
+    int (*rb)(void) = (int (*)(void))dlsym(h, "right_bump");
+    if (!rb || rb() != 1) {
+        fail("dlopen(libright.so) [depth-2]", "right_bump returned wrong value");
+        dlclose(h);
+        return;
+    }
+    dlclose(h);
+    pass("dlopen(libright.so) [depth-2 chain]");
+}
+
+/*
+ * Test 1: dlopen(libdiamond.so) must succeed (not hang, not error).
+ * Successful return implies the loader walked the entire diamond
+ * graph without re-opening libbase.so or otherwise dead-locking.
+ */
+static void test_diamond_dlopen(void)
+{
+    void *h = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("dlopen(libdiamond.so)", dlerror());
+        return;
+    }
+
+    int (*dl) (void) = (int (*)(void))dlsym(h, "diamond_left");
+    int (*dr) (void) = (int (*)(void))dlsym(h, "diamond_right");
+    int (*ob) (void) = (int (*)(void))dlsym(h, "diamond_observe");
+    int (*db) (void) = (int (*)(void))dlsym(h, "diamond_base_get");
+    if (!dl || !dr || !ob || !db) {
+        fail("dlopen(libdiamond.so)", "missing diamond_* symbols");
+        dlclose(h);
+        return;
+    }
+
+    /*
+     * Capture the baseline counter before the diamond arms run.  This
+     * keeps the test robust against any prior `test_chain_dlopen()`
+     * call leaving the counter at a non-zero value if Nanvix's
+     * `dlclose` ever stops fully unmapping the library (POSIX permits
+     * `dlclose` to defer the unmap).  We then assert deltas, not
+     * absolute values:
+     *
+     *   left_val      = base_get() + 1 after left's base_bump()
+     *   right_val     = base_get() + 2 after right's base_bump()
+     *   observed      = base_get() + 2
+     *   diamond_base  = base_get() + 2  (via libdiamond's direct edge)
+     *
+     * If libbase.so were loaded twice, libleft and libright would each
+     * see their own private `unique_counter` starting at zero, so
+     * left_val == 1, right_val == 1 (not 2), observed == 1 (not 2).
+     */
+    int (*base_get_addr)(void) = (int (*)(void))dlsym(h, "base_get");
+    int baseline = base_get_addr ? base_get_addr() : 0;
+
+    int left_val = dl();
+    int right_val = dr();
+    int observed = ob();
+    int diamond_base = db();
+
+    if (left_val != baseline + 1) {
+        char reason[96];
+        snprintf(reason, sizeof(reason),
+                 "left_bump=%d, expected %d", left_val, baseline + 1);
+        fail("dlopen(libdiamond.so)", reason);
+        dlclose(h);
+        return;
+    }
+    if (right_val != baseline + 2 || observed != baseline + 2) {
+        /* This is the giveaway for a duplicate libbase.so: libleft and
+         * libright each see their own private `unique_counter` instead
+         * of sharing one. */
+        char reason[160];
+        snprintf(reason, sizeof(reason),
+                 "right_bump=%d (expected %d), observed=%d (expected %d) "
+                 "-- libbase.so was loaded twice",
+                 right_val, baseline + 2, observed, baseline + 2);
+        fail("dlopen(libdiamond.so)", reason);
+        dlclose(h);
+        return;
+    }
+    if (diamond_base != baseline + 2) {
+        /* libdiamond's OWN direct DT_NEEDED edge on libbase.so resolved
+         * to a different instance than the arms bumped -- the loader
+         * re-opened libbase.so for the direct edge instead of binding to
+         * the copy an arm already loaded (the load-loop re-check). */
+        char reason[160];
+        snprintf(reason, sizeof(reason),
+                 "diamond_base_get=%d (expected %d) "
+                 "-- libdiamond's direct libbase.so edge was not consolidated",
+                 diamond_base, baseline + 2);
+        fail("dlopen(libdiamond.so)", reason);
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("dlopen(libdiamond.so)");
+}
+
+/*
+ * Test 2: Second dlopen returns the same handle (libdiamond.so is
+ * already in the registry).
+ */
+static void test_diamond_reopen(void)
+{
+    void *h1 = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h1 == NULL) {
+        fail("re-dlopen(libdiamond.so)", dlerror());
+        return;
+    }
+
+    void *h2 = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h2 == NULL) {
+        fail("re-dlopen(libdiamond.so)", dlerror());
+        dlclose(h1);
+        return;
+    }
+
+    if (h1 != h2) {
+        fail("re-dlopen(libdiamond.so)", "second dlopen returned a different handle");
+        dlclose(h1);
+        dlclose(h2);
+        return;
+    }
+
+    dlclose(h1);
+    dlclose(h2);
+    pass("re-dlopen(libdiamond.so) returns same handle");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn diamond DT_NEEDED tests ===\n");
+    fflush(stdout);
+
+    test_chain_dlopen();
+    test_diamond_dlopen();
+    test_diamond_reopen();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -88,7 +88,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
@@ -178,7 +178,7 @@ program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -66,6 +66,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-diamond-c"
+program = "./bin/dlfcn-diamond-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-diamond-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/dlfcn-global-c"
 program = "./bin/dlfcn-global-c.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-global-c.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -66,6 +66,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-diamond-c"
+program = "./bin/dlfcn-diamond-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-diamond-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/dlfcn-global-c"
 program = "./bin/dlfcn-global-c.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-global-c.img"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -87,7 +87,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
@@ -177,7 +177,7 @@ program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -133,7 +133,7 @@ program = "./bin/setenv-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "terminal"
 program = "./bin/stress-rust.initrd"
 expected_output = "ok"
@@ -229,7 +229,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "http"
 program = "./bin/stress-rust.initrd"
 input = "[]"

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -113,7 +113,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "http"
 program = "./bin/stress-rust.initrd"
 input = "[]"
@@ -206,7 +206,7 @@ program = "./bin/setenv-rust.initrd"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "terminal"
 program = "./bin/stress-rust.initrd"
 expected_output = "ok"

--- a/test/test.toml
+++ b/test/test.toml
@@ -88,7 +88,7 @@ input = "[]"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "http"
 program = "./bin/stress-rust.elf"
 input = "[]"
@@ -179,7 +179,7 @@ program = "./bin/thread-rust.elf"
 expected_output = "ok"
 
 [[tests]]
-build_modes = ["debug", "release"]
+build_modes = ["release"]
 executor = "terminal"
 program = "./bin/stress-rust.elf"
 expected_output = "ok"


### PR DESCRIPTION
## Summary

Supersedes #2478.

Fixes the dynamic loader's recursive `DT_NEEDED` resolution so it correctly
handles non-trivial dependency graphs — in particular the diamond shape that is
the norm in real-world shared-library chains:

```
libdiamond.so ─┬─ DT_NEEDED libleft.so  ──┐
               ├─ DT_NEEDED libright.so ──┼── DT_NEEDED libbase.so
               └─ DT_NEEDED libbase.so  ──┘   (direct edge)
```

`load_all_dependencies` previously could deadlock, duplicate libraries, or
recurse without bound on these graphs. Each recursive frame holds the library's
non-reentrant spin mutex while the registry scans (`retain` + the pre-open
lookup) lock every other entry to compare names. On a diamond graph an inner
frame would try to lock an ancestor whose mutex is still held by an outer frame
and block forever.

## Fixes

- **Deadlock:** thread an `ancestors` map (handle → name) through the recursion
  and skip the current library and every ancestor (by handle) in the registry
  scans, so a frame never locks a mutex held by an outer frame.
- **Duplicate transitive loads:** re-check the registry in the load loop before
  opening a dependency. An earlier-processed sibling may have transitively
  loaded a later sibling that the frame-entry `retain` could not have seen; bind
  to the existing instance instead of opening a second copy.
- **Unbounded recursion on cycles:** a dependency that resolves to the current
  library or an in-progress ancestor (matched by name) is now rejected with a
  clean error and rolled back, instead of recursing without bound.

## Test suite

Adds `dlfcn-diamond-c`, a POSIX C suite with i686 freestanding fixtures
(`libbase`/`libleft`/`libright`/`libdiamond`). `libdiamond` carries a direct
`DT_NEEDED` on `libbase` in addition to the two arms, so the suite covers both
consolidation paths: the arms' edges via the per-frame registry scan, and
`libdiamond`'s direct edge via the load-loop re-check. It asserts a single
shared `libbase` instance (one counter) across all edges and that a second
`dlopen` returns the same handle. Build wiring registers the suite in
`ALL_POSIX_TESTS`, builds the four fixtures and the per-suite RAMFS image, and
links the suite PIE.

## Files

| File | Change |
|---|---|
| `src/libs/syscall/src/dlfcn/syscall/dlopen.rs` | Thread `ancestors` through `load_all_dependencies_recursive`; skip ancestors in registry scans; add pre-open re-check; reject `DT_NEEDED` cycles. |
| `src/posix-tests/dlfcn-diamond-c/*` | New diamond `DT_NEEDED` test suite and fixtures. |
| `Makefile`, `build/make/posix-tests.mk`, `test/test-posix.toml`, `test/test-posix-windows.toml` | Build and test wiring. |

## Validation

- `./z build` — PASS
- New `dlfcn-diamond-c` suite passes end to end on the standalone VM.
