### PR TITLE
[kernel] Deliver Signals To Blocked Threads

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -1337,6 +1337,12 @@ fn exception_handler(info: &ExceptionInformation, ctx: &ContextInformation) {
                 error!("killing process (interrupted by signal)");
                 ErrorCode::Interrupted
             },
+            SleepError::Interrupted(InterruptReason::Signaled) => {
+                // A caught signal interrupted a thread parked in exception handling. There is no
+                // kernel call to restart on this path, so the process is torn down with EINTR.
+                error!("killing process (interrupted by signal during exception handling)");
+                ErrorCode::Interrupted
+            },
             SleepError::Interrupted(InterruptReason::TimedOut) => {
                 error!("killing process (timed out)");
                 ErrorCode::OperationTimedOut

--- a/src/kernel/src/hal/arch/mod.rs
+++ b/src/kernel/src/hal/arch/mod.rs
@@ -35,6 +35,7 @@ pub use x86::{
     forge_user_stack,
     install_fpu,
     join_kcall_result,
+    prepare_kcall_restart,
     read_trap_context,
     read_user_sp,
     redirect_to_handler,

--- a/src/kernel/src/hal/arch/x86/asm/hooks.rs
+++ b/src/kernel/src/hal/arch/x86/asm/hooks.rs
@@ -326,12 +326,17 @@ global_asm!(
     // clear/set the IF flag — the hardware handles it.
     //
     "_do_kcall:",
-    // Save execution context (esp and eflags saved by hardware;
-    // we do not save scratch registers eax, ecx, edx).
+    // Save execution context (esp and eflags saved by hardware). We do not save the scratch
+    // registers eax and edx (eax carries the call number on entry and the result on exit; edx
+    // carries the result's high word). We do save ecx — although it is also a scratch register —
+    // so that a caught signal handler installed with SA_RESTART can restart the interrupted call
+    // with its original second argument (which the user passes in ecx). The saved slot is rewritten
+    // by sigreturn() on the restart path and otherwise restores ecx to its entry value.
     "    pushl %ebp",
     "    pushl %esi",
     "    pushl %edi",
     "    pushl %ebx",
+    "    pushl %ecx",
 
     // Clear the direction flag.
     "    cld",
@@ -352,6 +357,7 @@ global_asm!(
     "    addl $5*{WORD_SIZE}, %esp",
 
     // Restore execution context.
+    "    popl %ecx",
     "    popl %ebx",
     "    popl %edi",
     "    popl %esi",

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -65,6 +65,7 @@ pub use interrupt::{
 pub use sigframe::split_kcall_result;
 pub use sigframe::{
     join_kcall_result,
+    prepare_kcall_restart,
     read_trap_context,
     read_user_sp,
     redirect_to_handler,

--- a/src/kernel/src/hal/arch/x86/cpu/sigframe.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/sigframe.rs
@@ -8,8 +8,9 @@
 //! (`_do_kcall`) leaves on the top of a thread's kernel stack. The stub runs before any Rust code,
 //! so the interrupted user state sits at fixed offsets below the top of the kernel stack: the
 //! hardware trap frame (`EIP`, `CS`, `EFLAGS`, user `ESP`, `SS`) followed by the callee-saved
-//! registers the stub pushes (`EBP`, `ESI`, `EDI`, `EBX`). These offsets mirror that stub and must
-//! change with it.
+//! registers and the scratch `ECX` the stub pushes (`EBP`, `ESI`, `EDI`, `EBX`, `ECX`); `ECX` is
+//! preserved so an `SA_RESTART` restart can reload the interrupted call's second argument. These
+//! offsets mirror that stub and must change with it.
 //!
 
 //==================================================================================================
@@ -36,13 +37,16 @@ const SELECTOR_RPL_MASK: u32 = 0b11;
 /// On-stack image of the interrupted user context, as the kernel-call entry stub (`_do_kcall`)
 /// leaves it just below the top of the kernel stack (`esp0`).
 ///
-/// Fields are ordered by ascending address: the stub pushes the callee-saved registers last (so
-/// `EBX` sits lowest), beneath the hardware trap frame the CPU pushes on the ring 3 -> ring 0
+/// Fields are ordered by ascending address: the stub pushes `ECX` last (so it sits lowest), beneath
+/// the callee-saved registers and the hardware trap frame the CPU pushes on the ring 3 -> ring 0
 /// transition. Each field therefore sits `size_of - offset_of` bytes *below* `esp0`, which the
 /// `OFF_*` constants encode so the stub layout has a single source of truth.
 #[repr(C)]
 struct TrapFrame {
-    /// `EBX` (pushed last by the entry stub; lowest address).
+    /// `ECX` (pushed last by the entry stub; lowest address). Preserved so an `SA_RESTART` restart
+    /// can reload the interrupted call's second argument.
+    ecx: u32,
+    /// `EBX` (pushed by the entry stub).
     ebx: u32,
     /// `EDI` (pushed by the entry stub).
     edi: u32,
@@ -62,8 +66,8 @@ struct TrapFrame {
     ss: u32,
 }
 
-// `TrapFrame` must be 36 bytes long (9 words). This must match the `_do_kcall` entry stub.
-::static_assert::assert_eq_size!(TrapFrame, 36);
+// `TrapFrame` must be 40 bytes long (10 words). This must match the `_do_kcall` entry stub.
+::static_assert::assert_eq_size!(TrapFrame, 40);
 
 impl TrapFrame {
     /// Size of the saved frame; `esp0` points just past its last word (`SS`).
@@ -87,6 +91,8 @@ impl TrapFrame {
     const OFF_EDI: usize = Self::SIZE - core::mem::offset_of!(Self, edi);
     /// Offset of the saved `EBX` below `esp0`.
     const OFF_EBX: usize = Self::SIZE - core::mem::offset_of!(Self, ebx);
+    /// Offset of the saved `ECX` below `esp0`.
+    const OFF_ECX: usize = Self::SIZE - core::mem::offset_of!(Self, ecx);
 }
 
 //==================================================================================================
@@ -160,7 +166,7 @@ pub unsafe fn read_trap_context(esp0: usize, result: i64) -> SignalCpuContext {
             flags: kstack_read(esp0, TrapFrame::OFF_EFLAGS),
             ax,
             bx: kstack_read(esp0, TrapFrame::OFF_EBX),
-            cx: 0,
+            cx: kstack_read(esp0, TrapFrame::OFF_ECX),
             dx,
             si: kstack_read(esp0, TrapFrame::OFF_ESI),
             di: kstack_read(esp0, TrapFrame::OFF_EDI),
@@ -200,8 +206,36 @@ pub unsafe fn restore_trap_context(esp0: usize, cpu: &SignalCpuContext) {
         kstack_write(esp0, TrapFrame::OFF_ESP, cpu.sp);
         kstack_write(esp0, TrapFrame::OFF_SS, cpu.ss);
         kstack_write(esp0, TrapFrame::OFF_EBX, cpu.bx);
+        kstack_write(esp0, TrapFrame::OFF_ECX, cpu.cx);
         kstack_write(esp0, TrapFrame::OFF_ESI, cpu.si);
         kstack_write(esp0, TrapFrame::OFF_EDI, cpu.di);
         kstack_write(esp0, TrapFrame::OFF_EBP, cpu.bp);
     }
+}
+
+/// Size in bytes of the kernel-call trap instruction (`int $KCALL_VECTOR`, encoded as `CD ib`),
+/// used to rewind a saved instruction pointer back onto the trap so the call re-executes.
+const KCALL_TRAP_INSN_SIZE: u32 = 2;
+
+/// Rewrites a saved user context so that, once restored by `sigreturn()`, the interrupted kernel
+/// call is transparently restarted (the kernel's analog of Linux's `ERESTARTSYS`).
+///
+/// The saved instruction pointer is rewound to the kernel-call trap instruction and the original
+/// call number and argument registers are reloaded, so re-executing the trap repeats the call with
+/// its initial arguments. The reloaded `EAX`/`EDX` reach the user through the `sigreturn()` return
+/// value, while `EBX`/`ECX`/`EDI` are restored from the trap frame; `ECX` relies on the entry stub
+/// having preserved it for exactly this purpose.
+///
+/// # Parameters
+///
+/// - `cpu`: Saved context to rewrite in place.
+/// - `number`: Kernel-call number (restored to the accumulator).
+/// - `args`: Original kernel-call arguments, in argument-register order.
+pub fn prepare_kcall_restart(cpu: &mut SignalCpuContext, number: u32, args: [u32; 4]) {
+    cpu.ip = cpu.ip.wrapping_sub(KCALL_TRAP_INSN_SIZE);
+    cpu.ax = number;
+    cpu.bx = args[0];
+    cpu.cx = args[1];
+    cpu.dx = args[2];
+    cpu.di = args[3];
 }

--- a/src/kernel/src/hal/arch/x86/mod.rs
+++ b/src/kernel/src/hal/arch/x86/mod.rs
@@ -49,6 +49,7 @@ pub use cpu::{
     forge_user_stack,
     install_fpu,
     join_kcall_result,
+    prepare_kcall_restart,
     read_trap_context,
     read_user_sp,
     redirect_to_handler,

--- a/src/kernel/src/hal/arch/x86_64/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86_64/cpu/mod.rs
@@ -62,6 +62,7 @@ pub use interrupt::{
 };
 pub use sigframe::{
     join_kcall_result,
+    prepare_kcall_restart,
     read_trap_context,
     read_user_sp,
     redirect_to_handler,

--- a/src/kernel/src/hal/arch/x86_64/cpu/sigframe.rs
+++ b/src/kernel/src/hal/arch/x86_64/cpu/sigframe.rs
@@ -72,3 +72,9 @@ pub unsafe fn redirect_to_handler(_esp0: usize, _handler_ip: usize, _frame_top: 
 ///
 /// As for [`read_user_sp`].
 pub unsafe fn restore_trap_context(_esp0: usize, _cpu: &SignalCpuContext) {}
+
+/// Rewrites a saved user context to transparently restart an interrupted kernel call.
+///
+/// Inert on x86-64 until asynchronous signal delivery is implemented; present so the
+/// architecture-neutral delivery logic compiles.
+pub fn prepare_kcall_restart(_cpu: &mut SignalCpuContext, _number: u32, _args: [u32; 4]) {}

--- a/src/kernel/src/hal/arch/x86_64/mod.rs
+++ b/src/kernel/src/hal/arch/x86_64/mod.rs
@@ -44,6 +44,7 @@ pub use cpu::{
     forge_user_stack,
     install_fpu,
     join_kcall_result,
+    prepare_kcall_restart,
     read_trap_context,
     read_user_sp,
     redirect_to_handler,

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -20,6 +20,7 @@ use crate::{
     pm::{
         self,
         InterruptReason,
+        KcallRestart,
         ProcessManager,
         SleepError,
     },
@@ -80,7 +81,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         // is synchronized.
         KcallNumber::JoinThread => match unsafe { pm::join_thread(pid, arg0, arg1) } {
             Ok(status) => KcallResult::Success(Into::<u32>::into(status).into()),
-            Err(sleep_error) => handle_sleep_error(sleep_error),
+            Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         KcallNumber::ExitThread => {
             // SAFETY: the calling process is not the kernel and it does not hold a mutable
@@ -138,12 +139,12 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         // SAFETY: The calling thread is not the kernel and no resources are held.
         KcallNumber::Recv => match unsafe { ipc::recv(tid, pid, arg0 as usize) } {
             Ok(()) => KcallResult::ok(),
-            Err(sleep_error) => handle_sleep_error(sleep_error),
+            Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         // SAFETY: The calling thread is not the kernel and no resources are held.
         KcallNumber::Push => match ipc::push(pid, tid, arg0, arg1, arg2 as usize, arg3) {
             Ok(()) => KcallResult::ok(),
-            Err(sleep_error) => handle_sleep_error(sleep_error),
+            Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         // SAFETY: The calling thread is not the kernel and no resources are held.
         KcallNumber::Pull => match ipc::pull(pid, tid, arg0, arg1, arg2 as usize, arg3) {
@@ -151,7 +152,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
                 Ok(bytes_u32) => KcallResult::Success(bytes_u32.into()),
                 Err(_) => KcallResult::Error(ErrorCode::InvalidArgument.into()),
             },
-            Err(sleep_error) => handle_sleep_error(sleep_error),
+            Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         // SAFETY: The calling thread does not hold a reference to the process manager.
         KcallNumber::Resume => unsafe { event::resume(arg0 as usize) },
@@ -159,7 +160,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::MutexLock => {
             match unsafe { pm::lock_mutex(pid, tid, arg0 as usize, arg1 as usize, arg2 as usize) } {
                 Ok(()) => KcallResult::ok(),
-                Err(sleep_error) => handle_sleep_error(sleep_error),
+                Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
             }
         },
         // SAFETY: The calling thread does not hold a reference to the process manager.
@@ -173,7 +174,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
                 pm::wait_cond(pid, tid, arg0 as usize, arg1 as usize, arg2 as usize, arg3 as usize)
             } {
                 Ok(()) => KcallResult::ok(),
-                Err(sleep_error) => handle_sleep_error(sleep_error),
+                Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
             }
         },
         // SAFETY: The calling thread is not the kernel, no resources are held, and the calling process does not hold a reference to the process manager.
@@ -191,7 +192,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         // SAFETY: The calling thread does not hold any resources.
         KcallNumber::Sleep => match unsafe { pm::sleep(arg0 as usize, arg1 as usize) } {
             Ok(()) => KcallResult::ok(),
-            Err(sleep_error) => handle_sleep_error(sleep_error),
+            Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
 
         // Handle `snapshot()` locally (microvm platform only).
@@ -219,8 +220,8 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::Sigprocmask => pm::sigprocmask(pid, tid, arg0, arg1, arg2),
         KcallNumber::Kill => pm::kill(pid, arg0, arg1),
         KcallNumber::Sigreturn => pm::sigreturn(),
-        KcallNumber::Sigpending => pm::sigpending(),
-        KcallNumber::Sigsuspend => pm::sigsuspend(),
+        KcallNumber::Sigpending => pm::sigpending(pid, tid, arg0),
+        KcallNumber::Sigsuspend => pm::sigsuspend(pid, tid, arg0),
         KcallNumber::SigRestorer => pm::sig_restorer(pid, arg0),
 
         // Unknown kernel call.
@@ -246,7 +247,14 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
     result
 }
 
-fn handle_sleep_error(sleep_error: SleepError) -> KcallResult {
+fn handle_sleep_error(
+    sleep_error: SleepError,
+    number: u32,
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+    arg3: u32,
+) -> KcallResult {
     match sleep_error {
         SleepError::Generic(generic_error) => {
             error!("failed to sleep: {:?}", generic_error);
@@ -262,6 +270,21 @@ fn handle_sleep_error(sleep_error: SleepError) -> KcallResult {
             InterruptReason::TimedOut => {
                 error!("failed to sleep: operation timed out");
                 KcallResult::Error(ErrorCode::OperationTimedOut.into())
+            },
+            InterruptReason::Signaled => {
+                // A deliverable, caught signal interrupted the blocking call. Record the call's
+                // number and arguments so the asynchronous-delivery checkpoint can transparently
+                // restart it when the interrupting handler is installed with `SA_RESTART`. Without
+                // `SA_RESTART`, the checkpoint discards this record and the `EINTR` reported here is
+                // what the call returns. The current blocking calls make no observable partial
+                // progress before interruption, so reporting `EINTR` (rather than a short count) is
+                // always correct here.
+                // SAFETY: the process manager is initialized and access to it is synchronized.
+                unsafe { ProcessManager::get_mut() }.set_running_thread_restart(KcallRestart {
+                    number,
+                    args: [arg0, arg1, arg2, arg3],
+                });
+                KcallResult::Error(ErrorCode::Interrupted.into())
             },
         },
     }

--- a/src/kernel/src/pm/kcall/sigpending.rs
+++ b/src/kernel/src/pm/kcall/sigpending.rs
@@ -5,8 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::kcall::KcallResult;
-use ::sys::error::ErrorCode;
+use crate::{
+    kcall::KcallResult,
+    mm::Vmem,
+    pm::{
+        self,
+        ProcessManager,
+    },
+};
+use ::core::mem::size_of;
+use ::sys::{
+    error::ErrorCode,
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        SigSet,
+        ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -15,17 +31,55 @@ use ::sys::error::ErrorCode;
 ///
 /// # Description
 ///
-/// Stub handler for the `sigpending()` kernel call, which retrieves the set of pending-but-blocked
-/// signals.
+/// Kernel call handler for `sigpending()`, which reports the set of signals that are pending on the
+/// calling process but blocked from delivery to the calling thread (`pending & blocked`).
 ///
-/// This is scaffolding for the signal subsystem and is not yet implemented: it always fails with
-/// [`ErrorCode::InvalidSysCall`]. A later phase of the signals effort replaces this stub with the
-/// real handler.
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process (owner of the output buffer).
+/// - `caller_tid`: Identifier of the calling thread (owner of the blocked mask).
+/// - `arg0`: User-space pointer that receives the pending-but-blocked signal set.
 ///
 /// # Returns
 ///
-/// Always returns a [`KcallResult`] carrying [`ErrorCode::InvalidSysCall`].
+/// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn sigpending() -> KcallResult {
-    KcallResult::Error(ErrorCode::InvalidSysCall.into())
+pub fn sigpending(
+    caller_pid: ProcessIdentifier,
+    caller_tid: ThreadIdentifier,
+    arg0: u32,
+) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    // The output buffer is mandatory and must lie in user space.
+    let set_ptr: usize = arg0 as usize;
+    if set_ptr == 0 {
+        let reason: &str = "null pending signal set buffer";
+        error!("{reason}");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+    let set_addr: VirtualAddress = VirtualAddress::from_raw_value(set_ptr);
+    if !Vmem::is_user_region(set_addr, size_of::<SigSet>()) {
+        let reason: &str = "pending signal set buffer does not lie in user space";
+        error!("{reason} (set={set_addr:?})");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Compute the pending-but-blocked set for the calling thread.
+    let pending: SigSet = match pm.sigpending(caller_pid, caller_tid) {
+        Ok(pending) => pending,
+        Err(error) => {
+            error!("{error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
+
+    // Report it through the user-supplied buffer.
+    if let Err(error) = pm::copy_to_user(pm, caller_pid, set_ptr as *mut SigSet, &pending) {
+        error!("failed to copy pending signal set to user space (error={error:?})");
+        return KcallResult::Error(error.code.into());
+    }
+
+    KcallResult::ok()
 }

--- a/src/kernel/src/pm/kcall/sigsuspend.rs
+++ b/src/kernel/src/pm/kcall/sigsuspend.rs
@@ -5,8 +5,29 @@
 // Imports
 //==================================================================================================
 
-use crate::kcall::KcallResult;
-use ::sys::error::ErrorCode;
+use crate::{
+    kcall::KcallResult,
+    mm::Vmem,
+    pm::{
+        self,
+        InterruptReason,
+        ProcessManager,
+        SleepError,
+    },
+};
+use ::core::mem::size_of;
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::VirtualAddress,
+    pm::{
+        ProcessIdentifier,
+        SigSet,
+        ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -15,17 +36,112 @@ use ::sys::error::ErrorCode;
 ///
 /// # Description
 ///
-/// Stub handler for the `sigsuspend()` kernel call, which atomically sets the calling thread's
-/// signal mask and blocks until a signal is delivered.
+/// Kernel call handler for `sigsuspend()`, which atomically replaces the calling thread's blocked
+/// mask with `mask` and suspends the thread until a caught signal is delivered.
 ///
-/// This is scaffolding for the signal subsystem and is not yet implemented: it always fails with
-/// [`ErrorCode::InvalidSysCall`]. A later phase of the signals effort replaces this stub with the
-/// real handler.
+/// The previous mask is saved and reinstated by `sigreturn()` once the interrupting handler returns,
+/// so the call leaves the mask unchanged. `sigsuspend()` always returns `EINTR`; it is never
+/// restarted, so no restart record is left for the delivery checkpoint.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process (owner of the mask buffer).
+/// - `caller_tid`: Identifier of the calling thread (owner of the blocked mask).
+/// - `arg0`: User-space pointer to the temporary mask to install while suspended.
 ///
 /// # Returns
 ///
-/// Always returns a [`KcallResult`] carrying [`ErrorCode::InvalidSysCall`].
+/// A [`KcallResult`] carrying [`ErrorCode::Interrupted`] once a signal is caught, or another error
+/// code on failure.
 ///
-pub fn sigsuspend() -> KcallResult {
-    KcallResult::Error(ErrorCode::InvalidSysCall.into())
+pub fn sigsuspend(
+    caller_pid: ProcessIdentifier,
+    caller_tid: ThreadIdentifier,
+    arg0: u32,
+) -> KcallResult {
+    // The mask buffer is mandatory and must lie in user space.
+    let mask_ptr: usize = arg0 as usize;
+    if mask_ptr == 0 {
+        let reason: &str = "null signal mask buffer";
+        error!("{reason}");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+    let mask_addr: VirtualAddress = VirtualAddress::from_raw_value(mask_ptr);
+    if !Vmem::is_user_region(mask_addr, size_of::<SigSet>()) {
+        let reason: &str = "signal mask buffer does not lie in user space";
+        error!("{reason} (mask={mask_addr:?})");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Read the temporary mask from user space.
+    let mask: SigSet = {
+        // SAFETY: the process manager is initialized and access is synchronized.
+        let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+        let mut value: SigSet = 0;
+        if let Err(error) =
+            pm::copy_from_user(pm, caller_pid, &mut value, mask_ptr as *const SigSet)
+        {
+            error!("failed to copy signal mask from user space (error={error:?})");
+            return KcallResult::Error(error.code.into());
+        }
+        value
+    };
+
+    // Atomically install the temporary mask, saving the current one for restoration by sigreturn().
+    // If the new mask makes an already-pending caught signal deliverable, do not sleep: return
+    // EINTR immediately and let the dispatcher's return-to-user checkpoint deliver the handler.
+    {
+        // SAFETY: the process manager is initialized and access is synchronized.
+        let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+        match pm.install_sigsuspend_mask(caller_pid, caller_tid, mask) {
+            Ok(true) => return KcallResult::Error(ErrorCode::Interrupted.into()),
+            Ok(false) => {},
+            Err(error) => {
+                error!("{error:?}");
+                return KcallResult::Error(error.code.into());
+            },
+        }
+    }
+
+    // Block until a signal is delivered. A spurious or job-control wakeup re-suspends with the
+    // temporary mask still installed; a caught signal interrupts the sleep and the call returns
+    // EINTR (its mask reinstated by sigreturn() once the handler runs); a fatal signal tears the
+    // process down.
+    loop {
+        // SAFETY: no borrow of the process manager is held, the calling thread is not the kernel,
+        // access to the process manager is synchronized, and the processor runs with interrupts
+        // disabled in privileged mode.
+        match unsafe { ProcessManager::sleep(None) } {
+            // Spurious or job-control wakeup: keep waiting.
+            Ok(()) => continue,
+            Err(SleepError::Interrupted(InterruptReason::Killed)) => {
+                // The process is being terminated. Complete the termination via exit(), which
+                // performs a context switch and never returns.
+                // SAFETY: the calling process is not the kernel and no borrow is held.
+                let error: Error =
+                    unsafe { ProcessManager::exit(ErrorCode::Interrupted.into()).unwrap_err() };
+                panic!("failed to exit() (error={error:?})");
+            },
+            // A caught signal (or, defensively, any other interruption) ends the suspension with
+            // EINTR; the pre-suspend mask is reinstated by sigreturn() after the handler runs.
+            Err(SleepError::Interrupted(_)) => {
+                return KcallResult::Error(ErrorCode::Interrupted.into());
+            },
+            Err(SleepError::Generic(error)) => {
+                error!("sigsuspend failed to sleep: {error:?}");
+                // The suspension failed before any handler ran, so sigreturn() will not restore the
+                // temporary mask. Reinstate the pre-suspend mask directly so the failed call leaves
+                // the thread's mask unchanged, as POSIX requires.
+                // SAFETY: no borrow of the process manager is held and access is synchronized.
+                let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+                if let Err(restore_error) = pm.restore_sigsuspend_mask(caller_tid) {
+                    error!(
+                        "failed to restore signal mask after sigsuspend failure \
+                         (error={restore_error:?})"
+                    );
+                }
+                return KcallResult::Error(error.code.into());
+            },
+        }
+    }
 }

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -58,7 +58,10 @@ pub use process::{
     SignalDeliveryOutcome,
     SleepError,
 };
-pub use thread::InterruptReason;
+pub use thread::{
+    InterruptReason,
+    KcallRestart,
+};
 
 ///
 /// # Description

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -53,6 +53,7 @@ use crate::{
                 KillOutcome,
                 SignalControl,
                 SignalDisposition,
+                UNBLOCKABLE,
             },
             InterruptedProcess,
             ProcessRef,
@@ -154,6 +155,30 @@ pub(super) fn test() -> bool {
 pub enum SleepError {
     Interrupted(InterruptReason),
     Generic(Error),
+}
+
+//==================================================================================================
+// Post Action
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Action the signal-posting primitive (`kill()`) must take after evaluating a posted signal's
+/// disposition, once the borrow of the process manager has been released so the action can re-borrow
+/// it.
+///
+enum PostAction {
+    /// Nothing further to do (the signal was ignored or discarded).
+    None,
+    /// The signal's default action terminates the target.
+    Terminate,
+    /// A caught signal was posted: interrupt a blocked candidate thread so its blocking call reports
+    /// `EINTR` (or restarts) and the handler is delivered at the return-to-user checkpoint.
+    Interrupt,
+    /// A job-control stop/continue signal was posted: wake a candidate thread (full semantics arrive
+    /// in a later phase).
+    Wake,
 }
 
 //==================================================================================================
@@ -628,6 +653,116 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Returns the set of signals that are pending on the calling process but blocked from delivery
+    /// to the calling thread (`pending & blocked`), as reported by `sigpending()`.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the calling process.
+    /// - `tid`: Identifier of the calling thread.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the pending-but-blocked signal set. Upon failure, an error is returned.
+    ///
+    pub fn sigpending(
+        &mut self,
+        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Result<SigSet, Error> {
+        let blocked: SigSet = self.find_thread_mut(tid)?.thread_state_mut().blocked();
+        let pending: SigSet = self
+            .find_process_mut(pid)?
+            .state_mut()
+            .signals_mut()
+            .pending();
+        Ok(pending & blocked)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Atomically installs the temporary blocked-signal mask for a `sigsuspend()` and records the
+    /// mask to reinstate once the call completes.
+    ///
+    /// The previous mask is saved so that `sigreturn()` restores it after the interrupting handler
+    /// runs, matching the POSIX requirement that `sigsuspend()` leave the mask unchanged on return.
+    /// Signals that can never be blocked (`SIGKILL`/`SIGSTOP`) are cleared from the installed mask.
+    /// The return value reports whether an already-pending caught signal is now deliverable under
+    /// the temporary mask; in that case `sigsuspend()` must return `EINTR` immediately so the
+    /// normal return-to-user checkpoint can deliver it without sleeping forever.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the calling thread.
+    /// - `mask`: The temporary mask to install for the duration of the suspension.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `true` is returned when a caught pending signal is deliverable under the
+    /// temporary mask. Upon failure, an error is returned instead.
+    ///
+    pub fn install_sigsuspend_mask(
+        &mut self,
+        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+        mask: SigSet,
+    ) -> Result<bool, Error> {
+        self.find_process(pid)?;
+
+        let installed: SigSet = mask & !UNBLOCKABLE;
+        let mut thread: ThreadRefMut = self.find_thread_mut(tid)?;
+        let state = thread.thread_state_mut();
+        let previous: SigSet = state.blocked();
+        state.set_saved_blocked(Some(previous));
+        state.set_blocked(installed);
+
+        let mut process: ProcessRefMut = self.find_process_mut(pid)?;
+        let signals: &mut SignalControl = process.state_mut().signals_mut();
+        let mut deliverable: SigSet = signals.pending() & !installed;
+        while deliverable != 0 {
+            let signum: usize = (deliverable.trailing_zeros() as usize) + 1;
+            if let Some(SignalDisposition::Handler(_)) = signals.disposition(signum) {
+                return Ok(true);
+            }
+            deliverable &= deliverable - 1;
+        }
+
+        Ok(false)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reinstates the blocked-signal mask that [`Self::install_sigsuspend_mask`] saved, undoing a
+    /// `sigsuspend()` that is unwinding without delivering a handler.
+    ///
+    /// On the normal path, `sigsuspend()` leaves mask restoration to `sigreturn()` once the
+    /// interrupting handler returns. When the call instead fails before any handler runs,
+    /// `sigreturn()` never executes, so this restores the saved mask directly to honor the POSIX
+    /// requirement that `sigsuspend()` leave the mask unchanged on return (even on failure). It is a
+    /// no-op when no mask was saved.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the calling thread.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn restore_sigsuspend_mask(&mut self, tid: ThreadIdentifier) -> Result<(), Error> {
+        let mut thread: ThreadRefMut = self.find_thread_mut(tid)?;
+        let state = thread.thread_state_mut();
+        if let Some(saved) = state.take_saved_blocked() {
+            state.set_blocked(saved & !UNBLOCKABLE);
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Posts a signal to a target process and evaluates its delivery.
     ///
     /// A process may always signal itself; posting to another process requires the
@@ -693,31 +828,31 @@ impl ProcessManager {
 
         // Resolve the effect of the signal from the target's disposition, posting it to the pending
         // set when delivery must be deferred. The borrow of the process manager is dropped before
-        // any termination or wakeup so those operations can re-borrow it.
-        let (terminate, wake): (bool, bool) = {
+        // any termination, interruption, or wakeup so those operations can re-borrow it.
+        let action: PostAction = {
             let mut process: ProcessRefMut = self.find_process_mut(target)?;
             let signals: &mut SignalControl = process.state_mut().signals_mut();
             match signals.disposition(signum) {
-                Some(SignalDisposition::Ignore) => (false, false),
+                Some(SignalDisposition::Ignore) => PostAction::None,
                 Some(SignalDisposition::Handler(_)) => {
                     signals.post(signum);
-                    (false, true)
+                    PostAction::Interrupt
                 },
                 Some(SignalDisposition::Default) => match default_action(signum) {
-                    DefaultAction::Terminate => (true, false),
+                    DefaultAction::Terminate => PostAction::Terminate,
                     DefaultAction::Core => {
                         info!(
                             "terminated by signal default core action (target={target:?}, \
                              signum={signum})"
                         );
-                        (true, false)
+                        PostAction::Terminate
                     },
-                    DefaultAction::Ignore => (false, false),
+                    DefaultAction::Ignore => PostAction::None,
                     DefaultAction::Stop | DefaultAction::Continue => {
                         // Job-control stop/continue semantics arrive in a later phase; for now the
                         // signal is recorded as pending and a candidate thread is woken.
                         signals.post(signum);
-                        (false, true)
+                        PostAction::Wake
                     },
                 },
                 None => {
@@ -728,11 +863,11 @@ impl ProcessManager {
             }
         };
 
-        if terminate {
-            return self.kill_terminate(caller, target);
-        }
-        if wake {
-            self.wakeup_signal_candidate(target);
+        match action {
+            PostAction::Terminate => return self.kill_terminate(caller, target),
+            PostAction::Interrupt => self.interrupt_signal_candidate(target, signum),
+            PostAction::Wake => self.wakeup_signal_candidate(target),
+            PostAction::None => {},
         }
         Ok(KillOutcome::Done)
     }
@@ -792,6 +927,68 @@ impl ProcessManager {
         if let Some(tid) = candidate {
             let _ = self.do_wakeup(tid);
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Interrupts a blocked candidate thread of a process to which a caught signal was posted, so
+    /// that the thread's blocking kernel call reports the interruption (returning `EINTR`, or
+    /// transparently restarting when the handler requests `SA_RESTART`) and the handler is delivered
+    /// at its return-to-user checkpoint.
+    ///
+    /// Only a fully-suspended process needs explicit help; a process that still has a ready or
+    /// running thread reaches its own checkpoint without being woken. A signal that the candidate
+    /// thread would block is left pending and interrupts nothing.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process whose candidate thread should be interrupted.
+    /// - `signum`: Signal number that was posted.
+    ///
+    fn interrupt_signal_candidate(&mut self, pid: ProcessIdentifier, signum: usize) {
+        let candidate: Option<ThreadIdentifier> = self
+            .suspended
+            .iter()
+            .find(|process| process.state().pid() == pid)
+            .and_then(|process| process.candidate_tid_for(signum));
+        if let Some(tid) = candidate {
+            self.interrupt_suspended_thread(tid);
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Moves the suspended process that owns thread `tid` to the interrupted list, recording the
+    /// interruption as [`InterruptReason::Signaled`] on that thread so it is resumed at the next
+    /// scheduling opportunity and its blocking call observes the interruption.
+    ///
+    /// Best-effort: if the thread is no longer suspended (for example, it was already woken by
+    /// another notifier), the process lists are left unchanged.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread to interrupt.
+    ///
+    fn interrupt_suspended_thread(&mut self, tid: ThreadIdentifier) {
+        let mut scanned: LinkedList<SleepingProcess> = LinkedList::new();
+        while let Some(process) = self.suspended.pop_front() {
+            if process.find_thread(tid).is_some() {
+                match process.interrupt_thread(tid, InterruptReason::Signaled) {
+                    Ok(interrupted_process) => self.interrupted.push_back(interrupted_process),
+                    Err(suspended_process) => self.suspended.push_front(suspended_process),
+                }
+                // Restore the processes scanned before the match, preserving their order.
+                while let Some(process) = scanned.pop_back() {
+                    self.suspended.push_front(process);
+                }
+                return;
+            }
+            scanned.push_back(process);
+        }
+        // Thread not found among suspended processes; rollback the list to its original state.
+        self.suspended = scanned;
     }
 
     ///

--- a/src/kernel/src/pm/process/manager/signal.rs
+++ b/src/kernel/src/pm/process/manager/signal.rs
@@ -34,6 +34,7 @@ use crate::{
             capture_fpu,
             install_fpu,
             join_kcall_result,
+            prepare_kcall_restart,
             read_trap_context,
             read_user_sp,
             redirect_to_handler,
@@ -63,6 +64,7 @@ use crate::{
                 UNBLOCKABLE,
             },
         },
+        KcallRestart,
         ORDER,
     },
 };
@@ -74,6 +76,7 @@ use ::sys::{
         ThreadIdentifier,
         SA_NODEFER,
         SA_RESETHAND,
+        SA_RESTART,
         SA_SIGINFO,
     },
 };
@@ -149,6 +152,24 @@ impl ProcessManager {
     ///
     /// # Description
     ///
+    /// Records, on the running thread, a blocking kernel call that a deliverable caught signal just
+    /// interrupted. The asynchronous-delivery checkpoint consumes this record to transparently
+    /// restart the call when the interrupting handler is installed with `SA_RESTART`.
+    ///
+    /// # Parameters
+    ///
+    /// - `restart`: The interrupted call's number and arguments.
+    ///
+    pub fn set_running_thread_restart(&mut self, restart: KcallRestart) {
+        let tid: ThreadIdentifier = self.get_tid();
+        if let Some(mut thread) = self.get_running_mut().find_thread_mut(tid) {
+            thread.thread_state_mut().set_restart(restart);
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Evaluates and, if warranted, performs delivery of a pending caught signal to the running
     /// thread at the kernel-call return-to-user boundary.
     ///
@@ -167,14 +188,18 @@ impl ProcessManager {
 
         // Locate the running thread's kernel stack and read its blocked mask.
         let owner_tid: ThreadIdentifier = ThreadIdentifier::from(FPU_OWNER_TID.load(ORDER));
-        let (esp0, blocked): (usize, u64) = {
+        let (esp0, blocked, restart): (usize, u64, Option<KcallRestart>) = {
             let mut thread = match self.get_running_mut().find_thread_mut(tid) {
                 Some(thread) => thread,
                 None => return SignalDeliveryOutcome::None,
             };
             let state = thread.thread_state_mut();
+            // Consume any restart record now so it never lingers past this kernel-call boundary,
+            // even if no signal turns out to be deliverable below.
+            let restart: Option<KcallRestart> = state.take_restart();
+            let blocked: u64 = state.blocked();
             match state.kernel_stack_top() {
-                Some(esp0) => (esp0.into_raw_value(), state.blocked()),
+                Some(esp0) => (esp0.into_raw_value(), blocked, restart),
                 None => return SignalDeliveryOutcome::None,
             }
         };
@@ -218,7 +243,19 @@ impl ProcessManager {
         };
 
         // Snapshot the interrupted CPU context and place the frame on the user stack.
-        let cpu: SignalCpuContext = unsafe { read_trap_context(esp0, result) };
+        let mut cpu: SignalCpuContext = unsafe { read_trap_context(esp0, result) };
+
+        // If a blocking call was interrupted by this signal and the handler that is about to run is
+        // installed with SA_RESTART, rewind the saved context to the kernel-call trap and reload the
+        // original argument registers, so the call transparently re-executes after the handler
+        // returns. Without SA_RESTART the recorded EINTR result (already in the saved accumulator)
+        // stands and the record is simply discarded.
+        if let Some(restart) = restart {
+            if (sa_flags & SA_RESTART) != 0 {
+                prepare_kcall_restart(&mut cpu, restart.number, restart.args);
+            }
+        }
+
         let user_sp: usize = cpu.sp as usize;
         let layout: FrameLayout = match frame_layout(user_sp) {
             Some(layout) => layout,
@@ -364,11 +401,18 @@ impl ProcessManager {
             Err(_) => return Err(SigReturnFailure::Forged),
         };
 
-        // Restore the blocked mask and FPU state, then rewrite the trap frame to resume.
-        let restored_blocked: u64 = frame.blocked & !UNBLOCKABLE;
+        // Restore the blocked mask and FPU state, then rewrite the trap frame to resume. If a
+        // `sigsuspend()` is unwinding through this return, reinstate the mask it saved (restoring
+        // the pre-suspend mask now that its interrupting handler has run) instead of the frame's
+        // saved mask.
         {
             if let Some(mut thread) = self.get_running_mut().find_thread_mut(tid) {
-                thread.thread_state_mut().set_blocked(restored_blocked);
+                let state = thread.thread_state_mut();
+                let restored_blocked: u64 = match state.take_saved_blocked() {
+                    Some(saved) => saved & !UNBLOCKABLE,
+                    None => frame.blocked & !UNBLOCKABLE,
+                };
+                state.set_blocked(restored_blocked);
             }
         }
         self.restore_thread_fpu(tid, owner_tid == tid, &frame.fpu);

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -85,6 +85,32 @@ impl SleepingProcess {
             .map(|thread| thread.id())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of a candidate thread that can take delivery of signal `signum`, i.e.
+    /// a sleeping thread that does not currently block it.
+    ///
+    /// A blocked signal must remain pending rather than interrupt a blocking call, so a thread whose
+    /// mask blocks `signum` is not a valid interruption candidate.
+    ///
+    /// # Parameters
+    ///
+    /// - `signum`: The signal number (1-based).
+    ///
+    /// # Returns
+    ///
+    /// The identifier of a sleeping thread that does not block `signum`, or [`None`] if every
+    /// sleeping thread blocks it.
+    ///
+    pub fn candidate_tid_for(&self, signum: usize) -> Option<ThreadIdentifier> {
+        let bit: u64 = 1u64 << (signum - 1);
+        self.sleeping_threads
+            .iter()
+            .find(|thread| (thread.thread_state().blocked() & bit) == 0)
+            .map(|thread| thread.id())
+    }
+
     pub fn terminate(self) -> InterruptedProcess {
         let (mut sleeping_threads, sleeping_thread): (VecDeque<SleepingThread>, SleepingThread) =
             self.sleeping_threads.pop_front();
@@ -111,6 +137,52 @@ impl SleepingProcess {
                     NonEmptyVecDeque::new(ready_thread),
                     None,
                     NonEmptyVecDeque::from(sleeping_threads),
+                    self.zombie_threads.take(),
+                ))
+            },
+            Err(sleeping_threads) => {
+                self.sleeping_threads = sleeping_threads;
+                Err(self)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Interrupts a single sleeping thread of this suspended process with the given reason, leaving
+    /// any remaining threads asleep.
+    ///
+    /// This is the signal-interruption counterpart of [`Self::wakeup`]: where `wakeup` resumes a
+    /// thread so its blocking call re-evaluates, this resumes a thread so its blocking call reports
+    /// the interruption (and, for [`InterruptReason::Signaled`], returns `EINTR` or transparently
+    /// restarts at the return-to-user checkpoint).
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread to interrupt.
+    /// - `reason`: Reason recorded for the interruption.
+    ///
+    /// # Returns
+    ///
+    /// On success, the process is returned as an [`InterruptedProcess`] carrying the interrupted
+    /// thread. If no sleeping thread matches `tid`, the unchanged [`SleepingProcess`] is returned.
+    ///
+    pub fn interrupt_thread(
+        mut self,
+        tid: ThreadIdentifier,
+        reason: InterruptReason,
+    ) -> Result<InterruptedProcess, SleepingProcess> {
+        let sleeping_threads: NonEmptyVecDeque<SleepingThread> = self.sleeping_threads;
+
+        // Search for the sleeping thread.
+        match sleeping_threads.remove_if(|thread| thread.id() == tid) {
+            Ok((sleeping_threads, sleeping_thread)) => {
+                let interrupted_thread: InterruptedThread = sleeping_thread.interrupt(reason);
+                Ok(InterruptedProcess::from_sleeping(
+                    self.state,
+                    NonEmptyVecDeque::from(sleeping_threads),
+                    NonEmptyVecDeque::new(interrupted_thread),
                     self.zombie_threads.take(),
                 ))
             },

--- a/src/kernel/src/pm/thread/interrupted.rs
+++ b/src/kernel/src/pm/thread/interrupted.rs
@@ -26,6 +26,8 @@ pub enum InterruptReason {
     Killed,
     /// Timer expired.
     TimedOut,
+    /// A deliverable, caught signal interrupted the call.
+    Signaled,
 }
 
 ///

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -46,6 +46,7 @@ pub use interrupted::{
 pub use ready::ReadyThread;
 pub use running::RunningThread;
 pub use sleeping::SleepingThread;
+pub use state::KcallRestart;
 pub use zombie::ZombieThread;
 
 //==================================================================================================

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -44,6 +44,25 @@ use ::sys::{
 ///
 /// # Description
 ///
+/// Kernel-call number and raw arguments captured when a blocking kernel call is interrupted by a
+/// deliverable, caught signal.
+///
+/// When the interrupting signal's handler is installed with `SA_RESTART`, the signal-delivery
+/// checkpoint uses this record to rewind the interrupted thread to its kernel-call trap instruction
+/// and reload the original argument registers, so the call is transparently restarted after the
+/// handler returns (the kernel's analog of Linux's `ERESTARTSYS`).
+///
+#[derive(Clone, Copy, Debug)]
+pub struct KcallRestart {
+    /// Kernel-call number (the value the user left in the accumulator).
+    pub number: u32,
+    /// Raw kernel-call arguments, in argument-register order.
+    pub args: [u32; 4],
+}
+
+///
+/// # Description
+///
 /// This structure represents the state of a thread.
 ///
 pub struct ThreadState {
@@ -76,11 +95,17 @@ pub struct ThreadState {
     /// Inert plumbing for the signal subsystem: written by a later phase of the signals effort.
     #[allow(dead_code)]
     pending: u64,
-    /// Saved blocked mask while a handler runs (restored by `sigreturn`).
+    /// Mask to restore once a pending `sigsuspend()` completes.
     ///
-    /// Inert plumbing for the signal subsystem: read by a later phase of the signals effort.
-    #[allow(dead_code)]
+    /// Set by `sigsuspend()` to the mask in effect before it installed its temporary mask. When
+    /// present, `sigreturn()` restores it (instead of the frame's saved mask) so the original mask
+    /// is reinstated after the interrupting handler runs.
     saved_blocked: Option<u64>,
+    /// Interrupted blocking kernel call awaiting an `SA_RESTART` decision, if any.
+    ///
+    /// Recorded when a caught signal interrupts a blocking call and consumed at the signal-delivery
+    /// checkpoint to transparently restart the call when the handler requests it.
+    restart: Option<KcallRestart>,
 }
 
 //==================================================================================================
@@ -127,6 +152,7 @@ impl ThreadState {
             blocked: 0,
             pending: 0,
             saved_blocked: None,
+            restart: None,
         }
     }
 
@@ -367,6 +393,59 @@ impl ThreadState {
     ///
     pub(crate) fn set_blocked(&mut self, mask: u64) {
         self.blocked = mask;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes the mask to restore once a pending `sigsuspend()` completes, clearing it.
+    ///
+    /// # Returns
+    ///
+    /// The saved mask, or [`None`] if no `sigsuspend()` is in progress.
+    ///
+    pub(crate) fn take_saved_blocked(&mut self) -> Option<u64> {
+        self.saved_blocked.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Records the mask to restore once a pending `sigsuspend()` completes.
+    ///
+    /// # Parameters
+    ///
+    /// - `mask`: The mask to restore, or [`None`] to clear any pending restoration.
+    ///
+    pub(crate) fn set_saved_blocked(&mut self, mask: Option<u64>) {
+        self.saved_blocked = mask;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Records the kernel call to restart should the interrupting signal request `SA_RESTART`.
+    ///
+    /// # Parameters
+    ///
+    /// - `restart`: The kernel-call number and arguments of the interrupted blocking call.
+    ///
+    pub(crate) fn set_restart(&mut self, restart: KcallRestart) {
+        self.restart = Some(restart);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes the recorded restart information, clearing it.
+    ///
+    /// # Returns
+    ///
+    /// The recorded [`KcallRestart`], or [`None`] if no blocking call was interrupted by a caught
+    /// signal at this kernel-call boundary.
+    ///
+    pub(crate) fn take_restart(&mut self) -> Option<KcallRestart> {
+        self.restart.take()
     }
 
     ///

--- a/src/libs/libc_signal/src/lib.rs
+++ b/src/libs/libc_signal/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod raise;
 pub mod signal;
+pub mod sigpending;
 pub mod sigprocmask;
 pub mod sigset;
 pub mod sigsuspend;

--- a/src/libs/libc_signal/src/sigpending.rs
+++ b/src/libs/libc_signal/src/sigpending.rs
@@ -1,0 +1,89 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::signal::sigset_t;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Stores, in the location referenced by `set`, the set of signals that are pending on the calling
+/// process and blocked from delivery to the calling thread.
+///
+/// # Parameters
+///
+/// - `set`: Receives the pending-but-blocked signal set.
+///
+/// # Returns
+///
+/// Zero on success, or `-1` on error with `errno` set.
+///
+/// # Safety
+///
+/// This function is unsafe because it is part of the C ABI surface and dereferences `set`, which
+/// must be a valid pointer to a `sigset_t`.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigpending.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigpending(set: *mut sigset_t) -> c_int {
+    unsafe { sigpending_impl(set) }
+}
+
+/// Guest implementation of [`sigpending`]: queries the Nanvix kernel.
+///
+/// # Safety
+///
+/// This function forwards a raw pointer to the backend. The caller must ensure `set` is a valid
+/// pointer to a `sigset_t`.
+#[cfg(not(any(feature = "std", test)))]
+unsafe fn sigpending_impl(set: *mut sigset_t) -> c_int {
+    extern "C" {
+        fn __nanvix_sigpending(set: *mut sigset_t) -> c_int;
+    }
+
+    unsafe { __nanvix_sigpending(set) }
+}
+
+/// Host-only implementation of [`sigpending`] used by unit tests: reports an empty pending set.
+///
+/// # Safety
+///
+/// This function dereferences `set` when it is non-null. The caller must ensure it is a valid
+/// pointer to a `sigset_t`.
+#[cfg(any(feature = "std", test))]
+unsafe fn sigpending_impl(set: *mut sigset_t) -> c_int {
+    if !set.is_null() {
+        unsafe {
+            *set = 0;
+        }
+    }
+    0
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sigpending_reports_empty_set() {
+        let mut set: sigset_t = 0xffff_ffff_ffff_ffff;
+        // SAFETY: `set` points to a valid `sigset_t` for the duration of the call.
+        assert_eq!(unsafe { sigpending(&mut set) }, 0);
+        assert_eq!(set, 0);
+    }
+}

--- a/src/libs/libc_signal/src/sigsuspend.rs
+++ b/src/libs/libc_signal/src/sigsuspend.rs
@@ -5,14 +5,12 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    set_errno,
-    signal::sigset_t,
-};
-use ::sysapi::{
-    errno::EINTR,
-    ffi::c_int,
-};
+#[cfg(any(feature = "std", test))]
+use crate::set_errno;
+use crate::signal::sigset_t;
+#[cfg(any(feature = "std", test))]
+use ::sysapi::errno::EINTR;
+use ::sysapi::ffi::c_int;
 
 //==================================================================================================
 // Standalone Functions
@@ -21,32 +19,58 @@ use ::sysapi::{
 ///
 /// # Description
 ///
-/// Replaces the calling process's signal mask with `mask` and suspends the process until a signal
-/// is delivered.
+/// Atomically replaces the calling thread's signal mask with `mask` and suspends the thread until a
+/// signal whose action is to run a handler is delivered. Once the handler returns, the previous
+/// mask is restored.
 ///
-/// Nanvix does not deliver asynchronous signals, so no signal can ever resume a suspended process.
 /// POSIX specifies that `sigsuspend()` always returns `-1` with `errno` set to `EINTR` once it is
-/// interrupted; with no delivery this reports that outcome immediately rather than blocking
-/// forever.
+/// interrupted by a caught signal.
 ///
 /// # Parameters
 ///
-/// - `mask`: The signal mask to install while suspended (ignored).
+/// - `mask`: The signal mask to install while suspended.
 ///
 /// # Returns
 ///
-/// Always returns `-1` with `errno` set to `EINTR`.
+/// Always returns `-1`; on the expected path `errno` is `EINTR`.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it is part of the C ABI surface; `mask` is not dereferenced.
+/// This function is unsafe because it is part of the C ABI surface and dereferences `mask`, which
+/// must be a valid pointer to a `sigset_t`.
 ///
 /// # References
 ///
 /// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigsuspend.html>
 ///
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn sigsuspend(_mask: *const sigset_t) -> c_int {
+pub unsafe extern "C" fn sigsuspend(mask: *const sigset_t) -> c_int {
+    unsafe { sigsuspend_impl(mask) }
+}
+
+/// Guest implementation of [`sigsuspend`]: delegates the suspension to the Nanvix kernel.
+///
+/// # Safety
+///
+/// This function forwards a raw pointer to the backend. The caller must ensure `mask` is a valid
+/// pointer to a `sigset_t`.
+#[cfg(not(any(feature = "std", test)))]
+unsafe fn sigsuspend_impl(mask: *const sigset_t) -> c_int {
+    extern "C" {
+        fn __nanvix_sigsuspend(mask: *const sigset_t) -> c_int;
+    }
+
+    unsafe { __nanvix_sigsuspend(mask) }
+}
+
+/// Host-only implementation of [`sigsuspend`] used by unit tests: reports immediate interruption
+/// without blocking.
+///
+/// # Safety
+///
+/// This function does not dereference `mask`.
+#[cfg(any(feature = "std", test))]
+unsafe fn sigsuspend_impl(_mask: *const sigset_t) -> c_int {
     set_errno(EINTR);
     -1
 }

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -218,6 +218,73 @@ pub unsafe extern "C" fn __nanvix_sigprocmask(
 }
 
 //==================================================================================================
+// Signal pending/suspend (sigpending/sigsuspend) backends required by libc_signal
+//==================================================================================================
+
+/// `sigpending` backend reports the calling thread's pending-but-blocked signal set via the
+/// `sigpending()` kernel call.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences `set`, which must be a valid,
+/// properly aligned pointer to a `sigset_t`.
+#[cfg(feature = "backend-nanvix")]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigpending(set: *mut libc_signal::signal::sigset_t) -> c_int {
+    match unsafe { ::sys::kcall::pm::__kcall_sigpending(set as *mut ::sys::pm::SigSet) } {
+        Ok(()) => 0,
+        Err(error) => {
+            *__errno() = error.code.get();
+            -1
+        },
+    }
+}
+
+/// Stub `sigpending` backend for builds that supply their own backend.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers.
+#[cfg(not(feature = "backend-nanvix"))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigpending(_set: *mut libc_signal::signal::sigset_t) -> c_int {
+    *__errno() = ::sysapi::errno::ENOSYS;
+    -1
+}
+
+/// `sigsuspend` backend installs `mask` and suspends until a caught signal is delivered via the
+/// `sigsuspend()` kernel call. It always returns `-1`; on the expected path `errno` is `EINTR`.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences `mask`, which must be a valid,
+/// properly aligned pointer to a `sigset_t`.
+#[cfg(feature = "backend-nanvix")]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigsuspend(mask: *const libc_signal::signal::sigset_t) -> c_int {
+    match unsafe { ::sys::kcall::pm::__kcall_sigsuspend(mask as *const ::sys::pm::SigSet) } {
+        // sigsuspend() never succeeds; this arm is unreachable but keeps the match total.
+        Ok(()) => 0,
+        Err(error) => {
+            *__errno() = error.code.get();
+            -1
+        },
+    }
+}
+
+/// Stub `sigsuspend` backend for builds that supply their own backend.
+///
+/// # Safety
+///
+/// This function writes to the errno location and dereferences raw pointers.
+#[cfg(not(feature = "backend-nanvix"))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __nanvix_sigsuspend(_mask: *const libc_signal::signal::sigset_t) -> c_int {
+    *__errno() = ::sysapi::errno::ENOSYS;
+    -1
+}
+
+//==================================================================================================
 // Stub symbols required by libstdc++ but not yet implemented
 //==================================================================================================
 

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -418,6 +418,90 @@ pub unsafe fn __kcall_sigprocmask(
 }
 
 //==================================================================================================
+// Sigpending
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Retrieves the set of signals that are pending on the calling process but blocked from delivery
+/// to the calling thread.
+///
+/// # Parameters
+///
+/// - `set`: User-space pointer that receives the pending-but-blocked signal set.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+/// # Safety
+///
+/// This function is unsafe because the caller must ensure that `set` is a valid, properly aligned
+/// pointer to a [`SigSet`] value.
+///
+pub unsafe fn __kcall_sigpending(set: *mut SigSet) -> Result<(), Error> {
+    // The kernel call carries the address in a single 32-bit register, so reject a pointer that does
+    // not fit rather than silently truncating it (which could forward a wrong address on a 64-bit
+    // image whose buffer sits above 4 GiB).
+    let set_raw: u32 = u32::try_from(set as usize).map_err(|_| {
+        Error::new(ErrorCode::InvalidArgument, "signal set address exceeds u32::MAX")
+    })?;
+
+    let result: i64 = kcall1!(KcallNumber::Sigpending.into(), set_raw);
+
+    if result < 0 {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to sigpending()"))
+    } else {
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Sigsuspend
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Atomically installs `mask` as the calling thread's blocked-signal mask and suspends the thread
+/// until a caught signal is delivered, after which the previous mask is restored.
+///
+/// Following POSIX, `sigsuspend()` always returns an error; on the expected path it is
+/// [`ErrorCode::Interrupted`] (`EINTR`).
+///
+/// # Parameters
+///
+/// - `mask`: User-space pointer to the temporary mask to install while suspended.
+///
+/// # Returns
+///
+/// Always returns an error: [`ErrorCode::Interrupted`] once a signal is caught, or another error
+/// code on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because the caller must ensure that `mask` is a valid, properly aligned
+/// pointer to a [`SigSet`] value.
+///
+pub unsafe fn __kcall_sigsuspend(mask: *const SigSet) -> Result<(), Error> {
+    // The kernel call carries the address in a single 32-bit register, so reject a pointer that does
+    // not fit rather than silently truncating it (which could forward a wrong address on a 64-bit
+    // image whose buffer sits above 4 GiB).
+    let mask_raw: u32 = u32::try_from(mask as usize).map_err(|_| {
+        Error::new(ErrorCode::InvalidArgument, "signal mask address exceeds u32::MAX")
+    })?;
+
+    let result: i64 = kcall1!(KcallNumber::Sigsuspend.into(), mask_raw);
+
+    if result < 0 {
+        Err(Error::new(ErrorCode::try_from(result)?, "sigsuspend() interrupted"))
+    } else {
+        Ok(())
+    }
+}
+
+//==================================================================================================
 // Sig Restorer
 //==================================================================================================
 

--- a/src/tests/integration/kill-rust/src/tests/kill.rs
+++ b/src/tests/integration/kill-rust/src/tests/kill.rs
@@ -69,19 +69,26 @@ use ::sys::{
     },
     pm::{
         ProcessIdentifier,
+        SA_RESTART,
         SA_SIGINFO,
+        SIG_BLOCK,
         SIG_MAX,
+        SIG_SETMASK,
         SIGKILL,
         SIGTERM,
         SIGUSR1,
         SIGUSR2,
         SigAction,
+        SigSet,
         ThreadIdentifier,
     },
 };
 use ::sysapi::{
     ffi::c_int,
-    sys_types::pid_t,
+    sys_types::{
+        pid_t,
+        time_t,
+    },
     sys_wait::{
         wexitstatus,
         wifexited,
@@ -107,6 +114,12 @@ const CHILD_FAIL: c_int = 111;
 /// terminated by the signal. Surfacing a distinct status turns a missed kill into a loud assertion
 /// failure rather than a silent pass.
 const CHILD_NOT_KILLED: c_int = 112;
+
+/// Duration, in seconds, of the timed sleeps that park a thread in an interruptible wait. It is
+/// comfortably longer than the interrupting signal needs to arrive (so the sleep is always
+/// interrupted mid-wait rather than completing on its own), yet bounded so that a regression in
+/// signal interruption stalls the suite for only this long instead of an hour.
+const INTERRUPTIBLE_SLEEP_SECS: time_t = 10;
 
 //==================================================================================================
 // Wait Selection
@@ -244,10 +257,11 @@ fn run_child(wait: ChildWait) -> ! {
             }
         },
         ChildWait::TimedSleep => {
-            // One hour — far longer than the test needs to deliver the signal, so the child is
-            // always terminated mid-wait rather than waking on its own.
+            // Comfortably longer than the test needs to deliver the signal, so the child is always
+            // terminated mid-wait rather than waking on its own, yet bounded so a regression does
+            // not stall the suite for an hour.
             let req: timespec = timespec {
-                tv_sec: 3600,
+                tv_sec: INTERRUPTIBLE_SLEEP_SECS,
                 tv_nsec: 0,
             };
             // SAFETY: `req` is a valid `timespec`; passing a null `rem` is permitted.
@@ -448,6 +462,302 @@ fn test_siginfo_signal_runs_three_arg_handler() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Blocking-Call Interruption
+//==================================================================================================
+
+/// Exit status reported by a signaller child that completed its job (posted the signal) successfully.
+const SIGNALLER_OK: c_int = 0;
+
+/// Sends an empty notification from the calling process to `to` over IPC.
+fn send_empty(to: ProcessIdentifier) -> Result<(), Error> {
+    let from: ProcessIdentifier = pm::getpid_uncached()?;
+    let message: Message = Message::new(
+        MessageSender::new(from, ThreadIdentifier::NONE),
+        MessageReceiver::new(to, ThreadIdentifier::NONE),
+        MessageType::Ipc,
+        None,
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    ipc::__kcall_send(&message)
+}
+
+/// Returns whether a blocking IPC receive reported interruption (`EINTR`).
+fn is_eintr_err(result: &Result<Message, Error>) -> bool {
+    matches!(result, Err(error) if error.code.get() == ErrorCode::Interrupted.get())
+}
+
+/// Installs a catching disposition for `SIGUSR1` with the given `sa_flags`.
+fn install_sigusr1_handler(sa_flags: c_int) -> Result<(), Error> {
+    let act: SigAction = SigAction {
+        sa_handler: sigusr1_handler_addr(),
+        sa_mask: 0,
+        sa_flags,
+        sa_sigaction: 0,
+    };
+    // SAFETY: `act` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    unsafe { pm::__kcall_sigaction(as_signum(SIGUSR1)?, &raw const act, ptr::null_mut()) }
+}
+
+/// Signaller child entry point: wait for the parent's go-ahead, then post `SIGUSR1` to the parent so
+/// it interrupts the parent's in-progress blocking call. The cross-process `kill()` is relayed
+/// through the process-manager daemon, whose several context switches let the parent reach its
+/// blocking point first. This function never returns to the caller.
+fn run_signaller_child() -> ! {
+    let parent: ProcessIdentifier = match pm::__kcall_getppid() {
+        Ok(parent) => parent,
+        // SAFETY: the freshly forked child holds no resources requiring cleanup.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+    if await_ready().is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    let signum: c_int = match as_signum(SIGUSR1) {
+        Ok(signum) => signum,
+        // SAFETY: as above.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+    if kill(i32::from(parent), signum) != 0 {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    // SAFETY: as above.
+    unsafe { bindings::_exit::_exit(SIGNALLER_OK) };
+}
+
+/// Forks a signaller child. Returns the child's PID in the parent; the child never returns here.
+fn spawn_signaller() -> Result<ProcessIdentifier, Error> {
+    let ret: pid_t = bindings::fork::fork();
+    if ret == 0 {
+        run_signaller_child();
+    }
+    assert!(ret > 0, "fork() failed in parent (ret={})", ret);
+    Ok(ProcessIdentifier::from(ret))
+}
+
+/// Reaps a signaller child and asserts it completed successfully.
+fn reap_signaller(child: ProcessIdentifier) {
+    let mut status: c_int = 0;
+    // SAFETY: `status` points to a valid `c_int`.
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, 0) };
+    assert!(
+        reaped == i32::from(child),
+        "waitpid() must reap the signaller child (ret={}, child={})",
+        reaped,
+        i32::from(child)
+    );
+    assert!(
+        wifexited(status),
+        "signaller child must surface as a normal exit (status={:#x})",
+        status
+    );
+    assert!(
+        wexitstatus(status) == SIGNALLER_OK,
+        "signaller child failed to post the signal (status={})",
+        wexitstatus(status)
+    );
+}
+
+/// Verifies that a deliverable caught signal interrupts a thread blocked in `recv()`, returning
+/// `EINTR` and running the handler, when the handler is installed without `SA_RESTART`.
+fn test_eintr_interrupts_recv() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(0)?;
+
+    let signaller: ProcessIdentifier = spawn_signaller()?;
+    // Release the signaller, then block. The relayed cross-process signal arrives once we are parked
+    // in recv().
+    send_empty(signaller)?;
+    let result: Result<Message, Error> = ipc::__kcall_recv();
+
+    assert!(
+        HANDLER_RAN.load(Ordering::SeqCst),
+        "SIGUSR1 handler did not run after interrupting a blocked recv()"
+    );
+    assert!(is_eintr_err(&result), "recv() must report EINTR when interrupted by a caught signal");
+    reap_signaller(signaller);
+    Ok(())
+}
+
+/// Verifies that a deliverable caught signal interrupts a thread blocked in a timed sleep, returning
+/// `EINTR` and running the handler, when the handler is installed without `SA_RESTART`.
+fn test_eintr_interrupts_sleep() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(0)?;
+
+    let signaller: ProcessIdentifier = spawn_signaller()?;
+    send_empty(signaller)?;
+    // Comfortably longer than the signal needs to arrive, so the sleep is always interrupted
+    // mid-wait rather than completing on its own, yet bounded so a regression does not stall the
+    // suite for an hour.
+    let req: timespec = timespec {
+        tv_sec: INTERRUPTIBLE_SLEEP_SECS,
+        tv_nsec: 0,
+    };
+    // SAFETY: `req` is a valid `timespec`; passing a null `rem` is permitted.
+    let ret: c_int = unsafe { nanosleep(&raw const req, ptr::null_mut()) };
+
+    assert!(
+        HANDLER_RAN.load(Ordering::SeqCst),
+        "SIGUSR1 handler did not run after interrupting a blocked sleep"
+    );
+    assert!(ret == -1, "nanosleep() must report interruption (ret={})", ret);
+    assert!(
+        read_errno() == ErrorCode::Interrupted.get(),
+        "nanosleep() must fail with EINTR (errno={})",
+        read_errno()
+    );
+    reap_signaller(signaller);
+    Ok(())
+}
+
+/// Verifies that an `SA_RESTART` handler transparently restarts a blocked sleep instead of reporting
+/// `EINTR`: the sleep is interrupted, the handler runs, and the call re-executes with its original
+/// arguments to completion. The sleep duration travels in the kernel call's second argument
+/// register, so a faithful restart must also restore that register.
+fn test_sa_restart_restarts_sleep() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(SA_RESTART)?;
+
+    let signaller: ProcessIdentifier = spawn_signaller()?;
+    send_empty(signaller)?;
+    // A sub-second sleep whose duration is carried entirely in the nanoseconds field (the call's
+    // second argument). The signal arrives well within it; the handler runs and the call restarts
+    // for the full duration, so a correct restart completes successfully rather than failing.
+    let req: timespec = timespec {
+        tv_sec: 0,
+        tv_nsec: 900_000_000,
+    };
+    // SAFETY: `req` is a valid `timespec`; passing a null `rem` is permitted.
+    let ret: c_int = unsafe { nanosleep(&raw const req, ptr::null_mut()) };
+
+    assert!(
+        HANDLER_RAN.load(Ordering::SeqCst),
+        "SIGUSR1 handler did not run during an SA_RESTART sleep"
+    );
+    assert!(
+        ret == 0,
+        "SA_RESTART nanosleep() must complete after restarting (ret={}, errno={})",
+        ret,
+        read_errno()
+    );
+    reap_signaller(signaller);
+    Ok(())
+}
+
+/// Verifies that `sigsuspend()` blocks with the supplied mask installed, is interrupted by a caught
+/// signal whose handler runs, and then reports `EINTR`.
+fn test_sigsuspend_returns_after_handler() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(0)?;
+
+    let signaller: ProcessIdentifier = spawn_signaller()?;
+    send_empty(signaller)?;
+    // Suspend with an empty mask so SIGUSR1 remains deliverable.
+    let mask: SigSet = 0;
+    // SAFETY: `mask` points to a valid `SigSet` for the duration of the call.
+    let result: Result<(), Error> = unsafe { pm::__kcall_sigsuspend(&raw const mask) };
+
+    assert!(HANDLER_RAN.load(Ordering::SeqCst), "SIGUSR1 handler did not run during sigsuspend()");
+    assert!(
+        matches!(&result, Err(error) if error.code.get() == ErrorCode::Interrupted.get()),
+        "sigsuspend() must report EINTR after a handler runs"
+    );
+    reap_signaller(signaller);
+    Ok(())
+}
+
+/// Verifies that `sigsuspend()` immediately delivers a signal that was already pending and becomes
+/// unblocked under the temporary mask, instead of sleeping until a later signal arrives.
+fn test_sigsuspend_delivers_pending_unblocked_signal() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(0)?;
+
+    let bit: SigSet = 1u64 << (SIGUSR1 - 1);
+    let block: SigSet = bit;
+    let mut old: SigSet = 0;
+    // Block SIGUSR1 so the self-directed signal below becomes pending.
+    // SAFETY: `block` and `old` point to valid `SigSet` values.
+    unsafe { pm::__kcall_sigprocmask(SIG_BLOCK, &raw const block, &raw mut old) }?;
+
+    let caller: ProcessIdentifier = pm::getpid_uncached()?;
+    post_signal(caller, as_signum(SIGUSR1)?);
+    assert!(!HANDLER_RAN.load(Ordering::SeqCst), "a blocked signal must stay pending");
+
+    let suspend_mask: SigSet = old & !bit;
+    // SAFETY: `suspend_mask` points to a valid `SigSet` for the duration of the call.
+    let result: Result<(), Error> = unsafe { pm::__kcall_sigsuspend(&raw const suspend_mask) };
+
+    assert!(
+        HANDLER_RAN.load(Ordering::SeqCst),
+        "sigsuspend() did not deliver the already-pending SIGUSR1"
+    );
+    assert!(
+        matches!(&result, Err(error) if error.code.get() == ErrorCode::Interrupted.get()),
+        "sigsuspend() must report EINTR after delivering a pending signal"
+    );
+
+    let mut current: SigSet = 0;
+    // SAFETY: `current` points to a valid `SigSet`; a null `set` requests only the old mask.
+    unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, ptr::null(), &raw mut current) }?;
+    assert!(
+        current & bit != 0,
+        "sigsuspend() must restore the pre-suspend blocked mask (current={:#x})",
+        current
+    );
+
+    // Restore the mask that was in effect before this test blocked SIGUSR1.
+    // SAFETY: `old` points to a valid `SigSet`; the old-mask output is not requested.
+    unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, &raw const old, ptr::null_mut()) }?;
+    Ok(())
+}
+
+/// Verifies that `sigpending()` reports a signal that is posted while blocked, that the blocked
+/// signal is not delivered, and that unblocking it delivers it and clears it from the pending set.
+fn test_sigpending_reports_blocked_pending() -> Result<(), Error> {
+    HANDLER_RAN.store(false, Ordering::SeqCst);
+    install_sigusr1_handler(0)?;
+
+    let bit: SigSet = 1u64 << (SIGUSR1 - 1);
+    let block: SigSet = bit;
+    let mut old: SigSet = 0;
+    // Block SIGUSR1 so a self-directed post stays pending instead of being delivered.
+    // SAFETY: `block` and `old` point to valid `SigSet` values.
+    unsafe { pm::__kcall_sigprocmask(SIG_BLOCK, &raw const block, &raw mut old) }?;
+
+    // Post SIGUSR1 to ourselves; it is blocked, so it must remain pending and undelivered.
+    let caller: ProcessIdentifier = pm::getpid_uncached()?;
+    post_signal(caller, as_signum(SIGUSR1)?);
+    assert!(!HANDLER_RAN.load(Ordering::SeqCst), "a blocked signal must not be delivered");
+
+    // sigpending() must report the pending-but-blocked signal.
+    let mut pending: SigSet = 0;
+    // SAFETY: `pending` points to a valid `SigSet`.
+    unsafe { pm::__kcall_sigpending(&raw mut pending) }?;
+    assert!(
+        pending & bit != 0,
+        "sigpending() must report the pending-but-blocked SIGUSR1 (pending={:#x})",
+        pending
+    );
+
+    // Unblocking delivers the pending signal at this call's return-to-user boundary.
+    // SAFETY: `old` points to a valid `SigSet`.
+    unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, &raw const old, ptr::null_mut()) }?;
+    assert!(HANDLER_RAN.load(Ordering::SeqCst), "unblocking a pending signal must deliver it");
+
+    // It must no longer be pending.
+    let mut pending_after: SigSet = 0;
+    // SAFETY: `pending_after` points to a valid `SigSet`.
+    unsafe { pm::__kcall_sigpending(&raw mut pending_after) }?;
+    assert!(
+        pending_after & bit == 0,
+        "a delivered signal must clear from the pending set (pending={:#x})",
+        pending_after
+    );
+    Ok(())
+}
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
@@ -463,5 +773,11 @@ pub fn run() -> Result<(), Error> {
     test_kill_rejects_invalid_signal()?;
     test_caught_signal_runs_handler()?;
     test_siginfo_signal_runs_three_arg_handler()?;
+    test_eintr_interrupts_recv()?;
+    test_eintr_interrupts_sleep()?;
+    test_sa_restart_restarts_sleep()?;
+    test_sigsuspend_returns_after_handler()?;
+    test_sigsuspend_delivers_pending_unblocked_signal()?;
+    test_sigpending_reports_blocked_pending()?;
     Ok(())
 }


### PR DESCRIPTION
## What

Implements asynchronous signal delivery to threads parked in blocking kernel calls, and fleshes out the previously-stubbed `sigpending()` and `sigsuspend()` kernel calls along with their libc/sys bindings.

A caught signal posted to a process whose candidate thread is blocked now:
- interrupts the blocking call with `EINTR` and runs the handler, or
- transparently **restarts** the call when the handler is installed with `SA_RESTART` (the kernel's analog of Linux's `ERESTARTSYS`).

## Why

The signal subsystem previously had inert plumbing and stub kernel calls for `sigpending()`/`sigsuspend()`, and blocking calls could not be interrupted by caught signals. This brings the kernel in line with POSIX signal-interruption and `SA_RESTART` semantics.

## Changes

**Kernel**
- Add `InterruptReason::Signaled` and `KcallRestart`, recording an interrupted blocking call's number and argument registers on the thread.
- Route blocking-kcall `SleepError` through `handle_sleep_error` so a caught-signal interruption reports `EINTR` and stashes a restart record; consume it at signal delivery and rewind the saved context to the kcall trap via `prepare_kcall_restart` when `SA_RESTART` is set.
- Preserve `ECX` in the x86 `_do_kcall` entry stub and surface it through the trap frame so a restarted call reloads its original second argument; add an inert x86-64 `prepare_kcall_restart` shim.
- Replace the `(terminate, wake)` post-action pair in `kill()` with a `PostAction` enum that also interrupts a suspended candidate thread (one that does not block the signal).
- Implement `sigpending()` (`pending & blocked`) and `sigsuspend()` (install temporary mask, suspend, restore via `sigreturn()`), returning `EINTR` immediately when a caught signal is already pending and deliverable.

**Libraries**
- Add `libc_signal::sigpending` and rework `sigsuspend`; add `__kcall_sigpending`/`__kcall_sigsuspend` in `sys` and `__nanvix_sigpending`/`__nanvix_sigsuspend` backends in `nanvix_libc`.

**Tests**
- Add `kill-rust` cases covering `EINTR` interruption of `recv()` and sleep, `SA_RESTART` sleep restart, and `sigsuspend()` delivery and pending-signal paths.