### PR TITLE
[tests] Add fork pid/pthread regression suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/src/posix-tests/fork-pid-c/main.c
+++ b/src/posix-tests/fork-pid-c/main.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Regression test: a fork()'d child must observe its OWN (new) process id.
+ *
+ * This guards against a stale cached pid in the child (see "Background"). It
+ * asserts the POSIX invariant and currently passes on the pinned Nanvix
+ * sysroot; it will fail if the cached-pid regression is reintroduced.
+ *
+ * Background
+ * ----------
+ * On Nanvix, getpid() is memoized in a per-process cached variable
+ * (CACHED_PID) in libposix. A fork()'d child inherits that cache through
+ * copy-on-write, so unless the cache is invalidated in the child, getpid()
+ * keeps returning the PARENT's pid. POSIX requires that, in the child,
+ * getpid() return the child's own (new) pid -- i.e. the same value the
+ * parent received from fork() -- and that getppid() return the parent's pid.
+ *
+ * The stale cache is not merely cosmetic: capability-sensitive kernel calls
+ * (e.g. mmap/mprotect during a subsequent execv()) are keyed by the caller's
+ * pid, so a child acting under the parent's identity fails those calls with
+ * EACCES. This is what broke fork()+exec() of a fresh interpreter.
+ *
+ * What this program demonstrates (run in standalone mode)
+ * -------------------------------------------------------
+ *   PID-START          - the test starts.
+ *   PARENT-PID-OK      - the parent obtained a non-zero pid.
+ *   CHILD-PID-RECEIVED - the child reported its getpid()/getppid() back.
+ *   PID-MATCHES-FORK   - the child's getpid() equals fork()'s return value
+ *                        AND differs from the parent's pid.  <-- on a correct
+ *                        system; on the buggy system the child reports the
+ *                        parent's pid, so this check FAILS.
+ *   PPID-OK            - the child's getppid() equals the parent's pid.
+ *   ok                - the whole sequence succeeded.
+ *
+ * Correct behavior : all markers print and the process exits 0.
+ * Buggy behavior   : prints PID-FORK-MISMATCH and exits non-zero (the child
+ *                    reported the parent's pid).
+ *
+ * The pid values are passed from the child to the parent over a pipe(); pipes
+ * themselves work on Nanvix, so they are a reliable side channel here.
+ */
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void emit(const char *s)
+{
+    const char *p = s;
+    while (*p) {
+        p++;
+    }
+    (void)write(STDOUT_FILENO, s, (size_t)(p - s));
+}
+
+/* Read exactly `len` bytes into `buf`, looping over short reads. A pipe read()
+   may return fewer bytes than requested even for a single small write, so the
+   caller must drain it. Returns `len` on success, or a smaller count on EOF, or
+   -1 on error. */
+static ssize_t read_full(int fd, void *buf, size_t len)
+{
+    unsigned char *p = (unsigned char *)buf;
+    size_t got = 0;
+    while (got < len) {
+        ssize_t r = read(fd, p + got, len - got);
+        if (r < 0) {
+            return (-1);
+        }
+        if (r == 0) {
+            break; /* EOF: writer closed before sending the full report. */
+        }
+        got += (size_t)r;
+    }
+    return ((ssize_t)got);
+}
+
+/* The child's report sent back to the parent over the pipe. */
+struct child_report {
+    pid_t self; /* child's getpid()  */
+    pid_t ppid; /* child's getppid() */
+};
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    emit("PID-START\n");
+
+    pid_t parent_pid = getpid();
+    if (parent_pid <= 0) {
+        emit("PARENT-PID-INVALID\n");
+        return (1);
+    }
+    emit("PARENT-PID-OK\n");
+
+    int p[2];
+    if (pipe(p) != 0) {
+        emit("PIPE-FAILED\n");
+        return (1);
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        emit("FORK-FAILED\n");
+        return (1);
+    }
+
+    if (pid == 0) {
+        /* Child: report the pids the kernel attributes to us. */
+        (void)close(p[0]);
+        struct child_report rep;
+        rep.self = getpid();
+        rep.ppid = getppid();
+        ssize_t w = write(p[1], &rep, sizeof(rep));
+        (void)close(p[1]);
+        _exit(w == (ssize_t)sizeof(rep) ? 0 : 1);
+    }
+
+    /* Parent. */
+    (void)close(p[1]);
+    struct child_report rep = {0, 0};
+    ssize_t n = read_full(p[0], &rep, sizeof(rep));
+    (void)close(p[0]);
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid) {
+        emit("WAITPID-FAILED\n");
+        return (1);
+    }
+    if (n != (ssize_t)sizeof(rep)) {
+        emit("CHILD-REPORT-FAILED\n");
+        return (1);
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        emit("CHILD-NONZERO-EXIT\n");
+        return (1);
+    }
+    emit("CHILD-PID-RECEIVED\n");
+
+    /* The child's getpid() must equal what fork() returned to the parent, and
+       must differ from the parent's own pid. On the stale-cache bug the child
+       reports the parent's pid instead. */
+    if (rep.self != pid || rep.self == parent_pid) {
+        emit("PID-FORK-MISMATCH\n");
+        return (1);
+    }
+    emit("PID-MATCHES-FORK\n");
+
+    /* The child's getppid() must be the parent's pid. */
+    if (rep.ppid != parent_pid) {
+        emit("PPID-MISMATCH\n");
+        return (1);
+    }
+    emit("PPID-OK\n");
+
+    emit("ok\n");
+    return (0);
+}

--- a/src/posix-tests/fork-pthread-c/main.c
+++ b/src/posix-tests/fork-pthread-c/main.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Regression test: a fork()'d child must be able to (re)initialize an inherited
+ * pthread mutex / condition variable.
+ *
+ * This guards the post-fork lock-rebuild path used by runtimes such as CPython
+ * (see "Background"). POSIX leaves re-initialization of an already-initialized
+ * mutex/cond UNDEFINED; Nanvix defines it as an idempotent "reset", and this
+ * test asserts that Nanvix-specific behavior. It currently passes on the pinned
+ * Nanvix sysroot and will fail if the re-init regression is reintroduced.
+ *
+ * Background
+ * ----------
+ * On Nanvix, libposix keeps address-keyed registries (MUTEXES / CONDITIONS)
+ * that map a pthread_mutex_t* / pthread_cond_t* to kernel synchronization
+ * objects. A fork()'d child inherits those registry entries via copy-on-write,
+ * but the kernel intentionally drops the per-process sync objects across fork
+ * and recreates them lazily. Consequently the child must be able to
+ * (re)initialize a mutex/cond at an address that is still present in the
+ * inherited registry.
+ *
+ * If pthread_mutex_init() / pthread_cond_init() reject an already-registered
+ * address, the child cannot rebuild its locks. This is exactly what runtimes
+ * such as CPython do after fork(): they re-create their locks (e.g. a fresh
+ * GIL) in the child. The bug surfaced there as
+ * "create_gil: PyMUTEX_INIT failed" and aborted the forked interpreter.
+ *
+ * What this program demonstrates (run in standalone mode)
+ * -------------------------------------------------------
+ *   PTHREAD-START     - the test starts.
+ *   PARENT-INIT-OK    - the parent initialized a mutex + cond and locked/
+ *                       unlocked the mutex.
+ *   CHILD-REINIT-OK   - the child re-initialized the SAME (inherited) mutex
+ *                       and cond addresses successfully.  <-- on a correct
+ *                       system; on the buggy system the re-init returns an
+ *                       error and this FAILS.
+ *   CHILD-USE-OK      - the child could lock/unlock the re-initialized mutex.
+ *   ok                - the whole sequence succeeded.
+ *
+ * Correct behavior : all markers print and the process exits 0.
+ * Buggy behavior   : the child's status byte is non-zero, the parent prints
+ *                    CHILD-REINIT-FAILED and exits non-zero.
+ *
+ * A one-byte status is passed from the child to the parent over a pipe();
+ * pipes themselves work on Nanvix, so they are a reliable side channel here.
+ */
+
+#include <pthread.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void emit(const char *s)
+{
+    const char *p = s;
+    while (*p) {
+        p++;
+    }
+    (void)write(STDOUT_FILENO, s, (size_t)(p - s));
+}
+
+/* Inherited by the child via copy-on-write at the SAME addresses. */
+static pthread_mutex_t mutex;
+static pthread_cond_t cond;
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    emit("PTHREAD-START\n");
+
+    /* Parent: initialize a mutex + cond, then exercise the mutex. */
+    if (pthread_mutex_init(&mutex, NULL) != 0) {
+        emit("PARENT-MUTEX-INIT-FAILED\n");
+        return (1);
+    }
+    if (pthread_cond_init(&cond, NULL) != 0) {
+        emit("PARENT-COND-INIT-FAILED\n");
+        return (1);
+    }
+    if (pthread_mutex_lock(&mutex) != 0 || pthread_mutex_unlock(&mutex) != 0) {
+        emit("PARENT-MUTEX-USE-FAILED\n");
+        return (1);
+    }
+    emit("PARENT-INIT-OK\n");
+
+    int p[2];
+    if (pipe(p) != 0) {
+        emit("PIPE-FAILED\n");
+        return (1);
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        emit("FORK-FAILED\n");
+        return (1);
+    }
+
+    if (pid == 0) {
+        /* Child: rebuild its synchronization primitives, mirroring what a
+           runtime does after fork(). The addresses are the inherited ones. */
+        (void)close(p[0]);
+        unsigned char st = 0;
+
+        if (pthread_mutex_init(&mutex, NULL) != 0) {
+            st = 1; /* re-init of inherited mutex rejected */
+        } else if (pthread_cond_init(&cond, NULL) != 0) {
+            st = 2; /* re-init of inherited cond rejected */
+        } else if (pthread_mutex_lock(&mutex) != 0 ||
+                   pthread_mutex_unlock(&mutex) != 0) {
+            st = 3; /* re-initialized mutex not usable */
+        }
+
+        (void)write(p[1], &st, 1);
+        (void)close(p[1]);
+        _exit(st == 0 ? 0 : 1);
+    }
+
+    /* Parent: collect the child's result. */
+    (void)close(p[1]);
+    unsigned char st = 0xff;
+    ssize_t n = read(p[0], &st, 1);
+    (void)close(p[0]);
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid) {
+        emit("WAITPID-FAILED\n");
+        return (1);
+    }
+    if (n != 1) {
+        emit("CHILD-REPORT-FAILED\n");
+        return (1);
+    }
+    if (st != 0) {
+        if (st == 3) {
+            emit("CHILD-MUTEX-USE-FAILED\n");
+        } else {
+            emit("CHILD-REINIT-FAILED\n");
+        }
+        return (1);
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        emit("CHILD-NONZERO-EXIT\n");
+        return (1);
+    }
+    emit("CHILD-REINIT-OK\n");
+    emit("CHILD-USE-OK\n");
+
+    emit("ok\n");
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -129,6 +129,20 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/fork-pid-c"
+program = "./bin/fork-pid-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/fork-pthread-c"
+program = "./bin/fork-pthread-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/hello-c"
 program = "./bin/hello-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -129,6 +129,20 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/fork-pid-c"
+program = "./bin/fork-pid-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/fork-pthread-c"
+program = "./bin/fork-pthread-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/hello-c"
 program = "./bin/hello-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Adds two ported POSIX C regression suites under `src/posix-tests/`, wired into `ALL_POSIX_TESTS` and booted standalone (exit-code-only) by the `nanvix-test` harness on both Linux and Windows.

## Suites

### `fork-pid-c`
Asserts that a `fork()`'d child observes its **own (new)** pid. `getpid()` is memoized per image (`CACHED_PID`); the child inherits that cache through copy-on-write, so without invalidation `getpid()` keeps returning the parent's pid. Because pid-keyed kernel calls (`mmap`/`mprotect` during a later `execv()`) fail `EACCES` under the wrong identity, this guards the cache-invalidation-on-fork path. The child reports `getpid()`/`getppid()` to the parent over a `pipe()`; the test fails if the child's pid does not equal `fork()`'s return value or matches the parent's pid.

### `fork-pthread-c`
Asserts that a `fork()`'d child can re-initialize an inherited pthread mutex/cond. The userspace `MUTEXES`/`CONDITIONS` registries are inherited via copy-on-write while the kernel drops and lazily recreates the per-process sync objects across `fork`; the child must be able to re-init at an address still present in the registry (init is idempotent by design). This mirrors runtimes such as CPython rebuilding their GIL in `PyOS_AfterFork_Child`. The child re-inits and exercises the primitives, reporting a status byte to the parent over a `pipe()`.

## Wiring

- **`Makefile`** — add `fork-pid-c`, `fork-pthread-c` to `ALL_POSIX_TESTS` (the `posix-tests.mk` `foreach` auto-generates the ELF/initrd rules; no fixtures needed).
- **`test/test-posix.toml`**, **`test/test-posix-windows.toml`** — add `[[tests]]` entries (`build_modes = ["debug", "release"]`, `terminal` executor, `expected_exit_code = 0`).

## Validation

- Both suites pass in **debug** and **release**.
- Unit tests unaffected (full `run-unit-tests` green).
