### PR TITLE
[build] Add stdalign.h

### DIFF
--- a/build/make/guest-c-apps.mk
+++ b/build/make/guest-c-apps.mk
@@ -32,10 +32,10 @@ GUEST_C_APP_CC := clang --target=i686-unknown-none
 #
 # Use -nostdinc for maximal isolation: it drops BOTH the host system include
 # paths and the compiler's builtin resource-directory headers. The freestanding
-# headers normally supplied by the compiler (stddef.h, stdarg.h, stdint.h,
-# stdbool.h) are vendored in-tree under include/, so the build is hermetic and
-# does not depend on the compiler's resource directory (which clang 18 omits
-# under -nostdinc on both Linux and Windows).
+# headers normally supplied by the compiler (stdalign.h, stdarg.h, stdbool.h,
+# stddef.h, stdint.h) are vendored in-tree under include/, so the build is
+# hermetic and does not depend on the compiler's resource directory (which clang
+# 18 omits under -nostdinc on both Linux and Windows).
 GUEST_C_APP_CFLAGS := -m32 -march=pentiumpro -ffreestanding -nostdinc -std=c17
 GUEST_C_APP_CFLAGS += -isystem $(ROOT_DIR)/include
 ifeq ($(RELEASE),yes)

--- a/include/stdalign.h
+++ b/include/stdalign.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDALIGN_H
+#define _NANVIX_STDALIGN_H
+
+/**
+ * @file stdalign.h
+ * @brief Alignment convenience macros.
+ *
+ * Freestanding header vendored in-tree so the guest C toolchain does not depend
+ * on the compiler's builtin resource-directory headers. The macros expand to the
+ * `_Alignas` and `_Alignof` operators that both clang and gcc provide for the
+ * active target.
+ */
+
+#ifndef __cplusplus
+
+/** @brief Convenience spelling of the `_Alignas` specifier. */
+#ifndef alignas
+#define alignas _Alignas
+#endif
+
+/** @brief Convenience spelling of the `_Alignof` operator. */
+#ifndef alignof
+#define alignof _Alignof
+#endif
+
+#endif /* !__cplusplus */
+
+/** @brief Indicates that `alignas` is defined. */
+#define __alignas_is_defined 1
+
+/** @brief Indicates that `alignof` is defined. */
+#define __alignof_is_defined 1
+
+#endif /* _NANVIX_STDALIGN_H */


### PR DESCRIPTION
## What

Add a vendored freestanding `<stdalign.h>` header under `include/` so that
guest C builds compiled with `-nostdinc` can use the C17 alignment
convenience macros.

- Defines `alignas` and `alignof` (C mode only) in terms of `_Alignas`
  and `_Alignof`.
- Exposes the standard `__alignas_is_defined` and `__alignof_is_defined`
  feature macros.
- Documents `stdalign.h` in the guest C toolchain's vendored header list
  in `build/make/guest-c-apps.mk`.

## Why

The guest C toolchain uses `-nostdinc` for hermetic builds and therefore
cannot rely on the compiler's builtin resource-directory headers. This
mirrors the existing in-tree `stdbool.h` / `stdarg.h` / `stddef.h`
headers so alignment macros are available without depending on the
compiler's resource directory.
