### PR TITLE
[tests] Add setjmp-c integration test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/src/posix-tests/setjmp-c/common.h
+++ b/src/posix-tests/setjmp-c/common.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+// Tests that setjmp() returns zero when invoked directly (not through longjmp()).
+extern void test_setjmp_direct_return(void);
+
+// Tests that longjmp() delivers its value to setjmp(), including the 0 -> 1 rule.
+extern void test_longjmp_return_value(void);
+
+// Tests that volatile automatic variables modified after setjmp() survive a longjmp().
+extern void test_volatile_locals_preserved(void);
+
+// Tests that setjmp() writes only within the jmp_buf and does not overflow into adjacent storage.
+extern void test_jmp_buf_no_overflow(void);
+
+// Tests that longjmp() unwinds intermediate call frames and resumes at the setjmp() frame, which
+// then returns normally to its own caller.
+extern void test_longjmp_across_calls(void);
+
+// Tests repeated longjmp() to a single re-armed setjmp() target (retry-loop pattern).
+extern void test_longjmp_retry_loop(void);
+
+// Tests sigsetjmp()/siglongjmp() non-local control flow.
+extern void test_sigsetjmp_siglongjmp(void);
+
+#endif /* _COMMON_H_ */

--- a/src/posix-tests/setjmp-c/direct_value.c
+++ b/src/posix-tests/setjmp-c/direct_value.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests that setjmp() returns zero when invoked directly (not through longjmp()).
+void test_setjmp_direct_return(void)
+{
+    fprintf(stderr, "testing setjmp() direct return ... ");
+
+    jmp_buf env;
+
+    // A direct setjmp() call evaluates to zero. Nothing arms a longjmp() on this
+    // buffer, so the body below must never run.
+    if (setjmp(env) != 0) {
+        assert(0 && "setjmp() reported a longjmp() return without one");
+    }
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests that longjmp() delivers its value to setjmp(), including the 0 -> 1 rule.
+void test_longjmp_return_value(void)
+{
+    fprintf(stderr, "testing longjmp() return value ... ");
+
+    // A non-zero value passed to longjmp() is delivered verbatim to setjmp().
+    {
+        jmp_buf env;
+        switch (setjmp(env)) {
+            case 0:
+                longjmp(env, 42);
+                assert(0 && "longjmp() returned");
+            case 42:
+                break;
+            default:
+                assert(0 && "longjmp() delivered the wrong value");
+        }
+    }
+
+    // POSIX requires that longjmp(env, 0) make setjmp() return 1, never 0.
+    {
+        jmp_buf env;
+        switch (setjmp(env)) {
+            case 0:
+                longjmp(env, 0);
+                assert(0 && "longjmp() returned");
+            case 1:
+                break;
+            default:
+                assert(0 && "longjmp(env, 0) must make setjmp() return 1");
+        }
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/setjmp-c/main.c
+++ b/src/posix-tests/setjmp-c/main.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests setjmp()/longjmp() non-local control flow.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_setjmp_direct_return();
+    test_longjmp_return_value();
+    test_volatile_locals_preserved();
+    test_jmp_buf_no_overflow();
+    test_longjmp_across_calls();
+    test_longjmp_retry_loop();
+    test_sigsetjmp_siglongjmp();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/posix-tests/setjmp-c/preserve.c
+++ b/src/posix-tests/setjmp-c/preserve.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests that volatile automatic variables modified after setjmp() survive a longjmp().
+void test_volatile_locals_preserved(void)
+{
+    fprintf(stderr, "testing volatile locals across longjmp() ... ");
+
+    jmp_buf env;
+    volatile int counter = 100;
+    volatile int reached = 0;
+
+    if (setjmp(env) == 0) {
+        // Mutate volatile locals after the context was saved, then jump back.
+        counter += 11;
+        reached = 1;
+        longjmp(env, 1);
+        assert(0 && "longjmp() returned");
+    }
+
+    // Resumed through longjmp(): volatile automatics keep their latest values.
+    assert(reached == 1);
+    assert(counter == 111);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests that setjmp() writes only within the jmp_buf and does not overflow into adjacent storage.
+void test_jmp_buf_no_overflow(void)
+{
+    fprintf(stderr, "testing jmp_buf bounds ... ");
+
+    // Sentinels placed immediately after the jmp_buf inside the same object. A
+    // setjmp() implementation that writes past the end of the buffer (e.g. one
+    // expecting a wider jmp_buf than the header declares) would clobber these and
+    // corrupt the caller's stack. They must stay intact across both setjmp() and
+    // longjmp(), which only touch the buffer itself.
+    struct {
+        jmp_buf env;
+        volatile unsigned int sentinel[4];
+    } guarded;
+
+    guarded.sentinel[0] = 0xDEADBEEFu;
+    guarded.sentinel[1] = 0xCAFEBABEu;
+    guarded.sentinel[2] = 0x12345678u;
+    guarded.sentinel[3] = 0xA5A5A5A5u;
+
+    if (setjmp(guarded.env) == 0) {
+        // Direct return: setjmp() must not have touched the trailing sentinels.
+        assert(guarded.sentinel[0] == 0xDEADBEEFu);
+        assert(guarded.sentinel[1] == 0xCAFEBABEu);
+        assert(guarded.sentinel[2] == 0x12345678u);
+        assert(guarded.sentinel[3] == 0xA5A5A5A5u);
+        longjmp(guarded.env, 1);
+        assert(0 && "longjmp() returned");
+    }
+
+    // Jump return: longjmp() only reads the buffer, so the sentinels still hold.
+    assert(guarded.sentinel[0] == 0xDEADBEEFu);
+    assert(guarded.sentinel[1] == 0xCAFEBABEu);
+    assert(guarded.sentinel[2] == 0x12345678u);
+    assert(guarded.sentinel[3] == 0xA5A5A5A5u);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/setjmp-c/sigjmp.c
+++ b/src/posix-tests/setjmp-c/sigjmp.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests sigsetjmp()/siglongjmp() non-local control flow.
+void test_sigsetjmp_siglongjmp(void)
+{
+    fprintf(stderr, "testing sigsetjmp()/siglongjmp() ... ");
+
+    sigjmp_buf env;
+    volatile int reached = 0;
+
+    switch (sigsetjmp(env, 1)) {
+        case 0:
+            reached = 1;
+            siglongjmp(env, 5);
+            assert(0 && "siglongjmp() returned");
+        case 5:
+            assert(reached == 1);
+            break;
+        default:
+            assert(0 && "siglongjmp() delivered the wrong value");
+    }
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/posix-tests/setjmp-c/unwind.c
+++ b/src/posix-tests/setjmp-c/unwind.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Private Variables
+//==================================================================================================
+
+// Shared jump target for the cross-frame unwinding test. It lives at file scope so
+// the deeply nested callee can reach the buffer saved by run_protected().
+static jmp_buf cross_call_env;
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Innermost frame: jumps back to the saved setjmp() site, unwinding itself and its caller.
+static void deep_callee(int code)
+{
+    longjmp(cross_call_env, code);
+    assert(0 && "longjmp() returned");
+}
+
+// Intermediate frame: holds a live local across the call so the unwinding crosses a real,
+// non-trivial stack frame, then calls the innermost frame.
+static void middle_callee(int code)
+{
+    volatile int guard = 0x5A5A;
+    deep_callee(code);
+    // Unreachable: deep_callee() never returns.
+    assert(guard == 0x5A5A);
+}
+
+// Saves a jump target, dives two frames deep, and is re-entered by longjmp(). Returns the value
+// delivered by longjmp(), proving the frame resumed cleanly and can itself return normally.
+static int run_protected(void)
+{
+    volatile int armed = 0;
+
+    switch (setjmp(cross_call_env)) {
+        case 0:
+            armed = 1;
+            middle_callee(7);
+            // Unreachable: middle_callee() always longjmp()s back here.
+            assert(0 && "middle_callee() returned");
+            return (-1);
+        case 7:
+            // Re-entered via longjmp() from deep_callee(), two frames down.
+            assert(armed == 1);
+            return (7);
+        default:
+            assert(0 && "longjmp() delivered the wrong value");
+            return (-1);
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests that longjmp() unwinds intermediate call frames and resumes at the setjmp() frame, which
+// then returns normally to its own caller.
+void test_longjmp_across_calls(void)
+{
+    fprintf(stderr, "testing longjmp() across call frames ... ");
+
+    // run_protected() only returns normally if longjmp() unwound the two nested
+    // frames, resumed at the setjmp() site, and left that frame intact enough to
+    // return here.
+    int result = run_protected();
+    assert(result == 7);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests repeated longjmp() to a single re-armed setjmp() target (retry-loop pattern).
+void test_longjmp_retry_loop(void)
+{
+    fprintf(stderr, "testing repeated longjmp() ... ");
+
+    jmp_buf env;
+    volatile int attempts = 0;
+
+    // setjmp() saves the context once; each longjmp() resumes here without
+    // re-running setjmp(). The volatile counter survives every jump, so the loop
+    // terminates after three passes.
+    (void)setjmp(env);
+
+    attempts += 1;
+    if (attempts < 3) {
+        longjmp(env, attempts);
+    }
+
+    assert(attempts == 3);
+
+    fprintf(stderr, "passed\n");
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -157,6 +157,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/setjmp-c"
+program = "./bin/setjmp-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/thread-c"
 program = "./bin/thread-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -157,6 +157,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/setjmp-c"
+program = "./bin/setjmp-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/thread-c"
 program = "./bin/thread-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
Add a guest C test suite exercising `setjmp()`/`longjmp()` and `sigsetjmp()`/`siglongjmp()` non-local control flow under the Nanvix sysroot.

The suite comprises seven test cases:
- Direct `setjmp()` return value (must be zero).
- `longjmp()` value delivery, including the POSIX 0→1 rule.
- Volatile automatic variable preservation across `longjmp()`.
- `jmp_buf` bounds check (sentinel overflow detection for issue #2647).
- `longjmp()` unwinding across intermediate call frames.
- Repeated `longjmp()` to a re-armed `setjmp()` target (retry-loop).
- `sigsetjmp()`/`siglongjmp()` round-trip.

Register `setjmp-c` in `ALL_POSIX_TESTS` (Makefile) and add `[[tests]]` entries to both `test/test-posix.toml` and `test/test-posix-windows.toml` so the harness runs the new suite on Linux and Windows standalone configurations.

Closes #2647