### PR TITLE
[kernel] Authoritative IPC client identity

### DIFF
--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -754,7 +754,7 @@ fn test_readdir_reports_directory_flag_and_size() {
 fn test_readdir_long_name_multipart_response() {
     let (mut handler, tmp) = setup();
     // A name longer than the inline `ReadDirEntry` capacity forces the multi-part
-    // response path. Use a name that comfortably exceeds MAX_DIR_ENTRY_NAME_LEN (29).
+    // response path. Use a name that comfortably exceeds MAX_DIR_ENTRY_NAME_LEN.
     let long_name: String = "l".repeat(180) + ".txt";
     assert!(long_name.len() > MAX_DIR_ENTRY_NAME_LEN, "test name must exceed the inline cap");
     fs::write(tmp.path().join(&long_name), b"payload!!").unwrap();

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -68,7 +68,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::syscall::venv::VirtualEnvironmentIdentifier;
 use ::syscomm::{
@@ -994,12 +997,15 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         let assembler: Arc<Mutex<RequestAssembler>> = self.assembler.clone();
         let venv_dir: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
 
-        let source: ThreadIdentifier = match { message.source }.as_id() {
-            Err(tid) => tid,
-            Ok(pid) => {
-                unimplemented!("received message from process {pid:?} instead of thread");
-            },
-        };
+        // The kernel stamps the originating thread into `message.source.tid`; a guest IKC request
+        // always names a concrete thread. A `NONE` sentinel names no specific thread, so reject it
+        // rather than keying virtual-environment state under the sentinel and misrouting work.
+        let source: ThreadIdentifier = { message.source }.tid;
+        if source.is_none() {
+            let reason: &str = "received message with no originating thread";
+            error!("forward_user_vm_msg_to_worker_thread(): {reason} (uvm_id={uvm_id})");
+            return Err(Error::new(ErrorCode::InvalidMessage, reason));
+        }
 
         // Ensure virtual environment association.
         let (channel_tx, channel_rx): (Sender<VenvCommand>, Option<Receiver<VenvCommand>>) = {
@@ -1091,8 +1097,8 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
 ///
 pub fn build_error(tid: ThreadIdentifier, error: ErrorCode) -> Message {
     Message::new(
-        MessageSender::from(::syscall::LINUXD),
-        MessageReceiver::from(tid),
+        MessageSender::new(::syscall::LINUXD, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
         MessageType::Ikc,
         Some(error),
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -73,7 +73,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::{
     sys_types::c_ssize_t,
@@ -499,12 +502,17 @@ impl WorkerThreadHandle {
                     break;
                 },
             };
-            let source: ThreadIdentifier = match { message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(_) => {
-                    unreachable!("messages that are in this channel always address threads");
-                },
-            };
+            // The kernel stamps the originating thread into `message.source.tid`; messages in this
+            // channel always address a thread. A `NONE` sentinel names no specific thread, so skip
+            // it rather than keying reply routing on the sentinel.
+            let source: ThreadIdentifier = { message.source }.tid;
+            if source.is_none() {
+                error!(
+                    "handle_message(): received message with no originating thread, skipping \
+                     (worker_tid={worker_tid:?})"
+                );
+                continue;
+            }
 
             match message.message_type {
                 sys::ipc::MessageType::Interrupt => {
@@ -1210,8 +1218,8 @@ impl WorkerThreadHandle {
     ///
     fn do_error(source: ThreadIdentifier, code: ErrorCode) -> Message {
         Message::new(
-            MessageSender::from(LINUXD),
-            MessageReceiver::from(source),
+            MessageSender::new(LINUXD, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(source)), source),
             MessageType::Ikc,
             Some(code),
             [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -22,7 +22,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::syscall::{
     sys::socket::{
@@ -110,13 +113,11 @@ pub fn dispatch_message(
     source: MessageSender,
     syscall_msg: SystemCallMessage,
 ) -> Option<Vec<Message>> {
-    let tid: ThreadIdentifier = match source.as_id() {
-        Err(tid) => tid,
-        Ok(pid) => {
-            error!("networkd::dispatch(): message source is a PID ({pid:?}), expected TID");
-            return None;
-        },
-    };
+    let tid: ThreadIdentifier = source.tid;
+    if tid.is_none() {
+        error!("networkd::dispatch(): message source has no thread id");
+        return None;
+    }
 
     match syscall_msg.header {
         SystemCallMessageHeader::AcceptSocketRequest => {
@@ -191,8 +192,8 @@ fn to_host_fd(guest_fd: i32) -> i32 {
 
 fn build_error(tid: ThreadIdentifier, error: ErrorCode) -> Message {
     Message::new(
-        MessageSender::from(::syscall::NETWORKD),
-        MessageReceiver::from(tid),
+        MessageSender::new(::syscall::NETWORKD, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
         MessageType::Ikc,
         Some(error),
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -13,7 +13,10 @@ use crate::{
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::syscall::{
     fcntl::message::{
@@ -69,6 +72,7 @@ pub(crate) struct AssemblerEntry {
 //==================================================================================================
 
 pub(crate) fn assemble_and_dispatch(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     header: SystemCallMessageHeader,
     part: SystemCallMessagePart,
@@ -104,7 +108,7 @@ pub(crate) fn assemble_and_dispatch(
     let parts: Vec<SystemCallMessagePart> = completed.assembler.take_parts();
 
     // Dispatch based on the header type.
-    Some(dispatch_assembled_request(source, completed.header, &parts, pending))
+    Some(dispatch_assembled_request(source_pid, source, completed.header, &parts, pending))
 }
 
 fn max_capacity_for_header(header: SystemCallMessageHeader) -> usize {
@@ -160,6 +164,7 @@ fn max_capacity_for_header(header: SystemCallMessageHeader) -> usize {
 }
 
 fn dispatch_assembled_request(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     header: SystemCallMessageHeader,
     parts: &[SystemCallMessagePart],
@@ -169,7 +174,8 @@ fn dispatch_assembled_request(
         SystemCallMessageHeader::OpenAtRequestPart => match OpenAtRequest::from_parts(parts) {
             Ok(req) => {
                 // Returns `None` when forwarded to hostfsd (response deferred to IKC completion).
-                handler::handle_openat_with_hostfs(source, req, pending).unwrap_or_default()
+                handler::handle_openat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default()
             },
             Err(e) => {
                 ::syslog::error!("dispatch: openat from_parts failed (error={:?})", e);
@@ -179,7 +185,8 @@ fn dispatch_assembled_request(
         SystemCallMessageHeader::RenameAtRequestPart => match RenameAtRequest::from_parts(parts) {
             Ok(req) => {
                 // Returns `None` when forwarded to hostfsd (response deferred to IKC completion).
-                handler::handle_renameat_with_hostfs(source, req, pending).unwrap_or_default()
+                handler::handle_renameat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default()
             },
             Err(e) => {
                 ::syslog::error!("dispatch: renameat from_parts failed (error={:?})", e);
@@ -189,7 +196,8 @@ fn dispatch_assembled_request(
         SystemCallMessageHeader::UnlinkAtRequestPart => match UnlinkAtRequest::from_parts(parts) {
             Ok(req) => {
                 // Returns `None` when forwarded to hostfsd (response deferred to IKC completion).
-                handler::handle_unlinkat_with_hostfs(source, req, pending).unwrap_or_default()
+                handler::handle_unlinkat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default()
             },
             Err(e) => {
                 ::syslog::error!("dispatch: unlinkat from_parts failed (error={:?})", e);
@@ -198,9 +206,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageHeader::FileStatAtRequestPart => {
             match FileStatAtRequest::from_parts(parts) {
-                Ok(req) => {
-                    handler::handle_fstatat_with_hostfs(source, req, pending).unwrap_or_default()
-                },
+                Ok(req) => handler::handle_fstatat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: fstatat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]
@@ -211,7 +218,8 @@ fn dispatch_assembled_request(
             match MakeDirectoryAtRequest::from_parts(parts) {
                 Ok(req) => {
                     // Returns `None` when forwarded to hostfsd (response deferred to IKC completion).
-                    handler::handle_mkdirat_with_hostfs(source, req, pending).unwrap_or_default()
+                    handler::handle_mkdirat_with_hostfs(source_pid, source, req, pending)
+                        .unwrap_or_default()
                 },
                 Err(e) => {
                     ::syslog::error!("dispatch: mkdirat from_parts failed (error={:?})", e);
@@ -242,9 +250,8 @@ fn dispatch_assembled_request(
                 // `None` means the request was forwarded to hostfsd and the response
                 // will be sent asynchronously when the IKC reply arrives; emit no
                 // immediate messages in that case.
-                Ok(req) => {
-                    handler::handle_symlinkat_with_hostfs(source, req, pending).unwrap_or_default()
-                },
+                Ok(req) => handler::handle_symlinkat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: symlinkat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]
@@ -260,9 +267,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageHeader::ReadLinkAtRequestPart => {
             match ReadLinkAtRequest::from_parts(parts) {
-                Ok(req) => {
-                    handler::handle_readlinkat_with_hostfs(source, req, pending).unwrap_or_default()
-                },
+                Ok(req) => handler::handle_readlinkat_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: readlinkat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/error.rs
+++ b/src/daemons/vfsd/src/error.rs
@@ -53,8 +53,8 @@ pub(crate) fn fat32_to_error_code(e: &::vfs::Fat32Error) -> ErrorCode {
 
 pub(crate) fn build_error(source: ThreadIdentifier, code: ErrorCode) -> Message {
     Message::new(
-        MessageSender::from(ProcessIdentifier::VFSD),
-        MessageReceiver::from(source),
+        MessageSender::VFSD,
+        MessageReceiver::new(ProcessIdentifier::from(i32::from(source)), source),
         MessageType::Ipc,
         Some(code),
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -10,10 +10,10 @@
 //! # Inline Data Limits
 //!
 //! Read operations are limited to [`MAX_INLINE_READ_DATA`](::hostfs_api::MAX_INLINE_READ_DATA)
-//! (38) bytes per request, and write operations to
-//! [`MAX_INLINE_WRITE_DATA`](::hostfs_api::MAX_INLINE_WRITE_DATA) (24) bytes. Larger
-//! requests are silently clamped. Callers (the guest VFS layer) must handle short
-//! reads/writes and issue additional requests for the remainder.
+//! bytes per request, and write operations to
+//! [`MAX_INLINE_WRITE_DATA`](::hostfs_api::MAX_INLINE_WRITE_DATA) bytes. Larger requests are
+//! silently clamped. Callers (the guest VFS layer) must handle short reads/writes and issue
+//! additional requests for the remainder.
 //!
 //! When forwarding to hostfsd, these handlers send the IKC request and push a
 //! [`PendingOp`] onto the pending queue. They return `None` to indicate that no
@@ -65,6 +65,7 @@ use ::syscall::{
 //==================================================================================================
 
 pub(crate) fn handle_close_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -106,7 +107,7 @@ pub(crate) fn handle_close_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Close,
                 },
             )
@@ -236,6 +237,7 @@ pub(crate) fn handle_dup2(
 }
 
 pub(crate) fn handle_seek_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -261,7 +263,7 @@ pub(crate) fn handle_seek_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Seek,
                 },
             )
@@ -276,6 +278,7 @@ pub(crate) fn handle_seek_with_hostfs(
 }
 
 pub(crate) fn handle_fsync_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -296,7 +299,7 @@ pub(crate) fn handle_fsync_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Flush,
                 },
             )
@@ -311,6 +314,7 @@ pub(crate) fn handle_fsync_with_hostfs(
 }
 
 pub(crate) fn handle_ftruncate_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -334,7 +338,7 @@ pub(crate) fn handle_ftruncate_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Truncate,
                 },
             )
@@ -353,6 +357,7 @@ pub(crate) fn handle_ftruncate_with_hostfs(
 //==================================================================================================
 
 pub(crate) fn handle_fstat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -373,7 +378,7 @@ pub(crate) fn handle_fstat_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Stat,
                 },
             )
@@ -388,6 +393,7 @@ pub(crate) fn handle_fstat_with_hostfs(
 }
 
 pub(crate) fn handle_fstatat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: FileStatAtRequest,
     pending: &mut PendingQueue,
@@ -422,7 +428,7 @@ pub(crate) fn handle_fstatat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind,
                         },
                     )
@@ -489,7 +495,7 @@ pub(crate) fn handle_read_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid,
-                    source_pid: Some(source_pid),
+                    source_pid,
                     kind: PendingOpKind::Read { count: buf_size },
                 },
             )
@@ -549,7 +555,7 @@ pub(crate) fn handle_write_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid,
-                            source_pid: Some(source_pid),
+                            source_pid,
                             kind: PendingOpKind::Write,
                         },
                     )
@@ -613,6 +619,7 @@ use alloc::{
 /// Returns `None` when the request was forwarded to hostfsd (the response is sent later
 /// from the event loop). Non-hostfs FDs fall through to the synchronous VFS handler.
 pub(crate) fn handle_getdents_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
@@ -651,7 +658,7 @@ pub(crate) fn handle_getdents_with_hostfs(
                 op_id,
                 PendingOp {
                     source_tid: source,
-                    source_pid: None,
+                    source_pid,
                     kind: PendingOpKind::Getdents {
                         remote_fd,
                         guest_fd: fd,
@@ -672,6 +679,7 @@ pub(crate) fn handle_getdents_with_hostfs(
 }
 
 pub(crate) fn handle_openat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: OpenAtRequest,
     pending: &mut PendingQueue,
@@ -696,7 +704,7 @@ pub(crate) fn handle_openat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind: PendingOpKind::Open { path: open_path },
                         },
                     )
@@ -714,6 +722,7 @@ pub(crate) fn handle_openat_with_hostfs(
 }
 
 pub(crate) fn handle_renameat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: RenameAtRequest,
     pending: &mut PendingQueue,
@@ -751,7 +760,7 @@ pub(crate) fn handle_renameat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind: PendingOpKind::Rename,
                         },
                     )
@@ -769,6 +778,7 @@ pub(crate) fn handle_renameat_with_hostfs(
 }
 
 pub(crate) fn handle_unlinkat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: UnlinkAtRequest,
     pending: &mut PendingQueue,
@@ -803,7 +813,7 @@ pub(crate) fn handle_unlinkat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind,
                         },
                     )
@@ -821,6 +831,7 @@ pub(crate) fn handle_unlinkat_with_hostfs(
 }
 
 pub(crate) fn handle_mkdirat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: MakeDirectoryAtRequest,
     pending: &mut PendingQueue,
@@ -844,7 +855,7 @@ pub(crate) fn handle_mkdirat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind: PendingOpKind::Mkdir,
                         },
                     )
@@ -862,6 +873,7 @@ pub(crate) fn handle_mkdirat_with_hostfs(
 }
 
 pub(crate) fn handle_symlinkat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: SymbolicLinkAtRequest,
     pending: &mut PendingQueue,
@@ -887,7 +899,7 @@ pub(crate) fn handle_symlinkat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind: PendingOpKind::Symlink,
                         },
                     )
@@ -905,6 +917,7 @@ pub(crate) fn handle_symlinkat_with_hostfs(
 }
 
 pub(crate) fn handle_readlinkat_with_hostfs(
+    source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
     request: ReadLinkAtRequest,
     pending: &mut PendingQueue,
@@ -929,7 +942,7 @@ pub(crate) fn handle_readlinkat_with_hostfs(
                         op_id,
                         PendingOp {
                             source_tid: source,
-                            source_pid: None,
+                            source_pid,
                             kind: PendingOpKind::Readlink { bufsiz },
                         },
                     )

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -116,8 +116,8 @@ pub fn strip_mount_prefix(path: &str) -> &str {
 /// heavy write traffic, the caller (vfsd event loop) may stall briefly until a slot opens.
 pub fn send_request(payload: &[u8; Message::PAYLOAD_SIZE]) -> bool {
     let message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::VFSD),
-        MessageReceiver::from(ProcessIdentifier::KERNEL),
+        MessageSender::VFSD,
+        MessageReceiver::KERNEL,
         MessageType::Ikc,
         None,
         *payload,

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -63,56 +63,32 @@ use alloc::{
 
 /// Extracts the caller's thread identifier from an IPC message.
 ///
-/// Guest syscall requests encode their source as the caller's thread id (`MessageSender::from` a
-/// `ThreadIdentifier`) because vfsd needs the TID to route the reply, so this almost always takes
-/// the TID branch and returns it as-is. A PID-encoded source (e.g. a message routed with a
-/// `ProcessIdentifier`) is handled by deriving a TID from the PID value, which is correct only for
-/// single-threaded processes where TID == PID.
+/// The kernel stamps the originating thread into `message.source.tid` on `send` (see
+/// `src/kernel/src/ipc/send.rs`), so vfsd reads it directly to route the reply back to the exact
+/// calling thread.
 fn caller_tid(message: &Message) -> ThreadIdentifier {
-    let source = message.source;
-    match source.as_id() {
-        Ok(pid) => {
-            // PID-encoded source — derive TID from PID value (valid for single-threaded callers).
-            ThreadIdentifier::from(i32::from(pid))
-        },
-        Err(tid) => tid,
-    }
+    // `source` is a `Copy` field of a `repr(packed)` `Message`; copy it out before projecting into
+    // it so that no reference to an unaligned field is formed.
+    let source: MessageSender = message.source;
+    source.tid
 }
 
 /// Extracts the caller's process identifier from an IPC message.
 ///
-/// A PID-encoded source (a daemon or the kernel) is authoritative and is returned as-is. Guest
-/// syscall requests instead encode their source as the caller's *thread* id, because vfsd needs the
-/// TID to route the reply. The owning PID is then recovered from an authoritative kernel lookup
-/// ([`__kcall_getpid_by_tid`](::sys::kcall::pm::__kcall_getpid_by_tid)) rather than by casting the
-/// TID: a process reached via `fork()` + `execv()` keeps its PID but is assigned a new main-thread
-/// TID, so `TID != PID` and a cast would key the request's per-process VFS state (fd table and cwd)
-/// under a phantom process — losing a child's writes after it exits and corrupting I/O on inherited
-/// descriptors (nanvix/nanvix#2650, #2637, #2529). The same lookup also attributes a request from a
-/// non-main thread of a multi-threaded caller to the correct process.
-///
-/// If the kernel cannot resolve the TID (which should not happen for an in-flight request, whose
-/// thread is blocked awaiting this reply), the legacy TID-cast is used as a fallback so the request
-/// is still answered rather than dropped.
+/// This returns `message.source.pid`, the kernel-attested caller identity that the `send` kernel
+/// call stamps on every message (see `src/kernel/src/ipc/send.rs`). Because the kernel — not the
+/// sender — fills this field, it is authoritative and unforgeable, and it is correct by construction
+/// in the cases where the historical `TID == PID` reconstruction failed: a process reached via
+/// `fork()` + `execv()` keeps its PID but is assigned a new main-thread TID (`TID != PID`), and a
+/// request issued by a non-main thread of a multi-threaded caller likewise has `TID != PID`. Keying
+/// per-process VFS state (fd table and cwd) by this PID therefore no longer misattributes a child's
+/// writes after it exits, nor corrupts I/O on inherited descriptors (nanvix/nanvix#2650, #2637,
+/// #2529).
 fn caller_pid(message: &Message) -> ProcessIdentifier {
-    let sender: MessageSender = message.source;
-    match sender.as_id() {
-        // A PID-encoded source (daemon/kernel peer) is already authoritative.
-        Ok(pid) => pid,
-        // A TID-encoded source is a guest syscall request: recover the owning PID authoritatively.
-        Err(tid) => match ::sys::kcall::pm::__kcall_getpid_by_tid(tid) {
-            Ok(pid) => pid,
-            Err(error) => {
-                ::syslog::warn!(
-                    "caller_pid(): kernel TID->PID resolution failed (tid={:?}, error={:?}); \
-                     falling back to TID cast",
-                    tid,
-                    error
-                );
-                ProcessIdentifier::from(i32::from(tid))
-            },
-        },
-    }
+    // `source` is a `Copy` field of a `repr(packed)` `Message`; copy it out before projecting into
+    // it so that no reference to an unaligned field is formed.
+    let source: MessageSender = message.source;
+    source.pid
 }
 
 //==================================================================================================
@@ -121,17 +97,13 @@ fn caller_pid(message: &Message) -> ProcessIdentifier {
 
 fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Result<bool, Error> {
     // State-mutating process-management messages are privileged: only procd may direct them. The
-    // caller (handle_ipc_message) routes here only when the message source is procd, which is the
-    // runtime gate. Note that this trusts `message.source`: the kernel currently only *logs* an
-    // invalid source and still delivers the message (see `src/kernel/src/ipc/send.rs`), so it does
-    // not by itself stop another process from spoofing a procd source. Robustly closing that gap
-    // would require the kernel to reject messages whose source does not match the real sender,
-    // tracked in issue #2527. The debug-assert below is a development sanity check of the routing
-    // invariant, not a security control.
+    // caller (handle_ipc_message) routes here only when the kernel-attested `message.source.pid` is
+    // PROCD, so a sender cannot reach this path by forging `message.source`. The debug assert below
+    // documents that routing invariant and catches accidental direct calls in development builds.
     debug_assert_eq!(
         caller_pid(&message),
         ProcessIdentifier::PROCD,
-        "handle_system_message invoked with non-procd source"
+        "handle_system_message invoked with non-procd client"
     );
     let sys_msg: SystemMessage = SystemMessage::from_bytes(message.payload)?;
     match sys_msg.header {
@@ -364,11 +336,9 @@ pub(crate) fn handle_ipc_message(
     }
 
     // Bind the VFS to the requesting process so that descriptor and working-directory operations
-    // resolve against its per-process state. Guest syscall messages encode their source as the
-    // caller's thread id, so `source_pid` is obtained by casting that TID to a PID (see
-    // `caller_pid`). This resolves to the correct process only for single-threaded callers where
-    // TID == PID; a request from a non-main thread of a multi-threaded process would be
-    // misattributed (see the TODO in `caller_pid` for the authoritative-PID fix). vfsd being
+    // resolve against its per-process state. `source_pid` is the kernel-attested caller identity
+    // (`message.source.pid`; see `caller_pid`), so it is correct even for `fork()` + `execv()`'d
+    // children and for requests from non-main threads of a multi-threaded caller. vfsd being
     // single-threaded is what makes mutating this global current-process selector race-free.
     ::vfs::fd::set_current_process(source_pid);
 
@@ -392,9 +362,13 @@ pub(crate) fn handle_ipc_message(
         // Short requests: single message request, single message response.
         //==========================================================================================
         SystemCallMessageHeader::CloseRequest => {
-            if let Some(response) =
-                handler::handle_close_with_hostfs(source_tid, syscall_msg, pending, pipe_wait)
-            {
+            if let Some(response) = handler::handle_close_with_hostfs(
+                source_pid,
+                source_tid,
+                syscall_msg,
+                pending,
+                pipe_wait,
+            ) {
                 send_response(&response);
             }
         },
@@ -412,14 +386,14 @@ pub(crate) fn handle_ipc_message(
         },
         SystemCallMessageHeader::SeekRequest => {
             if let Some(response) =
-                handler::handle_seek_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_seek_with_hostfs(source_pid, source_tid, syscall_msg, pending)
             {
                 send_response(&response);
             }
         },
         SystemCallMessageHeader::FileSyncRequest => {
             if let Some(response) =
-                handler::handle_fsync_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_fsync_with_hostfs(source_pid, source_tid, syscall_msg, pending)
             {
                 send_response(&response);
             }
@@ -430,7 +404,7 @@ pub(crate) fn handle_ipc_message(
         },
         SystemCallMessageHeader::FileTruncateRequest => {
             if let Some(response) =
-                handler::handle_ftruncate_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_ftruncate_with_hostfs(source_pid, source_tid, syscall_msg, pending)
             {
                 send_response(&response);
             }
@@ -524,7 +498,7 @@ pub(crate) fn handle_ipc_message(
         //==========================================================================================
         SystemCallMessageHeader::FileStatRequest => {
             if let Some(responses) =
-                handler::handle_fstat_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_fstat_with_hostfs(source_pid, source_tid, syscall_msg, pending)
             {
                 for response in responses {
                     send_response(&response);
@@ -539,7 +513,7 @@ pub(crate) fn handle_ipc_message(
         },
         SystemCallMessageHeader::GetDirectoryEntriesRequest => {
             if let Some(responses) =
-                handler::handle_getdents_with_hostfs(source_tid, syscall_msg, pending)
+                handler::handle_getdents_with_hostfs(source_pid, source_tid, syscall_msg, pending)
             {
                 for response in responses {
                     send_response(&response);
@@ -567,9 +541,14 @@ pub(crate) fn handle_ipc_message(
         | SystemCallMessageHeader::HostUmountRequestPart => {
             let part: SystemCallMessagePart =
                 SystemCallMessagePart::from_bytes(syscall_msg.payload);
-            if let Some(responses) =
-                assemble_and_dispatch(source_tid, syscall_msg.header, part, assemblers, pending)
-            {
+            if let Some(responses) = assemble_and_dispatch(
+                source_pid,
+                source_tid,
+                syscall_msg.header,
+                part,
+                assemblers,
+                pending,
+            ) {
                 for response in responses {
                     send_response(&response);
                 }

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -47,12 +47,8 @@ use ::sys::{
 pub(crate) struct PendingOp {
     /// Thread that initiated the request (to send the response back).
     pub source_tid: ThreadIdentifier,
-    /// Process that initiated the request, recorded for operations that need a PID to transfer
-    /// data buffers (the push/pull in read/write). Like every caller PID in vfsd it is derived by
-    /// casting the caller's TID (see `caller_pid` in `ipc.rs`), so it is correct only when
-    /// TID == PID. `None` for operations that never push/pull (close, seek, etc.) and therefore
-    /// need no PID at all.
-    pub source_pid: Option<ProcessIdentifier>,
+    /// Process that initiated the request.
+    pub source_pid: ProcessIdentifier,
     /// The kind of operation, which determines how to interpret the IKC response.
     pub kind: PendingOpKind,
 }
@@ -283,23 +279,17 @@ pub(crate) fn complete_pending_op(
     response_payload: &[u8; Message::PAYLOAD_SIZE],
 ) {
     // Bind the VFS to the requesting process so that descriptor allocation (e.g. for a completed
-    // open) and directory-cursor updates land in its per-process state. Use the PID recorded on the
-    // pending op, falling back to deriving it from the source TID for operations that do not carry
-    // a PID (close, seek, etc.). Both paths rely on the same TID == PID assumption: the recorded
-    // `source_pid` is itself obtained by casting the caller's TID in `handle_ipc_message` (guest
-    // syscalls encode their source as a TID), so neither is correct for a request issued from a
-    // non-main thread of a multi-threaded process. See the TODO in `caller_pid` (ipc.rs) for the
-    // authoritative-PID fix. vfsd being single-threaded is what makes mutating this global
-    // current-process selector race-free.
+    // open) and directory-cursor updates land in its per-process state. `source_pid` was copied
+    // from the kernel-attested `message.source.pid` when the request was dispatched, so it remains
+    // correct even when the caller's thread identifier differs from its process identifier. vfsd
+    // being single-threaded is what makes mutating this global current-process selector race-free.
     //
     // The caller is guaranteed to still be registered here: guest syscalls are synchronous, so it
     // stays blocked awaiting this very response and cannot exit, and the only involuntary
     // termination path (memd killing a faulting process) cannot target a process parked in a
     // syscall. Completion therefore never resurrects an exited process — which would re-create an
     // empty placeholder and leak any host handle this op allocates (e.g. a completed open).
-    let current_pid: ProcessIdentifier = pending
-        .source_pid
-        .unwrap_or_else(|| ProcessIdentifier::from(i32::from(pending.source_tid)));
+    let current_pid: ProcessIdentifier = pending.source_pid;
     ::vfs::fd::set_current_process(current_pid);
 
     // Validate that the response header matches the expected operation kind.
@@ -308,14 +298,13 @@ pub(crate) fn complete_pending_op(
         // For Read operations, the caller is blocked waiting for a push before consuming
         // the IPC response. Send an empty push so the caller can proceed and see the error.
         if let PendingOpKind::Read { .. } = &pending.kind {
-            if let Some(pid) = pending.source_pid {
-                if let Err(e) = ::sys::kcall::ipc::__kcall_push(pid, pending.source_tid, &[]) {
-                    ::syslog::error!(
-                        "hostfs pending op: failed to push empty response for desync case \
-                         (error={:?})",
-                        e
-                    );
-                }
+            if let Err(e) =
+                ::sys::kcall::ipc::__kcall_push(pending.source_pid, pending.source_tid, &[])
+            {
+                ::syslog::error!(
+                    "hostfs pending op: failed to push empty response for desync case (error={:?})",
+                    e
+                );
             }
         }
         send_response(&build_error(pending.source_tid, ErrorCode::IoErr));
@@ -326,8 +315,7 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::Open { path } => complete_open(pending.source_tid, response_payload, path),
         PendingOpKind::Close => complete_close(pending.source_tid, response_payload),
         PendingOpKind::Read { count } => {
-            let pid: ProcessIdentifier = pending.source_pid.unwrap_or(ProcessIdentifier::KERNEL);
-            complete_read(pid, pending.source_tid, count, response_payload)
+            complete_read(pending.source_pid, pending.source_tid, count, response_payload)
         },
         PendingOpKind::Write => complete_write(pending.source_tid, response_payload),
         PendingOpKind::Seek => complete_seek(pending.source_tid, response_payload),

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -478,8 +478,8 @@ impl EventManagerInner {
                 if let Some(idx) = selected {
                     if let Some(_event) = self.pending_interrupts[idx].pop_front() {
                         let message: Message = Message {
-                            source: MessageSender::from(ProcessIdentifier::KERNEL),
-                            destination: MessageReceiver::from(pid),
+                            source: MessageSender::KERNEL,
+                            destination: MessageReceiver::new(pid, ThreadIdentifier::NONE),
                             message_type: MessageType::Interrupt,
                             ..Message::default()
                         };
@@ -508,7 +508,7 @@ impl EventManagerInner {
                         info.instruction = Some(entry.2.info.instruction() as usize);
 
                         let mut message: Message = Message::from(info);
-                        message.destination = MessageReceiver::from(pid);
+                        message.destination = MessageReceiver::new(pid, ThreadIdentifier::NONE);
                         message.message_type = MessageType::Exception;
 
                         self.pending_exceptions[idx].push_back(entry);
@@ -549,11 +549,11 @@ impl EventManagerInner {
                         };
 
                         let message: Message = Message {
-                            source: MessageSender::from(ProcessIdentifier::KERNEL),
-                            destination: MessageReceiver::from(pid),
+                            source: MessageSender::KERNEL,
+                            destination: MessageReceiver::new(pid, ThreadIdentifier::NONE),
                             message_type,
-                            status: 0,
                             payload,
+                            ..Message::default()
                         };
 
                         return Ok(Some(message));
@@ -803,15 +803,12 @@ impl EventManagerInner {
     ) -> Result<(), Error> {
         pm.post_message(receiver, message)?;
 
-        match receiver.as_id() {
-            Ok(pid) => {
-                // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
-                unsafe { self.notify_all_process_threads(pid) }
-            },
-            Err(tid) => {
-                // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
-                unsafe { self.get_wait().notify_thread(tid) }
-            },
+        if receiver.tid.is_none() {
+            // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
+            unsafe { self.notify_all_process_threads(receiver.pid) }
+        } else {
+            // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
+            unsafe { self.get_wait().notify_thread(receiver.tid) }
         }
     }
 

--- a/src/kernel/src/ipc/mbx/mailbox.rs
+++ b/src/kernel/src/ipc/mbx/mailbox.rs
@@ -76,7 +76,7 @@ impl Mailbox {
         let message_index = self
             .buffer
             .iter()
-            .position(|msg| { msg.destination }.as_id() == Err(tid));
+            .position(|msg| { msg.destination }.tid == tid);
 
         // If a message was found, remove it from the buffer and return it.
         if let Some(index) = message_index {
@@ -87,7 +87,7 @@ impl Mailbox {
         let message_index = self
             .buffer
             .iter()
-            .position(|msg| { msg.destination }.as_id().is_ok());
+            .position(|msg| { msg.destination }.tid.is_none());
 
         // If a message was found, remove it from the buffer and return it.
         if let Some(index) = message_index {

--- a/src/kernel/src/ipc/send.rs
+++ b/src/kernel/src/ipc/send.rs
@@ -14,10 +14,7 @@ use crate::{
     },
 };
 use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
+    error::Error,
     ipc::{
         Message,
         MessageSender,
@@ -70,15 +67,12 @@ pub fn send(pid: ProcessIdentifier, tid: ThreadIdentifier, arg0: u32) -> KcallRe
         return KcallResult::Error(e.code.into());
     }
 
-    // Reject messages whose source does not match the calling thread or process. Without this
-    // check a process could forge the `source` field to impersonate another (possibly privileged)
-    // peer, since receivers authenticate callers on `message.source`.
-    if { message.source } != MessageSender::from(src_tid) && { message.source }
-        != MessageSender::from(src_pid)
-    {
-        error!("invalid message source (message={message:?})");
-        return KcallResult::Error(ErrorCode::OperationNotPermitted.into());
-    }
+    // Stamp the kernel-attested caller identity over whatever the sender supplied. The kernel knows
+    // the authoritative (pid, tid) of the calling thread, so a sender cannot forge `source`: a
+    // server may therefore trust `message.source.pid` for attribution (correct across
+    // `fork()` + `execv()` and for non-main threads, where TID != PID) and `message.source.tid` to
+    // route a reply to the exact calling thread (nanvix/nanvix#2662, #2650, #2529).
+    message.source = MessageSender::new(src_pid, src_tid);
 
     // Route message based on its type.
     match message.message_type {

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -67,21 +67,6 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         },
         // Handle `gettid()` locally.
         KcallNumber::GetTid => KcallResult::Success(<i64>::from(tid).into()),
-        // Resolve a thread identifier to its owning process identifier. This lets a privileged
-        // server (vfsd) attribute a request to the correct process even after the caller has
-        // execv()'d, which assigns a new main-thread TID while preserving the PID (so TID != PID).
-        KcallNumber::GetPidByTid => match ThreadIdentifier::try_from(i64::from(arg0)) {
-            Ok(target_tid) => {
-                // SAFETY: the process manager is initialized and access is synchronized; the
-                // immutable borrow used above for `pid`/`tid` yielded Copy values and is not live.
-                let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
-                match pm.try_get_pid_by_tid(target_tid) {
-                    Ok(target_pid) => KcallResult::Success(<i64>::from(target_pid).into()),
-                    Err(e) => KcallResult::Error(e.code.into()),
-                }
-            },
-            Err(e) => KcallResult::Error(e.code.into()),
-        },
         KcallNumber::Exit => {
             // SAFETY: the calling process is not the kernel.
             let e: Error = unsafe { ProcessManager::exit(ExitStatus::from(arg0)).unwrap_err() };

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -2431,34 +2431,6 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Resolves a thread identifier to the identifier of the process that owns it.
-    ///
-    /// This is the authoritative inverse of the historical `TID == PID` coincidence. A process
-    /// reached via `fork()` + `execv()` keeps its process identifier but is assigned a new
-    /// main-thread identifier, so its main-thread `tid` no longer equals its `pid`. Callers that
-    /// must attribute a request to the owning process — most notably vfsd, which keys per-process
-    /// state by `pid` — use this to recover the authoritative `pid` from the request's `tid`.
-    ///
-    /// # Parameters
-    ///
-    /// - `tid`: Identifier of the thread whose owning process is sought.
-    ///
-    /// # Returns
-    ///
-    /// Upon success, the identifier of the process that owns `tid` is returned. Otherwise, an error
-    /// is returned.
-    ///
-    pub fn try_get_pid_by_tid(
-        &mut self,
-        tid: ThreadIdentifier,
-    ) -> Result<ProcessIdentifier, Error> {
-        let mut process: ProcessRefMut<'_> = self.find_process_by_tid(tid)?;
-        Ok(process.state_mut().pid())
-    }
-
-    ///
-    /// # Description
-    ///
     /// Finds a thread.
     ///
     /// # Arguments
@@ -3340,9 +3312,10 @@ impl ProcessManager {
         message: Message,
     ) -> Result<(), Error> {
         {
-            let mut process: ProcessRefMut = match receiver.as_id() {
-                Ok(pid) => self.find_process_mut(pid)?,
-                Err(tid) => self.find_process_by_tid(tid)?,
+            let mut process: ProcessRefMut = if receiver.tid.is_none() {
+                self.find_process_mut(receiver.pid)?
+            } else {
+                self.find_process_by_tid(receiver.tid)?
             };
             process.state_mut().post_message(message);
         }

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -32,7 +32,6 @@ use ::sys::{
         MessageType,
     },
     mm::Address,
-    pm::ProcessIdentifier,
 };
 
 //==================================================================================================
@@ -53,8 +52,8 @@ fn test_mailbox_is_empty_tracks_buffered_messages() -> bool {
     }
 
     let message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::KERNEL),
-        MessageReceiver::from(ProcessIdentifier::KERNEL),
+        MessageSender::KERNEL,
+        MessageReceiver::KERNEL,
         MessageType::Ipc,
         Option::<ErrorCode>::None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -5,15 +5,16 @@
 //!
 //! This crate defines the binary protocol used for communication between the guest-side VFS daemon
 //! (`vfsd`) and the host-side filesystem daemon (`hostfsd`). Messages are encoded into the
-//! fixed-size IPC message payload (48 bytes) using a compact binary format.
+//! fixed-size IPC message payload (`Message::PAYLOAD_SIZE` bytes) using a compact binary format.
 //!
 //! # Protocol Overview
 //!
 //! All messages use the [`SystemCallMessage`] wire format: a 2-byte
-//! [`SystemCallMessageHeader`] discriminant, a 4-byte operation identifier (`op_id`), and
-//! 42 bytes of operation-specific data. The `op_id` is assigned by vfsd when sending a
-//! request and echoed back by hostfsd in the corresponding response, allowing vfsd to
-//! match responses to pending operations without relying on FIFO ordering.
+//! [`SystemCallMessageHeader`] discriminant, a 4-byte operation identifier (`op_id`), and the
+//! remaining (`Message::PAYLOAD_SIZE` - `HOSTFS_DATA_START`) bytes of operation-specific data. The
+//! `op_id` is assigned by vfsd when sending a request and echoed back by hostfsd in the
+//! corresponding response, allowing vfsd to match responses to pending operations without relying
+//! on FIFO ordering.
 //!
 //! Each host filesystem operation maps to a pair of header variants (request + response)
 //! defined in the `syscall` crate.
@@ -240,26 +241,34 @@ impl OperationIdAllocator {
 pub const HOSTFS_DATA_START: usize = 6;
 
 /// Maximum path length that fits inline in a single message payload.
-/// Calculated as: PAYLOAD_SIZE(48) - header(2) - op_id(4) - flags(4) - path_len(2) = 36.
-pub const MAX_INLINE_PATH_LEN: usize = 36;
+///
+/// Derived from the live [`Message::PAYLOAD_SIZE`] so it tracks the IPC payload size automatically
+/// (the kernel-stamped client identity in nanvix/nanvix#2662 shrank the payload). The binding
+/// (tightest) inline path request is `open`/`mkdir`, whose data section is
+/// `[flags|mode: u32][path_len: u16][path...]`, i.e. 6 bytes precede the path. Longer paths fall
+/// back to the multi-part form in [`long_msg`].
+pub const MAX_INLINE_PATH_LEN: usize = Message::PAYLOAD_SIZE - HOSTFS_DATA_START - 4 - 2;
 
 /// Maximum inline data length for read responses.
-/// Calculated as: PAYLOAD_SIZE(48) - header(2) - op_id(4) - bytes_read(4) = 38.
-pub const MAX_INLINE_READ_DATA: usize = 38;
+///
+/// The read-response data section is `[bytes_read: i32][data...]`, so 4 bytes precede the data.
+pub const MAX_INLINE_READ_DATA: usize = Message::PAYLOAD_SIZE - HOSTFS_DATA_START - 4;
 
 /// Maximum inline data length for write requests.
-/// Calculated as: PAYLOAD_SIZE(48) - header(2) - op_id(4) - fd(4) - count(4) - offset(8) - data_len(2) = 24.
 ///
-/// The guest-side VFS layer (`handle_write_with_hostfs`) clamps the write buffer to this
-/// size before encoding the request, so `count` and `data_len` are always <= 24 on the wire.
-/// The guest is responsible for issuing multiple write requests to transfer larger buffers.
-/// Callers observe the returned `bytes_written` count and retry the remainder as needed.
-pub const MAX_INLINE_WRITE_DATA: usize = 24;
+/// The write-request data section is `[fd: i32][count: u32][offset: i64][data_len: u16][data...]`,
+/// so 18 bytes precede the data. The guest-side VFS layer (`handle_write_with_hostfs`) clamps the
+/// write buffer to this size before encoding the request, so `count` and `data_len` never exceed it
+/// on the wire. The guest issues multiple write requests to transfer larger buffers, observing the
+/// returned `bytes_written` count and retrying the remainder.
+pub const MAX_INLINE_WRITE_DATA: usize =
+    Message::PAYLOAD_SIZE - HOSTFS_DATA_START - (4 + 4 + 8 + 2);
 
 /// Maximum filename length in a directory entry response.
-/// Calculated as: PAYLOAD_SIZE(48) - header(2) - op_id(4) - name_len(2) - is_dir(1) - size(8) = 31.
-/// Set to 29 to leave 2 bytes of padding for future extensibility.
-pub const MAX_DIR_ENTRY_NAME_LEN: usize = 29;
+///
+/// The directory-entry data section is `[name_len: u16][is_dir: u8][size: u64][name...]`, so 11
+/// bytes precede the name. Names longer than this are truncated to the inline capacity.
+pub const MAX_DIR_ENTRY_NAME_LEN: usize = Message::PAYLOAD_SIZE - HOSTFS_DATA_START - (2 + 1 + 8);
 
 //==================================================================================================
 // Error Codes

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -709,14 +709,9 @@ impl ProcessDaemon {
     }
 
     fn handle_ipc_message(&mut self, message: Message) -> Result<(), Error> {
-        let destination: ProcessIdentifier = match { message.source }.as_id() {
-            Ok(pid) => pid,
-            Err(tid) => {
-                let reason: &str = "invalid IPC message source";
-                ::syslog::error!("handle_ipc_message(): {reason:?} (tid={:?})", tid);
-                return Err(Error::new(ErrorCode::InvalidArgument, reason));
-            },
-        };
+        // The kernel stamps the authoritative originating process into `message.source.pid`, so the
+        // caller identity is taken directly from it.
+        let destination: ProcessIdentifier = { message.source }.pid;
         let message: SystemMessage = SystemMessage::from_bytes(message.payload)?;
 
         ::syslog::info!("received system message (header={:?})", message.header);

--- a/src/libs/proc/src/message/exec.rs
+++ b/src/libs/proc/src/message/exec.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -212,8 +215,8 @@ fn wrap(
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     Message::new(
-        MessageSender::from(source),
-        MessageReceiver::from(destination),
+        MessageSender::new(source, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/fork_clone.rs
+++ b/src/libs/proc/src/message/fork_clone.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -230,8 +233,8 @@ pub fn fork_clone_request(
     // Construct an IPC message. The notification is sent by the process manager daemon to the
     // filesystem daemon.
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),
@@ -275,8 +278,8 @@ pub fn fork_clone_ack(
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     let ipc_message: Message = Message::new(
-        MessageSender::from(source),
-        MessageReceiver::from(destination),
+        MessageSender::new(source, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/fork_sync.rs
+++ b/src/libs/proc/src/message/fork_sync.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -187,8 +190,8 @@ fn wrap(
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     Message::new(
-        MessageSender::from(source),
-        MessageReceiver::from(destination),
+        MessageSender::new(source, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/lookup.rs
+++ b/src/libs/proc/src/message/lookup.rs
@@ -26,7 +26,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -244,8 +247,8 @@ pub fn lookup_request(name: &str, pid: ProcessIdentifier) -> Result<Message, Err
 
     // Construct an IPC  message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(pid),
-        MessageReceiver::from(ProcessIdentifier::PROCD),
+        MessageSender::new(pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),
@@ -289,8 +292,8 @@ pub fn lookup_response(
 
     // Construct an IPC  message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(destination),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/process_exit.rs
+++ b/src/libs/proc/src/message/process_exit.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -130,8 +133,8 @@ pub fn process_exit_request(pid: ProcessIdentifier) -> Result<Message, Error> {
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/shutdown.rs
+++ b/src/libs/proc/src/message/shutdown.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -135,8 +138,8 @@ pub fn shutdown_request(destination: ProcessIdentifier, code: u8) -> Result<Mess
 
     // Construct an IPC message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(destination),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         sys_message.into_bytes(),

--- a/src/libs/proc/src/message/signup.rs
+++ b/src/libs/proc/src/message/signup.rs
@@ -26,7 +26,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -255,8 +258,8 @@ pub fn signup_request(pid: ProcessIdentifier, name: &str) -> Result<Message, Err
 
     // Construct an IPC  message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(pid),
-        MessageReceiver::from(ProcessIdentifier::PROCD),
+        MessageSender::new(pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),
@@ -301,8 +304,8 @@ pub fn signup_response(
 
     // Construct an IPC message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(destination),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/wait.rs
+++ b/src/libs/proc/src/message/wait.rs
@@ -20,7 +20,10 @@ use ::sys::{
         SystemMessage,
         SystemMessageHeader,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -284,8 +287,8 @@ pub fn wait_request(
 
     // Construct an IPC message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(caller),
-        MessageReceiver::from(ProcessIdentifier::PROCD),
+        MessageSender::new(caller, ThreadIdentifier::NONE),
+        MessageReceiver::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),
@@ -332,8 +335,8 @@ pub fn wait_response(
 
     // Construct an IPC message.
     let ipc_message: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::PROCD),
-        MessageReceiver::from(destination),
+        MessageSender::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageReceiver::new(destination, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/sys/src/sys/event/information.rs
+++ b/src/libs/sys/src/sys/event/information.rs
@@ -17,7 +17,10 @@ use crate::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::core::fmt::Debug;
 
@@ -48,32 +51,38 @@ impl From<EventInformation> for Message {
             .copy_from_slice(&info.pid.to_ne_bytes());
         offset += core::mem::size_of::<ProcessIdentifier>();
 
+        // The optional fields below carry 32-bit guest quantities (exception number, error code,
+        // fault address and faulting instruction). They are serialized as fixed-width `u32` rather
+        // than native `usize` so the encoding is identical on the 32-bit guest (where this runs at
+        // runtime) and on a 64-bit host (where it is exercised by unit tests), and so the worst
+        // case fits within the message payload. On the guest `usize` is 32 bits, so this is lossless
+        // and byte-for-byte identical to the previous native encoding.
         if let Some(number) = info.number {
-            payload[offset..offset + core::mem::size_of::<usize>()]
-                .copy_from_slice(&number.to_ne_bytes());
-            offset += core::mem::size_of::<usize>();
+            payload[offset..offset + core::mem::size_of::<u32>()]
+                .copy_from_slice(&(number as u32).to_ne_bytes());
+            offset += core::mem::size_of::<u32>();
         }
 
         if let Some(code) = info.code {
-            payload[offset..offset + core::mem::size_of::<usize>()]
-                .copy_from_slice(&code.to_ne_bytes());
-            offset += core::mem::size_of::<usize>();
+            payload[offset..offset + core::mem::size_of::<u32>()]
+                .copy_from_slice(&(code as u32).to_ne_bytes());
+            offset += core::mem::size_of::<u32>();
         }
 
         if let Some(address) = info.address {
-            payload[offset..offset + core::mem::size_of::<usize>()]
-                .copy_from_slice(&address.to_ne_bytes());
-            offset += core::mem::size_of::<usize>();
+            payload[offset..offset + core::mem::size_of::<u32>()]
+                .copy_from_slice(&(address as u32).to_ne_bytes());
+            offset += core::mem::size_of::<u32>();
         }
 
         if let Some(instruction) = info.instruction {
-            payload[offset..offset + core::mem::size_of::<usize>()]
-                .copy_from_slice(&instruction.to_ne_bytes());
+            payload[offset..offset + core::mem::size_of::<u32>()]
+                .copy_from_slice(&(instruction as u32).to_ne_bytes());
         }
 
         Message::new(
-            MessageSender::from(info.pid),
-            MessageReceiver::from(info.pid),
+            MessageSender::new(info.pid, ThreadIdentifier::NONE),
+            MessageReceiver::new(info.pid, ThreadIdentifier::NONE),
             MessageType::Exception,
             None,
             payload,
@@ -119,7 +128,8 @@ impl EventInformation {
 
     /// # Description
     ///
-    /// Reads an optional `usize` from `payload` at the current `offset`, advancing `offset`.
+    /// Reads an optional fixed-width `u32` from `payload` at the current `offset`, advancing
+    /// `offset`, and widens it to `usize`.
     ///
     /// # Parameters
     ///
@@ -130,16 +140,16 @@ impl EventInformation {
     ///
     /// `Some(value)` if enough bytes remain, or `None` if the payload has insufficient bytes.
     ///
-    fn read_optional_usize(payload: &[u8], offset: &mut usize) -> Option<usize> {
-        let size: usize = core::mem::size_of::<usize>();
+    fn read_optional_u32(payload: &[u8], offset: &mut usize) -> Option<usize> {
+        let size: usize = core::mem::size_of::<u32>();
         let end: usize = offset.checked_add(size)?;
         if end > payload.len() {
             return None;
         }
-        let bytes: [u8; core::mem::size_of::<usize>()] =
+        let bytes: [u8; core::mem::size_of::<u32>()] =
             payload.get(*offset..end)?.try_into().ok()?;
         *offset = end;
-        Some(usize::from_ne_bytes(bytes))
+        Some(u32::from_ne_bytes(bytes) as usize)
     }
 }
 
@@ -161,10 +171,10 @@ impl TryFrom<Message> for EventInformation {
             "invalid process identifier",
         )?);
 
-        let number: Option<usize> = Self::read_optional_usize(payload, &mut offset);
-        let code: Option<usize> = Self::read_optional_usize(payload, &mut offset);
-        let address: Option<usize> = Self::read_optional_usize(payload, &mut offset);
-        let instruction: Option<usize> = Self::read_optional_usize(payload, &mut offset);
+        let number: Option<usize> = Self::read_optional_u32(payload, &mut offset);
+        let code: Option<usize> = Self::read_optional_u32(payload, &mut offset);
+        let address: Option<usize> = Self::read_optional_u32(payload, &mut offset);
+        let instruction: Option<usize> = Self::read_optional_u32(payload, &mut offset);
 
         Ok(Self {
             id,

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -22,81 +22,97 @@ use ::core::mem;
 // Structures
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Identity of the process and thread that originated a message.
+///
+/// Both halves are carried explicitly: `pid` attributes the message to a process (used by servers
+/// that key per-process state, such as vfsd), while `tid` names the originating thread (or
+/// [`ThreadIdentifier::NONE`] when unspecified). The kernel stamps the authoritative identity on
+/// every message that passes through the `send` kernel call (see `src/kernel/src/ipc/send.rs`), so
+/// a server may trust these fields instead of reconstructing identity from a sign-encoded value.
+/// This is correct across `fork()` + `execv()` (which keeps the process identifier but installs a
+/// new main-thread thread identifier, so `TID != PID`) and for requests issued by non-main threads
+/// of a multi-threaded caller (nanvix/nanvix#2650, nanvix/nanvix#2529).
+///
+/// # Notes
+///
+/// - All fields are intentionally public to enable zero-copy message parsing.
+///
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct MessageSender(i32);
+#[repr(C)]
+pub struct MessageSender {
+    /// Process that originated the message.
+    pub pid: ProcessIdentifier,
+    /// Thread that originated the message, or [`ThreadIdentifier::NONE`] when unspecified.
+    pub tid: ThreadIdentifier,
+}
+::static_assert::assert_eq_size!(MessageSender, 2 * mem::size_of::<u32>());
 
 impl MessageSender {
+    /// The size of a message sender, in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
     /// The kernel process is the sender of the message.
-    pub const KERNEL: Self = MessageSender(ProcessIdentifier::KERNEL_RAW);
+    pub const KERNEL: Self = Self::new(ProcessIdentifier::KERNEL, ThreadIdentifier::NONE);
     /// The memory management daemon is the sender of the message (standalone mode only).
     /// NOTE: Aliases [`Self::NETWORKD`] — these are mutually exclusive deployment modes.
-    pub const MEMD: Self = MessageSender(ProcessIdentifier::MEMD_RAW);
+    pub const MEMD: Self = Self::new(ProcessIdentifier::MEMD, ThreadIdentifier::NONE);
     /// The network daemon is the sender of the message (hosted mode only).
     /// NOTE: Aliases [`Self::MEMD`] — these are mutually exclusive deployment modes.
-    pub const NETWORKD: Self = MessageSender(ProcessIdentifier::NETWORKD_RAW);
+    pub const NETWORKD: Self = Self::new(ProcessIdentifier::NETWORKD, ThreadIdentifier::NONE);
     /// The VFS daemon is the sender of the message.
-    pub const VFSD: Self = MessageSender(ProcessIdentifier::VFSD_RAW);
-}
+    pub const VFSD: Self = Self::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE);
 
-impl MessageSender {
-    pub fn as_id(&self) -> Result<ProcessIdentifier, ThreadIdentifier> {
-        if self.0 >= 0 {
-            Ok(ProcessIdentifier::from(self.0))
-        } else {
-            Err(ThreadIdentifier::from(-self.0))
-        }
+    /// Creates a message sender from an explicit process and thread identifier.
+    pub const fn new(pid: ProcessIdentifier, tid: ThreadIdentifier) -> Self {
+        Self { pid, tid }
     }
 }
 
-impl From<ProcessIdentifier> for MessageSender {
-    fn from(pid: ProcessIdentifier) -> Self {
-        Self(pid.into())
-    }
-}
-
-impl From<ThreadIdentifier> for MessageSender {
-    fn from(tid: ThreadIdentifier) -> Self {
-        let tid: i32 = tid.into();
-        Self(-tid)
-    }
-}
-
+///
+/// # Description
+///
+/// Destination of a message, naming the receiving process and optionally a specific thread.
+///
+/// When `tid` is [`ThreadIdentifier::NONE`] the message is delivered to the process mailbox of
+/// `pid` (any thread may consume it); otherwise it is delivered to the named thread. This explicit
+/// tuple replaces the previous sign-encoded routing discriminator.
+///
+/// # Notes
+///
+/// - All fields are intentionally public to enable zero-copy message parsing.
+///
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct MessageReceiver(i32);
-
-impl MessageReceiver {
-    pub fn as_id(&self) -> Result<ProcessIdentifier, ThreadIdentifier> {
-        if self.0 >= 0 {
-            Ok(ProcessIdentifier::from(self.0))
-        } else {
-            Err(ThreadIdentifier::from(-self.0))
-        }
-    }
+#[repr(C)]
+pub struct MessageReceiver {
+    /// Process that should receive the message.
+    pub pid: ProcessIdentifier,
+    /// Thread that should receive the message, or [`ThreadIdentifier::NONE`] for the process
+    /// mailbox.
+    pub tid: ThreadIdentifier,
 }
+::static_assert::assert_eq_size!(MessageReceiver, 2 * mem::size_of::<u32>());
 
 impl MessageReceiver {
+    /// The size of a message receiver, in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
     /// The kernel process is the receiver of the message.
-    pub const KERNEL: Self = MessageReceiver(ProcessIdentifier::KERNEL_RAW);
+    pub const KERNEL: Self = Self::new(ProcessIdentifier::KERNEL, ThreadIdentifier::NONE);
     /// The memory management daemon is the receiver of the message (standalone mode only).
     /// NOTE: Aliases [`Self::NETWORKD`] — these are mutually exclusive deployment modes.
-    pub const MEMD: Self = MessageReceiver(ProcessIdentifier::MEMD_RAW);
+    pub const MEMD: Self = Self::new(ProcessIdentifier::MEMD, ThreadIdentifier::NONE);
     /// The network daemon is the receiver of the message (hosted mode only).
     /// NOTE: Aliases [`Self::MEMD`] — these are mutually exclusive deployment modes.
-    pub const NETWORKD: Self = MessageReceiver(ProcessIdentifier::NETWORKD_RAW);
+    pub const NETWORKD: Self = Self::new(ProcessIdentifier::NETWORKD, ThreadIdentifier::NONE);
     /// The VFS daemon is the receiver of the message.
-    pub const VFSD: Self = MessageReceiver(ProcessIdentifier::VFSD_RAW);
-}
+    pub const VFSD: Self = Self::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE);
 
-impl From<ProcessIdentifier> for MessageReceiver {
-    fn from(pid: ProcessIdentifier) -> Self {
-        Self(pid.into())
-    }
-}
-
-impl From<ThreadIdentifier> for MessageReceiver {
-    fn from(tid: ThreadIdentifier) -> Self {
-        let tid: i32 = tid.into();
-        Self(-tid)
+    /// Creates a message receiver from an explicit process and thread identifier.
+    pub const fn new(pid: ProcessIdentifier, tid: ThreadIdentifier) -> Self {
+        Self { pid, tid }
     }
 }
 
@@ -130,9 +146,9 @@ pub struct Message {
 //==================================================================================================
 
 impl Message {
-    /// The size of the message header fields (source, destination and type).
+    /// The size of the message header fields (type, source, destination and status).
     pub const HEADER_SIZE: usize =
-        2 * mem::size_of::<ProcessIdentifier>() + MessageType::SIZE + mem::size_of::<i32>();
+        MessageType::SIZE + MessageSender::SIZE + MessageReceiver::SIZE + mem::size_of::<i32>();
     /// The size of the message's payload.
     pub const PAYLOAD_SIZE: usize = config::kernel::IPC_MESSAGE_SIZE - Self::HEADER_SIZE;
 

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -214,41 +214,6 @@ pub fn __kcall_gettid() -> Result<ThreadIdentifier, Error> {
 }
 
 //==================================================================================================
-// Resolve Thread Identifier to Process Identifier
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Resolves a thread identifier to the identifier of the process that owns it.
-///
-/// This is the authoritative inverse of the historical `TID == PID` coincidence. A process reached
-/// via `fork()` + `execv()` keeps its process identifier but is assigned a new main-thread
-/// identifier, so its main-thread thread identifier no longer equals its process identifier.
-/// Privileged servers that attribute requests to a process by identity (e.g. vfsd, which keys its
-/// per-process file-descriptor table and working directory by PID) use this to recover the
-/// authoritative PID from a request's TID rather than casting the TID.
-///
-/// # Parameters
-///
-/// - `tid`: Identifier of the thread whose owning process is sought.
-///
-/// # Returns
-///
-/// Upon successful completion, the identifier of the process that owns `tid` is returned. Upon
-/// failure (e.g. no live thread bears that identifier), an error is returned instead.
-///
-pub fn __kcall_getpid_by_tid(tid: ThreadIdentifier) -> Result<ProcessIdentifier, Error> {
-    let result: i64 = kcall1!(KcallNumber::GetPidByTid.into(), u32::try_from(tid)?);
-
-    if unlikely(result < 0) {
-        Err(Error::new(ErrorCode::try_from(result)?, "failed to getpid_by_tid()"))
-    } else {
-        ProcessIdentifier::try_from(result)
-    }
-}
-
-//==================================================================================================
 // Exit
 //==================================================================================================
 

--- a/src/libs/sys/src/sys/number.rs
+++ b/src/libs/sys/src/sys/number.rs
@@ -113,8 +113,6 @@ pub enum KcallNumber {
     Duplicate = KcallNumber::NR_DUPLICATE_SYSCALL,
     /// Replaces the image of the calling process.
     Execv = KcallNumber::NR_EXECV_SYSCALL,
-    /// Resolves a thread identifier to the identifier of its owning process.
-    GetPidByTid = KcallNumber::NR_GET_PID_BY_TID_SYSCALL,
     /// Gets and/or sets the disposition of a signal.
     Sigaction = KcallNumber::NR_SIGACTION_SYSCALL,
     /// Gets and/or modifies the calling thread's blocked signal mask.
@@ -173,7 +171,6 @@ impl KcallNumber {
     const NR_DUPLICATE_SYSCALL: u32 = 37;
     const NR_GET_PPID_SYSCALL: u32 = 38;
     const NR_EXECV_SYSCALL: u32 = 39;
-    const NR_GET_PID_BY_TID_SYSCALL: u32 = 40;
     const NR_SIGACTION_SYSCALL: u32 = 41;
     const NR_SIGPROCMASK_SYSCALL: u32 = 42;
     const NR_KILL_SYSCALL: u32 = 43;
@@ -227,7 +224,6 @@ impl From<u32> for KcallNumber {
             Self::NR_DETACH_THREAD_SYSCALL => KcallNumber::DetachThread,
             Self::NR_DUPLICATE_SYSCALL => KcallNumber::Duplicate,
             Self::NR_EXECV_SYSCALL => KcallNumber::Execv,
-            Self::NR_GET_PID_BY_TID_SYSCALL => KcallNumber::GetPidByTid,
             Self::NR_SIGACTION_SYSCALL => KcallNumber::Sigaction,
             Self::NR_SIGPROCMASK_SYSCALL => KcallNumber::Sigprocmask,
             Self::NR_KILL_SYSCALL => KcallNumber::Kill,
@@ -283,7 +279,6 @@ impl From<KcallNumber> for u32 {
             KcallNumber::DetachThread => KcallNumber::NR_DETACH_THREAD_SYSCALL,
             KcallNumber::Duplicate => KcallNumber::NR_DUPLICATE_SYSCALL,
             KcallNumber::Execv => KcallNumber::NR_EXECV_SYSCALL,
-            KcallNumber::GetPidByTid => KcallNumber::NR_GET_PID_BY_TID_SYSCALL,
             KcallNumber::Sigaction => KcallNumber::NR_SIGACTION_SYSCALL,
             KcallNumber::Sigprocmask => KcallNumber::NR_SIGPROCMASK_SYSCALL,
             KcallNumber::Kill => KcallNumber::NR_KILL_SYSCALL,

--- a/src/libs/sys/src/sys/pm/tid.rs
+++ b/src/libs/sys/src/sys/pm/tid.rs
@@ -65,6 +65,22 @@ impl ThreadIdentifier {
     /// Identifier of the VFS daemon thread (main thread, assumes TID == PID).
     pub const VFSD: ThreadIdentifier = ThreadIdentifier(Self::VFSD_RAW);
 
+    /// Raw sentinel meaning "no specific thread".
+    ///
+    /// Real thread identifiers are non-negative, so this negative value is distinct from every
+    /// live thread. It lets [`MessageReceiver`](crate::ipc::MessageReceiver) address a process
+    /// mailbox (any thread) rather than a specific thread, and lets
+    /// [`MessageSender`](crate::ipc::MessageSender) leave the originating thread unspecified.
+    pub const NONE_RAW: i32 = -1;
+
+    /// Sentinel thread identifier meaning "no specific thread" (see [`Self::NONE_RAW`]).
+    pub const NONE: ThreadIdentifier = ThreadIdentifier(Self::NONE_RAW);
+
+    /// Returns `true` if this is the [`Self::NONE`] sentinel (i.e. no specific thread).
+    pub fn is_none(&self) -> bool {
+        self.0 == Self::NONE_RAW
+    }
+
     pub fn to_ne_bytes(&self) -> [u8; core::mem::size_of::<i32>()] {
         self.0.to_ne_bytes()
     }

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -110,8 +110,8 @@ impl GetDirectoryEntriesRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/message/fadvise.rs
@@ -83,8 +83,8 @@ impl FileAdvisoryInformationRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -136,8 +136,8 @@ impl FileAdvisoryInformationResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/message/fallocate.rs
@@ -79,8 +79,8 @@ impl FileSpaceControlRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -131,8 +131,8 @@ impl FileSpaceControlResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/message/fcntl.rs
@@ -78,8 +78,8 @@ impl FileControlRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -131,8 +131,8 @@ impl FileControlResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -280,8 +280,8 @@ impl OpenAtResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -344,8 +344,8 @@ impl RenameAtResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::RenameAtResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -271,8 +271,8 @@ impl UnlinkAtResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::UnlinkAtResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/message/part.rs
+++ b/src/libs/syscall/src/message/part.rs
@@ -217,16 +217,16 @@ impl SystemCallMessagePart {
         let message: SystemCallMessage = SystemCallMessage::new(header, message.into_bytes());
         if is_response {
             Ok(Message::new(
-                MessageSender::from(daemon),
-                MessageReceiver::from(tid),
+                MessageSender::new(daemon, ThreadIdentifier::NONE),
+                MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
                 message_type,
                 None,
                 message.into_bytes(),
             ))
         } else {
             Ok(Message::new(
-                MessageSender::from(tid),
-                MessageReceiver::from(daemon),
+                MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+                MessageReceiver::new(daemon, ThreadIdentifier::NONE),
                 message_type,
                 None,
                 message.into_bytes(),

--- a/src/libs/syscall/src/sys/ioctl/message/tty.rs
+++ b/src/libs/syscall/src/sys/ioctl/message/tty.rs
@@ -89,8 +89,8 @@ impl TtyControlRequest {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -155,8 +155,8 @@ impl TtyControlResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/mount/message/mount.rs
+++ b/src/libs/syscall/src/sys/mount/message/mount.rs
@@ -247,8 +247,8 @@ impl MountResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/mount/message/umount.rs
+++ b/src/libs/syscall/src/sys/mount/message/umount.rs
@@ -177,8 +177,8 @@ impl UmountResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/select/message/mod.rs
+++ b/src/libs/syscall/src/sys/select/message/mod.rs
@@ -372,8 +372,8 @@ impl SelectResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::SelectResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/accept.rs
+++ b/src/libs/syscall/src/sys/socket/message/accept.rs
@@ -20,7 +20,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::sys_socket::sockaddr;
 
@@ -61,8 +64,8 @@ impl AcceptSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -111,8 +114,8 @@ impl AcceptSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/bind.rs
+++ b/src/libs/syscall/src/sys/socket/message/bind.rs
@@ -21,7 +21,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -64,8 +67,8 @@ impl BindSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -121,8 +124,8 @@ impl BindSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/connect.rs
+++ b/src/libs/syscall/src/sys/socket/message/connect.rs
@@ -24,7 +24,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -76,8 +79,8 @@ impl ConnectSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -127,8 +130,8 @@ impl ConnectSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/message/getpeername.rs
@@ -21,7 +21,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -62,8 +65,8 @@ impl GetPeerNameRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -108,8 +111,8 @@ impl GetPeerNameResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/message/getsockname.rs
@@ -21,7 +21,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -62,8 +65,8 @@ impl GetSockNameRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -108,8 +111,8 @@ impl GetSockNameResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/listen.rs
+++ b/src/libs/syscall/src/sys/socket/message/listen.rs
@@ -20,7 +20,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -63,8 +66,8 @@ impl ListenSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -109,8 +112,8 @@ impl ListenSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -17,7 +17,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::sys_types::c_size_t;
 
@@ -65,8 +68,8 @@ impl ReceiveSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -113,8 +116,8 @@ impl ReceiveSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -17,7 +17,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::sys_types::{
     c_size_t,
@@ -74,8 +77,8 @@ impl SendSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -122,8 +125,8 @@ impl SendSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/message/shutdown.rs
@@ -21,7 +21,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -65,8 +68,8 @@ impl ShutdownSocketRequest {
         );
 
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -111,8 +114,8 @@ impl ShutdownSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/socket.rs
+++ b/src/libs/syscall/src/sys/socket/message/socket.rs
@@ -25,7 +25,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -77,8 +80,8 @@ impl CreateSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -125,8 +128,8 @@ impl CreateSocketResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/message/socketpair.rs
@@ -25,7 +25,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -78,8 +81,8 @@ impl CreateSocketPairRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::NETWORK_DESTINATION),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
             MessageType::Ikc,
             None,
             message.into_bytes(),
@@ -129,8 +132,8 @@ impl CreateSocketPairResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(crate::NETWORK_SOURCE),
-            MessageReceiver::from(tid),
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmod.rs
@@ -77,8 +77,8 @@ impl FileChmodRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileChmodRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -124,8 +124,8 @@ impl FileChmodResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -293,8 +293,8 @@ impl FileChmodAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstat.rs
@@ -73,8 +73,8 @@ impl FileStatRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileStatRequest, message.into_bytes());
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/message/futimens.rs
@@ -97,8 +97,8 @@ impl UpdateFileAccessTimeRequest {
             request.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -149,8 +149,8 @@ impl UpdateFileAccessTimeResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -298,8 +298,8 @@ impl MakeDirectoryAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -325,8 +325,8 @@ impl UpdateFileAccessTimeAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/time/message/mod.rs
+++ b/src/libs/syscall/src/sys/time/message/mod.rs
@@ -64,8 +64,8 @@ impl TimesRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -118,8 +118,8 @@ impl TimesResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/times/message/mod.rs
+++ b/src/libs/syscall/src/sys/times/message/mod.rs
@@ -64,8 +64,8 @@ impl TimesRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -118,8 +118,8 @@ impl TimesResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/exec/mod.rs
+++ b/src/libs/syscall/src/unistd/exec/mod.rs
@@ -529,17 +529,8 @@ pub fn exec_startup_barrier() {
         },
     };
 
-    let sender = message.source;
-    let source: ProcessIdentifier = match sender.as_id() {
-        Ok(source) => source,
-        Err(tid) => {
-            ::syslog::warn!(
-                "exec_startup_barrier(): unexpected non-process message source while awaiting \
-                 exec ack (tid={tid:?})"
-            );
-            return;
-        },
-    };
+    // The kernel stamps the authoritative originating process into `message.source.pid`.
+    let source: ProcessIdentifier = { message.source }.pid;
     if source != ProcessIdentifier::PROCD {
         ::syslog::warn!(
             "exec_startup_barrier(): unexpected message source while awaiting exec ack \

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -233,8 +233,8 @@ impl ChangeDirectoryResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/close.rs
+++ b/src/libs/syscall/src/unistd/message/close.rs
@@ -65,8 +65,8 @@ impl CloseRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::CloseRequest, message.into_bytes());
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -120,8 +120,8 @@ impl CloseResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::CloseResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/dup2.rs
+++ b/src/libs/syscall/src/unistd/message/dup2.rs
@@ -78,8 +78,8 @@ impl Dup2Request {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::Dup2Request, message.into_bytes());
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -141,8 +141,8 @@ impl Dup2Response {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::Dup2Response, message.into_bytes());
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -289,8 +289,8 @@ impl FileAccessAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchdir.rs
+++ b/src/libs/syscall/src/unistd/message/fchdir.rs
@@ -69,8 +69,8 @@ impl FileChdirRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileChdirRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -120,8 +120,8 @@ impl FileChdirResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchown.rs
+++ b/src/libs/syscall/src/unistd/message/fchown.rs
@@ -84,8 +84,8 @@ impl FileChownRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileChownRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -131,8 +131,8 @@ impl FileChownResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -319,8 +319,8 @@ impl FileChownAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/message/fdatasync.rs
@@ -67,8 +67,8 @@ impl FileDataSyncRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -125,8 +125,8 @@ impl FileDataSyncResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fsync.rs
+++ b/src/libs/syscall/src/unistd/message/fsync.rs
@@ -63,8 +63,8 @@ impl FileSyncRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileSyncRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -118,8 +118,8 @@ impl FileSyncResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::FileSyncResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/message/ftruncate.rs
@@ -70,8 +70,8 @@ impl FileTruncateRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -122,8 +122,8 @@ impl FileTruncateResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/getcwd.rs
+++ b/src/libs/syscall/src/unistd/message/getcwd.rs
@@ -77,8 +77,8 @@ impl GetCurrentWorkingDirectoryRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/getids.rs
+++ b/src/libs/syscall/src/unistd/message/getids.rs
@@ -63,8 +63,8 @@ impl GetIdsRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::GetIdsRequest, message.into_bytes());
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -122,8 +122,8 @@ impl GetIdsResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::GetIdsResponse, message.into_bytes());
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -329,8 +329,8 @@ impl LinkAtResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::LinkAtResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/lseek.rs
+++ b/src/libs/syscall/src/unistd/message/lseek.rs
@@ -72,8 +72,8 @@ impl SeekRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::SeekRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -122,8 +122,8 @@ impl SeekResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::SeekResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/pipe.rs
+++ b/src/libs/syscall/src/unistd/message/pipe.rs
@@ -59,8 +59,8 @@ impl PipeRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::PipeRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -120,8 +120,8 @@ impl PipeResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::PipeResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -79,8 +79,8 @@ impl PartialReadRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -129,8 +129,8 @@ impl PartialReadResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -80,8 +80,8 @@ impl PartialWriteRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -132,8 +132,8 @@ impl PartialWriteResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -68,8 +68,8 @@ impl ReadRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::ReadRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -116,8 +116,8 @@ impl ReadResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::ReadResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/register_socket.rs
+++ b/src/libs/syscall/src/unistd/message/register_socket.rs
@@ -76,8 +76,8 @@ impl RegisterSocketRequest {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -147,8 +147,8 @@ impl RegisterSocketResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/resolve_fd.rs
+++ b/src/libs/syscall/src/unistd/message/resolve_fd.rs
@@ -78,8 +78,8 @@ impl ResolveFdRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::ResolveFdRequest, message.into_bytes());
         Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -166,8 +166,8 @@ impl ResolveFdResponse {
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -285,8 +285,8 @@ impl SymbolicLinkAtResponse {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -68,8 +68,8 @@ impl WriteRequest {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::WriteRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(destination),
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
             message_type,
             None,
             message.into_bytes(),
@@ -119,8 +119,8 @@ impl WriteResponse {
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageHeader::WriteResponse, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(source),
-            MessageReceiver::from(tid),
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
             message_type,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -212,8 +212,14 @@ fn write_ipc(
         total_written += written;
         offset += written as usize;
 
-        // Short write: fewer bytes written than requested.
-        if (written as usize) < chunk_size {
+        // Stop only when the backend makes no forward progress. A backend may accept fewer bytes
+        // than requested per request — notably hostfs caps each IKC write at
+        // `MAX_INLINE_WRITE_DATA`, which shrank when the IPC payload gave up 8 bytes to the
+        // kernel-stamped client identity (nanvix/nanvix#2662) — so a short write is not
+        // end-of-stream: the next iteration writes the remainder and the caller still observes a
+        // full write. Breaking on `written == 0` keeps the guard against an unbounded loop when no
+        // forward progress is possible.
+        if written == 0 {
             break;
         }
     }

--- a/src/tests/linux-app/src/file_system.rs
+++ b/src/tests/linux-app/src/file_system.rs
@@ -664,7 +664,10 @@ fn test_pipe_blocking_fork() {
             ipc,
             pm,
         },
-        pm::ProcessIdentifier,
+        pm::{
+            ProcessIdentifier,
+            ThreadIdentifier,
+        },
     };
 
     /// Total bytes streamed; exceeds the 64 KiB pipe capacity to force the writer to block.
@@ -712,8 +715,8 @@ fn test_pipe_blocking_fork() {
         let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
         payload[0] = u8::from(passed);
         let reply: Message = Message::new(
-            MessageSender::from(my_pid),
-            MessageReceiver::from(parent_pid),
+            MessageSender::new(my_pid, ThreadIdentifier::NONE),
+            MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
             MessageType::Ipc,
             None,
             payload,
@@ -819,7 +822,10 @@ fn test_pipe_eof_on_writer_exit() {
             ipc,
             pm,
         },
-        pm::ProcessIdentifier,
+        pm::{
+            ProcessIdentifier,
+            ThreadIdentifier,
+        },
     };
 
     /// Bound on close retries absorbing the asynchronous fork-clone descriptor duplication.
@@ -865,8 +871,8 @@ fn test_pipe_eof_on_writer_exit() {
             let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
             payload[0] = READY;
             let reply: Message = Message::new(
-                MessageSender::from(my_pid),
-                MessageReceiver::from(parent_pid),
+                MessageSender::new(my_pid, ThreadIdentifier::NONE),
+                MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
                 MessageType::Ipc,
                 None,
                 payload,
@@ -933,7 +939,10 @@ fn test_pipe_epipe_on_reader_exit() {
             ipc,
             pm,
         },
-        pm::ProcessIdentifier,
+        pm::{
+            ProcessIdentifier,
+            ThreadIdentifier,
+        },
     };
 
     /// Bound on close retries absorbing the asynchronous fork-clone descriptor duplication.
@@ -984,8 +993,8 @@ fn test_pipe_epipe_on_reader_exit() {
             let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
             payload[0] = READY;
             let reply: Message = Message::new(
-                MessageSender::from(my_pid),
-                MessageReceiver::from(parent_pid),
+                MessageSender::new(my_pid, ThreadIdentifier::NONE),
+                MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
                 MessageType::Ipc,
                 None,
                 payload,

--- a/src/tests/mount-test/src/symlink_ops.rs
+++ b/src/tests/mount-test/src/symlink_ops.rs
@@ -54,8 +54,8 @@ pub fn test() -> Result<(), Error> {
     }
 
     // Inline-path tests: all use short link names whose wire path (after stripping
-    // the `/mnt/` mount prefix) fits within `MAX_INLINE_PATH_LEN` (36 bytes), so
-    // readlink/lstat take the single-message fast path.
+    // the `/mnt/` mount prefix) fits within `MAX_INLINE_PATH_LEN`, so readlink/lstat take the
+    // single-message fast path.
     test_symlink_create_readlink()?;
     test_lstat_does_not_follow()?;
     test_stat_follows_symlink()?;
@@ -195,11 +195,11 @@ fn test_symlink_to_nonexistent_target() -> Result<(), Error> {
 /// Tests that readlink/lstat/stat work over the multi-part wire format.
 ///
 /// Uses a link path whose wire form (after the `/mnt/` prefix is stripped) exceeds
-/// `hostfs_api::MAX_INLINE_PATH_LEN` (36 bytes), so vfsd sends the request through
-/// the multi-part assembler rather than the inline single-message fast path. This
+/// `hostfs_api::MAX_INLINE_PATH_LEN`, so vfsd sends the request through the multi-part assembler
+/// rather than the inline single-message fast path. This
 /// covers both no-follow (`lstat`) and follow (`stat`) multi-part dispatch paths.
 fn test_long_path_multipart() -> Result<(), Error> {
-    // Stripped wire path: "long-symlink-name-padding-AAAAAAAAAAAA.lnk" (42 bytes > 36).
+    // Stripped wire path: "long-symlink-name-padding-AAAAAAAAAAAA.lnk".
     let link_path: FileSystemPath =
         FileSystemPath::new("/mnt/long-symlink-name-padding-AAAAAAAAAAAA.lnk")?;
     let target: FileSystemPath = FileSystemPath::new("symlink-target.txt")?;

--- a/src/tests/setenv-rust/src/tests/fork.rs
+++ b/src/tests/setenv-rust/src/tests/fork.rs
@@ -44,7 +44,10 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::{
     ffi::c_int,
@@ -91,8 +94,8 @@ fn reap_child(child: ProcessIdentifier) -> Result<c_int, Error> {
 /// Releases a child blocked on [`ipc::__kcall_recv`] by sending it an empty IPC message.
 fn release_child(parent: ProcessIdentifier, child: ProcessIdentifier) -> Result<(), Error> {
     let go: Message = Message::new(
-        MessageSender::from(parent),
-        MessageReceiver::from(child),
+        MessageSender::new(parent, ThreadIdentifier::NONE),
+        MessageReceiver::new(child, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-fork-guestfs/src/tests/fork_fds.rs
+++ b/src/tests/test-fork-guestfs/src/tests/fork_fds.rs
@@ -60,7 +60,10 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 use ::syscall::{
@@ -200,8 +203,8 @@ fn run_child(parent_pid: ProcessIdentifier, my_pid: ProcessIdentifier) -> Result
     payload[1] = first_byte;
     payload[2] = count;
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -255,8 +258,8 @@ fn test_fork_descriptor_inheritance() -> Result<(), Error> {
 
     // Release the child to perform its read against the inherited descriptor.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-fork-hostfs/src/tests/fork_hostfs.rs
+++ b/src/tests/test-fork-hostfs/src/tests/fork_hostfs.rs
@@ -65,7 +65,10 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 use ::syscall::{
@@ -208,8 +211,8 @@ fn run_child(parent_pid: ProcessIdentifier, my_pid: ProcessIdentifier) -> Result
     payload[1] = first_byte;
     payload[2] = count;
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -268,8 +271,8 @@ fn test_fork_hostfs_descriptor_inheritance() -> Result<(), Error> {
 
     // Release the child to perform its read against the inherited descriptor.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-fork-kcall/src/tests/fork.rs
+++ b/src/tests/test-fork-kcall/src/tests/fork.rs
@@ -57,7 +57,10 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
     time::SystemTime,
 };
 use ::sysapi::{
@@ -170,8 +173,8 @@ fn run_child(parent_pid: ProcessIdentifier) -> Result<(), Error> {
     payload[0] = observed_before;
     payload[1..5].copy_from_slice(&ppid.to_le_bytes());
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -225,8 +228,8 @@ fn test_fork_cow_and_lineage() -> Result<(), Error> {
 
     // Release the child to perform its observation.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],
@@ -292,8 +295,8 @@ fn report_cached_pid(parent: ProcessIdentifier) -> Result<(), Error> {
     let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     payload[0..4].copy_from_slice(&i32::from(cached_pid).to_le_bytes());
     let reply: Message = Message::new(
-        MessageSender::from(real_pid),
-        MessageReceiver::from(parent),
+        MessageSender::new(real_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -493,8 +496,8 @@ fn run_child_mutex_condvar(parent_pid: ProcessIdentifier) -> Result<(), Error> {
     payload[2] = observed_after;
     payload[4..8].copy_from_slice(&errcode.to_le_bytes());
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -578,8 +581,8 @@ fn test_fork_mutex_condvar() -> Result<(), Error> {
 
     // Release the child to perform its observation.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-kernel/src/duplicate.rs
+++ b/src/tests/test-kernel/src/duplicate.rs
@@ -47,6 +47,7 @@ use ::sys::{
         MutexAddress,
         ProcessIdentifier,
         ThreadCreateArgs,
+        ThreadIdentifier,
     },
     time::SystemTime,
 };
@@ -163,8 +164,8 @@ extern "C" fn child_entry(_arg: usize) -> usize {
     payload[0] = observed_before;
     payload[1] = observed_after;
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -221,8 +222,8 @@ fn test_duplicate_cow() -> Result<(), Error> {
 
     // Release the child to perform its observation.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],
@@ -378,8 +379,8 @@ fn test_duplicate_cow_refork() -> Result<(), Error> {
 
         // Release the second child to perform its observation and write.
         let go: Message = Message::new(
-            MessageSender::from(parent_pid),
-            MessageReceiver::from(second_child),
+            MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+            MessageReceiver::new(second_child, ThreadIdentifier::NONE),
             MessageType::Ipc,
             None,
             [0u8; Message::PAYLOAD_SIZE],
@@ -593,8 +594,8 @@ fn child_mutex_condvar_report() -> Result<(), Error> {
     payload[1] = observed_before;
     payload[2] = observed_after;
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -687,8 +688,8 @@ fn test_duplicate_mutex_condvar() -> Result<(), Error> {
 
         // Release the child to perform its observation and write.
         let go: Message = Message::new(
-            MessageSender::from(parent_pid),
-            MessageReceiver::from(child_pid),
+            MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+            MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
             MessageType::Ipc,
             None,
             [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-kernel/src/getppid.rs
+++ b/src/tests/test-kernel/src/getppid.rs
@@ -43,6 +43,7 @@ use ::sys::{
         Capability,
         ProcessIdentifier,
         ThreadCreateArgs,
+        ThreadIdentifier,
     },
 };
 
@@ -129,8 +130,8 @@ extern "C" fn child_entry(_arg: usize) -> usize {
     let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     payload[0..4].copy_from_slice(&ppid_raw.to_le_bytes());
     let reply: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -239,8 +240,8 @@ fn observe_child_parent(
 
     // Release the child to perform its observation.
     let go: Message = Message::new(
-        MessageSender::from(parent_pid),
-        MessageReceiver::from(child_pid),
+        MessageSender::new(parent_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(child_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/test-kernel/src/source_spoofing.rs
+++ b/src/tests/test-kernel/src/source_spoofing.rs
@@ -1,26 +1,25 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-//! # IPC Source-Spoofing Regression Tests
+//! # IPC Source-Stamping Regression Tests
 //!
-//! Regression coverage for the kernel IPC `send()` path, which must reject messages whose
-//! `source` field does not match the trusted identity of the calling process or thread.
+//! Regression coverage for the kernel IPC `send()` path, which stamps the authoritative identity
+//! of the calling process and thread into `message.source` (overwriting whatever the sender
+//! supplied) so that a receiver can trust `message.source.pid` for request attribution.
 //!
-//! Before the fix the kernel only logged a warning when it detected a forged `source` and still
-//! delivered the message with the attacker-supplied value intact. Because daemons authenticate
-//! callers on `message.source` (e.g. vfsd treats a message as coming from `PROCD`), any
-//! unprivileged process could impersonate a privileged peer and trick a receiver into performing
-//! privileged actions on its behalf. This is a broken-access-control / source-spoofing
-//! vulnerability (OWASP A01).
+//! Before this guarantee the kernel only logged a warning when it detected a forged `source` and
+//! still delivered the message with the attacker-supplied value intact. Any receiver that trusted
+//! `message.source` for request attribution could then be tricked into performing privileged
+//! actions on the sender's behalf. This is a broken-access-control / source-spoofing vulnerability
+//! (OWASP A01).
 //!
 //! The tests below verify that:
 //!
-//! 1. A send whose `source` is forged to impersonate a different privileged daemon (one whose
-//!    identity matches neither the caller's PID-encoded identity nor its negative TID-encoded
-//!    identity) is rejected with [`ErrorCode::OperationNotPermitted`] and is therefore not
-//!    delivered.
-//! 2. A send carrying the caller's own legitimate PID-encoded `source` still succeeds and is
-//!    delivered intact, ensuring the rejection does not break well-formed messages.
+//! 1. A send whose `source` is forged to impersonate a different privileged daemon is delivered
+//!    with the forged identity overwritten by the caller's true [`ProcessIdentifier`], so the
+//!    forged value never reaches the receiver.
+//! 2. A send carrying the caller's own legitimate `source` still round-trips with the caller's
+//!    identity intact, ensuring the stamping does not corrupt well-formed messages.
 
 //==================================================================================================
 // Imports
@@ -41,25 +40,26 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
 // Test Cases
 //==================================================================================================
 
-/// Verifies that the kernel rejects a send whose `source` is forged to impersonate another process.
+/// Verifies that the kernel overwrites a forged `source` with the caller's true identity.
 ///
-/// The forged source is chosen to match neither the caller's PID-encoded identity nor its
-/// (negative) TID-encoded identity, so the kernel must reject the send with
-/// [`ErrorCode::OperationNotPermitted`] instead of delivering the forged message.
-fn test_reject_spoofed_source() -> Result<(), Error> {
+/// The forged source impersonates a different privileged daemon. A correct kernel stamps the
+/// caller's authoritative [`ProcessIdentifier`] over it, so the delivered message must carry the
+/// caller's own pid — never the forged one.
+fn test_spoofed_source_is_overwritten() -> Result<(), Error> {
     let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
     // Impersonate a privileged daemon other than ourselves. In the test-kernel environment this
-    // process runs as PROCD, so forge VFSD; if it ever runs as VFSD, forge PROCD instead. Either
-    // way the forged source matches neither our PID-encoded identity nor our (negative)
-    // TID-encoded identity, so a correct kernel must reject it.
+    // process runs as PROCD, so forge VFSD; if it ever runs as VFSD, forge PROCD instead.
     let forged_pid: ProcessIdentifier = if my_pid == ProcessIdentifier::VFSD {
         ProcessIdentifier::PROCD
     } else {
@@ -69,32 +69,40 @@ fn test_reject_spoofed_source() -> Result<(), Error> {
     // Guard against the spoof silently becoming a no-op if the environment ever changes.
     assert!(forged_pid != my_pid, "forged source must differ from the caller's own identity");
 
-    // The message is addressed to ourselves so that the buggy delivery path (which would otherwise
-    // reach a real daemon) has no external side effects.
+    // The message is addressed to ourselves so that delivery has no external side effects.
     let spoofed: Message = Message::new(
-        MessageSender::from(forged_pid),
-        MessageReceiver::from(my_pid),
+        MessageSender::new(forged_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(my_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],
     );
 
-    match ipc::__kcall_send(&spoofed) {
-        // The kernel accepted the forged source. This is the bug under test: the send must be
-        // rejected, not delivered.
-        Ok(()) => Err(Error::new(
+    // The send succeeds: the kernel does not reject the forged source, it overwrites it.
+    ipc::__kcall_send(&spoofed)?;
+
+    // Drain the delivered message and confirm the forged identity did not survive.
+    let received: Message = ipc::__kcall_recv()?;
+    let source = { received.source };
+    if source.pid == forged_pid {
+        return Err(Error::new(
             ErrorCode::OperationNotPermitted,
-            "kernel accepted a spoofed message source",
-        )),
-        // The kernel rejected the forged source as expected.
-        Err(e) if e.code == ErrorCode::OperationNotPermitted => Ok(()),
-        // The send failed for an unexpected reason; surface it so the failure is not masked.
-        Err(e) => Err(e),
+            "kernel delivered a spoofed message source",
+        ));
     }
+    if source.pid != my_pid {
+        return Err(Error::new(
+            ErrorCode::OperationNotPermitted,
+            "kernel stamped an unexpected source identity",
+        ));
+    }
+
+    Ok(())
 }
 
-/// Verifies that a send carrying the caller's legitimate PID-encoded source still succeeds and is
-/// delivered intact, ensuring the spoof rejection does not reject well-formed messages.
+/// Verifies that a send carrying the caller's legitimate source still round-trips with the
+/// caller's identity intact, ensuring the authoritative stamping does not corrupt well-formed
+/// messages.
 fn test_allow_legitimate_source() -> Result<(), Error> {
     let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
@@ -103,8 +111,8 @@ fn test_allow_legitimate_source() -> Result<(), Error> {
     let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     payload[0] = PAYLOAD_MARKER;
     let legit: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(my_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(my_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,
@@ -112,14 +120,11 @@ fn test_allow_legitimate_source() -> Result<(), Error> {
     ipc::__kcall_send(&legit)?;
 
     // Drain the delivered message so it does not leak into later tests, and confirm that the
-    // legitimate source and payload survived the round trip unchanged.
+    // kernel-stamped source identifies the caller and the payload survived the round trip.
     let received: Message = ipc::__kcall_recv()?;
-    let received_source: MessageSender = { received.source };
+    let received_source = { received.source };
     let received_payload: [u8; Message::PAYLOAD_SIZE] = { received.payload };
-    assert!(
-        received_source == MessageSender::from(my_pid),
-        "legitimate message source was altered in transit"
-    );
+    assert!(received_source.pid == my_pid, "legitimate message source was altered in transit");
     assert!(
         received_payload[0] == PAYLOAD_MARKER,
         "legitimate message payload corrupted in transit"
@@ -136,8 +141,8 @@ fn test_allow_legitimate_source() -> Result<(), Error> {
 pub fn run() -> Result<(), Error> {
     ::syslog::info!("test-kernel: source_spoofing: starting source-spoofing regression tests");
 
-    test_reject_spoofed_source()?;
-    ::syslog::info!("test-kernel: source_spoofing: PASS - reject_spoofed_source");
+    test_spoofed_source_is_overwritten()?;
+    ::syslog::info!("test-kernel: source_spoofing: PASS - spoofed_source_is_overwritten");
 
     test_allow_legitimate_source()?;
     ::syslog::info!("test-kernel: source_spoofing: PASS - allow_legitimate_source");

--- a/src/tests/testd/src/pm/terminate.rs
+++ b/src/tests/testd/src/pm/terminate.rs
@@ -45,6 +45,7 @@ use ::sys::{
         Capability,
         ProcessIdentifier,
         ThreadCreateArgs,
+        ThreadIdentifier,
     },
 };
 
@@ -115,8 +116,8 @@ extern "C" fn terminate_child_entry(_arg: usize) -> usize {
 
     // Acknowledge creation to the parent.
     let ack: Message = Message::new(
-        MessageSender::from(my_pid),
-        MessageReceiver::from(parent_pid),
+        MessageSender::new(my_pid, ThreadIdentifier::NONE),
+        MessageReceiver::new(parent_pid, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/tests/waitpid-rust/src/tests/waitpid.rs
+++ b/src/tests/waitpid-rust/src/tests/waitpid.rs
@@ -51,7 +51,10 @@ use ::sys::{
         ipc,
         pm,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::{
     ffi::c_int,
@@ -125,8 +128,8 @@ fn spawn_blocked_child(status: c_int) -> Result<ProcessIdentifier, Error> {
 /// Releases a child created by [`spawn_blocked_child`] by sending it an empty IPC message.
 fn release_child(parent: ProcessIdentifier, child: ProcessIdentifier) -> Result<(), Error> {
     let go: Message = Message::new(
-        MessageSender::from(parent),
-        MessageReceiver::from(child),
+        MessageSender::new(parent, ThreadIdentifier::NONE),
+        MessageReceiver::new(child, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         [0u8; Message::PAYLOAD_SIZE],
@@ -144,8 +147,8 @@ fn report_pid(to: ProcessIdentifier, pid: ProcessIdentifier) -> Result<(), Error
     let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
     payload[0..4].copy_from_slice(&i32::from(pid).to_le_bytes());
     let report: Message = Message::new(
-        MessageSender::from(from),
-        MessageReceiver::from(to),
+        MessageSender::new(from, ThreadIdentifier::NONE),
+        MessageReceiver::new(to, ThreadIdentifier::NONE),
         MessageType::Ipc,
         None,
         payload,

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -385,17 +385,17 @@ impl StandaloneVmHandle {
 ///
 /// Extracts the [`ThreadIdentifier`] from a message sender field.
 ///
-/// Write/Read requests encode the originating thread as a negative value in the
-/// [`MessageSender`](::sys::ipc::MessageSender) field.
+/// The kernel stamps the originating thread into the
+/// [`MessageSender::tid`](::sys::ipc::MessageSender) field of write/read requests, so it is read
+/// directly here.
 ///
 fn extract_tid(source: ::sys::ipc::MessageSender) -> ThreadIdentifier {
-    match source.as_id() {
-        Err(tid) => tid,
-        Ok(_pid) => {
-            warn!("standalone io_handler: message source is a PID, expected TID");
-            ThreadIdentifier::from(1i32)
-        },
+    let tid: ThreadIdentifier = source.tid;
+    if tid.is_none() {
+        warn!("standalone io_handler: message source has no thread id");
+        return ThreadIdentifier::from(1i32);
     }
+    tid
 }
 
 ///
@@ -526,8 +526,8 @@ async fn standalone_io_handler(
                             let mut send_failed = false;
                             for payload in response_payloads {
                                 let response: Message = Message::new(
-                                    MessageSender::from(ProcessIdentifier::KERNEL),
-                                    MessageReceiver::from(ProcessIdentifier::VFSD),
+                                    MessageSender::KERNEL,
+                                    MessageReceiver::VFSD,
                                     MessageType::Ikc,
                                     None,
                                     payload,
@@ -726,7 +726,7 @@ async fn standalone_io_handler(
                             let tid: ThreadIdentifier = extract_tid(msg.source);
                             let error_response: Message = Message::new(
                                 MessageSender::NETWORKD,
-                                MessageReceiver::from(tid),
+                                MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
                                 MessageType::Ikc,
                                 Some(ErrorCode::OperationNotSupported),
                                 [0u8; Message::PAYLOAD_SIZE],
@@ -916,8 +916,8 @@ async fn send_hostfs_error(
     }
 
     let err_response: Message = Message::new(
-        MessageSender::from(ProcessIdentifier::KERNEL),
-        MessageReceiver::from(ProcessIdentifier::VFSD),
+        MessageSender::KERNEL,
+        MessageReceiver::VFSD,
         MessageType::Ikc,
         None,
         err_payload,

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -127,12 +127,10 @@ impl Benchmark {
             let warmup_syscall_msg: SystemCallMessage =
                 SystemCallMessage::try_from_bytes(warmup_read_msg.payload)
                     .map_err(|_| anyhow::anyhow!("warmup: error parsing SystemCall message"))?;
-            // NOTE: `as_id()` returns `Err(ThreadIdentifier)` when the source is a
-            // thread (expected) and `Ok(ProcessIdentifier)` when it is a process.
-            let warmup_tid: ThreadIdentifier = match { warmup_read_msg.source }.as_id() {
-                Err(tid) => tid,
-                Ok(pid) => anyhow::bail!("warmup: unexpected message source: {pid:?}"),
-            };
+            let warmup_tid: ThreadIdentifier = { warmup_read_msg.source }.tid;
+            if warmup_tid.is_none() {
+                anyhow::bail!("warmup: message source has no thread id");
+            }
             let _warmup_read_req: ReadRequest = ReadRequest::from_bytes(warmup_syscall_msg.payload);
 
             // Step 2: Receive the bulk pull request from the guest kernel.
@@ -235,10 +233,10 @@ impl Benchmark {
                         ));
                     },
                 };
-            let tid: ThreadIdentifier = match { ipc_read_message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(pid) => return Err(anyhow::anyhow!("unexpected message source: {pid:?}")),
-            };
+            let tid: ThreadIdentifier = { ipc_read_message.source }.tid;
+            if tid.is_none() {
+                return Err(anyhow::anyhow!("unexpected message source: no thread id"));
+            }
             let _read_request: ReadRequest = ReadRequest::from_bytes(syscall_message.payload);
 
             // Step 2: Receive the bulk pull request from the guest kernel.


### PR DESCRIPTION
## Summary

Replaces the sign-encoded IPC sender/receiver discriminator with an explicit, kernel-attested client identity so a server can reliably answer "which process is calling me?" for every request.

Previously a server reconstructed the caller's PID by casting the caller's thread id (TID), which is correct only while `TID == PID`. That cast misattributed per-process state after `fork()`+`execv()` (which keeps the PID but installs a new main-thread TID) and for requests from non-main threads of a multi-threaded caller.

## Changes

### ABI (`libs/sys`)
- Turn `MessageSender` and `MessageReceiver` into explicit `#[repr(C)]` `{ pid, tid }` tuples (8 bytes each), replacing the `i32` `+pid` / `-tid` sign encoding and its `as_id()` accessor.
- Add `ThreadIdentifier::NONE` (-1) / `is_none()` meaning "no specific thread" (process-mailbox addressing, unspecified sender thread).
- Recompute `Message::HEADER_SIZE` from the new fields; the payload shrinks 51 -> 43 bytes. Every fixed message keeps its compile-time `assert_eq_size!` gate against the reduced payload.
- Derive `hostfs-api` inline limits from `Message::PAYLOAD_SIZE` instead of hardcoding them.

### Kernel
- `send()` now stamps the authoritative `(src_pid, src_tid)` over `message.source` unconditionally instead of rejecting a forged source. The field is therefore unforgeable: a receiver may trust `message.source.pid` for attribution and `message.source.tid` to route a reply to the exact calling thread.
- Route delivery by `destination.tid` (process mailbox when `tid.is_none()`).

### Servers
- `vfsd` and `procd` read the kernel-stamped `message.source.pid` directly, so per-process VFS state (fd table, cwd) is no longer misattributed across `fork()`+`execv()` or for non-main threads.
- `networkd` and `linuxd` read `message.source.tid` for thread-addressed reply routing under the new API.

### Removed stopgaps
- The `GetPidByTid` kernel call (NR 40, `ProcessManager::try_get_pid_by_tid`, `__kcall_getpid_by_tid`) and the TID->PID cast in `vfsd`. The generation-tagged identity from the issue is deferred since PIDs are not recycled today.

### Other fallout
- `EventInformation` serializes its optional fault fields as fixed-width `u32` (was native `usize`) so the encoding is identical on the 32-bit guest and the 64-bit host used by unit tests, and fits the smaller payload.
- The `write_ipc` loop now stops only on zero forward progress (was a short write): hostfs caps each request at its inline-write limit, so a short write is normal and the remainder is sent on the next iteration.

## Testing
- Added IPC source-stamping regression coverage (`test-kernel`): a forged source is overwritten with the caller's true identity, and a legitimate self-addressed message still round-trips intact.
- `.\z.ps1 build -- run-unit-tests` - passed.
- `.\z.ps1 build -- run-nanvix-tests` - passed.

## Refs
#2662, #2650, #2529, #2637, #2527
