### PR TITLE
[libc_stdlib] Add PTY Stubs and Widen rand()

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -17,7 +17,6 @@
 
 #include <stddef.h>
 #include <sys/wait.h>
-#include <fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +35,7 @@ extern "C" {
 #endif
 
 #ifndef RAND_MAX
-#define RAND_MAX 32767 /**< Maximum value returned by rand(). */
+#define RAND_MAX 2147483647 /**< Maximum value returned by rand(). */
 #endif
 
 #ifndef MB_CUR_MAX
@@ -128,6 +127,7 @@ extern char *secure_getenv(const char *name);
 extern int setenv(const char *name, const char *value, int overwrite);
 extern int unsetenv(const char *name);
 extern int putenv(char *string);
+extern int clearenv(void);
 
 /*==================================================================================================
  * Process Control
@@ -158,12 +158,23 @@ extern size_t wcstombs(char *restrict dst, const wchar_t *restrict src, size_t n
 extern char *mkdtemp(char *template);
 extern int mkostemp(char *template, int flag);
 extern int mkstemp(char *template);
+extern char *mktemp(char *template);
 
 /*==================================================================================================
  * Path Utilities
  *==================================================================================================*/
 
 extern char *realpath(const char *restrict path, char *restrict resolved_path);
+
+/*==================================================================================================
+ * Pseudo-Terminals
+ *==================================================================================================*/
+
+extern int posix_openpt(int flags);
+extern int grantpt(int fd);
+extern int unlockpt(int fd);
+extern char *ptsname(int fd);
+extern int ptsname_r(int fd, char *buf, size_t buflen);
 
 #ifdef __cplusplus
 }

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -11,7 +11,7 @@ description = """
 Declares memory allocation, string conversion, integer arithmetic, searching
 and sorting, pseudo-random sequence generation, environment, and process
 control interfaces implemented by the libc_stdlib Rust crate."""
-includes = ["stddef.h", "sys/wait.h", "fcntl.h"]
+includes = ["stddef.h", "sys/wait.h"]
 guard = "_NANVIX_STDLIB_H"
 content_order = [
     "macros",
@@ -26,6 +26,7 @@ content_order = [
     "section:7",
     "section:8",
     "section:9",
+    "section:10",
 ]
 
 [[macros]]
@@ -42,7 +43,7 @@ guard = "EXIT_FAILURE"
 
 [[macros]]
 name = "RAND_MAX"
-value = "32767"
+value = "2147483647"
 comment = "Maximum value returned by rand()."
 guard = "RAND_MAX"
 
@@ -118,7 +119,14 @@ functions = ["rand", "srand"]
 
 [[sections]]
 title = "Environment"
-functions = ["getenv", "secure_getenv", "setenv", "unsetenv", "putenv"]
+functions = [
+    "getenv",
+    "secure_getenv",
+    "setenv",
+    "unsetenv",
+    "putenv",
+    "clearenv",
+]
 
 [[sections]]
 title = "Process Control"
@@ -138,11 +146,15 @@ functions = ["mblen", "mbtowc", "mbstowcs", "wctomb", "wcstombs"]
 
 [[sections]]
 title = "Temporary Files"
-functions = ["mkdtemp", "mkostemp", "mkstemp"]
+functions = ["mkdtemp", "mkostemp", "mkstemp", "mktemp"]
 
 [[sections]]
 title = "Path Utilities"
 functions = ["realpath"]
+
+[[sections]]
+title = "Pseudo-Terminals"
+functions = ["posix_openpt", "grantpt", "unlockpt", "ptsname", "ptsname_r"]
 
 [overrides]
 _Exit = '''

--- a/src/libs/libc_stdlib/src/lib.rs
+++ b/src/libs/libc_stdlib/src/lib.rs
@@ -97,6 +97,7 @@ mod mkostemp;
 mod mkstemp;
 mod mktemp;
 mod posix_memalign;
+mod pty;
 mod putenv;
 mod qsort;
 mod quick_exit;
@@ -172,6 +173,13 @@ pub use mkostemp::mkostemp;
 pub use mkstemp::mkstemp;
 pub use mktemp::mktemp;
 pub use posix_memalign::posix_memalign;
+pub use pty::{
+    grantpt,
+    posix_openpt,
+    ptsname,
+    ptsname_r,
+    unlockpt,
+};
 pub use putenv::putenv;
 pub use qsort::{
     qsort,

--- a/src/libs/libc_stdlib/src/pty.rs
+++ b/src/libs/libc_stdlib/src/pty.rs
@@ -1,0 +1,196 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Pseudo-terminal (PTY) interfaces.
+//!
+//! Nanvix does not provide a pseudo-terminal subsystem, so these interfaces are stubs that fail
+//! with `ENOSYS`. They exist so that portable software which references the POSIX PTY API compiles
+//! and links; applets that depend on PTYs are non-functional and documented as gaps.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::core::ptr::null_mut;
+use ::sysapi::{
+    errno::ENOSYS,
+    ffi::{
+        c_char,
+        c_int,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Opens an unused pseudo-terminal master device. Nanvix has no pseudo-terminal subsystem, so this
+/// always fails.
+///
+/// # Parameters
+///
+/// - `flags`: File status flags for the new descriptor.
+///
+/// # Returns
+///
+/// `-1`, with `errno` set to `ENOSYS`.
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies global state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn posix_openpt(_flags: c_int) -> c_int {
+    set_errno(ENOSYS);
+    -1
+}
+
+///
+/// # Description
+///
+/// Grants access to the slave pseudo-terminal associated with a master. Nanvix has no
+/// pseudo-terminal subsystem, so this always fails.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor of the master pseudo-terminal.
+///
+/// # Returns
+///
+/// `-1`, with `errno` set to `ENOSYS`.
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies global state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn grantpt(_fd: c_int) -> c_int {
+    set_errno(ENOSYS);
+    -1
+}
+
+///
+/// # Description
+///
+/// Unlocks the slave pseudo-terminal associated with a master. Nanvix has no pseudo-terminal
+/// subsystem, so this always fails.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor of the master pseudo-terminal.
+///
+/// # Returns
+///
+/// `-1`, with `errno` set to `ENOSYS`.
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies global state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn unlockpt(_fd: c_int) -> c_int {
+    set_errno(ENOSYS);
+    -1
+}
+
+///
+/// # Description
+///
+/// Returns the name of the slave pseudo-terminal associated with a master. Nanvix has no
+/// pseudo-terminal subsystem, so this always fails.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor of the master pseudo-terminal.
+///
+/// # Returns
+///
+/// A null pointer, with `errno` set to `ENOSYS`.
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies global state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ptsname(_fd: c_int) -> *mut c_char {
+    set_errno(ENOSYS);
+    null_mut()
+}
+
+///
+/// # Description
+///
+/// Reentrant variant of [`ptsname`]. Nanvix has no pseudo-terminal subsystem, so this always
+/// fails.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor of the master pseudo-terminal.
+/// - `buf`: Destination buffer for the slave name.
+/// - `buflen`: Size of `buf`, in bytes.
+///
+/// # Returns
+///
+/// `ENOSYS`. Unlike most interfaces, `ptsname_r` returns the error number directly rather than
+/// setting `errno`.
+///
+/// # Safety
+///
+/// This function is unsafe because it receives raw pointers from foreign callers.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ptsname_r(_fd: c_int, _buf: *mut c_char, _buflen: c_size_t) -> c_int {
+    ENOSYS
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{
+        grantpt,
+        posix_openpt,
+        ptsname,
+        ptsname_r,
+        unlockpt,
+    };
+    use crate::set_errno;
+    use ::core::ptr::null_mut;
+    use ::sysapi::{
+        errno::{
+            __errno_location,
+            ENOSYS,
+        },
+        ffi::c_int,
+    };
+
+    fn get_errno() -> c_int {
+        unsafe { *__errno_location() }
+    }
+
+    #[test]
+    fn pty_stubs_fail_with_enosys() {
+        set_errno(0);
+        assert_eq!(unsafe { posix_openpt(0) }, -1);
+        assert_eq!(get_errno(), ENOSYS);
+
+        set_errno(0);
+        assert_eq!(unsafe { grantpt(0) }, -1);
+        assert_eq!(get_errno(), ENOSYS);
+
+        set_errno(0);
+        assert_eq!(unsafe { unlockpt(0) }, -1);
+        assert_eq!(get_errno(), ENOSYS);
+
+        set_errno(0);
+        assert!(unsafe { ptsname(0) }.is_null());
+        assert_eq!(get_errno(), ENOSYS);
+
+        set_errno(0);
+        assert_eq!(unsafe { ptsname_r(0, null_mut(), 0) }, ENOSYS);
+        assert_eq!(get_errno(), 0);
+    }
+}

--- a/src/libs/libc_stdlib/src/rand.rs
+++ b/src/libs/libc_stdlib/src/rand.rs
@@ -11,18 +11,12 @@ use ::sysapi::ffi::{
 };
 
 //==================================================================================================
-// Constants
-//==================================================================================================
-
-/// Modulus for the LCG output range. `rand()` returns values in `[0, RAND_RANGE - 1]`.
-const RAND_RANGE: c_uint = 32768;
-
-//==================================================================================================
 // Global State
 //==================================================================================================
 
-/// Internal LCG seed state.
-static mut NEXT: c_uint = 1;
+/// Internal LCG seed state. Initialized to match the state produced by `srand(1)`, as required
+/// when `rand()` is called before any call to `srand()`.
+static mut NEXT: u64 = 0;
 
 //==================================================================================================
 // Standalone Functions
@@ -31,7 +25,7 @@ static mut NEXT: c_uint = 1;
 ///
 /// # Description
 ///
-/// Generates a pseudo-random integer in the range `[0, 32767]`.
+/// Generates a pseudo-random integer in the range `[0, 2147483647]`.
 ///
 /// # Returns
 ///
@@ -47,8 +41,10 @@ static mut NEXT: c_uint = 1;
 ///
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn rand() -> c_int {
-    NEXT = NEXT.wrapping_mul(1_103_515_245).wrapping_add(12345);
-    c_int::try_from((NEXT / 65536) % RAND_RANGE).unwrap_or_default()
+    // 64-bit LCG (constants from musl); return the high 31 bits, which have the best
+    // distribution. This yields RAND_MAX == 0x7fffffff, as expected by portable software.
+    NEXT = NEXT.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    c_int::try_from(NEXT >> 33).unwrap_or_default()
 }
 
 ///
@@ -70,7 +66,9 @@ pub unsafe extern "C" fn rand() -> c_int {
 ///
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn srand(seed: c_uint) {
-    NEXT = seed;
+    // Compute `seed - 1` in 32 bits (matching musl's `unsigned` arithmetic) before widening, so
+    // that `srand(0)` yields a state of `0xffff_ffff` rather than `0xffff_ffff_ffff_ffff`.
+    NEXT = u64::from(seed.wrapping_sub(1));
 }
 
 #[cfg(all(test, feature = "std"))]
@@ -80,25 +78,51 @@ mod tests {
         srand,
     };
 
-    const RAND_MAX: i32 = 32767;
+    const RAND_MAX: i32 = 2_147_483_647;
 
-    #[test]
-    fn deterministic_sequence() {
-        unsafe { srand(1) };
-        let first = unsafe { rand() };
-        let second = unsafe { rand() };
-        unsafe { srand(1) };
-        assert_eq!(unsafe { rand() }, first);
-        assert_eq!(unsafe { rand() }, second);
+    /// Collects `N` consecutive values from `rand()`.
+    fn sequence<const N: usize>() -> [i32; N] {
+        ::core::array::from_fn(|_| unsafe { rand() })
     }
 
+    // All assertions share a single test because `rand()`/`srand()` operate on a process-global
+    // seed. Keeping them in one test serializes access and lets the implicit-seed case observe the
+    // pristine initial state before any call to `srand()`.
     #[test]
-    fn values_in_range() {
+    fn rand_behaviour() {
+        // Calling `rand()` before any call to `srand()` must yield the same sequence as `srand(1)`.
+        let implicit: [i32; 8] = sequence();
+        unsafe { srand(1) };
+        let seeded_one: [i32; 8] = sequence();
+        assert_eq!(implicit, seeded_one);
+
+        // The selected LCG matches musl's sequence.
+        assert_eq!(
+            seeded_one,
+            [
+                0,
+                740_882_966,
+                1_616_430_695,
+                1_708_849_955,
+                1_669_437_588,
+                406_334_850,
+                276_737_754,
+                1_296_416_700,
+            ]
+        );
+
+        // Re-seeding with the same value repeats the sequence.
+        unsafe { srand(1) };
+        let first: [i32; 8] = sequence();
+        unsafe { srand(1) };
+        let second: [i32; 8] = sequence();
+        assert_eq!(first, second);
+
+        // Generated values stay within `[0, RAND_MAX]`.
         unsafe { srand(42) };
         for _ in 0..100 {
             let val = unsafe { rand() };
-            assert!(val >= 0);
-            assert!(val <= RAND_MAX);
+            assert!((0..=RAND_MAX).contains(&val));
         }
     }
 }


### PR DESCRIPTION
## What

Extends `libc_stdlib` with the POSIX pseudo-terminal API surface and brings `rand()`/`srand()` in line with the 31-bit `RAND_MAX` that portable software expects.

### Libraries
- Add a new `pty` module exposing `posix_openpt()`, `grantpt()`, `unlockpt()`, `ptsname()`, and `ptsname_r()`. Nanvix has no PTY subsystem, so these are stubs that fail with `ENOSYS` (`ptsname_r` returns the error directly; the rest set `errno`).
- Replace the `rand()` generator with a 64-bit musl-style LCG that returns the high 31 bits, yielding `RAND_MAX == 0x7fffffff`, and adjust `srand()` to seed state as `seed - 1` so the implicit-seed sequence matches `srand(1)`.

### Headers
- Declare the PTY functions plus `clearenv()` and `mktemp()` in `<stdlib.h>`, drop the now-unneeded `fcntl.h` include, and bump `RAND_MAX` to `2147483647` via `header.toml`.

### Tests
- Cover the PTY stubs' `ENOSYS` behavior and pin the `rand()` sequence, re-seed determinism, and value range.

## Why

These stubs let PTY-referencing portable software compile and link against Nanvix, while the wider `RAND_MAX` and musl-aligned sequence make `rand()` behave as portable software expects. `posix_openpt()` is declared from `<stdlib.h>` per POSIX Issue 8, so no extra `fcntl.h` dependency is pulled into the generated header.