### PR TITLE
[signals] Signal dispositions and thread masks (sigaction/sigprocmask)

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -223,10 +223,11 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         #[cfg(not(feature = "microvm"))]
         KcallNumber::Snapshot => KcallResult::Error(ErrorCode::OperationNotSupported.into()),
 
-        // Signal subsystem kernel calls. These are currently inert stubs that return a
-        // not-implemented error; later phases of the signals effort implement the real handlers.
-        KcallNumber::Sigaction => pm::sigaction(),
-        KcallNumber::Sigprocmask => pm::sigprocmask(),
+        // Signal subsystem kernel calls. `sigaction()` manages per-process dispositions and
+        // `sigprocmask()` manages the calling thread's blocked mask; the remaining calls are still
+        // inert stubs implemented by later phases of the signals effort.
+        KcallNumber::Sigaction => pm::sigaction(pid, arg0, arg1, arg2),
+        KcallNumber::Sigprocmask => pm::sigprocmask(pid, tid, arg0, arg1, arg2),
         KcallNumber::Kill => pm::kill(),
         KcallNumber::Sigreturn => pm::sigreturn(),
         KcallNumber::Sigpending => pm::sigpending(),

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -46,8 +46,15 @@ use crate::hal::mem::{
     TruncatedMemoryRegion,
     VirtualAddress,
 };
-use ::alloc::collections::LinkedList;
+use ::alloc::{
+    boxed::Box,
+    collections::LinkedList,
+};
 use ::arch::mem;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 //==================================================================================================
 // Re-exports
@@ -167,3 +174,16 @@ pub use kernel_vas::init;
 
 type VirtMemRegion = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
 type PhysMemRegion = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Allocates `value` in a [`Box`] on the kernel heap using fallible allocation.
+///
+/// Unlike [`Box::new`], this returns an [`ErrorCode::OutOfMemory`] error when the allocation fails
+/// instead of aborting, so callers can propagate the failure.
+pub fn try_box<T>(value: T) -> Result<Box<T>, Error> {
+    Box::try_new(value)
+        .map_err(|_| Error::new(ErrorCode::OutOfMemory, "failed to allocate memory on kernel heap"))
+}

--- a/src/kernel/src/pm/kcall/sigaction.rs
+++ b/src/kernel/src/pm/kcall/sigaction.rs
@@ -5,8 +5,32 @@
 // Imports
 //==================================================================================================
 
-use crate::kcall::KcallResult;
-use ::sys::error::ErrorCode;
+use crate::{
+    kcall::KcallResult,
+    mm::Vmem,
+    pm::{
+        self,
+        process::state::signal::{
+            SignalDisposition,
+            SignalHandler,
+        },
+        ProcessManager,
+    },
+};
+use ::core::mem::size_of;
+use ::sys::{
+    error::ErrorCode,
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        SigAction,
+        SIGKILL,
+        SIGSTOP,
+        SIG_DFL,
+        SIG_IGN,
+        SIG_MAX,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -15,17 +39,122 @@ use ::sys::error::ErrorCode;
 ///
 /// # Description
 ///
-/// Stub handler for the `sigaction()` kernel call, which gets and/or sets the disposition of a
-/// signal.
+/// Kernel call handler for `sigaction()`, which gets and/or sets the disposition of a signal for
+/// the calling process.
 ///
-/// This is scaffolding for the signal subsystem and is not yet implemented: it always fails with
-/// [`ErrorCode::InvalidSysCall`]. A later phase of the signals effort replaces this stub with the
-/// real handler.
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Signal number.
+/// - `arg1`: User-space pointer to the new action, or null to leave the disposition unchanged.
+/// - `arg2`: User-space pointer that receives the previous action, or null if not wanted.
 ///
 /// # Returns
 ///
-/// Always returns a [`KcallResult`] carrying [`ErrorCode::InvalidSysCall`].
+/// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn sigaction() -> KcallResult {
-    KcallResult::Error(ErrorCode::InvalidSysCall.into())
+pub fn sigaction(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    // Validate the signal number. Out-of-range values (including would-be negative `c_int`s, which
+    // arrive here as large unsigned values) are rejected.
+    let signum: usize = match usize::try_from(arg0) {
+        Ok(signum) if (1..=SIG_MAX).contains(&signum) => signum,
+        _ => {
+            let reason: &str = "invalid signal number";
+            error!("{reason} (signum={arg0})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        },
+    };
+
+    let act_ptr: usize = arg1 as usize;
+    let oldact_ptr: usize = arg2 as usize;
+
+    // Check if the old action buffer lies in user space, if provided. Do this before mutating the
+    // disposition so an invalid output pointer cannot turn the call into a partial success.
+    if oldact_ptr != 0 {
+        let oldact_addr: VirtualAddress = VirtualAddress::from_raw_value(oldact_ptr);
+        if !Vmem::is_user_region(oldact_addr, size_of::<SigAction>()) {
+            let reason: &str = "old action buffer does not lie in user space";
+            error!("{reason} (oldact={oldact_addr:?})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        }
+    }
+
+    // Build the new disposition from the user-supplied action, if one was provided.
+    let new: Option<SignalDisposition> = if act_ptr != 0 {
+        // The disposition of SIGKILL and SIGSTOP can never be changed.
+        if signum == SIGKILL || signum == SIGSTOP {
+            let reason: &str = "cannot change the disposition of SIGKILL or SIGSTOP";
+            error!("{reason} (signum={signum})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        }
+
+        // Check if the new action lies in user space.
+        let act_addr: VirtualAddress = VirtualAddress::from_raw_value(act_ptr);
+        if !Vmem::is_user_region(act_addr, size_of::<SigAction>()) {
+            let reason: &str = "new action does not lie in user space";
+            error!("{reason} (act={act_addr:?})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        }
+
+        // Copy the new action from user space.
+        let mut act: SigAction = SigAction::default();
+        if let Err(error) =
+            pm::copy_from_user(pm, caller_pid, &mut act, act_ptr as *const SigAction)
+        {
+            error!("failed to copy new action from user space (error={error:?})");
+            return KcallResult::Error(error.code.into());
+        }
+
+        // Map the handler field to a disposition.
+        match act.sa_handler {
+            SIG_DFL => Some(SignalDisposition::Default),
+            SIG_IGN => Some(SignalDisposition::Ignore),
+            entry => {
+                // A caught signal must point to a handler in user space.
+                let entry_addr: VirtualAddress = VirtualAddress::from_raw_value(entry);
+                if !Vmem::is_user_addr(entry_addr) {
+                    let reason: &str = "signal handler does not lie in user space";
+                    error!("{reason} (handler={entry_addr:?})");
+                    return KcallResult::Error(ErrorCode::InvalidArgument.into());
+                }
+                let handler = match crate::mm::try_box(SignalHandler {
+                    entry: entry_addr,
+                    mask: act.sa_mask,
+                    flags: act.sa_flags,
+                    sigaction: act.sa_sigaction,
+                }) {
+                    Ok(handler) => handler,
+                    Err(error) => {
+                        error!("{error:?}");
+                        return KcallResult::Error(error.code.into());
+                    },
+                };
+                Some(SignalDisposition::Handler(handler))
+            },
+        }
+    } else {
+        None
+    };
+
+    // Swap the disposition, capturing the previous one for the `oldact` return.
+    let old: SigAction = match pm.sigaction(caller_pid, signum, new) {
+        Ok(old) => old,
+        Err(error) => {
+            error!("{error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
+
+    // Report the previous action through `oldact`, if requested.
+    if oldact_ptr != 0 {
+        if let Err(error) = pm::copy_to_user(pm, caller_pid, oldact_ptr as *mut SigAction, &old) {
+            error!("failed to copy old action to user space (error={error:?})");
+            return KcallResult::Error(error.code.into());
+        }
+    }
+
+    KcallResult::ok()
 }

--- a/src/kernel/src/pm/kcall/sigprocmask.rs
+++ b/src/kernel/src/pm/kcall/sigprocmask.rs
@@ -5,8 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::kcall::KcallResult;
-use ::sys::error::ErrorCode;
+use crate::{
+    kcall::KcallResult,
+    mm::Vmem,
+    pm::{
+        self,
+        ProcessManager,
+    },
+};
+use ::core::mem::size_of;
+use ::sys::{
+    error::ErrorCode,
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        SigSet,
+        ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -15,17 +31,84 @@ use ::sys::error::ErrorCode;
 ///
 /// # Description
 ///
-/// Stub handler for the `sigprocmask()` kernel call, which gets and/or modifies the calling
-/// thread's blocked signal mask.
+/// Kernel call handler for `sigprocmask()`, which gets and/or modifies the blocked-signal mask of
+/// the calling thread.
 ///
-/// This is scaffolding for the signal subsystem and is not yet implemented: it always fails with
-/// [`ErrorCode::InvalidSysCall`]. A later phase of the signals effort replaces this stub with the
-/// real handler.
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process (owner of the `set`/`oldset` buffers).
+/// - `caller_tid`: Identifier of the calling thread (owner of the blocked mask).
+/// - `arg0`: How to combine `set` with the current mask (`SIG_BLOCK`, `SIG_UNBLOCK`, or
+///   `SIG_SETMASK`); consulted only when `set` is non-null.
+/// - `arg1`: User-space pointer to the signals to apply, or null to leave the mask unchanged.
+/// - `arg2`: User-space pointer that receives the previous mask, or null if not wanted.
 ///
 /// # Returns
 ///
-/// Always returns a [`KcallResult`] carrying [`ErrorCode::InvalidSysCall`].
+/// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn sigprocmask() -> KcallResult {
-    KcallResult::Error(ErrorCode::InvalidSysCall.into())
+pub fn sigprocmask(
+    caller_pid: ProcessIdentifier,
+    caller_tid: ThreadIdentifier,
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    // The `how` value is a bit-preserving reinterpretation of the raw argument; it is only
+    // consulted when `set` is provided.
+    let how: i32 = arg0 as i32;
+    let set_ptr: usize = arg1 as usize;
+    let oldset_ptr: usize = arg2 as usize;
+
+    // Check if the old signal set buffer lies in user space, if provided. Do this before mutating
+    // the mask so an invalid output pointer cannot turn the call into a partial success.
+    if oldset_ptr != 0 {
+        let oldset_addr: VirtualAddress = VirtualAddress::from_raw_value(oldset_ptr);
+        if !Vmem::is_user_region(oldset_addr, size_of::<SigSet>()) {
+            let reason: &str = "old signal set buffer does not lie in user space";
+            error!("{reason} (oldset={oldset_addr:?})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        }
+    }
+
+    // Read the signals to apply from user space, if provided.
+    let set: Option<SigSet> = if set_ptr != 0 {
+        let set_addr: VirtualAddress = VirtualAddress::from_raw_value(set_ptr);
+        if !Vmem::is_user_region(set_addr, size_of::<SigSet>()) {
+            let reason: &str = "signal set does not lie in user space";
+            error!("{reason} (set={set_addr:?})");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        }
+        let mut value: SigSet = 0;
+        if let Err(error) = pm::copy_from_user(pm, caller_pid, &mut value, set_ptr as *const SigSet)
+        {
+            error!("failed to copy signal set from user space (error={error:?})");
+            return KcallResult::Error(error.code.into());
+        }
+        Some(value)
+    } else {
+        None
+    };
+
+    // Apply the change to the calling thread's mask, capturing the previous mask.
+    let old: SigSet = match pm.sigprocmask(caller_tid, how, set) {
+        Ok(old) => old,
+        Err(error) => {
+            error!("{error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
+
+    // Report the previous mask through `oldset`, if requested.
+    if oldset_ptr != 0 {
+        if let Err(error) = pm::copy_to_user(pm, caller_pid, oldset_ptr as *mut SigSet, &old) {
+            error!("failed to copy old signal set to user space (error={error:?})");
+            return KcallResult::Error(error.code.into());
+        }
+    }
+
+    KcallResult::ok()
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -39,6 +39,11 @@ use crate::{
     pm::{
         clock,
         process::state::{
+            signal::{
+                compute_blocked,
+                SignalControl,
+                SignalDisposition,
+            },
             InterruptedProcess,
             ProcessRef,
             ProcessRefMut,
@@ -103,6 +108,8 @@ use ::sys::{
         ConditionAddress,
         MutexAddress,
         ProcessIdentifier,
+        SigAction,
+        SigSet,
         ThreadCreateArgs,
         ThreadIdentifier,
     },
@@ -493,6 +500,117 @@ impl ProcessManager {
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets and/or sets the disposition of a signal for a target process.
+    ///
+    /// The previous disposition is always captured (for the `oldact` return) before the new
+    /// disposition, if any, is installed.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process whose disposition is to be changed.
+    /// - `signum`: The signal number (1-based).
+    /// - `new`: The disposition to install, or [`None`] to leave the disposition unchanged.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the previous disposition rendered as a [`SigAction`] is returned. Upon
+    /// failure, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::NoSuchProcess`]: The specified process does not exist.
+    /// - [`ErrorCode::InvalidArgument`]: The signal number is out of range.
+    ///
+    pub fn sigaction(
+        &mut self,
+        pid: ProcessIdentifier,
+        signum: usize,
+        new: Option<SignalDisposition>,
+    ) -> Result<SigAction, Error> {
+        // Search for the process across all states.
+        let mut process: ProcessRefMut = self.find_process_mut(pid)?;
+        let signals: &mut SignalControl = process.state_mut().signals_mut();
+
+        // Capture the previous disposition for the `oldact` return before installing the new one.
+        let old: SigAction = match signals.disposition(signum) {
+            Some(disposition) => disposition.to_sigaction(),
+            None => {
+                let reason: &str = "invalid signal number";
+                error!("{reason} (pid={pid:?}, signum={signum})");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+
+        // Install the new disposition, if one was requested.
+        if let Some(disposition) = new {
+            if signals.set_disposition(signum, disposition).is_none() {
+                // Unreachable: `disposition()` above already validated `signum`.
+                let reason: &str = "invalid signal number";
+                error!("{reason} (pid={pid:?}, signum={signum})");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+        }
+
+        Ok(old)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets and/or modifies the blocked-signal mask of the calling thread.
+    ///
+    /// The previous mask is always captured (for the `oldset` return) before the new mask, if any,
+    /// is installed. Signals that can never be blocked (`SIGKILL`/`SIGSTOP`) are silently cleared
+    /// from the resulting mask.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the calling thread.
+    /// - `how`: One of `SIG_BLOCK`, `SIG_UNBLOCK`, or `SIG_SETMASK` (only consulted when `set` is
+    ///   provided).
+    /// - `set`: The signals to apply per `how`, or [`None`] to leave the mask unchanged.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the previous blocked-signal mask is returned. Upon failure, an error is
+    /// returned instead.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::NoSuchEntry`]: The specified thread does not exist.
+    /// - [`ErrorCode::InvalidArgument`]: `how` is not a recognized value.
+    ///
+    pub fn sigprocmask(
+        &mut self,
+        tid: ThreadIdentifier,
+        how: i32,
+        set: Option<SigSet>,
+    ) -> Result<SigSet, Error> {
+        // Search for the calling thread across all states.
+        let mut thread: ThreadRefMut = self.find_thread_mut(tid)?;
+        let state = thread.thread_state_mut();
+
+        // Capture the previous mask for the `oldset` return before applying any change.
+        let old: SigSet = state.blocked();
+
+        // Apply the requested change to the per-thread blocked mask, if one was requested.
+        if let Some(set) = set {
+            match compute_blocked(how, old, set) {
+                Some(next) => state.set_blocked(next),
+                None => {
+                    let reason: &str = "invalid sigprocmask how";
+                    error!("{reason} (tid={tid:?}, how={how})");
+                    return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                },
+            }
+        }
+
+        Ok(old)
     }
 
     ///

--- a/src/kernel/src/pm/process/mod.rs
+++ b/src/kernel/src/pm/process/mod.rs
@@ -7,7 +7,7 @@
 
 mod capability;
 mod manager;
-mod state;
+pub(crate) mod state;
 
 //==================================================================================================
 // Exports

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -15,7 +15,9 @@
 mod interrupted;
 mod runnable;
 mod running;
-mod signal;
+pub(crate) mod signal;
+#[cfg(feature = "test")]
+mod signal_test;
 mod sleeping;
 #[cfg(feature = "test")]
 mod test_detach;
@@ -95,7 +97,10 @@ pub use zombie::ZombieProcess;
 /// Runs all in-kernel unit tests for the process state module.
 #[cfg(feature = "test")]
 pub(super) fn test() -> bool {
-    test_detach::test()
+    let mut passed: bool = true;
+    passed &= test_detach::test();
+    passed &= signal_test::test();
+    passed
 }
 
 //==================================================================================================
@@ -222,9 +227,7 @@ pub struct ProcessState {
     pending_exit_status: Option<ExitStatus>,
     /// Per-process signal control block.
     ///
-    /// Inert plumbing for the signal subsystem: the block is default-initialized so existing
-    /// behavior is unchanged, and it is read by later phases of the signals effort.
-    #[allow(dead_code)]
+    /// Holds the process-wide signal dispositions installed via `sigaction()`.
     signals: SignalControl,
 }
 
@@ -309,6 +312,19 @@ impl ProcessState {
 
     pub fn vmem_mut(&mut self) -> &mut Vmem {
         &mut self.vmem
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a mutable reference to the per-process signal control block.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the [`SignalControl`] of this process.
+    ///
+    pub fn signals_mut(&mut self) -> &mut SignalControl {
+        &mut self.signals
     }
 
     ///

--- a/src/kernel/src/pm/process/state/signal.rs
+++ b/src/kernel/src/pm/process/state/signal.rs
@@ -5,8 +5,32 @@
 // Imports
 //==================================================================================================
 
-use crate::hal::mem::VirtualAddress;
+use crate::hal::mem::{
+    Address,
+    VirtualAddress,
+};
 use ::alloc::boxed::Box;
+use ::sys::pm::{
+    SigAction,
+    SigSet,
+    SIGKILL,
+    SIGSTOP,
+    SIG_BLOCK,
+    SIG_DFL,
+    SIG_IGN,
+    SIG_SETMASK,
+    SIG_UNBLOCK,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Signals that can never be blocked, caught, or ignored: `SIGKILL` and `SIGSTOP`.
+///
+/// POSIX requires that any attempt to block these signals be silently ignored rather than reported
+/// as an error, so they are cleared from every computed blocked-signal mask.
+pub const UNBLOCKABLE: SigSet = (1u64 << (SIGKILL - 1)) | (1u64 << (SIGSTOP - 1));
 
 //==================================================================================================
 // Structures
@@ -20,7 +44,6 @@ use ::alloc::boxed::Box;
 // Boxed by [`SignalDisposition::Handler`] so that a disposition is only pointer-sized. Storing this
 // payload inline in every one of the 64 disposition slots would push the per-process table past the
 // kernel heap's maximum slab size (512 bytes); see [`crate::mm::kheap`].
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SignalHandler {
     /// Entry point of the user-space handler.
@@ -29,6 +52,8 @@ pub struct SignalHandler {
     pub mask: u64,
     /// Handler flags.
     pub flags: i32,
+    /// Extended handler slot used when `SA_SIGINFO` is set.
+    pub sigaction: usize,
 }
 
 ///
@@ -36,8 +61,6 @@ pub struct SignalHandler {
 ///
 /// Disposition of a single signal.
 ///
-// Variants other than `Default` are constructed by later phases of the signals effort.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum SignalDisposition {
     /// Take the default action for the signal.
@@ -53,9 +76,8 @@ pub enum SignalDisposition {
 ///
 /// Per-process signal control block.
 ///
-// Inert plumbing for the signal subsystem: the block is default-initialized so existing behavior
-// is unchanged, and its fields are read by later phases of the signals effort.
-#[allow(dead_code)]
+// The disposition table is read and written by `sigaction()`; the remaining fields are inert
+// plumbing read by later phases of the signals effort.
 #[derive(Debug)]
 pub struct SignalControl {
     /// Disposition for each of the 64 signals, indexed by `signum - 1`.
@@ -64,8 +86,14 @@ pub struct SignalControl {
     // maximum slab size (512 bytes) and keeps `ProcessState` in its original size class.
     dispositions: Box<[SignalDisposition; 64]>,
     /// Process-directed pending signals not yet claimed by a thread.
+    ///
+    /// Written by a later phase of the signals effort (signal posting).
+    #[allow(dead_code)]
     pending: u64,
     /// Address of the user-space return trampoline (restorer).
+    ///
+    /// Read by a later phase of the signals effort (asynchronous delivery).
+    #[allow(dead_code)]
     restorer: Option<VirtualAddress>,
 }
 
@@ -83,8 +111,134 @@ pub struct SignalControl {
 ::static_assert::assert_eq!(::core::mem::align_of::<[SignalDisposition; 64]>() <= 512);
 
 //==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Combines the `current` blocked-signal mask with `set` according to `how`.
+///
+/// # Parameters
+///
+/// - `how`: One of [`SIG_BLOCK`], [`SIG_UNBLOCK`], or [`SIG_SETMASK`].
+/// - `current`: The current blocked-signal mask.
+/// - `set`: The signals to apply per `how`.
+///
+/// # Returns
+///
+/// The updated mask, or [`None`] if `how` is not a recognized value.
+///
+pub(super) fn apply_how(how: i32, current: SigSet, set: SigSet) -> Option<SigSet> {
+    match how {
+        SIG_BLOCK => Some(current | set),
+        SIG_UNBLOCK => Some(current & !set),
+        SIG_SETMASK => Some(set),
+        _ => None,
+    }
+}
+
+///
+/// # Description
+///
+/// Computes the next blocked-signal mask, applying `how` and then silently clearing the signals
+/// that can never be blocked ([`UNBLOCKABLE`]).
+///
+/// # Parameters
+///
+/// - `how`: One of [`SIG_BLOCK`], [`SIG_UNBLOCK`], or [`SIG_SETMASK`].
+/// - `current`: The current blocked-signal mask.
+/// - `set`: The signals to apply per `how`.
+///
+/// # Returns
+///
+/// The updated mask with [`SIGKILL`]/[`SIGSTOP`] cleared, or [`None`] if `how` is invalid.
+///
+pub fn compute_blocked(how: i32, current: SigSet, set: SigSet) -> Option<SigSet> {
+    apply_how(how, current, set).map(|next| next & !UNBLOCKABLE)
+}
+
+//==================================================================================================
 // Implementations
 //==================================================================================================
+
+impl SignalDisposition {
+    ///
+    /// # Description
+    ///
+    /// Renders this disposition as the [`SigAction`] structure returned through the `oldact`
+    /// argument of `sigaction()`.
+    ///
+    /// # Returns
+    ///
+    /// The [`SigAction`] that describes this disposition.
+    ///
+    pub fn to_sigaction(&self) -> SigAction {
+        match self {
+            SignalDisposition::Default => SigAction {
+                sa_handler: SIG_DFL,
+                sa_mask: 0,
+                sa_flags: 0,
+                sa_sigaction: 0,
+            },
+            SignalDisposition::Ignore => SigAction {
+                sa_handler: SIG_IGN,
+                sa_mask: 0,
+                sa_flags: 0,
+                sa_sigaction: 0,
+            },
+            SignalDisposition::Handler(handler) => SigAction {
+                sa_handler: handler.entry.into_raw_value(),
+                sa_mask: handler.mask,
+                sa_flags: handler.flags,
+                sa_sigaction: handler.sigaction,
+            },
+        }
+    }
+}
+
+impl SignalControl {
+    ///
+    /// # Description
+    ///
+    /// Returns the disposition currently installed for signal `signum`.
+    ///
+    /// # Parameters
+    ///
+    /// - `signum`: The signal number (1-based).
+    ///
+    /// # Returns
+    ///
+    /// A reference to the disposition for `signum`, or [`None`] if `signum` is out of range.
+    ///
+    pub fn disposition(&self, signum: usize) -> Option<&SignalDisposition> {
+        self.dispositions.get(signum.wrapping_sub(1))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs `disposition` for signal `signum`, returning the disposition it replaced.
+    ///
+    /// # Parameters
+    ///
+    /// - `signum`: The signal number (1-based).
+    /// - `disposition`: The disposition to install.
+    ///
+    /// # Returns
+    ///
+    /// The previous disposition for `signum`, or [`None`] if `signum` is out of range (in which
+    /// case nothing is installed).
+    ///
+    pub fn set_disposition(
+        &mut self,
+        signum: usize,
+        disposition: SignalDisposition,
+    ) -> Option<SignalDisposition> {
+        let slot: &mut SignalDisposition = self.dispositions.get_mut(signum.wrapping_sub(1))?;
+        Some(::core::mem::replace(slot, disposition))
+    }
+}
 
 impl Default for SignalControl {
     fn default() -> Self {

--- a/src/kernel/src/pm/process/state/signal_test.rs
+++ b/src/kernel/src/pm/process/state/signal_test.rs
@@ -1,0 +1,299 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::signal::{
+    apply_how,
+    compute_blocked,
+    SignalControl,
+    SignalDisposition,
+    SignalHandler,
+    UNBLOCKABLE,
+};
+use crate::hal::mem::VirtualAddress;
+use ::alloc::boxed::Box;
+use ::sys::pm::{
+    SigAction,
+    SIGKILL,
+    SIGSTOP,
+    SIG_BLOCK,
+    SIG_DFL,
+    SIG_IGN,
+    SIG_SETMASK,
+    SIG_UNBLOCK,
+};
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Bit for signal `signum` (1-based) in a signal set.
+fn bit(signum: usize) -> u64 {
+    1u64 << (signum - 1)
+}
+
+/// Builds a catch disposition with the given handler entry, mask, flags, and extended action.
+fn handler(entry: usize, mask: u64, flags: i32, sigaction: usize) -> SignalDisposition {
+    SignalDisposition::Handler(Box::new(SignalHandler {
+        entry: VirtualAddress::new(entry),
+        mask,
+        flags,
+        sigaction,
+    }))
+}
+
+//==================================================================================================
+// Mask Arithmetic Tests
+//==================================================================================================
+
+///
+/// # Description
+///
+/// `SIG_BLOCK` unions the requested signals into the current mask.
+///
+fn test_apply_how_block_computes_union() -> bool {
+    if apply_how(SIG_BLOCK, 0b0001, 0b0100) != Some(0b0101) {
+        error!("SIG_BLOCK did not compute the union of the masks");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// `SIG_UNBLOCK` clears only the requested signals from the current mask.
+///
+fn test_apply_how_unblock_clears_requested_bits() -> bool {
+    if apply_how(SIG_UNBLOCK, 0b0111, 0b0010) != Some(0b0101) {
+        error!("SIG_UNBLOCK did not clear the requested bits");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// `SIG_SETMASK` replaces the current mask with the requested signals.
+///
+fn test_apply_how_setmask_replaces_mask() -> bool {
+    if apply_how(SIG_SETMASK, 0b1111, 0b0010) != Some(0b0010) {
+        error!("SIG_SETMASK did not replace the mask");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// An unrecognized `how` value is rejected.
+///
+fn test_apply_how_rejects_invalid_how() -> bool {
+    if apply_how(42, 0, 0).is_some() {
+        error!("an invalid `how` value was accepted");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// `SIGKILL` and `SIGSTOP` are silently cleared from any computed mask, even when the caller asks
+/// to set a full mask.
+///
+fn test_compute_blocked_clears_unblockable() -> bool {
+    // Setting a full mask must leave SIGKILL/SIGSTOP unblocked.
+    match compute_blocked(SIG_SETMASK, 0, u64::MAX) {
+        Some(mask) if mask & UNBLOCKABLE == 0 => {},
+        other => {
+            error!("SIG_SETMASK with a full mask did not clear SIGKILL/SIGSTOP (mask={other:?})");
+            return false;
+        },
+    }
+
+    // Blocking SIGKILL/SIGSTOP explicitly is silently ignored.
+    match compute_blocked(SIG_BLOCK, 0, bit(SIGKILL) | bit(SIGSTOP)) {
+        Some(0) => {},
+        other => {
+            error!("blocking SIGKILL/SIGSTOP was not silently ignored (mask={other:?})");
+            return false;
+        },
+    }
+
+    // An invalid `how` is still rejected.
+    if compute_blocked(99, 0, 0).is_some() {
+        error!("compute_blocked() accepted an invalid `how` value");
+        return false;
+    }
+
+    true
+}
+
+//==================================================================================================
+// Disposition Tests
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A freshly constructed control block reports the default disposition for every signal.
+///
+fn test_disposition_defaults_to_default() -> bool {
+    let control: SignalControl = SignalControl::default();
+    for signum in 1..=64 {
+        match control.disposition(signum) {
+            Some(SignalDisposition::Default) => {},
+            other => {
+                error!("signal {signum} was not default-initialized (disposition={other:?})");
+                return false;
+            },
+        }
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Installing a disposition returns the one it replaced and stores the new one, exercising the
+/// atomic swap performed by `sigaction()`.
+///
+fn test_set_disposition_swaps_and_returns_previous() -> bool {
+    let mut control: SignalControl = SignalControl::default();
+
+    // Installing over the initial default returns the default.
+    match control.set_disposition(1, handler(0x1000, 0b10, 4, 0x3000)) {
+        Some(SignalDisposition::Default) => {},
+        other => {
+            error!("installing over the default did not return the default (old={other:?})");
+            return false;
+        },
+    }
+
+    // The handler is now the active disposition.
+    match control.disposition(1) {
+        Some(SignalDisposition::Handler(installed))
+            if installed.entry == VirtualAddress::new(0x1000)
+                && installed.mask == 0b10
+                && installed.flags == 4
+                && installed.sigaction == 0x3000 => {},
+        other => {
+            error!("the installed handler was not stored verbatim (disposition={other:?})");
+            return false;
+        },
+    }
+
+    // Installing again returns the previous handler.
+    match control.set_disposition(1, SignalDisposition::Ignore) {
+        Some(SignalDisposition::Handler(old)) if old.entry == VirtualAddress::new(0x1000) => {},
+        other => {
+            error!("installing over a handler did not return the handler (old={other:?})");
+            return false;
+        },
+    }
+
+    // Other signals remain untouched.
+    match control.disposition(2) {
+        Some(SignalDisposition::Default) => {},
+        other => {
+            error!("an unrelated signal disposition was modified (disposition={other:?})");
+            return false;
+        },
+    }
+
+    true
+}
+
+///
+/// # Description
+///
+/// Out-of-range signal numbers neither install nor report a disposition.
+///
+fn test_set_disposition_rejects_out_of_range() -> bool {
+    let mut control: SignalControl = SignalControl::default();
+
+    if control.disposition(0).is_some() {
+        error!("signal number 0 was treated as in range");
+        return false;
+    }
+    if control.disposition(65).is_some() {
+        error!("signal number 65 was treated as in range");
+        return false;
+    }
+    if control
+        .set_disposition(0, SignalDisposition::Ignore)
+        .is_some()
+    {
+        error!("set_disposition() accepted signal number 0");
+        return false;
+    }
+    if control
+        .set_disposition(65, SignalDisposition::Ignore)
+        .is_some()
+    {
+        error!("set_disposition() accepted signal number 65");
+        return false;
+    }
+
+    true
+}
+
+///
+/// # Description
+///
+/// Each disposition renders to the matching `oldact` structure returned by `sigaction()`.
+///
+fn test_to_sigaction_round_trips_dispositions() -> bool {
+    let default_action: SigAction = SignalDisposition::Default.to_sigaction();
+    if default_action.sa_handler != SIG_DFL {
+        error!("default disposition did not render as SIG_DFL");
+        return false;
+    }
+
+    let ignore_action: SigAction = SignalDisposition::Ignore.to_sigaction();
+    if ignore_action.sa_handler != SIG_IGN {
+        error!("ignore disposition did not render as SIG_IGN");
+        return false;
+    }
+
+    let handler_action: SigAction = handler(0x2000, 0b101, 8, 0x4000).to_sigaction();
+    if handler_action.sa_handler != 0x2000
+        || handler_action.sa_mask != 0b101
+        || handler_action.sa_flags != 8
+        || handler_action.sa_sigaction != 0x4000
+    {
+        error!("handler disposition did not render its entry, mask, flags, and extended action");
+        return false;
+    }
+
+    true
+}
+
+//==================================================================================================
+// Test Aggregator
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Runs all in-kernel unit tests for the signal control block and signal-mask arithmetic.
+///
+pub(super) fn test() -> bool {
+    let mut passed: bool = true;
+    passed &= run_test!(test_apply_how_block_computes_union);
+    passed &= run_test!(test_apply_how_unblock_clears_requested_bits);
+    passed &= run_test!(test_apply_how_setmask_replaces_mask);
+    passed &= run_test!(test_apply_how_rejects_invalid_how);
+    passed &= run_test!(test_compute_blocked_clears_unblockable);
+    passed &= run_test!(test_disposition_defaults_to_default);
+    passed &= run_test!(test_set_disposition_swaps_and_returns_previous);
+    passed &= run_test!(test_set_disposition_rejects_out_of_range);
+    passed &= run_test!(test_to_sigaction_round_trips_dispositions);
+    passed
+}

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -69,14 +69,16 @@ pub struct ThreadState {
     detached: bool,
     /// Signals currently blocked for this thread.
     ///
-    /// Inert plumbing for the signal subsystem: these fields are default-initialized so existing
-    /// behavior is unchanged, and are read by later phases of the signals effort.
-    #[allow(dead_code)]
+    /// Per-thread blocked-signal mask managed by `sigprocmask()`.
     blocked: u64,
     /// Signals pending specifically against this thread (e.g. synchronous faults).
+    ///
+    /// Inert plumbing for the signal subsystem: written by a later phase of the signals effort.
     #[allow(dead_code)]
     pending: u64,
     /// Saved blocked mask while a handler runs (restored by `sigreturn`).
+    ///
+    /// Inert plumbing for the signal subsystem: read by a later phase of the signals effort.
     #[allow(dead_code)]
     saved_blocked: Option<u64>,
 }
@@ -339,6 +341,32 @@ impl ThreadState {
     ///
     pub(super) fn get_thread_data_area(&self) -> Option<VirtualAddress> {
         self.user_tda
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the set of signals currently blocked for this thread.
+    ///
+    /// # Returns
+    ///
+    /// The per-thread blocked-signal mask.
+    ///
+    pub(crate) fn blocked(&self) -> u64 {
+        self.blocked
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces the set of signals currently blocked for this thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `mask`: The new per-thread blocked-signal mask.
+    ///
+    pub(crate) fn set_blocked(&mut self, mask: u64) {
+        self.blocked = mask;
     }
 }
 

--- a/src/libs/libc_signal/src/sigprocmask.rs
+++ b/src/libs/libc_signal/src/sigprocmask.rs
@@ -5,14 +5,17 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    set_errno,
-    signal::sigset_t,
-};
+#[cfg(any(feature = "std", test))]
+use crate::set_errno;
+use crate::signal::sigset_t;
+#[cfg(any(feature = "std", test))]
 use ::core::sync::atomic::{
     AtomicU64,
     Ordering,
 };
+#[cfg(not(any(feature = "std", test)))]
+use ::sysapi::ffi::c_int;
+#[cfg(any(feature = "std", test))]
 use ::sysapi::{
     errno::EINVAL,
     ffi::c_int,
@@ -33,6 +36,7 @@ pub const SIG_SETMASK: c_int = 2;
 ///
 /// POSIX requires that any attempt to block these signals be silently ignored rather than
 /// reported as an error, so they are masked out of every computed blocked-signal set.
+#[cfg(any(feature = "std", test))]
 const UNBLOCKABLE: sigset_t = (1u64 << (9 - 1)) | (1u64 << (19 - 1));
 
 //==================================================================================================
@@ -45,6 +49,7 @@ const UNBLOCKABLE: sigset_t = (1u64 << (9 - 1)) | (1u64 << (19 - 1));
 /// bookkeeping: it is faithfully maintained so that callers which save and
 /// restore the mask (e.g. xz's single-threaded `mythread_sigmask`) observe
 /// consistent values, but it has no effect on signal delivery.
+#[cfg(any(feature = "std", test))]
 static SIGNAL_MASK: AtomicU64 = AtomicU64::new(0);
 
 //==================================================================================================
@@ -80,6 +85,32 @@ pub unsafe extern "C" fn sigprocmask(
     set: *const sigset_t,
     oldset: *mut sigset_t,
 ) -> c_int {
+    unsafe { sigprocmask_impl(how, set, oldset) }
+}
+
+/// Guest implementation of [`sigprocmask`]: delegates mask state to the Nanvix kernel.
+///
+/// # Safety
+///
+/// This function forwards raw pointers to the backend. The caller must ensure `set` and `oldset`
+/// are either null or valid pointers to `sigset_t` values.
+#[cfg(not(any(feature = "std", test)))]
+unsafe fn sigprocmask_impl(how: c_int, set: *const sigset_t, oldset: *mut sigset_t) -> c_int {
+    extern "C" {
+        fn __nanvix_sigprocmask(how: c_int, set: *const sigset_t, oldset: *mut sigset_t) -> c_int;
+    }
+
+    unsafe { __nanvix_sigprocmask(how, set, oldset) }
+}
+
+/// Host-only implementation of [`sigprocmask`] used by unit tests.
+///
+/// # Safety
+///
+/// This function dereferences `set` and `oldset` when they are non-null. The caller must ensure
+/// they are valid pointers to `sigset_t` values.
+#[cfg(any(feature = "std", test))]
+unsafe fn sigprocmask_impl(how: c_int, set: *const sigset_t, oldset: *mut sigset_t) -> c_int {
     let current: sigset_t = SIGNAL_MASK.load(Ordering::Relaxed);
 
     if !oldset.is_null() {
@@ -107,6 +138,7 @@ pub unsafe extern "C" fn sigprocmask(
 ///
 /// Combines the `current` mask with `value` according to `how`. Returns [`None`] when `how` is not
 /// one of [`SIG_BLOCK`], [`SIG_UNBLOCK`], or [`SIG_SETMASK`].
+#[cfg(any(feature = "std", test))]
 fn apply_how(how: c_int, current: sigset_t, value: sigset_t) -> Option<sigset_t> {
     match how {
         SIG_BLOCK => Some(current | value),

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -82,19 +82,133 @@ pub unsafe extern "C" fn __errno() -> *mut c_int {
 }
 
 //==================================================================================================
-// Stub symbols required by libc_signal (not available in the posix crate)
+// Signal disposition (sigaction) backend required by libc_signal
 //==================================================================================================
 
-/// Stub `sigaction` — returns -1 with `ENOSYS` since kernel signal support is not yet available.
+// `libc_signal::signal::sigaction_t` (the C ABI view) and `sys::pm::SigAction` (the kernel-call
+// view) are not textually identical — `sa_sigaction` is `Option<extern "C" fn(...)>` on the libc
+// side but `usize` in `SigAction` (pointer-sized via the null-pointer optimization). The pointer
+// casts in `sigaction` below are only sound while the two stay ABI-compatible, so guard the size,
+// alignment, and field offsets at compile time; any future divergence fails the build instead of
+// silently corrupting the ABI.
+#[cfg(feature = "backend-nanvix")]
+const _: () = {
+    use ::libc_signal::signal::sigaction_t;
+    use ::sys::pm::SigAction;
+    assert!(::core::mem::size_of::<sigaction_t>() == ::core::mem::size_of::<SigAction>());
+    assert!(::core::mem::align_of::<sigaction_t>() == ::core::mem::align_of::<SigAction>());
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_handler)
+            == ::core::mem::offset_of!(SigAction, sa_handler)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_mask)
+            == ::core::mem::offset_of!(SigAction, sa_mask)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_flags)
+            == ::core::mem::offset_of!(SigAction, sa_flags)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_sigaction)
+            == ::core::mem::offset_of!(SigAction, sa_sigaction)
+    );
+};
+
+/// `sigaction` — installs and/or queries the disposition of a signal via the `sigaction()` kernel
+/// call. This is the backend symbol that `libc_signal`'s `signal()` shim links against.
+///
+/// `libc_signal::signal::sigaction_t` and `sys::pm::SigAction` are ABI-compatible (same `repr(C)`
+/// size, alignment, and field offsets for `sa_handler`, `sa_mask`, `sa_flags`, `sa_sigaction`,
+/// asserted at compile time above), so the action pointers are reinterpreted across the boundary
+/// without translation.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers. `act` and `oldact`
+/// must be either null or valid, properly aligned pointers to `sigaction_t` values.
+#[cfg(feature = "backend-nanvix")]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigaction(
+    signum: c_int,
+    act: *const libc_signal::signal::sigaction_t,
+    oldact: *mut libc_signal::signal::sigaction_t,
+) -> c_int {
+    match unsafe {
+        ::sys::kcall::pm::__kcall_sigaction(
+            signum,
+            act as *const ::sys::pm::SigAction,
+            oldact as *mut ::sys::pm::SigAction,
+        )
+    } {
+        Ok(()) => 0,
+        Err(error) => {
+            *__errno() = error.code.get();
+            -1
+        },
+    }
+}
+
+/// Stub `sigaction` for builds that supply their own backend (no kernel-call surface available).
 ///
 /// # Safety
 ///
 /// This function writes to the errno location and dereferences raw pointers.
+#[cfg(not(feature = "backend-nanvix"))]
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn sigaction(
     _signum: c_int,
     _act: *const libc_signal::signal::sigaction_t,
     _oldact: *mut libc_signal::signal::sigaction_t,
+) -> c_int {
+    *__errno() = ::sysapi::errno::ENOSYS;
+    -1
+}
+
+//==================================================================================================
+// Signal mask (sigprocmask) backend required by libc_signal
+//==================================================================================================
+
+/// `sigprocmask` backend gets and/or modifies the calling thread's blocked-signal mask via the
+/// `sigprocmask()` kernel call.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers. `set` and `oldset`
+/// must be either null or valid, properly aligned pointers to `sigset_t` values.
+#[cfg(feature = "backend-nanvix")]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigprocmask(
+    how: c_int,
+    set: *const libc_signal::signal::sigset_t,
+    oldset: *mut libc_signal::signal::sigset_t,
+) -> c_int {
+    match unsafe {
+        ::sys::kcall::pm::__kcall_sigprocmask(
+            how,
+            set as *const ::sys::pm::SigSet,
+            oldset as *mut ::sys::pm::SigSet,
+        )
+    } {
+        Ok(()) => 0,
+        Err(error) => {
+            *__errno() = error.code.get();
+            -1
+        },
+    }
+}
+
+/// Stub `sigprocmask` backend for builds that supply their own backend.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers.
+#[cfg(not(feature = "backend-nanvix"))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigprocmask(
+    _how: c_int,
+    _set: *const libc_signal::signal::sigset_t,
+    _oldset: *mut libc_signal::signal::sigset_t,
 ) -> c_int {
     *__errno() = ::sysapi::errno::ENOSYS;
     -1

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -23,6 +23,8 @@ use crate::{
         ExecvArgs,
         MutexAddress,
         ProcessIdentifier,
+        SigAction,
+        SigSet,
         ThreadCreateArgs,
         ThreadIdentifier,
     },
@@ -324,6 +326,93 @@ pub fn __kcall_terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     // NOTE: errors are unlikely because terminate typically succeeds for a valid process.
     if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to terminate()"))
+    } else {
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Sigaction
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets and/or sets the disposition of a signal for the calling process.
+///
+/// # Parameters
+///
+/// - `signum`: Signal number.
+/// - `act`: Pointer to the new action, or null to leave the disposition unchanged.
+/// - `oldact`: Pointer that receives the previous action, or null if not wanted.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+/// # Safety
+///
+/// This function is unsafe because the caller must ensure that `act` and `oldact` are either null
+/// or valid, properly aligned pointers to [`SigAction`] values.
+///
+pub unsafe fn __kcall_sigaction(
+    signum: i32,
+    act: *const SigAction,
+    oldact: *mut SigAction,
+) -> Result<(), Error> {
+    let result: i64 = kcall3!(
+        KcallNumber::Sigaction.into(),
+        signum as u32,
+        act as usize as u32,
+        oldact as usize as u32
+    );
+
+    if result < 0 {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to sigaction()"))
+    } else {
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Sigprocmask
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets and/or modifies the blocked-signal mask of the calling thread.
+///
+/// # Parameters
+///
+/// - `how`: How to combine `set` with the current mask (`SIG_BLOCK`, `SIG_UNBLOCK`, or
+///   `SIG_SETMASK`); ignored when `set` is null.
+/// - `set`: Pointer to the signals to apply, or null to leave the mask unchanged.
+/// - `oldset`: Pointer that receives the previous mask, or null if not wanted.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+/// # Safety
+///
+/// This function is unsafe because the caller must ensure that `set` and `oldset` are either null
+/// or valid, properly aligned pointers to [`SigSet`] values.
+///
+pub unsafe fn __kcall_sigprocmask(
+    how: i32,
+    set: *const SigSet,
+    oldset: *mut SigSet,
+) -> Result<(), Error> {
+    let result: i64 = kcall3!(
+        KcallNumber::Sigprocmask.into(),
+        how as u32,
+        set as usize as u32,
+        oldset as usize as u32
+    );
+
+    if result < 0 {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to sigprocmask()"))
     } else {
         Ok(())
     }

--- a/src/libs/sys/src/sys/pm/mod.rs
+++ b/src/libs/sys/src/sys/pm/mod.rs
@@ -9,6 +9,7 @@ mod capability;
 mod execv_args;
 mod gid;
 mod pid;
+mod signal;
 mod sync;
 mod thread_create_args;
 mod tid;
@@ -22,6 +23,18 @@ pub use capability::Capability;
 pub use execv_args::ExecvArgs;
 pub use gid::GroupIdentifier;
 pub use pid::ProcessIdentifier;
+pub use signal::{
+    SigAction,
+    SigSet,
+    SIGKILL,
+    SIGSTOP,
+    SIG_BLOCK,
+    SIG_DFL,
+    SIG_IGN,
+    SIG_MAX,
+    SIG_SETMASK,
+    SIG_UNBLOCK,
+};
 pub use sync::{
     ConditionAddress,
     MutexAddress,

--- a/src/libs/sys/src/sys/pm/signal.rs
+++ b/src/libs/sys/src/sys/pm/signal.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A signal set.
+///
+/// A signal set is a 64-bit bitmask in which bit `n - 1` represents signal `n` (signal numbers run
+/// from `1` to [`SIG_MAX`]). This matches the `sigset_t` convention used by the user-space
+/// `<signal.h>` shims, so a set crosses the kernel-call boundary unchanged.
+///
+pub type SigSet = u64;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum supported signal number. Signal numbers are `1..=SIG_MAX`.
+pub const SIG_MAX: usize = 64;
+
+/// `sa_handler` sentinel selecting the signal's default action.
+pub const SIG_DFL: usize = 0;
+
+/// `sa_handler` sentinel selecting that the signal be ignored.
+pub const SIG_IGN: usize = 1;
+
+/// Signal number of `SIGKILL`, which can never be caught, blocked, or ignored.
+pub const SIGKILL: usize = 9;
+
+/// Signal number of `SIGSTOP`, which can never be caught, blocked, or ignored.
+pub const SIGSTOP: usize = 19;
+
+/// `how` argument to `sigprocmask()`: add the signals in `set` to the blocked mask.
+pub const SIG_BLOCK: i32 = 0;
+
+/// `how` argument to `sigprocmask()`: remove the signals in `set` from the blocked mask.
+pub const SIG_UNBLOCK: i32 = 1;
+
+/// `how` argument to `sigprocmask()`: replace the blocked mask with `set`.
+pub const SIG_SETMASK: i32 = 2;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Signal action structure exchanged with the `sigaction()` kernel call.
+///
+/// The field layout mirrors the C `struct sigaction` declared in `<signal.h>` and the
+/// `sigaction_t` type used by the user-space signal shims, so the structure is copied across the
+/// kernel-call boundary without any translation. The handler fields are pointer-sized integers
+/// rather than function pointers because `<signal.h>` uses non-function sentinels ([`SIG_DFL`] and
+/// [`SIG_IGN`]); the kernel never calls through these values, it only stores and returns them.
+///
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct SigAction {
+    /// Signal handler: [`SIG_DFL`], [`SIG_IGN`], or the address of a user-space handler.
+    pub sa_handler: usize,
+    /// Additional signals to block while the handler runs.
+    pub sa_mask: SigSet,
+    /// Handler flags (`SA_SIGINFO`, `SA_RESTART`, `SA_NODEFER`, `SA_RESETHAND`, ...).
+    pub sa_flags: i32,
+    /// Extended handler slot, used by the C ABI when `SA_SIGINFO` is set. The kernel preserves
+    /// this slot but does not interpret it in this phase.
+    pub sa_sigaction: usize,
+}

--- a/src/libs/syscall/src/signal/bindings/sigaction.rs
+++ b/src/libs/syscall/src/signal/bindings/sigaction.rs
@@ -6,7 +6,6 @@
 //==================================================================================================
 
 use crate::signal::sigaction_t;
-use ::sys::error::ErrorCode;
 use ::sysapi::{
     errno::__errno_location,
     ffi::c_int,
@@ -14,9 +13,49 @@ use ::sysapi::{
 use ::syslog::trace_syscall;
 
 //==================================================================================================
+// Compile-Time ABI Assertions
+//==================================================================================================
+
+// `sigaction_t` (the user-space C ABI view) and `sys::pm::SigAction` (the kernel-call view) are not
+// textually identical — `sa_sigaction` is `Option<extern "C" fn(...)>` here but `usize` in
+// `SigAction` (pointer-sized via the null-pointer optimization). The pointer casts in [`sigaction`]
+// are only sound while the two stay ABI-compatible, so guard the size, alignment, and field offsets
+// at compile time; any future divergence fails the build instead of silently corrupting the ABI.
+const _: () = {
+    assert!(
+        ::core::mem::size_of::<sigaction_t>() == ::core::mem::size_of::<::sys::pm::SigAction>()
+    );
+    assert!(
+        ::core::mem::align_of::<sigaction_t>() == ::core::mem::align_of::<::sys::pm::SigAction>()
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_handler)
+            == ::core::mem::offset_of!(::sys::pm::SigAction, sa_handler)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_mask)
+            == ::core::mem::offset_of!(::sys::pm::SigAction, sa_mask)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_flags)
+            == ::core::mem::offset_of!(::sys::pm::SigAction, sa_flags)
+    );
+    assert!(
+        ::core::mem::offset_of!(sigaction_t, sa_sigaction)
+            == ::core::mem::offset_of!(::sys::pm::SigAction, sa_sigaction)
+    );
+};
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
+/// `sigaction` — installs and/or queries the disposition of a signal via the `sigaction()` kernel
+/// call.
+///
+/// `sigaction_t` and `sys::pm::SigAction` are ABI-compatible (same `repr(C)` size, alignment, and
+/// field offsets, asserted at compile time above), so the action pointers are reinterpreted across
+/// the kernel-call boundary without translation.
 #[unsafe(no_mangle)]
 #[trace_syscall]
 pub extern "C" fn sigaction(
@@ -24,8 +63,19 @@ pub extern "C" fn sigaction(
     act: *const sigaction_t,
     oldact: *mut sigaction_t,
 ) -> c_int {
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    match unsafe {
+        ::sys::kcall::pm::__kcall_sigaction(
+            signum,
+            act as *const ::sys::pm::SigAction,
+            oldact as *mut ::sys::pm::SigAction,
+        )
+    } {
+        Ok(()) => 0,
+        Err(error) => {
+            unsafe {
+                *__errno_location() = error.code.get();
+            }
+            -1
+        },
     }
-    -1
 }


### PR DESCRIPTION
## Summary

Implements Phase 2 of the signals umbrella effort (#2690): the two kernel
calls that manage *what a signal does* (its disposition) and *which signals
a thread blocks* (its mask). This makes the existing `libc_signal` shims —
`signal()`, `sigaction()`, and `sigprocmask()` — work end to end, even though
no signal is delivered yet.

## Changes

Bundled as four focused commits:

- **`[sys]`** — Add the shared signal ABI: the `SigAction` struct and `SigSet`
  alias, the signal/`how` constants, and the typed `__kcall_sigaction` /
  `__kcall_sigprocmask` wrappers.
- **`[kernel]`** — Implement the `sigaction()` and `sigprocmask()` kernel
  calls: per-process disposition swap and per-thread blocked-mask updates,
  with in-kernel unit tests.
- **`[syscall]`** — Bind the typed `sigaction()` syscall to the kernel call.
- **`[nanvix_libc]`** — Wire the C library `sigaction`/`sigprocmask` backends
  to the kernel calls (guest), keeping the host atomic mask for unit tests.

## Acceptance criteria (#2692)

- [x] `sigaction` atomically swaps dispositions and rejects invalid `signum`
  and out-of-range handler addresses.
- [x] Setting a handler for `SIGKILL`/`SIGSTOP` is rejected; masking them is
  silently ignored.
- [x] `sigprocmask` implements `SIG_BLOCK`/`SIG_UNBLOCK`/`SIG_SETMASK` on the
  per-thread mask.
- [x] `libc_signal`'s `signal()`/`sigaction()`/`sigprocmask()` work end to end.
- [x] Unit tests cover the disposition swap and mask arithmetic.

## Implementation notes

- Signal sets are `u64` bitmasks where bit `n - 1` represents signal `n`.
- Dispositions are per process; blocked masks are per thread.
- `SIGKILL`/`SIGSTOP` are uncatchable and unblockable: rejected in the
  `sigaction` set and silently cleared from any requested mask.
- The `sa_sigaction` extended slot is preserved across a disposition swap.
- Output buffers (`oldact`/`oldset`) are validated before any signal state
  is mutated, so a bad output pointer cannot cause a partial success.

## Testing

- `run-unit-tests` (default and `DEPLOYMENT_MODE=multi-process`)
- `all-kernel` and `run-kernel-tests` (in-kernel signal unit tests)
- `run-nanvix-tests` for `standalone` and `multi-process`
- `format-check`, `lint-check`, `spellcheck` (also enforced per commit)

Closes #2692. Part of #2690.
