### PR TITLE
[ci] F: Add Copilot Prompts And Doc Guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,11 @@ When modifying or generating code, keep platform differences in mind:
 - Do not modify unrelated code paths or tests.
 - Update documentation when behavior or interfaces change.
 - Prefer existing project tooling and scripts over ad-hoc commands.
+- Never stage or commit changes unless the user explicitly asks. Leave edits in the working
+  tree for review.
+- When the user does ask to commit, follow the commit-message convention in
+  [CONTRIBUTING.md](../CONTRIBUTING.md) (`[module] (B|E|F|W): Subject`, title at most 50
+  characters) and never bypass git hooks (no `--no-verify`).
 
 ## Validation
 

--- a/.github/prompts/address-pr-comments.prompt.md
+++ b/.github/prompts/address-pr-comments.prompt.md
@@ -1,0 +1,14 @@
+---
+description: "Address review comments left on a PR without committing the fixes"
+name: "Address PR Comments"
+argument-hint: "PR number (e.g. 2438)"
+agent: "agent"
+---
+Address the review comments left on the pull request identified in the input.
+
+- Fetch the PR's review comments and unresolved threads using GitHub tooling (e.g. `gh pr view` / `gh api`).
+  Focus on unresolved threads first.
+- For each comment, make the corresponding code edit and briefly note how it was addressed.
+- When verification is needed, run the relevant tests per the
+  [test skill](../skills/test/SKILL.md), piping large output through `tail`/`grep`.
+- Do **not** commit the fixes. Leave the changes in the working tree for review.

--- a/.github/prompts/commit-message.prompt.md
+++ b/.github/prompts/commit-message.prompt.md
@@ -1,0 +1,90 @@
+---
+description: Generate a Nanvix-conformant commit message for the currently staged changes.
+name: "Commit Message"
+agent: "agent"
+---
+
+# Suggest a Commit Message
+
+Generate a commit message for the **currently staged** changes only. Do not stage,
+commit, amend, or push anything — only produce the message text for the user to use.
+
+Consider **only** what is in the staging area (the index). Ignore unstaged and
+working-tree changes entirely. If nothing is staged, say so and stop without
+producing a message.
+
+## Steps
+
+1. Inspect staged changes with `git diff --cached --stat` first to see scope, then
+   `git diff --cached` for detail. Do **not** paste the full diff back into the chat —
+   read it, then write the message.
+   - Work from the diff hunks alone. Do **not** open whole source files with
+     `read_file` to gather context — the staged hunks are sufficient to describe
+     what changed and why.
+   - Only if a hunk is genuinely ambiguous, open **at most one or two** files, and
+     read just the relevant range rather than the entire file.
+2. Determine the single most appropriate `module-name` and type tag (below). If the
+   change spans modules, pick the dominant one; do not invent multi-scope subjects.
+3. Write the message following the format and body rules below.
+4. Output the final message inside one fenced ```text block so it can be copied as-is.
+
+## Subject Line
+
+Format (enforced by `.githooks/commit-msg`):
+
+```text
+[module-name] (B|E|F|W): Short Description
+```
+
+- **module-name** — affected component. Valid names are Cargo workspace members plus:
+  `build`, `ci`, `contrib`, `doc`, `git`, `scripts`, `tests`
+  (e.g. `kernel`, `proc`, `sys`, `syscall`, `libc_time`, `tests`, `doc`).
+- **Type tag** — `B` bug fix · `E` enhancement · `F` feature · `W` work in progress.
+- **Title must be at most 50 characters** (including the `[module] X:` prefix).
+- Use the imperative mood and Title Case for the description (e.g. `Add`, `Harden`,
+  `Implement`), matching existing history.
+
+## Body
+
+- Separate the subject from the body with one blank line; wrap the body at ~72 columns.
+- Open with a short imperative paragraph stating **what** changed and **why** /
+  the observable effect — not a restatement of the diff.
+- Group mechanical details under labelled bullet sections when the change touches
+  several areas (mirror existing commits), for example:
+  - `Kernel:` / `Libraries:` / `Tests:` / `Build and harness wiring:` — adjust to fit.
+  - Each bullet is a concise, specific statement; sub-bullets are allowed.
+- Reference issues/PRs when relevant using the project's style:
+  `Part of #2690`, `closes #2693`. Only include refs you can justify from the diff or
+  the user's explicit input — never fabricate issue numbers.
+- Mention test/run commands only when they add real value (e.g. how to run new tests).
+
+## Reference Examples
+
+```text
+[proc] E: Harden authorize_kill()
+
+Rework ProcessDaemon::authorize_kill() to fail closed when process
+identities are missing. Previously, an absent caller or target identity
+fell through to `_ => Ok(())`, implicitly authorizing the signal — a
+fail-open authorization gap. Each lookup now returns
+ErrorCode::NoSuchProcess with a logged reason, and authorization only
+succeeds when both identities exist and can_signal() permits it.
+
+Add unit tests covering:
+- root caller and same-user callers (allowed),
+- different-user caller (PermissionDenied),
+- unknown caller and unknown target (NoSuchProcess).
+```
+
+```text
+[doc] E: Update build instructions
+```
+
+## Rules
+
+- Read the diff; do not echo it back.
+- Consider only staged changes; never describe unstaged or working-tree changes.
+- If nothing is staged, report that and stop; do not produce a message.
+- Base the message on the diff hunks; do not open whole source files for context.
+- One subject line only, ≤ 50 chars, exact `[module] (B|E|F|W): ...` format.
+- Do not run any mutating git command. Output the message and stop.

--- a/.github/prompts/create-draft-pr.prompt.md
+++ b/.github/prompts/create-draft-pr.prompt.md
@@ -1,0 +1,25 @@
+---
+description: "Push the current branch and open a draft pull request against the default branch"
+name: "Create Draft PR"
+argument-hint: "Optional: issue number this PR addresses (e.g. 2698)"
+agent: "agent"
+---
+Open a **draft** pull request for the current branch.
+
+- Confirm the working state first: run `git status -sb` and `git --no-pager log
+  origin/dev..HEAD --oneline` to see the branch and the commits that will ship. Never
+  create a PR from `dev`; if the current branch is the default branch, stop and report.
+- Do **not** stage, commit, or amend anything. Only push and open the PR. If there are
+  uncommitted changes, report them and stop — let the user commit first.
+- Push the current branch to `origin` with upstream tracking
+  (`git push -u origin HEAD`).
+- Derive the PR title from the commit history (use the subject when there is a single
+  commit). Keep it consistent with the project's commit-message convention.
+- Write a concise body summarizing **what** changed and **why** based on the commits and
+  diff (`git --no-pager diff origin/dev...HEAD`); do not dump the full diff. If an issue
+  number was provided in the input, reference it (e.g. `Part of #2698`, `closes #2698`)
+  only when justified.
+- Open the PR as a draft against the default branch `dev`, for example:
+  `gh pr create --draft --base dev --title "..." --body "..."`. Prefer the GitHub PR
+  tools when available.
+- Report the resulting PR URL. Do not mark it ready for review.

--- a/.github/prompts/review-changes.prompt.md
+++ b/.github/prompts/review-changes.prompt.md
@@ -1,0 +1,16 @@
+---
+description: "Review current changes, address findings, and verify tests pass without committing"
+name: "Review Changes"
+argument-hint: "Optional: issue number this change should fix (e.g. 2674)"
+agent: "agent"
+---
+Review the current changes (staged and unstaged) in this repository.
+
+- Inspect the diff with `git --no-pager diff` and `git --no-pager diff --staged`. Prefer
+  `--stat` first, then drill into specific files — do not dump full diffs into context.
+- Report findings, issues, and observations. Address them with code edits.
+- If an issue number was provided in the input, confirm the change actually fixes it.
+- Ensure unit, in-kernel, and integration tests pass. Follow the
+  [test skill](../skills/test/SKILL.md) for the exact `./z` commands. When viewing test
+  output, pipe through `tail`/`grep` so large logs do not flood the conversation.
+- Do **not** commit nor stage any fixes. Leave changes in the working tree for review.

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -143,6 +143,10 @@ Any unrecognized target is forwarded to `make`, just like on Linux:
 ./z build -- spellcheck-fix
 ```
 
+When spell checking flags a legitimate domain term or acronym (for example, `vas` for
+Virtual Address Space, or `slab`), add it to `.codespellrc` rather than rewording the code
+or documentation.
+
 ## Formal Verification
 
 Nanvix uses Verus for formal verification of selected kernel crates. The expected Verus version is pinned in `build/verus-version`. Verification requires `VERUS_EXECUTABLE_DIR` to be set; when unset, `make verify` is a no-op.
@@ -183,6 +187,13 @@ Nanvix uses Verus for formal verification of selected kernel crates. The expecte
 
 The pipeline covers: spell checking, formatting, linting, building, and testing across multiple
 machine and deployment configurations.
+
+> **Validate across deployment modes before declaring success.** Lint runs with
+> `-- -D warnings`, so warnings like `dead_code` become hard failures; code compiled only under
+> a non-default `DEPLOYMENT_MODE` (for example, a helper used only with `standalone`) may build
+> cleanly in the default config but fail the pre-commit hook and CI under `single-process` or
+> `multi-process`. Do not report a change as done after checking only the default mode — run
+> `./scripts/pipeline.sh`, or repeat the relevant `lint-check`/`build` across `DEPLOYMENT_MODE={standalone,single-process,multi-process}`.
 
 ## IDE Setup (Optional)
 

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -26,6 +26,8 @@ or language-specific conventions.
 - For APIs, include sections as applicable: `# Description`, `# Parameters`, `# Returns`, `# Errors`.
 - For unsafe APIs, include a `# Safety` section describing invariants.
 - `TODO` and `FIXME` comments should reference an issue (for example: `TODO (#1234): ...`).
+- In source code, restrict issue/PR/task references to `TODO`/`FIXME` comments only (e.g., `TODO (#1234): ...`).
+- Avoid issue numbers in other code/doc comments and in commit messages.
 - Prefer comments that explain *why*.
 - End comments with a period.
 


### PR DESCRIPTION
Add a set of GitHub Copilot prompt files and tighten contributor-facing
documentation so day-to-day agent workflows are consistent and safe.

## What changed

Prompts (`.github/prompts/`):
- `commit-message` — generate a Nanvix-conformant message for staged changes
  only, without mutating git state.
- `review-changes` — review staged/unstaged changes, address findings, and run
  tests without committing.
- `address-pr-comments` — resolve PR review threads, leaving fixes uncommitted.
- `create-draft-pr` — push the current branch and open a draft PR against `dev`.

Instructions and skills:
- `copilot-instructions.md` — never stage/commit without explicit consent; when
  asked to commit, follow the CONTRIBUTING subject convention and never bypass
  git hooks.
- `skills/build/SKILL.md` — document the spellcheck allowlist (`.codespellrc`)
  and the `-D dead-code` lint pitfall across `DEPLOYMENT_MODE` values.
- `skills/coding-standards/SKILL.md` — restrict issue/PR references to
  `TODO`/`FIXME` comments.

Documentation-only change; no runtime or build behavior is affected.