### PR TITLE
[test] Add dlfcn-weak-c suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c file-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -111,6 +111,10 @@ POSIX_TEST_PIE_dlfcn-diamond-c := yes
 # `g_dtor_ran` global lands in `.dynsym`; the loader's global symbol table then
 # satisfies libctor.so's `extern volatile int g_dtor_ran` reference at load time.
 POSIX_TEST_PIE_dlfcn-init-runpath-c := yes
+# dlfcn-weak-c links PIE with --export-dynamic so the main executable's
+# `main_callback`/`weak_data` globals land in `.dynsym`; the loader resolves the
+# helper `.so` files' weak undefined references against that global scope.
+POSIX_TEST_PIE_dlfcn-weak-c := yes
 
 define POSIX_TEST_RULE
 POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TESTS_SRCDIR)/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TESTS_SRCDIR)/$(1)/*.c))
@@ -181,10 +185,12 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_dlfcn-diamond-c)
+	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
 
 #---------------------------------------------------------------------------------------------------
@@ -420,6 +426,68 @@ $(POSIX_TEST_RUNPATH_IMG): $(POSIX_TEST_RUNPATH_LIBDIR)/libctor.so \
 	$(CP_CMD) $(POSIX_TEST_RUNPATH_LIBDIR)/libchild.so $(POSIX_TEST_RUNPATH_SEED)/lib/subdir/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_RUNPATH_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-weak-c: STB_WEAK undefined-symbol fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+# This suite ships SEVEN shared libraries built from FOUR sources, each compiled
+# with different -D defines, to exercise the loader's handling of weak undefined
+# symbols across both i686 relocation classes (built with the same freestanding
+# host toolchain as the global/needed fixtures above):
+#   * libweak-func-resolved.so / libweak-func-missing.so  (weak_func.c)
+#       NULL-guarded weak function ref  -> R_386_GLOB_DAT.
+#   * libweak-data-resolved.so / libweak-data-missing.so  (weak_data.c)
+#       NULL-guarded weak data ref      -> R_386_GLOB_DAT.
+#   * libweak-plt-resolved.so / libweak-plt-missing.so    (weak_func_plt.c)
+#       unguarded weak function call    -> R_386_JUMP_SLOT.
+#   * libstrong-missing.so                                (strong_missing.c)
+#       unguarded strong undefined call -> R_386_JUMP_SLOT (regression guard).
+#
+# The "resolved" variants reference the symbol names the main executable exports
+# (main_callback/weak_data); the "missing" variants reference names nothing
+# defines, so the loader must zero them per the STB_WEAK rule. The suite ELF is
+# PIE + --export-dynamic (POSIX_TEST_PIE_dlfcn-weak-c above) so its
+# main_callback/weak_data land in .dynsym for the resolved cases.
+
+POSIX_TEST_WEAK_SUITE  := dlfcn-weak-c
+POSIX_TEST_WEAK_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_WEAK_SUITE)/libs
+POSIX_TEST_WEAK_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_WEAK_SUITE)-seed
+POSIX_TEST_WEAK_IMG    := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_WEAK_SUITE).img
+
+# $(1) = output .so name; $(2) = source file under libs/; $(3) = extra -D defines.
+define POSIX_TEST_WEAK_SOLIB_RULE
+$$(POSIX_TEST_WEAK_LIBDIR)/$(1): $$(POSIX_TESTS_SRCDIR)/$$(POSIX_TEST_WEAK_SUITE)/libs/$(2)
+	@$$(MKDIR_CMD) $$(dir $$@)
+	@echo "[posix-test] building $$(POSIX_TEST_WEAK_SUITE)/$(1)"
+	$$(GUEST_C_APP_CC) $$(POSIX_TEST_SOLIB_CFLAGS) $(3) -c $$< -o $$@.o
+	$$(GUEST_C_APP_LD) $$(POSIX_TEST_SOLIB_LDFLAGS) $$@.o -o $$@
+endef
+
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-func-resolved.so,weak_func.c,-DCALLBACK_NAME=main_callback))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-func-missing.so,weak_func.c,-DCALLBACK_NAME=missing_callback))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-data-resolved.so,weak_data.c,-DWEAK_DATA_NAME=weak_data))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-data-missing.so,weak_data.c,-DWEAK_DATA_NAME=missing_weak_data))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-plt-resolved.so,weak_func_plt.c,-DCALLBACK_NAME=main_callback))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libweak-plt-missing.so,weak_func_plt.c,-DCALLBACK_NAME=missing_plt_callback))
+$(eval $(call POSIX_TEST_WEAK_SOLIB_RULE,libstrong-missing.so,strong_missing.c,))
+
+# The seven fixtures, in main.c's dlopen() order.
+POSIX_TEST_WEAK_LIBS := \
+	libstrong-missing.so \
+	libweak-func-resolved.so libweak-func-missing.so \
+	libweak-data-resolved.so libweak-data-missing.so \
+	libweak-plt-resolved.so libweak-plt-missing.so
+
+# Per-suite RAMFS image carrying all seven fixtures under lib/, where main.c
+# dlopen()s them.
+$(POSIX_TEST_WEAK_IMG): $(foreach lib,$(POSIX_TEST_WEAK_LIBS),$(POSIX_TEST_WEAK_LIBDIR)/$(lib)) \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_WEAK_SEED)/lib
+	$(CP_CMD) $(foreach lib,$(POSIX_TEST_WEAK_LIBS),$(POSIX_TEST_WEAK_LIBDIR)/$(lib)) \
+		$(POSIX_TEST_WEAK_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_WEAK_SEED)
+
 # The per-suite boot arguments that pair each suite with its RAMFS image
 # (`-ramfs <img>`) or enable host networking (`-allow-host-networking`) now live
 # in the nanvix-test harness configs (test/test-posix.toml and
@@ -440,7 +508,8 @@ $(POSIX_TEST_RUNPATH_IMG): $(POSIX_TEST_RUNPATH_LIBDIR)/libctor.so \
 all-posix-test-images: $(POSIX_TEST_INITRDS) \
 		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
 		$(POSIX_TEST_SOLIB_IMGS) \
-		$(POSIX_TEST_RUNPATH_IMG)
+		$(POSIX_TEST_RUNPATH_IMG) \
+		$(POSIX_TEST_WEAK_IMG)
 	@echo "All POSIX C test-suite images built."
 
 .PHONY: run-posix-tests
@@ -465,7 +534,7 @@ ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
 else ifeq ($(DEPLOYMENT_MODE),standalone)
-run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG)
+run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG) $(POSIX_TEST_WEAK_IMG)
 	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }

--- a/src/posix-tests/dlfcn-weak-c/libs/strong_missing.c
+++ b/src/posix-tests/dlfcn-weak-c/libs/strong_missing.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+extern int strong_missing(void);
+
+int call_strong(void)
+{
+    return (strong_missing());
+}

--- a/src/posix-tests/dlfcn-weak-c/libs/weak_data.c
+++ b/src/posix-tests/dlfcn-weak-c/libs/weak_data.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <stddef.h>
+
+#ifndef WEAK_DATA_NAME
+#define WEAK_DATA_NAME weak_data
+#endif
+
+extern int WEAK_DATA_NAME __attribute__((weak));
+
+int read_weak_data(void)
+{
+    if (&WEAK_DATA_NAME != NULL) {
+        return (WEAK_DATA_NAME);
+    }
+
+    return (-1);
+}

--- a/src/posix-tests/dlfcn-weak-c/libs/weak_func.c
+++ b/src/posix-tests/dlfcn-weak-c/libs/weak_func.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <stddef.h>
+
+#ifndef CALLBACK_NAME
+#define CALLBACK_NAME main_callback
+#endif
+
+extern int CALLBACK_NAME(int) __attribute__((weak));
+
+int try_callback(void)
+{
+    if (&CALLBACK_NAME != NULL) {
+        return (CALLBACK_NAME(7));
+    }
+
+    return (-1);
+}

--- a/src/posix-tests/dlfcn-weak-c/libs/weak_func_plt.c
+++ b/src/posix-tests/dlfcn-weak-c/libs/weak_func_plt.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Companion to libs/weak_func.c that exercises the *PLT* path for weak
+ * undefined function references.
+ *
+ * Calling the weak symbol without a preceding `&fn != NULL` check lets the
+ * compiler route the call through the PLT, producing a `R_386_JUMP_SLOT`
+ * relocation rather than the GOT-indirect `R_386_GLOB_DAT` emitted by
+ * libs/weak_func.c. Together the two helpers cover both relocation classes
+ * the dynamic loader must handle for weak undefined symbols.
+ *
+ * Safety note: the `missing` variant of this helper produces a `.so` whose
+ * weak symbol resolves to address zero at runtime. The main test driver
+ * MUST NOT invoke `call_weak_unchecked` against that variant -- doing so
+ * would jump to NULL. Resolving `dlsym(handle, "call_weak_unchecked")` is
+ * safe; the goal of the missing variant is only to prove that the loader
+ * accepts the `.so` under RTLD_NOW despite the weak undefined PLT entry.
+ */
+
+#ifndef CALLBACK_NAME
+#define CALLBACK_NAME main_callback
+#endif
+
+extern int CALLBACK_NAME(int) __attribute__((weak));
+
+int call_weak_unchecked(int x)
+{
+    return (CALLBACK_NAME(x));
+}

--- a/src/posix-tests/dlfcn-weak-c/main.c
+++ b/src/posix-tests/dlfcn-weak-c/main.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Resolved and unresolved weak cases use separate helper shared objects with
+ * distinct weak symbol names so this single executable can export
+ * main_callback/weak_data without also satisfying the missing-symbol cases.
+ * The strong-UND regression uses RTLD_NOW so failure is asserted at dlopen(),
+ * avoiding an unsafe lazy call into an unresolved strong symbol.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+int weak_data = 99;
+
+int main_callback(int x)
+{
+    return (x * 10);
+}
+
+void clear_dlerror(void)
+{
+    (void)dlerror();
+}
+
+// Opens a dynamic load library.
+void *open_library(const char *path, int flags)
+{
+    clear_dlerror();
+
+    void *handle = dlopen(path, flags);
+    assert(handle != NULL);
+
+    return (handle);
+}
+
+// Closes a dynamic load library.
+void close_library(void *handle)
+{
+    assert(dlclose(handle) == 0);
+}
+
+// Resolves a symbol in a dynamic load library.
+void *resolve_symbol(void *handle, const char *symbol)
+{
+    clear_dlerror();
+
+    void *sym = dlsym(handle, symbol);
+    const char *error = dlerror();
+    assert(error == NULL);
+    assert(sym != NULL);
+
+    return (sym);
+}
+
+// Tests if a weak undefined function resolves to the main executable.
+//
+// Relocation: R_386_GLOB_DAT (GOT-indirect call guarded by `if (&fn)`).
+void test_weak_und_function_resolved(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*try_callback)(void) = NULL;
+    *(void **)(&try_callback) = resolve_symbol(handle, "try_callback");
+    assert(try_callback != NULL);
+    assert(try_callback() == 70);
+
+    close_library(handle);
+}
+
+// Tests if a missing weak undefined function resolves to zero.
+//
+// Relocation: R_386_GLOB_DAT (GOT-indirect call guarded by `if (&fn)`).
+void test_weak_und_function_missing(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*try_callback)(void) = NULL;
+    *(void **)(&try_callback) = resolve_symbol(handle, "try_callback");
+    assert(try_callback != NULL);
+    assert(try_callback() == -1);
+
+    close_library(handle);
+}
+
+// Tests if weak undefined data resolves to the main executable.
+//
+// Relocation: R_386_GLOB_DAT (GOT-indirect load guarded by `if (&data)`).
+void test_weak_und_data_resolved(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*read_weak_data)(void) = NULL;
+    *(void **)(&read_weak_data) = resolve_symbol(handle, "read_weak_data");
+    assert(read_weak_data != NULL);
+    assert(read_weak_data() == 99);
+
+    close_library(handle);
+}
+
+// Tests if missing weak undefined data resolves to zero.
+//
+// Relocation: R_386_GLOB_DAT (GOT-indirect load guarded by `if (&data)`).
+void test_weak_und_data_missing(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*read_weak_data)(void) = NULL;
+    *(void **)(&read_weak_data) = resolve_symbol(handle, "read_weak_data");
+    assert(read_weak_data != NULL);
+    assert(read_weak_data() == -1);
+
+    close_library(handle);
+}
+
+// Tests if a weak undefined function called via PLT resolves to the main exe.
+//
+// Relocation: R_386_JUMP_SLOT (unguarded PLT call).
+void test_weak_und_function_plt_resolved(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*call_weak_unchecked)(int) = NULL;
+    *(void **)(&call_weak_unchecked) = resolve_symbol(handle, "call_weak_unchecked");
+    assert(call_weak_unchecked != NULL);
+    assert(call_weak_unchecked(7) == 70);
+
+    close_library(handle);
+}
+
+// Tests that the loader accepts a .so whose weak undefined PLT slot is missing.
+//
+// Relocation: R_386_JUMP_SLOT (unguarded PLT call).
+//
+// Note: we deliberately resolve, but DO NOT call, `call_weak_unchecked` here.
+// Calling it would jump through a PLT entry whose target was zeroed by the
+// loader (weak undefined missing -> 0), trapping the test. The contract this
+// case verifies is purely "dlopen with RTLD_NOW succeeds despite the weak
+// undefined symbol", not "the call returns a value".
+void test_weak_und_function_plt_missing(const char *path)
+{
+    void *handle = open_library(path, RTLD_NOW);
+
+    int (*call_weak_unchecked)(int) = NULL;
+    *(void **)(&call_weak_unchecked) = resolve_symbol(handle, "call_weak_unchecked");
+    assert(call_weak_unchecked != NULL);
+
+    close_library(handle);
+}
+
+// Tests if a missing strong undefined symbol still fails to load.
+//
+// Relocation: R_386_JUMP_SLOT against a strong UND symbol; dlopen(RTLD_NOW)
+// must reject the .so at load time rather than producing a callable handle.
+void test_strong_und_missing(const char *path)
+{
+    clear_dlerror();
+
+    void *handle = dlopen(path, RTLD_NOW);
+    const char *error = dlerror();
+    assert(handle == NULL);
+    assert(error != NULL);
+}
+
+/**
+ * @brief Tests STB_WEAK undefined-symbol handling in the dynamic loader.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Run the strong-undefined rejection case first. It exercises a different
+    // loader path (dlopen must fail outright) from the weak cases, so ordering
+    // it ahead keeps a regression there reported independently of the weak ones.
+    test_strong_und_missing("lib/libstrong-missing.so");
+    test_weak_und_function_resolved("lib/libweak-func-resolved.so");
+    test_weak_und_function_missing("lib/libweak-func-missing.so");
+    test_weak_und_data_resolved("lib/libweak-data-resolved.so");
+    test_weak_und_data_missing("lib/libweak-data-missing.so");
+    test_weak_und_function_plt_resolved("lib/libweak-plt-resolved.so");
+    test_weak_und_function_plt_missing("lib/libweak-plt-missing.so");
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -106,6 +106,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-weak-c"
+program = "./bin/dlfcn-weak-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-weak-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/echo-c"
 program = "./bin/echo-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -106,6 +106,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/dlfcn-weak-c"
+program = "./bin/dlfcn-weak-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-dlfcn-weak-c.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/echo-c"
 program = "./bin/echo-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Port a new POSIX C test suite (`dlfcn-weak-c`) that exercises the dynamic loader's handling of weak undefined symbols across both i686 relocation classes, plus a strong-undefined regression guard.

## Details

The suite ships seven shared-library fixtures built from four sources (each compiled with different `-D` defines) and a PIE main executable that exports `main_callback`/`weak_data`:

- `weak_func.c` → `libweak-func-{resolved,missing}.so` — NULL-guarded weak function ref (`R_386_GLOB_DAT`)
- `weak_data.c` → `libweak-data-{resolved,missing}.so` — NULL-guarded weak data ref (`R_386_GLOB_DAT`)
- `weak_func_plt.c` → `libweak-plt-{resolved,missing}.so` — unguarded weak function call (`R_386_JUMP_SLOT`)
- `strong_missing.c` → `libstrong-missing.so` — unguarded strong undefined call (`R_386_JUMP_SLOT` regression)

`resolved` fixtures reference the names the main executable exports; `missing` fixtures reference undefined names the loader must zero per the `STB_WEAK` rule. The strong-undefined case uses `RTLD_NOW` so `dlopen()` is asserted to fail at load time rather than trapping on a lazy call.

### Build wiring (`build/make/posix-tests.mk`)

- Link `dlfcn-weak-c` PIE with `--export-dynamic` so its globals land in `.dynsym` for the resolved cases.
- Add `POSIX_TEST_WEAK_SOLIB_RULE` to build the seven `.so` fixtures and a per-suite RAMFS image staging them under `lib/`.
- Extend `all-posix-test-images`, `run-posix-tests`, and `clean` targets.

### Test registration

- Register the suite in `ALL_POSIX_TESTS` (`Makefile`).
- Add matching `[[tests]]` entries (debug + release, `expected_exit_code = 0`) to both `test/test-posix.toml` and `test/test-posix-windows.toml`.

## Validation

Validated via `run-unit-tests`, `run-nanvix-tests`, and `run-posix-tests` on Windows standalone/WHP.
