### PR TITLE
[stdio] E: Extend <stdio.h> (asprintf, dprintf, getline, fseeko, float printf)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c setjmp-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c setjmp-c stdio-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -208,7 +208,7 @@ POSIX_TEST_INITRDS := $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite
 # into lib/) so dlfcn-c can dlopen("lib/libmul.so"). Suites that need the image
 # are listed in POSIX_TEST_RAMFS_SUITES. Suites with their own fixtures (the
 # dlfcn global/needed variants, below) override the image with a per-suite one.
-POSIX_TEST_RAMFS_SUITES := file-c dlfcn-c dlfcn-pie-c dlfcn-global-c dlfcn-needed-c dlfcn-diamond-c
+POSIX_TEST_RAMFS_SUITES := file-c stdio-c dlfcn-c dlfcn-pie-c dlfcn-global-c dlfcn-needed-c dlfcn-diamond-c
 POSIX_TEST_RAMFS_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-seed
 POSIX_TEST_RAMFS_IMG    := $(BINARIES_DIR)/posix-tests-ramfs.img
 
@@ -243,7 +243,7 @@ $(POSIX_TEST_RAMFS_IMG): $(POSIX_TEST_RAMFS_SEED)/marker.txt \
 # for R_386_* against local symbols), mirroring the prebuilt libmul.so recipe.
 
 POSIX_TEST_SOLIB_SUITES := dlfcn-global-c dlfcn-needed-c
-POSIX_TEST_SOLIB_CFLAGS := -m32 -march=pentiumpro -nostdlib -ffreestanding -fPIC -O2
+POSIX_TEST_SOLIB_CFLAGS := -m32 -march=pentiumpro -nostdlib -ffreestanding -fPIC -O2 -isystem $(ROOT_DIR)/include
 POSIX_TEST_SOLIB_LDFLAGS := -shared -melf_i386 -z notext
 
 # Consumer libraries that should carry a DT_NEEDED entry on libprovider.so.

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -16,6 +16,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,6 +102,7 @@ extern FILE *stderr(void);
 
 extern FILE *fopen(const char *pathname, const char *mode);
 extern FILE *fdopen(int fd, const char *mode);
+extern FILE *freopen(const char *pathname, const char *mode, FILE *stream);
 extern int fclose(FILE *stream);
 extern int fflush(FILE *stream);
 extern void clearerr(FILE *stream);
@@ -125,6 +127,7 @@ extern int setvbuf(FILE *stream, char *buf, int mode, size_t size);
  *==================================================================================================*/
 
 extern int fseek(FILE *stream, long offset, int whence);
+extern int fseeko(FILE *stream, off_t offset, int whence);
 extern long ftell(FILE *stream);
 extern void rewind(FILE *stream);
 
@@ -151,6 +154,8 @@ extern int ungetc(int c, FILE *stream);
 extern char *fgets(char *s, int size, FILE *stream);
 extern int fputs(const char *s, FILE *stream);
 extern int puts(const char *s);
+extern ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream);
+extern ssize_t getline(char **lineptr, size_t *n, FILE *stream);
 
 /*==================================================================================================
  * Block I/O
@@ -165,12 +170,16 @@ extern size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 extern int printf(const char *fmt, ...);
 extern int fprintf(FILE *stream, const char *fmt, ...);
+extern int dprintf(int fd, const char *fmt, ...);
 extern int sprintf(char *buf, const char *fmt, ...);
 extern int snprintf(char *buf, size_t size, const char *fmt, ...);
+extern int asprintf(char **strp, const char *fmt, ...);
+extern int vdprintf(int fd, const char *fmt, va_list ap);
 extern int vprintf(const char *fmt, va_list ap);
 extern int vfprintf(FILE *stream, const char *fmt, va_list ap);
 extern int vsprintf(char *buf, const char *fmt, va_list ap);
 extern int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
 
 /*==================================================================================================
  * Error Reporting

--- a/src/libs/libc_stdio/header.toml
+++ b/src/libs/libc_stdio/header.toml
@@ -8,7 +8,7 @@ brief = "Standard input/output."
 description = '''
 Declares functions for formatted and unformatted I/O, stream management,
 and error reporting. Implemented by the libc_stdio Rust crate.'''
-includes = ["stdarg.h", "stddef.h"]
+includes = ["stdarg.h", "stddef.h", "sys/types.h"]
 guard = "_NANVIX_STDIO_H"
 content_order = [
     "raw:0",
@@ -96,6 +96,7 @@ title = "Stream Operations"
 text = '''
 extern FILE *fopen(const char *pathname, const char *mode);
 extern FILE *fdopen(int fd, const char *mode);
+extern FILE *freopen(const char *pathname, const char *mode, FILE *stream);
 extern int fclose(FILE *stream);
 extern int fflush(FILE *stream);
 extern void clearerr(FILE *stream);
@@ -129,7 +130,7 @@ functions = ["stdin", "stdout", "stderr"]
 
 [[sections]]
 title = "Positioning"
-functions = ["fseek", "ftell", "rewind"]
+functions = ["fseek", "fseeko", "ftell", "rewind"]
 
 [[sections]]
 title = "Character I/O"
@@ -137,7 +138,7 @@ functions = ["fgetc", "getc", "getchar", "fputc", "putchar", "ungetc"]
 
 [[sections]]
 title = "String I/O"
-functions = ["fgets", "fputs", "puts"]
+functions = ["fgets", "fputs", "puts", "getdelim", "getline"]
 
 [[sections]]
 title = "Block I/O"
@@ -148,12 +149,16 @@ title = "Formatted I/O"
 functions = [
     "printf",
     "fprintf",
+    "dprintf",
     "sprintf",
     "snprintf",
+    "asprintf",
+    "vdprintf",
     "vprintf",
     "vfprintf",
     "vsprintf",
     "vsnprintf",
+    "vasprintf",
 ]
 
 [[sections]]

--- a/src/libs/libc_stdio/src/asprintf.rs
+++ b/src/libs/libc_stdio/src/asprintf.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats output according to `fmt` and the trailing variadic arguments, allocating a buffer large
+/// enough to hold the result (including the terminating null byte). This is a variadic wrapper
+/// around [`vasprintf`](`crate::vasprintf::vasprintf`).
+///
+/// # Parameters
+///
+/// - `strp`: Output pointer that receives the address of the allocated, formatted string.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written (excluding the terminating null byte) on success, or `-1` on
+/// error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `strp` points to a writable `char *` location.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://man7.org/linux/man-pages/man3/asprintf.3.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn asprintf(strp: *mut *mut c_char, fmt: *const c_char, args: ...) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vasprintf.
+    unsafe { crate::vasprintf::vasprintf(strp, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/dprintf.rs
+++ b/src/libs/libc_stdio/src/dprintf.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats output according to `fmt` and the trailing variadic arguments and writes it directly to
+/// the file descriptor `fd`. Unlike [`fprintf`](`crate::fprintf::fprintf`) it operates on a raw
+/// descriptor rather than a [`FILE`](`crate::streams::FILE`) stream.
+///
+/// # Parameters
+///
+/// - `fd`: Destination file descriptor.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `...`: Arguments matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of bytes written on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `fd` is a valid, writable file descriptor.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - The variadic arguments match the format specifiers.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/dprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn dprintf(fd: c_int, fmt: *const c_char, args: ...) -> c_int {
+    // SAFETY: forwarding the variadic argument list to vdprintf.
+    unsafe { crate::vdprintf::vdprintf(fd, fmt, args) }
+}

--- a/src/libs/libc_stdio/src/float_fmt.rs
+++ b/src/libs/libc_stdio/src/float_fmt.rs
@@ -1,0 +1,760 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+//! Floating-point conversion for the `printf` family.
+//!
+//! This module implements the `%f`/`%F`, `%e`/`%E` and `%g`/`%G` conversions. The in-tree C library
+//! historically supported only integer and string conversions, so a `double` specifier was emitted
+//! literally (e.g. `printf("%f", x)` printed the text `%f`). The digit generation here is performed
+//! entirely with integer arithmetic — every finite `double` equals `mantissa * 2^exp2` with a 53-bit
+//! integer mantissa, and the scaled value `mantissa * 2^exp2 * 10^k` is evaluated in a 128-bit
+//! fixed-point accumulator and rounded to nearest, ties to even. The result is therefore correctly
+//! rounded for the range of magnitudes and precisions that fit in that accumulator, which covers the
+//! conversions used in practice (up to ~38 significant digits and magnitudes up to ~1e38). Requested
+//! precisions beyond that are clamped to the supported number of significant digits, and larger
+//! magnitudes degrade to a bounded best-effort rather than producing incorrect digits for the common
+//! case; neither occurs for the workloads this library targets.
+//==================================================================================================
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::format_engine::{
+    write_padding,
+    FormatFlags,
+    WriteTarget,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default precision applied when a conversion does not specify one.
+const DEFAULT_PRECISION: usize = 6;
+
+/// Maximum number of significant decimal digits that fit in the 128-bit accumulator.
+const MAX_SIG_DIGITS: usize = 38;
+
+/// Size of the stack buffer used to assemble the numeric body (sign and field padding excluded).
+const BODY_MAX: usize = 512;
+
+//==================================================================================================
+// Public Entry Point
+//==================================================================================================
+
+/// Formats a floating-point conversion (`spec` is one of `f F e E g G`) and writes it to `writer`.
+///
+/// The caller supplies the parsed flags, field `width`, and precision (with `has_precision`
+/// indicating whether one was given). All padding and sign handling required by the field width is
+/// performed here.
+pub(crate) fn format_float<W: WriteTarget>(
+    writer: &mut W,
+    value: f64,
+    spec: u8,
+    flags: &FormatFlags,
+    width: usize,
+    has_precision: bool,
+    precision: usize,
+) -> Result<(), ()> {
+    let upper: bool = spec.is_ascii_uppercase();
+    let lower: u8 = spec | 0x20;
+    let neg: bool = value.is_sign_negative();
+    let sign: Option<u8> = sign_char(neg, flags);
+
+    // Non-finite values format as text and are never zero-padded.
+    if value.is_nan() {
+        let text: &[u8] = if upper { b"NAN" } else { b"nan" };
+        return emit(writer, sign, text.len(), flags, width, false, |w| w.write_bytes(text));
+    }
+    if value.is_infinite() {
+        let text: &[u8] = if upper { b"INF" } else { b"inf" };
+        return emit(writer, sign, text.len(), flags, width, false, |w| w.write_bytes(text));
+    }
+
+    let (_, mantissa, exp2) = decompose_f64(value);
+
+    // Resolve the effective precision and clamp it to the number of significant digits the integer
+    // accumulator can represent. This bounds the digits written to `buf` so that an arbitrarily large
+    // requested precision cannot overflow it (the output is a bounded best-effort in that case).
+    let precision: usize = if has_precision {
+        precision
+    } else {
+        DEFAULT_PRECISION
+    };
+    let precision: usize = precision.min(MAX_SIG_DIGITS);
+
+    let mut buf: [u8; BODY_MAX] = [0u8; BODY_MAX];
+    let len: usize = match lower {
+        b'f' => build_fixed(mantissa, exp2, precision, flags.alternate, &mut buf),
+        b'e' => build_scientific(mantissa, exp2, precision, flags.alternate, upper, &mut buf),
+        // `g`/`G`
+        _ => build_general(mantissa, exp2, precision, flags.alternate, upper, &mut buf),
+    };
+
+    emit(writer, sign, len, flags, width, true, |w| w.write_bytes(&buf[..len]))
+}
+
+//==================================================================================================
+// Field Emission
+//==================================================================================================
+
+/// Returns the sign character to print for a value, honoring the `+` and space flags.
+fn sign_char(neg: bool, flags: &FormatFlags) -> Option<u8> {
+    if neg {
+        Some(b'-')
+    } else if flags.force_sign {
+        Some(b'+')
+    } else if flags.space_sign {
+        Some(b' ')
+    } else {
+        Option::None
+    }
+}
+
+/// Emits a sign and body within a field of the requested width, applying the alignment flags.
+///
+/// `body_len` is the number of bytes the `body` closure writes (the sign is accounted separately).
+/// `zero_pad_allowed` disables `0`-padding for conversions where it does not apply (the non-finite
+/// `inf`/`nan` spellings).
+fn emit<W, F>(
+    writer: &mut W,
+    sign: Option<u8>,
+    body_len: usize,
+    flags: &FormatFlags,
+    width: usize,
+    zero_pad_allowed: bool,
+    mut body: F,
+) -> Result<(), ()>
+where
+    W: WriteTarget,
+    F: FnMut(&mut W) -> Result<(), ()>,
+{
+    let sign_len: usize = usize::from(sign.is_some());
+    let content: usize = sign_len + body_len;
+    let pad: usize = width.saturating_sub(content);
+
+    if flags.left_align {
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        body(writer)?;
+        write_padding(writer, b' ', pad)?;
+    } else if zero_pad_allowed && flags.zero_pad {
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        write_padding(writer, b'0', pad)?;
+        body(writer)?;
+    } else {
+        write_padding(writer, b' ', pad)?;
+        if let Some(s) = sign {
+            writer.write_byte(s)?;
+        }
+        body(writer)?;
+    }
+    Ok(())
+}
+
+//==================================================================================================
+// Float Decomposition and Fixed-Point Scaling
+//==================================================================================================
+
+/// Decomposes a finite `f64` into `(sign, mantissa, exp2)` with magnitude `mantissa * 2^exp2`.
+///
+/// The mantissa is the full 53-bit significand, including the implicit leading bit for normal
+/// values; subnormals carry their stored fraction with the fixed minimum exponent.
+fn decompose_f64(value: f64) -> (bool, u64, i32) {
+    let bits: u64 = value.to_bits();
+    let sign: bool = (bits >> 63) != 0;
+    let exp_field: u32 = ((bits >> 52) & 0x7ff) as u32;
+    let frac: u64 = bits & 0x000f_ffff_ffff_ffff;
+    if exp_field == 0 {
+        // Subnormal (or zero): no implicit leading bit, exponent fixed at the smallest normal scale.
+        (sign, frac, -1074)
+    } else {
+        // Normal: restore the implicit leading bit. The unbiased exponent is `exp_field - 1023`, and
+        // the significand is scaled by `2^-52`, so `exp2 = exp_field - 1023 - 52`.
+        (sign, frac | (1u64 << 52), exp_field as i32 - 1075)
+    }
+}
+
+/// Returns `5^n` as a `u128`, or [`None`] on overflow.
+fn pow5(n: u32) -> Option<u128> {
+    let mut result: u128 = 1;
+    for _ in 0..n {
+        result = result.checked_mul(5)?;
+    }
+    Some(result)
+}
+
+/// Shifts `value` left by `shift`, returning [`None`] when significant bits would be lost.
+fn shl_checked(value: u128, shift: u32) -> Option<u128> {
+    if value == 0 {
+        return Some(0);
+    }
+    if shift >= 128 || value.leading_zeros() < shift {
+        return Option::None;
+    }
+    Some(value << shift)
+}
+
+/// Computes `round(mantissa * 2^exp2 * 10^pow10)` to nearest, ties to even, as a `u128`.
+///
+/// Returns [`None`] when the exact intermediate does not fit in the 128-bit accumulator.
+fn round_scaled(mantissa: u64, exp2: i32, pow10: i32) -> Option<u128> {
+    // value * 10^pow10 = mantissa * 2^(exp2 + pow10) * 5^pow10.
+    let pow2: i32 = exp2 + pow10;
+    let pow5_exp: i32 = pow10;
+
+    let mut num: u128 = mantissa as u128;
+    let mut den: u128 = 1;
+
+    if pow5_exp >= 0 {
+        num = num.checked_mul(pow5(pow5_exp as u32)?)?;
+    } else {
+        den = den.checked_mul(pow5((-pow5_exp) as u32)?)?;
+    }
+
+    if pow2 >= 0 {
+        num = shl_checked(num, pow2 as u32)?;
+    } else {
+        den = shl_checked(den, (-pow2) as u32)?;
+    }
+
+    Some(round_div(num, den))
+}
+
+/// Returns `round(num / den)` to nearest, ties to even. `den` must be non-zero.
+fn round_div(num: u128, den: u128) -> u128 {
+    let quotient: u128 = num / den;
+    let remainder: u128 = num % den;
+    // Compare the remainder against half of the divisor without risking overflow: `remainder` and
+    // `den - remainder` straddle the half-way point.
+    let complement: u128 = den - remainder;
+    if remainder > complement {
+        quotient + 1
+    } else if remainder < complement {
+        quotient
+    } else {
+        // Exactly half-way: round to even.
+        quotient + (quotient & 1)
+    }
+}
+
+/// Writes the decimal digits of `value` (most-significant first) into `out`, returning the count.
+fn u128_to_digits(value: u128, out: &mut [u8]) -> usize {
+    if value == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    let mut tmp: [u8; 40] = [0u8; 40];
+    let mut count: usize = 0;
+    let mut v: u128 = value;
+    while v > 0 {
+        tmp[count] = b'0' + (v % 10) as u8;
+        v /= 10;
+        count += 1;
+    }
+    for i in 0..count {
+        out[i] = tmp[count - 1 - i];
+    }
+    count
+}
+
+//==================================================================================================
+// Fixed Notation (%f)
+//==================================================================================================
+
+/// Assembles the body of a `%f` conversion into `buf`, returning the number of bytes written.
+fn build_fixed(
+    mantissa: u64,
+    exp2: i32,
+    precision: usize,
+    alternate: bool,
+    buf: &mut [u8],
+) -> usize {
+    match round_scaled(mantissa, exp2, precision as i32) {
+        Some(scaled) => {
+            let mut digits: [u8; 40] = [0u8; 40];
+            let count: usize = u128_to_digits(scaled, &mut digits);
+            let mut pos: usize = 0;
+
+            if precision == 0 {
+                // No fractional digits: the whole number is the integer part.
+                for &d in &digits[..count] {
+                    push(buf, &mut pos, d);
+                }
+                if alternate {
+                    push(buf, &mut pos, b'.');
+                }
+            } else if count > precision {
+                // The integer part is the leading `count - precision` digits.
+                let int_len: usize = count - precision;
+                for &d in &digits[..int_len] {
+                    push(buf, &mut pos, d);
+                }
+                push(buf, &mut pos, b'.');
+                for &d in &digits[int_len..count] {
+                    push(buf, &mut pos, d);
+                }
+            } else {
+                // The value is below 1: a single `0`, then leading fractional zeros, then the digits.
+                push(buf, &mut pos, b'0');
+                push(buf, &mut pos, b'.');
+                for _ in 0..(precision - count) {
+                    push(buf, &mut pos, b'0');
+                }
+                for &d in &digits[..count] {
+                    push(buf, &mut pos, d);
+                }
+            }
+            pos
+        },
+        // Magnitude/precision beyond the 128-bit accumulator (not reached for practical inputs).
+        Option::None => build_fixed_fallback(mantissa, exp2, precision, alternate, buf),
+    }
+}
+
+/// Best-effort `%f` for magnitudes/precisions that overflow the exact path: prints the integer part
+/// (correct for magnitudes below `2^128`) with a zero fraction.
+fn build_fixed_fallback(
+    mantissa: u64,
+    exp2: i32,
+    precision: usize,
+    alternate: bool,
+    buf: &mut [u8],
+) -> usize {
+    let integer: u128 = if exp2 >= 0 {
+        shl_checked(mantissa as u128, exp2 as u32).unwrap_or(u128::MAX)
+    } else {
+        let shift: u32 = (-exp2) as u32;
+        if shift >= 128 {
+            0
+        } else {
+            (mantissa as u128) >> shift
+        }
+    };
+
+    let mut digits: [u8; 40] = [0u8; 40];
+    let count: usize = u128_to_digits(integer, &mut digits);
+    let mut pos: usize = 0;
+    for &d in &digits[..count] {
+        push(buf, &mut pos, d);
+    }
+    if precision > 0 {
+        push(buf, &mut pos, b'.');
+        for _ in 0..precision {
+            push(buf, &mut pos, b'0');
+        }
+    } else if alternate {
+        push(buf, &mut pos, b'.');
+    }
+    pos
+}
+
+//==================================================================================================
+// Scientific Notation (%e)
+//==================================================================================================
+
+/// Computes the `sig` leading significant digits (most-significant first) and the decimal exponent
+/// `x` such that the value is `d.ddd... * 10^x`. `mantissa` must be non-zero.
+fn scientific_digits(mantissa: u64, exp2: i32, sig: usize, digits: &mut [u8; 40]) -> i32 {
+    let sig: usize = sig.clamp(1, MAX_SIG_DIGITS);
+
+    // Estimate the decimal exponent from the binary one: log10(value) ≈ log2(value) * log10(2), with
+    // log10(2) ≈ 1233 / 4096. The estimate is within one or two of the true value and is corrected
+    // below by checking the digit count of the scaled integer.
+    let msb: i32 = 63 - mantissa.leading_zeros() as i32;
+    let approx_log2: i32 = exp2 + msb;
+    let mut x: i32 = ((approx_log2 as i64 * 1233) >> 12) as i32;
+
+    let mut guard: u32 = 0;
+    loop {
+        guard += 1;
+        let pow: i32 = (sig as i32 - 1) - x;
+        let scaled: u128 = round_scaled(mantissa, exp2, pow).unwrap_or(0);
+        let count: usize = u128_to_digits(scaled, digits);
+        if count == sig {
+            return x;
+        }
+        if count > sig {
+            x += (count - sig) as i32;
+        } else {
+            x -= (sig - count) as i32;
+        }
+        if guard > 8 {
+            // Convergence guard for inputs at the edge of the accumulator's range.
+            return x;
+        }
+    }
+}
+
+/// Assembles the body of a `%e` conversion into `buf`, returning the number of bytes written.
+fn build_scientific(
+    mantissa: u64,
+    exp2: i32,
+    precision: usize,
+    alternate: bool,
+    upper: bool,
+    buf: &mut [u8],
+) -> usize {
+    let sig: usize = (precision + 1).clamp(1, MAX_SIG_DIGITS);
+    let mut digits: [u8; 40] = [0u8; 40];
+    let exponent: i32 = if mantissa == 0 {
+        digits[0] = b'0';
+        0
+    } else {
+        scientific_digits(mantissa, exp2, sig, &mut digits)
+    };
+    // Only one digit is meaningful for zero; otherwise the buffer holds `sig` significant digits.
+    let available: usize = if mantissa == 0 { 1 } else { sig };
+
+    let mut pos: usize = 0;
+    push(buf, &mut pos, digits[0]);
+    if precision > 0 || alternate {
+        push(buf, &mut pos, b'.');
+    }
+    // The fractional part has `precision` digits: the significant digits after the leading one
+    // (`digits[1..available]`, capped at `precision`), followed by zero padding.
+    let significant: usize = (available - 1).min(precision);
+    for &digit in &digits[1..1 + significant] {
+        push(buf, &mut pos, digit);
+    }
+    for _ in significant..precision {
+        push(buf, &mut pos, b'0');
+    }
+    push_exponent(buf, &mut pos, exponent, upper);
+    pos
+}
+
+/// Appends the exponent suffix (`e±dd`, at least two exponent digits) of a scientific conversion.
+fn push_exponent(buf: &mut [u8], pos: &mut usize, exponent: i32, upper: bool) {
+    push(buf, pos, if upper { b'E' } else { b'e' });
+    let negative: bool = exponent < 0;
+    push(buf, pos, if negative { b'-' } else { b'+' });
+
+    let mut magnitude: u32 = exponent.unsigned_abs();
+    let mut tmp: [u8; 8] = [0u8; 8];
+    let mut count: usize = 0;
+    loop {
+        tmp[count] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+        count += 1;
+        if magnitude == 0 {
+            break;
+        }
+    }
+    while count < 2 {
+        tmp[count] = b'0';
+        count += 1;
+    }
+    for i in (0..count).rev() {
+        push(buf, pos, tmp[i]);
+    }
+}
+
+//==================================================================================================
+// General Notation (%g)
+//==================================================================================================
+
+/// Assembles the body of a `%g` conversion into `buf`, returning the number of bytes written.
+fn build_general(
+    mantissa: u64,
+    exp2: i32,
+    precision: usize,
+    alternate: bool,
+    upper: bool,
+    buf: &mut [u8],
+) -> usize {
+    // A precision of 0 is treated as 1 significant digit, per the conversion's definition.
+    let sig: usize = if precision == 0 { 1 } else { precision };
+
+    // Determine the exponent the value would have in scientific notation.
+    let exponent: i32 = if mantissa == 0 {
+        0
+    } else {
+        let mut digits: [u8; 40] = [0u8; 40];
+        scientific_digits(mantissa, exp2, sig, &mut digits)
+    };
+
+    let len: usize = if exponent >= -4 && exponent < sig as i32 {
+        // Fixed notation with precision chosen so that `sig` significant digits are shown.
+        let fixed_precision: usize = (sig as i32 - 1 - exponent).max(0) as usize;
+        build_fixed(mantissa, exp2, fixed_precision, alternate, buf)
+    } else {
+        build_scientific(mantissa, exp2, sig - 1, alternate, upper, buf)
+    };
+
+    if alternate {
+        // The alternate form keeps trailing zeros and the decimal point.
+        len
+    } else {
+        strip_trailing_zeros(buf, len)
+    }
+}
+
+/// Removes trailing fractional zeros (and a now-trailing decimal point) from a `%g` body, leaving
+/// any exponent suffix intact. Returns the new length.
+fn strip_trailing_zeros(buf: &mut [u8], len: usize) -> usize {
+    // Locate an exponent marker, if any; only the mantissa is trimmed.
+    let exp_pos: Option<usize> = buf[..len].iter().position(|&c| c == b'e' || c == b'E');
+    let mantissa_end: usize = exp_pos.unwrap_or(len);
+
+    // Trimming only applies when a decimal point is present.
+    if !buf[..mantissa_end].contains(&b'.') {
+        return len;
+    }
+
+    let mut end: usize = mantissa_end;
+    while end > 0 && buf[end - 1] == b'0' {
+        end -= 1;
+    }
+    if end > 0 && buf[end - 1] == b'.' {
+        end -= 1;
+    }
+
+    match exp_pos {
+        None => end,
+        Some(start) => {
+            // Shift the exponent suffix down to close the gap left by the trimmed zeros.
+            let suffix_len: usize = len - start;
+            for i in 0..suffix_len {
+                buf[end + i] = buf[start + i];
+            }
+            end + suffix_len
+        },
+    }
+}
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Writes `byte` at `*pos` in `buf` and advances `pos`. A write that would fall past the end of
+/// `buf` is silently dropped and leaves `pos` unchanged.
+fn push(buf: &mut [u8], pos: &mut usize, byte: u8) {
+    if *pos < buf.len() {
+        buf[*pos] = byte;
+        *pos += 1;
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use ::std::{
+        format,
+        string::String,
+        vec::Vec,
+    };
+
+    /// Collects formatted bytes into a string for assertions.
+    struct VecWriter {
+        data: Vec<u8>,
+    }
+
+    impl WriteTarget for VecWriter {
+        fn write_byte(&mut self, b: u8) -> Result<(), ()> {
+            self.data.push(b);
+            Ok(())
+        }
+
+        fn total(&self) -> usize {
+            self.data.len()
+        }
+    }
+
+    /// Formats `value` with the given specifier, flags, width and precision.
+    fn run(
+        value: f64,
+        spec: u8,
+        flags: &FormatFlags,
+        width: usize,
+        has_precision: bool,
+        precision: usize,
+    ) -> String {
+        let mut writer: VecWriter = VecWriter { data: Vec::new() };
+        format_float(&mut writer, value, spec, flags, width, has_precision, precision)
+            .expect("format_float writes to an in-memory buffer");
+        String::from_utf8(writer.data).expect("ascii output")
+    }
+
+    /// Plain flags (no `-`, `+`, space, `0` or `#`).
+    fn plain() -> FormatFlags {
+        FormatFlags {
+            left_align: false,
+            force_sign: false,
+            space_sign: false,
+            zero_pad: false,
+            alternate: false,
+        }
+    }
+
+    #[test]
+    fn fixed_matches_std_default_precision() {
+        let cases: [f64; 9] = [
+            0.0,
+            1.0,
+            1.5,
+            2.5,
+            3.40192,
+            1234.5,
+            0.1,
+            0.0009765625,
+            9999.99995,
+        ];
+        for &v in &cases {
+            assert_eq!(run(v, b'f', &plain(), 0, false, 0), format!("{:.6}", v), "value {v}");
+        }
+    }
+
+    #[test]
+    fn fixed_matches_std_various_precisions() {
+        let values: [f64; 6] = [0.0, 1.0, 3.40192837465019, 2.5, 0.125, 1234.875];
+        for &v in &values {
+            for p in 0..=15usize {
+                assert_eq!(
+                    run(v, b'f', &plain(), 0, true, p),
+                    format!("{:.*}", p, v),
+                    "value {v} precision {p}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_negative_and_integers() {
+        assert_eq!(run(-3.5, b'f', &plain(), 0, true, 2), "-3.50");
+        assert_eq!(run(-0.0, b'f', &plain(), 0, true, 1), "-0.0");
+        assert_eq!(run(2.0, b'f', &plain(), 0, true, 0), "2");
+        assert_eq!(run(2.0, b'f', &plain(), 0, false, 0), "2.000000");
+    }
+
+    #[test]
+    fn fixed_rounding_half_to_even() {
+        // 0.5 and 2.5 at precision 0 round to the nearest even integer.
+        assert_eq!(run(0.5, b'f', &plain(), 0, true, 0), "0");
+        assert_eq!(run(1.5, b'f', &plain(), 0, true, 0), "2");
+        assert_eq!(run(2.5, b'f', &plain(), 0, true, 0), "2");
+        assert_eq!(run(3.5, b'f', &plain(), 0, true, 0), "4");
+    }
+
+    #[test]
+    fn scientific_matches_std() {
+        let values: [f64; 7] = [0.0, 1.0, 1234.5, 0.000123, 6.022e23, 9.999e9, 5.0e-7];
+        for &v in &values {
+            for p in 0..=12usize {
+                assert_eq!(
+                    run(v, b'e', &plain(), 0, true, p),
+                    c_scientific(v, p),
+                    "value {v} precision {p}"
+                );
+            }
+        }
+    }
+
+    /// Renders `value` in C `%e` style by taking the mantissa from Rust's formatter and rewriting the
+    /// exponent in C form (explicit sign, at least two digits). Rust uses a minimal exponent without a
+    /// sign for non-negative exponents, so the suffix cannot be compared directly.
+    fn c_scientific(value: f64, precision: usize) -> String {
+        let std: String = format!("{:.*e}", precision, value);
+        let (mantissa, exp) = std.split_once('e').expect("scientific output");
+        let exp: i32 = exp.parse().expect("exponent");
+        format!("{}e{}{:02}", mantissa, if exp < 0 { '-' } else { '+' }, exp.abs())
+    }
+
+    #[test]
+    fn scientific_exponent_has_two_digits() {
+        assert_eq!(run(1.0, b'e', &plain(), 0, true, 2), "1.00e+00");
+        assert_eq!(run(1234.5, b'e', &plain(), 0, true, 4), "1.2345e+03");
+        assert_eq!(run(0.0009765625, b'e', &plain(), 0, true, 3), "9.766e-04");
+    }
+
+    #[test]
+    fn scientific_uppercase() {
+        assert_eq!(run(1234.5, b'E', &plain(), 0, true, 2), "1.23E+03");
+        assert_eq!(run(f64::INFINITY, b'E', &plain(), 0, false, 0), "INF");
+    }
+
+    #[test]
+    fn general_strips_trailing_zeros() {
+        assert_eq!(run(1.0, b'g', &plain(), 0, false, 0), "1");
+        assert_eq!(run(100000.0, b'g', &plain(), 0, false, 0), "100000");
+        assert_eq!(run(0.0001, b'g', &plain(), 0, false, 0), "0.0001");
+        // Beyond 1e-4 the conversion switches to scientific notation.
+        assert_eq!(run(0.00001, b'g', &plain(), 0, false, 0), "1e-05");
+        assert_eq!(run(1234567.0, b'g', &plain(), 0, false, 0), "1.23457e+06");
+    }
+
+    #[test]
+    fn general_alternate_keeps_zeros() {
+        let mut flags: FormatFlags = plain();
+        flags.alternate = true;
+        assert_eq!(run(1.0, b'g', &flags, 0, true, 6), "1.00000");
+    }
+
+    #[test]
+    fn special_values() {
+        assert_eq!(run(f64::NAN, b'f', &plain(), 0, false, 0), "nan");
+        assert_eq!(run(f64::INFINITY, b'f', &plain(), 0, false, 0), "inf");
+        assert_eq!(run(f64::NEG_INFINITY, b'f', &plain(), 0, false, 0), "-inf");
+    }
+
+    #[test]
+    fn width_and_alignment() {
+        assert_eq!(run(3.5, b'f', &plain(), 10, true, 2), "      3.50");
+
+        let mut left: FormatFlags = plain();
+        left.left_align = true;
+        assert_eq!(run(3.5, b'f', &left, 10, true, 2), "3.50      ");
+
+        let mut zero: FormatFlags = plain();
+        zero.zero_pad = true;
+        assert_eq!(run(3.5, b'f', &zero, 10, true, 2), "0000003.50");
+
+        let mut zero_neg: FormatFlags = plain();
+        zero_neg.zero_pad = true;
+        assert_eq!(run(-3.5, b'f', &zero_neg, 10, true, 2), "-000003.50");
+    }
+
+    #[test]
+    fn sign_flags() {
+        let mut plus: FormatFlags = plain();
+        plus.force_sign = true;
+        assert_eq!(run(3.5, b'f', &plus, 0, true, 1), "+3.5");
+
+        let mut space: FormatFlags = plain();
+        space.space_sign = true;
+        assert_eq!(run(3.5, b'f', &space, 0, true, 1), " 3.5");
+    }
+
+    #[test]
+    fn alternate_forces_point() {
+        let mut flags: FormatFlags = plain();
+        flags.alternate = true;
+        assert_eq!(run(4.0, b'f', &flags, 0, true, 0), "4.");
+        assert_eq!(run(4.0, b'e', &flags, 0, true, 0), "4.e+00");
+    }
+
+    #[test]
+    fn large_precision_is_bounded() {
+        // A precision far beyond the accumulator's range is clamped to the supported number of
+        // significant digits, so the body stays well within `buf` instead of being truncated at its
+        // end (which an unclamped precision would do, leaving the length pinned at `BODY_MAX`).
+        for spec in *b"feg" {
+            let out: String = run(1.0, spec, &plain(), 0, true, 1000);
+            assert!(
+                out.len() < BODY_MAX,
+                "{} body length {} is not bounded",
+                spec as char,
+                out.len()
+            );
+        }
+    }
+}

--- a/src/libs/libc_stdio/src/format_engine.rs
+++ b/src/libs/libc_stdio/src/format_engine.rs
@@ -23,17 +23,17 @@ use ::sysapi::ffi::{
 //==================================================================================================
 
 /// Flags parsed from a printf format specifier.
-struct FormatFlags {
+pub(crate) struct FormatFlags {
     /// Left-align the output within the field width (`-`).
-    left_align: bool,
+    pub(crate) left_align: bool,
     /// Always print a sign character (`+`).
-    force_sign: bool,
+    pub(crate) force_sign: bool,
     /// Print a space before positive numbers (` `).
-    space_sign: bool,
+    pub(crate) space_sign: bool,
     /// Pad with zeros instead of spaces (`0`).
-    zero_pad: bool,
+    pub(crate) zero_pad: bool,
     /// Use alternate form (`#`).
-    alternate: bool,
+    pub(crate) alternate: bool,
 }
 
 /// Length modifier for printf format specifiers.
@@ -91,6 +91,9 @@ pub(crate) trait ArgSource {
     fn next_ptr(&mut self) -> usize;
     /// Fetches the next `*const c_char` string argument.
     fn next_str(&mut self) -> *const c_char;
+    /// Fetches the next `f64` (double) argument. A `float` is promoted to `double` when passed
+    /// through an ellipsis, so this also serves the `float` case.
+    fn next_double(&mut self) -> f64;
 }
 
 //==================================================================================================
@@ -426,7 +429,11 @@ fn parse_length(fmt: *const c_char, start: usize) -> (LengthMod, usize) {
 }
 
 /// Writes padding characters to the writer.
-fn write_padding<W: WriteTarget>(writer: &mut W, ch: u8, count: usize) -> Result<(), ()> {
+pub(crate) fn write_padding<W: WriteTarget>(
+    writer: &mut W,
+    ch: u8,
+    count: usize,
+) -> Result<(), ()> {
     // Emit padding in fixed-size chunks so that file-descriptor-backed writers do not incur
     // one syscall per padding byte for large widths/precisions.
     const CHUNK: usize = 64;
@@ -828,6 +835,18 @@ pub(crate) fn format_core<W: WriteTarget, A: ArgSource>(
                 let (start, len) = format_unsigned(ptr as u64, 16, false, &mut buf);
                 let _ = writer.write_bytes(&buf[start..start + len]);
             },
+            b'f' | b'F' | b'e' | b'E' | b'g' | b'G' => {
+                let value: f64 = args.next_double();
+                let _ = crate::float_fmt::format_float(
+                    writer,
+                    value,
+                    spec,
+                    &flags,
+                    width,
+                    has_precision,
+                    precision,
+                );
+            },
             b'%' => {
                 let _ = writer.write_byte(b'%');
             },
@@ -892,6 +911,7 @@ mod test {
         sizes: Vec<usize>,
         ptrs: Vec<usize>,
         strs: Vec<*const c_char>,
+        doubles: Vec<f64>,
         int_idx: usize,
         uint_idx: usize,
         long_idx: usize,
@@ -901,6 +921,7 @@ mod test {
         size_idx: usize,
         ptr_idx: usize,
         str_idx: usize,
+        double_idx: usize,
     }
 
     impl TestArgs {
@@ -915,6 +936,7 @@ mod test {
                 sizes: Vec::new(),
                 ptrs: Vec::new(),
                 strs: Vec::new(),
+                doubles: Vec::new(),
                 int_idx: 0,
                 uint_idx: 0,
                 long_idx: 0,
@@ -924,6 +946,7 @@ mod test {
                 size_idx: 0,
                 ptr_idx: 0,
                 str_idx: 0,
+                double_idx: 0,
             }
         }
     }
@@ -972,6 +995,11 @@ mod test {
         fn next_str(&mut self) -> *const c_char {
             let v: *const c_char = self.strs[self.str_idx];
             self.str_idx += 1;
+            v
+        }
+        fn next_double(&mut self) -> f64 {
+            let v: f64 = self.doubles[self.double_idx];
+            self.double_idx += 1;
             v
         }
     }

--- a/src/libs/libc_stdio/src/freopen.rs
+++ b/src/libs/libc_stdio/src/freopen.rs
@@ -1,0 +1,141 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    fcntl::{
+        file_access_mode::{
+            O_RDONLY,
+            O_RDWR,
+            O_WRONLY,
+        },
+        file_creation_flags::{
+            O_CREAT,
+            O_TRUNC,
+        },
+        file_status_flags::O_APPEND,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::mode_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reopens the stream `stream`, associating it with the file named by `pathname`. The original
+/// stream is flushed and its underlying file descriptor is retargeted to the newly opened file so
+/// that existing `FILE *` references (such as `stdout`) remain valid. If `pathname` is null the
+/// stream is left associated with its current descriptor (changing the access mode of an already
+/// open descriptor is not supported).
+///
+/// # Parameters
+///
+/// - `pathname`: Pointer to a null-terminated path string, or null to keep the current file.
+/// - `mode`: Pointer to a null-terminated mode string (`"r"`, `"w"`, `"a"`, `"r+"`, `"w+"`, or
+///   `"a+"`).
+/// - `stream`: Pointer to the [`FILE`] stream to reopen.
+///
+/// # Returns
+///
+/// `stream` on success, or a null pointer on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `pathname`, when non-null, points to a valid null-terminated string.
+/// - `mode` points to a valid, null-terminated mode string.
+/// - `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/freopen.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn freopen(
+    pathname: *const c_char,
+    mode: *const c_char,
+    stream: *mut FILE,
+) -> *mut FILE {
+    extern "C" {
+        fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int;
+        fn close(fd: c_int) -> c_int;
+        fn dup2(oldfd: c_int, newfd: c_int) -> c_int;
+    }
+
+    if mode.is_null() || stream.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Parse the mode string, matching fopen(). Guard against an empty mode string so that the second
+    // and third bytes are only read when they lie within the null-terminated string.
+    let first: u8 = *mode as u8;
+    if first == 0 {
+        return core::ptr::null_mut();
+    }
+    let second: u8 = *mode.add(1) as u8;
+    let third: u8 = if second != 0 { *mode.add(2) as u8 } else { 0 };
+    let has_plus: bool = second == b'+' || third == b'+';
+
+    let flags: c_int = match (first, has_plus) {
+        (b'r', false) => O_RDONLY,
+        (b'r', true) => O_RDWR,
+        (b'w', false) => O_WRONLY | O_CREAT | O_TRUNC,
+        (b'w', true) => O_RDWR | O_CREAT | O_TRUNC,
+        (b'a', false) => O_WRONLY | O_CREAT | O_APPEND,
+        (b'a', true) => O_RDWR | O_CREAT | O_APPEND,
+        _ => return core::ptr::null_mut(),
+    };
+
+    // Flush any pending output before detaching from the old file.
+    // SAFETY: stream is a valid FILE pointer.
+    unsafe { crate::fflush::fflush(stream) };
+
+    // With no pathname, leave the stream attached to its current descriptor.
+    if pathname.is_null() {
+        return stream;
+    }
+
+    let perm: mode_t = 0o666;
+    // SAFETY: pathname is non-null, flags and permissions are valid.
+    let newfd: c_int = unsafe { open(pathname, flags, perm) };
+    if newfd < 0 {
+        return core::ptr::null_mut();
+    }
+
+    let oldfd: c_int = (*stream).fd;
+    if oldfd < 0 {
+        // SAFETY: newfd is a valid open descriptor.
+        unsafe { close(newfd) };
+        return core::ptr::null_mut();
+    }
+
+    // Retarget the stream's descriptor at the freshly opened file.
+    if newfd != oldfd {
+        // SAFETY: both descriptors are valid; dup2 closes oldfd if necessary.
+        if unsafe { dup2(newfd, oldfd) } < 0 {
+            // SAFETY: newfd is a valid open descriptor.
+            unsafe { close(newfd) };
+            return core::ptr::null_mut();
+        }
+        // SAFETY: newfd has been duplicated onto oldfd and is no longer needed.
+        unsafe { close(newfd) };
+    }
+
+    // Reset the stream's status indicators for the new file.
+    (*stream).eof = 0;
+    (*stream).error = 0;
+    (*stream).ungetc_buf = -1;
+
+    stream
+}

--- a/src/libs/libc_stdio/src/fseeko.rs
+++ b/src/libs/libc_stdio/src/fseeko.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::streams::FILE;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::off_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the file position indicator for the stream pointed to by `stream`. This is identical to
+/// [`fseek`](`crate::fseek::fseek`) except that the `offset` argument has type [`off_t`], allowing
+/// the full range of file offsets to be expressed.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `offset`: Number of bytes to offset from `whence`.
+/// - `whence`: Position from which `offset` is applied (`SEEK_SET`, `SEEK_CUR`, or `SEEK_END`).
+///
+/// # Returns
+///
+/// Zero on success, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fseeko.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fseeko(stream: *mut FILE, offset: off_t, whence: c_int) -> c_int {
+    extern "C" {
+        fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    }
+
+    if stream.is_null() {
+        return -1;
+    }
+
+    let fd: c_int = (*stream).fd;
+    // SAFETY: fd comes from a valid FILE, offset and whence are caller-provided.
+    let ret: off_t = unsafe { lseek(fd, offset, whence) };
+    if ret < 0 {
+        (*stream).error = 1;
+        return -1;
+    }
+
+    // A successful seek clears the end-of-file indicator and the push-back buffer.
+    (*stream).eof = 0;
+    (*stream).ungetc_buf = -1;
+
+    0
+}

--- a/src/libs/libc_stdio/src/getdelim.rs
+++ b/src/libs/libc_stdio/src/getdelim.rs
@@ -1,0 +1,172 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    fgetc::fgetc,
+    streams::FILE,
+};
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::{
+        c_size_t,
+        c_ssize_t,
+    },
+};
+
+//==================================================================================================
+// Private Standalone Functions
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn realloc(ptr: *mut c_void, size: c_size_t) -> *mut c_void;
+}
+
+/// Minimum capacity used when a fresh buffer has to be allocated.
+const INITIAL_CAPACITY: usize = 120;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads a line from `stream`, up to and including the next `delim` byte (or end-of-file),
+/// storing it in a dynamically sized buffer. The buffer pointed to by `*lineptr` is grown with
+/// [`realloc`] as needed and `*n` is updated to reflect its capacity; passing a null `*lineptr`
+/// (with `*n` ignored) requests a freshly allocated buffer. The resulting line is always
+/// null-terminated.
+///
+/// # Parameters
+///
+/// - `lineptr`: Address of the caller's buffer pointer; updated when the buffer is (re)allocated.
+/// - `n`: Address of the caller's capacity counter; updated when the buffer is (re)allocated.
+/// - `delim`: Delimiter byte that terminates the line.
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// The number of bytes read (including the delimiter but excluding the terminating null byte), or
+/// `-1` on end-of-file with no bytes read or on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `lineptr`, `n`, and `stream` point to valid objects, and that any non-null `*lineptr` was
+/// obtained from the C allocator with a capacity of `*n` bytes.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getdelim.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getdelim(
+    lineptr: *mut *mut c_char,
+    n: *mut c_size_t,
+    delim: c_int,
+    stream: *mut FILE,
+) -> c_ssize_t {
+    if lineptr.is_null() || n.is_null() || stream.is_null() {
+        return -1;
+    }
+
+    let mut buf: *mut c_char = *lineptr;
+    let mut cap: usize = *n as usize;
+
+    // Allocate an initial buffer if the caller did not provide one.
+    if buf.is_null() || cap == 0 {
+        cap = INITIAL_CAPACITY;
+        buf = malloc(cap as c_size_t).cast::<c_char>();
+        if buf.is_null() {
+            return -1;
+        }
+        *lineptr = buf;
+        *n = cap as c_size_t;
+    }
+
+    let delim_byte: c_int = delim & 0xff;
+    let mut pos: usize = 0;
+
+    loop {
+        let c: c_int = fgetc(stream);
+        if c == -1 {
+            // End-of-file or read error: report failure only when nothing was read.
+            if pos == 0 {
+                return -1;
+            }
+            break;
+        }
+
+        // Ensure room for the byte just read plus the terminating null byte.
+        if pos + 1 >= cap {
+            let new_cap: usize = match cap.checked_mul(2) {
+                Some(value) => value,
+                None => return -1,
+            };
+            let new_buf: *mut c_char =
+                realloc(buf.cast::<c_void>(), new_cap as c_size_t).cast::<c_char>();
+            if new_buf.is_null() {
+                return -1;
+            }
+            buf = new_buf;
+            cap = new_cap;
+            *lineptr = buf;
+            *n = cap as c_size_t;
+        }
+
+        *buf.add(pos).cast::<u8>() = (c & 0xff) as u8;
+        pos += 1;
+
+        if c == delim_byte {
+            break;
+        }
+    }
+
+    *buf.add(pos) = 0;
+    pos as c_ssize_t
+}
+
+///
+/// # Description
+///
+/// Reads a line from `stream`, up to and including the next newline byte (or end-of-file). This is
+/// equivalent to [`getdelim`] with a delimiter of `'\n'`.
+///
+/// # Parameters
+///
+/// - `lineptr`: Address of the caller's buffer pointer; updated when the buffer is (re)allocated.
+/// - `n`: Address of the caller's capacity counter; updated when the buffer is (re)allocated.
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Returns
+///
+/// The number of bytes read (including the newline but excluding the terminating null byte), or
+/// `-1` on end-of-file with no bytes read or on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `lineptr`, `n`, and `stream` point to valid objects, and that any non-null `*lineptr` was
+/// obtained from the C allocator with a capacity of `*n` bytes.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getline.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getline(
+    lineptr: *mut *mut c_char,
+    n: *mut c_size_t,
+    stream: *mut FILE,
+) -> c_ssize_t {
+    getdelim(lineptr, n, c_int::from(b'\n'), stream)
+}

--- a/src/libs/libc_stdio/src/lib.rs
+++ b/src/libs/libc_stdio/src/lib.rs
@@ -40,10 +40,13 @@
 // Modules
 //==================================================================================================
 
+mod float_fmt;
 mod format_engine;
 mod streams;
 
+pub mod asprintf;
 pub mod clearerr;
+pub mod dprintf;
 pub mod fclose;
 pub mod fdopen;
 pub mod feof;
@@ -57,10 +60,13 @@ pub mod fprintf;
 pub mod fputc;
 pub mod fputs;
 pub mod fread;
+pub mod freopen;
 pub mod fseek;
+pub mod fseeko;
 pub mod ftell;
 pub mod fwrite;
 pub mod getchar;
+pub mod getdelim;
 pub mod perror;
 pub mod printf;
 pub mod putchar;
@@ -75,6 +81,8 @@ pub mod sscanf;
 pub mod swprintf;
 pub mod tmpfile;
 pub mod ungetc;
+pub mod vasprintf;
+pub mod vdprintf;
 pub mod vfprintf;
 pub mod vprintf;
 pub mod vsnprintf;

--- a/src/libs/libc_stdio/src/printf.rs
+++ b/src/libs/libc_stdio/src/printf.rs
@@ -60,6 +60,9 @@ impl<'a> ArgSource for VaListArgs<'a> {
     fn next_str(&mut self) -> *const c_char {
         unsafe { self.va.next_arg::<*const c_char>() }
     }
+    fn next_double(&mut self) -> f64 {
+        unsafe { self.va.next_arg::<f64>() }
+    }
 }
 
 //==================================================================================================

--- a/src/libs/libc_stdio/src/vasprintf.rs
+++ b/src/libs/libc_stdio/src/vasprintf.rs
@@ -1,0 +1,92 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::ffi::VaList;
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats output according to `fmt` and the argument list `ap`, allocating a buffer large enough
+/// to hold the result (including the terminating null byte) with `malloc()`. On success the address
+/// of the allocated buffer is stored in `*strp`; the caller is responsible for freeing it.
+///
+/// # Parameters
+///
+/// - `strp`: Output pointer that receives the address of the allocated, formatted string.
+/// - `fmt`: Pointer to a null-terminated printf format string.
+/// - `ap`: Variable argument list matching the format specifiers in `fmt`.
+///
+/// # Returns
+///
+/// The number of characters written (excluding the terminating null byte) on success, or `-1` on
+/// error. On error the contents of `*strp` are undefined and no memory is left allocated.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `strp` points to a writable `char *` location.
+/// - `fmt` points to a valid, null-terminated format string.
+/// - `ap` provides arguments matching the format specifiers.
+///
+/// # References
+///
+/// - <https://man7.org/linux/man-pages/man3/asprintf.3.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vasprintf(
+    strp: *mut *mut c_char,
+    fmt: *const c_char,
+    ap: VaList<'_>,
+) -> c_int {
+    extern "C" {
+        fn malloc(size: c_size_t) -> *mut c_void;
+        fn free(ptr: *mut c_void);
+    }
+
+    if strp.is_null() {
+        return -1;
+    }
+
+    // Measure the formatted length using an independent cursor over the argument list.
+    let measure: VaList<'_> = ap.clone();
+    // SAFETY: a null buffer of size zero is valid for vsnprintf; it only computes the length.
+    let len: c_int = unsafe { crate::vsnprintf::vsnprintf(core::ptr::null_mut(), 0, fmt, measure) };
+    if len < 0 {
+        return -1;
+    }
+
+    let size: c_size_t = (len as c_size_t) + 1;
+    // SAFETY: allocating the measured number of bytes plus the null terminator.
+    let buf: *mut c_void = unsafe { malloc(size) };
+    if buf.is_null() {
+        return -1;
+    }
+
+    let out: *mut c_char = buf.cast::<c_char>();
+    // SAFETY: out points to `size` writable bytes; ap matches the format specifiers.
+    let ret: c_int = unsafe { crate::vsnprintf::vsnprintf(out, size, fmt, ap) };
+    if ret < 0 {
+        // SAFETY: buf was returned by malloc and has not been freed.
+        unsafe { free(buf) };
+        return -1;
+    }
+
+    *strp = out;
+    ret
+}

--- a/src/libs/libc_stdio/src/vdprintf.rs
+++ b/src/libs/libc_stdio/src/vdprintf.rs
@@ -17,13 +17,6 @@ use ::sysapi::ffi::{
 };
 
 //==================================================================================================
-// Constants
-//==================================================================================================
-
-/// File descriptor for standard output.
-const STDOUT_FD: c_int = 1;
-
-//==================================================================================================
 // VaList Adapter
 //==================================================================================================
 
@@ -34,33 +27,43 @@ struct VaListArgs<'a> {
 
 impl<'a> ArgSource for VaListArgs<'a> {
     fn next_int(&mut self) -> c_int {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<c_int>() }
     }
     fn next_uint(&mut self) -> u32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<u32>() }
     }
     fn next_long(&mut self) -> i32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<i32>() }
     }
     fn next_ulong(&mut self) -> u32 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<u32>() }
     }
     fn next_longlong(&mut self) -> i64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<i64>() }
     }
     fn next_ulonglong(&mut self) -> u64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<u64>() }
     }
     fn next_size(&mut self) -> usize {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<usize>() }
     }
     fn next_ptr(&mut self) -> usize {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<usize>() }
     }
     fn next_str(&mut self) -> *const c_char {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<*const c_char>() }
     }
     fn next_double(&mut self) -> f64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<f64>() }
     }
 }
@@ -72,34 +75,36 @@ impl<'a> ArgSource for VaListArgs<'a> {
 ///
 /// # Description
 ///
-/// Writes formatted output to standard output.
+/// Formats output according to `fmt` and `ap` and writes it directly to the file descriptor `fd`.
 ///
 /// # Parameters
 ///
+/// - `fd`: Destination file descriptor.
 /// - `fmt`: Pointer to a null-terminated printf format string.
 /// - `ap`: Variable argument list matching the format specifiers in `fmt`.
 ///
 /// # Returns
 ///
-/// The number of characters written on success, or `-1` on error.
+/// The number of bytes written on success, or `-1` on error.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences a raw pointer. The caller must ensure that:
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that:
+/// - `fd` is a valid, writable file descriptor.
 /// - `fmt` points to a valid, null-terminated format string.
 /// - `ap` provides arguments matching the format specifiers.
 ///
 /// # References
 ///
-/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vprintf.html>
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vdprintf.html>
 ///
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn vprintf(fmt: *const c_char, ap: VaList<'_>) -> c_int {
-    let mut writer: FdWriter = FdWriter::new(STDOUT_FD);
+pub unsafe extern "C" fn vdprintf(fd: c_int, fmt: *const c_char, ap: VaList<'_>) -> c_int {
+    let mut writer: FdWriter = FdWriter::new(fd);
     let mut args: VaListArgs<'_> = VaListArgs { va: ap };
-    let ret: c_int = format_core(&mut writer, fmt, &mut args);
-    if ret < 0 {
-        return ret;
+    let fmt_ret: c_int = format_core(&mut writer, fmt, &mut args);
+    if fmt_ret < 0 {
+        return fmt_ret;
     }
     writer.result()
 }

--- a/src/libs/libc_stdio/src/vfprintf.rs
+++ b/src/libs/libc_stdio/src/vfprintf.rs
@@ -56,6 +56,9 @@ impl<'a> ArgSource for VaListArgs<'a> {
     fn next_str(&mut self) -> *const c_char {
         unsafe { self.va.next_arg::<*const c_char>() }
     }
+    fn next_double(&mut self) -> f64 {
+        unsafe { self.va.next_arg::<f64>() }
+    }
 }
 
 //==================================================================================================

--- a/src/libs/libc_stdio/src/vsnprintf.rs
+++ b/src/libs/libc_stdio/src/vsnprintf.rs
@@ -66,6 +66,10 @@ impl<'a> ArgSource for VaListArgs<'a> {
         // SAFETY: caller guarantees matching format specifiers and arguments.
         unsafe { self.va.next_arg::<*const c_char>() }
     }
+    fn next_double(&mut self) -> f64 {
+        // SAFETY: caller guarantees matching format specifiers and arguments.
+        unsafe { self.va.next_arg::<f64>() }
+    }
 }
 
 //==================================================================================================

--- a/src/libs/libc_stdio/src/vsprintf.rs
+++ b/src/libs/libc_stdio/src/vsprintf.rs
@@ -54,6 +54,9 @@ impl<'a> ArgSource for VaListArgs<'a> {
     fn next_str(&mut self) -> *const c_char {
         unsafe { self.va.next_arg::<*const c_char>() }
     }
+    fn next_double(&mut self) -> f64 {
+        unsafe { self.va.next_arg::<f64>() }
+    }
 }
 
 //==================================================================================================

--- a/src/posix-tests/stdio-c/main.c
+++ b/src/posix-tests/stdio-c/main.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Calls vdprintf() with a freshly built variable argument list.
+static int call_vdprintf(int fd, const char *format, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, format);
+    ret = vdprintf(fd, format, args);
+    va_end(args);
+
+    return ret;
+}
+
+// Tests formatted output into caller-owned and dynamically allocated buffers.
+static void test_formatted_buffers(void)
+{
+    char buffer[64];
+    char *dynamic_buffer;
+    int ret;
+
+    ret = snprintf(buffer, sizeof(buffer), "int=%d float=%.1f sci=%.1e", 42, 3.5, 25.0);
+    assert(ret == (int)strlen("int=42 float=3.5 sci=2.5e+01"));
+    assert(strcmp(buffer, "int=42 float=3.5 sci=2.5e+01") == 0);
+
+    dynamic_buffer = NULL;
+    ret = asprintf(&dynamic_buffer, "hex=%#x text=%s value=%.2f", 255, "ok", 1.25);
+    assert(ret == (int)strlen("hex=0xff text=ok value=1.25"));
+    assert(dynamic_buffer != NULL);
+    assert(strcmp(dynamic_buffer, "hex=0xff text=ok value=1.25") == 0);
+    free(dynamic_buffer);
+}
+
+// Tests descriptor-backed formatted output and delimiter-based input.
+static void test_descriptor_and_line_io(void)
+{
+    const char *filename = "stdio-c.tmp";
+    FILE *stream;
+    char *line;
+    size_t capacity;
+    ssize_t length;
+    int fd;
+    int ret;
+
+    stream = fopen(filename, "w+");
+    assert(stream != NULL);
+
+    fd = fileno(stream);
+    assert(fd >= 0);
+
+    ret = dprintf(fd, "alpha %d %.1f\n", 7, 2.5);
+    assert(ret == (int)strlen("alpha 7 2.5\n"));
+
+    ret = call_vdprintf(fd, "beta %s!", "done");
+    assert(ret == (int)strlen("beta done!"));
+
+    assert(fseeko(stream, 0, SEEK_SET) == 0);
+
+    line = NULL;
+    capacity = 0;
+    length = getline(&line, &capacity, stream);
+    assert(length == (ssize_t)strlen("alpha 7 2.5\n"));
+    assert(strcmp(line, "alpha 7 2.5\n") == 0);
+
+    length = getdelim(&line, &capacity, '!', stream);
+    assert(length == (ssize_t)strlen("beta done!"));
+    assert(strcmp(line, "beta done!") == 0);
+
+    free(line);
+    assert(fclose(stream) == 0);
+    assert(remove(filename) == 0);
+}
+
+// Tests reopening an existing FILE object on a new pathname.
+static void test_freopen(void)
+{
+    const char *first = "stdio-c-freopen-a.tmp";
+    const char *second = "stdio-c-freopen-b.tmp";
+    FILE *stream;
+    char buffer[16];
+
+    stream = fopen(first, "w+");
+    assert(stream != NULL);
+    assert(fputs("old\n", stream) >= 0);
+
+    assert(freopen(second, "w+", stream) == stream);
+    assert(fputs("new\n", stream) >= 0);
+    assert(fseeko(stream, 0, SEEK_SET) == 0);
+    assert(fgets(buffer, sizeof(buffer), stream) == buffer);
+    assert(strcmp(buffer, "new\n") == 0);
+
+    assert(fclose(stream) == 0);
+    assert(remove(first) == 0);
+    assert(remove(second) == 0);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests standard I/O calls exposed by <stdio.h>.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_formatted_buffers();
+    test_descriptor_and_line_io();
+    test_freopen();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -186,6 +186,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/stdio-c"
+program = "./bin/stdio-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/thread-c"
 program = "./bin/thread-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -186,6 +186,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/stdio-c"
+program = "./bin/stdio-c.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/thread-c"
 program = "./bin/thread-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **7 commit(s)** that pertain to this crate.

### Commits
- [stdio] E: Add fseeko() with full off_t range
- [stdio] E: Add freopen() stream reassociation
- [stdio] E: Add dprintf() formatted descriptor output
- [stdio] E: Add vasprintf() allocating formatter
- [stdio] E: Add asprintf() allocating formatter
- [stdio] E: Add getline() and getdelim() to libc_stdio
- [stdio] E: Implement %f/%F, %e/%E and %g/%G printf conversions

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
