### PR TITLE
[signal] Add sigsuspend() and NSIG

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -147,6 +147,7 @@ extern int sigaddset(sigset_t *set, int signum);
 extern int sigdelset(sigset_t *set, int signum);
 extern int sigismember(const sigset_t *set, int signum);
 extern int sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+extern int sigsuspend(const sigset_t *mask);
 extern int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
 extern int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset);
 

--- a/include/signal.h
+++ b/include/signal.h
@@ -127,6 +127,7 @@ struct sigaction {
 #define SIGIO 29
 #define SIGSYS 31
 #define _NSIG 65
+#define NSIG _NSIG
 #endif
 
 /*==================================================================================================

--- a/src/libs/libc_signal/header.toml
+++ b/src/libs/libc_signal/header.toml
@@ -114,6 +114,7 @@ text = '''
 #define SIGIO 29
 #define SIGSYS 31
 #define _NSIG 65
+#define NSIG _NSIG
 #endif'''
 
 [[sections]]

--- a/src/libs/libc_signal/header.toml
+++ b/src/libs/libc_signal/header.toml
@@ -129,6 +129,7 @@ functions = [
     "sigdelset",
     "sigismember",
     "sigprocmask",
+    "sigsuspend",
     "sigaction",
     "pthread_sigmask",
 ]

--- a/src/libs/libc_signal/src/lib.rs
+++ b/src/libs/libc_signal/src/lib.rs
@@ -34,6 +34,7 @@ pub mod raise;
 pub mod signal;
 pub mod sigprocmask;
 pub mod sigset;
+pub mod sigsuspend;
 
 //==================================================================================================
 // Imports

--- a/src/libs/libc_signal/src/sigsuspend.rs
+++ b/src/libs/libc_signal/src/sigsuspend.rs
@@ -1,0 +1,68 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    set_errno,
+    signal::sigset_t,
+};
+use ::sysapi::{
+    errno::EINTR,
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Replaces the calling process's signal mask with `mask` and suspends the process until a signal
+/// is delivered.
+///
+/// Nanvix does not deliver asynchronous signals, so no signal can ever resume a suspended process.
+/// POSIX specifies that `sigsuspend()` always returns `-1` with `errno` set to `EINTR` once it is
+/// interrupted; with no delivery this reports that outcome immediately rather than blocking
+/// forever.
+///
+/// # Parameters
+///
+/// - `mask`: The signal mask to install while suspended (ignored).
+///
+/// # Returns
+///
+/// Always returns `-1` with `errno` set to `EINTR`.
+///
+/// # Safety
+///
+/// This function is unsafe because it is part of the C ABI surface; `mask` is not dereferenced.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigsuspend.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigsuspend(_mask: *const sigset_t) -> c_int {
+    set_errno(EINTR);
+    -1
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sigsuspend_always_reports_interruption() {
+        let mask: sigset_t = 0;
+        // SAFETY: `mask` points to a valid `sigset_t` for the duration of the call.
+        assert_eq!(unsafe { sigsuspend(&mask) }, -1);
+    }
+}


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **2 commit(s)** that pertain to this crate.

### Commits
- [signal] E: Add sigsuspend() interruption stub
- [signal] E: Define NSIG in signal.h

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
