### PR TITLE
[kernel] Use fallible heap allocators

### DIFF
--- a/src/kernel/src/hal/arch/x86/mem/gdt.rs
+++ b/src/kernel/src/hal/arch/x86/mem/gdt.rs
@@ -311,10 +311,10 @@ impl Gdt {
         );
 
         // Set the GDTPTR.
-        let gdtr = GdtPtr(Pin::new(Box::new(::arch::mem::gdtr::Gdtr::new(
+        let gdtr = GdtPtr(Pin::new(crate::mm::try_box(::arch::mem::gdtr::Gdtr::new(
             GDT as u32,
             (GDT_NUM_ENTRIES * mem::size_of::<Gdte>()) as u16,
-        ))));
+        ))?));
 
         info!("loading the GDT...");
         Self::load(gdtr.0.as_ref().get_ref() as *const ::arch::mem::gdtr::Gdtr);

--- a/src/kernel/src/hal/arch/x86_64/mem/gdt.rs
+++ b/src/kernel/src/hal/arch/x86_64/mem/gdt.rs
@@ -308,10 +308,10 @@ impl Gdt {
         *tss_high_ptr.add(1) = 0;
 
         // Set the GDTPTR.
-        let gdtr = GdtPtr(Pin::new(Box::new(::arch::mem::gdtr::Gdtr::new(
+        let gdtr = GdtPtr(Pin::new(crate::mm::try_box(::arch::mem::gdtr::Gdtr::new(
             GDT as u64,
             (GDT_NUM_ENTRIES * mem::size_of::<Gdte>()) as u16,
-        ))));
+        ))?));
 
         info!("loading the GDT...");
         Self::load(gdtr.0.as_ref().get_ref() as *const ::arch::mem::gdtr::Gdtr);

--- a/src/kernel/src/hal/mem/types/region.rs
+++ b/src/kernel/src/hal/mem/types/region.rs
@@ -14,10 +14,7 @@ use crate::hal::mem::types::{
         VirtualAddress,
     },
 };
-use ::alloc::string::{
-    String,
-    ToString,
-};
+use ::alloc::string::String;
 use ::arch::mem::PAGE_ALIGNMENT;
 use ::sys::error::{
     Error,
@@ -184,7 +181,7 @@ impl<T: Address> MemoryRegion<T> {
         }
 
         Ok(Self {
-            name: name.to_string(),
+            name: crate::mm::try_string_from_str(name)?,
             start,
             size,
             typ,

--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -467,7 +467,7 @@ fn do_elf32_load(
             virt_addr_base, virt_addr_end, file_off_base, file_off_end, access
         );
 
-        let mut uframe_buf: Vec<UserFrame> = Vec::with_capacity(1);
+        let mut uframe_buf: Vec<UserFrame> = crate::mm::try_vec_with_capacity(1)?;
         for vaddr in (virt_addr_base..virt_addr_end).step_by(mem::PAGE_SIZE) {
             let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
 

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -91,7 +91,7 @@ impl KernelStack {
     ///
     pub fn new(mm: &mut VirtMemoryManager) -> Result<Self, Error> {
         let count: usize = config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE;
-        let mut kframes: Vec<KernelFrame> = Vec::with_capacity(count);
+        let mut kframes: Vec<KernelFrame> = crate::mm::try_vec_with_capacity(count)?;
         mm.alloc_kpages(true, count, &mut kframes)?;
         let kpages: Vec<KernelPage> = kframes.into_iter().map(KernelPage::new).collect();
 

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -49,6 +49,8 @@ use crate::hal::mem::{
 use ::alloc::{
     boxed::Box,
     collections::LinkedList,
+    string::String,
+    vec::Vec,
 };
 use ::arch::mem;
 use ::sys::error::{
@@ -179,11 +181,62 @@ type PhysMemRegion = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
 // Standalone Functions
 //==================================================================================================
 
+/// Builds an [`ErrorCode::OutOfMemory`] error for a failed kernel heap allocation.
+fn out_of_memory() -> Error {
+    Error::new(ErrorCode::OutOfMemory, "failed to allocate memory on kernel heap")
+}
+
+//--------------------------------------------------------------------------------------------------
+// Box
+//--------------------------------------------------------------------------------------------------
+
 /// Allocates `value` in a [`Box`] on the kernel heap using fallible allocation.
 ///
 /// Unlike [`Box::new`], this returns an [`ErrorCode::OutOfMemory`] error when the allocation fails
 /// instead of aborting, so callers can propagate the failure.
 pub fn try_box<T>(value: T) -> Result<Box<T>, Error> {
-    Box::try_new(value)
-        .map_err(|_| Error::new(ErrorCode::OutOfMemory, "failed to allocate memory on kernel heap"))
+    Box::try_new(value).map_err(|_| out_of_memory())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Vec
+//--------------------------------------------------------------------------------------------------
+
+/// Creates an empty [`Vec`] with at least `capacity` elements pre-allocated on the kernel heap
+/// using fallible allocation.
+///
+/// Unlike [`Vec::with_capacity`], this returns an [`ErrorCode::OutOfMemory`] error when the
+/// allocation fails instead of aborting, so callers can propagate the failure.
+pub fn try_vec_with_capacity<T>(capacity: usize) -> Result<Vec<T>, Error> {
+    let mut vec: Vec<T> = Vec::new();
+    vec.try_reserve_exact(capacity)
+        .map_err(|_| out_of_memory())?;
+    Ok(vec)
+}
+
+//--------------------------------------------------------------------------------------------------
+// String
+//--------------------------------------------------------------------------------------------------
+
+/// Creates an empty [`String`] with at least `capacity` bytes pre-allocated on the kernel heap
+/// using fallible allocation.
+///
+/// Unlike [`String::with_capacity`], this returns an [`ErrorCode::OutOfMemory`] error when the
+/// allocation fails instead of aborting, so callers can propagate the failure.
+pub fn try_string_with_capacity(capacity: usize) -> Result<String, Error> {
+    let mut string: String = String::new();
+    string
+        .try_reserve_exact(capacity)
+        .map_err(|_| out_of_memory())?;
+    Ok(string)
+}
+
+/// Creates a [`String`] containing a copy of `value` on the kernel heap using fallible allocation.
+///
+/// Unlike [`str::to_string`], this returns an [`ErrorCode::OutOfMemory`] error when the allocation
+/// fails instead of aborting, so callers can propagate the failure.
+pub fn try_string_from_str(value: &str) -> Result<String, Error> {
+    let mut string: String = try_string_with_capacity(value.len())?;
+    string.push_str(value);
+    Ok(string)
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1072,7 +1072,7 @@ impl ProcessManager {
                 AccessPermission::RDWR,
                 true,
                 1,
-                &mut Vec::with_capacity(1),
+                &mut crate::mm::try_vec_with_capacity(1)?,
             )?;
             // Write args as a NUL-terminated string directly to user space.
             Self::write_nul_terminated_to_user(
@@ -1104,7 +1104,7 @@ impl ProcessManager {
                 AccessPermission::RDWR,
                 true,
                 1,
-                &mut Vec::with_capacity(1),
+                &mut crate::mm::try_vec_with_capacity(1)?,
             )?;
 
             // Write env as a NUL-terminated string directly to user space.
@@ -1153,7 +1153,7 @@ impl ProcessManager {
                 AccessPermission::RDWR,
                 true,
                 count,
-                &mut Vec::with_capacity(count),
+                &mut crate::mm::try_vec_with_capacity(count)?,
             )?;
 
             // Construct the ready main thread. This is infallible.


### PR DESCRIPTION
## Summary

Harden kernel heap allocations on early-boot and process paths so that out-of-memory
conditions propagate as `ErrorCode::OutOfMemory` instead of aborting the kernel. This
extends the existing `try_box` work with a small set of fallible allocation helpers and
switches the remaining infallible allocation sites over to them.

## Changes

**Kernel (`mm` helpers):**
- Add a shared `out_of_memory()` error constructor and refactor `try_box()` to use it.
- Add `try_vec_with_capacity()` backed by `Vec::try_reserve_exact()`.
- Add `try_string_with_capacity()` backed by `String::try_reserve_exact()`.
- Add `try_string_from_str()` to copy a `&str` via fallible allocation.

**Kernel (call sites):**
- GDT init (`x86`/`x86_64`) allocates the `Gdtr` via `try_box(...)?`.
- `MemoryRegion` names are built with `try_string_from_str()` (drops the unused
  `ToString` import).
- ELF loader, kernel stack, and process-manager argv/env buffers allocate with
  `try_vec_with_capacity()`.

## Validation

- `rust-lint-check-kernel` (clippy `-D warnings`) — pass
- `format-check-kernel` — pass
- `run-unit-tests` — pass
- `run-kernel-tests` — pass
- `run-nanvix-tests` (integration) — pass


## Issues

Closes #2706 