### PR TITLE
[sysapi] Add sys/sysmacros.h Device Macros

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_SYSMACROS_H
+#define _NANVIX_SYS_SYSMACROS_H
+
+/**
+ * @file sys/sysmacros.h
+ * @brief Device number macros.
+ *
+ * `major()` and `minor()` extract the major and minor components of a `dev_t`
+ * device number, and `makedev()` composes one from a major/minor pair.
+ */
+
+#include <sys/types.h>
+
+#ifndef major
+#define major(dev) ((unsigned int)(((dev_t)(dev) >> 8) & 0xffu))
+#endif
+#ifndef minor
+#define minor(dev) ((unsigned int)((dev_t)(dev) & 0xffu))
+#endif
+#ifndef makedev
+#define makedev(maj, min) ((dev_t)(((((dev_t)(maj)) & 0xffu) << 8) | (((dev_t)(min)) & 0xffu)))
+#endif
+
+#endif /* _NANVIX_SYS_SYSMACROS_H */

--- a/src/libs/sysapi/headers/sys_sysmacros.toml
+++ b/src/libs/sysapi/headers/sys_sysmacros.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/sysmacros.h.
+
+file = "sys/sysmacros.h"
+brief = "Device number macros."
+description = '''
+`major()` and `minor()` extract the major and minor components of a `dev_t`
+device number, and `makedev()` composes one from a major/minor pair.'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_SYSMACROS_H"
+extern_c = false
+content_order = ["raw:0"]
+
+[[raw_sections]]
+title = ""
+text = '''
+#ifndef major
+#define major(dev) ((unsigned int)(((dev_t)(dev) >> 8) & 0xffu))
+#endif
+#ifndef minor
+#define minor(dev) ((unsigned int)((dev_t)(dev) & 0xffu))
+#endif
+#ifndef makedev
+#define makedev(maj, min) ((dev_t)(((((dev_t)(maj)) & 0xffu) << 8) | (((dev_t)(min)) & 0xffu)))
+#endif'''

--- a/src/tests/integration/test-c-bindings/main.c
+++ b/src/tests/integration/test-c-bindings/main.c
@@ -7,6 +7,7 @@
 #include <sched.h>
 #include <stdint.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <time.h>
 
@@ -117,6 +118,12 @@ int main(int argc, const char *argv[])
     STATIC_ASSERT_SIZE(ssize_t, sizeof(int));
     STATIC_ASSERT_SIZE(time_t, sizeof(long long));
     STATIC_ASSERT_SIZE(uid_t, sizeof(unsigned int));
+
+    // Assert behavior of device-number macros in <sys/sysmacros.h>.
+    STATIC_ASSERT(major(makedev(0x12, 0x34)), 0x12);
+    STATIC_ASSERT(minor(makedev(0x12, 0x34)), 0x34);
+    STATIC_ASSERT(major(makedev(0x1ff, 0x2ff)), 0xff);
+    STATIC_ASSERT(minor(makedev(0x1ff, 0x2ff)), 0xff);
 
     // Assert size of types in <time.h>.
     STATIC_ASSERT_SIZE(struct timespec, sizeof(time_t) + sizeof(long));


### PR DESCRIPTION
## What

Adds a header specification for `sys/sysmacros.h` and its generated header,
providing the standard `major()`, `minor()`, and `makedev()` device-number
macros.

## Why

These macros are part of the standard device-number API and were previously
missing. The implementations cast operands through `dev_t` and mask each
component to 8 bits, so high minor bits cannot bleed into the major field and
large or signed inputs are handled safely.

## Changes

- New header spec `src/libs/sysapi/headers/sys_sysmacros.toml` emitting
  `sys/sysmacros.h` via `gen-headers` (guard `_NANVIX_SYS_SYSMACROS_H`,
  includes `sys/types.h`).
- Generated `include/sys/sysmacros.h` with the matching
  `major()`/`minor()`/`makedev()` definitions.

## Validation

- `gen-headers --check` reports headers up to date.
- `./z build -- run-unit-tests`, `run-nanvix-tests`, and `test` pass.