### PR TITLE
[sysapi] E: Add POSIX header definitions (WCOREDUMP, SOCK_RDM, UTIME_*, link/chroot)

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -32,6 +32,7 @@ extern "C" {
 #define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
 #define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
 #define SOCK_RAW 3 /**< Raw protocol interface. */
+#define SOCK_RDM 4 /**< Reliably-delivered messages. */
 #define SOCK_SEQPACKET 5 /**< Sequenced, reliable, connection-mode records. */
 #define SOL_SOCKET 0xffff /**< Options at the socket level. */
 #define SO_REUSEADDR 0x0004 /**< Reuse of local addresses is supported. */

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -76,6 +76,10 @@ struct stat {
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
 
+/* Special tv_nsec values for utimensat()/futimens(). */
+#define UTIME_NOW ((1L << 30) - 1L)
+#define UTIME_OMIT ((1L << 30) - 2L)
+
 /* File-type test macros. */
 #define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
 #define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)

--- a/include/sys/wait.h
+++ b/include/sys/wait.h
@@ -34,6 +34,11 @@ extern "C" {
 #define WTERMSIG(status) ((status) & 0x7f)
 #define WIFSTOPPED(status) (((status) & 0xff) == 0x7f)
 #define WSTOPSIG(status) WEXITSTATUS(status)
+/* Non-standard but widely used (glibc/BSD): reports whether the child produced
+ * a core dump. Nanvix never sets the core-dump bit, so WCOREDUMP() is always
+ * false, but the macro lets portable software referencing it compile. */
+#define WCOREFLAG 0x80
+#define WCOREDUMP(status) ((status) & WCOREFLAG)
 
 /*==================================================================================================
  * Functions

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -91,6 +91,8 @@ extern long pathconf(const char *path, int name);
 extern char **environ;
 extern off_t lseek(int fd, off_t offset, int whence);
 extern int unlink(const char *path);
+extern int link(const char *oldpath, const char *newpath);
+extern int chroot(const char *path);
 extern int rmdir(const char *path);
 extern long sysconf(int name);
 

--- a/src/libs/sysapi/headers/sys_socket.toml
+++ b/src/libs/sysapi/headers/sys_socket.toml
@@ -56,6 +56,7 @@ text = '''
 #define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
 #define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
 #define SOCK_RAW 3 /**< Raw protocol interface. */
+#define SOCK_RDM 4 /**< Reliably-delivered messages. */
 #define SOCK_SEQPACKET 5 /**< Sequenced, reliable, connection-mode records. */
 #define SOL_SOCKET 0xffff /**< Options at the socket level. */
 #define SO_REUSEADDR 0x0004 /**< Reuse of local addresses is supported. */

--- a/src/libs/sysapi/headers/sys_stat.toml
+++ b/src/libs/sysapi/headers/sys_stat.toml
@@ -12,11 +12,7 @@ status. The layout mirrors the Rust definition in the sysapi crate
 includes = ["sys/types.h", "time.h"]
 guard = "_NANVIX_SYS_STAT_H"
 scan_crates = ["posix", "syscall"]
-content_order = [
-    "raw:0",
-    "types",
-    "section:0",
-]
+content_order = ["raw:0", "types", "section:0"]
 
 [[types]]
 text = '''
@@ -41,6 +37,10 @@ struct stat {
 #define st_atime st_atim.tv_sec
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
+
+/* Special tv_nsec values for utimensat()/futimens(). */
+#define UTIME_NOW ((1L << 30) - 1L)
+#define UTIME_OMIT ((1L << 30) - 2L)
 
 /* File-type test macros. */
 #define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
@@ -80,7 +80,21 @@ text = '''
 
 [[sections]]
 title = "File Status"
-functions = ["stat", "fstat", "lstat", "mkdir", "mkdirat", "umask", "fchmodat", "lchmod", "futimens", "utimensat", "chmod", "fchmod", "mknod"]
+functions = [
+    "stat",
+    "fstat",
+    "lstat",
+    "mkdir",
+    "mkdirat",
+    "umask",
+    "fchmodat",
+    "lchmod",
+    "futimens",
+    "utimensat",
+    "chmod",
+    "fchmod",
+    "mknod",
+]
 
 [overrides]
 umask = '''

--- a/src/libs/sysapi/headers/sys_wait.toml
+++ b/src/libs/sysapi/headers/sys_wait.toml
@@ -30,7 +30,12 @@ text = '''
 #define WIFSIGNALED(status) (((status) & 0x7f) != 0 && ((status) & 0x7f) != 0x7f)
 #define WTERMSIG(status) ((status) & 0x7f)
 #define WIFSTOPPED(status) (((status) & 0xff) == 0x7f)
-#define WSTOPSIG(status) WEXITSTATUS(status)'''
+#define WSTOPSIG(status) WEXITSTATUS(status)
+/* Non-standard but widely used (glibc/BSD): reports whether the child produced
+ * a core dump. Nanvix never sets the core-dump bit, so WCOREDUMP() is always
+ * false, but the macro lets portable software referencing it compile. */
+#define WCOREFLAG 0x80
+#define WCOREDUMP(status) ((status) & WCOREFLAG)'''
 
 [[sections]]
 title = "Functions"

--- a/src/libs/sysapi/headers/unistd.toml
+++ b/src/libs/sysapi/headers/unistd.toml
@@ -81,6 +81,8 @@ extern long pathconf(const char *path, int name);
 extern char **environ;
 extern off_t lseek(int fd, off_t offset, int whence);
 extern int unlink(const char *path);
+extern int link(const char *oldpath, const char *newpath);
+extern int chroot(const char *path);
 extern int rmdir(const char *path);
 extern long sysconf(int name);'''
 

--- a/src/libs/sysapi/src/sys_socket.rs
+++ b/src/libs/sysapi/src/sys_socket.rs
@@ -106,6 +106,8 @@ pub mod socket_types {
     pub const SOCK_STREAM: c_int = 1;
     /// Provides raw network protocol access.
     pub const SOCK_RAW: c_int = 3;
+    /// Provides reliably-delivered messages.
+    pub const SOCK_RDM: c_int = 4;
     /// Provides datagrams, which are connectionless-mode, unreliable messages of fixed maximum length.
     pub const SOCK_DGRAM: c_int = 2;
     /// Provides sequenced, reliable, bidirectional, connection-mode transmission paths for records.


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **4 commit(s)** that pertain to this crate.

### Commits
- [sysapi] E: Add WCOREDUMP/WCOREFLAG to <sys/wait.h>
- [unistd] E: Declare link() and chroot() in unistd.h
- [socket] E: Define SOCK_RDM in sys/socket.h
- [stat] E: Define UTIME_NOW and UTIME_OMIT in sys/stat.h

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
