### PR TITLE
[regex] Add libc_regex crate (regcomp/regexec/regerror/regfree)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_regex"
+version = "0.17.34"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_setjmp"
 version = "0.17.34"
 dependencies = [
@@ -2452,6 +2459,7 @@ dependencies = [
  "libc_inttypes",
  "libc_langinfo",
  "libc_locale",
+ "libc_regex",
  "libc_setjmp",
  "libc_signal",
  "libc_stdio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ members = [
         "src/libs/libc_stdio",
         "src/libs/libc_stdlib",
         "src/libs/libc_math",
+        "src/libs/libc_regex",
         "src/libs/libc_string",
         "src/libs/libc_time",
         "src/libs/libc_wchar",
@@ -247,6 +248,7 @@ libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
 libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }
+libc_regex = { path = "src/libs/libc_regex", default-features = false }
 libc_signal = { path = "src/libs/libc_signal", default-features = false }
 libc_stdio = { path = "src/libs/libc_stdio", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -382,14 +382,14 @@ ALL_GUEST_RUST_LIBS := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi \
 	syscall sysalloc syslog-macros syslog sys \
-	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math \
+	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_regex \
 	libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time \
 	libc_wchar libc_wctype \
 	mmio-tag multiimage vfs-bench-common
 ALL_GUEST_RUST_LIBS_TEST_LIST := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions proc raw-array nanvix-slab sorted-vec static_assert \
-	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math \
+	libc_assert libc_ctype libc_inttypes libc_langinfo libc_locale libc_math libc_regex \
 	libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time \
 	libc_wchar libc_wctype \
 	syslog-macros syslog sys mmio-tag syscall vfs
@@ -425,7 +425,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c setjmp-c stdio-c thread-c
+ALL_POSIX_TESTS := c-bindings ctor-c dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c dlfcn-weak-c echo-c file-c fork-pid-c fork-pthread-c hello-c memory-c misc-c network-c noop-c regex-c setjmp-c stdio-c thread-c
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/include/regex.h
+++ b/include/regex.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_REGEX_H
+#define _NANVIX_REGEX_H
+
+/**
+ * @file regex.h
+ * @brief POSIX regular expressions.
+ *
+ * Declares the POSIX regular-expression interface (regcomp/regexec/regerror/
+ * regfree). Implemented by the libc_regex Rust crate as a Thompson/Pike NFA
+ * simulation with submatch tracking, supporting BRE and ERE, anchors, character
+ * classes, quantifiers, capturing groups, and alternation.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/* Signed offset wide enough to hold a ptrdiff_t/ssize_t value, as POSIX requires. */
+typedef ptrdiff_t regoff_t;
+
+/** @brief Compiled regular expression. */
+typedef struct {
+    size_t re_nsub; /**< Number of parenthesized subexpressions. */
+    void *__priv;   /**< Opaque pointer to the compiled program.  */
+    int __cflags;   /**< Compile flags captured at regcomp() time. */
+} regex_t;
+
+/** @brief Match offsets for a single (sub)expression. */
+typedef struct {
+    regoff_t rm_so; /**< Byte offset of the match start, or -1. */
+    regoff_t rm_eo; /**< Byte offset past the match end, or -1. */
+} regmatch_t;
+
+/*==================================================================================================
+ * Flags and Error Codes
+ *==================================================================================================*/
+
+/* cflags for regcomp(). */
+#define REG_EXTENDED 0x0001
+#define REG_ICASE    0x0002
+#define REG_NEWLINE  0x0004
+#define REG_NOSUB    0x0008
+#define REG_MINIMAL  0x0010
+
+/* eflags for regexec(). */
+#define REG_NOTBOL 0x0100
+#define REG_NOTEOL 0x0200
+
+/* Result and error codes. */
+#define REG_NOERROR  0
+#define REG_NOMATCH  1
+#define REG_BADPAT   2
+#define REG_ECOLLATE 3
+#define REG_ECTYPE   4
+#define REG_EESCAPE  5
+#define REG_ESUBREG  6
+#define REG_EBRACK   7
+#define REG_EPAREN   8
+#define REG_EBRACE   9
+#define REG_BADBR    10
+#define REG_ERANGE   11
+#define REG_ESPACE   12
+#define REG_BADRPT   13
+
+/*==================================================================================================
+ * Regular Expression Functions
+ *==================================================================================================*/
+
+extern int regcomp(regex_t *restrict preg, const char *restrict pattern, int cflags);
+extern int regexec(const regex_t *restrict preg, const char *restrict string, size_t nmatch,
+                   regmatch_t pmatch[restrict], int eflags);
+extern size_t regerror(int errcode, const regex_t *restrict preg, char *restrict errbuf,
+                       size_t errbuf_size);
+extern void regfree(regex_t *preg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_REGEX_H */

--- a/src/libs/libc_regex/Cargo.toml
+++ b/src/libs/libc_regex/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_regex"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_regex/header.toml
+++ b/src/libs/libc_regex/header.toml
@@ -1,0 +1,73 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for regex.h.
+
+file = "regex.h"
+brief = "POSIX regular expressions."
+description = '''
+Declares the POSIX regular-expression interface (regcomp/regexec/regerror/
+regfree). Implemented by the libc_regex Rust crate as a Thompson/Pike NFA
+simulation with submatch tracking, supporting BRE and ERE, anchors, character
+classes, quantifiers, capturing groups, and alternation.'''
+includes = ["stddef.h"]
+guard = "_NANVIX_REGEX_H"
+content_order = ["types", "raw:0", "raw:1"]
+
+[[types]]
+text = '''
+/* Signed offset wide enough to hold a ptrdiff_t/ssize_t value, as POSIX requires. */
+typedef ptrdiff_t regoff_t;
+
+/** @brief Compiled regular expression. */
+typedef struct {
+    size_t re_nsub; /**< Number of parenthesized subexpressions. */
+    void *__priv;   /**< Opaque pointer to the compiled program.  */
+    int __cflags;   /**< Compile flags captured at regcomp() time. */
+} regex_t;
+
+/** @brief Match offsets for a single (sub)expression. */
+typedef struct {
+    regoff_t rm_so; /**< Byte offset of the match start, or -1. */
+    regoff_t rm_eo; /**< Byte offset past the match end, or -1. */
+} regmatch_t;'''
+
+[[raw_sections]]
+title = "Flags and Error Codes"
+text = '''
+/* cflags for regcomp(). */
+#define REG_EXTENDED 0x0001
+#define REG_ICASE    0x0002
+#define REG_NEWLINE  0x0004
+#define REG_NOSUB    0x0008
+#define REG_MINIMAL  0x0010
+
+/* eflags for regexec(). */
+#define REG_NOTBOL 0x0100
+#define REG_NOTEOL 0x0200
+
+/* Result and error codes. */
+#define REG_NOERROR  0
+#define REG_NOMATCH  1
+#define REG_BADPAT   2
+#define REG_ECOLLATE 3
+#define REG_ECTYPE   4
+#define REG_EESCAPE  5
+#define REG_ESUBREG  6
+#define REG_EBRACK   7
+#define REG_EPAREN   8
+#define REG_EBRACE   9
+#define REG_BADBR    10
+#define REG_ERANGE   11
+#define REG_ESPACE   12
+#define REG_BADRPT   13'''
+
+[[raw_sections]]
+title = "Regular Expression Functions"
+text = '''
+extern int regcomp(regex_t *restrict preg, const char *restrict pattern, int cflags);
+extern int regexec(const regex_t *restrict preg, const char *restrict string, size_t nmatch,
+                   regmatch_t pmatch[restrict], int eflags);
+extern size_t regerror(int errcode, const regex_t *restrict preg, char *restrict errbuf,
+                       size_t errbuf_size);
+extern void regfree(regex_t *preg);'''

--- a/src/libs/libc_regex/src/ast.rs
+++ b/src/libs/libc_regex/src/ast.rs
@@ -1,0 +1,36 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use alloc::boxed::Box;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Abstract syntax tree node for a parsed regular expression.
+pub(crate) enum Ast {
+    /// Matches the empty string.
+    Empty,
+    /// Matches a single literal byte.
+    Char(u8),
+    /// Matches any byte (except a newline under `REG_NEWLINE`).
+    Any,
+    /// Matches a byte against a 256-bit membership bitmap.
+    Set([u8; 32]),
+    /// Asserts the beginning of the line/string.
+    Bol,
+    /// Asserts the end of the line/string.
+    Eol,
+    /// Concatenation of two subexpressions.
+    Cat(Box<Ast>, Box<Ast>),
+    /// Alternation of two subexpressions.
+    Alt(Box<Ast>, Box<Ast>),
+    /// Repetition of a subexpression `[min, max]` (`max == -1` means unbounded).
+    Rep(Box<Ast>, i32, i32, bool),
+    /// Capturing group with a 1-based index.
+    Group(i32, Box<Ast>),
+}

--- a/src/libs/libc_regex/src/lib.rs
+++ b/src/libs/libc_regex/src/lib.rs
@@ -1,0 +1,52 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+// `deny` (not `forbid`) for the integer-cast lints so individual functions may relax them with a
+// localized `#[allow]` and a justification, mirroring the other arithmetic-heavy libc crates.
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+extern crate alloc;
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod ast;
+mod matcher;
+mod parser;
+mod prog;
+
+pub mod regcomp;
+pub mod regerror;
+pub mod regexec;
+pub mod regfree;
+pub mod types;
+
+#[cfg(all(test, feature = "std"))]
+mod tests;

--- a/src/libs/libc_regex/src/matcher.rs
+++ b/src/libs/libc_regex/src/matcher.rs
@@ -1,0 +1,213 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::prog::{
+    Inst,
+    Prog,
+};
+use alloc::vec::Vec;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// A live NFA thread: a program counter plus its submatch slots.
+struct Thread {
+    pc: usize,
+    slots: Vec<i32>,
+    cost: i32,
+}
+
+/// A successful whole match plus its lazy-repetition priority cost.
+struct Match {
+    slots: Vec<i32>,
+    cost: i32,
+}
+
+/// Pike VM execution state shared across the recursive thread expansion.
+struct Vm<'a> {
+    prog: &'a Prog,
+    s: &'a [u8],
+    notbol: bool,
+    noteol: bool,
+    /// Per-instruction generation markers used to deduplicate threads within a step.
+    onlist: Vec<i32>,
+}
+
+impl Vm<'_> {
+    /// Adds the thread at `pc` to `list`, following epsilon transitions (`Jmp`/`Split`/`Save`) and
+    /// resolving anchors (`Bol`/`Eol`). Consuming instructions are appended to `list`.
+    fn add_thread(
+        &mut self,
+        list: &mut Vec<Thread>,
+        pc: usize,
+        slots: &mut [i32],
+        sp: usize,
+        gen: i32,
+        cost: i32,
+    ) {
+        if self.onlist.get(pc) == Some(&gen) {
+            return;
+        }
+        if let Some(slot) = self.onlist.get_mut(pc) {
+            *slot = gen;
+        }
+        let inst: &Inst = match self.prog.insts.get(pc) {
+            Some(inst) => inst,
+            None => return,
+        };
+        match *inst {
+            Inst::Jmp(x) => self.add_thread(list, x, slots, sp, gen, cost),
+            Inst::Split(x, y, penalize_y) => {
+                let mut copy: Vec<i32> = slots.to_vec();
+                self.add_thread(list, x, slots, sp, gen, cost);
+                let y_cost: i32 = if penalize_y {
+                    cost.saturating_add(1)
+                } else {
+                    cost
+                };
+                self.add_thread(list, y, &mut copy, sp, gen, y_cost);
+            },
+            Inst::Save(slot_idx) => {
+                let saved: i32 = slots.get(slot_idx).copied().unwrap_or(-1);
+                if let Some(cell) = slots.get_mut(slot_idx) {
+                    *cell = i32::try_from(sp).unwrap_or(-1);
+                }
+                self.add_thread(list, pc + 1, slots, sp, gen, cost);
+                if let Some(cell) = slots.get_mut(slot_idx) {
+                    *cell = saved;
+                }
+            },
+            Inst::Bol => {
+                if sp == 0 {
+                    if !self.notbol {
+                        self.add_thread(list, pc + 1, slots, sp, gen, cost);
+                    }
+                } else if self.prog.newline && self.s.get(sp - 1) == Some(&b'\n') {
+                    self.add_thread(list, pc + 1, slots, sp, gen, cost);
+                }
+            },
+            Inst::Eol => {
+                if sp == self.s.len() {
+                    if !self.noteol {
+                        self.add_thread(list, pc + 1, slots, sp, gen, cost);
+                    }
+                } else if self.prog.newline && self.s.get(sp) == Some(&b'\n') {
+                    self.add_thread(list, pc + 1, slots, sp, gen, cost);
+                }
+            },
+            // Consuming instruction (Char/Any/AnyByte/Set) or Match: park the thread for this step.
+            _ => list.push(Thread {
+                pc,
+                slots: slots.to_vec(),
+                cost,
+            }),
+        }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns `true` if `candidate` is a better whole match than `current`.
+fn better_match(candidate: &Thread, current: Option<&Match>) -> bool {
+    let candidate_start: i32 = candidate.slots.first().copied().unwrap_or(-1);
+    let candidate_end: i32 = candidate.slots.get(1).copied().unwrap_or(-1);
+    if candidate_start < 0 || candidate_end < candidate_start {
+        return false;
+    }
+
+    let current: &Match = match current {
+        Some(current) => current,
+        None => return true,
+    };
+    let current_start: i32 = current.slots.first().copied().unwrap_or(-1);
+    let current_end: i32 = current.slots.get(1).copied().unwrap_or(-1);
+
+    if candidate_start != current_start {
+        return current_start < 0 || candidate_start < current_start;
+    }
+    if candidate.cost != current.cost {
+        return candidate.cost < current.cost;
+    }
+    candidate_end > current_end
+}
+
+/// Runs the compiled program against `s`, returning the winning submatch slots on success.
+///
+/// The result is a vector of `2 * (nsub + 1)` byte offsets (`-1` when unset); slot `0`/`1` hold the
+/// whole match. Returns `None` if the pattern does not match.
+pub(crate) fn exec(prog: &Prog, s: &[u8], notbol: bool, noteol: bool) -> Option<Vec<i32>> {
+    let nslots: usize = 2 * (usize::try_from(prog.nsub).unwrap_or(0) + 1);
+    let mut vm: Vm = Vm {
+        prog,
+        s,
+        notbol,
+        noteol,
+        onlist: alloc::vec![-1i32; prog.insts.len()],
+    };
+
+    let mut clist: Vec<Thread> = Vec::new();
+    let mut nlist: Vec<Thread> = Vec::new();
+    let mut matched: Option<Match> = None;
+    let mut gen: i32 = 0;
+
+    {
+        let mut init: Vec<i32> = alloc::vec![-1i32; nslots];
+        vm.add_thread(&mut clist, 0, &mut init, 0, gen, 0);
+    }
+
+    let slen: usize = s.len();
+    let mut sp: usize = 0;
+    loop {
+        nlist.clear();
+        gen += 1;
+        let ch: u8 = if sp < slen { s[sp] } else { 0 };
+        let fch: u8 = if prog.icase {
+            ch.to_ascii_lowercase()
+        } else {
+            ch
+        };
+
+        let mut t: usize = 0;
+        while t < clist.len() {
+            let pc: usize = clist[t].pc;
+            let consume: bool = match prog.insts.get(pc) {
+                Some(Inst::Char(c)) => sp < slen && fch == *c,
+                Some(Inst::Any) => sp < slen && !(prog.newline && ch == b'\n'),
+                Some(Inst::AnyByte) => sp < slen,
+                Some(Inst::Set(set)) => {
+                    sp < slen && (set[usize::from(ch >> 3)] & (1u8 << (ch & 7)) != 0)
+                },
+                Some(Inst::Match) => {
+                    if better_match(&clist[t], matched.as_ref()) {
+                        matched = Some(Match {
+                            slots: clist[t].slots.clone(),
+                            cost: clist[t].cost,
+                        });
+                    }
+                    false
+                },
+                _ => false,
+            };
+            if consume {
+                let mut sl: Vec<i32> = clist[t].slots.clone();
+                vm.add_thread(&mut nlist, pc + 1, &mut sl, sp + 1, gen, clist[t].cost);
+            }
+            t += 1;
+        }
+
+        core::mem::swap(&mut clist, &mut nlist);
+        if sp >= slen {
+            break;
+        }
+        sp += 1;
+    }
+
+    matched.map(|matched| matched.slots)
+}

--- a/src/libs/libc_regex/src/parser.rs
+++ b/src/libs/libc_regex/src/parser.rs
@@ -1,0 +1,499 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    ast::Ast,
+    types::{
+        REG_BADBR,
+        REG_EBRACE,
+        REG_EBRACK,
+        REG_ECTYPE,
+        REG_EESCAPE,
+        REG_EPAREN,
+        REG_ERANGE,
+    },
+};
+use ::sysapi::ffi::c_int;
+use alloc::boxed::Box;
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Returns `true` if `c` is whitespace under the C locale (matches `isspace`).
+fn is_space_c(c: u8) -> bool {
+    matches!(c, b' ' | b'\t' | b'\n' | 0x0b | 0x0c | b'\r')
+}
+
+/// Sets the membership bit for byte `c` in a 32-byte (256-bit) bitmap.
+fn set_add(set: &mut [u8; 32], c: u8) {
+    set[usize::from(c >> 3)] |= 1u8 << (c & 7);
+}
+
+/// Clears the membership bit for byte `c` in a 32-byte (256-bit) bitmap.
+fn set_remove(set: &mut [u8; 32], c: u8) {
+    set[usize::from(c >> 3)] &= !(1u8 << (c & 7));
+}
+
+//==================================================================================================
+// Parser
+//==================================================================================================
+
+/// Recursive-descent parser that turns a pattern into an [`Ast`].
+pub(crate) struct Parser<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    ere: bool,
+    /// Whether matching is newline-sensitive (`REG_NEWLINE`).
+    newline: bool,
+    /// Whether ERE duplication symbols prefer shortest matches by default.
+    minimal: bool,
+    /// First error encountered (`0` means none).
+    pub(crate) err: c_int,
+    /// Number of capturing groups seen so far.
+    pub(crate) ngroup: i32,
+}
+
+impl<'a> Parser<'a> {
+    /// Creates a new parser over `bytes`, selecting ERE or BRE syntax.
+    pub(crate) fn new(bytes: &'a [u8], ere: bool, newline: bool, minimal: bool) -> Self {
+        Self {
+            bytes,
+            pos: 0,
+            ere,
+            newline,
+            minimal,
+            err: 0,
+            ngroup: 0,
+        }
+    }
+
+    /// Returns `true` if the whole pattern has been consumed.
+    pub(crate) fn at_end(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+
+    /// Returns the current byte, if any.
+    fn cur(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    /// Returns the byte `off` positions ahead of the cursor, if any.
+    fn at(&self, off: usize) -> Option<u8> {
+        self.bytes.get(self.pos + off).copied()
+    }
+
+    /// Parses a top-level alternation: `cat ('|' cat)*`.
+    pub(crate) fn parse_alt(&mut self) -> Option<Box<Ast>> {
+        let mut left: Box<Ast> = self.parse_cat()?;
+        loop {
+            let is_alt: bool = if self.ere && self.cur() == Some(b'|') {
+                self.pos += 1;
+                true
+            } else if !self.ere && self.cur() == Some(b'\\') && self.at(1) == Some(b'|') {
+                self.pos += 2;
+                true
+            } else {
+                false
+            };
+            if !is_alt {
+                break;
+            }
+            let right: Box<Ast> = self.parse_cat()?;
+            left = Box::new(Ast::Alt(left, right));
+        }
+        Some(left)
+    }
+
+    /// Parses a concatenation of quantified atoms.
+    fn parse_cat(&mut self) -> Option<Box<Ast>> {
+        let mut head: Option<Box<Ast>> = None;
+        while !self.at_cat_end() && self.err == 0 {
+            let mut atom: Box<Ast> = self.parse_atom()?;
+            loop {
+                let quant: Option<(i32, i32, bool)> = self.parse_quant();
+                if self.err != 0 {
+                    return None;
+                }
+                match quant {
+                    Some((mn, mx, minimal)) => atom = Box::new(Ast::Rep(atom, mn, mx, minimal)),
+                    None => break,
+                }
+            }
+            head = Some(match head {
+                None => atom,
+                Some(h) => Box::new(Ast::Cat(h, atom)),
+            });
+        }
+        Some(head.unwrap_or_else(|| Box::new(Ast::Empty)))
+    }
+
+    /// Returns `true` when the parser is at the end of a concatenation.
+    fn at_cat_end(&self) -> bool {
+        match self.cur() {
+            None => true,
+            Some(c) => {
+                if self.ere {
+                    c == b'|' || c == b')'
+                } else if c == b'\\' {
+                    matches!(self.at(1), Some(b'|') | Some(b')'))
+                } else {
+                    false
+                }
+            },
+        }
+    }
+
+    /// Parses a single atom (no trailing quantifier).
+    fn parse_atom(&mut self) -> Option<Box<Ast>> {
+        let c: u8 = match self.cur() {
+            Some(c) => c,
+            None => return Some(Box::new(Ast::Empty)),
+        };
+
+        // Grouping.
+        if self.ere && c == b'(' {
+            self.pos += 1;
+            self.ngroup += 1;
+            let g: i32 = self.ngroup;
+            let inner: Box<Ast> = self.parse_alt()?;
+            if self.cur() != Some(b')') {
+                self.err = REG_EPAREN;
+                return None;
+            }
+            self.pos += 1;
+            return Some(Box::new(Ast::Group(g, inner)));
+        }
+        if !self.ere && c == b'\\' && self.at(1) == Some(b'(') {
+            self.pos += 2;
+            self.ngroup += 1;
+            let g: i32 = self.ngroup;
+            let inner: Box<Ast> = self.parse_alt()?;
+            if self.cur() != Some(b'\\') || self.at(1) != Some(b')') {
+                self.err = REG_EPAREN;
+                return None;
+            }
+            self.pos += 2;
+            return Some(Box::new(Ast::Group(g, inner)));
+        }
+
+        if c == b'.' {
+            self.pos += 1;
+            return Some(Box::new(Ast::Any));
+        }
+        if c == b'[' {
+            self.pos += 1;
+            return self.parse_set();
+        }
+        if c == b'^' {
+            self.pos += 1;
+            return Some(Box::new(Ast::Bol));
+        }
+        if c == b'$' {
+            self.pos += 1;
+            return Some(Box::new(Ast::Eol));
+        }
+
+        // Escapes.
+        if c == b'\\' {
+            if let Some(e) = self.at(1) {
+                self.pos += 2;
+                return Some(match e {
+                    b'n' => Box::new(Ast::Char(b'\n')),
+                    b't' => Box::new(Ast::Char(b'\t')),
+                    b'r' => Box::new(Ast::Char(b'\r')),
+                    b'w' | b'W' | b's' | b'S' | b'd' | b'D' => {
+                        Box::new(Ast::Set(shorthand_class(e, self.newline)))
+                    },
+                    // Escaped literal (covers \\, \., \*, digits, etc.). Backreferences are not
+                    // supported by the NFA, so a \1 is treated as the literal digit.
+                    _ => Box::new(Ast::Char(e)),
+                });
+            }
+            self.err = REG_EESCAPE;
+            return None;
+        }
+
+        // Ordinary literal byte.
+        self.pos += 1;
+        Some(Box::new(Ast::Char(c)))
+    }
+
+    /// Parses a bracket expression `[...]`, with the leading `[` already consumed.
+    fn parse_set(&mut self) -> Option<Box<Ast>> {
+        let mut set: [u8; 32] = [0u8; 32];
+        let mut negate: bool = false;
+        if self.cur() == Some(b'^') {
+            negate = true;
+            self.pos += 1;
+        }
+        // A ']' immediately after '[' or '[^' is a literal ']'.
+        let mut first: bool = true;
+        while let Some(c) = self.cur() {
+            if c == b']' && !first {
+                self.pos += 1;
+                if negate {
+                    for b in set.iter_mut() {
+                        *b = !*b;
+                    }
+                    // POSIX: under `REG_NEWLINE`, a non-matching list never matches a newline.
+                    if self.newline {
+                        set_remove(&mut set, b'\n');
+                    }
+                }
+                return Some(Box::new(Ast::Set(set)));
+            }
+            first = false;
+
+            if c == b'[' && self.at(1) == Some(b':') {
+                self.pos += 2;
+                if !self.set_posix_class(&mut set) {
+                    return None;
+                }
+                continue;
+            }
+
+            self.pos += 1;
+            // Range: a-z (but '-' at the end or before ']' is a literal).
+            if self.cur() == Some(b'-') {
+                if let Some(hi) = self.at(1) {
+                    if hi != b']' {
+                        self.pos += 2;
+                        if hi < c {
+                            self.err = REG_ERANGE;
+                            return None;
+                        }
+                        let mut ci: u8 = c;
+                        loop {
+                            set_add(&mut set, ci);
+                            if ci == hi {
+                                break;
+                            }
+                            ci += 1;
+                        }
+                        continue;
+                    }
+                }
+            }
+            set_add(&mut set, c);
+        }
+        self.err = REG_EBRACK;
+        None
+    }
+
+    /// Adds a POSIX named class (e.g. `[:alpha:]`) to `set`, with `[:` already consumed.
+    fn set_posix_class(&mut self, set: &mut [u8; 32]) -> bool {
+        // Find the terminating ":]".
+        let start: usize = self.pos;
+        let mut q: usize = self.pos;
+        while let Some(b) = self.bytes.get(q) {
+            if *b == b':' {
+                break;
+            }
+            q += 1;
+        }
+        if self.bytes.get(q) != Some(&b':') || self.bytes.get(q + 1) != Some(&b']') {
+            self.err = REG_ECTYPE;
+            return false;
+        }
+        let name: &[u8] = match self.bytes.get(start..q) {
+            Some(n) => n,
+            None => {
+                self.err = REG_ECTYPE;
+                return false;
+            },
+        };
+        self.pos = q + 2;
+
+        let pred: fn(u8) -> bool = match name {
+            b"alpha" => |c| c.is_ascii_alphabetic(),
+            b"digit" => |c| c.is_ascii_digit(),
+            b"alnum" => |c| c.is_ascii_alphanumeric(),
+            b"space" => is_space_c,
+            b"upper" => |c| c.is_ascii_uppercase(),
+            b"lower" => |c| c.is_ascii_lowercase(),
+            b"blank" => |c| c == b' ' || c == b'\t',
+            b"punct" => |c| c.is_ascii_punctuation(),
+            b"cntrl" => |c| c.is_ascii_control(),
+            b"graph" => |c| c.is_ascii_graphic(),
+            b"print" => |c| c.is_ascii_graphic() || c == b' ',
+            b"xdigit" => |c| c.is_ascii_hexdigit(),
+            _ => {
+                self.err = REG_ECTYPE;
+                return false;
+            },
+        };
+        for b in 0u8..=255 {
+            if pred(b) {
+                set_add(set, b);
+            }
+        }
+        true
+    }
+
+    /// Parses a `{n,m}` / `\{n,m\}` interval, returning `(min, max)` (`max == -1` is unbounded).
+    fn parse_interval(&mut self) -> Option<(i32, i32)> {
+        let mut min: i32 = 0;
+        let mut max: i32 = 0;
+        let mut have_min: bool = false;
+        let mut have_max: bool = false;
+        let mut comma: bool = false;
+        while let Some(c) = self.cur() {
+            if c.is_ascii_digit() {
+                min = match accumulate_digit(min, c) {
+                    Some(v) => v,
+                    None => {
+                        self.err = REG_BADBR;
+                        return None;
+                    },
+                };
+                have_min = true;
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.cur() == Some(b',') {
+            comma = true;
+            self.pos += 1;
+            while let Some(c) = self.cur() {
+                if c.is_ascii_digit() {
+                    max = match accumulate_digit(max, c) {
+                        Some(v) => v,
+                        None => {
+                            self.err = REG_BADBR;
+                            return None;
+                        },
+                    };
+                    have_max = true;
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        // Consume the closing brace: '}' (ERE) or '\}' (BRE).
+        if self.ere {
+            if self.cur() != Some(b'}') {
+                self.err = REG_EBRACE;
+                return None;
+            }
+            self.pos += 1;
+        } else {
+            if self.cur() != Some(b'\\') || self.at(1) != Some(b'}') {
+                self.err = REG_EBRACE;
+                return None;
+            }
+            self.pos += 2;
+        }
+        if !have_min {
+            self.err = REG_BADBR;
+            return None;
+        }
+        let pmax: i32 = if !comma {
+            min
+        } else if !have_max {
+            -1
+        } else {
+            max
+        };
+        if pmax != -1 && pmax < min {
+            self.err = REG_BADBR;
+            return None;
+        }
+        Some((min, pmax))
+    }
+
+    /// Consumes a quantifier if present, returning `(min, max)`; `None` means no quantifier (or an
+    /// error, in which case `self.err` is set).
+    fn parse_quant(&mut self) -> Option<(i32, i32, bool)> {
+        let c: u8 = self.cur()?;
+        if c == b'*' {
+            self.pos += 1;
+            return Some((0, -1, self.parse_minimal_suffix()));
+        }
+        if self.ere {
+            if c == b'+' {
+                self.pos += 1;
+                return Some((1, -1, self.parse_minimal_suffix()));
+            }
+            if c == b'?' {
+                self.pos += 1;
+                return Some((0, 1, self.parse_minimal_suffix()));
+            }
+            if c == b'{' {
+                self.pos += 1;
+                return self.parse_interval().map(|(min, max)| {
+                    let minimal: bool = self.parse_minimal_suffix();
+                    (min, max, minimal)
+                });
+            }
+        } else if c == b'\\' {
+            if let Some(e) = self.at(1) {
+                if e == b'+' {
+                    self.pos += 2;
+                    return Some((1, -1, false));
+                }
+                if e == b'?' {
+                    self.pos += 2;
+                    return Some((0, 1, false));
+                }
+                if e == b'{' {
+                    self.pos += 2;
+                    return self.parse_interval().map(|(min, max)| (min, max, false));
+                }
+            }
+        }
+        None
+    }
+
+    /// Parses an ERE repetition modifier (`?`) and returns whether the repetition is minimal.
+    fn parse_minimal_suffix(&mut self) -> bool {
+        let mut minimal: bool = self.ere && self.minimal;
+        if self.ere && self.cur() == Some(b'?') {
+            self.pos += 1;
+            minimal = !minimal;
+        }
+        minimal
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Accumulates decimal digit `c` into `acc`, returning `None` on `i32` overflow.
+fn accumulate_digit(acc: c_int, c: u8) -> Option<c_int> {
+    acc.checked_mul(10)?.checked_add(c_int::from(c - b'0'))
+}
+
+/// Builds the membership bitmap for a GNU shorthand class (`\w \W \s \S \d \D`).
+fn shorthand_class(e: u8, newline: bool) -> [u8; 32] {
+    let mut set: [u8; 32] = [0u8; 32];
+    let lower: u8 = e.to_ascii_lowercase();
+    for b in 0u8..=255 {
+        let add: bool = match lower {
+            b'w' => b.is_ascii_alphanumeric() || b == b'_',
+            b's' => is_space_c(b),
+            b'd' => b.is_ascii_digit(),
+            _ => false,
+        };
+        if add {
+            set_add(&mut set, b);
+        }
+    }
+    if e.is_ascii_uppercase() {
+        for x in set.iter_mut() {
+            *x = !*x;
+        }
+        // POSIX: under `REG_NEWLINE`, a complemented class never matches a newline.
+        if newline {
+            set_remove(&mut set, b'\n');
+        }
+    }
+    set
+}

--- a/src/libs/libc_regex/src/prog.rs
+++ b/src/libs/libc_regex/src/prog.rs
@@ -1,0 +1,243 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::ast::Ast;
+use alloc::vec::Vec;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// A single instruction of the compiled NFA program.
+pub(crate) enum Inst {
+    /// Match a single literal byte.
+    Char(u8),
+    /// Match any byte (except a newline under `REG_NEWLINE`).
+    Any,
+    /// Match any byte unconditionally, including a newline under `REG_NEWLINE`.
+    ///
+    /// Used only by the unanchored search prelude, whose byte-skipping must not be constrained by
+    /// newline sensitivity (which POSIX applies only to `.`, anchors, and complemented classes).
+    AnyByte,
+    /// Match a byte against a 256-bit class bitmap.
+    Set([u8; 32]),
+    /// Record the current position into the given submatch slot.
+    Save(usize),
+    /// Fork execution: try the first target, then the second.
+    ///
+    /// When the boolean is set, taking the second target adds a lazy-repetition penalty.
+    Split(usize, usize, bool),
+    /// Jump to the given target.
+    Jmp(usize),
+    /// Assert the beginning of the line/string.
+    Bol,
+    /// Assert the end of the line/string.
+    Eol,
+    /// Accept the match.
+    Match,
+}
+
+/// A compiled regular expression program.
+pub(crate) struct Prog {
+    /// Instruction stream.
+    pub(crate) insts: Vec<Inst>,
+    /// Number of capturing groups.
+    pub(crate) nsub: i32,
+    /// Whether matching is case-insensitive.
+    pub(crate) icase: bool,
+    /// Whether matching is newline-sensitive.
+    pub(crate) newline: bool,
+}
+
+//==================================================================================================
+// Compiler
+//==================================================================================================
+
+/// Appends an instruction and returns its index.
+fn emit(insts: &mut Vec<Inst>, inst: Inst) -> usize {
+    insts.push(inst);
+    insts.len() - 1
+}
+
+/// Sets the first target of a `Split` instruction.
+fn patch_split_x(insts: &mut [Inst], idx: usize, x: usize) {
+    if let Some(Inst::Split(xx, _, _)) = insts.get_mut(idx) {
+        *xx = x;
+    }
+}
+
+/// Sets the second target of a `Split` instruction.
+fn patch_split_y(insts: &mut [Inst], idx: usize, y: usize) {
+    if let Some(Inst::Split(_, yy, _)) = insts.get_mut(idx) {
+        *yy = y;
+    }
+}
+
+/// Sets the target of a `Jmp` instruction.
+fn patch_jmp(insts: &mut [Inst], idx: usize, x: usize) {
+    if let Some(Inst::Jmp(xx)) = insts.get_mut(idx) {
+        *xx = x;
+    }
+}
+
+/// Sets the membership bit for byte `c` in a 32-byte bitmap.
+fn bit_set(set: &mut [u8; 32], c: u8) {
+    set[usize::from(c >> 3)] |= 1u8 << (c & 7);
+}
+
+/// Folds a class bitmap so that, for every member, both ASCII cases are present.
+fn fold_set_icase(set: &mut [u8; 32]) {
+    let orig: [u8; 32] = *set;
+    for b in 0u8..=255 {
+        if orig[usize::from(b >> 3)] & (1u8 << (b & 7)) != 0 {
+            bit_set(set, b.to_ascii_lowercase());
+            bit_set(set, b.to_ascii_uppercase());
+        }
+    }
+}
+
+/// Emits the instructions for a single AST node.
+fn compile_node(insts: &mut Vec<Inst>, node: &Ast) {
+    match node {
+        Ast::Empty => {},
+        Ast::Char(c) => {
+            emit(insts, Inst::Char(*c));
+        },
+        Ast::Any => {
+            emit(insts, Inst::Any);
+        },
+        Ast::Set(s) => {
+            emit(insts, Inst::Set(*s));
+        },
+        Ast::Bol => {
+            emit(insts, Inst::Bol);
+        },
+        Ast::Eol => {
+            emit(insts, Inst::Eol);
+        },
+        Ast::Cat(l, r) => {
+            compile_node(insts, l);
+            compile_node(insts, r);
+        },
+        Ast::Alt(l, r) => {
+            // split A, B ; A: l ; jmp End ; B: r ; End:
+            let split: usize = emit(insts, Inst::Split(0, 0, false));
+            let here: usize = insts.len();
+            patch_split_x(insts, split, here);
+            compile_node(insts, l);
+            let jmp: usize = emit(insts, Inst::Jmp(0));
+            let here: usize = insts.len();
+            patch_split_y(insts, split, here);
+            compile_node(insts, r);
+            let here: usize = insts.len();
+            patch_jmp(insts, jmp, here);
+        },
+        Ast::Rep(sub, min, max, minimal) => compile_rep(insts, sub, *min, *max, *minimal),
+        Ast::Group(g, sub) => {
+            let base: usize = 2 * usize::try_from(*g).unwrap_or(0);
+            emit(insts, Inst::Save(base));
+            compile_node(insts, sub);
+            emit(insts, Inst::Save(base + 1));
+        },
+    }
+}
+
+/// Emits the instructions for a repetition `[min, max]` of `sub`.
+fn compile_rep(insts: &mut Vec<Inst>, sub: &Ast, min: i32, max: i32, minimal: bool) {
+    // Emit `min` mandatory copies.
+    let mn: i32 = min.max(0);
+    for _ in 0..mn {
+        compile_node(insts, sub);
+    }
+    if max == -1 {
+        // zero-or-more tail: L: split A, B ; A: sub ; jmp L ; B:
+        let l: usize = insts.len();
+        let split: usize = emit(insts, Inst::Split(0, 0, minimal));
+        let here: usize = insts.len();
+        if minimal {
+            patch_split_y(insts, split, here);
+        } else {
+            patch_split_x(insts, split, here);
+        }
+        compile_node(insts, sub);
+        emit(insts, Inst::Jmp(l));
+        let here: usize = insts.len();
+        if minimal {
+            patch_split_x(insts, split, here);
+        } else {
+            patch_split_y(insts, split, here);
+        }
+    } else {
+        // up to (max - min) optional copies: split Ai, End ; sub
+        let opt: i32 = (max - mn).max(0);
+        let mut splits: Vec<usize> = Vec::new();
+        for _ in 0..opt {
+            let split: usize = emit(insts, Inst::Split(0, 0, minimal));
+            splits.push(split);
+            let here: usize = insts.len();
+            if minimal {
+                patch_split_y(insts, split, here);
+            } else {
+                patch_split_x(insts, split, here);
+            }
+            compile_node(insts, sub);
+        }
+        let here: usize = insts.len();
+        for s in &splits {
+            if minimal {
+                patch_split_x(insts, *s, here);
+            } else {
+                patch_split_y(insts, *s, here);
+            }
+        }
+    }
+}
+
+/// Compiles an AST into a runnable [`Prog`].
+///
+/// The program is prefixed with a non-greedy ".*?" skip loop so the pattern can start at any
+/// position (leftmost match), and the whole match is captured into slots `0`/`1`.
+pub(crate) fn build_prog(tree: &Ast, nsub: i32, icase: bool, newline: bool) -> Prog {
+    let mut insts: Vec<Inst> = Vec::new();
+
+    // Unanchored leftmost search prelude:
+    //   0: SPLIT 3, 1   (try the pattern first; else skip a byte)
+    //   1: ANYBYTE
+    //   2: JMP 0
+    //   3: SAVE 0       (pattern start)
+    //
+    // The skip step uses `AnyByte` (not `Any`) so the search can advance past newlines even under
+    // `REG_NEWLINE`; newline sensitivity must constrain only `.`, anchors, and complemented
+    // classes, not the leftmost-search machinery.
+    emit(&mut insts, Inst::Split(3, 1, false));
+    emit(&mut insts, Inst::AnyByte);
+    emit(&mut insts, Inst::Jmp(0));
+    emit(&mut insts, Inst::Save(0));
+
+    compile_node(&mut insts, tree);
+
+    emit(&mut insts, Inst::Save(1));
+    emit(&mut insts, Inst::Match);
+
+    // Fold literals and classes to be case-insensitive, if requested.
+    if icase {
+        for inst in insts.iter_mut() {
+            match inst {
+                Inst::Char(c) => *c = c.to_ascii_lowercase(),
+                Inst::Set(s) => fold_set_icase(s),
+                _ => {},
+            }
+        }
+    }
+
+    Prog {
+        insts,
+        nsub,
+        icase,
+        newline,
+    }
+}

--- a/src/libs/libc_regex/src/regcomp.rs
+++ b/src/libs/libc_regex/src/regcomp.rs
@@ -1,0 +1,94 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    parser::Parser,
+    prog::{
+        build_prog,
+        Prog,
+    },
+    types::{
+        regex_t,
+        REG_BADPAT,
+        REG_EXTENDED,
+        REG_ICASE,
+        REG_MINIMAL,
+        REG_NEWLINE,
+        REG_NOERROR,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_void,
+};
+use alloc::boxed::Box;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Compiles the regular expression `pattern` into `preg` according to `cflags`.
+///
+/// # Parameters
+///
+/// - `preg`: Output compiled-expression structure.
+/// - `pattern`: NUL-terminated regular expression to compile.
+/// - `cflags`: Bitwise OR of `REG_EXTENDED`, `REG_ICASE`, `REG_MINIMAL`, `REG_NEWLINE`, and
+///   `REG_NOSUB`.
+///
+/// # Returns
+///
+/// Returns `REG_NOERROR` (`0`) on success, or a non-zero `REG_*` error code on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `preg` and `pattern`. The
+/// caller must ensure that `preg` points to a writable `regex_t` and that `pattern` points to a
+/// valid NUL-terminated string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn regcomp(
+    preg: *mut regex_t,
+    pattern: *const c_char,
+    cflags: c_int,
+) -> c_int {
+    if preg.is_null() || pattern.is_null() {
+        return REG_BADPAT;
+    }
+
+    let bytes: &[u8] = core::ffi::CStr::from_ptr(pattern).to_bytes();
+    let ere: bool = cflags & REG_EXTENDED != 0;
+    let icase: bool = cflags & REG_ICASE != 0;
+    let newline: bool = cflags & REG_NEWLINE != 0;
+    let minimal: bool = ere && cflags & REG_MINIMAL != 0;
+
+    let mut parser: Parser = Parser::new(bytes, ere, newline, minimal);
+    let tree = parser.parse_alt();
+    if parser.err != 0 || !parser.at_end() {
+        return if parser.err != 0 {
+            parser.err
+        } else {
+            REG_BADPAT
+        };
+    }
+    let tree = match tree {
+        Some(tree) => tree,
+        None => return REG_BADPAT,
+    };
+
+    let prog: Prog = build_prog(&tree, parser.ngroup, icase, newline);
+    let boxed: Box<Prog> = Box::new(prog);
+
+    (*preg).re_nsub = usize::try_from(parser.ngroup).unwrap_or(0);
+    (*preg).priv_ = Box::into_raw(boxed).cast::<c_void>();
+    (*preg).cflags = cflags;
+    REG_NOERROR
+}

--- a/src/libs/libc_regex/src/regerror.rs
+++ b/src/libs/libc_regex/src/regerror.rs
@@ -1,0 +1,90 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::types::{
+    regex_t,
+    REG_BADBR,
+    REG_BADPAT,
+    REG_BADRPT,
+    REG_EBRACE,
+    REG_EBRACK,
+    REG_ECOLLATE,
+    REG_ECTYPE,
+    REG_EESCAPE,
+    REG_EPAREN,
+    REG_ERANGE,
+    REG_ESPACE,
+    REG_ESUBREG,
+    REG_NOMATCH,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Produces a human-readable message for the regex error code `errcode`.
+///
+/// # Parameters
+///
+/// - `errcode`: A `REG_*` error code returned by `regcomp()` or `regexec()`.
+/// - `_preg`: Unused; accepted for POSIX compatibility.
+/// - `errbuf`: Optional buffer that receives the NUL-terminated message.
+/// - `errbuf_size`: Size of `errbuf`, in bytes.
+///
+/// # Returns
+///
+/// Returns the size of the buffer needed to hold the message, including the terminating NUL.
+///
+/// # Safety
+///
+/// This function is unsafe because it writes through the raw pointer `errbuf`. The caller must
+/// ensure that `errbuf` (if non-null) has room for `errbuf_size` bytes.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn regerror(
+    errcode: c_int,
+    _preg: *const regex_t,
+    errbuf: *mut c_char,
+    errbuf_size: usize,
+) -> usize {
+    let msg: &[u8] = match errcode {
+        REG_NOMATCH => b"no match",
+        REG_BADPAT => b"invalid regular expression",
+        REG_ECOLLATE => b"invalid collating element",
+        REG_EBRACK => b"unbalanced [",
+        REG_EPAREN => b"unbalanced (",
+        REG_EBRACE => b"unbalanced {",
+        REG_BADBR => b"invalid {} content",
+        REG_ERANGE => b"invalid range",
+        REG_ECTYPE => b"invalid character class",
+        REG_EESCAPE => b"trailing backslash",
+        REG_ESUBREG => b"invalid back reference",
+        REG_ESPACE => b"out of memory",
+        REG_BADRPT => b"invalid repetition",
+        _ => b"regex error",
+    };
+    let len: usize = msg.len();
+    if !errbuf.is_null() && errbuf_size > 0 {
+        let n: usize = if len < errbuf_size - 1 {
+            len
+        } else {
+            errbuf_size - 1
+        };
+        for (i, &b) in msg.iter().take(n).enumerate() {
+            *errbuf.add(i).cast::<u8>() = b;
+        }
+        *errbuf.add(n).cast::<u8>() = 0;
+    }
+    len + 1
+}

--- a/src/libs/libc_regex/src/regexec.rs
+++ b/src/libs/libc_regex/src/regexec.rs
@@ -1,0 +1,92 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    matcher::exec,
+    prog::Prog,
+    types::{
+        regex_t,
+        regmatch_t,
+        regoff_t,
+        REG_NOERROR,
+        REG_NOMATCH,
+        REG_NOSUB,
+        REG_NOTBOL,
+        REG_NOTEOL,
+    },
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Matches the compiled regular expression `preg` against `string`.
+///
+/// # Parameters
+///
+/// - `preg`: Compiled expression produced by `regcomp()`.
+/// - `string`: NUL-terminated subject string.
+/// - `nmatch`: Number of entries available in `pmatch`.
+/// - `pmatch`: Optional array that receives the match and submatch offsets.
+/// - `eflags`: Bitwise OR of `REG_NOTBOL` and `REG_NOTEOL`.
+///
+/// # Returns
+///
+/// Returns `REG_NOERROR` (`0`) if the pattern matches, or `REG_NOMATCH` otherwise.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `preg`, `string`, and (when
+/// non-null) `pmatch`. The caller must ensure that `preg` was initialized by `regcomp()`, that
+/// `string` points to a valid NUL-terminated string, and that `pmatch` (if non-null) has room for
+/// `nmatch` entries.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn regexec(
+    preg: *const regex_t,
+    string: *const c_char,
+    nmatch: usize,
+    pmatch: *mut regmatch_t,
+    eflags: c_int,
+) -> c_int {
+    if preg.is_null() || string.is_null() {
+        return REG_NOMATCH;
+    }
+    let priv_: *mut core::ffi::c_void = (*preg).priv_;
+    if priv_.is_null() {
+        return REG_NOMATCH;
+    }
+    let prog: &Prog = &*priv_.cast::<Prog>();
+    let s: &[u8] = core::ffi::CStr::from_ptr(string).to_bytes();
+    let notbol: bool = eflags & REG_NOTBOL != 0;
+    let noteol: bool = eflags & REG_NOTEOL != 0;
+
+    match exec(prog, s, notbol, noteol) {
+        None => REG_NOMATCH,
+        Some(matched) => {
+            let nosub: bool = (*preg).cflags & REG_NOSUB != 0;
+            if !nosub && nmatch > 0 && !pmatch.is_null() {
+                for i in 0..nmatch {
+                    let so: i32 = matched.get(2 * i).copied().unwrap_or(-1);
+                    let eo: i32 = matched.get(2 * i + 1).copied().unwrap_or(-1);
+                    let m: &mut regmatch_t = &mut *pmatch.add(i);
+                    // Widen the engine's internal `i32` offsets to the public `regoff_t`.
+                    m.rm_so = regoff_t::try_from(so).unwrap_or(-1);
+                    m.rm_eo = regoff_t::try_from(eo).unwrap_or(-1);
+                }
+            }
+            REG_NOERROR
+        },
+    }
+}

--- a/src/libs/libc_regex/src/regfree.rs
+++ b/src/libs/libc_regex/src/regfree.rs
@@ -1,0 +1,44 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    prog::Prog,
+    types::regex_t,
+};
+use alloc::boxed::Box;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Releases the storage associated with the compiled expression `preg`.
+///
+/// # Parameters
+///
+/// - `preg`: Compiled expression produced by `regcomp()`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `preg` and reclaims the boxed
+/// program it owns. The caller must ensure that `preg` was initialized by `regcomp()` and is not
+/// used again after this call (without a fresh `regcomp()`).
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn regfree(preg: *mut regex_t) {
+    if preg.is_null() {
+        return;
+    }
+    let priv_: *mut core::ffi::c_void = (*preg).priv_;
+    if priv_.is_null() {
+        return;
+    }
+    drop(Box::from_raw(priv_.cast::<Prog>()));
+    (*preg).priv_ = core::ptr::null_mut();
+}

--- a/src/libs/libc_regex/src/tests.rs
+++ b/src/libs/libc_regex/src/tests.rs
@@ -1,0 +1,265 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    regcomp::regcomp,
+    regerror::regerror,
+    regexec::regexec,
+    regfree::regfree,
+    types::{
+        regex_t,
+        regmatch_t,
+        REG_EESCAPE,
+        REG_EXTENDED,
+        REG_ICASE,
+        REG_MINIMAL,
+        REG_NEWLINE,
+        REG_NOERROR,
+        REG_NOMATCH,
+        REG_NOTBOL,
+        REG_NOTEOL,
+    },
+};
+use ::std::{
+    ffi::CString,
+    vec::Vec,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Returns a freshly zeroed `regex_t`.
+fn blank() -> regex_t {
+    regex_t {
+        re_nsub: 0,
+        priv_: core::ptr::null_mut(),
+        cflags: 0,
+    }
+}
+
+/// Compiles `pattern` with `cflags`, returning the compiled expression and the status code.
+fn compile(pattern: &str, cflags: c_int) -> (regex_t, c_int) {
+    let mut re: regex_t = blank();
+    let cs: CString = CString::new(pattern).expect("pattern has no interior NUL");
+    let rc: c_int = unsafe { regcomp(&mut re, cs.as_ptr(), cflags) };
+    (re, rc)
+}
+
+/// Executes `re` against `string`, capturing up to `nmatch` offsets.
+fn run(re: &regex_t, string: &str, nmatch: usize, eflags: c_int) -> (c_int, Vec<(isize, isize)>) {
+    let cs: CString = CString::new(string).expect("string has no interior NUL");
+    let mut pm: Vec<regmatch_t> = ::std::vec![regmatch_t { rm_so: -2, rm_eo: -2 }; nmatch.max(1)];
+    let rc: c_int = unsafe { regexec(re, cs.as_ptr(), nmatch, pm.as_mut_ptr(), eflags) };
+    let offs: Vec<(isize, isize)> = pm.iter().map(|m| (m.rm_so, m.rm_eo)).collect();
+    (rc, offs)
+}
+
+/// Convenience: compile + match in one shot, returning the whole-match offsets.
+fn whole_match(pattern: &str, cflags: c_int, string: &str) -> Option<(isize, isize)> {
+    let (mut re, rc) = compile(pattern, cflags);
+    assert_eq!(rc, REG_NOERROR, "compile failed for {pattern:?}");
+    let (rc, offs) = run(&re, string, 1, 0);
+    unsafe { regfree(&mut re) };
+    if rc == REG_NOERROR {
+        Some(offs[0])
+    } else {
+        None
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[test]
+fn literal_bre() {
+    assert_eq!(whole_match("abc", 0, "xabcy"), Some((1, 4)));
+    assert_eq!(whole_match("abc", 0, "xyz"), None);
+}
+
+#[test]
+fn anchors() {
+    assert_eq!(whole_match("^abc", 0, "abcd"), Some((0, 3)));
+    assert_eq!(whole_match("^abc", 0, "xabc"), None);
+    assert_eq!(whole_match("abc$", 0, "xabc"), Some((1, 4)));
+    assert_eq!(whole_match("abc$", 0, "abcx"), None);
+}
+
+#[test]
+fn dot_any() {
+    assert_eq!(whole_match("a.c", 0, "axc"), Some((0, 3)));
+    assert_eq!(whole_match("a.c", 0, "ac"), None);
+}
+
+#[test]
+fn star_and_plus() {
+    assert_eq!(whole_match("ab*c", 0, "ac"), Some((0, 2)));
+    assert_eq!(whole_match("ab*c", 0, "abbbc"), Some((0, 5)));
+    // '+' is special only in ERE.
+    assert_eq!(whole_match("ab+c", REG_EXTENDED, "ac"), None);
+    assert_eq!(whole_match("ab+c", REG_EXTENDED, "abc"), Some((0, 3)));
+}
+
+#[test]
+fn alternation_ere() {
+    assert_eq!(whole_match("cat|dog", REG_EXTENDED, "hotdog"), Some((3, 6)));
+    assert_eq!(whole_match("cat|dog", REG_EXTENDED, "bird"), None);
+}
+
+#[test]
+fn bre_alternation_and_groups() {
+    // BRE uses \| and \( \).
+    assert_eq!(whole_match("\\(ab\\)*", 0, "ababx"), Some((0, 4)));
+    assert_eq!(whole_match("a\\|b", 0, "b"), Some((0, 1)));
+}
+
+#[test]
+fn capture_groups() {
+    let (mut re, rc) = compile("(a+)(b+)", REG_EXTENDED);
+    assert_eq!(rc, REG_NOERROR);
+    assert_eq!(re.re_nsub, 2);
+    let (rc, offs) = run(&re, "aabbb", 3, 0);
+    unsafe { regfree(&mut re) };
+    assert_eq!(rc, REG_NOERROR);
+    assert_eq!(offs[0], (0, 5));
+    assert_eq!(offs[1], (0, 2));
+    assert_eq!(offs[2], (2, 5));
+}
+
+#[test]
+fn character_classes() {
+    assert_eq!(whole_match("[0-9][0-9]*", 0, "abc123"), Some((3, 6)));
+    assert_eq!(whole_match("[[:digit:]][[:digit:]]*", 0, "x42y"), Some((1, 3)));
+    assert_eq!(whole_match("[^0-9]*", 0, "ab9"), Some((0, 2)));
+}
+
+#[test]
+fn shorthand_classes() {
+    assert_eq!(whole_match("\\w\\w*", REG_EXTENDED, " foo "), Some((1, 4)));
+    assert_eq!(whole_match("\\d\\d*", REG_EXTENDED, "a12"), Some((1, 3)));
+}
+
+#[test]
+fn intervals() {
+    assert_eq!(whole_match("a{2,3}", REG_EXTENDED, "aaaa"), Some((0, 3)));
+    assert_eq!(whole_match("a{2}", REG_EXTENDED, "aaaa"), Some((0, 2)));
+    assert_eq!(whole_match("a{2,}", REG_EXTENDED, "aaaa"), Some((0, 4)));
+    assert_eq!(whole_match("ba{2,3}", REG_EXTENDED, "ba"), None);
+}
+
+#[test]
+fn case_insensitive() {
+    assert_eq!(whole_match("abc", REG_ICASE, "xABCy"), Some((1, 4)));
+    assert_eq!(whole_match("[a-z]*", REG_ICASE, "ABC"), Some((0, 3)));
+}
+
+#[test]
+fn newline_sensitivity() {
+    // Under REG_NEWLINE, '.' (and ANY) no longer match a newline.
+    assert_eq!(whole_match("a.b", REG_EXTENDED, "a\nb"), Some((0, 3)));
+    assert_eq!(whole_match("a.b", REG_EXTENDED | REG_NEWLINE, "a\nb"), None);
+    // '$' matches just before an embedded newline under REG_NEWLINE.
+    assert_eq!(whole_match("a$", REG_NEWLINE, "a\nb"), Some((0, 1)));
+    assert_eq!(whole_match("a$", 0, "a\nb"), None);
+
+    // The unanchored search must still advance past embedded newlines under REG_NEWLINE, so a
+    // pattern can match on a line after the first.
+    assert_eq!(whole_match("b", REG_NEWLINE, "a\nb"), Some((2, 3)));
+    assert_eq!(whole_match("b", REG_EXTENDED | REG_NEWLINE, "a\nb"), Some((2, 3)));
+
+    // A positive bracket expression still matches '\n' when it is explicitly included.
+    assert_eq!(whole_match("a[\n]b", REG_EXTENDED | REG_NEWLINE, "a\nb"), Some((0, 3)));
+    assert_eq!(whole_match("[\n]", REG_NEWLINE, "a\nb"), Some((1, 2)));
+    // A complemented bracket expression does not match '\n' under REG_NEWLINE, even though it
+    // would otherwise (without the flag).
+    assert_eq!(whole_match("a[^x]b", REG_EXTENDED | REG_NEWLINE, "a\nb"), None);
+    assert_eq!(whole_match("a[^x]b", REG_EXTENDED, "a\nb"), Some((0, 3)));
+}
+
+#[test]
+fn notbol_noteol() {
+    let (mut re, rc) = compile("^a", 0);
+    assert_eq!(rc, REG_NOERROR);
+    let (rc_plain, _) = run(&re, "abc", 1, 0);
+    let (rc_notbol, _) = run(&re, "abc", 1, REG_NOTBOL);
+    unsafe { regfree(&mut re) };
+    assert_eq!(rc_plain, REG_NOERROR);
+    assert_eq!(rc_notbol, REG_NOMATCH);
+
+    let (mut re, rc) = compile("c$", 0);
+    assert_eq!(rc, REG_NOERROR);
+    let (rc_plain, _) = run(&re, "abc", 1, 0);
+    let (rc_noteol, _) = run(&re, "abc", 1, REG_NOTEOL);
+    unsafe { regfree(&mut re) };
+    assert_eq!(rc_plain, REG_NOERROR);
+    assert_eq!(rc_noteol, REG_NOMATCH);
+}
+
+#[test]
+fn leftmost_longest_like() {
+    // Leftmost start wins; the greedy star then extends as far as possible.
+    assert_eq!(whole_match("a.*b", REG_EXTENDED, "xaybzbq"), Some((1, 6)));
+}
+
+#[test]
+fn leftmost_longest_alternation() {
+    assert_eq!(whole_match("a|ab", REG_EXTENDED, "ab"), Some((0, 2)));
+    // The shorter first-group alternative yields the longest overall match.
+    assert_eq!(whole_match("(ab|a)(c|bcd)", REG_EXTENDED, "abcd"), Some((0, 4)));
+}
+
+#[test]
+fn minimal_repetition() {
+    assert_eq!(whole_match("a.*b", REG_EXTENDED | REG_MINIMAL, "axbyb"), Some((0, 3)));
+    assert_eq!(whole_match("a.*?b", REG_EXTENDED, "axbyb"), Some((0, 3)));
+    assert_eq!(whole_match("a.*?b.*c", REG_EXTENDED, "axbycxxc"), Some((0, 8)));
+}
+
+#[test]
+fn compile_errors() {
+    let (_, rc) = compile("(", REG_EXTENDED);
+    assert_ne!(rc, REG_NOERROR);
+    let (_, rc) = compile("[abc", REG_EXTENDED);
+    assert_ne!(rc, REG_NOERROR);
+    let (_, rc) = compile("a{3,2}", REG_EXTENDED);
+    assert_ne!(rc, REG_NOERROR);
+    let (_, rc) = compile("abc\\", REG_EXTENDED);
+    assert_eq!(rc, REG_EESCAPE);
+}
+
+#[test]
+fn regerror_message() {
+    let mut buf: [c_char; 32] = [0; 32];
+    let need: usize =
+        unsafe { regerror(REG_NOMATCH, core::ptr::null(), buf.as_mut_ptr(), buf.len()) };
+    assert_eq!(need, b"no match".len() + 1);
+    let bytes: Vec<u8> = buf
+        .iter()
+        .take_while(|&&c| c != 0)
+        .map(|&c| c as u8)
+        .collect();
+    assert_eq!(&bytes, b"no match");
+}
+
+#[test]
+fn regerror_truncation() {
+    let mut buf: [c_char; 4] = [0; 4];
+    let need: usize =
+        unsafe { regerror(REG_BADPAT_CODE, core::ptr::null(), buf.as_mut_ptr(), buf.len()) };
+    // The needed size reflects the full message, even though the buffer is small.
+    assert!(need > 4);
+    // The buffer is NUL-terminated within its bounds.
+    assert_eq!(buf[3], 0);
+}
+
+/// Local alias so the truncation test does not need to import the constant by a long path.
+const REG_BADPAT_CODE: c_int = crate::types::REG_BADPAT;

--- a/src/libs/libc_regex/src/types.rs
+++ b/src/libs/libc_regex/src/types.rs
@@ -1,0 +1,107 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Signed byte offset within a string, as used by `regmatch_t`.
+///
+/// POSIX requires `regoff_t` to be a signed integer type wide enough to hold the largest value
+/// representable by `ptrdiff_t`/`ssize_t`. It is therefore defined as `isize`, matching the
+/// `ptrdiff_t`-based typedef emitted in the generated `regex.h`.
+pub type regoff_t = isize;
+
+/// Compiled regular expression.
+///
+/// Only `re_nsub` is part of the public POSIX contract; the remaining fields are private to this
+/// implementation. The layout matches the `regex_t` declared in the generated `regex.h`.
+#[repr(C)]
+pub struct regex_t {
+    /// Number of parenthesized subexpressions in the pattern.
+    pub re_nsub: usize,
+    /// Opaque pointer to the compiled program (a boxed [`crate::prog::Prog`]).
+    pub priv_: *mut c_void,
+    /// Compile flags captured at `regcomp()` time.
+    pub cflags: c_int,
+}
+
+/// Match offsets for a single (sub)expression.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct regmatch_t {
+    /// Byte offset of the start of the match, or `-1` if unused.
+    pub rm_so: regoff_t,
+    /// Byte offset just past the end of the match, or `-1` if unused.
+    pub rm_eo: regoff_t,
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Compile flags (cflags) for `regcomp()`.
+
+/// Use Extended Regular Expression syntax.
+pub const REG_EXTENDED: c_int = 0x0001;
+/// Ignore case when matching.
+pub const REG_ICASE: c_int = 0x0002;
+/// Newline-sensitive matching.
+pub const REG_NEWLINE: c_int = 0x0004;
+/// Report only success/failure; do not record submatches.
+pub const REG_NOSUB: c_int = 0x0008;
+/// Prefer the leftmost shortest match for ERE duplication symbols.
+pub const REG_MINIMAL: c_int = 0x0010;
+
+// Execution flags (eflags) for `regexec()`.
+
+/// The beginning of the string is not the beginning of a line.
+pub const REG_NOTBOL: c_int = 0x0100;
+/// The end of the string is not the end of a line.
+pub const REG_NOTEOL: c_int = 0x0200;
+
+// Result and error codes.
+
+/// Success.
+pub const REG_NOERROR: c_int = 0;
+/// The pattern did not match.
+pub const REG_NOMATCH: c_int = 1;
+/// Invalid regular expression.
+pub const REG_BADPAT: c_int = 2;
+/// Invalid collating element.
+pub const REG_ECOLLATE: c_int = 3;
+/// Invalid character class name.
+pub const REG_ECTYPE: c_int = 4;
+/// Trailing backslash.
+pub const REG_EESCAPE: c_int = 5;
+/// Invalid back reference.
+pub const REG_ESUBREG: c_int = 6;
+/// Unbalanced `[` `]`.
+pub const REG_EBRACK: c_int = 7;
+/// Unbalanced `(` `)`.
+pub const REG_EPAREN: c_int = 8;
+/// Unbalanced `{` `}`.
+pub const REG_EBRACE: c_int = 9;
+/// Invalid content of `{` `}`.
+pub const REG_BADBR: c_int = 10;
+/// Invalid range end.
+pub const REG_ERANGE: c_int = 11;
+/// Out of memory.
+pub const REG_ESPACE: c_int = 12;
+/// `?`, `*`, or `+` not preceded by a valid expression.
+pub const REG_BADRPT: c_int = 13;

--- a/src/libs/nanvix_libc/Cargo.toml
+++ b/src/libs/nanvix_libc/Cargo.toml
@@ -19,6 +19,7 @@ libc_ctype = { workspace = true }
 libc_inttypes = { workspace = true }
 libc_langinfo = { workspace = true }
 libc_locale = { workspace = true }
+libc_regex = { workspace = true }
 # NOTE: the math routines (`libc_math`) are deliberately NOT pulled in here — they
 # are shipped as the separate `libm.a` archive (the `nanvix_libm` crate), mirroring
 # the GCC + newlib split of `libc.a` / `libm.a`. `libc.a` references no math

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -21,6 +21,7 @@ extern crate libc_ctype;
 extern crate libc_inttypes;
 extern crate libc_langinfo;
 extern crate libc_locale;
+extern crate libc_regex;
 extern crate libc_setjmp;
 extern crate libc_signal;
 extern crate libc_stdio;

--- a/src/posix-tests/regex-c/main.c
+++ b/src/posix-tests/regex-c/main.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <regex.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Compiles a regular expression and asserts success.
+static void compile_regex(regex_t *regex, const char *pattern, int cflags)
+{
+    int ret;
+
+    ret = regcomp(regex, pattern, cflags);
+    assert(ret == 0);
+}
+
+// Tests required POSIX types and leftmost-longest matching.
+static void test_leftmost_longest(void)
+{
+    regex_t regex;
+    regmatch_t match[1];
+    int ret;
+
+    assert(sizeof(match[0].rm_so) >= sizeof(ptrdiff_t));
+    assert(sizeof(match[0].rm_eo) >= sizeof(ptrdiff_t));
+
+    compile_regex(&regex, "a|ab", REG_EXTENDED);
+    ret = regexec(&regex, "ab", 1, match, 0);
+    assert(ret == 0);
+    assert(match[0].rm_so == 0);
+    assert(match[0].rm_eo == 2);
+    regfree(&regex);
+}
+
+// Tests REG_MINIMAL support added by POSIX Issue 8.
+static void test_minimal_repetition(void)
+{
+    regex_t regex;
+    regmatch_t match[1];
+    int ret;
+
+    compile_regex(&regex, "a.*b", REG_EXTENDED | REG_MINIMAL);
+    ret = regexec(&regex, "axbyb", 1, match, 0);
+    assert(ret == 0);
+    assert(match[0].rm_so == 0);
+    assert(match[0].rm_eo == 3);
+    regfree(&regex);
+}
+
+// Tests submatch reporting and unused pmatch entries.
+static void test_submatches(void)
+{
+    regex_t regex;
+    regmatch_t match[4];
+    int ret;
+
+    compile_regex(&regex, "(a+)(b+)", REG_EXTENDED);
+    assert(regex.re_nsub == 2);
+
+    ret = regexec(&regex, "zaabbbx", 4, match, 0);
+    assert(ret == 0);
+    assert(match[0].rm_so == 1);
+    assert(match[0].rm_eo == 6);
+    assert(match[1].rm_so == 1);
+    assert(match[1].rm_eo == 3);
+    assert(match[2].rm_so == 3);
+    assert(match[2].rm_eo == 6);
+    assert(match[3].rm_so == -1);
+    assert(match[3].rm_eo == -1);
+    regfree(&regex);
+}
+
+// Tests REG_NOSUB and regerror() buffer sizing/truncation.
+static void test_error_paths(void)
+{
+    regex_t regex;
+    char buffer[8];
+    size_t needed;
+    int ret;
+
+    compile_regex(&regex, "abc", REG_NOSUB);
+    ret = regexec(&regex, "abc", 0, NULL, 0);
+    assert(ret == 0);
+    regfree(&regex);
+
+    ret = regcomp(&regex, "abc\\", REG_EXTENDED);
+    assert(ret == REG_EESCAPE);
+
+    needed = regerror(REG_NOMATCH, NULL, buffer, sizeof(buffer));
+    assert(needed == strlen("no match") + 1);
+    assert(buffer[sizeof(buffer) - 1] == '\0');
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests POSIX regular-expression calls exposed by <regex.h>.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_leftmost_longest();
+    test_minimal_repetition();
+    test_submatches();
+    test_error_paths();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -179,6 +179,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/regex-c"
+program = "./bin/regex-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/setjmp-c"
 program = "./bin/setjmp-c.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -179,6 +179,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/regex-c"
+program = "./bin/regex-c.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/setjmp-c"
 program = "./bin/setjmp-c.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
Part of splitting the libc/BusyBox enablement work into per-crate branches, each based on `dev`. This PR groups the **1 commit(s)** that pertain to this crate.

### Commits
- [regex] E: Add libc_regex crate with regcomp()/regexec()/regerror()/regfree()

### Validation
- `./z build -- run-unit-tests`: ✅ pass
- `./z build -- run-nanvix-tests` (microvm): ✅ pass (64 integration tests)
