### PR TITLE
[libc_sys_resource] Add sys/resource.h surface

### DIFF
--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_RESOURCE_H
+#define _NANVIX_SYS_RESOURCE_H
+
+/**
+ * @file sys/resource.h
+ * @brief Resource limits and priorities.
+ *
+ * Declares the resource limit interfaces (getrlimit/setrlimit) and the process
+ * priority interfaces (getpriority/setpriority), together with the rlimit
+ * structure and the associated resource and priority identifiers. The rlimit
+ * layout mirrors the Rust definition in the sysapi crate (sys_resource.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Resource Limit Identifiers
+ *==================================================================================================*/
+
+#define RLIMIT_CPU 0      /**< CPU time, in seconds.          */
+#define RLIMIT_FSIZE 1    /**< Maximum file size.             */
+#define RLIMIT_DATA 2     /**< Maximum data segment size.     */
+#define RLIMIT_STACK 3    /**< Maximum stack size.            */
+#define RLIMIT_CORE 4     /**< Maximum core file size.        */
+#define RLIMIT_RSS 5      /**< Maximum resident set size.     */
+#define RLIMIT_NPROC 6    /**< Maximum number of processes.   */
+#define RLIMIT_NOFILE 7   /**< Maximum number of open files.  */
+#define RLIMIT_MEMLOCK 8  /**< Maximum locked-in-memory size. */
+#define RLIMIT_AS 9       /**< Maximum address space size.    */
+#define RLIMIT_NLIMITS 10 /**< Number of resource limits.     */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Resource limit value type. */
+typedef unsigned long rlim_t;
+
+/** @brief Resource limit. */
+struct rlimit {
+    rlim_t rlim_cur; /**< Soft limit. */
+    rlim_t rlim_max; /**< Hard limit. */
+};
+
+/*==================================================================================================
+ * Resource Limit Values
+ *==================================================================================================*/
+
+/** @brief Unlimited resource value. */
+#define RLIM_INFINITY ((rlim_t)-1)
+/** @brief Unrepresentable saved soft-limit value. */
+#define RLIM_SAVED_CUR RLIM_INFINITY
+/** @brief Unrepresentable saved hard-limit value. */
+#define RLIM_SAVED_MAX RLIM_INFINITY
+
+/*==================================================================================================
+ * Priority Identifiers
+ *==================================================================================================*/
+
+#define PRIO_PROCESS 0 /**< Identifies a process.       */
+#define PRIO_PGRP 1    /**< Identifies a process group. */
+#define PRIO_USER 2    /**< Identifies a user.          */
+
+/*==================================================================================================
+ * Resource Limits
+ *==================================================================================================*/
+
+extern int getrlimit(int resource, struct rlimit *rlim);
+extern int setrlimit(int resource, const struct rlimit *rlim);
+
+/*==================================================================================================
+ * Process Priorities
+ *==================================================================================================*/
+
+extern int getpriority(int which, int who);
+extern int setpriority(int which, int who, int prio);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_RESOURCE_H */

--- a/src/libs/libc_sys_resource/src/lib.rs
+++ b/src/libs/libc_sys_resource/src/lib.rs
@@ -20,8 +20,20 @@ use ::syscall::errno::__errno_location;
 use ::syslog::trace_syscall;
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+const PRIO_PROCESS: c_int = 0;
+const PRIO_PGRP: c_int = 1;
+const PRIO_USER: c_int = 2;
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
+
+fn valid_priority_selector(which: c_int) -> bool {
+    matches!(which, PRIO_PROCESS | PRIO_PGRP | PRIO_USER)
+}
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
@@ -45,4 +57,41 @@ pub unsafe extern "C" fn setrlimit(_resource: c_int, _rlim: *const rlimit) -> c_
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }
     -1
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[trace_syscall]
+pub unsafe extern "C" fn getpriority(which: c_int, _who: c_int) -> c_int {
+    if !valid_priority_selector(which) {
+        ::syslog::warn!("getpriority(): invalid priority selector (which={})", which);
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+        }
+        return -1;
+    }
+
+    // Nanvix has no process-scheduling-priority concept; report the normal
+    // priority (0). Callers (nice, renice, start-stop-daemon) treat 0 as the
+    // default nice value.
+    ::syslog::debug!("getpriority(): not implemented; reporting normal priority");
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[trace_syscall]
+pub unsafe extern "C" fn setpriority(which: c_int, _who: c_int, _prio: c_int) -> c_int {
+    if !valid_priority_selector(which) {
+        ::syslog::warn!("setpriority(): invalid priority selector (which={})", which);
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+        }
+        return -1;
+    }
+
+    // Nanvix has no process-scheduling-priority concept; accept and ignore the
+    // request so that nice/renice succeed as no-ops rather than hard-failing.
+    ::syslog::debug!("setpriority(): not implemented; ignoring");
+    0
 }

--- a/src/libs/sysapi/headers/sys_resource.toml
+++ b/src/libs/sysapi/headers/sys_resource.toml
@@ -1,0 +1,69 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/resource.h.
+# The rlimit layout mirrors src/libs/sysapi/src/sys_resource.rs; the resource
+# limit and priority interfaces are generated from the libc_sys_resource crate.
+
+file = "sys/resource.h"
+brief = "Resource limits and priorities."
+description = """
+Declares the resource limit interfaces (getrlimit/setrlimit) and the process
+priority interfaces (getpriority/setpriority), together with the rlimit
+structure and the associated resource and priority identifiers. The rlimit
+layout mirrors the Rust definition in the sysapi crate (sys_resource.rs)."""
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_RESOURCE_H"
+scan_crates = ["libc_sys_resource"]
+content_order = ["raw:0", "types:0", "raw:1", "raw:2", "section:0", "section:1"]
+
+[[raw_sections]]
+title = "Resource Limit Identifiers"
+text = """
+#define RLIMIT_CPU 0      /**< CPU time, in seconds.          */
+#define RLIMIT_FSIZE 1    /**< Maximum file size.             */
+#define RLIMIT_DATA 2     /**< Maximum data segment size.     */
+#define RLIMIT_STACK 3    /**< Maximum stack size.            */
+#define RLIMIT_CORE 4     /**< Maximum core file size.        */
+#define RLIMIT_RSS 5      /**< Maximum resident set size.     */
+#define RLIMIT_NPROC 6    /**< Maximum number of processes.   */
+#define RLIMIT_NOFILE 7   /**< Maximum number of open files.  */
+#define RLIMIT_MEMLOCK 8  /**< Maximum locked-in-memory size. */
+#define RLIMIT_AS 9       /**< Maximum address space size.    */
+#define RLIMIT_NLIMITS 10 /**< Number of resource limits.     */"""
+
+[[types]]
+text = """
+/** @brief Resource limit value type. */
+typedef unsigned long rlim_t;
+
+/** @brief Resource limit. */
+struct rlimit {
+    rlim_t rlim_cur; /**< Soft limit. */
+    rlim_t rlim_max; /**< Hard limit. */
+};"""
+
+[[raw_sections]]
+title = "Resource Limit Values"
+text = """
+/** @brief Unlimited resource value. */
+#define RLIM_INFINITY ((rlim_t)-1)
+/** @brief Unrepresentable saved soft-limit value. */
+#define RLIM_SAVED_CUR RLIM_INFINITY
+/** @brief Unrepresentable saved hard-limit value. */
+#define RLIM_SAVED_MAX RLIM_INFINITY"""
+
+[[raw_sections]]
+title = "Priority Identifiers"
+text = """
+#define PRIO_PROCESS 0 /**< Identifies a process.       */
+#define PRIO_PGRP 1    /**< Identifies a process group. */
+#define PRIO_USER 2    /**< Identifies a user.          */"""
+
+[[sections]]
+title = "Resource Limits"
+functions = ["getrlimit", "setrlimit"]
+
+[[sections]]
+title = "Process Priorities"
+functions = ["getpriority", "setpriority"]


### PR DESCRIPTION
## What

Generates the POSIX `sys/resource.h` header and backs it with priority
interfaces so that callers like `nice`/`renice`/`start-stop-daemon` link
and behave sanely on Nanvix, which has no scheduling-priority concept.

## Why

Nanvix lacks a process-scheduling-priority model. Rather than leaving these
interfaces undeclared (breaking linkage) or hard-failing, the priority
calls degrade gracefully while still validating their inputs.

## Changes

**Libraries (`libc_sys_resource`):**
- Implement `getpriority()`/`setpriority()`: validate the selector
  (`PRIO_PROCESS`/`PRIO_PGRP`/`PRIO_USER`) and fail with `EINVAL` otherwise;
  for valid selectors report normal priority (`0`) and accept
  `setpriority()` as a no-op instead of hard-failing.

**Headers:**
- Add the sysapi header spec `sys_resource.toml` describing the `rlimit`
  layout, `RLIMIT_*`/`PRIO_*` identifiers, `RLIM_INFINITY` values, and the
  `getrlimit`/`setrlimit`/`getpriority`/`setpriority` prototypes.
- Add the generated `include/sys/resource.h` produced from that spec.

## Validation

- `format-check`, `gen-headers-check`, `lint-check` clean.
- `run-unit-tests` and `run-nanvix-tests` pass (Windows standalone).