### PR TITLE
[stdlib] Add temp-file and environment helpers

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -37,6 +37,7 @@ extern "C" {
 #define O_NONBLOCK 0x4000 /**< Non-blocking mode. */
 #define O_NOCTTY 0x8000 /**< Do not assign controlling terminal. */
 #define O_CLOEXEC 0x40000 /**< Close-on-exec. */
+#define O_CLOFORK 0x80000 /**< Close-on-fork. */
 #define O_NOFOLLOW 0x100000 /**< Do not follow symbolic links. */
 #define O_DIRECTORY 0x200000 /**< Fail if not a directory. */
 #define AT_FDCWD -100 /**< Use the current working directory. */
@@ -66,6 +67,7 @@ extern "C" {
 
 /* File-descriptor flags (F_GETFD/F_SETFD). */
 #define FD_CLOEXEC 1
+#define FD_CLOFORK 2
 
 /* Lock types (struct flock l_type). */
 #define F_RDLCK 0

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -155,6 +155,8 @@ extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n
  * Temporary Files
  *==================================================================================================*/
 
+extern char *mkdtemp(char *template);
+extern int mkostemp(char *template, int flag);
 extern int mkstemp(char *template);
 
 /*==================================================================================================

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -138,7 +138,7 @@ functions = ["mblen", "mbtowc", "mbstowcs", "wctomb", "wcstombs"]
 
 [[sections]]
 title = "Temporary Files"
-functions = ["mkstemp"]
+functions = ["mkdtemp", "mkostemp", "mkstemp"]
 
 [[sections]]
 title = "Path Utilities"
@@ -181,5 +181,7 @@ wcstombs = '''
 extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n);'''
 mkstemp = '''
 extern int mkstemp(char *template);'''
+mkostemp = '''
+extern int mkostemp(char *template, int flag);'''
 realpath = '''
 extern char *realpath(const char *restrict path, char *restrict resolved_path);'''

--- a/src/libs/libc_stdlib/src/env_table.rs
+++ b/src/libs/libc_stdlib/src/env_table.rs
@@ -54,6 +54,16 @@ static ENV_TABLE: Lazy<Mutex<Vec<EnvEntry>>> = Lazy::new(|| Mutex::new(Vec::new(
 /// Optional callback invoked after a successful `set()` that writes a new or updated value.
 static SETENV_CALLBACK: Lazy<Mutex<Option<SetenvCallback>>> = Lazy::new(|| Mutex::new(None));
 
+/// Null-terminated array of pointers that backs the C-visible `environ` global.
+///
+/// One entry per environment variable (each pointing at a table entry's `KEY=VALUE` C string),
+/// followed by a single `0` terminator. Pointer values are stored as `usize` (rather than
+/// `*mut c_char`) so the static is `Send`/`Sync`, matching how [`EnvStorage::Borrowed`] keeps its
+/// address. It is rebuilt by [`sync_environ`] after every mutation and the `environ` global is
+/// repointed at its buffer, so C code reading `extern char **environ` always observes the current
+/// environment.
+static ENVIRON_ARRAY: Lazy<Mutex<Vec<usize>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -79,12 +89,13 @@ static SETENV_CALLBACK: Lazy<Mutex<Option<SetenvCallback>>> = Lazy::new(|| Mutex
 /// - Each string in the array remains valid for the duration of this call.
 ///
 pub unsafe fn init_from_raw(envp: *const *const c_char) {
-    if envp.is_null() {
-        return;
-    }
-
     let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
     table.clear();
+
+    if envp.is_null() {
+        sync_environ(&table);
+        return;
+    }
 
     let mut i: usize = 0;
     loop {
@@ -107,6 +118,9 @@ pub unsafe fn init_from_raw(envp: *const *const c_char) {
 
         i += 1;
     }
+
+    // Publish the freshly populated table through the C-visible `environ` global.
+    sync_environ(&table);
 }
 
 ///
@@ -167,23 +181,21 @@ pub fn set(key: &str, value: &[u8], overwrite: bool) -> Result<bool, ()> {
 
     let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
 
-    // Check if the key already exists.
-    for entry in table.iter_mut() {
-        if entry.matches_key(key) {
-            if overwrite {
-                *entry = EnvEntry::owned(key, value);
-                // Release the lock before invoking the callback.
-                drop(table);
-                invoke_setenv_callback(key, value);
-                return Ok(true);
+    // Locate an existing entry by index so the table can be reborrowed for `sync_environ` after the
+    // mutation without holding a `iter_mut()` borrow across the call.
+    let existing: Option<usize> = table.iter().position(|entry| entry.matches_key(key));
+    match existing {
+        Some(idx) => {
+            if !overwrite {
+                return Ok(false);
             }
-            return Ok(false);
-        }
+            table[idx] = EnvEntry::owned(key, value);
+        },
+        None => insert_entry(&mut table, key, value),
     }
 
-    // Key not found, insert new entry.
-    insert_entry(&mut table, key, value);
-    // Release the lock before invoking the callback.
+    // Repoint `environ`, then release the lock before invoking the callback.
+    sync_environ(&table);
     drop(table);
     invoke_setenv_callback(key, value);
     Ok(true)
@@ -201,6 +213,18 @@ pub fn set(key: &str, value: &[u8], overwrite: bool) -> Result<bool, ()> {
 pub fn unset(key: &str) {
     let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
     table.retain(|entry| !entry.matches_key(key));
+    sync_environ(&table);
+}
+
+///
+/// # Description
+///
+/// Removes every variable from the environment table, leaving it empty.
+///
+pub fn clear() {
+    let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
+    table.clear();
+    sync_environ(&table);
 }
 
 ///
@@ -235,15 +259,12 @@ pub unsafe fn put_raw(string: *mut c_char) -> Result<(), ()> {
     let value: &[u8] = &bytes[eq_pos + 1..];
 
     let mut table: spin::MutexGuard<'_, Vec<EnvEntry>> = ENV_TABLE.lock();
-    for entry in table.iter_mut() {
-        if entry.matches_key(key) {
-            *entry = EnvEntry::borrowed(string);
-            drop(table);
-            invoke_setenv_callback(key, value);
-            return Ok(());
-        }
+    let existing: Option<usize> = table.iter().position(|entry| entry.matches_key(key));
+    match existing {
+        Some(idx) => table[idx] = EnvEntry::borrowed(string),
+        None => table.push(EnvEntry::borrowed(string)),
     }
-    table.push(EnvEntry::borrowed(string));
+    sync_environ(&table);
     drop(table);
     invoke_setenv_callback(key, value);
     Ok(())
@@ -307,6 +328,46 @@ fn invoke_setenv_callback(key: &str, value: &[u8]) {
 // Helper Functions
 //==================================================================================================
 
+/// Rebuilds the C-visible [`ENVIRON_ARRAY`] from the current table and repoints the `environ`
+/// global at it.
+///
+/// The caller must hold the [`ENV_TABLE`] lock and pass the live entries, so this runs while the
+/// table is quiesced and the rebuilt pointer array is always consistent with it. Each surviving
+/// entry contributes the address of its `KEY=VALUE` C string; a trailing `0` terminates the array,
+/// matching the `char **environ` contract.
+///
+/// In a hosted (unit-test) build there is no C `environ` symbol to publish, so the array is still
+/// maintained — letting the table logic be exercised directly — but the global write is compiled
+/// out. In the freestanding libc the `environ` global is updated in place.
+fn sync_environ(table: &[EnvEntry]) {
+    let mut array: spin::MutexGuard<'_, Vec<usize>> = ENVIRON_ARRAY.lock();
+    array.clear();
+    array.reserve(table.len() + 1);
+    for entry in table.iter() {
+        array.push(entry.raw_ptr() as usize);
+    }
+    array.push(0);
+
+    let base: usize = array.as_ptr() as usize;
+
+    #[cfg(not(feature = "std"))]
+    {
+        unsafe extern "C" {
+            static mut environ: *mut *mut c_char;
+        }
+        // SAFETY: `environ` is the process-wide `char **environ` defined by libposix startup. The
+        // write is performed under the `ENV_TABLE` lock (held by the caller) and `ENVIRON_ARRAY`
+        // lock (held here), serializing it against any concurrent rebuild. Reads of `environ` from
+        // C are inherently unsynchronized, exactly as on a conventional libc.
+        unsafe {
+            let slot: *mut *mut *mut c_char = &raw mut environ;
+            *slot = base as *mut *mut c_char;
+        }
+    }
+    #[cfg(feature = "std")]
+    let _ = base;
+}
+
 /// Builds a null-terminated `KEY=VALUE\0` byte vector.
 fn make_raw(key: &str, value: &[u8]) -> Vec<u8> {
     let mut raw: Vec<u8> = Vec::with_capacity(key.len() + 1 + value.len() + 1);
@@ -345,6 +406,15 @@ impl EnvEntry {
     fn borrowed(ptr: *mut c_char) -> Self {
         Self {
             storage: EnvStorage::Borrowed(ptr as usize),
+        }
+    }
+
+    /// Returns a pointer to the first byte of the null-terminated `KEY=VALUE` C string, suitable for
+    /// publishing through the `environ` array.
+    fn raw_ptr(&self) -> *const c_char {
+        match &self.storage {
+            EnvStorage::Owned(raw) => raw.as_ptr().cast::<c_char>(),
+            EnvStorage::Borrowed(addr) => *addr as *const c_char,
         }
     }
 
@@ -429,6 +499,17 @@ mod test {
         let _guard = setup();
         let ptr: *const c_char = get("TEST_NONEXISTENT");
         assert!(ptr.is_null());
+    }
+
+    /// Tests that `clear()` removes every variable from the environment.
+    #[test]
+    fn test_clear() {
+        let _guard = setup();
+        assert_eq!(set("TEST_CLEAR_A", b"1", true), Ok(true));
+        assert_eq!(set("TEST_CLEAR_B", b"2", true), Ok(true));
+        clear();
+        assert!(get("TEST_CLEAR_A").is_null());
+        assert!(get("TEST_CLEAR_B").is_null());
     }
 
     /// Tests that overwrite=false preserves an existing variable.
@@ -635,5 +716,68 @@ mod test {
         assert!(!ptr.is_null());
         let value: &ffi::CStr = unsafe { ffi::CStr::from_ptr(ptr) };
         assert_eq!(value.to_bytes(), b"\xff\xfe");
+    }
+
+    /// Reads the [`ENVIRON_ARRAY`] back into owned `KEY=VALUE` strings, dereferencing each published
+    /// pointer up to the terminating NULL. Mirrors how C code walks `char **environ`.
+    fn environ_view() -> Vec<String> {
+        let array: spin::MutexGuard<'_, Vec<usize>> = ENVIRON_ARRAY.lock();
+        let mut out: Vec<String> = Vec::new();
+        for &addr in array.iter() {
+            if addr == 0 {
+                break;
+            }
+            let s: &ffi::CStr = unsafe { ffi::CStr::from_ptr(addr as *const c_char) };
+            if let Ok(text) = s.to_str() {
+                out.push(String::from(text));
+            }
+        }
+        out
+    }
+
+    /// Tests that the `environ` view tracks `set()`, `unset()`, and `clear()` mutations.
+    #[test]
+    fn environ_tracks_set_unset_clear() {
+        let _guard = setup();
+        // `setup()` cleared the table directly; the first mutation rebuilds the view from scratch.
+        assert_eq!(set("EVZ_A", b"1", true), Ok(true));
+        assert_eq!(set("EVZ_B", b"2", true), Ok(true));
+        let mut view: Vec<String> = environ_view();
+        view.sort();
+        assert_eq!(view, vec![String::from("EVZ_A=1"), String::from("EVZ_B=2")]);
+
+        // Overwriting an existing key keeps a single, updated entry.
+        assert_eq!(set("EVZ_A", b"9", true), Ok(true));
+        let mut view: Vec<String> = environ_view();
+        view.sort();
+        assert_eq!(view, vec![String::from("EVZ_A=9"), String::from("EVZ_B=2")]);
+
+        unset("EVZ_A");
+        assert_eq!(environ_view(), vec![String::from("EVZ_B=2")]);
+
+        clear();
+        assert!(environ_view().is_empty());
+    }
+
+    /// Tests that `put_raw()` publishes the caller-owned string through the `environ` view.
+    #[test]
+    fn environ_tracks_put_raw() {
+        let _guard = setup();
+        clear();
+        let raw: &[u8] = b"EVZ_P=val\0";
+        assert_eq!(unsafe { put_raw(raw.as_ptr() as *mut c_char) }, Ok(()));
+        assert_eq!(environ_view(), vec![String::from("EVZ_P=val")]);
+    }
+
+    /// Tests that `init_from_raw()` publishes the startup environment through the `environ` view.
+    #[test]
+    fn environ_tracks_init_from_raw() {
+        let _guard = setup();
+        let entries: [&[u8]; 2] = [b"EVZ_I=seed\0", b"\0"];
+        let ptrs: [*const c_char; 2] = [entries[0].as_ptr().cast::<c_char>(), ::core::ptr::null()];
+        unsafe {
+            init_from_raw(ptrs.as_ptr());
+        }
+        assert_eq!(environ_view(), vec![String::from("EVZ_I=seed")]);
     }
 }

--- a/src/libs/libc_stdlib/src/lib.rs
+++ b/src/libs/libc_stdlib/src/lib.rs
@@ -91,6 +91,9 @@ mod lldiv;
 mod malloc;
 mod malloc_usable_size;
 mod memalign;
+mod mkdtemp;
+mod mkostemp;
+mod mkstemp;
 mod posix_memalign;
 mod putenv;
 mod qsort;
@@ -108,6 +111,7 @@ mod strtoll;
 mod strtoul;
 mod strtoull;
 mod system;
+mod tmpname;
 mod unsetenv;
 
 //==================================================================================================
@@ -159,6 +163,9 @@ pub use lldiv::{
 pub use malloc::malloc;
 pub use malloc_usable_size::malloc_usable_size;
 pub use memalign::memalign;
+pub use mkdtemp::mkdtemp;
+pub use mkostemp::mkostemp;
+pub use mkstemp::mkstemp;
 pub use posix_memalign::posix_memalign;
 pub use putenv::putenv;
 pub use qsort::{

--- a/src/libs/libc_stdlib/src/mkdtemp.rs
+++ b/src/libs/libc_stdlib/src/mkdtemp.rs
@@ -1,0 +1,95 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    set_errno,
+    tmpname,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EEXIST,
+        EINVAL,
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_stat::file_mode::S_IRWXU,
+    sys_types::mode_t,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of distinct names to try before giving up.
+const MAX_ATTEMPTS: u32 = 128;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Generates a unique temporary directory name from `template` and creates the directory with mode
+/// `0700`. The trailing `XXXXXX` of `template` is replaced in place with the characters used in the
+/// successful name.
+///
+/// # Parameters
+///
+/// - `template`: Pointer to a modifiable null-terminated string ending in `XXXXXX`.
+///
+/// # Returns
+///
+/// `template` on success, or a null pointer on error with `errno` set (`EINVAL` if the template
+/// does not end in `XXXXXX`, or the error reported by `mkdir()`).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `template` points to a writable null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdtemp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mkdtemp(template: *mut c_char) -> *mut c_char {
+    unsafe extern "C" {
+        fn mkdir(path: *const c_char, mode: mode_t) -> c_int;
+    }
+
+    let Some(len) = tmpname::validate(template) else {
+        set_errno(EINVAL);
+        return core::ptr::null_mut();
+    };
+
+    let mut attempts: u32 = 0;
+    while attempts < MAX_ATTEMPTS {
+        // SAFETY: validate() confirmed the template is at least SUFFIX_LEN bytes long.
+        unsafe { tmpname::randomize_suffix(template, len) };
+
+        // SAFETY: template is a valid null-terminated path; mode is valid.
+        if unsafe { mkdir(template, S_IRWXU) } == 0 {
+            return template;
+        }
+
+        // Only a name collision warrants another attempt; any other error is fatal and `mkdir()`
+        // has already set `errno`.
+        // SAFETY: __errno_location() returns a valid pointer to errno.
+        if unsafe { *__errno_location() } != EEXIST {
+            return core::ptr::null_mut();
+        }
+
+        attempts += 1;
+    }
+
+    set_errno(EEXIST);
+    core::ptr::null_mut()
+}

--- a/src/libs/libc_stdlib/src/mkostemp.rs
+++ b/src/libs/libc_stdlib/src/mkostemp.rs
@@ -1,0 +1,110 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    set_errno,
+    tmpname,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EEXIST,
+        EINVAL,
+    },
+    fcntl::{
+        file_access_mode::O_RDWR,
+        file_creation_flags::{
+            O_CREAT,
+            O_EXCL,
+        },
+    },
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_stat::file_mode::{
+        S_IRUSR,
+        S_IWUSR,
+    },
+    sys_types::mode_t,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum number of distinct names to try before giving up.
+const MAX_ATTEMPTS: u32 = 128;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Generates a unique temporary file name from `template`, creates and opens the file with mode
+/// `0600`, and returns its file descriptor. The trailing `XXXXXX` of `template` is replaced in place
+/// with the characters used in the successful name. The file is created with `O_EXCL`, so it is
+/// guaranteed not to have existed beforehand. Additional `flag` bits are passed to `open()` together
+/// with `O_RDWR | O_CREAT | O_EXCL`.
+///
+/// # Parameters
+///
+/// - `template`: Pointer to a modifiable null-terminated string ending in `XXXXXX`.
+/// - `flag`: Additional flags to pass to `open()`.
+///
+/// # Returns
+///
+/// An open file descriptor on success, or `-1` on error with `errno` set (`EINVAL` if the template
+/// does not end in `XXXXXX`, or the error reported by `open()`).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `template` points to a writable null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkostemp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mkostemp(template: *mut c_char, flag: c_int) -> c_int {
+    unsafe extern "C" {
+        fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int;
+    }
+
+    let Some(len) = tmpname::validate(template) else {
+        set_errno(EINVAL);
+        return -1;
+    };
+
+    let mut attempts: u32 = 0;
+    while attempts < MAX_ATTEMPTS {
+        // SAFETY: validate() confirmed the template is at least SUFFIX_LEN bytes long.
+        unsafe { tmpname::randomize_suffix(template, len) };
+
+        // SAFETY: template is a valid null-terminated path; flags and mode are valid.
+        let fd: c_int =
+            unsafe { open(template, flag | O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR) };
+        if fd >= 0 {
+            return fd;
+        }
+
+        // Only a name collision warrants another attempt; any other error is fatal and `open()`
+        // has already set `errno`.
+        // SAFETY: __errno_location() returns a valid pointer to errno.
+        if unsafe { *__errno_location() } != EEXIST {
+            return -1;
+        }
+
+        attempts += 1;
+    }
+
+    set_errno(EEXIST);
+    -1
+}

--- a/src/libs/libc_stdlib/src/mkstemp.rs
+++ b/src/libs/libc_stdlib/src/mkstemp.rs
@@ -1,0 +1,48 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::mkostemp;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Generates a unique temporary file name from `template`, creates and opens the file with mode
+/// `0600`, and returns its file descriptor. The trailing `XXXXXX` of `template` is replaced in place
+/// with the characters used in the successful name. The file is created with `O_EXCL`, so it is
+/// guaranteed not to have existed beforehand.
+///
+/// # Parameters
+///
+/// - `template`: Pointer to a modifiable null-terminated string ending in `XXXXXX`.
+///
+/// # Returns
+///
+/// An open file descriptor on success, or `-1` on error with `errno` set (`EINVAL` if the template
+/// does not end in `XXXXXX`, or the error reported by `open()`).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `template` points to a writable null-terminated string.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkstemp.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mkstemp(template: *mut c_char) -> c_int {
+    // SAFETY: forwarded under the same caller contract as mkstemp().
+    unsafe { mkostemp::mkostemp(template, 0) }
+}

--- a/src/libs/libc_stdlib/src/tmpname.rs
+++ b/src/libs/libc_stdlib/src/tmpname.rs
@@ -1,0 +1,186 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Shared backing logic for the `mktemp`-family functions: validating the caller's template and
+//! filling its trailing `XXXXXX` placeholder with pseudo-random characters.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::sync::atomic::{
+    AtomicU32,
+    Ordering,
+};
+use ::sysapi::ffi::c_char;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of trailing `X` characters a template must end with.
+pub(crate) const SUFFIX_LEN: usize = 6;
+
+/// Portable alphabet used to fill the random suffix.
+const CHARS: &[u8; 62] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+//==================================================================================================
+// Static Data
+//==================================================================================================
+
+/// Per-call counter that perturbs the seed so successive calls produce distinct names.
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+//==================================================================================================
+// Internal Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Validates a `mktemp`-style template. The template must be a non-null C string of at least
+/// [`SUFFIX_LEN`] characters whose final [`SUFFIX_LEN`] characters are all `'X'`.
+///
+/// # Returns
+///
+/// The length of the template (excluding the null terminator) on success, or `None` if the template
+/// is null or does not end with the required `XXXXXX` placeholder.
+///
+/// # Safety
+///
+/// `tmpl`, when non-null, must point to a valid null-terminated string.
+///
+pub(crate) unsafe fn validate(tmpl: *const c_char) -> Option<usize> {
+    if tmpl.is_null() {
+        return None;
+    }
+
+    let base: *const u8 = tmpl.cast::<u8>();
+    let mut len: usize = 0;
+    // SAFETY: tmpl is a valid null-terminated string, so the scan stops at the null byte.
+    while unsafe { *base.add(len) } != 0 {
+        len += 1;
+    }
+
+    if len < SUFFIX_LEN {
+        return None;
+    }
+
+    let mut i: usize = 0;
+    while i < SUFFIX_LEN {
+        // SAFETY: len - SUFFIX_LEN + i is within the string bounds.
+        if unsafe { *base.add(len - SUFFIX_LEN + i) } != b'X' {
+            return None;
+        }
+        i += 1;
+    }
+
+    Some(len)
+}
+
+///
+/// # Description
+///
+/// Overwrites the final [`SUFFIX_LEN`] bytes of the template with pseudo-random characters drawn
+/// from a portable alphabet. The seed combines the process identifier with a monotonically
+/// increasing counter so that repeated calls (including retries after a collision) yield different
+/// suffixes.
+///
+/// # Parameters
+///
+/// - `tmpl`: Pointer to the template whose suffix is to be replaced.
+/// - `len`: Length of the template, as returned by [`validate`].
+///
+/// # Safety
+///
+/// `tmpl` must point to a writable buffer holding at least `len` bytes, with `len >= SUFFIX_LEN`.
+///
+pub(crate) unsafe fn randomize_suffix(tmpl: *mut c_char, len: usize) {
+    let pid_bits: u32 = pid_seed();
+    let counter: u32 = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut state: u32 = pid_bits ^ counter.wrapping_mul(2_654_435_761);
+
+    let dst: *mut u8 = tmpl.cast::<u8>();
+    let start: usize = len - SUFFIX_LEN;
+    let mut i: usize = 0;
+    while i < SUFFIX_LEN {
+        state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+        let idx: usize = ((state >> 16) % 62) as usize;
+        // SAFETY: start + i < len, so the write stays within the template buffer.
+        unsafe {
+            *dst.add(start + i) = CHARS[idx];
+        }
+        i += 1;
+    }
+}
+
+/// Returns the process identifier, used to perturb the random suffix seed.
+///
+/// In the freestanding libc this resolves to the `getpid` symbol provided by libposix startup. In a
+/// hosted (unit-test) build there is no such symbol to link against, so a constant seed is used and
+/// distinct names rely solely on the per-call [`COUNTER`].
+#[cfg(not(feature = "std"))]
+fn pid_seed() -> u32 {
+    extern "C" {
+        fn getpid() -> ::sysapi::sys_types::pid_t;
+    }
+
+    // SAFETY: getpid() takes no arguments and has no preconditions.
+    u32::from_ne_bytes(unsafe { getpid() }.to_ne_bytes())
+}
+
+/// Hosted-build stand-in for [`pid_seed`]; see its documentation.
+#[cfg(feature = "std")]
+fn pid_seed() -> u32 {
+    0
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        randomize_suffix,
+        validate,
+        SUFFIX_LEN,
+    };
+    use ::sysapi::ffi::c_char;
+
+    #[test]
+    fn test_validate_accepts_suffix() {
+        let tmpl: &[u8] = b"foo.XXXXXX\0";
+        let len: Option<usize> = unsafe { validate(tmpl.as_ptr().cast::<c_char>()) };
+        assert_eq!(len, Some(10));
+    }
+
+    #[test]
+    fn test_validate_rejects_short() {
+        let tmpl: &[u8] = b"XXXXX\0";
+        assert_eq!(unsafe { validate(tmpl.as_ptr().cast::<c_char>()) }, None);
+    }
+
+    #[test]
+    fn test_validate_rejects_missing_suffix() {
+        let tmpl: &[u8] = b"foobar\0";
+        assert_eq!(unsafe { validate(tmpl.as_ptr().cast::<c_char>()) }, None);
+    }
+
+    #[test]
+    fn test_validate_rejects_null() {
+        assert_eq!(unsafe { validate(core::ptr::null()) }, None);
+    }
+
+    #[test]
+    fn test_randomize_replaces_suffix() {
+        let mut tmpl: [u8; 11] = *b"foo.XXXXXX\0";
+        let len: usize = unsafe { validate(tmpl.as_ptr().cast::<c_char>()) }.unwrap_or(0);
+        assert_eq!(len, 10);
+        unsafe { randomize_suffix(tmpl.as_mut_ptr().cast::<c_char>(), len) };
+
+        // The fixed prefix and null terminator are untouched.
+        assert_eq!(&tmpl[..4], b"foo.");
+        assert_eq!(tmpl[10], 0);
+        // Every suffix byte is replaced with an alphanumeric character from the alphabet.
+        for &b in &tmpl[len - SUFFIX_LEN..len] {
+            assert!(b.is_ascii_alphanumeric(), "byte {b:#x} not in alphabet");
+        }
+    }
+}

--- a/src/libs/posix/src/start.rs
+++ b/src/libs/posix/src/start.rs
@@ -196,13 +196,11 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
     // null-terminated array of "KEY=VALUE" C strings, which is exactly
     // the format expected by `__nanvix_env_init`.
     //
-    // NOTE: `setenv` / `unsetenv` update only `env_table` (the
-    // libposix-side storage); they do NOT rebuild `environ`.  C code
-    // that mutates the environment via these functions and then reads
-    // back `extern char **environ` will observe a snapshot taken at
-    // process start, not the mutated state.  Keeping these two views
-    // in sync is left for a follow-up that introduces an
-    // `env_table`-backed `environ` proxy.
+    // `__nanvix_env_init` rebuilds an `env_table`-backed `environ` array and
+    // repoints this `environ` global at it, and every later setenv() /
+    // putenv() / unsetenv() keeps the two views in sync.  C code
+    // that mutates the environment therefore observes the change through
+    // `extern char **environ` as well as through getenv().
     unsafe {
         __nanvix_env_init(environ as *const *const c_char);
     }

--- a/src/libs/sysapi/headers/fcntl.toml
+++ b/src/libs/sysapi/headers/fcntl.toml
@@ -11,11 +11,7 @@ constants mirror the Rust definitions in the sysapi crate (fcntl.rs).'''
 includes = ["sys/types.h", "sys/stat.h"]
 guard = "_NANVIX_FCNTL_H"
 scan_crates = ["syscall"]
-content_order = [
-    "raw:0",
-    "raw:1",
-    "section:0",
-]
+content_order = ["raw:0", "raw:1", "section:0"]
 
 [[raw_sections]]
 title = "Constants"
@@ -32,6 +28,7 @@ text = '''
 #define O_NONBLOCK 0x4000 /**< Non-blocking mode. */
 #define O_NOCTTY 0x8000 /**< Do not assign controlling terminal. */
 #define O_CLOEXEC 0x40000 /**< Close-on-exec. */
+#define O_CLOFORK 0x80000 /**< Close-on-fork. */
 #define O_NOFOLLOW 0x100000 /**< Do not follow symbolic links. */
 #define O_DIRECTORY 0x200000 /**< Fail if not a directory. */
 #define AT_FDCWD -100 /**< Use the current working directory. */
@@ -60,6 +57,7 @@ text = '''
 
 /* File-descriptor flags (F_GETFD/F_SETFD). */
 #define FD_CLOEXEC 1
+#define FD_CLOFORK 2
 
 /* Lock types (struct flock l_type). */
 #define F_RDLCK 0
@@ -77,7 +75,14 @@ struct flock {
 
 [[sections]]
 title = ""
-functions = ["open", "openat", "fcntl", "posix_fadvise", "posix_fallocate", "renameat"]
+functions = [
+    "open",
+    "openat",
+    "fcntl",
+    "posix_fadvise",
+    "posix_fallocate",
+    "renameat",
+]
 
 [overrides]
 open = '''


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **6 commit(s)** that pertain to this crate.

### Commits
- [stdlib] E: Add clearenv() to empty the environment
- [stdlib] E: Add mktemp() temporary-name generator
- [stdlib] E: Implement mkstemp() unique file creation
- [stdlib] E: Add mkdtemp() unique directory creation
- [stdlib] E: Make stdlib.h provide alloca()
- [stdlib] E: Keep environ in sync with the environment table

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
