### PR TITLE
[syscall] Multi-part select request

### DIFF
--- a/src/daemons/linuxd/src/assemble.rs
+++ b/src/daemons/linuxd/src/assemble.rs
@@ -37,11 +37,14 @@ use ::syscall::{
         SystemCallMessagePart,
     },
     poll::message::PollRequest,
-    sys::stat::message::{
-        FileChmodAtRequest,
-        FileStatAtRequest,
-        MakeDirectoryAtRequest,
-        UpdateFileAccessTimeAtRequest,
+    sys::{
+        select::message::SelectRequest,
+        stat::message::{
+            FileChmodAtRequest,
+            FileStatAtRequest,
+            MakeDirectoryAtRequest,
+            UpdateFileAccessTimeAtRequest,
+        },
     },
     unistd::message::{
         ChangeDirectoryRequest,
@@ -638,5 +641,48 @@ impl<T> RequestAssemblerTrait<T> for PollRequest {
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
         crate::linux::poll::do_poll(syscall_table, source, request)
+    }
+}
+
+impl<T> RequestAssemblerTrait<T> for SelectRequest {
+    fn new_assembler() -> RequestAssemblerType {
+        let capacity: usize = Self::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
+        RequestAssemblerType::SelectRequest(
+            SystemCallLongMessage::new(capacity).expect("capacity is set to a valid value"),
+        )
+    }
+
+    fn add_part(
+        assembler: &mut RequestAssemblerType,
+        part: SystemCallMessagePart,
+    ) -> Result<(), WorkerThreadError> {
+        match assembler {
+            RequestAssemblerType::SelectRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
+        }
+    }
+
+    fn is_complete(assembler: &RequestAssemblerType) -> Result<bool, Error> {
+        match assembler {
+            RequestAssemblerType::SelectRequest(assembler) => Ok(assembler.is_complete()),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+        }
+    }
+
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<SystemCallMessagePart> {
+        match assembler {
+            RequestAssemblerType::SelectRequest(assembler) => assembler.take_parts(),
+            _ => unreachable!("invalid assembler type"),
+        }
+    }
+
+    fn process_request(
+        syscall_table: &SyscallTable<T>,
+        source: ThreadIdentifier,
+        request: Self,
+    ) -> Result<Vec<Message>, WorkerThreadError> {
+        // `do_select()` yields a single response message; wrap it to satisfy the trait contract.
+        crate::linux::sys_select::do_select(syscall_table, source, request)
+            .map(|message| vec![message])
     }
 }

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -117,6 +117,7 @@ pub enum RequestAssemblerType {
     ChangeDirectoryRequest(SystemCallLongMessage),
     FileAccessAtRequest(SystemCallLongMessage),
     PollRequest(SystemCallLongMessage),
+    SelectRequest(SystemCallLongMessage),
 }
 
 pub trait RequestAssemblerTrait<T>
@@ -303,5 +304,73 @@ mod tests {
         );
 
         task_a.await.expect("task_a should complete");
+    }
+
+    /// Validates that a `SelectRequest` survives the linuxd receive path: split into
+    /// `SelectRequestPart`s on the client side, then reassembled by the worker's
+    /// `RequestAssembler` back into the original request (without executing `do_select`).
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn select_request_assembles_into_request() {
+        use ::sysapi::sys_select::{
+            fd_set,
+            timeval,
+        };
+        use ::syscall::sys::select::message::SelectRequest;
+
+        let source: ThreadIdentifier = ThreadIdentifier::from(7_i32);
+
+        let mut readfds: fd_set = fd_set::default();
+        readfds.set_bit(0).expect("fd in range");
+        readfds.set_bit(5).expect("fd in range");
+        let mut writefds: fd_set = fd_set::default();
+        writefds.set_bit(2).expect("fd in range");
+        let timeout: timeval = timeval {
+            tv_sec: 1,
+            tv_usec: 2,
+        };
+
+        let original: SelectRequest =
+            SelectRequest::new(6, &Some(&mut readfds), &Some(&mut writefds), &None, &Some(timeout))
+                .expect("valid SelectRequest");
+
+        let parts: Vec<SystemCallMessagePart> = extract_parts(
+            original
+                .into_parts(source, ::syscall::LINUXD, MessageType::Ikc)
+                .expect("valid parts"),
+        );
+
+        // The request is transported as a `SelectRequestPart` stream; the part count is derived
+        // from the wire size and the per-part payload, so it stays correct across ABI/message-size
+        // changes (including the single-part case). Feed the parts through the assembler in order.
+        let expected_parts: usize =
+            SelectRequest::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
+        assert_eq!(parts.len(), expected_parts, "unexpected number of parts");
+
+        let mut assembler: RequestAssembler = RequestAssembler::default();
+        let mut result: Option<SelectRequest> = None;
+        for part in parts {
+            let r: Option<SelectRequest> = assembler
+                .assemble_and_take::<(), SelectRequest>(source, part)
+                .expect("assembly should succeed");
+            if r.is_some() {
+                result = r;
+            }
+        }
+
+        let request: SelectRequest = result.expect("request should be fully assembled");
+        assert_eq!(request.nfds, 6, "nfds mismatch");
+        assert_eq!(
+            request.readfds.map(|s| s.to_bytes()),
+            Some(readfds.to_bytes()),
+            "readfds mismatch"
+        );
+        assert_eq!(
+            request.writefds.map(|s| s.to_bytes()),
+            Some(writefds.to_bytes()),
+            "writefds mismatch"
+        );
+        assert!(request.errorfds.is_none(), "errorfds should be absent");
+        assert_eq!(request.timeout, Some(timeout.to_bytes()), "timeout mismatch");
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -17,7 +17,6 @@ use crate::{
     linux::{
         dirent,
         fcntl,
-        sys_select,
         sys_socket,
         sys_times,
         unistd,
@@ -592,7 +591,6 @@ impl WorkerThreadHandle {
                                 | SystemCallMessageHeader::PartialWriteRequest
                                 | SystemCallMessageHeader::ReceiveSocketRequest
                                 | SystemCallMessageHeader::SeekRequest
-                                | SystemCallMessageHeader::SelectRequest
                                 | SystemCallMessageHeader::SendSocketRequest
                                 | SystemCallMessageHeader::ShutdownSocketRequest
                                 | SystemCallMessageHeader::TimesRequest
@@ -657,7 +655,8 @@ impl WorkerThreadHandle {
                                 | SystemCallMessageHeader::OpenAtRequestPart
                                 | SystemCallMessageHeader::RenameAtRequestPart
                                 | SystemCallMessageHeader::UnlinkAtRequestPart
-                                | SystemCallMessageHeader::PollRequestPart => {
+                                | SystemCallMessageHeader::PollRequestPart
+                                | SystemCallMessageHeader::SelectRequestPart => {
                                     match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
@@ -889,10 +888,6 @@ impl WorkerThreadHandle {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
                 unistd::do_lseek(&syscall_table, source, request)
             },
-            SystemCallMessageHeader::SelectRequest => {
-                let request: SelectRequest = SelectRequest::from_bytes(message.payload)?;
-                sys_select::do_select(&syscall_table, source, request)
-            },
             SystemCallMessageHeader::SendSocketRequest => {
                 let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
                 sys_socket::do_send(&syscall_table, source, request)
@@ -1067,6 +1062,15 @@ impl WorkerThreadHandle {
             },
             SystemCallMessageHeader::PollRequestPart => {
                 Self::handle_long_request::<T, PollRequest>(
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
+                )
+            },
+            SystemCallMessageHeader::SelectRequestPart => {
+                Self::handle_long_request::<T, SelectRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -324,6 +324,11 @@ pub enum SystemCallMessageHeader {
     RegisterSocketResponse,
     TtyControlRequest,
     TtyControlResponse,
+    // Multi-part variant of `SelectRequest`. `select()` is the lone fixed syscall message whose
+    // wire layout exceeds the single-message payload once a client-id trailer is reserved, so its
+    // request is transported as a `*Part` stream (see `SelectRequest`). Appended here to preserve
+    // the on-the-wire discriminants of existing variants.
+    SelectRequestPart,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -494,6 +499,7 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == RegisterSocketResponse as u16 => Ok(RegisterSocketResponse),
             x if x == TtyControlRequest as u16 => Ok(TtyControlRequest),
             x if x == TtyControlResponse as u16 => Ok(TtyControlResponse),
+            x if x == SelectRequestPart as u16 => Ok(SelectRequestPart),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/select/message/mod.rs
+++ b/src/libs/syscall/src/sys/select/message/mod.rs
@@ -6,9 +6,16 @@
 //==================================================================================================
 
 use crate::{
+    message::{
+        MessageDeserializer,
+        MessagePartitioner,
+        MessageSerializer,
+        SystemCallMessagePart,
+    },
     SystemCallMessage,
     SystemCallMessageHeader,
 };
+use ::alloc::vec::Vec;
 use ::core::mem;
 use ::sys::{
     error::{
@@ -73,9 +80,13 @@ fn decode_optional_fd_set(bytes: &[u8], offset: usize) -> Result<Option<fd_set>,
 /// interoperate byte-for-byte:
 ///
 /// `nfds (1) | readfds (1 + fd_set::WIRE_SIZE) | writefds (1 + fd_set::WIRE_SIZE) |
-///  errorfds (1 + fd_set::WIRE_SIZE) | timeout (1 + timeval::WIRE_SIZE)` followed by padding.
+///  errorfds (1 + fd_set::WIRE_SIZE) | timeout (1 + timeval::WIRE_SIZE)`.
 ///
 /// Each optional field is prefixed by a one-byte presence flag (`0` = absent, `1` = present).
+///
+/// The serialized form (exactly [`Self::WIRE_SIZE`] bytes) is transported as a variable-length,
+/// multi-part `SelectRequestPart` stream — the same pattern used by the path-bearing requests
+/// (`openat`, `renameat`, …) — rather than a single fixed-size [`SystemCallMessage`].
 #[derive(Debug)]
 pub struct SelectRequest {
     /// Number of file descriptors in each set (must be <= FD_SETSIZE).
@@ -89,10 +100,6 @@ pub struct SelectRequest {
     /// Timeout, encoded in `timeval`'s fixed-width wire format for cross-architecture IPC.
     pub timeout: Option<[u8; timeval::WIRE_SIZE]>,
 }
-
-// Ensure the fixed-width wire layout fits within the payload, so the manual offsets/slices in
-// `from_bytes()`/`into_bytes()` cannot overflow `PAYLOAD_SIZE` and panic at runtime.
-::static_assert::assert_eq!(SelectRequest::WIRE_SIZE <= SystemCallMessage::PAYLOAD_SIZE);
 
 // Ensure that the maximum number of file descriptors can be encoded in a `u8`.
 ::static_assert::assert_eq!(FD_SETSIZE < u8::MAX as usize);
@@ -116,25 +123,90 @@ impl SelectRequest {
     /// Total number of meaningful wire bytes.
     const WIRE_SIZE: usize = Self::OFFSET_TIMEOUT + Self::OPTIONAL_TIMEOUT_WIRE_SIZE;
 
+    /// Maximum size of the serialized request.
+    ///
+    /// The wire layout is fixed-width, so the maximum size equals [`Self::WIRE_SIZE`]. The
+    /// serialized form is transported as a `SelectRequestPart` stream bounded by
+    /// [`SystemCallMessagePart::PAYLOAD_SIZE`], so it is not constrained by the single-message
+    /// [`SystemCallMessage::PAYLOAD_SIZE`].
+    pub const MAX_SIZE: usize = Self::WIRE_SIZE;
+
     /// Creates a new `SelectRequest`.
-    fn new(
-        nfds: u8,
+    ///
+    /// Validates that `nfds` does not exceed [`FD_SETSIZE`] and fits in a `u8`, then copies the
+    /// referenced descriptor sets and timeout into an owned request.
+    pub fn new(
+        nfds: usize,
         readfds: &Option<&mut fd_set>,
         writefds: &Option<&mut fd_set>,
         errorfds: &Option<&mut fd_set>,
         timeout: &Option<timeval>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        // Validate number of file descriptors.
+        if nfds > FD_SETSIZE {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of file descriptors exceeds maximum supported",
+            ));
+        }
+
+        // Attempt to encode nfds as u8 (should always succeed due to static assert, but be safe).
+        let nfds: u8 = match nfds.try_into() {
+            Ok(v) => v,
+            Err(_e) => {
+                return Err(Error::new(
+                    ErrorCode::ValueOutOfRange,
+                    "cannot encode number of file descriptors",
+                ));
+            },
+        };
+
+        Ok(Self {
             nfds,
             readfds: readfds.as_ref().map(|fd_set| **fd_set),
             writefds: writefds.as_ref().map(|fd_set| **fd_set),
             errorfds: errorfds.as_ref().map(|fd_set| **fd_set),
             timeout: timeout.as_ref().map(|tv| tv.to_bytes()),
-        }
+        })
     }
+}
 
+impl MessageSerializer for SelectRequest {
+    /// Serializes the request into its fixed-width wire representation.
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = ::alloc::vec![0u8; Self::WIRE_SIZE];
+        bytes[Self::OFFSET_NFDS] = self.nfds;
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_READFDS, self.readfds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_WRITEFDS, self.writefds);
+        encode_optional_fd_set(&mut bytes, Self::OFFSET_ERRORFDS, self.errorfds);
+        if let Some(payload) = self.timeout {
+            bytes[Self::OFFSET_TIMEOUT] = 1;
+            bytes[Self::OFFSET_TIMEOUT + 1..Self::OFFSET_TIMEOUT + 1 + timeval::WIRE_SIZE]
+                .copy_from_slice(&payload);
+        }
+        bytes
+    }
+}
+
+impl MessageDeserializer for SelectRequest {
     /// Deserializes a request from its fixed-width wire representation.
-    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Result<Self, Error> {
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        // The wire layout is fixed-width, so the reassembled buffer must be exactly `WIRE_SIZE`
+        // bytes (== `MAX_SIZE`). Reject anything shorter (would overflow the field slices) or
+        // longer (unexpected trailing bytes).
+        if bytes.len() < Self::WIRE_SIZE {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "select request message is too short",
+            ));
+        }
+        if bytes.len() > Self::MAX_SIZE {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "select request message is too long",
+            ));
+        }
+
         let nfds: u8 = bytes[Self::OFFSET_NFDS];
         // Reject messages whose number of file descriptors exceeds the wire contract bound.
         if nfds as usize > FD_SETSIZE {
@@ -143,9 +215,9 @@ impl SelectRequest {
                 "number of file descriptors exceeds maximum supported in select message",
             ));
         }
-        let readfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_READFDS)?;
-        let writefds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_WRITEFDS)?;
-        let errorfds: Option<fd_set> = decode_optional_fd_set(&bytes, Self::OFFSET_ERRORFDS)?;
+        let readfds: Option<fd_set> = decode_optional_fd_set(bytes, Self::OFFSET_READFDS)?;
+        let writefds: Option<fd_set> = decode_optional_fd_set(bytes, Self::OFFSET_WRITEFDS)?;
+        let errorfds: Option<fd_set> = decode_optional_fd_set(bytes, Self::OFFSET_ERRORFDS)?;
         let timeout: Option<[u8; timeval::WIRE_SIZE]> = match bytes[Self::OFFSET_TIMEOUT] {
             0 => None,
             1 => {
@@ -170,65 +242,29 @@ impl SelectRequest {
             timeout,
         })
     }
+}
 
-    /// Serializes the request into its fixed-width wire representation.
-    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
-        let mut bytes: [u8; SystemCallMessage::PAYLOAD_SIZE] = [0; SystemCallMessage::PAYLOAD_SIZE];
-        bytes[Self::OFFSET_NFDS] = self.nfds;
-        encode_optional_fd_set(&mut bytes, Self::OFFSET_READFDS, self.readfds);
-        encode_optional_fd_set(&mut bytes, Self::OFFSET_WRITEFDS, self.writefds);
-        encode_optional_fd_set(&mut bytes, Self::OFFSET_ERRORFDS, self.errorfds);
-        if let Some(payload) = self.timeout {
-            bytes[Self::OFFSET_TIMEOUT] = 1;
-            bytes[Self::OFFSET_TIMEOUT + 1..Self::OFFSET_TIMEOUT + 1 + timeval::WIRE_SIZE]
-                .copy_from_slice(&payload);
-        }
-        bytes
-    }
-
-    /// Builds a kernel IPC message for a `select()` system call request.
-    #[allow(clippy::too_many_arguments)]
-    pub fn build(
+impl MessagePartitioner for SelectRequest {
+    /// Creates a new message request part for the `select()` system call.
+    fn new_part(
         tid: ThreadIdentifier,
-        nfds: usize,
-        readfds: &Option<&mut fd_set>,
-        writefds: &Option<&mut fd_set>,
-        errorfds: &Option<&mut fd_set>,
-        timeout: &Option<timeval>,
+        total_parts: u16,
+        part_number: u16,
+        payload_size: u8,
+        payload: [u8; SystemCallMessagePart::PAYLOAD_SIZE],
         destination: ProcessIdentifier,
         message_type: MessageType,
     ) -> Result<Message, Error> {
-        // Validate number of file descriptors.
-        if nfds > FD_SETSIZE {
-            return Err(Error::new(
-                ErrorCode::InvalidArgument,
-                "number of file descriptors exceeds maximum supported",
-            ));
-        }
-
-        // Attempt to encode nfds as u8 (should always succeed due to static assert, but be safe).
-        let nfds_u8: u8 = match nfds.try_into() {
-            Ok(v) => v,
-            Err(_e) => {
-                return Err(Error::new(
-                    ErrorCode::ValueOutOfRange,
-                    "cannot encode number of file descriptors",
-                ));
-            },
-        };
-
-        let message: SelectRequest =
-            SelectRequest::new(nfds_u8, readfds, writefds, errorfds, timeout);
-        let message: SystemCallMessage =
-            SystemCallMessage::new(SystemCallMessageHeader::SelectRequest, message.into_bytes());
-        let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+        SystemCallMessagePart::build_request(
+            tid,
+            SystemCallMessageHeader::SelectRequestPart,
+            total_parts,
+            part_number,
+            payload_size,
+            payload,
+            destination,
             message_type,
-            None,
-            message.into_bytes(),
-        );
-        Ok(message)
+        )
     }
 }
 
@@ -343,5 +379,146 @@ impl SelectResponse {
             message.into_bytes(),
         );
         message
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Thread identifier used as the message sender in the part-transport round trips.
+    const TEST_TID: i32 = 1;
+    /// Destination process identifier used in the part-transport round trips.
+    const TEST_DEST: i32 = 2;
+
+    /// Reassembles the `SystemCallMessagePart`s carried by the IPC messages produced by
+    /// `into_parts()`, asserting every part is tagged as a `SelectRequestPart`.
+    fn extract_parts(messages: Vec<Message>) -> Vec<SystemCallMessagePart> {
+        messages
+            .into_iter()
+            .map(|msg| {
+                let daemon_msg: SystemCallMessage = SystemCallMessage::try_from_bytes(msg.payload)
+                    .expect("valid SystemCallMessage");
+                // Copy the header out of the packed message before comparing it.
+                let header: SystemCallMessageHeader = daemon_msg.header;
+                assert_eq!(
+                    header,
+                    SystemCallMessageHeader::SelectRequestPart,
+                    "unexpected part header"
+                );
+                SystemCallMessagePart::from_bytes(daemon_msg.payload)
+            })
+            .collect()
+    }
+
+    /// Builds an `fd_set` with the given file descriptors set.
+    fn fd_set_with(bits: &[usize]) -> fd_set {
+        let mut set: fd_set = fd_set::default();
+        for &fd in bits {
+            set.set_bit(fd).expect("fd within range");
+        }
+        set
+    }
+
+    /// Serializes `request`, splits it into parts, reassembles them, and asserts the decoded
+    /// request matches the original byte-for-byte.
+    fn assert_round_trip(request: SelectRequest) {
+        // Snapshot the request fields before the value is consumed by `into_parts()`.
+        let nfds: u8 = request.nfds;
+        let readfds: Option<[u8; fd_set::WIRE_SIZE]> = request.readfds.map(|s| s.to_bytes());
+        let writefds: Option<[u8; fd_set::WIRE_SIZE]> = request.writefds.map(|s| s.to_bytes());
+        let errorfds: Option<[u8; fd_set::WIRE_SIZE]> = request.errorfds.map(|s| s.to_bytes());
+        let timeout: Option<[u8; timeval::WIRE_SIZE]> = request.timeout;
+
+        // The fixed-width wire layout always serializes to exactly `WIRE_SIZE` bytes.
+        assert_eq!(request.to_bytes().len(), SelectRequest::WIRE_SIZE, "unexpected wire size");
+
+        // Split into a `SelectRequestPart` stream and reassemble it.
+        let messages: Vec<Message> = request
+            .into_parts(
+                ThreadIdentifier::from(TEST_TID),
+                ProcessIdentifier::from(TEST_DEST),
+                MessageType::Ikc,
+            )
+            .expect("partition should succeed");
+
+        // A 45-byte request spans two parts on the current ABI; this exercises the part boundary.
+        let expected_parts: usize =
+            SelectRequest::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
+        assert_eq!(messages.len(), expected_parts, "unexpected number of parts");
+
+        let parts: Vec<SystemCallMessagePart> = extract_parts(messages);
+        let decoded: SelectRequest =
+            SelectRequest::from_parts(&parts).expect("reassembly should succeed");
+
+        assert_eq!(decoded.nfds, nfds, "nfds mismatch");
+        assert_eq!(decoded.readfds.map(|s| s.to_bytes()), readfds, "readfds mismatch");
+        assert_eq!(decoded.writefds.map(|s| s.to_bytes()), writefds, "writefds mismatch");
+        assert_eq!(decoded.errorfds.map(|s| s.to_bytes()), errorfds, "errorfds mismatch");
+        assert_eq!(decoded.timeout, timeout, "timeout mismatch");
+    }
+
+    /// Round-trips a request with every descriptor set and the timeout present.
+    #[test]
+    fn round_trip_all_sets_present() {
+        let mut readfds: fd_set = fd_set_with(&[0, 3, 7]);
+        let mut writefds: fd_set = fd_set_with(&[1, 2]);
+        let mut errorfds: fd_set = fd_set_with(&[FD_SETSIZE - 1]);
+        let timeout: timeval = timeval {
+            tv_sec: 5,
+            tv_usec: 123,
+        };
+        let request: SelectRequest = SelectRequest::new(
+            8,
+            &Some(&mut readfds),
+            &Some(&mut writefds),
+            &Some(&mut errorfds),
+            &Some(timeout),
+        )
+        .expect("valid request");
+        assert_round_trip(request);
+    }
+
+    /// Round-trips a request with every optional field absent.
+    #[test]
+    fn round_trip_all_sets_absent() {
+        let request: SelectRequest =
+            SelectRequest::new(0, &None, &None, &None, &None).expect("valid request");
+        assert_round_trip(request);
+    }
+
+    /// `new()` rejects an `nfds` greater than `FD_SETSIZE`.
+    #[test]
+    fn new_rejects_nfds_above_setsize() {
+        assert!(
+            SelectRequest::new(FD_SETSIZE + 1, &None, &None, &None, &None).is_err(),
+            "nfds above FD_SETSIZE must be rejected"
+        );
+    }
+
+    /// `new()` accepts the maximum representable descriptor set size.
+    #[test]
+    fn new_accepts_nfds_at_setsize() {
+        let request: SelectRequest =
+            SelectRequest::new(FD_SETSIZE, &None, &None, &None, &None).expect("valid request");
+        assert_eq!(request.nfds, FD_SETSIZE as u8, "nfds mismatch");
+    }
+
+    /// `try_from_bytes()` rejects a buffer shorter than the fixed wire layout.
+    #[test]
+    fn try_from_bytes_rejects_short_buffer() {
+        let short: Vec<u8> = ::alloc::vec![0u8; SelectRequest::WIRE_SIZE - 1];
+        assert!(SelectRequest::try_from_bytes(&short).is_err(), "short buffer must be rejected");
+    }
+
+    /// `try_from_bytes()` rejects unexpected trailing bytes.
+    #[test]
+    fn try_from_bytes_rejects_long_buffer() {
+        let long: Vec<u8> = ::alloc::vec![0u8; SelectRequest::WIRE_SIZE + 1];
+        assert!(SelectRequest::try_from_bytes(&long).is_err(), "long buffer must be rejected");
     }
 }

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::{
+    message::MessagePartitioner,
     sys::select::message::{
         SelectRequest,
         SelectResponse,
@@ -13,6 +14,7 @@ use crate::{
     SystemCallMessage,
     SystemCallMessageHeader,
 };
+use ::alloc::vec::Vec;
 use ::sys::{
     error::{
         Error,
@@ -85,18 +87,13 @@ pub fn select(
 
     let tid: ThreadIdentifier = pm::__kcall_gettid()?;
 
-    // Build request and send it.
-    let request: Message = SelectRequest::build(
-        tid,
-        nfds,
-        &readfds,
-        &writefds,
-        &errorfds,
-        timeout,
-        crate::LINUXD,
-        ::sys::ipc::MessageType::Ikc,
-    )?;
-    ::sys::kcall::ipc::__kcall_send(&request)?;
+    // Build the request and send it as a multi-part `SelectRequestPart` stream.
+    let request: SelectRequest = SelectRequest::new(nfds, &readfds, &writefds, &errorfds, timeout)?;
+    let requests: Vec<Message> =
+        request.into_parts(tid, crate::LINUXD, ::sys::ipc::MessageType::Ikc)?;
+    for request in &requests {
+        ::sys::kcall::ipc::__kcall_send(request)?;
+    }
 
     // Receive response.
     let response: Message = ::sys::kcall::ipc::__kcall_recv()?;


### PR DESCRIPTION
## Summary

The `select()` request wire layout exceeds the single IPC message payload once the client-id trailer is reserved, so it can no longer be sent as one fixed-size `SystemCallMessage`. This converts `SelectRequest` to the multi-part transport already used by the path-bearing requests (`openat`, `renameat`, …).

## Changes

- **syscall**: Implement `MessageSerializer`, `MessageDeserializer`, and `MessagePartitioner` for `SelectRequest`; drop the fixed-size `build()`/`into_bytes()`/`from_bytes()` path and the `WIRE_SIZE <= PAYLOAD_SIZE` static assert. `new()` now validates `nfds` and returns `Result`; `try_from_bytes()` rejects buffers that are too short or too long. `select()` partitions the request into a `SelectRequestPart` stream and sends each part before awaiting the response.
- **syscall**: Add `SystemCallMessageHeader::SelectRequestPart`, appended at the end of the enum (and its `TryFrom<u16>`) to preserve the on-the-wire discriminants of existing variants.
- **linuxd**: Add `RequestAssemblerType::SelectRequest` and a `RequestAssemblerTrait` impl so `SelectRequestPart` streams are reassembled under the assembler lock and dispatched to `do_select()`; route `SelectRequestPart` through `handle_long_request` and remove the old single-message `SelectRequest` dispatch.

## Tests

- Unit tests covering part round-trips, `nfds` boundary handling, short/long buffer rejection, and end-to-end reassembly in linuxd.
- `./z build -- run-unit-tests`
- `DEPLOYMENT_MODE=standalone ./z build -- run-nanvix-tests`
- `DEPLOYMENT_MODE=multi-process ./z build -- run-nanvix-tests`
- ABI sweep at `ipc_message_size = 56` to confirm guest crates still compile.


## Issues

Closes #2661