### PR TITLE
[time] Implement strftime() and strptime()

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -104,6 +104,8 @@ extern char *asctime(const struct tm *timeptr);
 extern char *asctime_r(const struct tm *timeptr, char *buf);
 extern char *ctime(const time_t *timep);
 extern char *ctime_r(const time_t *timep, char *buf);
+extern size_t strftime(char *s, size_t max, const char *format,
+                       const struct tm *timeptr);
 
 /*==================================================================================================
  * Clocks
@@ -113,6 +115,12 @@ extern int clock_gettime(clockid_t clock_id, struct timespec *tp);
 extern int clock_getres(clockid_t clock_id, struct timespec *res);
 extern int clock_settime(clockid_t clock_id, const struct timespec *tp);
 extern int nanosleep(const struct timespec *req, struct timespec *rem);
+
+/*==================================================================================================
+ * Time Parsing
+ *==================================================================================================*/
+
+extern char *strptime(const char *s, const char *format, struct tm *tm);
 
 #ifdef __cplusplus
 }

--- a/src/libs/libc_time/header.toml
+++ b/src/libs/libc_time/header.toml
@@ -10,7 +10,7 @@ Declares functions for calendar time manipulation and conversion.
 Implemented by the libc_time Rust crate.'''
 includes = ["stddef.h"]
 guard = "_NANVIX_TIME_H"
-content_order = ["types", "section:0", "section:1", "raw:0", "raw:1"]
+content_order = ["types", "section:0", "section:1", "raw:0", "raw:1", "raw:2"]
 
 [[types]]
 text = '''
@@ -74,7 +74,9 @@ text = '''
 extern char *asctime(const struct tm *timeptr);
 extern char *asctime_r(const struct tm *timeptr, char *buf);
 extern char *ctime(const time_t *timep);
-extern char *ctime_r(const time_t *timep, char *buf);'''
+extern char *ctime_r(const time_t *timep, char *buf);
+extern size_t strftime(char *s, size_t max, const char *format,
+                       const struct tm *timeptr);'''
 
 # Implemented by the syscall crate; declared here so callers of time.h can use them.
 [[raw_sections]]
@@ -84,6 +86,11 @@ extern int clock_gettime(clockid_t clock_id, struct timespec *tp);
 extern int clock_getres(clockid_t clock_id, struct timespec *res);
 extern int clock_settime(clockid_t clock_id, const struct timespec *tp);
 extern int nanosleep(const struct timespec *req, struct timespec *rem);'''
+
+[[raw_sections]]
+title = "Time Parsing"
+text = '''
+extern char *strptime(const char *s, const char *format, struct tm *tm);'''
 
 [[sections]]
 title = "Calendar Time"

--- a/src/libs/libc_time/src/lib.rs
+++ b/src/libs/libc_time/src/lib.rs
@@ -42,5 +42,7 @@ pub mod gmtime_r;
 pub mod localtime;
 pub mod localtime_r;
 pub mod mktime;
+pub mod strftime;
+pub mod strptime;
 pub mod time;
 pub mod tm_struct;

--- a/src/libs/libc_time/src/strftime.rs
+++ b/src/libs/libc_time/src/strftime.rs
@@ -1,0 +1,451 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+// Formatting inherently narrows wide arithmetic results back to the C ABI integer widths; on the
+// 32-bit Nanvix target these casts are exact.
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::{
+    tm,
+    DAY_NAMES,
+    FULL_DAY_NAMES,
+    FULL_MONTH_NAMES,
+    MONTH_NAMES,
+    TM_YEAR_BASE,
+};
+use ::sysapi::{
+    ffi::c_char,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Bounded Output Writer
+//==================================================================================================
+
+/// Bounded writer that appends bytes to the destination buffer, reserving space for the trailing
+/// null byte and flagging overflow instead of writing past the end.
+struct Writer {
+    /// Destination buffer.
+    buf: *mut c_char,
+    /// Capacity of the destination buffer, including the trailing null byte.
+    max: usize,
+    /// Number of bytes written so far.
+    pos: usize,
+    /// Set once a write could not fit; all subsequent writes are suppressed.
+    overflow: bool,
+}
+
+impl Writer {
+    /// Appends a single byte, flagging overflow if there is no room left for it plus a final null.
+    unsafe fn put(&mut self, byte: u8) {
+        if self.overflow {
+            return;
+        }
+        if self.pos + 1 >= self.max {
+            self.overflow = true;
+            return;
+        }
+        *self.buf.add(self.pos) = byte as c_char;
+        self.pos += 1;
+    }
+
+    /// Appends a byte slice.
+    unsafe fn put_bytes(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.put(b);
+        }
+    }
+
+    /// Appends a non-negative integer with the given minimum field width and padding byte.
+    unsafe fn put_uint(&mut self, value: u64, width: usize, pad: u8) {
+        let mut digits: [u8; 20] = [0; 20];
+        let mut count: usize = 0;
+        let mut v: u64 = value;
+
+        // Generate decimal digits least-significant first.
+        loop {
+            digits[count] = b'0' + (v % 10) as u8;
+            count += 1;
+            v /= 10;
+            if v == 0 {
+                break;
+            }
+        }
+
+        // Left-pad to the requested width.
+        let mut pad_count: usize = width.saturating_sub(count);
+        while pad_count > 0 {
+            self.put(pad);
+            pad_count -= 1;
+        }
+
+        // Emit digits most-significant first.
+        while count > 0 {
+            count -= 1;
+            self.put(digits[count]);
+        }
+    }
+
+    /// Appends a signed integer (used for the four-or-more-digit year).
+    unsafe fn put_int(&mut self, value: i64) {
+        if value < 0 {
+            self.put(b'-');
+            self.put_uint(value.unsigned_abs(), 0, b'0');
+        } else {
+            self.put_uint(value as u64, 0, b'0');
+        }
+    }
+}
+
+//==================================================================================================
+// Conversion Helpers
+//==================================================================================================
+
+/// Returns the 12-hour clock hour for the given 24-hour value, in `[1, 12]`.
+fn hour12(hour24: i32) -> i32 {
+    let h: i32 = hour24 % 12;
+    if h == 0 {
+        12
+    } else {
+        h
+    }
+}
+
+/// Computes the week-of-year number for the `%U`/`%W` specifiers.
+///
+/// `week_start` is the weekday (`0` = Sunday) that begins each numbered week.
+fn week_of_year(yday: i32, wday: i32, week_start: i32) -> i32 {
+    let offset: i32 = (wday + 7 - week_start) % 7;
+    (yday + 7 - offset) / 7
+}
+
+//==================================================================================================
+// Core Formatter
+//==================================================================================================
+
+/// Expands `fmt` against the broken-down time `t`, writing the result through `w`.
+unsafe fn run(w: &mut Writer, fmt: &[u8], t: &tm) {
+    let mut i: usize = 0;
+    while i < fmt.len() {
+        let c: u8 = fmt[i];
+        if c != b'%' {
+            w.put(c);
+            i += 1;
+            continue;
+        }
+
+        i += 1;
+        if i >= fmt.len() {
+            // Trailing '%': emit verbatim.
+            w.put(b'%');
+            break;
+        }
+
+        // Skip the POSIX locale modifiers 'E' and 'O'; they select alternate
+        // representations that collapse to the default in the C locale.
+        let mut spec: u8 = fmt[i];
+        if spec == b'E' || spec == b'O' {
+            i += 1;
+            if i >= fmt.len() {
+                break;
+            }
+            spec = fmt[i];
+        }
+
+        emit_spec(w, spec, t);
+        i += 1;
+    }
+}
+
+/// Emits a single conversion specifier `spec`.
+unsafe fn emit_spec(w: &mut Writer, spec: u8, t: &tm) {
+    match spec {
+        b'a' => {
+            if let Some(name) = name_for(&DAY_NAMES, t.tm_wday, 7) {
+                w.put_bytes(name);
+            }
+        },
+        b'A' => {
+            if (0..7).contains(&t.tm_wday) {
+                w.put_bytes(FULL_DAY_NAMES[t.tm_wday as usize]);
+            }
+        },
+        b'b' | b'h' => {
+            if let Some(name) = name_for(&MONTH_NAMES, t.tm_mon, 12) {
+                w.put_bytes(name);
+            }
+        },
+        b'B' => {
+            if (0..12).contains(&t.tm_mon) {
+                w.put_bytes(FULL_MONTH_NAMES[t.tm_mon as usize]);
+            }
+        },
+        b'c' => run(w, b"%a %b %e %H:%M:%S %Y", t),
+        b'C' => w.put_uint(((t.tm_year as i64 + TM_YEAR_BASE) / 100) as u64, 2, b'0'),
+        b'd' => w.put_uint(t.tm_mday as u64, 2, b'0'),
+        b'D' => run(w, b"%m/%d/%y", t),
+        b'e' => w.put_uint(t.tm_mday as u64, 2, b' '),
+        b'F' => run(w, b"%Y-%m-%d", t),
+        b'H' => w.put_uint(t.tm_hour as u64, 2, b'0'),
+        b'I' => w.put_uint(hour12(t.tm_hour) as u64, 2, b'0'),
+        b'j' => w.put_uint((t.tm_yday + 1) as u64, 3, b'0'),
+        b'k' => w.put_uint(t.tm_hour as u64, 2, b' '),
+        b'l' => w.put_uint(hour12(t.tm_hour) as u64, 2, b' '),
+        b'm' => w.put_uint((t.tm_mon + 1) as u64, 2, b'0'),
+        b'M' => w.put_uint(t.tm_min as u64, 2, b'0'),
+        b'n' => w.put(b'\n'),
+        b'p' => w.put_bytes(if t.tm_hour < 12 { b"AM" } else { b"PM" }),
+        b'P' => w.put_bytes(if t.tm_hour < 12 { b"am" } else { b"pm" }),
+        b'r' => run(w, b"%I:%M:%S %p", t),
+        b'R' => run(w, b"%H:%M", t),
+        b'S' => w.put_uint(t.tm_sec as u64, 2, b'0'),
+        b't' => w.put(b'\t'),
+        b'T' => run(w, b"%H:%M:%S", t),
+        b'u' => {
+            let iso: i32 = if t.tm_wday == 0 { 7 } else { t.tm_wday };
+            w.put_uint(iso as u64, 0, b'0');
+        },
+        b'U' => w.put_uint(week_of_year(t.tm_yday, t.tm_wday, 0) as u64, 2, b'0'),
+        b'w' => w.put_uint(t.tm_wday as u64, 0, b'0'),
+        b'W' => w.put_uint(week_of_year(t.tm_yday, t.tm_wday, 1) as u64, 2, b'0'),
+        b'y' => w.put_uint((t.tm_year as i64 + TM_YEAR_BASE).rem_euclid(100) as u64, 2, b'0'),
+        b'Y' => w.put_int(t.tm_year as i64 + TM_YEAR_BASE),
+        b'z' => w.put_bytes(b"+0000"),
+        b'Z' => w.put_bytes(b"UTC"),
+        b'%' => w.put(b'%'),
+        // Unknown specifier: emit it verbatim, preceded by the percent sign.
+        other => {
+            w.put(b'%');
+            w.put(other);
+        },
+    }
+}
+
+/// Returns the abbreviated name for `index` from `table` if `index` is within `[0, len)`.
+fn name_for(table: &[&'static [u8; 3]], index: i32, len: i32) -> Option<&'static [u8]> {
+    if index >= 0 && index < len {
+        Some(&table[index as usize][..])
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats the broken-down time `tm` according to the format string `format`, writing the result
+/// (including a terminating null byte) into the buffer `s`.
+///
+/// The conversion specifiers follow POSIX in the C locale: `%a %A %b %B %c %C %d %D %e %F %H %I %j
+/// %k %l %m %M %n %p %P %r %R %S %t %T %u %U %w %W %y %Y %z %Z %%`. The `E`/`O` locale modifiers
+/// are accepted and ignored. Time zones are not modeled, so `%z`/`%Z` always render UTC.
+///
+/// # Parameters
+///
+/// - `s`: Destination buffer.
+/// - `max`: Capacity of `s`, including space for the terminating null byte.
+/// - `format`: Null-terminated format string.
+/// - `timeptr`: Pointer to the broken-down time to format.
+///
+/// # Returns
+///
+/// The number of bytes written, excluding the terminating null byte. If the result (including the
+/// null byte) does not fit within `max`, returns `0` and the buffer contents are unspecified.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that `s`
+/// has room for at least `max` bytes and that `format` and `timeptr` point to valid objects.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strftime.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strftime(
+    s: *mut c_char,
+    max: c_size_t,
+    format: *const c_char,
+    timeptr: *const tm,
+) -> c_size_t {
+    if s.is_null() || format.is_null() || timeptr.is_null() {
+        return 0;
+    }
+    if max == 0 {
+        return 0;
+    }
+
+    let t: &tm = &*timeptr;
+
+    // Collect the null-terminated format string into a byte slice.
+    let mut len: usize = 0;
+    while *format.add(len) != 0 {
+        len += 1;
+    }
+    let fmt: &[u8] = core::slice::from_raw_parts(format.cast::<u8>(), len);
+
+    let mut writer: Writer = Writer {
+        buf: s,
+        max: max as usize,
+        pos: 0,
+        overflow: false,
+    };
+
+    run(&mut writer, fmt, t);
+
+    if writer.overflow {
+        return 0;
+    }
+
+    // Terminate the string. `pos < max` holds because `put` reserves the final byte.
+    *s.add(writer.pos) = 0;
+    writer.pos as c_size_t
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strftime;
+    use crate::tm_struct::{
+        days_from_civil,
+        tm,
+    };
+    use ::std::{
+        ffi::CString,
+        string::String,
+        vec,
+    };
+    use ::sysapi::sys_types::c_size_t;
+
+    /// Builds a broken-down time, deriving `tm_wday`/`tm_yday` from the civil date so the tests do
+    /// not hard-code (and risk mis-stating) those fields.
+    fn make_tm(year: i32, mon: i32, mday: i32, hour: i32, min: i32, sec: i32) -> tm {
+        let mut t: tm = tm::new();
+        t.tm_year = year - 1900;
+        t.tm_mon = mon - 1;
+        t.tm_mday = mday;
+        t.tm_hour = hour;
+        t.tm_min = min;
+        t.tm_sec = sec;
+
+        let days: i64 = days_from_civil(i64::from(year), i64::from(mon), i64::from(mday));
+        // 1970-01-01 was a Thursday (weekday 4).
+        t.tm_wday = (((days % 7) + 4) % 7 + 7) as i32 % 7;
+        let jan1: i64 = days_from_civil(i64::from(year), 1, 1);
+        t.tm_yday = (days - jan1) as i32;
+        t
+    }
+
+    fn fmt(t: &tm, format: &str) -> String {
+        let f: CString = CString::new(format).unwrap_or_else(|_| CString::default());
+        let mut buf: vec::Vec<u8> = vec![0u8; 256];
+        let n: c_size_t =
+            unsafe { strftime(buf.as_mut_ptr().cast::<i8>(), 256 as c_size_t, f.as_ptr(), t) };
+        String::from_utf8_lossy(&buf[..n as usize]).into_owned()
+    }
+
+    #[test]
+    fn date_and_time() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        assert_eq!(fmt(&t, "%Y-%m-%d"), "2021-03-14");
+        assert_eq!(fmt(&t, "%H:%M:%S"), "09:05:07");
+        assert_eq!(fmt(&t, "%F %T"), "2021-03-14 09:05:07");
+    }
+
+    #[test]
+    fn names() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        // 2021-03-14 is a Sunday.
+        assert_eq!(fmt(&t, "%a"), "Sun");
+        assert_eq!(fmt(&t, "%A"), "Sunday");
+        assert_eq!(fmt(&t, "%b"), "Mar");
+        assert_eq!(fmt(&t, "%B"), "March");
+        assert_eq!(fmt(&t, "%h"), "Mar");
+    }
+
+    #[test]
+    fn am_pm_and_12hour() {
+        let am: tm = make_tm(2021, 3, 14, 9, 49, 8);
+        assert_eq!(fmt(&am, "%I:%M:%S %p"), "09:49:08 AM");
+        let pm: tm = make_tm(2021, 3, 14, 21, 49, 8);
+        assert_eq!(fmt(&pm, "%I:%M:%S %p"), "09:49:08 PM");
+        assert_eq!(fmt(&pm, "%H"), "21");
+        assert_eq!(fmt(&pm, "%l"), " 9");
+        assert_eq!(fmt(&pm, "%P"), "pm");
+        let midnight: tm = make_tm(2021, 3, 14, 0, 0, 0);
+        assert_eq!(fmt(&midnight, "%I %p"), "12 AM");
+    }
+
+    #[test]
+    fn numeric_fields() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        assert_eq!(fmt(&t, "%j"), "073");
+        assert_eq!(fmt(&t, "%y"), "21");
+        assert_eq!(fmt(&t, "%C"), "20");
+        assert_eq!(fmt(&t, "%w"), "0");
+        assert_eq!(fmt(&t, "%u"), "7");
+        assert_eq!(fmt(&t, "%e"), "14");
+        let single: tm = make_tm(2021, 3, 3, 0, 0, 0);
+        assert_eq!(fmt(&single, "%e"), " 3");
+        assert_eq!(fmt(&single, "%d"), "03");
+    }
+
+    #[test]
+    fn two_digit_year_stays_in_range() {
+        // Years whose offset from `TM_YEAR_BASE` is negative must still wrap into `00..=99`.
+        let mut t: tm = tm::new();
+        t.tm_year = -1 - 1900;
+        assert_eq!(fmt(&t, "%y"), "99");
+    }
+
+    #[test]
+    fn literals_and_unknown() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        assert_eq!(fmt(&t, "100%% done"), "100% done");
+        assert_eq!(fmt(&t, "a%nb%tc"), "a\nb\tc");
+        assert_eq!(fmt(&t, "%z %Z"), "+0000 UTC");
+    }
+
+    #[test]
+    fn truncation_returns_zero() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        let f: CString = CString::new("%Y").unwrap_or_else(|_| CString::default());
+        let mut buf: vec::Vec<u8> = vec![0u8; 4];
+        // "2021" needs 4 bytes plus a null terminator: it cannot fit in 4 bytes.
+        let n: c_size_t =
+            unsafe { strftime(buf.as_mut_ptr().cast::<i8>(), 4 as c_size_t, f.as_ptr(), &t) };
+        assert_eq!(n, 0);
+        // A five-byte buffer is exactly enough.
+        let mut buf2: vec::Vec<u8> = vec![0u8; 5];
+        let n2: c_size_t =
+            unsafe { strftime(buf2.as_mut_ptr().cast::<i8>(), 5 as c_size_t, f.as_ptr(), &t) };
+        assert_eq!(n2, 4);
+    }
+
+    #[test]
+    fn zero_capacity_returns_zero() {
+        let t: tm = make_tm(2021, 3, 14, 9, 5, 7);
+        let f: CString = CString::new("").unwrap_or_else(|_| CString::default());
+        let mut buf: [u8; 1] = *b"x";
+        let n: c_size_t =
+            unsafe { strftime(buf.as_mut_ptr().cast::<i8>(), 0 as c_size_t, f.as_ptr(), &t) };
+        assert_eq!(n, 0);
+        assert_eq!(buf[0], b'x');
+    }
+}

--- a/src/libs/libc_time/src/strptime.rs
+++ b/src/libs/libc_time/src/strptime.rs
@@ -1,0 +1,562 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::tm_struct::{
+    tm,
+    FULL_DAY_NAMES,
+    FULL_MONTH_NAMES,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Abbreviated weekday names, indexed by `tm_wday` (`0` = Sunday).
+const DAY_ABBR: [&[u8]; 7] = [b"Sun", b"Mon", b"Tue", b"Wed", b"Thu", b"Fri", b"Sat"];
+
+/// Abbreviated month names, indexed by `tm_mon` (`0` = January).
+const MON_ABBR: [&[u8]; 12] = [
+    b"Jan", b"Feb", b"Mar", b"Apr", b"May", b"Jun", b"Jul", b"Aug", b"Sep", b"Oct", b"Nov", b"Dec",
+];
+
+//==================================================================================================
+// Private Standalone Functions
+//==================================================================================================
+
+/// Returns `true` if `b` is an ASCII whitespace character.
+fn is_space(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
+}
+
+/// Reads the byte pointed to by `p`.
+///
+/// The caller must ensure that `p` points to a valid, readable byte.
+unsafe fn peek(p: *const c_char) -> u8 {
+    *p.cast::<u8>()
+}
+
+/// Returns `true` if the string at `s` begins with `name`, compared case-insensitively.
+///
+/// The caller must ensure that `s` points to a valid NUL-terminated string.
+unsafe fn starts_with_ci(s: *const c_char, name: &[u8]) -> bool {
+    let mut k: usize = 0;
+    while k < name.len() {
+        let sb: u8 = peek(s.add(k));
+        if sb == 0 || !sb.eq_ignore_ascii_case(&name[k]) {
+            return false;
+        }
+        k += 1;
+    }
+    true
+}
+
+/// Searches `names` for the first entry that prefixes the string at `s` (case-insensitive).
+///
+/// Returns the matching index and the length of the matched name. The caller must ensure that `s`
+/// points to a valid NUL-terminated string.
+unsafe fn find_name(s: *const c_char, names: &[&[u8]]) -> Option<(c_int, usize)> {
+    for (idx, name) in names.iter().enumerate() {
+        if starts_with_ci(s, name) {
+            return Some((c_int::try_from(idx).unwrap_or(0), name.len()));
+        }
+    }
+    None
+}
+
+/// Matches the string at `s` against the full names first, then the abbreviated ones.
+///
+/// The caller must ensure that `s` points to a valid NUL-terminated string.
+unsafe fn match_name(s: *const c_char, full: &[&[u8]], abbr: &[&[u8]]) -> Option<(c_int, usize)> {
+    if let Some(found) = find_name(s, full) {
+        return Some(found);
+    }
+    find_name(s, abbr)
+}
+
+/// Parses up to `maxw` decimal digits, skipping any leading ASCII whitespace.
+///
+/// Returns the parsed value together with the pointer positioned just past the last digit, or
+/// `None` if no digit was found. The caller must ensure that `s` points to a valid NUL-terminated
+/// string.
+unsafe fn read_num(mut s: *const c_char, maxw: u32) -> Option<(c_int, *const c_char)> {
+    while is_space(peek(s)) {
+        s = s.add(1);
+    }
+    let mut val: c_int = 0;
+    let mut count: u32 = 0;
+    while count < maxw {
+        let b: u8 = peek(s);
+        if !b.is_ascii_digit() {
+            break;
+        }
+        val = val * 10 + c_int::from(b - b'0');
+        s = s.add(1);
+        count += 1;
+    }
+    if count == 0 {
+        None
+    } else {
+        Some((val, s))
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Parses the string `s` according to the format string `format`, storing the recognized fields in
+/// the broken-down time structure pointed to by `tm`. The supported conversion specifiers mirror
+/// the common POSIX/glibc set: `%a %A %b %B %h %c %C %d %e %D %F %H %I %j %m %M %n %p %r %R %S %t
+/// %T %U %w %W %x %X %y %Y %%`. The `E` and `O` locale modifiers are accepted and ignored.
+///
+/// Only the fields named by the format are modified; the caller is expected to initialize `tm`.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to the input string to parse.
+/// - `format`: Pointer to the format string.
+/// - `tm`: Pointer to the broken-down time structure to populate.
+///
+/// # Returns
+///
+/// On success, returns a pointer to the first character in `s` that was not consumed. On failure
+/// (a mismatch or a null argument), returns a null pointer.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `s`, `format`, and `tm`. The
+/// caller must ensure that `s` and `format` point to valid NUL-terminated strings and that `tm`
+/// points to a valid, writable `tm` structure.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strptime(
+    s: *const c_char,
+    format: *const c_char,
+    tm: *mut tm,
+) -> *mut c_char {
+    if s.is_null() || format.is_null() || tm.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    let mut s: *const c_char = s;
+    let mut f: *const c_char = format;
+
+    // Deferred year reconstruction for the %C / %y specifiers.
+    let mut century: c_int = -1;
+    let mut year2: c_int = -1;
+    let mut am_pm: Option<bool> = None;
+    let mut hour12_active: bool = false;
+
+    loop {
+        let fc: u8 = peek(f);
+        if fc == 0 {
+            break;
+        }
+
+        if is_space(fc) {
+            while is_space(peek(s)) {
+                s = s.add(1);
+            }
+            f = f.add(1);
+            continue;
+        }
+
+        if fc != b'%' {
+            if peek(s) != fc {
+                return core::ptr::null_mut();
+            }
+            s = s.add(1);
+            f = f.add(1);
+            continue;
+        }
+
+        // Consume the '%' and any locale modifier.
+        f = f.add(1);
+        let mut spec: u8 = peek(f);
+        if spec == b'E' || spec == b'O' {
+            f = f.add(1);
+            spec = peek(f);
+        }
+        if spec == 0 {
+            break;
+        }
+
+        match spec {
+            b'%' => {
+                if peek(s) != b'%' {
+                    return core::ptr::null_mut();
+                }
+                s = s.add(1);
+            },
+            b'n' | b't' => {
+                while is_space(peek(s)) {
+                    s = s.add(1);
+                }
+            },
+            b'a' | b'A' => match match_name(s, &FULL_DAY_NAMES, &DAY_ABBR) {
+                Some((idx, len)) => {
+                    (*tm).tm_wday = idx;
+                    s = s.add(len);
+                },
+                None => return core::ptr::null_mut(),
+            },
+            b'b' | b'B' | b'h' => match match_name(s, &FULL_MONTH_NAMES, &MON_ABBR) {
+                Some((idx, len)) => {
+                    (*tm).tm_mon = idx;
+                    s = s.add(len);
+                },
+                None => return core::ptr::null_mut(),
+            },
+            b'd' | b'e' => match read_num(s, 2) {
+                Some((v, ns)) if (1..=31).contains(&v) => {
+                    (*tm).tm_mday = v;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'H' => match read_num(s, 2) {
+                Some((v, ns)) if (0..=23).contains(&v) => {
+                    (*tm).tm_hour = v;
+                    hour12_active = false;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'I' => match read_num(s, 2) {
+                Some((v, ns)) if (1..=12).contains(&v) => {
+                    (*tm).tm_hour = v;
+                    hour12_active = true;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'm' => match read_num(s, 2) {
+                Some((v, ns)) if (1..=12).contains(&v) => {
+                    (*tm).tm_mon = v - 1;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'M' => match read_num(s, 2) {
+                Some((v, ns)) if (0..=59).contains(&v) => {
+                    (*tm).tm_min = v;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'S' => match read_num(s, 2) {
+                // A value of 60 is accepted to allow for a leap second.
+                Some((v, ns)) if (0..=60).contains(&v) => {
+                    (*tm).tm_sec = v;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'j' => match read_num(s, 3) {
+                Some((v, ns)) if (1..=366).contains(&v) => {
+                    (*tm).tm_yday = v - 1;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'w' => match read_num(s, 1) {
+                Some((v, ns)) if (0..=6).contains(&v) => {
+                    (*tm).tm_wday = v;
+                    s = ns;
+                },
+                _ => return core::ptr::null_mut(),
+            },
+            b'U' | b'W' => match read_num(s, 2) {
+                Some((v, ns)) if (0..=53).contains(&v) => s = ns,
+                _ => return core::ptr::null_mut(),
+            },
+            b'C' => match read_num(s, 2) {
+                Some((v, ns)) => {
+                    century = v;
+                    s = ns;
+                },
+                None => return core::ptr::null_mut(),
+            },
+            b'y' => match read_num(s, 2) {
+                Some((v, ns)) => {
+                    year2 = v;
+                    s = ns;
+                },
+                None => return core::ptr::null_mut(),
+            },
+            b'Y' => match read_num(s, 4) {
+                Some((v, ns)) => {
+                    (*tm).tm_year = v - 1900;
+                    century = -1;
+                    year2 = -1;
+                    s = ns;
+                },
+                None => return core::ptr::null_mut(),
+            },
+            b'p' | b'P' => {
+                if starts_with_ci(s, b"AM") {
+                    am_pm = Some(false);
+                    s = s.add(2);
+                } else if starts_with_ci(s, b"PM") {
+                    am_pm = Some(true);
+                    s = s.add(2);
+                } else {
+                    return core::ptr::null_mut();
+                }
+            },
+            b'D' | b'x' => {
+                let r: *mut c_char = strptime(s, c"%m/%d/%y".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+            },
+            b'F' => {
+                let r: *mut c_char = strptime(s, c"%Y-%m-%d".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+            },
+            b'R' => {
+                let r: *mut c_char = strptime(s, c"%H:%M".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+                hour12_active = false;
+            },
+            b'T' | b'X' => {
+                let r: *mut c_char = strptime(s, c"%H:%M:%S".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+                hour12_active = false;
+            },
+            b'r' => {
+                let r: *mut c_char = strptime(s, c"%I:%M:%S %p".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+            },
+            b'c' => {
+                let r: *mut c_char = strptime(s, c"%a %b %e %H:%M:%S %Y".as_ptr(), tm);
+                if r.is_null() {
+                    return core::ptr::null_mut();
+                }
+                s = r.cast_const();
+                hour12_active = false;
+            },
+            _ => return core::ptr::null_mut(),
+        }
+
+        f = f.add(1);
+    }
+
+    if hour12_active {
+        match am_pm {
+            Some(false) if (*tm).tm_hour == 12 => (*tm).tm_hour = 0,
+            Some(true) if (*tm).tm_hour < 12 => (*tm).tm_hour += 12,
+            _ => {},
+        }
+    }
+
+    // Reconstruct the year from the century and/or two-digit year, if either was seen.
+    if century >= 0 && year2 >= 0 {
+        (*tm).tm_year = century * 100 + year2 - 1900;
+    } else if year2 >= 0 {
+        (*tm).tm_year = if year2 < 69 { year2 + 100 } else { year2 };
+    } else if century >= 0 {
+        (*tm).tm_year = century * 100 - 1900;
+    }
+
+    s.cast_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::strptime;
+    use crate::tm_struct::tm;
+    use ::std::ffi::CString;
+
+    unsafe fn parse(input: &str, fmt: &str, t: &mut tm) -> isize {
+        let s: CString = CString::new(input).unwrap_or_else(|_| CString::default());
+        let f: CString = CString::new(fmt).unwrap_or_else(|_| CString::default());
+        let ret: *mut i8 = strptime(s.as_ptr(), f.as_ptr(), t);
+        if ret.is_null() {
+            -1
+        } else {
+            // Number of bytes consumed from the input.
+            ret.cast_const().offset_from(s.as_ptr())
+        }
+    }
+
+    #[test]
+    fn iso_date() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("2021-03-14", "%Y-%m-%d", &mut t) };
+        assert_eq!(consumed, 10);
+        assert_eq!(t.tm_year, 121);
+        assert_eq!(t.tm_mon, 2);
+        assert_eq!(t.tm_mday, 14);
+    }
+
+    #[test]
+    fn abbreviated_month() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("Mar", "%b", &mut t) };
+        assert_eq!(consumed, 3);
+        assert_eq!(t.tm_mon, 2);
+    }
+
+    #[test]
+    fn full_month_preferred() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("June", "%B", &mut t) };
+        assert_eq!(consumed, 4);
+        assert_eq!(t.tm_mon, 5);
+    }
+
+    #[test]
+    fn time_of_day() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("13:30:45", "%T", &mut t) };
+        assert_eq!(consumed, 8);
+        assert_eq!(t.tm_hour, 13);
+        assert_eq!(t.tm_min, 30);
+        assert_eq!(t.tm_sec, 45);
+    }
+
+    #[test]
+    fn leap_second_allowed() {
+        // A seconds value of 60 is accepted to represent a leap second.
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("23:59:60", "%T", &mut t) };
+        assert_eq!(consumed, 8);
+        assert_eq!(t.tm_sec, 60);
+    }
+
+    #[test]
+    fn twelve_hour_pm() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("01:30 PM", "%I:%M %p", &mut t) };
+        assert_eq!(consumed, 8);
+        assert_eq!(t.tm_hour, 13);
+        assert_eq!(t.tm_min, 30);
+    }
+
+    #[test]
+    fn am_pm_before_twelve_hour() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("PM 03", "%p %I", &mut t) };
+        assert_eq!(consumed, 5);
+        assert_eq!(t.tm_hour, 15);
+    }
+
+    #[test]
+    fn twelve_hour_midnight() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("12:00 AM", "%I:%M %p", &mut t) };
+        assert_eq!(consumed, 8);
+        assert_eq!(t.tm_hour, 0);
+    }
+
+    #[test]
+    fn us_date() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("03/14/21", "%D", &mut t) };
+        assert_eq!(consumed, 8);
+        assert_eq!(t.tm_mon, 2);
+        assert_eq!(t.tm_mday, 14);
+        assert_eq!(t.tm_year, 121);
+    }
+
+    #[test]
+    fn weekday_name() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("Monday", "%A", &mut t) };
+        assert_eq!(consumed, 6);
+        assert_eq!(t.tm_wday, 1);
+    }
+
+    #[test]
+    fn space_padded_day() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse(" 7", "%e", &mut t) };
+        assert_eq!(consumed, 2);
+        assert_eq!(t.tm_mday, 7);
+    }
+
+    #[test]
+    fn trailing_text_returned() {
+        let mut t: tm = tm::new();
+        // Only "%Y" is consumed; the remainder is left for the caller.
+        let consumed: isize = unsafe { parse("2021 rest", "%Y", &mut t) };
+        assert_eq!(consumed, 4);
+        assert_eq!(t.tm_year, 121);
+    }
+
+    #[test]
+    fn century_and_year() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("2021", "%C%y", &mut t) };
+        assert_eq!(consumed, 4);
+        assert_eq!(t.tm_year, 121);
+    }
+
+    #[test]
+    fn literal_mismatch_fails() {
+        let mut t: tm = tm::new();
+        let consumed: isize = unsafe { parse("2021/03", "%Y-%m", &mut t) };
+        assert_eq!(consumed, -1);
+    }
+
+    #[test]
+    fn out_of_range_numeric_fields_fail() {
+        // Each specifier must reject values outside its valid range.
+        let cases: [(&str, &str); 13] = [
+            ("00", "%d"),
+            ("32", "%d"),
+            ("24", "%H"),
+            ("00", "%I"),
+            ("13", "%I"),
+            ("00", "%m"),
+            ("13", "%m"),
+            ("367", "%j"),
+            ("7", "%w"),
+            ("54", "%U"),
+            ("54", "%W"),
+            ("60", "%M"),
+            ("61", "%S"),
+        ];
+        for (input, fmt) in cases {
+            let mut t: tm = tm::new();
+            let consumed: isize = unsafe { parse(input, fmt, &mut t) };
+            assert_eq!(consumed, -1, "expected {fmt} to reject {input:?}");
+        }
+    }
+
+    #[test]
+    fn null_arguments_fail() {
+        let mut t: tm = tm::new();
+        let f: CString = CString::new("%Y").unwrap_or_else(|_| CString::default());
+        assert!(unsafe { strptime(core::ptr::null(), f.as_ptr(), &mut t) }.is_null());
+    }
+}

--- a/src/libs/libc_time/src/tm_struct.rs
+++ b/src/libs/libc_time/src/tm_struct.rs
@@ -58,9 +58,36 @@ pub const DAYS_IN_MONTH: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30
 /// Abbreviated day names.
 pub const DAY_NAMES: [&[u8; 3]; 7] = [b"Sun", b"Mon", b"Tue", b"Wed", b"Thu", b"Fri", b"Sat"];
 
+/// Full day names.
+pub const FULL_DAY_NAMES: [&[u8]; 7] = [
+    b"Sunday",
+    b"Monday",
+    b"Tuesday",
+    b"Wednesday",
+    b"Thursday",
+    b"Friday",
+    b"Saturday",
+];
+
 /// Abbreviated month names.
 pub const MONTH_NAMES: [&[u8; 3]; 12] = [
     b"Jan", b"Feb", b"Mar", b"Apr", b"May", b"Jun", b"Jul", b"Aug", b"Sep", b"Oct", b"Nov", b"Dec",
+];
+
+/// Full month names.
+pub const FULL_MONTH_NAMES: [&[u8]; 12] = [
+    b"January",
+    b"February",
+    b"March",
+    b"April",
+    b"May",
+    b"June",
+    b"July",
+    b"August",
+    b"September",
+    b"October",
+    b"November",
+    b"December",
 ];
 
 //==================================================================================================

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -236,21 +236,6 @@ pub unsafe extern "C" fn strxfrm(dest: *mut c_char, src: *const c_char, n: c_siz
     len
 }
 
-/// Stub `strftime` — returns 0 (failure) since full locale-aware formatting is not implemented.
-///
-/// # Safety
-///
-/// Caller must ensure valid pointers.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn strftime(
-    _s: *mut c_char,
-    _max: c_size_t,
-    _format: *const c_char,
-    _tm: *const c_void,
-) -> c_size_t {
-    0
-}
-
 /// Stub `wcsftime` — returns 0 (failure).
 ///
 /// # Safety


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **2 commit(s)** that pertain to this crate.

### Commits
- [time] E: Add strptime() to libc_time
- [time] E: Implement strftime() in libc_time

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
