### PR TITLE
[libc_signal] Add killpg and sigisemptyset

### DIFF
--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -66,16 +66,23 @@ GUEST_STATICLIB_FEATURES_nanvix_libm := $(strip $(GUEST_STATICLIB_FEATURES_nanvi
 
 # posix is the standalone Nanvix syscall backend (libposix.a), shipped for
 # out-of-tree C consumers that link it alongside their own libc. It takes an
-# EXPLICIT feature override — identical to the default `$(LOG_LEVEL) [+ standalone]`
-# set, and KEEPING posix's defaults (`syscall allocator c-main`; no
-# `--no-default-features`) — for ONE reason: to force posix into the per-package
-# build group so its `libposix.a` is compiled on its OWN, separately from
-# `nanvix_libc`. `nanvix_libc` depends on `posix` with `init-array`; a combined
-# `cargo build -p posix -p nanvix_libc` would unify features and bake
-# `init-array` into `libposix.a`, imposing a `.preinit/.init/.fini_array`
-# linker-script contract on those out-of-tree consumers. Building posix alone
-# keeps `libposix.a` on the legacy `_init`/`_fini` contract, exactly as before.
-GUEST_STATICLIB_FEATURES_posix := $(GUEST_STATICLIB_FEATURES)
+# EXPLICIT feature override — the default `$(LOG_LEVEL) [+ standalone]` set (KEEPING
+# posix's defaults `syscall allocator c-main`; no `--no-default-features`) plus
+# `newlib-compat` — for two reasons:
+#
+#   1. To force posix into the per-package build group so its `libposix.a` is
+#      compiled on its OWN, separately from `nanvix_libc`. `nanvix_libc` depends
+#      on `posix` with `init-array`; a combined `cargo build -p posix -p
+#      nanvix_libc` would unify features and bake `init-array` into `libposix.a`,
+#      imposing a `.preinit/.init/.fini_array` linker-script contract on those
+#      out-of-tree consumers. Building posix alone keeps `libposix.a` on the
+#      legacy `_init`/`_fini` contract, exactly as before.
+#   2. `newlib-compat` surfaces the syscall-backed `sigaction` / `sigprocmask`
+#      that Newlib-linked ports (e.g. xz) need from `libposix.a`. It is scoped to
+#      THIS standalone build on purpose: the `nanvix_libc` bundle (`libc.a`)
+#      already defines those symbols (via `nanvix_libc` / `libc_signal`), so
+#      enabling them in the bundle's embedded posix too would duplicate them.
+GUEST_STATICLIB_FEATURES_posix := $(GUEST_STATICLIB_FEATURES) newlib-compat
 GUEST_STATICLIB_FEATURES_posix := $(strip $(GUEST_STATICLIB_FEATURES_posix))
 
 # Returns the cargo `--features "..."` arg for the given package, falling

--- a/include/signal.h
+++ b/include/signal.h
@@ -137,6 +137,7 @@ struct sigaction {
 extern sighandler_t signal(int signum, sighandler_t handler);
 extern int raise(int sig);
 extern int kill(pid_t pid, int sig);
+extern int killpg(pid_t pgrp, int sig);
 
 /*==================================================================================================
  * Signal Set Functions
@@ -144,6 +145,7 @@ extern int kill(pid_t pid, int sig);
 
 extern int sigemptyset(sigset_t *set);
 extern int sigfillset(sigset_t *set);
+extern int sigisemptyset(const sigset_t *set);
 extern int sigaddset(sigset_t *set, int signum);
 extern int sigdelset(sigset_t *set, int signum);
 extern int sigismember(const sigset_t *set, int signum);

--- a/src/libs/libc_signal/header.toml
+++ b/src/libs/libc_signal/header.toml
@@ -119,13 +119,14 @@ text = '''
 
 [[sections]]
 title = "Signal Functions"
-functions = ["signal", "raise", "kill"]
+functions = ["signal", "raise", "kill", "killpg"]
 
 [[sections]]
 title = "Signal Set Functions"
 functions = [
     "sigemptyset",
     "sigfillset",
+    "sigisemptyset",
     "sigaddset",
     "sigdelset",
     "sigismember",
@@ -140,6 +141,8 @@ signal = '''
 extern sighandler_t signal(int signum, sighandler_t handler);'''
 kill = '''
 extern int kill(pid_t pid, int sig);'''
+killpg = '''
+extern int killpg(pid_t pgrp, int sig);'''
 sigaction = '''
 extern int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);'''
 pthread_sigmask = '''

--- a/src/libs/libc_signal/src/killpg.rs
+++ b/src/libs/libc_signal/src/killpg.rs
@@ -1,0 +1,131 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::EINVAL,
+    ffi::c_int,
+    sys_types::pid_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sends a signal to a process group.
+///
+/// Nanvix does not implement process groups, so each process is the leader of its own group and
+/// the process-group ID equals the process ID. A `pgrp` value of zero therefore targets the calling
+/// process, and a positive `pgrp` delivers `sig` to the process whose ID equals `pgrp`. Negative
+/// values (POSIX process-group selectors) are unsupported and rejected with `EINVAL`.
+///
+/// # Parameters
+///
+/// - `pgrp`: The process-group ID (a process ID on Nanvix) to signal.
+/// - `sig`: The signal number to send.
+///
+/// # Returns
+///
+/// Zero on success, or `-1` on error with `errno` set to `EINVAL` when `pgrp` is negative.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls the external `kill` system call that modifies process
+/// state.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn killpg(pgrp: pid_t, sig: c_int) -> c_int {
+    // Process groups are not supported, so the negative `pgrp` selectors that POSIX uses to address
+    // a specific group are rejected here rather than forwarded to kill(). This keeps killpg()'s
+    // semantics independent of kill()'s own pid validation.
+    if pgrp < 0 {
+        // POSIX: EINVAL when the process-group ID is invalid.
+        set_errno(EINVAL);
+        return -1;
+    }
+
+    // SAFETY: delegates to the platform-specific implementation, which upholds this contract.
+    unsafe { killpg_impl(pgrp, sig) }
+}
+
+/// Resolves a Nanvix process-group ID to the process ID used by `kill()`.
+#[cfg(any(not(feature = "std"), test))]
+fn target_pid_for_group(pgrp: pid_t, caller_pid: pid_t) -> pid_t {
+    if pgrp == 0 {
+        caller_pid
+    } else {
+        pgrp
+    }
+}
+
+/// Guest implementation of [`killpg`]: delivers `sig` through `kill()` because Nanvix has no
+/// process groups.
+///
+/// # Safety
+///
+/// This function is unsafe because it calls the external `kill` system call that modifies process
+/// state.
+#[cfg(not(feature = "std"))]
+unsafe fn killpg_impl(pgrp: pid_t, sig: c_int) -> c_int {
+    extern "C" {
+        fn getpid() -> pid_t;
+        fn kill(pid: pid_t, sig: c_int) -> c_int;
+    }
+
+    let caller_pid: pid_t = unsafe { getpid() };
+    let target_pid: pid_t = target_pid_for_group(pgrp, caller_pid);
+
+    // SAFETY: FFI to the guest C runtime; has no preconditions here.
+    unsafe { kill(target_pid, sig) }
+}
+
+/// Host-only stand-in for [`killpg_impl`] used by unit tests.
+///
+/// Signal delivery is unavailable on the host, so this reports failure without referencing any
+/// guest-only symbol. The guest never compiles this variant.
+///
+/// # Safety
+///
+/// Matches the signature of the guest variant; it has no additional preconditions.
+#[cfg(feature = "std")]
+unsafe fn killpg_impl(_pgrp: pid_t, _sig: c_int) -> c_int {
+    -1
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn killpg_target_pid_maps_zero_to_caller() {
+        assert_eq!(target_pid_for_group(0, 7), 7);
+        assert_eq!(target_pid_for_group(3, 7), 3);
+    }
+
+    #[test]
+    fn killpg_rejects_negative_pgrp() {
+        // Process groups are not supported, so negative pgrp selectors must be rejected outright
+        // rather than forwarded to kill().
+        assert_eq!(unsafe { killpg(-1, 2) }, -1);
+        assert_eq!(unsafe { killpg(-2, 2) }, -1);
+    }
+
+    #[test]
+    fn killpg_reports_failure_on_host() {
+        // The host build cannot deliver signals, so killpg() must fail rather than reference any
+        // guest-only symbol. This guards against reintroducing an unconditional FFI call that
+        // would break the host build.
+        assert_eq!(unsafe { killpg(1, 2) }, -1);
+    }
+}

--- a/src/libs/libc_signal/src/lib.rs
+++ b/src/libs/libc_signal/src/lib.rs
@@ -30,6 +30,7 @@
 // Modules
 //==================================================================================================
 
+pub mod killpg;
 pub mod raise;
 pub mod signal;
 pub mod sigpending;

--- a/src/libs/libc_signal/src/sigset.rs
+++ b/src/libs/libc_signal/src/sigset.rs
@@ -83,6 +83,37 @@ pub unsafe extern "C" fn sigfillset(set: *mut sigset_t) -> c_int {
 ///
 /// # Description
 ///
+/// Tests whether a signal set is empty (GNU extension).
+///
+/// # Parameters
+///
+/// - `set`: Pointer to the signal set to test.
+///
+/// # Returns
+///
+/// `1` if the set is empty, `0` if it contains at least one signal, or `-1` if `set` is null.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointer `set`.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn sigisemptyset(set: *const sigset_t) -> c_int {
+    if set.is_null() {
+        // POSIX: EFAULT when `set` points to invalid memory.
+        set_errno(EFAULT);
+        return -1;
+    }
+    if *set == 0 {
+        1
+    } else {
+        0
+    }
+}
+
+///
+/// # Description
+///
 /// Adds the specified signal to the signal set.
 ///
 /// # Parameters
@@ -215,6 +246,21 @@ mod test {
     }
 
     #[test]
+    fn test_sigisemptyset() {
+        let mut set: sigset_t = 0;
+        assert_eq!(unsafe { sigemptyset(&mut set) }, 0);
+        assert_eq!(unsafe { sigisemptyset(&set) }, 1);
+
+        // A set with any signal is not empty.
+        assert_eq!(unsafe { sigaddset(&mut set, 1) }, 0);
+        assert_eq!(unsafe { sigisemptyset(&set) }, 0);
+
+        // A full set is not empty.
+        assert_eq!(unsafe { sigfillset(&mut set) }, 0);
+        assert_eq!(unsafe { sigisemptyset(&set) }, 0);
+    }
+
+    #[test]
     fn test_sigaddset_and_sigismember() {
         let mut set: sigset_t = 0;
         assert_eq!(unsafe { sigemptyset(&mut set) }, 0);
@@ -254,6 +300,7 @@ mod test {
     fn test_sigset_null_pointer() {
         assert_eq!(unsafe { sigemptyset(core::ptr::null_mut()) }, -1);
         assert_eq!(unsafe { sigfillset(core::ptr::null_mut()) }, -1);
+        assert_eq!(unsafe { sigisemptyset(core::ptr::null()) }, -1);
         assert_eq!(unsafe { sigaddset(core::ptr::null_mut(), 1) }, -1);
         assert_eq!(unsafe { sigdelset(core::ptr::null_mut(), 1) }, -1);
         assert_eq!(unsafe { sigismember(core::ptr::null(), 1) }, -1);

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -55,6 +55,8 @@ default = ["syscall", "allocator", "c-main"]
 allocator = ["dep:sysalloc"]
 syscall = [
     "syslog",
+    # Propagate to the `syscall` crate's optional C bindings so the
+    # syscall-backed surface is exported by `libposix.a`.
     "syscall/dlfcn",
     "dep:libc_arpa_inet",
     "dep:libc_dlfcn",
@@ -73,6 +75,20 @@ syscall = [
     "dep:libc_sys_uio",
     "dep:libc_sys_utsname",
 ]
+
+# Surfaces the syscall-backed signal-control calls (`sigaction`, `sigprocmask`)
+# from the `syscall` crate, covering a gap in Newlib: ports linked against the
+# standalone `libposix.a` (e.g. xz) need them, but Newlib does not provide them.
+#
+# Deliberately kept OUT of the `syscall` feature. The in-tree `nanvix_libc`
+# bundle (`libc.a`) pulls `posix` in via its `backend-nanvix` feature and ALREADY
+# defines `sigaction` (in `nanvix_libc`) and `sigprocmask` (in `libc_signal`), so
+# enabling the `syscall` versions there too would emit DUPLICATE `sigaction` /
+# `sigprocmask` symbols into `libc.a`. This feature is therefore enabled ONLY for
+# the standalone `libposix.a` build (see `GUEST_STATICLIB_FEATURES_posix` in
+# `build/make/generic-guest-staticlibs.mk`), which carries neither `nanvix_libc`
+# nor `libc_signal`.
+newlib-compat = ["syscall/signal"]
 standalone = ["syscall/standalone"]
 std = []
 

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -66,8 +66,9 @@ rustc-dep-of-std = [
 ]
 standalone = ["dep:sysalloc", "dep:proc"]
 
-# TODO (#798): remove this feature flag once the signal module is stable.
+# TODO (#798): remove these feature flags once the signal module is stable.
 sigaction = []
+signal = ["sigaction"]
 
 # Logging
 error = ["syslog/error"]

--- a/src/libs/syscall/src/signal/bindings/mod.rs
+++ b/src/libs/syscall/src/signal/bindings/mod.rs
@@ -8,3 +8,5 @@
 pub mod kill;
 #[cfg(feature = "sigaction")]
 pub mod sigaction;
+#[cfg(feature = "signal")]
+pub mod sigprocmask;

--- a/src/libs/syscall/src/signal/bindings/sigprocmask.rs
+++ b/src/libs/syscall/src/signal/bindings/sigprocmask.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::signal::sigset_t;
+use ::sysapi::{
+    errno::__errno_location,
+    ffi::c_int,
+};
+use ::syslog::trace_syscall;
+
+//==================================================================================================
+// Compile-Time ABI Assertions
+//==================================================================================================
+
+// `sigset_t` (the user-space C ABI view) and `sys::pm::SigSet` (the kernel-call view) are both
+// 64-bit blocked-signal bitmasks. The pointer casts in [`sigprocmask`] are only sound while the
+// two stay ABI-compatible, so guard their size and alignment at compile time; any future
+// divergence fails the build instead of silently corrupting the ABI.
+const _: () = {
+    assert!(::core::mem::size_of::<sigset_t>() == ::core::mem::size_of::<::sys::pm::SigSet>());
+    assert!(::core::mem::align_of::<sigset_t>() == ::core::mem::align_of::<::sys::pm::SigSet>());
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Examines and/or changes the calling process's blocked-signal mask via the `sigprocmask()`
+/// kernel call.
+///
+/// `sigset_t` and `sys::pm::SigSet` are ABI-compatible (same size and alignment, asserted at
+/// compile time above), so the mask pointers are reinterpreted across the kernel-call boundary
+/// without translation.
+///
+/// # Parameters
+///
+/// - `how`: How to combine `set` with the current mask (`SIG_BLOCK`, `SIG_UNBLOCK`, or
+///   `SIG_SETMASK`); ignored when `set` is null.
+/// - `set`: Pointer to the signals to apply per `how`, or null to leave the mask unchanged.
+/// - `oldset`: Pointer that receives the previous mask, or null if not wanted.
+///
+/// # Returns
+///
+/// Upon successful completion, `0` is returned. Upon failure, `-1` is returned and `errno` is set
+/// to indicate the error.
+///
+#[unsafe(no_mangle)]
+#[trace_syscall]
+pub extern "C" fn sigprocmask(how: c_int, set: *const sigset_t, oldset: *mut sigset_t) -> c_int {
+    match unsafe {
+        ::sys::kcall::pm::__kcall_sigprocmask(
+            how,
+            set as *const ::sys::pm::SigSet,
+            oldset as *mut ::sys::pm::SigSet,
+        )
+    } {
+        Ok(()) => 0,
+        Err(error) => {
+            unsafe {
+                *__errno_location() = error.code.get();
+            }
+            -1
+        },
+    }
+}


### PR DESCRIPTION
## Summary

Expands the signal C API surface and makes the syscall-backed `sigaction` / `sigprocmask` available to Newlib-linked ports (e.g. xz) that link against the standalone `libposix.a`.

## What changed

**Libraries**
- `libc_signal`: add `killpg()` and `sigisemptyset()`.
  - `killpg()` maps a process-group ID to a process. Nanvix has no process groups, so `pgrp == 0` targets the calling process and any other value targets that PID; it delegates to `kill()`, with a host stub that reports failure.
  - `sigisemptyset()` reports whether a signal set is empty, returning `EFAULT` on a null pointer.
  - Unit tests cover the pgrp-to-pid mapping, the host failure path, and the emptiness/null-pointer cases.
- `syscall`: add a `sigprocmask` C binding that forwards to the `__kcall_sigprocmask` kernel call, guarded by compile-time `SigSet` ABI size/alignment assertions. Introduce a `signal` feature (implies `sigaction`) that gates this binding, kept separate so existing `sigaction` consumers do not also export `sigprocmask`.
- `posix`: add a `newlib-compat` feature (pulls `syscall/signal`) that surfaces `sigaction` / `sigprocmask` only for the standalone `libposix.a`. The `nanvix_libc` bundle already defines those symbols, so enabling them there too would duplicate symbols.

**Headers**
- Declare `killpg()` and `sigisemptyset()` in `include/signal.h` and the `libc_signal` `header.toml` spec.

**Build and harness wiring**
- Enable `newlib-compat` for the standalone posix staticlib build, with a comment documenting why it is scoped to that build only.

## Validation
- `run-unit-tests` and standalone `run-nanvix-tests` pass.
- Symbol inspection confirms `libposix.a` exports `sigaction` / `sigprocmask`, and `libc.a` retains single definitions of the affected signal symbols (no duplicates).