### PR TITLE
[ci] Sweep warm-start-vmm payload sizes

### DIFF
--- a/.github/actions/benchmark-run/action.yml
+++ b/.github/actions/benchmark-run/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Number of benchmark iterations"
     required: true
     default: "100"
+  payload-size:
+    description: "Optional echo payload size for warm-start benchmarks (warm-start-vmm minimum: 4)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -26,14 +30,25 @@ runs:
         BENCHMARKS: ${{ inputs.benchmarks }}
         MACHINE_TYPE: ${{ inputs.machine-type }}
         ITERATIONS: ${{ inputs.iterations }}
+        PAYLOAD_SIZE: ${{ inputs.payload-size }}
       run: |
         for bench in ${BENCHMARKS}; do
+          payload_args=()
+          case "${bench}" in
+            warm-start|warm-start-l2|warm-start-vmm)
+              if [[ -n "${PAYLOAD_SIZE}" ]]; then
+                payload_args=(--payload-size "${PAYLOAD_SIZE}")
+              fi
+              ;;
+          esac
+
           python3 ./scripts/benchmark.py \
             run \
             --benchmark "${bench}" \
             --machine-type "${MACHINE_TYPE}" \
             --hwloc "$HOME/hwloc.json" \
             --iterations "${ITERATIONS}" \
+            "${payload_args[@]}" \
             --clh-bin-path "$HOME/toolchain/bin" \
             --output-dir "$(pwd)" \
             --commit "${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -947,6 +947,7 @@ jobs:
             standard-benchmarks: "boot-time cold-start cold-start-uvm concurrent
               round-trip-latency snapshot-restore warm-start warm-start-vmm"
             standard-iterations: "100"
+            payload-size: ""
             echo-benchmarks: "echo-breakdown"
             echo-iterations: "1000"
             vfs-benchmarks: "vfs-bench"
@@ -1014,6 +1015,7 @@ jobs:
           benchmarks: "${{ matrix.standard-benchmarks }}"
           machine-type: "${{ matrix.machine-type }}"
           iterations: "${{ matrix.standard-iterations }}"
+          payload-size: "${{ matrix.payload-size }}"
 
       - name: "Build (Echo-Breakdown)"
         if: matrix.echo-benchmarks != ''
@@ -1106,6 +1108,7 @@ jobs:
           - machine-type: microvm
             standard-benchmarks: "boot-time cold-start snapshot-restore vfs-bench warm-start-vmm"
             standard-iterations: "100"
+            payload-size: ""
             profiler: "PROFILER=yes"
     runs-on:
       group: Benchmark
@@ -1226,16 +1229,25 @@ jobs:
           BENCHMARKS: ${{ matrix.standard-benchmarks }}
           MACHINE_TYPE: ${{ matrix.machine-type }}
           ITERATIONS: ${{ matrix.standard-iterations }}
+          PAYLOAD_SIZE: ${{ matrix.payload-size }}
         run: |
           foreach ($bench in $env:BENCHMARKS -split ' ') {
             Write-Host "[INFO] Running benchmark '${bench}'..."
-            python scripts/benchmark.py `
-              run `
-              --benchmark $bench `
-              --machine-type $env:MACHINE_TYPE `
-              --iterations $env:ITERATIONS `
-              --output-dir "." `
-              --commit "${{ github.sha }}"
+            $benchmarkArgs = @(
+              "run",
+              "--benchmark", $bench,
+              "--machine-type", $env:MACHINE_TYPE,
+              "--iterations", $env:ITERATIONS
+            )
+            if (($bench -in @("warm-start", "warm-start-l2", "warm-start-vmm")) -and
+                -not [string]::IsNullOrWhiteSpace($env:PAYLOAD_SIZE)) {
+              $benchmarkArgs += @("--payload-size", $env:PAYLOAD_SIZE)
+            }
+            $benchmarkArgs += @(
+              "--output-dir", ".",
+              "--commit", "${{ github.sha }}"
+            )
+            python scripts/benchmark.py @benchmarkArgs
             if ($LASTEXITCODE -ne 0) {
               Write-Error "Benchmark '${bench}' failed with exit code $LASTEXITCODE"
               exit $LASTEXITCODE
@@ -1314,15 +1326,16 @@ jobs:
         if: github.ref_name != 'dev'
         shell: bash
         # vfs-bench and echo-breakdown are excluded: they use different CSV schemas
-        # (not percentile-based). round-trip-latency is also excluded (multi-row).
+        # (not percentile-based). Size-sweep benchmarks are also excluded (multi-row).
         run: |
           git fetch origin dev --quiet
           git checkout origin/dev -- data/baremetal
+          benchmarks="boot-time,cold-start,cold-start-uvm,concurrent,warm-start"
           python3 ./scripts/benchmark.py \
             ci-gate \
             --dev-dir "data/baremetal" \
             --target-dir "$(pwd)" \
-            --benchmarks "boot-time,cold-start,cold-start-uvm,concurrent,warm-start,warm-start-vmm" \
+            --benchmarks "${benchmarks}" \
             --machine-types "microvm" \
             --archs "X64" \
             --regression-threshold 40 \
@@ -1407,14 +1420,16 @@ jobs:
         if: github.ref_name != 'dev'
         shell: bash
         # vfs-bench is excluded: it uses a different CSV schema (not percentile-based).
+        # Size-sweep benchmarks are also excluded (multi-row).
         run: |
           git fetch origin dev --quiet
           git checkout origin/dev -- data/windows-baremetal
+          benchmarks="boot-time,cold-start"
           python3 ./scripts/benchmark.py \
             ci-gate \
             --dev-dir "data/windows-baremetal" \
             --target-dir "$(pwd)" \
-            --benchmarks "boot-time,cold-start,warm-start-vmm" \
+            --benchmarks "${benchmarks}" \
             --machine-types "microvm" \
             --archs "X64" \
             --regression-threshold 40 \

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -30,6 +30,9 @@ NA = "NA"
 NANVIX_BENCH_BINARY = "nanvix-bench.exe" if IS_WINDOWS else "nanvix-bench.elf"
 PERCENTILES = ["p50", "p95", "p99"]
 ROUND_TRIP_SIZES = ["32B", "64B", "128B", "256B", "512B", "1KiB", "4KiB"]
+WARM_START_DEFAULT_SIZE = "32B"
+WARM_START_VMM_SIZES = ["32B", "1KiB", "4KiB", "8KiB", "16KiB", "32KiB", "64KiB"]
+WARM_START_VMM_MIN_PAYLOAD_SIZE = 4
 X86_64_ARCH = "X64"
 
 # ======================================================================
@@ -51,6 +54,23 @@ VFS_BENCH = "vfs-bench"
 WARM_START_BENCH = "warm-start"
 WARM_START_L2_BENCH = WARM_START_BENCH + L2_SUFFIX
 WARM_START_VMM_BENCH = "warm-start-vmm"
+PAYLOAD_SIZE_BENCHMARKS = [
+    WARM_START_BENCH,
+    WARM_START_L2_BENCH,
+    WARM_START_VMM_BENCH,
+]
+SIZE_ANNOTATED_BENCHMARKS = {
+    WARM_START_BENCH: [WARM_START_DEFAULT_SIZE],
+    WARM_START_L2_BENCH: [WARM_START_DEFAULT_SIZE],
+}
+SIZE_SWEEP_BENCHMARKS = {
+    ROUND_TRIP_LATENCY_BENCH: ROUND_TRIP_SIZES,
+    WARM_START_VMM_BENCH: WARM_START_VMM_SIZES,
+}
+SIZE_AWARE_BENCHMARKS = {
+    **SIZE_ANNOTATED_BENCHMARKS,
+    **SIZE_SWEEP_BENCHMARKS,
+}
 
 # ======================================================================
 # Benchmark Constants
@@ -73,9 +93,6 @@ PERCENTILE_BENCHMARKS = [
     CONCURRENT_BENCH,
     CONCURRENT_L2_BENCH,
     SNAPSHOT_RESTORE_BENCH,
-    WARM_START_BENCH,
-    WARM_START_L2_BENCH,
-    WARM_START_VMM_BENCH,
 ]
 
 # ======================================================================
@@ -256,7 +273,60 @@ def gen_filename_for_benchmark(benchmark: str, machine_type: str, arch: str) -> 
     return f"nanvix_bench_{benchmark}_{machine_type}_{arch}.csv"
 
 
-def filter_benchmark_stdout(benchmark: str, raw_stdout: str, commit: str) -> str:
+def _format_size_key(size_bytes: int) -> str:
+    """Format a byte size like nanvix-bench size-sweep output after normalization."""
+    if size_bytes >= 1024 and size_bytes % 1024 == 0:
+        return f"{size_bytes // 1024}KiB"
+    return f"{size_bytes}B"
+
+
+def _parse_percentile_values(benchmark: str, raw_stdout: str) -> dict[str, int]:
+    """Extract p50/p95/p99 values from scalar percentile benchmark output."""
+    # The snapshot-restore benchmark prints multiple percentile blocks
+    # (Cold-start, Snapshot restore, Post-restore execution). Restrict
+    # parsing to the headline "Snapshot restore (...)" section so the
+    # CSV continues to track the same metric across releases. For all
+    # other percentile benchmarks the full stdout is scanned.
+    if benchmark == SNAPSHOT_RESTORE_BENCH:
+        section_match = re.search(
+            r"^Snapshot restore \(.*?\):\s*\n(?P<body>(?:[ \t]+.*\n?)+)",
+            raw_stdout,
+            re.MULTILINE,
+        )
+        if section_match is None:
+            print(
+                "ERROR: missing 'Snapshot restore (...)' section in "
+                f"benchmark '{benchmark}' output"
+            )
+            raise ValueError("Missing 'Snapshot restore' section")
+        search_scope = section_match.group("body")
+    else:
+        search_scope = raw_stdout
+
+    pattern = re.compile(
+        r"^\s*(p50|p95|p99)\s*:\s*([0-9]+)\s*us\b", re.IGNORECASE | re.MULTILINE
+    )
+    values: dict[str, int] = {}
+    for k, v in pattern.findall(search_scope):
+        values[k.lower()] = int(v)
+
+    # Ensure all three percentiles are present.
+    missing = [p for p in PERCENTILES if p not in values]
+    if missing:
+        print(
+            f"ERROR: missing percentile values for benchmark '{benchmark}': {missing}"
+        )
+        raise ValueError("Missing percentile values in benchmark results")
+
+    return values
+
+
+def filter_benchmark_stdout(
+    benchmark: str,
+    raw_stdout: str,
+    commit: str,
+    expected_sizes: Optional[list[str]] = None,
+) -> str:
     """
     Convert a benchmark's raw stdout into a formatted CSV string.
 
@@ -274,50 +344,35 @@ def filter_benchmark_stdout(benchmark: str, raw_stdout: str, commit: str) -> str
     A CSV string (header + data rows) with the benchmark metrics.
     """
     if benchmark in PERCENTILE_BENCHMARKS:
-        # The snapshot-restore benchmark prints multiple percentile blocks
-        # (Cold-start, Snapshot restore, Post-restore execution). Restrict
-        # parsing to the headline "Snapshot restore (...)" section so the
-        # CSV continues to track the same metric across releases. For all
-        # other percentile benchmarks the full stdout is scanned.
-        if benchmark == SNAPSHOT_RESTORE_BENCH:
-            section_match = re.search(
-                r"^Snapshot restore \(.*?\):\s*\n(?P<body>(?:[ \t]+.*\n?)+)",
-                raw_stdout,
-                re.MULTILINE,
-            )
-            if section_match is None:
-                print(
-                    "ERROR: missing 'Snapshot restore (...)' section in "
-                    f"benchmark '{benchmark}' output"
-                )
-                raise ValueError("Missing 'Snapshot restore' section")
-            search_scope = section_match.group("body")
-        else:
-            search_scope = raw_stdout
-
-        pattern = re.compile(
-            r"^\s*(p50|p95|p99)\s*:\s*([0-9]+)\s*us\b", re.IGNORECASE | re.MULTILINE
-        )
-        values = {}
-        for k, v in pattern.findall(search_scope):
-            values[k.lower()] = int(v)
-
-        # Ensure all three percentiles are present.
-        missing = [p for p in PERCENTILES if p not in values]
-        if missing:
-            print(
-                f"ERROR: missing percentile values for benchmark '{benchmark}': {missing}"
-            )
-            raise ValueError("Missing percentile values in benchmark results")
-
+        values = _parse_percentile_values(benchmark, raw_stdout)
         header = "commit," + ",".join(PERCENTILES)
         data = commit + "," + ",".join(str(values[p]) for p in PERCENTILES)
         filtered_stdout = header + "\n" + data
 
-    elif benchmark == ROUND_TRIP_LATENCY_BENCH:
+    elif benchmark in SIZE_ANNOTATED_BENCHMARKS:
+        values = _parse_percentile_values(benchmark, raw_stdout)
+        if expected_sizes is None:
+            expected_sizes = SIZE_ANNOTATED_BENCHMARKS[benchmark]
+        if len(expected_sizes) != 1:
+            print(f"ERROR: expected one size for '{benchmark}' - got: {expected_sizes}")
+            raise ValueError("Invalid size annotation")
+
+        header = "commit,size," + ",".join(PERCENTILES)
+        data = (
+            commit
+            + ","
+            + expected_sizes[0]
+            + ","
+            + ",".join(str(values[p]) for p in PERCENTILES)
+        )
+        filtered_stdout = header + "\n" + data
+
+    elif benchmark in SIZE_SWEEP_BENCHMARKS:
         header = "commit,size," + ",".join(PERCENTILES)
         data_lines = []
         actual_sizes = []
+        if expected_sizes is None:
+            expected_sizes = SIZE_SWEEP_BENCHMARKS[benchmark]
         for line in raw_stdout.splitlines():
             if not line.strip():
                 continue
@@ -338,9 +393,9 @@ def filter_benchmark_stdout(benchmark: str, raw_stdout: str, commit: str) -> str
             data_lines.append(",".join([commit, size, p50, p95, p99]))
 
         # Sanity check we have a value for each size.
-        if actual_sizes != ROUND_TRIP_SIZES:
+        if actual_sizes != expected_sizes:
             print(f"ERROR: did not collect expected sizes in '{benchmark}'")
-            print(f"ERROR: expected: {ROUND_TRIP_SIZES} - got: {actual_sizes}")
+            print(f"ERROR: expected: {expected_sizes} - got: {actual_sizes}")
             raise ValueError("Not expected values.")
 
         filtered_stdout = header + "\n" + "\n".join(data_lines)
@@ -509,7 +564,7 @@ def read_benchmark_values_from_file(
 
     - ``benchmark``: Name of the benchmark.
     - ``file_path``: Path to the CSV file.
-    - ``percentile``: For round-trip-latency, which percentile column to read.
+    - ``percentile``: For size-aware benchmarks, which percentile column to read.
 
     # Returns
 
@@ -532,13 +587,37 @@ def read_benchmark_values_from_file(
             print(f"WARNING: could not read {file_path}: {exc}")
             result_dict = {p: NA for p in PERCENTILES}
 
-    elif benchmark == ROUND_TRIP_LATENCY_BENCH:
+    elif benchmark in SIZE_AWARE_BENCHMARKS:
         try:
             with open(file_path, "r") as f:
                 lines = [line.strip() for line in f.readlines() if line.strip()]
 
             if len(lines) < 2:
                 raise ValueError("No data rows")
+
+            if percentile is None:
+                percentile = PERCENTILES[0]
+
+            header = lines[0].split(",")
+            expected_sizes: list[str] = SIZE_AWARE_BENCHMARKS[benchmark]
+            if header == ["commit", *PERCENTILES]:
+                # Transitional compatibility for histories recorded before a
+                # benchmark migrated from the scalar (commit,p50,p95,p99) format
+                # to the size-aware (commit,size,p50,p95,p99) format. The legacy
+                # benchmark only ever exercised the default payload, so its last
+                # row maps onto the default (first) payload size. Size-annotated
+                # benchmarks (warm-start, warm-start-l2) have that as their only
+                # size; size-sweep benchmarks (warm-start-vmm) report the larger
+                # sweep sizes as NA since no scalar history exists for them.
+                result_dict = {size: NA for size in expected_sizes}
+                last_commit = lines[-1].split(",")[0]
+                col_idx = PERCENTILES.index(percentile) + 1
+                default_size = expected_sizes[0]
+                for line in lines[1:]:
+                    parts = line.split(",")
+                    if parts[0] == last_commit:
+                        result_dict[default_size] = parts[col_idx]
+                return result_dict
 
             # Find the last commit present in the file.
             last_commit = lines[-1].split(",")[0]
@@ -554,12 +633,12 @@ def read_benchmark_values_from_file(
                     result_dict[size] = parts[col_idx]
 
             # Fill in any missing sizes with NA.
-            for size in ROUND_TRIP_SIZES:
+            for size in expected_sizes:
                 if size not in result_dict:
                     result_dict[size] = NA
         except (FileNotFoundError, ValueError, IndexError) as exc:
             print(f"WARNING: could not read {file_path}: {exc}")
-            result_dict = {s: NA for s in ROUND_TRIP_SIZES}
+            result_dict = {s: NA for s in SIZE_AWARE_BENCHMARKS[benchmark]}
 
     elif benchmark == VFS_BENCH:
         # VFS benchmark CSV: commit,section,operation,samples,p50,p95,p99
@@ -675,7 +754,7 @@ def generate_benchmark_table(
     table_width = 2 + first_col_width + (groups_count * (machine_col_width + 3))
 
     # Create header for this benchmark
-    if benchmark == ROUND_TRIP_LATENCY_BENCH and percentile is not None:
+    if benchmark in SIZE_AWARE_BENCHMARKS and percentile is not None:
         header = make_header(benchmark + f"-{percentile}", table_width)
     else:
         header = make_header(benchmark, table_width)
@@ -761,7 +840,7 @@ def ci_summary(args):
             bench_summary += "\n" + generate_benchmark_table(
                 args.dev_dir, args.target_dir, benchmark, machines, archs
             )
-        elif benchmark == ROUND_TRIP_LATENCY_BENCH:
+        elif benchmark in SIZE_AWARE_BENCHMARKS:
             for percentile in PERCENTILES:
                 bench_summary += "\n" + generate_benchmark_table(
                     args.dev_dir,
@@ -857,13 +936,15 @@ def ci_summary(args):
 
 
 def _read_baseline_moving_avg(
-    benchmark: str, file_path: str, window: int = 20
+    benchmark: str, file_path: str, window: int = 20, size: Optional[str] = None
 ) -> Optional[float]:
     """
     Read the last ``window`` p50 values from a baseline CSV and return their average.
 
-    Only works for percentile benchmarks (``commit,p50,p95,p99`` format).
-    Returns ``None`` when the file is missing or contains no valid p50 values.
+    Works for scalar percentile benchmarks (``commit,p50,p95,p99``) and size-annotated
+    warm-start benchmarks (``commit,size,p50,p95,p99``). Legacy warm-start files in
+    scalar format are read as the default ``32B`` payload size. Returns ``None`` when
+    the file is missing or contains no valid p50 values.
 
     # Parameters
 
@@ -871,7 +952,10 @@ def _read_baseline_moving_avg(
     - ``file_path``: Path to the baseline CSV file.
     - ``window``: Number of most-recent data rows to average.
     """
-    if benchmark not in PERCENTILE_BENCHMARKS:
+    if (
+        benchmark not in PERCENTILE_BENCHMARKS
+        and benchmark not in SIZE_ANNOTATED_BENCHMARKS
+    ):
         return None
 
     try:
@@ -882,11 +966,40 @@ def _read_baseline_moving_avg(
             if header is None:
                 print(f"WARNING: no data rows in baseline: {file_path}")
                 return None
+            header_cols = header.strip().split(",")
+            p50_idx = 1
+            size_idx = None
+            expected_size = size
+            if benchmark in SIZE_ANNOTATED_BENCHMARKS:
+                if expected_size is None:
+                    expected_size = SIZE_ANNOTATED_BENCHMARKS[benchmark][0]
+                if header_cols == ["commit", *PERCENTILES]:
+                    if expected_size != SIZE_ANNOTATED_BENCHMARKS[benchmark][0]:
+                        return None
+                    size_idx = None
+                elif header_cols == ["commit", "size", *PERCENTILES]:
+                    p50_idx = 2
+                    size_idx = 1
+                else:
+                    print(
+                        f"WARNING: unsupported baseline header for {benchmark}: "
+                        f"{header.strip()}"
+                    )
+                    return None
             tail: collections.deque[str] = collections.deque(maxlen=window)
             for line in reader:
                 stripped = line.strip()
-                if stripped:
-                    tail.append(stripped)
+                if not stripped:
+                    continue
+                parts = stripped.split(",")
+                if (
+                    size_idx is not None
+                    and expected_size is not None
+                    and len(parts) > size_idx
+                    and parts[size_idx] != expected_size
+                ):
+                    continue
+                tail.append(stripped)
     except FileNotFoundError:
         print(f"WARNING: baseline file not found: {file_path}")
         return None
@@ -898,10 +1011,10 @@ def _read_baseline_moving_avg(
     p50_values: list[float] = []
     for row in tail:
         parts = row.split(",")
-        if len(parts) < 2:
+        if len(parts) <= p50_idx:
             continue
         try:
-            p50_values.append(float(parts[1]))
+            p50_values.append(float(parts[p50_idx]))
         except (ValueError, TypeError):
             continue
 
@@ -920,8 +1033,9 @@ def ci_gate(args) -> int:
     moving average of the last N baseline p50 values in dev-dir. Exits
     non-zero if any benchmark regresses beyond the configured threshold.
 
-    Only percentile benchmarks (commit,p50,p95,p99) are checked. Benchmarks
-    with missing baseline or missing results are skipped with a warning.
+    Scalar percentile benchmarks (commit,p50,p95,p99) and size-annotated warm-start
+    benchmarks are checked. Size-sweep benchmarks and benchmarks with missing baseline
+    or missing results are skipped with a warning.
     """
     threshold = args.regression_threshold
     window = args.baseline_window
@@ -933,14 +1047,90 @@ def ci_gate(args) -> int:
     checked = 0
 
     for benchmark in benchmarks:
-        if benchmark not in PERCENTILE_BENCHMARKS:
-            print(f"SKIP: '{benchmark}' is not a percentile benchmark")
+        if (
+            benchmark not in PERCENTILE_BENCHMARKS
+            and benchmark not in SIZE_ANNOTATED_BENCHMARKS
+        ):
+            print(f"SKIP: '{benchmark}' is not a regression-gated benchmark")
             continue
 
         for machine, arch in itertools.product(machines, archs):
             csv_name = gen_filename_for_benchmark(benchmark, machine, arch)
             dev_path = os.path.join(args.dev_dir, csv_name)
             tgt_path = os.path.join(args.target_dir, csv_name)
+
+            if benchmark in SIZE_ANNOTATED_BENCHMARKS:
+                tgt_vals = read_benchmark_values_from_file(benchmark, tgt_path, "p50")
+                saw_result_size = False
+                checked_any_size = False
+                for size, tgt_val in tgt_vals.items():
+                    if tgt_val == NA:
+                        continue
+                    saw_result_size = True
+
+                    dev_avg = _read_baseline_moving_avg(
+                        benchmark, dev_path, window, size
+                    )
+                    if dev_avg is None:
+                        print(
+                            f"SKIP: no baseline for {benchmark} {size} "
+                            f"({machine}/{arch})"
+                        )
+                        continue
+                    if dev_avg == 0:
+                        print(
+                            f"WARNING: zero baseline avg for {benchmark} {size} "
+                            f"({machine}/{arch}), skipping"
+                        )
+                        continue
+
+                    try:
+                        tgt_p50 = float(tgt_val)
+                    except (ValueError, TypeError) as e:
+                        print(
+                            f"SKIP: invalid p50 value for {benchmark} {size} "
+                            f"({machine}/{arch}): {e}"
+                        )
+                        continue
+
+                    checked += 1
+                    checked_any_size = True
+                    delta_pct = (tgt_p50 - dev_avg) / dev_avg * 100
+
+                    if delta_pct > threshold:
+                        regressions.append(
+                            {
+                                "benchmark": f"{benchmark} {size}",
+                                "machine": machine,
+                                "arch": arch,
+                                "dev_avg": round(dev_avg, 1),
+                                "tgt_p50": tgt_p50,
+                                "delta_pct": round(delta_pct, 1),
+                            }
+                        )
+                        print(
+                            f"REGRESSION: {benchmark} {size} ({machine}/{arch}): "
+                            f"p50 {tgt_p50} vs baseline avg {round(dev_avg, 1)} "
+                            f"(+{round(delta_pct, 1)}%, threshold: {threshold}%)"
+                        )
+                    else:
+                        status = (
+                            f"+{delta_pct:.1f}%"
+                            if delta_pct > 0
+                            else f"{delta_pct:.1f}%"
+                        )
+                        print(
+                            f"OK: {benchmark} {size} ({machine}/{arch}): "
+                            f"p50 {tgt_p50} vs baseline avg {round(dev_avg, 1)} ({status})"
+                        )
+
+                if not saw_result_size:
+                    print(f"SKIP: no results for {benchmark} ({machine}/{arch})")
+                elif not checked_any_size:
+                    print(
+                        f"SKIP: no comparable baseline for {benchmark} ({machine}/{arch})"
+                    )
+                continue
 
             # Read baseline moving average of p50 values.
             dev_avg = _read_baseline_moving_avg(benchmark, dev_path, window)
@@ -1077,10 +1267,6 @@ def run_benchmark(args):
         f"[BENCHMARK] Running '{args.benchmark}' benchmark "
         f"(machine={args.machine_type}, arch={X86_64_ARCH})"
     )
-    print(
-        f"[BENCHMARK] Configuration: iterations={args.iterations}, "
-        f"hwloc={args.hwloc}"
-    )
     # Normalize paths so that Unix-style "./" prefixes are converted to
     # platform-native form (cmd.exe does not understand "./").
     args.bin_dir = os.path.normpath(args.bin_dir)
@@ -1133,6 +1319,27 @@ def run_benchmark(args):
     # a number of concurrent user VMs.
     is_concurrent_bench = args.benchmark.startswith(CONCURRENT_BENCH)
     print(f"[BENCHMARK] Is concurrent benchmark: {is_concurrent_bench}")
+    payload_size = args.payload_size
+    print(
+        f"[BENCHMARK] Configuration: iterations={args.iterations}, "
+        f"hwloc={args.hwloc}, payload_size={payload_size}"
+    )
+    if payload_size is not None and args.benchmark not in PAYLOAD_SIZE_BENCHMARKS:
+        print(
+            f"ERROR: --payload-size is not supported for benchmark '{args.benchmark}'."
+        )
+        raise ValueError("Unsupported payload-size benchmark")
+    if (
+        payload_size is not None
+        and args.benchmark == WARM_START_VMM_BENCH
+        and payload_size < WARM_START_VMM_MIN_PAYLOAD_SIZE
+    ):
+        print(
+            "ERROR: --payload-size for warm-start-vmm must be at least "
+            f"{WARM_START_VMM_MIN_PAYLOAD_SIZE} bytes because it includes the "
+            "length prefix."
+        )
+        raise ValueError("Invalid warm-start-vmm payload size")
 
     nanvix_bench_cmd = [
         os.path.join(args.bin_dir, NANVIX_BENCH_BINARY),
@@ -1142,6 +1349,11 @@ def run_benchmark(args):
             f"-iterations {args.iterations}"
             if not is_concurrent_bench
             else f"-num-concurrent-vms {NUM_CONCURRENT_VMS}"
+        ),
+        (
+            f"-payload-size {payload_size}"
+            if payload_size is not None and args.benchmark in PAYLOAD_SIZE_BENCHMARKS
+            else ""
         ),
         f"-clh-bin-path {args.clh_bin_path}",
     ]
@@ -1219,7 +1431,12 @@ def run_benchmark(args):
         raw_stdout = result.stdout.decode("utf-8")
         raw_stderr = result.stderr.decode("utf-8", errors="replace")
         print(f"[BENCHMARK] Raw stdout length: {len(raw_stdout)} bytes")
-        filtered_stdout = filter_benchmark_stdout(args.benchmark, raw_stdout, commit)
+        expected_sizes = None
+        if args.benchmark in SIZE_AWARE_BENCHMARKS and payload_size is not None:
+            expected_sizes = [_format_size_key(payload_size)]
+        filtered_stdout = filter_benchmark_stdout(
+            args.benchmark, raw_stdout, commit, expected_sizes
+        )
         print(f"[BENCHMARK] Filtered stdout length: {len(filtered_stdout)} bytes")
         print(f"[BENCHMARK] Writing results to: {output_file}")
         with open(output_file, "w") as fh:
@@ -1331,12 +1548,27 @@ def persist_results(args: argparse.Namespace) -> None:
 
             existing_header: str = existing_lines[0] if existing_lines else ""
             if existing_header != header:
-                print(
-                    f"WARNING: header mismatch for {filename}: "
-                    f"source='{header}' vs target='{existing_header}'. "
-                    f"Skipping."
-                )
-                continue
+                if benchmark in SIZE_AWARE_BENCHMARKS:
+                    print(
+                        f"WARNING: resetting history for {filename}: "
+                        f"source='{header}' vs target='{existing_header}'."
+                    )
+                    new_rows = data_rows
+                    with open(target_path, "w") as f:
+                        f.write(header + "\n")
+                        for row in new_rows:
+                            f.write(row + "\n")
+                    if max_history > 0:
+                        _prune_history(target_path, header, max_history)
+                    print(f"Persisted {len(new_rows)} row(s) to {target_path}")
+                    continue
+                else:
+                    print(
+                        f"WARNING: header mismatch for {filename}: "
+                        f"source='{header}' vs target='{existing_header}'. "
+                        f"Skipping."
+                    )
+                    continue
 
             # Collect commit hashes already present in the target file to
             # prevent duplicate rows from CI retries.
@@ -1474,6 +1706,16 @@ if __name__ == "__main__":
         type=int,
         default=100,
         help="Path to file with the hardware locality information",
+    )
+    run_parser.add_argument(
+        "--payload-size",
+        type=_positive_int,
+        default=None,
+        help=(
+            "Echo payload size in bytes for warm-start, warm-start-l2, and "
+            "warm-start-vmm benchmarks. For warm-start-vmm, the size includes "
+            "the 4-byte length prefix. Defaults to nanvix-bench's built-in value."
+        ),
     )
     run_parser.add_argument(
         "--output-dir",

--- a/scripts/plot-performance.py
+++ b/scripts/plot-performance.py
@@ -87,15 +87,15 @@ SUPPORTED_BENCHMARKS: list[str] = [
     "concurrent",
     "concurrent_l2",
     "snapshot_restore",
-    "warm_start",
-    "warm_start_l2",
-    "warm_start_vmm",
 ]
 
 # Benchmarks whose CSV files follow the ``commit,size,p50,p95,p99`` schema.
 # Each produces one plot per message size.
 SIZED_BENCHMARKS: list[str] = [
     "round_trip_latency",
+    "warm_start",
+    "warm_start_l2",
+    "warm_start_vmm",
 ]
 
 # Human-readable titles for each benchmark.

--- a/src/benchmarks/echo-rust-nostd/src/main.rs
+++ b/src/benchmarks/echo-rust-nostd/src/main.rs
@@ -13,6 +13,10 @@ extern crate libc_string;
 extern crate nvx;
 extern crate nvx_crt0;
 
+use ::alloc::{
+    vec,
+    vec::Vec,
+};
 use ::sys::error::Error;
 use ::sysapi::{
     sys_types::c_ssize_t,
@@ -27,7 +31,8 @@ use ::syscall::unistd;
 // Constants
 //==================================================================================================
 
-const MAX_REQUEST_SIZE: usize = 4096;
+// Keep this independent from benchmark CLI options: this app is reused by multiple benchmark modes.
+const MAX_REQUEST_SIZE: usize = 64 * 1024;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,7 +42,7 @@ const MAX_REQUEST_SIZE: usize = 4096;
 pub fn main() -> Result<(), Error> {
     let stdin: i32 = STDIN_FILENO;
     let stdout: i32 = STDOUT_FILENO;
-    let mut buffer: [u8; MAX_REQUEST_SIZE] = [0; MAX_REQUEST_SIZE];
+    let mut buffer: Vec<u8> = vec![0; MAX_REQUEST_SIZE];
 
     loop {
         let nread: c_ssize_t = match unistd::read(stdin, &mut buffer) {

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::benchmark::BenchmarkFlavour;
+use crate::{
+    benchmark::BenchmarkFlavour,
+    benchmarks::DEFAULT_PAYLOAD_SIZE,
+};
 use ::anyhow::Result;
 use ::nanvixd::config::DEFAULT_TMP_DIRECTORY;
 use ::std::str::FromStr;
@@ -18,6 +21,8 @@ pub struct Args {
     benchmark: BenchmarkFlavour,
     hwloc_file: Option<String>,
     iterations: usize,
+    payload_size: usize,
+    payload_size_override: Option<usize>,
     num_concurrent_vms: Option<usize>,
     netns_pool_size: Option<usize>,
     clh_bin_path: String,
@@ -33,9 +38,11 @@ impl Args {
     const OPT_BENCHMARK: &'static str = "-benchmark";
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
+    const OPT_PAYLOAD_SIZE: &'static str = "-payload-size";
     const OPT_NUM_CONCURRENT_VMS: &'static str = "-num-concurrent-vms";
     const OPT_NETNS_POOL_SIZE: &'static str = "-netns-pool-size";
     const DEFAULT_NETNS_POOL_SIZE: usize = ::nanvixd::args::Args::DEFAULT_NETNS_POOL_SIZE;
+    const WARM_START_VMM_PAYLOAD_PREFIX_SIZE: usize = ::std::mem::size_of::<u32>();
     const OPT_CLH_BIN_PATH: &'static str = "-clh-bin-path";
     const OPT_TMP_DIR: &'static str = "-tmp-dir";
 
@@ -132,6 +139,9 @@ Options:
   {hwloc} <hwloc.json>                Hardware locality configuration file for CPU \
              affinity/topology.
   {iterations} <num>                  Number of iterations to run (default: 100).
+  {payload_size} <bytes>              Echo payload size for warm-start, warm-start-l2, and \
+             warm-start-vmm benchmarks (default: {default_payload_size}; warm-start-vmm counts \
+             its {warm_start_vmm_prefix_size}-byte prefix and sweeps sizes when omitted).
   {num_concurrent_vms} <num>          Number of concurrent VMs (mandatory for concurrent and \
              concurrent-l2 benchmarks).
   {netns_pool_size} <size>            Netns pool prefill size for nanvixd (concurrent-l2 only; \
@@ -149,6 +159,9 @@ Examples:
   # Run boot-time with a custom hwloc and 1000 iterations
   {program_name} {benchmark} boot-time {hwloc} hwloc.json {iterations} 1000
 
+  # Run warm-start with a 32KiB payload
+  {program_name} {benchmark} warm-start {payload_size} 32768
+
   # Run concurrent benchmark with 4 concurrent VMs
   {program_name} {benchmark} concurrent {num_concurrent_vms} 4
 ",
@@ -156,6 +169,9 @@ Examples:
             benchmark = Self::OPT_BENCHMARK,
             hwloc = Self::OPT_HWLOC,
             iterations = Self::OPT_ITERATIONS,
+            payload_size = Self::OPT_PAYLOAD_SIZE,
+            default_payload_size = DEFAULT_PAYLOAD_SIZE,
+            warm_start_vmm_prefix_size = Self::WARM_START_VMM_PAYLOAD_PREFIX_SIZE,
             num_concurrent_vms = Self::OPT_NUM_CONCURRENT_VMS,
             netns_pool_size = Self::OPT_NETNS_POOL_SIZE,
             default_netns_pool_size = Self::DEFAULT_NETNS_POOL_SIZE,
@@ -170,6 +186,7 @@ Examples:
         let mut benchmark_str: String = String::new();
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
+        let mut payload_size: Option<usize> = None;
         let mut num_concurrent_vms: Option<usize> = None;
         let mut netns_pool_size: Option<usize> = None;
         let mut clh_bin_path: String = "./toolchain/bin".to_string();
@@ -206,6 +223,25 @@ Examples:
                         return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_ITERATIONS));
                     }
                     iterations = args[i].parse::<usize>()?;
+                },
+                Self::OPT_PAYLOAD_SIZE => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_PAYLOAD_SIZE
+                        ));
+                    }
+                    let parsed_payload_size: usize = args[i].parse::<usize>()?;
+                    if parsed_payload_size == 0 {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "{} must be a positive integer",
+                            Self::OPT_PAYLOAD_SIZE,
+                        ));
+                    }
+                    payload_size = Some(parsed_payload_size);
                 },
                 Self::OPT_NUM_CONCURRENT_VMS => {
                     i += 1;
@@ -305,6 +341,35 @@ Examples:
                     }
                 }
 
+                // Reject -payload-size when it would be silently ignored.
+                if payload_size.is_some()
+                    && !matches!(
+                        benchmark,
+                        BenchmarkFlavour::WarmStart
+                            | BenchmarkFlavour::WarmStartL2
+                            | BenchmarkFlavour::WarmStartVMM
+                    )
+                {
+                    Self::usage(args[0].as_str());
+                    return Err(anyhow::anyhow!(
+                        "{benchmark} benchmark does not accept {}",
+                        Self::OPT_PAYLOAD_SIZE,
+                    ));
+                }
+
+                if let Some(payload_size) = payload_size
+                    && matches!(benchmark, BenchmarkFlavour::WarmStartVMM)
+                    && payload_size < Self::WARM_START_VMM_PAYLOAD_PREFIX_SIZE
+                {
+                    Self::usage(args[0].as_str());
+                    return Err(anyhow::anyhow!(
+                        "{benchmark} benchmark requires {} >= {} because the size includes the \
+                         length prefix",
+                        Self::OPT_PAYLOAD_SIZE,
+                        Self::WARM_START_VMM_PAYLOAD_PREFIX_SIZE,
+                    ));
+                }
+
                 // Derive netns pool size from the benchmark flavour.
                 let netns_pool_size = match benchmark {
                     BenchmarkFlavour::ConcurrentL2 => {
@@ -318,6 +383,8 @@ Examples:
                     benchmark,
                     hwloc_file,
                     iterations,
+                    payload_size: payload_size.unwrap_or(DEFAULT_PAYLOAD_SIZE),
+                    payload_size_override: payload_size,
                     num_concurrent_vms,
                     netns_pool_size,
                     clh_bin_path,
@@ -343,6 +410,14 @@ Examples:
         self.iterations
     }
 
+    pub fn payload_size(&self) -> usize {
+        self.payload_size
+    }
+
+    pub fn payload_size_override(&self) -> Option<usize> {
+        self.payload_size_override
+    }
+
     pub fn num_concurrent_vms(&self) -> Option<usize> {
         self.num_concurrent_vms
     }
@@ -357,5 +432,62 @@ Examples:
 
     pub fn tmp_dir(&self) -> String {
         self.tmp_dir.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+
+    #[test]
+    fn parse_rejects_zero_payload_size() {
+        let args: Vec<String> = vec![
+            "nanvix-bench".to_string(),
+            "-benchmark".to_string(),
+            "warm-start".to_string(),
+            "-payload-size".to_string(),
+            "0".to_string(),
+        ];
+
+        let error: anyhow::Error = match Args::parse(args) {
+            Ok(_) => panic!("expected zero payload size to be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("positive integer"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn parse_accepts_warm_start_vmm_payload_size_override() {
+        let args: Vec<String> = vec![
+            "nanvix-bench".to_string(),
+            "-benchmark".to_string(),
+            "warm-start-vmm".to_string(),
+            "-payload-size".to_string(),
+            "4096".to_string(),
+        ];
+
+        let args: Args = Args::parse(args).expect("expected warm-start-vmm payload size to parse");
+
+        assert_eq!(args.payload_size(), 4096);
+        assert_eq!(args.payload_size_override(), Some(4096));
+    }
+
+    #[test]
+    fn parse_rejects_too_small_warm_start_vmm_payload_size() {
+        let args: Vec<String> = vec![
+            "nanvix-bench".to_string(),
+            "-benchmark".to_string(),
+            "warm-start-vmm".to_string(),
+            "-payload-size".to_string(),
+            "2".to_string(),
+        ];
+
+        let error: anyhow::Error = match Args::parse(args) {
+            Ok(_) => panic!("expected too-small warm-start-vmm payload size to be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains(">= 4"), "unexpected error: {error}");
     }
 }

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -161,6 +161,8 @@ impl FromStr for BenchmarkFlavour {
 
 pub struct Benchmark {
     pub iterations: usize,
+    pub payload_size: usize,
+    pub payload_size_override: Option<usize>,
     pub hwloc_file: Option<String>,
     pub hwloc: Option<HwLoc>,
     pub flavour: BenchmarkFlavour,

--- a/src/utils/nanvix-bench/src/benchmarks/system/warm_start.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/system/warm_start.rs
@@ -3,7 +3,6 @@
 
 use super::super::{
     CLEANUP_SLEEP_DURATION,
-    DEFAULT_PAYLOAD_SIZE,
     WARMUP_SLEEP_DURATION,
 };
 use crate::benchmark::{
@@ -31,17 +30,19 @@ impl Benchmark {
     /// into the VM once it has started executing.
     pub async fn run_warm_start(&mut self, linuxd_deployment: &LinuxdDeployment) -> Result<()> {
         // Display a progress bar
-        let pb = ProgressBar::new(self.iterations.try_into().unwrap());
+        let iterations: u64 = u64::try_from(self.iterations)
+            .map_err(|e| anyhow::anyhow!("iteration count exceeds u64: {e}"))?;
+        let pb: ProgressBar = ProgressBar::new(iterations);
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
-                .expect("error creating progress bar")
+                .map_err(|e| anyhow::anyhow!("error creating progress bar: {e}"))?
                 .progress_chars("#>-"),
         );
         pb.set_message("Benchmark progress:");
 
         // Payload we are sending over the wire
-        let payload = [7u8; DEFAULT_PAYLOAD_SIZE];
+        let payload: Vec<u8> = vec![7u8; self.payload_size];
 
         let (new_msg_headers, new_msg) = self.prepare_new_message(None, None)?;
 
@@ -54,20 +55,18 @@ impl Benchmark {
             let (user_vm_id, mut gateway_stream) = self
                 .start(new_msg, new_msg_headers, linuxd_deployment)
                 .await?;
+            let mut response_payload: Vec<u8> = vec![0u8; payload.len()];
 
             // Warmup: send one untimed echo to trigger lazy initialization (worker thread
             // creation, TCP path warm-up, etc.) so that timed iterations reflect steady-state
             // latency.
             {
-                let mut warmup_response = [0u8; DEFAULT_PAYLOAD_SIZE];
                 gateway_stream.write_all(&payload).await?;
-                gateway_stream.read_exact(&mut warmup_response).await?;
+                gateway_stream.read_exact(&mut response_payload).await?;
                 sleep(Duration::from_millis(WARMUP_SLEEP_DURATION)).await;
             }
 
             for _ in 0..self.iterations {
-                let mut response_payload = [0u8; DEFAULT_PAYLOAD_SIZE];
-
                 let start = Instant::now();
                 gateway_stream.write_all(&payload).await?;
                 gateway_stream.read_exact(&mut response_payload).await?;

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -4,7 +4,6 @@
 use super::super::{
     CHANNEL_CAPACITY,
     CLEANUP_SLEEP_DURATION,
-    DEFAULT_PAYLOAD_SIZE,
     WARMUP_SLEEP_DURATION,
 };
 use crate::benchmark::Benchmark;
@@ -16,6 +15,7 @@ use ::indicatif::{
 use ::log::{
     debug,
     error,
+    warn,
 };
 use ::nanvix::{
     sys::{
@@ -33,9 +33,11 @@ use ::nanvix::{
     },
     syscall::{
         SystemCallMessage,
+        SystemCallMessageHeader,
         unistd::message::{
             ReadRequest,
             ReadResponse,
+            WriteRequest,
             WriteResponse,
         },
     },
@@ -50,6 +52,7 @@ use ::nanvix::{
     },
 };
 use ::std::{
+    collections::HashMap,
     mem,
     time::Instant,
 };
@@ -58,26 +61,303 @@ use ::tokio::{
     time::sleep,
 };
 
+enum GuestRequest {
+    ReadPull(ThreadIdentifier, DataChunkHeader),
+    WritePush(ThreadIdentifier, DataChunk),
+}
+
+const MESSAGE_SIZES: [(&str, usize); 7] = [
+    ("32B", 32),
+    ("1KiB", 1024),
+    ("4KiB", 4 * 1024),
+    ("8KiB", 8 * 1024),
+    ("16KiB", 16 * 1024),
+    ("32KiB", 32 * 1024),
+    ("64KiB", 64 * 1024),
+];
+const PAYLOAD_SIZE_PREFIX_BYTES: usize = mem::size_of::<u32>();
+
+fn format_message_size(total_size: usize) -> String {
+    if total_size >= 1024 && total_size.is_multiple_of(1024) {
+        format!("{}KiB", total_size / 1024)
+    } else {
+        format!("{total_size}B")
+    }
+}
+
+fn make_payload(total_size: usize) -> Result<Vec<u8>> {
+    let data_size: usize = total_size
+        .checked_sub(PAYLOAD_SIZE_PREFIX_BYTES)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "payload size must be at least {PAYLOAD_SIZE_PREFIX_BYTES} bytes because it \
+                 includes the length prefix"
+            )
+        })?;
+    let payload_size_header: u32 =
+        u32::try_from(data_size).map_err(|e| anyhow::anyhow!("payload size exceeds u32: {e}"))?;
+    let mut payload: Vec<u8> = Vec::with_capacity(total_size);
+    payload.extend_from_slice(&payload_size_header.to_le_bytes());
+    payload.resize(total_size, 7u8);
+
+    Ok(payload)
+}
+
+fn message_payloads(payload_size_override: Option<usize>) -> Result<Vec<(String, Vec<u8>)>> {
+    let message_sizes: Vec<(String, usize)> = match payload_size_override {
+        Some(payload_size) => vec![(format_message_size(payload_size), payload_size)],
+        None => MESSAGE_SIZES
+            .iter()
+            .map(|(label, payload_size)| ((*label).to_string(), *payload_size))
+            .collect(),
+    };
+
+    message_sizes
+        .iter()
+        .map(|(label, payload_size)| Ok((label.clone(), make_payload(*payload_size)?)))
+        .collect()
+}
+
+async fn receive_message(
+    output_rx: &mut mpsc::Receiver<IkcFrame>,
+    expected: &str,
+    context: &str,
+) -> Result<Message> {
+    match output_rx.recv().await {
+        Some(IkcFrame::Message(message)) => Ok(message),
+        Some(IkcFrame::Bulk(_)) => {
+            anyhow::bail!("{context}: unexpected bulk transfer while waiting for {expected}")
+        },
+        None => anyhow::bail!("{context}: channel closed while waiting for {expected}"),
+    }
+}
+
+async fn receive_bulk(
+    output_rx: &mut mpsc::Receiver<IkcFrame>,
+    expected: &str,
+    context: &str,
+) -> Result<DataChunk> {
+    match output_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => Ok(bulk),
+        Some(IkcFrame::Message(_)) => {
+            anyhow::bail!("{context}: unexpected IKC message while waiting for {expected}")
+        },
+        None => anyhow::bail!("{context}: channel closed while waiting for {expected}"),
+    }
+}
+
+fn message_source_tid(message: &Message, context: &str) -> Result<ThreadIdentifier> {
+    let tid: ThreadIdentifier = { message.source }.tid;
+    if tid == ThreadIdentifier::NONE {
+        anyhow::bail!("{context}: message source has no thread id");
+    } else {
+        Ok(tid)
+    }
+}
+
+fn chunk_response_header(
+    request_header: &DataChunkHeader,
+    chunk_len: usize,
+) -> Result<DataChunkHeader> {
+    Ok(DataChunkHeader::new(
+        request_header.source_pid(),
+        request_header.source_tid(),
+        request_header.destination_pid(),
+        request_header.destination_tid(),
+        request_header.data_addr(),
+        u32::try_from(chunk_len)
+            .map_err(|e| anyhow::anyhow!("bulk chunk length exceeds u32: {e}"))?,
+    ))
+}
+
+async fn send_read_chunk(
+    input_tx: &mpsc::Sender<IkcFrame>,
+    tid: ThreadIdentifier,
+    pull_header: &DataChunkHeader,
+    chunk: &[u8],
+    context: &str,
+) -> Result<()> {
+    let bulk_response: DataChunk =
+        DataChunk::new(chunk_response_header(pull_header, chunk.len())?, chunk.to_vec());
+    input_tx.send(IkcFrame::Bulk(bulk_response)).await?;
+
+    let empty_buf: [u8; ReadResponse::BUFFER_SIZE] = [0u8; ReadResponse::BUFFER_SIZE];
+    let read_response: Message = ReadResponse::build(
+        tid,
+        i32::try_from(chunk.len())
+            .map_err(|e| anyhow::anyhow!("{context}: read response length exceeds i32: {e}"))?,
+        empty_buf,
+        ProcessIdentifier::KERNEL,
+        MessageType::Ikc,
+    );
+    input_tx.send(IkcFrame::Message(read_response)).await?;
+
+    Ok(())
+}
+
+async fn receive_guest_request(
+    output_rx: &mut mpsc::Receiver<IkcFrame>,
+    context: &str,
+) -> Result<GuestRequest> {
+    let message: Message =
+        receive_message(output_rx, "ReadRequest or WriteRequest", context).await?;
+    let syscall_message: SystemCallMessage = SystemCallMessage::try_from_bytes(message.payload)
+        .map_err(|_| anyhow::anyhow!("{context}: error parsing SystemCall message"))?;
+    match syscall_message.header {
+        SystemCallMessageHeader::ReadRequest => {
+            let tid: ThreadIdentifier = message_source_tid(&message, context)?;
+            let read_request: ReadRequest = ReadRequest::from_bytes(syscall_message.payload);
+            let requested_count: usize = read_request.count as usize;
+
+            let pull: DataChunk = receive_bulk(output_rx, "bulk pull request", context).await?;
+            let pull_header: DataChunkHeader = *pull.header();
+            let pull_len: usize = pull_header.data_len() as usize;
+            if pull_len > requested_count {
+                anyhow::bail!(
+                    "{context}: pull length exceeds read request count (pull={pull_len}, \
+                     request={requested_count})"
+                );
+            }
+
+            Ok(GuestRequest::ReadPull(tid, pull_header))
+        },
+        SystemCallMessageHeader::WriteRequest => {
+            let tid: ThreadIdentifier = message_source_tid(&message, context)?;
+            let write_request: WriteRequest = WriteRequest::from_bytes(syscall_message.payload);
+            let requested_count: usize = write_request.count as usize;
+
+            let push: DataChunk = receive_bulk(output_rx, "bulk push data", context).await?;
+            let pushed_len: usize = push.data().len();
+            let header_len: usize = push.header().data_len() as usize;
+            if pushed_len != header_len {
+                anyhow::bail!(
+                    "{context}: pushed data length does not match header (data={pushed_len}, \
+                     header={header_len})"
+                );
+            }
+            if pushed_len > requested_count {
+                anyhow::bail!(
+                    "{context}: pushed data length exceeds write request count \
+                     (data={pushed_len}, request={requested_count})"
+                );
+            }
+
+            Ok(GuestRequest::WritePush(tid, push))
+        },
+        header => anyhow::bail!("{context}: unexpected syscall message: {header:?}"),
+    }
+}
+
+async fn send_write_response(
+    input_tx: &mpsc::Sender<IkcFrame>,
+    tid: ThreadIdentifier,
+    count: usize,
+    context: &str,
+) -> Result<()> {
+    let write_response: Message = WriteResponse::build(
+        tid,
+        i32::try_from(count)
+            .map_err(|e| anyhow::anyhow!("{context}: write response length exceeds i32: {e}"))?,
+        ProcessIdentifier::KERNEL,
+        MessageType::Ikc,
+    );
+    input_tx.send(IkcFrame::Message(write_response)).await?;
+
+    Ok(())
+}
+
+async fn run_echo_cycle(
+    output_rx: &mut mpsc::Receiver<IkcFrame>,
+    input_tx: &mpsc::Sender<IkcFrame>,
+    first_request: GuestRequest,
+    expected: &[u8],
+    context: &str,
+) -> Result<(ThreadIdentifier, usize)> {
+    let mut sent: usize = 0;
+    let mut received: usize = 0;
+    let mut next_request: Option<GuestRequest> = Some(first_request);
+
+    loop {
+        let request: GuestRequest = match next_request.take() {
+            Some(request) => request,
+            None => receive_guest_request(output_rx, context).await?,
+        };
+
+        match request {
+            GuestRequest::ReadPull(tid, pull_header) => {
+                if sent == expected.len() {
+                    anyhow::bail!("{context}: guest requested more input after full payload");
+                }
+                let requested_len: usize = pull_header.data_len() as usize;
+                if requested_len == 0 {
+                    anyhow::bail!("{context}: zero-length pull request while payload remains");
+                }
+
+                let remaining: usize = expected.len() - sent;
+                let chunk_len: usize = requested_len.min(remaining);
+                send_read_chunk(
+                    input_tx,
+                    tid,
+                    &pull_header,
+                    &expected[sent..sent + chunk_len],
+                    context,
+                )
+                .await?;
+                sent += chunk_len;
+            },
+            GuestRequest::WritePush(tid, push) => {
+                let chunk: &[u8] = push.data();
+                if chunk.is_empty() && received < expected.len() {
+                    anyhow::bail!("{context}: zero-length push before full payload was echoed");
+                }
+                let next_received: usize = received
+                    .checked_add(chunk.len())
+                    .ok_or_else(|| anyhow::anyhow!("{context}: echoed payload length overflow"))?;
+                if next_received > expected.len() {
+                    anyhow::bail!(
+                        "{context}: echoed payload exceeds expected length (received={}, \
+                         chunk={}, expected={})",
+                        received,
+                        chunk.len(),
+                        expected.len()
+                    );
+                }
+                if chunk != &expected[received..next_received] {
+                    anyhow::bail!("{context}: echoed payload mismatch at offset {received}");
+                }
+
+                received = next_received;
+                if received == expected.len() {
+                    return Ok((tid, chunk.len()));
+                }
+
+                send_write_response(input_tx, tid, chunk.len(), context).await?;
+            },
+        }
+    }
+}
+
 impl Benchmark {
     /// In this micro-benchmark we measure the time for a message to travel
     /// all the way from the VMM to the guest application and back. To achieve
     /// this, we connect the user VM to a gateway that emulates linuxd.
     pub async fn run_warm_start_vmm(&mut self) -> Result<()> {
-        // Display a progress bar.
-        let pb = ProgressBar::new(self.iterations.try_into().unwrap());
+        let payloads: Vec<(String, Vec<u8>)> = message_payloads(self.payload_size_override)?;
+        let total_iterations: usize = self
+            .iterations
+            .checked_mul(payloads.len())
+            .ok_or_else(|| anyhow::anyhow!("total iteration count overflows usize"))?;
+        let total_iterations: u64 = u64::try_from(total_iterations)
+            .map_err(|e| anyhow::anyhow!("iteration count exceeds u64: {e}"))?;
+        let pb: ProgressBar = ProgressBar::new(total_iterations);
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
-                .expect("error creating progress bar")
+                .map_err(|e| anyhow::anyhow!("error creating progress bar: {e}"))?
                 .progress_chars("#>-"),
         );
         pb.set_message("Benchmark progress:");
 
-        // Payload we are sending over the wire.
-        let data = [7u8; DEFAULT_PAYLOAD_SIZE];
-        let mut payload: Vec<u8> = Vec::with_capacity(mem::size_of::<u32>() + data.len());
-        payload.extend_from_slice(&(DEFAULT_PAYLOAD_SIZE as u32).to_le_bytes());
-        payload.extend_from_slice(&data);
         let (vcpu_thread_stdout_tx, mut vcpu_thread_stdout_rx) =
             mpsc::channel::<IkcFrame>(CHANNEL_CAPACITY);
         let (io_thread_data_tx, memory_thread_data_rx) =
@@ -116,234 +396,52 @@ impl Benchmark {
         // Warmup: run one untimed echo cycle through the full IKC protocol to trigger
         // lazy initialization so that timed iterations reflect steady-state latency.
         {
-            // Step 1: Receive the ReadRequest IKC message from the guest.
-            let warmup_read_msg: Message = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Message(message)) => message,
-                Some(IkcFrame::Bulk(_)) => {
-                    anyhow::bail!("warmup: unexpected bulk during ReadRequest")
-                },
-                None => anyhow::bail!("warmup: channel closed during ReadRequest"),
-            };
-            let warmup_syscall_msg: SystemCallMessage =
-                SystemCallMessage::try_from_bytes(warmup_read_msg.payload)
-                    .map_err(|_| anyhow::anyhow!("warmup: error parsing SystemCall message"))?;
-            let warmup_tid: ThreadIdentifier = { warmup_read_msg.source }.tid;
-            if warmup_tid.is_none() {
-                anyhow::bail!("warmup: message source has no thread id");
-            }
-            let _warmup_read_req: ReadRequest = ReadRequest::from_bytes(warmup_syscall_msg.payload);
-
-            // Step 2: Receive the bulk pull request from the guest kernel.
-            let warmup_pull_header: DataChunkHeader = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
-                Some(IkcFrame::Message(_)) => {
-                    anyhow::bail!("warmup: unexpected message during bulk pull")
-                },
-                None => anyhow::bail!("warmup: channel closed during bulk pull"),
-            };
-
-            // Step 3: Send the bulk data response back to the kernel buffer.
-            let warmup_bulk_response: DataChunk = DataChunk::new(
-                DataChunkHeader::new(
-                    warmup_pull_header.source_pid(),
-                    warmup_pull_header.source_tid(),
-                    warmup_pull_header.destination_pid(),
-                    warmup_pull_header.destination_tid(),
-                    warmup_pull_header.data_addr(),
-                    payload.len() as u32,
-                ),
-                payload.clone(),
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Bulk(warmup_bulk_response))
-                .await?;
-
-            // Step 4: Send ReadResponse metadata.
-            let warmup_empty_buf: [u8; ReadResponse::BUFFER_SIZE] =
-                [0u8; ReadResponse::BUFFER_SIZE];
-            let warmup_read_response: Message = ReadResponse::build(
-                warmup_tid,
-                payload.len() as i32,
-                warmup_empty_buf,
-                ProcessIdentifier::KERNEL,
-                MessageType::Ikc,
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Message(warmup_read_response))
-                .await?;
-
-            // Step 5: Receive the WriteRequest IKC message from the guest.
-            match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Message(_)) => {},
-                Some(IkcFrame::Bulk(_)) => {
-                    anyhow::bail!("warmup: unexpected bulk during WriteRequest")
-                },
-                None => anyhow::bail!("warmup: channel closed during WriteRequest"),
-            };
-
-            // Step 6: Receive the bulk push data from the guest.
-            match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Bulk(_)) => {},
-                Some(IkcFrame::Message(_)) => {
-                    anyhow::bail!("warmup: unexpected message during bulk push")
-                },
-                None => anyhow::bail!("warmup: channel closed during bulk push"),
-            };
-
-            // Step 7: Send WriteResponse to acknowledge the write.
-            let warmup_write_response: Message = WriteResponse::build(
-                warmup_tid,
-                payload.len() as i32,
-                ProcessIdentifier::KERNEL,
-                MessageType::Ikc,
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Message(warmup_write_response))
-                .await?;
+            let payload: &[u8] = payloads
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("no payload sizes configured for warm-start-vmm"))?
+                .1
+                .as_slice();
+            let first_request: GuestRequest =
+                receive_guest_request(&mut vcpu_thread_stdout_rx, "warmup").await?;
+            let (tid, count): (ThreadIdentifier, usize) = run_echo_cycle(
+                &mut vcpu_thread_stdout_rx,
+                &io_thread_data_tx,
+                first_request,
+                payload,
+                "warmup",
+            )
+            .await?;
+            send_write_response(&io_thread_data_tx, tid, count, "warmup").await?;
 
             sleep(std::time::Duration::from_millis(WARMUP_SLEEP_DURATION)).await;
         }
 
-        let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
-        for _ in 0..self.iterations {
-            // Step 1: Receive the ReadRequest IKC message from the guest.
-            let ipc_read_message: Message = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Message(message)) => message,
-                Some(IkcFrame::Bulk(_)) => {
-                    let reason: String = "unexpected data chunk transfer received while waiting \
-                                          for ReadRequest"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-                None => {
-                    let reason: String = "user VM channel closed unexpectedly while waiting for \
-                                          ReadRequest"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            };
-            let syscall_message: SystemCallMessage =
-                match SystemCallMessage::try_from_bytes(ipc_read_message.payload) {
-                    Ok(message) => message,
-                    Err(_) => {
-                        return Err(anyhow::anyhow!(
-                            "Error parsing IPC message to SystemCall message"
-                        ));
-                    },
-                };
-            let tid: ThreadIdentifier = { ipc_read_message.source }.tid;
-            if tid.is_none() {
-                return Err(anyhow::anyhow!("unexpected message source: no thread id"));
+        let mut latencies: HashMap<String, Vec<u128>> = HashMap::new();
+        for (label, payload) in &payloads {
+            for _ in 0..self.iterations {
+                let first_request: GuestRequest =
+                    receive_guest_request(&mut vcpu_thread_stdout_rx, "run_warm_start_vmm()")
+                        .await?;
+                let start = Instant::now();
+                let (tid, count): (ThreadIdentifier, usize) = run_echo_cycle(
+                    &mut vcpu_thread_stdout_rx,
+                    &io_thread_data_tx,
+                    first_request,
+                    payload,
+                    "run_warm_start_vmm()",
+                )
+                .await?;
+                latencies
+                    .entry(label.clone())
+                    .or_default()
+                    .push(start.elapsed().as_micros());
+
+                send_write_response(&io_thread_data_tx, tid, count, "run_warm_start_vmm()").await?;
+
+                sleep(std::time::Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
+
+                pb.inc(1);
             }
-            let _read_request: ReadRequest = ReadRequest::from_bytes(syscall_message.payload);
-
-            // Step 2: Receive the bulk pull request from the guest kernel.
-            let pull_header: DataChunkHeader = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
-                Some(IkcFrame::Message(_)) => {
-                    let reason: String = "unexpected IKC message received while waiting for bulk \
-                                          pull request"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-                None => {
-                    let reason: String = "user VM channel closed unexpectedly while waiting for \
-                                          bulk pull request"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            };
-
-            // Now we are ready to push bulk data and ReadResponse, and wait for a WriteRequest.
-            let start = Instant::now();
-
-            // Step 3: Send the bulk data response back to the kernel buffer.
-            let bulk_response: DataChunk = DataChunk::new(
-                DataChunkHeader::new(
-                    pull_header.source_pid(),
-                    pull_header.source_tid(),
-                    pull_header.destination_pid(),
-                    pull_header.destination_tid(),
-                    pull_header.data_addr(),
-                    payload.len() as u32,
-                ),
-                payload.clone(),
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Bulk(bulk_response))
-                .await?;
-
-            // Step 4: Send ReadResponse metadata (buffer is empty; data was sent via bulk).
-            let empty_buf: [u8; ReadResponse::BUFFER_SIZE] = [0u8; ReadResponse::BUFFER_SIZE];
-            let read_response: Message = ReadResponse::build(
-                tid,
-                payload.len() as i32,
-                empty_buf,
-                ProcessIdentifier::KERNEL,
-                MessageType::Ikc,
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Message(read_response))
-                .await?;
-
-            // Step 5: Receive the WriteRequest IKC message from the guest.
-            let _write_request: Message = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Message(message)) => message,
-                Some(IkcFrame::Bulk(_)) => {
-                    let reason: String = "unexpected data chunk transfer received while waiting \
-                                          for WriteRequest"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-                None => {
-                    let reason: String = "user VM channel closed unexpectedly while waiting for \
-                                          WriteRequest"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            };
-
-            // Step 6: Receive the bulk push data from the guest.
-            let _push_data: DataChunk = match vcpu_thread_stdout_rx.recv().await {
-                Some(IkcFrame::Bulk(bulk)) => bulk,
-                Some(IkcFrame::Message(_)) => {
-                    let reason: String = "unexpected IKC message received while waiting for bulk \
-                                          push data"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-                None => {
-                    let reason: String = "user VM channel closed unexpectedly while waiting for \
-                                          bulk push data"
-                        .to_string();
-                    error!("run_warm_start_vmm(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            };
-
-            latencies.push(start.elapsed().as_micros());
-
-            // Step 7: Send WriteResponse to acknowledge the write.
-            let write_response: Message = WriteResponse::build(
-                tid,
-                payload.len() as i32,
-                ProcessIdentifier::KERNEL,
-                MessageType::Ikc,
-            );
-            io_thread_data_tx
-                .send(IkcFrame::Message(write_response))
-                .await?;
-
-            sleep(std::time::Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
-
-            pb.inc(1);
         }
 
         io_control_command_tx
@@ -389,10 +487,18 @@ impl Benchmark {
         }
 
         pb.finish();
-        latencies.sort();
-        println!("p50: {} us", latencies[(self.iterations as f32 * 0.5) as usize]);
-        println!("p95: {} us", latencies[(self.iterations as f32 * 0.95) as usize]);
-        println!("p99: {} us", latencies[(self.iterations as f32 * 0.99) as usize]);
+        println!("Size:\tp50\tp95\tp99 [us]");
+        for (label, _) in payloads.iter() {
+            if let Some(latencies) = latencies.get_mut(label) {
+                latencies.sort();
+                let p50: u128 = latencies[(self.iterations as f32 * 0.5) as usize];
+                let p95: u128 = latencies[(self.iterations as f32 * 0.95) as usize];
+                let p99: u128 = latencies[(self.iterations as f32 * 0.99) as usize];
+                println!("{label}:\t{p50}\t{p95}\t{p99}");
+            } else {
+                warn!("No latencies recorded for {label}");
+            }
+        }
 
         Ok(())
     }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -187,6 +187,8 @@ async fn main() -> Result<()> {
 
     let mut benchmark = Benchmark {
         iterations: args.iterations(),
+        payload_size: args.payload_size(),
+        payload_size_override: args.payload_size_override(),
         hwloc_file: args.hwloc_file(),
         hwloc,
         flavour: args.benchmark(),


### PR DESCRIPTION
 ## Summary
- Add configurable payload sizes for `warm-start` and `warm-start-vmm` benchmarks. 
- Update `warm-start-vmm` to support chunked echo payloads and validate echoed data.
- Add CI coverage for `warm-start-vmm` payload sizes: 32B, 1KiB, 4KiB, 8KiB, 16KiB, 32KiB, and 64KiB. 
- Wire the sweep into benchmark reporting and remove `warm-start-vmm` from regression gating since sweeps get skipped anyway.