### PR TITLE
[libc_wchar] Implement wcsftime()

### DIFF
--- a/include/wchar.h
+++ b/include/wchar.h
@@ -141,6 +141,12 @@ extern int mbsinit(const mbstate_t *ps);
 extern size_t mbsrtowcs(wchar_t *dest, const char **src, size_t n, mbstate_t *ps);
 extern size_t wcsrtombs(char *dest, const wchar_t **src, size_t n, mbstate_t *ps);
 
+/*==================================================================================================
+ * Wide Character Time
+ *==================================================================================================*/
+
+extern size_t wcsftime(wchar_t *s, size_t maxsize, const wchar_t *format, const struct tm *timeptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -22,6 +22,7 @@ content_order = [
     "section:5",
     "section:6",
     "section:7",
+    "section:8",
 ]
 
 [[types]]
@@ -105,6 +106,10 @@ functions = [
     "wcsrtombs",
 ]
 
+[[sections]]
+title = "Wide Character Time"
+functions = ["wcsftime"]
+
 [overrides]
 wcscoll = '''
 extern int wcscoll(const wchar_t *s1, const wchar_t *s2);'''
@@ -112,6 +117,8 @@ wcsxfrm = '''
 extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);'''
 wcstok = '''
 extern wchar_t *wcstok(wchar_t *ws, const wchar_t *delim, wchar_t **ptr);'''
+wcsftime = '''
+extern size_t wcsftime(wchar_t *s, size_t maxsize, const wchar_t *format, const struct tm *timeptr);'''
 wmemchr = '''
 extern wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);'''
 vswprintf = '''

--- a/src/libs/libc_wchar/src/lib.rs
+++ b/src/libs/libc_wchar/src/lib.rs
@@ -40,6 +40,7 @@ pub mod wcschr;
 pub mod wcscmp;
 pub mod wcscoll;
 pub mod wcscpy;
+pub mod wcsftime;
 pub mod wcslen;
 pub mod wcsncmp;
 pub mod wcsncpy;

--- a/src/libs/libc_wchar/src/wcs_narrow.rs
+++ b/src/libs/libc_wchar/src/wcs_narrow.rs
@@ -49,6 +49,34 @@ impl Drop for NarrowString {
 // Helpers
 //==================================================================================================
 
+/// Copies `len` wide single-byte characters to a heap-allocated narrow string.
+///
+/// # Safety
+///
+/// `nptr` must point to at least `len` valid wide characters followed by any storage needed by the
+/// caller's scan.
+unsafe fn copy_narrow_alloc(nptr: *const wchar_t, len: usize) -> Option<NarrowString> {
+    let size: c_size_t = c_size_t::try_from(len.saturating_add(1)).ok()?;
+    let ptr: *mut c_char = unsafe { malloc(size) }.cast::<c_char>();
+    if ptr.is_null() {
+        return None;
+    }
+    for i in 0..len {
+        let c: wchar_t = unsafe { *nptr.add(i) };
+        let cp: u32 = u32::from_ne_bytes(c.to_ne_bytes());
+        let byte: u8 = match u8::try_from(cp) {
+            Ok(byte) => byte,
+            Err(_) => {
+                unsafe { free(ptr.cast::<c_void>()) };
+                return None;
+            },
+        };
+        unsafe { *ptr.add(i) = c_char::from_ne_bytes([byte]) };
+    }
+    unsafe { *ptr.add(len) = 0 };
+    Some(NarrowString { ptr })
+}
+
 /// Copies the ASCII prefix of a wide numeric string to a heap-allocated narrow string.
 ///
 /// # Safety
@@ -68,18 +96,30 @@ pub(crate) unsafe fn to_narrow_alloc(nptr: *const wchar_t) -> Option<NarrowStrin
         len += 1;
     }
 
-    let size: c_size_t = c_size_t::try_from(len.saturating_add(1)).ok()?;
-    let ptr: *mut c_char = unsafe { malloc(size) }.cast::<c_char>();
-    if ptr.is_null() {
-        return None;
-    }
-    for i in 0..len {
-        let c: wchar_t = unsafe { *nptr.add(i) };
+    unsafe { copy_narrow_alloc(nptr, len) }
+}
+
+/// Copies a full null-terminated wide string of single-byte characters to a heap-allocated narrow
+/// string.
+///
+/// # Safety
+///
+/// `nptr` must point to a valid, null-terminated wide string.
+pub(crate) unsafe fn to_narrow_alloc_full(nptr: *const wchar_t) -> Option<NarrowString> {
+    let mut len: usize = 0;
+    loop {
+        let c: wchar_t = unsafe { *nptr.add(len) };
+        if c == 0 {
+            break;
+        }
         let cp: u32 = u32::from_ne_bytes(c.to_ne_bytes());
-        unsafe { *ptr.add(i) = c_char::from_ne_bytes([(cp & 0xff) as u8]) };
+        if cp > u32::from(u8::MAX) {
+            return None;
+        }
+        len += 1;
     }
-    unsafe { *ptr.add(len) = 0 };
-    Some(NarrowString { ptr })
+
+    unsafe { copy_narrow_alloc(nptr, len) }
 }
 
 //==================================================================================================
@@ -105,5 +145,24 @@ mod test {
         }
         assert_eq!(unsafe { *narrow.as_ptr().add(80) }, c_char::from_ne_bytes(*b"x"));
         assert_eq!(unsafe { *narrow.as_ptr().add(81) }, 0);
+    }
+
+    #[test]
+    fn test_to_narrow_alloc_full_accepts_single_byte_characters() {
+        let wide: [wchar_t; 3] = [0x41, 0xff, 0];
+
+        let narrow: NarrowString = unsafe { to_narrow_alloc_full(wide.as_ptr()) }
+            .expect("full narrow allocation should succeed");
+
+        assert_eq!(unsafe { *narrow.as_ptr() }, c_char::from_ne_bytes(*b"A"));
+        assert_eq!(unsafe { *narrow.as_ptr().add(1) }, c_char::from_ne_bytes([0xff]));
+        assert_eq!(unsafe { *narrow.as_ptr().add(2) }, 0);
+    }
+
+    #[test]
+    fn test_to_narrow_alloc_full_rejects_unrepresentable_characters() {
+        let wide: [wchar_t; 3] = [0x41, 0x100, 0];
+
+        assert!(unsafe { to_narrow_alloc_full(wide.as_ptr()) }.is_none());
     }
 }

--- a/src/libs/libc_wchar/src/wcsftime.rs
+++ b/src/libs/libc_wchar/src/wcsftime.rs
@@ -1,0 +1,233 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::cast_sign_loss)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcs_narrow::to_narrow_alloc_full,
+};
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Opaque broken-down time structure declared in `<time.h>`.
+///
+/// It is used solely as a pointer target that is forwarded verbatim to `strftime()`; the layout is
+/// never inspected here, so an opaque placeholder is sufficient and keeps this crate decoupled from
+/// the time crate.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct tm {
+    _private: [u8; 0],
+}
+
+//==================================================================================================
+// External Symbols
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+    fn strftime(
+        s: *mut c_char,
+        max: c_size_t,
+        format: *const c_char,
+        timeptr: *const tm,
+    ) -> c_size_t;
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats the broken-down time `timeptr` into the wide-character array `s` according to the
+/// wide-character format string `format`. Nanvix operates in the C locale, so this delegates to
+/// [`strftime`]: the single-byte format string is narrowed, formatted, and the resulting bytes are
+/// widened back into `s`.
+///
+/// # Parameters
+///
+/// - `s`: Destination wide-character buffer.
+/// - `maxsize`: Capacity of `s`, in wide characters (including the null terminator).
+/// - `format`: Null-terminated wide-character format string.
+/// - `timeptr`: Broken-down time to format.
+///
+/// # Returns
+///
+/// The number of wide characters written to `s`, excluding the null terminator, or `0` if the
+/// result (including the terminator) would not fit in `maxsize` wide characters.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that `s`
+/// points to storage for at least `maxsize` wide characters and that `format` and `timeptr` point
+/// to valid objects.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wcsftime.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsftime(
+    s: *mut wchar_t,
+    maxsize: c_size_t,
+    format: *const wchar_t,
+    timeptr: *const tm,
+) -> c_size_t {
+    if s.is_null() || format.is_null() || timeptr.is_null() || maxsize == 0 {
+        return 0;
+    }
+
+    // Narrow the format string to bytes for strftime().
+    let narrow_format: crate::wcs_narrow::NarrowString =
+        match unsafe { to_narrow_alloc_full(format) } {
+            Some(f) => f,
+            None => return 0,
+        };
+
+    // Format into a narrow scratch buffer with the same element budget as the wide destination.
+    let narrow_buf: *mut c_char = unsafe { malloc(maxsize) }.cast::<c_char>();
+    if narrow_buf.is_null() {
+        return 0;
+    }
+
+    let written: c_size_t =
+        unsafe { strftime(narrow_buf, maxsize, narrow_format.as_ptr(), timeptr) };
+    if written == 0 {
+        // A 0 return is either an overflow or a valid empty result; in both cases the contents of
+        // the narrow buffer are unspecified, so deterministically terminate the destination. The
+        // earlier `maxsize == 0` guard guarantees there is room for the terminator.
+        unsafe { *s = 0 };
+        unsafe { free(narrow_buf.cast::<c_void>()) };
+        return 0;
+    }
+
+    // Widen the formatted bytes back into the destination. strftime() guarantees that
+    // `written < maxsize`, so the terminating null at index `written` stays in bounds.
+    for i in 0..written as usize {
+        let byte: u8 = unsafe { *narrow_buf.add(i) }.to_ne_bytes()[0];
+        unsafe { *s.add(i) = wchar_t::from(byte) };
+    }
+    unsafe { *s.add(written as usize) = 0 };
+
+    unsafe { free(narrow_buf.cast::<c_void>()) };
+    written
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use ::sysapi::ffi::c_int;
+
+    #[repr(C)]
+    struct HostTm {
+        tm_sec: c_int,
+        tm_min: c_int,
+        tm_hour: c_int,
+        tm_mday: c_int,
+        tm_mon: c_int,
+        tm_year: c_int,
+        tm_wday: c_int,
+        tm_yday: c_int,
+        tm_isdst: c_int,
+    }
+
+    fn make_time() -> HostTm {
+        HostTm {
+            tm_sec: 7,
+            tm_min: 5,
+            tm_hour: 9,
+            tm_mday: 14,
+            tm_mon: 2,
+            tm_year: 121,
+            tm_wday: 0,
+            tm_yday: 72,
+            tm_isdst: 0,
+        }
+    }
+
+    fn c_size_len(len: usize) -> c_size_t {
+        c_size_t::try_from(len).expect("buffer length should fit in c_size_t")
+    }
+
+    #[test]
+    fn test_wcsftime_formats_time() {
+        let mut dest: [wchar_t; 5] = [0; 5];
+        let format: [wchar_t; 3] = [0x25, 0x59, 0];
+        let time: HostTm = make_time();
+
+        let written: c_size_t = unsafe {
+            wcsftime(
+                dest.as_mut_ptr(),
+                c_size_len(dest.len()),
+                format.as_ptr(),
+                (&time as *const HostTm).cast::<tm>(),
+            )
+        };
+
+        assert_eq!(written, 4);
+        assert_eq!(dest, [0x32, 0x30, 0x32, 0x31, 0]);
+    }
+
+    #[test]
+    fn test_wcsftime_empty_format_terminates_destination() {
+        let mut dest: [wchar_t; 1] = [0x78];
+        let format: [wchar_t; 1] = [0];
+        let time: HostTm = make_time();
+
+        let written: c_size_t = unsafe {
+            wcsftime(
+                dest.as_mut_ptr(),
+                c_size_len(dest.len()),
+                format.as_ptr(),
+                (&time as *const HostTm).cast::<tm>(),
+            )
+        };
+
+        assert_eq!(written, 0);
+        assert_eq!(dest[0], 0);
+    }
+
+    #[test]
+    fn test_wcsftime_rejects_unrepresentable_format_character() {
+        let mut dest: [wchar_t; 4] = [-1; 4];
+        let format: [wchar_t; 4] = [0x58, 0x100, 0x59, 0];
+        let time: HostTm = make_time();
+
+        let written: c_size_t = unsafe {
+            wcsftime(
+                dest.as_mut_ptr(),
+                c_size_len(dest.len()),
+                format.as_ptr(),
+                (&time as *const HostTm).cast::<tm>(),
+            )
+        };
+
+        assert_eq!(written, 0);
+        assert_eq!(dest, [-1; 4]);
+    }
+}

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -292,21 +292,6 @@ pub unsafe extern "C" fn __nanvix_sigsuspend(_mask: *const libc_signal::signal::
 // Stub symbols required by libstdc++ but not yet implemented
 //==================================================================================================
 
-/// Stub `wcsftime` — returns 0 (failure).
-///
-/// # Safety
-///
-/// Caller must ensure valid pointers.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn wcsftime(
-    _s: *mut i32,
-    _max: c_size_t,
-    _format: *const i32,
-    _tm: *const c_void,
-) -> c_size_t {
-    0
-}
-
 /// C++ ABI: register a function to be called at exit or when a shared library is unloaded.
 ///
 /// # Safety


### PR DESCRIPTION
## What

Implement `wcsftime()` in `libc_wchar` and remove the failure-only stub that
previously lived in `nanvix_libc`. The wide format string is narrowed to
single-byte characters and delegated to `strftime()` (Nanvix operates in the C
locale), then the formatted bytes are widened back into the destination buffer.

## Why

The previous `nanvix_libc` stub always returned `0` (failure), so wide-character
time formatting was effectively unimplemented. This provides a working
implementation and exposes it through the public C header surface.

## Changes

**Libraries**
- Add a `copy_narrow_alloc()` helper and a strict `to_narrow_alloc_full()`
  variant that converts an entire null-terminated wide string, failing on any
  code point outside `0..=255` instead of silently truncating at the first
  non-ASCII character.
- Route `wcsftime()` through `to_narrow_alloc_full()` so the whole format is
  honored, and terminate the destination when `strftime()` returns `0` for a
  valid empty result rather than treating it solely as overflow.
- Drop the old `wcsftime` stub from `nanvix_libc`.

**Headers**
- Declare `wcsftime()` in `wchar.h` and wire the new section into the
  `libc_wchar` `header.toml` specification.

**Tests**
- Cover full-string narrowing (single-byte accept, unrepresentable reject) and
  `wcsftime()` formatting, empty-format termination, and rejection of
  unrepresentable format characters.

## Validation

- `run-unit-tests`, `run-kernel-tests`, `run-nanvix-tests`, and `format-check`
  pass.