### PR TITLE
[libgen] Add libc_libgen crate (basename, dirname)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_libgen"
+version = "0.17.36"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_locale"
 version = "0.17.36"
 dependencies = [
@@ -2458,6 +2465,7 @@ dependencies = [
  "libc_ctype",
  "libc_inttypes",
  "libc_langinfo",
+ "libc_libgen",
  "libc_locale",
  "libc_regex",
  "libc_setjmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
         "src/libs/libc_ctype",
         "src/libs/libc_inttypes",
         "src/libs/libc_langinfo",
+        "src/libs/libc_libgen",
         "src/libs/libc_locale",
         "src/libs/libc_setjmp",
         "src/libs/libc_signal",
@@ -245,6 +246,7 @@ libc_assert = { path = "src/libs/libc_assert", default-features = false }
 libc_ctype = { path = "src/libs/libc_ctype", default-features = false }
 libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
 libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
+libc_libgen = { path = "src/libs/libc_libgen", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
 libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -382,14 +382,14 @@ ALL_GUEST_RUST_LIBS := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi \
 	syscall sysalloc syslog-macros syslog sys \
-	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_regex \
+	libc_assert libc_ctype libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_regex \
 	libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time \
 	libc_wchar libc_wctype \
 	mmio-tag multiimage vfs-bench-common
 ALL_GUEST_RUST_LIBS_TEST_LIST := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions proc raw-array nanvix-slab sorted-vec static_assert \
-	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_regex \
+	libc_assert libc_ctype libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_regex \
 	libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time \
 	libc_wchar libc_wctype \
 	syslog-macros syslog sys mmio-tag syscall vfs
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c regex-c setjmp-c stdio-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c libgen-c memory-c misc-c network-c noop-c regex-c setjmp-c stdio-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/include/libgen.h
+++ b/include/libgen.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_LIBGEN_H
+#define _NANVIX_LIBGEN_H
+
+/**
+ * @file libgen.h
+ * @brief Definitions for pattern matching functions.
+ *
+ * Declares basename() and dirname(), the POSIX pathname component functions
+ * implemented by the libc_libgen Rust crate.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Pathname Manipulation
+ *==================================================================================================*/
+
+extern char *basename(char *path);
+extern char *dirname(char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_LIBGEN_H */

--- a/src/libs/libc_libgen/Cargo.toml
+++ b/src/libs/libc_libgen/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_libgen"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_libgen/header.toml
+++ b/src/libs/libc_libgen/header.toml
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for libgen.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/libgen.h.
+
+file = "libgen.h"
+brief = "Definitions for pattern matching functions."
+description = """
+Declares basename() and dirname(), the POSIX pathname component functions
+implemented by the libc_libgen Rust crate."""
+includes = []
+guard = "_NANVIX_LIBGEN_H"
+
+[[sections]]
+title = "Pathname Manipulation"
+functions = ["basename", "dirname"]

--- a/src/libs/libc_libgen/src/basename.rs
+++ b/src/libs/libc_libgen/src/basename.rs
@@ -1,0 +1,152 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    c_len,
+    dot_ptr,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_uchar,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reports the final component of the path name `path`.
+///
+/// Trailing `'/'` characters are not counted as part of the path. If `path` consists entirely of
+/// `'/'` characters, then `"/"` is returned. If `path` is a null pointer or points to an empty
+/// string, then `"."` is returned.
+///
+/// This function may modify the string pointed to by `path` and may return a pointer into it. When
+/// `path` is a null pointer, points to an empty string, or consists entirely of `'/'` characters,
+/// the returned pointer may reference read-only storage that the caller must not modify; copy the
+/// result first if it needs to be changed. The function is thread-safe.
+///
+/// # Parameters
+///
+/// - `path`: The path name to inspect. May be modified in place.
+///
+/// # Returns
+///
+/// A pointer to a string that is the final component of `path`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It dereferences the raw pointer `path`.
+/// - It performs pointer arithmetic over `path` without bounds checking.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/basename.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn basename(path: *mut c_char) -> *mut c_char {
+    if path.is_null() || *path == 0 {
+        return dot_ptr();
+    }
+
+    let p: *mut c_uchar = path.cast::<c_uchar>();
+    let mut i: usize = c_len(p) - 1;
+
+    // Strip trailing slashes, but keep at least the first byte so an all-slash path stays "/".
+    while i != 0 && *p.add(i) == b'/' {
+        *p.add(i) = 0;
+        i -= 1;
+    }
+
+    // Back up to the first byte of the final component.
+    while i != 0 && *p.add(i - 1) != b'/' {
+        i -= 1;
+    }
+
+    path.add(i)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::basename;
+    use ::std::{
+        ffi::CStr,
+        string::String,
+        vec::Vec,
+    };
+    use ::sysapi::ffi::c_char;
+
+    /// Builds a mutable, null-terminated C string from `s`.
+    fn c_string(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s
+            .bytes()
+            .map(|b| c_char::try_from(b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0);
+        v
+    }
+
+    /// Reads back the C string returned by `basename` as an owned `String`.
+    fn run(s: &str) -> String {
+        let mut buf: Vec<c_char> = c_string(s);
+        let ret: *mut c_char = unsafe { basename(buf.as_mut_ptr()) };
+        let bytes: &[u8] = unsafe { CStr::from_ptr(ret) }.to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("valid utf-8")
+    }
+
+    #[test]
+    fn basename_returns_final_component() {
+        assert_eq!(run("/usr/lib"), "lib");
+        assert_eq!(run("usr/lib"), "lib");
+        assert_eq!(run("lib"), "lib");
+    }
+
+    #[test]
+    fn basename_handles_roots_and_dots() {
+        assert_eq!(run("/"), "/");
+        assert_eq!(run("//"), "/");
+        assert_eq!(run("///"), "/");
+        assert_eq!(run("."), ".");
+        assert_eq!(run(".."), "..");
+        assert_eq!(run(""), ".");
+    }
+
+    #[test]
+    fn basename_handles_null_pointer() {
+        let ret: *mut c_char = unsafe { basename(::std::ptr::null_mut()) };
+        let bytes: &[u8] = unsafe { CStr::from_ptr(ret) }.to_bytes();
+        let s: String = String::from_utf8(bytes.to_vec()).expect("valid utf-8");
+        assert_eq!(s, ".");
+    }
+
+    #[test]
+    fn basename_strips_trailing_slashes() {
+        assert_eq!(run("/usr/lib/"), "lib");
+        assert_eq!(run("/usr/lib//"), "lib");
+        assert_eq!(run("usr/"), "usr");
+    }
+
+    /// Cases taken verbatim from the POSIX `basename()` sample-input table.
+    #[test]
+    fn basename_matches_posix_examples() {
+        assert_eq!(run("usr"), "usr");
+        assert_eq!(run("usr/"), "usr");
+        assert_eq!(run("/usr/"), "usr");
+        assert_eq!(run("/usr/lib"), "lib");
+        assert_eq!(run("//usr//lib//"), "lib");
+        assert_eq!(run("/home//dwc//test"), "test");
+        assert_eq!(run("/home/.././test"), "test");
+        assert_eq!(run("/home/dwc/."), ".");
+    }
+}

--- a/src/libs/libc_libgen/src/dirname.rs
+++ b/src/libs/libc_libgen/src/dirname.rs
@@ -1,0 +1,177 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    c_len,
+    dot_ptr,
+    slash_ptr,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_uchar,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reports the parent directory portion of the path name `path`.
+///
+/// Trailing `'/'` characters are not counted as part of the path. If `path` does not contain a
+/// `'/'`, then `"."` is returned. If `path` is a null pointer or points to an empty string, then
+/// `"."` is returned.
+///
+/// This function may modify the string pointed to by `path` and may return a pointer into it. When
+/// `path` is a null pointer, points to an empty string, contains no `'/'`, or names the root
+/// directory, the returned pointer may reference read-only storage that the caller must not modify;
+/// copy the result first if it needs to be changed. The function is thread-safe.
+///
+/// # Parameters
+///
+/// - `path`: The path name to inspect. May be modified in place.
+///
+/// # Returns
+///
+/// A pointer to a string that is the parent directory of `path`.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It dereferences the raw pointer `path`.
+/// - It performs pointer arithmetic over `path` without bounds checking.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/dirname.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn dirname(path: *mut c_char) -> *mut c_char {
+    if path.is_null() || *path == 0 {
+        return dot_ptr();
+    }
+
+    let p: *mut c_uchar = path.cast::<c_uchar>();
+    let mut i: usize = c_len(p) - 1;
+
+    // Strip trailing slashes; a path consisting solely of slashes resolves to the root.
+    loop {
+        if *p.add(i) != b'/' {
+            break;
+        }
+        if i == 0 {
+            return slash_ptr();
+        }
+        i -= 1;
+    }
+
+    // Skip the trailing (basename) component; with no separator the directory is the cwd.
+    loop {
+        if *p.add(i) == b'/' {
+            break;
+        }
+        if i == 0 {
+            return dot_ptr();
+        }
+        i -= 1;
+    }
+
+    // Strip the slash(es) separating the directory from the basename; all slashes means root.
+    loop {
+        if *p.add(i) != b'/' {
+            break;
+        }
+        if i == 0 {
+            return slash_ptr();
+        }
+        i -= 1;
+    }
+
+    *p.add(i + 1) = 0;
+    path
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::dirname;
+    use ::std::{
+        ffi::CStr,
+        string::String,
+        vec::Vec,
+    };
+    use ::sysapi::ffi::c_char;
+
+    /// Builds a mutable, null-terminated C string from `s`.
+    fn c_string(s: &str) -> Vec<c_char> {
+        let mut v: Vec<c_char> = s
+            .bytes()
+            .map(|b| c_char::try_from(b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0);
+        v
+    }
+
+    /// Reads back the C string returned by `dirname` as an owned `String`.
+    fn run(s: &str) -> String {
+        let mut buf: Vec<c_char> = c_string(s);
+        let ret: *mut c_char = unsafe { dirname(buf.as_mut_ptr()) };
+        let bytes: &[u8] = unsafe { CStr::from_ptr(ret) }.to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("valid utf-8")
+    }
+
+    #[test]
+    fn dirname_returns_parent_directory() {
+        assert_eq!(run("/usr/lib"), "/usr");
+        assert_eq!(run("/usr/"), "/");
+        assert_eq!(run("usr/lib"), "usr");
+    }
+
+    #[test]
+    fn dirname_handles_roots_and_dots() {
+        assert_eq!(run("/"), "/");
+        assert_eq!(run("//"), "/");
+        assert_eq!(run("///"), "/");
+        assert_eq!(run("usr"), ".");
+        assert_eq!(run("."), ".");
+        assert_eq!(run(".."), ".");
+        assert_eq!(run(""), ".");
+    }
+
+    #[test]
+    fn dirname_handles_null_pointer() {
+        let ret: *mut c_char = unsafe { dirname(::std::ptr::null_mut()) };
+        let bytes: &[u8] = unsafe { CStr::from_ptr(ret) }.to_bytes();
+        let s: String = String::from_utf8(bytes.to_vec()).expect("valid utf-8");
+        assert_eq!(s, ".");
+    }
+
+    #[test]
+    fn dirname_strips_trailing_slashes() {
+        assert_eq!(run("/usr/lib/"), "/usr");
+        assert_eq!(run("/a//b"), "/a");
+        assert_eq!(run("a/b/"), "a");
+    }
+
+    /// Cases taken from the POSIX `dirname()` sample-input table. Where the standard permits more
+    /// than one result, the value produced by this implementation is asserted.
+    #[test]
+    fn dirname_matches_posix_examples() {
+        assert_eq!(run("usr/"), ".");
+        assert_eq!(run("/usr/"), "/");
+        assert_eq!(run("/usr/lib"), "/usr");
+        assert_eq!(run("//usr//lib//"), "//usr");
+        assert_eq!(run("/home//dwc//test"), "/home//dwc");
+        assert_eq!(run("/home/.././test"), "/home/../.");
+        assert_eq!(run("/home/dwc/."), "/home/dwc");
+    }
+}

--- a/src/libs/libc_libgen/src/lib.rs
+++ b/src/libs/libc_libgen/src/lib.rs
@@ -1,0 +1,77 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod basename;
+pub mod dirname;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_uchar,
+};
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+/// Returns the number of bytes in the null-terminated C string `p`, excluding the terminator.
+///
+/// # Safety
+///
+/// `p` must point to a valid null-terminated C string.
+pub(crate) unsafe fn c_len(p: *const c_uchar) -> usize {
+    let mut n: usize = 0;
+    while *p.add(n) != 0 {
+        n += 1;
+    }
+    n
+}
+
+/// Returns a pointer to the static `"."` string used when a path has no directory component.
+///
+/// The returned buffer must be treated as read-only by callers, matching the POSIX contract that
+/// the result may reference statically allocated storage.
+pub(crate) fn dot_ptr() -> *mut c_char {
+    static DOT: [u8; 2] = [b'.', 0];
+    (&raw const DOT).cast::<c_char>().cast_mut()
+}
+
+/// Returns a pointer to the static `"/"` string used when a path's directory component is the root.
+///
+/// The returned buffer must be treated as read-only by callers, matching the POSIX contract that
+/// the result may reference statically allocated storage.
+pub(crate) fn slash_ptr() -> *mut c_char {
+    static SLASH: [u8; 2] = [b'/', 0];
+    (&raw const SLASH).cast::<c_char>().cast_mut()
+}

--- a/src/libs/nanvix_libc/Cargo.toml
+++ b/src/libs/nanvix_libc/Cargo.toml
@@ -18,6 +18,7 @@ libc_assert = { workspace = true }
 libc_ctype = { workspace = true }
 libc_inttypes = { workspace = true }
 libc_langinfo = { workspace = true }
+libc_libgen = { workspace = true }
 libc_locale = { workspace = true }
 libc_regex = { workspace = true }
 # NOTE: the math routines (`libc_math`) are deliberately NOT pulled in here — they

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -20,6 +20,7 @@ extern crate libc_assert;
 extern crate libc_ctype;
 extern crate libc_inttypes;
 extern crate libc_langinfo;
+extern crate libc_libgen;
 extern crate libc_locale;
 extern crate libc_regex;
 extern crate libc_setjmp;

--- a/src/posix-tests/libgen-c/main.c
+++ b/src/posix-tests/libgen-c/main.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <libgen.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+static int is_either(const char *actual, const char *expected_a, const char *expected_b)
+{
+    return ((strcmp(actual, expected_a) == 0) || (strcmp(actual, expected_b) == 0));
+}
+
+static void test_basename(void)
+{
+    char usr[] = "usr";
+    assert(strcmp(basename(usr), "usr") == 0);
+
+    char usr_slash[] = "usr/";
+    assert(strcmp(basename(usr_slash), "usr") == 0);
+
+    char empty[] = "";
+    assert(strcmp(basename(empty), ".") == 0);
+    assert(strcmp(basename(NULL), ".") == 0);
+
+    char root[] = "/";
+    assert(strcmp(basename(root), "/") == 0);
+
+    char double_slash[] = "//";
+    assert(is_either(basename(double_slash), "/", "//"));
+
+    char many_slashes[] = "///";
+    assert(strcmp(basename(many_slashes), "/") == 0);
+
+    char usr_lib[] = "/usr/lib";
+    assert(strcmp(basename(usr_lib), "lib") == 0);
+
+    char usr_lib_slash[] = "/usr/lib//";
+    assert(strcmp(basename(usr_lib_slash), "lib") == 0);
+
+    char repeated_slashes[] = "//usr//lib//";
+    assert(strcmp(basename(repeated_slashes), "lib") == 0);
+
+    char dot_component[] = "/home/dwc/.";
+    assert(strcmp(basename(dot_component), ".") == 0);
+}
+
+static void test_dirname(void)
+{
+    char usr[] = "usr";
+    assert(strcmp(dirname(usr), ".") == 0);
+
+    char usr_slash[] = "usr/";
+    assert(strcmp(dirname(usr_slash), ".") == 0);
+
+    char empty[] = "";
+    assert(strcmp(dirname(empty), ".") == 0);
+    assert(strcmp(dirname(NULL), ".") == 0);
+
+    char root[] = "/";
+    assert(strcmp(dirname(root), "/") == 0);
+
+    char double_slash[] = "//";
+    assert(is_either(dirname(double_slash), "/", "//"));
+
+    char many_slashes[] = "///";
+    assert(is_either(dirname(many_slashes), "/", "///"));
+
+    char usr_lib[] = "/usr/lib";
+    assert(strcmp(dirname(usr_lib), "/usr") == 0);
+
+    char usr_slash_abs[] = "/usr/";
+    assert(strcmp(dirname(usr_slash_abs), "/") == 0);
+
+    char repeated_slashes[] = "//usr//lib//";
+    assert(is_either(dirname(repeated_slashes), "//usr", "/usr"));
+
+    char nested[] = "/home//dwc//test";
+    assert(is_either(dirname(nested), "/home//dwc", "/home/dwc"));
+
+    char dotdot[] = "/home/.././test";
+    assert(is_either(dirname(dotdot), "/home/../.", "/home/.."));
+
+    char dot_component[] = "/home/dwc/.";
+    assert(strcmp(dirname(dot_component), "/home/dwc") == 0);
+}
+
+/**
+ * @brief Tests POSIX basename() and dirname().
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_basename();
+    test_dirname();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -150,6 +150,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/libgen-c"
+program = "./bin/libgen-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/memory-c"
 program = "./bin/memory-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -150,6 +150,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/libgen-c"
+program = "./bin/libgen-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/memory-c"
 program = "./bin/memory-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **2 commit(s)** that pertain to this crate.

### Commits
- [libgen] E: Add libc_libgen crate with dirname()
- [libgen] E: Add basename() to libc_libgen

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
