### PR TITLE
[tests] Add dlfcn-init-runpath-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-global-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -106,6 +106,10 @@ POSIX_TEST_PIE_LDFLAGS := -pie --export-dynamic --no-dynamic-linker -z notext -z
 POSIX_TEST_PIE_dlfcn-pie-c := yes
 POSIX_TEST_PIE_dlfcn-global-c := yes
 POSIX_TEST_PIE_dlfcn-needed-c := yes
+# dlfcn-init-runpath-c links PIE with --export-dynamic so the main executable's
+# `g_dtor_ran` global lands in `.dynsym`; the loader's global symbol table then
+# satisfies libctor.so's `extern volatile int g_dtor_ran` reference at load time.
+POSIX_TEST_PIE_dlfcn-init-runpath-c := yes
 
 define POSIX_TEST_RULE
 POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TESTS_SRCDIR)/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TESTS_SRCDIR)/$(1)/*.c))
@@ -174,8 +178,10 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite).initrd)
 	$(RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs.img
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
+	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
+	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
 
 #---------------------------------------------------------------------------------------------------
@@ -271,6 +277,71 @@ $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(eval $(call POSIX_TEST_SOLIB_RULE,$
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite)))
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-init-runpath-c: constructor/destructor + DT_RUNPATH fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+# This suite ships THREE shared libraries (built with the same freestanding host
+# toolchain as the global/needed fixtures above):
+#   * libctor.so   - carries `.init_array`/`.fini_array` (a constructor and a
+#                    destructor). The destructor stores a sentinel into the main
+#                    executable's exported `g_dtor_ran` global, so libctor.so is
+#                    left with an UNDEFINED `g_dtor_ran` that the loader resolves
+#                    from the global scope (the suite ELF is PIE +
+#                    --export-dynamic, see POSIX_TEST_PIE_* above). Staged at
+#                    lib/libctor.so.
+#   * libchild.so  - a self-contained dependency, given an explicit SONAME so the
+#                    DT_NEEDED entry recorded in libparent.so is the bare name
+#                    `libchild.so` regardless of linker (GNU ld vs ld.lld). Staged
+#                    ONLY at lib/subdir/libchild.so (never lib/).
+#   * libparent.so - DT_NEEDED=libchild.so (via -lchild) and DT_RUNPATH=lib/subdir
+#                    (via --enable-new-dtags -rpath lib/subdir). --enable-new-dtags
+#                    forces DT_RUNPATH instead of the deprecated DT_RPATH, which
+#                    the Nanvix loader intentionally ignores. The loader must
+#                    consult DT_RUNPATH to locate libchild.so. Staged at
+#                    lib/libparent.so.
+
+POSIX_TEST_RUNPATH_SUITE  := dlfcn-init-runpath-c
+POSIX_TEST_RUNPATH_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_RUNPATH_SUITE)/libs
+POSIX_TEST_RUNPATH_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_RUNPATH_SUITE)-seed
+POSIX_TEST_RUNPATH_IMG    := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_RUNPATH_SUITE).img
+
+# libctor.so: constructor/destructor witness. The undefined `g_dtor_ran` is left
+# for the loader to resolve from the main executable's global scope at load time.
+$(POSIX_TEST_RUNPATH_LIBDIR)/libctor.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_RUNPATH_SUITE)/libs/ctor.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_RUNPATH_SUITE)/libctor.so (.init_array/.fini_array)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# libchild.so: self-contained dependency with SONAME=libchild.so.
+$(POSIX_TEST_RUNPATH_LIBDIR)/libchild.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_RUNPATH_SUITE)/libs/subdir/child.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_RUNPATH_SUITE)/libchild.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libchild.so $@.o -o $@
+
+# libparent.so: DT_NEEDED=libchild.so, DT_RUNPATH=lib/subdir.
+$(POSIX_TEST_RUNPATH_LIBDIR)/libparent.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_RUNPATH_SUITE)/libs/parent.c \
+		$(POSIX_TEST_RUNPATH_LIBDIR)/libchild.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_RUNPATH_SUITE)/libparent.so (DT_NEEDED libchild.so, DT_RUNPATH lib/subdir)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o \
+		-L$(POSIX_TEST_RUNPATH_LIBDIR) -lchild --enable-new-dtags -rpath lib/subdir -o $@
+
+# Per-suite RAMFS image: libctor.so + libparent.so under lib/, libchild.so under
+# lib/subdir/ (reachable ONLY via libparent.so's DT_RUNPATH).
+$(POSIX_TEST_RUNPATH_IMG): $(POSIX_TEST_RUNPATH_LIBDIR)/libctor.so \
+		$(POSIX_TEST_RUNPATH_LIBDIR)/libparent.so \
+		$(POSIX_TEST_RUNPATH_LIBDIR)/libchild.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_RUNPATH_SEED)/lib/subdir
+	$(CP_CMD) $(POSIX_TEST_RUNPATH_LIBDIR)/libctor.so $(POSIX_TEST_RUNPATH_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_RUNPATH_LIBDIR)/libparent.so $(POSIX_TEST_RUNPATH_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_RUNPATH_LIBDIR)/libchild.so $(POSIX_TEST_RUNPATH_SEED)/lib/subdir/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_RUNPATH_SEED)
+
 # The per-suite boot arguments that pair each suite with its RAMFS image
 # (`-ramfs <img>`) or enable host networking (`-allow-host-networking`) now live
 # in the nanvix-test harness configs (test/test-posix.toml and
@@ -290,7 +361,8 @@ POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST
 .PHONY: all-posix-test-images
 all-posix-test-images: $(POSIX_TEST_INITRDS) \
 		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
-		$(POSIX_TEST_SOLIB_IMGS)
+		$(POSIX_TEST_SOLIB_IMGS) \
+		$(POSIX_TEST_RUNPATH_IMG)
 	@echo "All POSIX C test-suite images built."
 
 .PHONY: run-posix-tests
@@ -315,7 +387,7 @@ ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
 else ifeq ($(DEPLOYMENT_MODE),standalone)
-run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS)
+run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG)
 	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }

--- a/src/posix-tests/dlfcn-init-runpath-c/libs/ctor.c
+++ b/src/posix-tests/dlfcn-init-runpath-c/libs/ctor.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libctor.so - shared library that exercises `.init_array` and
+ * `.fini_array` semantics required by the System V gABI.
+ *
+ * The constructor sets `ctor_ran` to a known sentinel value, and the
+ * destructor writes a different sentinel into the test program's
+ * `g_dtor_ran` global so that observation outlives the unloaded
+ * library. `g_dtor_ran` is declared `extern` here and resolved by the
+ * Nanvix loader's global symbol table (the main executable was linked
+ * with `--export-dynamic`).
+ */
+
+/* Public state exposed via dlsym so the test can read it after dlopen. */
+volatile int ctor_ran = 0;
+
+/* Main executable owns the destructor witness. */
+extern volatile int g_dtor_ran;
+
+static void __attribute__((constructor)) my_ctor(void)
+{
+    ctor_ran = 0xC70A;
+}
+
+static void __attribute__((destructor)) my_dtor(void)
+{
+    g_dtor_ran = 0xD70A;
+}
+
+/* Sanity entry point so the test can confirm dlsym still works. */
+int ctor_value(void)
+{
+    return 42;
+}

--- a/src/posix-tests/dlfcn-init-runpath-c/libs/parent.c
+++ b/src/posix-tests/dlfcn-init-runpath-c/libs/parent.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libparent.so - shared library whose DT_NEEDED entry points at
+ * libchild.so, but whose runtime search path (DT_RUNPATH) is
+ * `lib/subdir/`. The Nanvix loader must consult DT_RUNPATH before
+ * falling back to the default `lib/` directory, otherwise libchild.so
+ * will not be located and dlopen will fail.
+ */
+
+extern int child_value(int x);
+
+int parent_value(int x)
+{
+    return child_value(x) * 2;
+}

--- a/src/posix-tests/dlfcn-init-runpath-c/libs/subdir/child.c
+++ b/src/posix-tests/dlfcn-init-runpath-c/libs/subdir/child.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libchild.so - dependency of libparent.so. Installed under a
+ * non-default directory (`lib/subdir/`) so the only way the loader
+ * can find it via the DT_NEEDED edge in libparent.so is by honouring
+ * libparent's DT_RUNPATH.
+ */
+
+int child_value(int x)
+{
+    return x + 7;
+}

--- a/src/posix-tests/dlfcn-init-runpath-c/main.c
+++ b/src/posix-tests/dlfcn-init-runpath-c/main.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-init-runpath-c: Tests for `.init_array` / `.fini_array`
+ * constructor and destructor invocation, and for DT_RUNPATH-driven
+ * dependency search.
+ *
+ * Test 1 (constructor): dlopen libctor.so, dlsym `ctor_ran`, and
+ *   confirm the constructor sentinel was written.
+ *
+ * Test 2 (destructor): dlclose libctor.so and confirm the destructor
+ *   wrote its sentinel into the main executable's `g_dtor_ran` global.
+ *   `g_dtor_ran` must be exported via --export-dynamic so the loader's
+ *   global symbol table can satisfy the `extern volatile int g_dtor_ran;`
+ *   reference in the library.
+ *
+ * Test 3 (DT_RUNPATH): dlopen lib/libparent.so, which has
+ *   DT_NEEDED=libchild.so and DT_RUNPATH=lib/subdir/. The loader must
+ *   probe DT_RUNPATH before the default `lib/` directory; otherwise
+ *   libchild.so is not located.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Witness for libctor.so's destructor -- defined here so it survives the
+ * library being unloaded. Marked volatile to keep the optimiser away.
+ */
+volatile int g_dtor_ran = 0;
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 1 (constructor) + Test 2 (destructor): the constructor in
+ * `.init_array` must run before dlopen returns, and the destructor in
+ * `.fini_array` must run on dlclose. Both are checked here so the
+ * destructor witness (`g_dtor_ran`) is observed while it is fresh.
+ */
+static void test_init_array(void)
+{
+    void *h = dlopen("lib/libctor.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("init_array fires on dlopen", dlerror());
+        return;
+    }
+
+    volatile int *ctor_ran = (volatile int *)dlsym(h, "ctor_ran");
+    if (ctor_ran == NULL) {
+        fail("init_array fires on dlopen", "ctor_ran symbol missing");
+        dlclose(h);
+        return;
+    }
+
+    if (*ctor_ran != 0xC70A) {
+        fail("init_array fires on dlopen", "constructor sentinel not set");
+        dlclose(h);
+        return;
+    }
+
+    /* Sanity check: ordinary symbol resolution still works after init. */
+    int (*fn)(void) = NULL;
+    *(void **)(&fn) = dlsym(h, "ctor_value");
+    if (fn == NULL || fn() != 42) {
+        fail("init_array fires on dlopen", "ctor_value() wrong");
+        dlclose(h);
+        return;
+    }
+
+    /* Reset the dtor witness so test_fini_array measures a fresh signal. */
+    g_dtor_ran = 0;
+    if (dlclose(h) != 0) {
+        fail("fini_array fires on dlclose", dlerror());
+        return;
+    }
+
+    pass("init_array fires on dlopen");
+
+    /* Bridge directly into the destructor test while the witness is fresh. */
+    if (g_dtor_ran != 0xD70A) {
+        fail("fini_array fires on dlclose", "destructor sentinel not set");
+        return;
+    }
+    pass("fini_array fires on dlclose");
+}
+
+/*
+ * Test 3: DT_RUNPATH must be consulted when resolving DT_NEEDED bare
+ * names. libparent.so depends on libchild.so but libchild.so only
+ * exists under lib/subdir/, which is libparent's DT_RUNPATH.
+ */
+static void test_dt_runpath(void)
+{
+    void *h = dlopen("lib/libparent.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("DT_RUNPATH dependency search", dlerror());
+        return;
+    }
+
+    int (*fn)(int) = NULL;
+    *(void **)(&fn) = dlsym(h, "parent_value");
+    if (fn == NULL || fn(5) != 24) {
+        /* parent_value(5) = child_value(5) * 2 = (5 + 7) * 2 = 24 */
+        fail("DT_RUNPATH dependency search", "parent_value() wrong");
+        dlclose(h);
+        return;
+    }
+
+    if (dlclose(h) != 0) {
+        fail("DT_RUNPATH dependency search", dlerror());
+        return;
+    }
+    pass("DT_RUNPATH dependency search");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn init_array + DT_RUNPATH tests ===\n");
+    fflush(stdout);
+
+    test_init_array();
+    test_dt_runpath();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-init-runpath-c"
+program = "./bin/dlfcn-init-runpath-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-init-runpath-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/dlfcn-needed-c"
 program = "./bin/dlfcn-needed-c.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-needed-c.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-init-runpath-c"
+program = "./bin/dlfcn-init-runpath-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-init-runpath-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/dlfcn-needed-c"
 program = "./bin/dlfcn-needed-c.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-needed-c.img"


### PR DESCRIPTION
## Summary

Adds a new POSIX C test suite, `dlfcn-init-runpath-c`, that exercises ELF dynamic-loading semantics not covered by the existing dlfcn suites:

- `.init_array` constructor invocation on `dlopen()`
- `.fini_array` destructor invocation on `dlclose()`
- `DT_RUNPATH`-driven resolution of `DT_NEEDED` dependencies

## Fixtures

The suite ships three shared libraries built with the freestanding guest C toolchain:

- **libctor.so** — constructor sets a `ctor_ran` sentinel; destructor writes a sentinel into the main executable''s exported `g_dtor_ran`. The undefined `g_dtor_ran` is resolved from the global scope, so the suite ELF is linked PIE with `--export-dynamic`. Staged at `lib/libctor.so`.
- **libchild.so** — self-contained dependency with an explicit `SONAME=libchild.so`. Staged ONLY at `lib/subdir/libchild.so`.
- **libparent.so** — `DT_NEEDED=libchild.so` and `DT_RUNPATH=lib/subdir` (via `--enable-new-dtags`). The loader must consult `DT_RUNPATH` to locate libchild.so, since it is absent from the default `lib/` directory.

## Test coverage

1. constructor runs before `dlopen()` returns (init_array)
2. destructor runs on `dlclose()` (fini_array), observed via the main executable''s witness global
3. `DT_NEEDED` bare names resolved through `DT_RUNPATH` by loading libparent.so and calling `parent_value()`

## Wire-up

- `Makefile`: add `dlfcn-init-runpath-c` to `ALL_POSIX_TESTS`.
- `build/make/posix-tests.mk`: register the PIE config and add build rules for the three fixtures plus the per-suite RAMFS image, wired into `all-posix-test-images`, `run-posix-tests`, and `clean-posix-tests`.
- `test/test-posix.toml` and `test/test-posix-windows.toml`: add a terminal test entry pairing the suite with its RAMFS image, expecting exit code 0.

## Validation (Windows, standalone/WHP)

- Focused build of the suite initrd and RAMFS image: passed
- `llvm-readobj` confirms `libparent.so` has `RUNPATH [lib/subdir]` and `NEEDED [libchild.so]`
- `run-unit-tests`: passed
- `run-nanvix-tests`: passed
- `run-posix-tests`: passed, including `posix/dlfcn-init-runpath-c` (exit 0)