### PR TITLE
[libc_time] Add timegm and UTC time-zone API

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -70,6 +70,7 @@ struct tm {
     int tm_wday;  /**< Days since Sunday [0, 6].    */
     int tm_yday;  /**< Days since Jan 1 [0, 365].   */
     int tm_isdst; /**< Daylight Saving Time flag.   */
+    long tm_gmtoff; /**< Seconds east of UTC (always 0). */
 };
 
 /** @brief Time specification for clock_gettime(). */
@@ -86,6 +87,7 @@ extern time_t time(time_t *tloc);
 extern clock_t clock(void);
 extern double difftime(time_t time1, time_t time0);
 extern time_t mktime(struct tm *timeptr);
+extern time_t timegm(struct tm *timeptr);
 
 /*==================================================================================================
  * Time Conversion
@@ -121,6 +123,15 @@ extern int nanosleep(const struct timespec *req, struct timespec *rem);
  *==================================================================================================*/
 
 extern char *strptime(const char *s, const char *format, struct tm *tm);
+
+/*==================================================================================================
+ * Time Zone
+ *==================================================================================================*/
+
+extern char *tzname[2];
+extern long timezone;
+extern int daylight;
+extern void tzset(void);
 
 #ifdef __cplusplus
 }

--- a/src/libs/libc_time/header.toml
+++ b/src/libs/libc_time/header.toml
@@ -10,7 +10,7 @@ Declares functions for calendar time manipulation and conversion.
 Implemented by the libc_time Rust crate.'''
 includes = ["stddef.h"]
 guard = "_NANVIX_TIME_H"
-content_order = ["types", "section:0", "section:1", "raw:0", "raw:1", "raw:2"]
+content_order = ["types", "section:0", "section:1", "raw:0", "raw:1", "raw:2", "raw:3"]
 
 [[types]]
 text = '''
@@ -60,6 +60,7 @@ struct tm {
     int tm_wday;  /**< Days since Sunday [0, 6].    */
     int tm_yday;  /**< Days since Jan 1 [0, 365].   */
     int tm_isdst; /**< Daylight Saving Time flag.   */
+    long tm_gmtoff; /**< Seconds east of UTC (always 0). */
 };
 
 /** @brief Time specification for clock_gettime(). */
@@ -92,9 +93,19 @@ title = "Time Parsing"
 text = '''
 extern char *strptime(const char *s, const char *format, struct tm *tm);'''
 
+# Time-zone interface. Nanvix is fixed to UTC; these symbols are provided by the
+# nanvix_libc shim so that portable software referencing them compiles and links.
+[[raw_sections]]
+title = "Time Zone"
+text = '''
+extern char *tzname[2];
+extern long timezone;
+extern int daylight;
+extern void tzset(void);'''
+
 [[sections]]
 title = "Calendar Time"
-functions = ["time", "clock", "difftime", "mktime"]
+functions = ["time", "clock", "difftime", "mktime", "timegm"]
 
 [[sections]]
 title = "Time Conversion"

--- a/src/libs/libc_time/src/asctime.rs
+++ b/src/libs/libc_time/src/asctime.rs
@@ -59,6 +59,7 @@ mod test {
             tm_wday: 4,
             tm_yday: 0,
             tm_isdst: 0,
+            tm_gmtoff: 0,
         };
         let ret: *mut i8 = unsafe { asctime(&t) };
         assert!(!ret.is_null());

--- a/src/libs/libc_time/src/asctime_r.rs
+++ b/src/libs/libc_time/src/asctime_r.rs
@@ -202,6 +202,7 @@ mod test {
             tm_wday: 3,
             tm_yday: 180,
             tm_isdst: 0,
+            tm_gmtoff: 0,
         };
         let mut buf: [c_char; 26] = [0; 26];
         let ret: *mut c_char = unsafe { asctime_r(&t, buf.as_mut_ptr()) };
@@ -221,6 +222,7 @@ mod test {
             tm_wday: 4,
             tm_yday: 0,
             tm_isdst: 0,
+            tm_gmtoff: 0,
         };
         let mut buf: [c_char; 26] = [0; 26];
         let ret: *mut c_char = unsafe { asctime_r(&t, buf.as_mut_ptr()) };
@@ -265,6 +267,7 @@ mod test {
             tm_wday: 4,
             tm_yday: 0,
             tm_isdst: 0,
+            tm_gmtoff: 0,
         };
         let mut buf: [c_char; 26] = [0; 26];
 

--- a/src/libs/libc_time/src/gmtime_r.rs
+++ b/src/libs/libc_time/src/gmtime_r.rs
@@ -112,6 +112,7 @@ pub unsafe extern "C" fn gmtime_r(timep: *const time_t, result: *mut tm) -> *mut
     (*result).tm_wday = wday;
     (*result).tm_yday = yday as c_int;
     (*result).tm_isdst = 0;
+    (*result).tm_gmtoff = 0;
 
     result
 }

--- a/src/libs/libc_time/src/lib.rs
+++ b/src/libs/libc_time/src/lib.rs
@@ -45,4 +45,5 @@ pub mod mktime;
 pub mod strftime;
 pub mod strptime;
 pub mod time;
+pub mod timegm;
 pub mod tm_struct;

--- a/src/libs/libc_time/src/timegm.rs
+++ b/src/libs/libc_time/src/timegm.rs
@@ -1,0 +1,99 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    mktime::mktime,
+    tm_struct::tm,
+};
+use ::sysapi::sys_types::time_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts a broken-down time structure, interpreted as Coordinated Universal Time (UTC), to a
+/// calendar time (`time_t`). The `tm` structure is normalized so that its fields are within their
+/// proper ranges.
+///
+/// Nanvix keeps all time in UTC and applies no timezone offset, so `timegm` is equivalent to
+/// [`mktime`].
+///
+/// # Parameters
+///
+/// - `timeptr`: Pointer to the broken-down time to convert.
+///
+/// # Returns
+///
+/// On success, the calendar time in seconds since the epoch. On error, `(time_t)(-1)`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences and writes to the raw pointer `timeptr`.
+///
+/// # References
+///
+/// - <https://www.man7.org/linux/man-pages/man3/timegm.3.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn timegm(timeptr: *mut tm) -> time_t {
+    mktime(timeptr)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::timegm;
+    use crate::tm_struct::tm;
+    use ::sysapi::sys_types::time_t;
+
+    #[test]
+    fn test_timegm_epoch() {
+        let mut t: tm = tm::new();
+        t.tm_year = 70;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        let result: time_t = unsafe { timegm(&mut t) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_timegm_known_date() {
+        // 2000-01-01 00:00:00 UTC.
+        let mut t: tm = tm::new();
+        t.tm_year = 100;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        let result: time_t = unsafe { timegm(&mut t) };
+        assert_eq!(result, 946_684_800);
+    }
+
+    #[test]
+    fn test_timegm_normalizes() {
+        // 1970-01-01 00:00:90 (90 seconds should normalize to 00:01:30).
+        let mut t: tm = tm::new();
+        t.tm_year = 70;
+        t.tm_mon = 0;
+        t.tm_mday = 1;
+        t.tm_sec = 90;
+        let result: time_t = unsafe { timegm(&mut t) };
+        assert_eq!(result, 90);
+        assert_eq!(t.tm_min, 1);
+        assert_eq!(t.tm_sec, 30);
+    }
+
+    #[test]
+    fn test_timegm_null() {
+        let result: time_t = unsafe { timegm(core::ptr::null_mut()) };
+        assert_eq!(result, -1);
+    }
+}

--- a/src/libs/libc_time/src/tm_struct.rs
+++ b/src/libs/libc_time/src/tm_struct.rs
@@ -11,7 +11,10 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::c_int;
+use ::sysapi::ffi::{
+    c_int,
+    c_long,
+};
 
 //==================================================================================================
 // Constants
@@ -116,6 +119,8 @@ pub struct tm {
     pub tm_yday: c_int,
     /// Daylight Saving Time flag.
     pub tm_isdst: c_int,
+    /// Seconds east of UTC. Always `0` on Nanvix, which keeps time in UTC.
+    pub tm_gmtoff: c_long,
 }
 
 impl tm {
@@ -131,6 +136,7 @@ impl tm {
             tm_wday: 0,
             tm_yday: 0,
             tm_isdst: 0,
+            tm_gmtoff: 0,
         }
     }
 }


### PR DESCRIPTION
## What

Implement `timegm()` and round out the time-zone surface of `libc_time`.

### Libraries
- Add `timegm()` in `src/libs/libc_time/src/timegm.rs`, delegating to `mktime()` and
  normalizing the broken-down time. Includes unit tests for the epoch, a known date,
  field normalization, and the null case.
- Register the new module in `lib.rs`.
- Add the `tm_gmtoff` field to `struct tm` (always `0`, UTC) and initialize it in
  `tm::new()`; set it in `gmtime_r()` and in the `asctime`/`asctime_r` test initializers.

### Header
- Declare `timegm()`, the `tm_gmtoff` field, and the time-zone interface (`tzname`,
  `timezone`, `daylight`, `tzset`) in `include/time.h`.
- Update `header.toml` `content_order`, the Calendar Time section, and add a Time Zone
  raw section to emit the new declarations.

## Why

Nanvix keeps all time in UTC, so `timegm()` is equivalent to `mktime()`. The new symbols
let portable software that references the time-zone interface compile and link.

## Validation

- `./z build -- run-unit-tests` — pass
- `./z build -- run-kernel-tests` — pass
- `./z build -- run-nanvix-tests` — pass