### PR TITLE
[libc_pthread] pthread_mutexattr_set/gettype

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -125,6 +125,8 @@ extern int pthread_mutex_trylock(pthread_mutex_t *mutex);
 extern int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime);
 extern int pthread_mutexattr_init(pthread_mutexattr_t *attr);
 extern int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
+extern int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type_);
+extern int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type_);
 
 /*==================================================================================================
  * Condition Variables

--- a/src/libs/libc_pthread/src/mutex.rs
+++ b/src/libs/libc_pthread/src/mutex.rs
@@ -11,6 +11,12 @@ use ::sys::{
 };
 use ::sysapi::{
     ffi::c_int,
+    pthread::pthread_mutex_type::{
+        PTHREAD_MUTEX_DEFAULT,
+        PTHREAD_MUTEX_ERRORCHECK,
+        PTHREAD_MUTEX_NORMAL,
+        PTHREAD_MUTEX_RECURSIVE,
+    },
     sys_types::{
         pthread_mutex_t,
         pthread_mutexattr_t,
@@ -47,7 +53,13 @@ use ::syslog::trace_libcall;
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/511.
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!("pthread_mutexattr_init(): invalid attr pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    *attr = pthread_mutexattr_t::default();
     0
 }
 
@@ -79,6 +91,109 @@ pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) 
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/509
+    0
+}
+
+//==================================================================================================
+// pthread_mutexattr_settype()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the mutex type attribute in a mutex attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object.
+/// - `type_`: Mutex type to set.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_settype()` function returns `0` on success. On error, it returns an error
+/// number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_mutexattr_t` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_mutexattr_settype(
+    attr: *mut pthread_mutexattr_t,
+    type_: c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!("pthread_mutexattr_settype(): invalid attr pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `type_` is a supported mutex type.
+    match type_ {
+        PTHREAD_MUTEX_NORMAL
+        | PTHREAD_MUTEX_RECURSIVE
+        | PTHREAD_MUTEX_ERRORCHECK
+        | PTHREAD_MUTEX_DEFAULT => {
+            (*attr).set_type(type_);
+            0
+        },
+        _ => {
+            ::syslog::warn!("pthread_mutexattr_settype(): invalid mutex type (type={})", type_);
+            ErrorCode::InvalidArgument.get()
+        },
+    }
+}
+
+//==================================================================================================
+// pthread_mutexattr_gettype()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the mutex type attribute from a mutex attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object.
+/// - `type_`: Pointer where the mutex type is stored on success.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_gettype()` function returns `0` on success. On error, it returns an error
+/// number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_mutexattr_t` object.
+/// - `type_` points to a valid `int` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_mutexattr_gettype(
+    attr: *const pthread_mutexattr_t,
+    type_: *mut c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!("pthread_mutexattr_gettype(): invalid attr pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `type_` is not valid.
+    if type_.is_null() {
+        ::syslog::warn!("pthread_mutexattr_gettype(): invalid type pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    *type_ = (*attr).type_();
     0
 }
 

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -121,6 +121,8 @@ functions = [
     "pthread_mutex_timedlock",
     "pthread_mutexattr_init",
     "pthread_mutexattr_destroy",
+    "pthread_mutexattr_settype",
+    "pthread_mutexattr_gettype",
 ]
 
 [[sections]]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -21,7 +21,7 @@ use crate::{
         c_ushort,
         c_void,
     },
-    pthread::pthread_mutex_type::PTHREAD_MUTEX_NORMAL,
+    pthread::pthread_mutex_type::PTHREAD_MUTEX_DEFAULT,
     sched::{
         sched_param,
         sched_policy::SCHED_OTHER,
@@ -245,13 +245,25 @@ impl pthread_mutexattr_t {
     /// Size of `pthread_mutexattr_t` structure.
     pub const SIZE: usize =
         Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_TYPE + Self::SIZE_OF_RECURSIVE;
+
+    /// Returns the mutex type stored in the attributes object.
+    pub fn type_(&self) -> c_int {
+        self.type_
+    }
+
+    /// Sets the mutex type stored in the attributes object.
+    pub fn set_type(&mut self, type_: c_int) {
+        self.type_ = type_;
+        self.recursive = (type_ == crate::pthread::pthread_mutex_type::PTHREAD_MUTEX_RECURSIVE)
+            as crate::ffi::c_int;
+    }
 }
 
 impl Default for pthread_mutexattr_t {
     fn default() -> Self {
         Self {
             is_initialized: 1,
-            type_: PTHREAD_MUTEX_NORMAL,
+            type_: PTHREAD_MUTEX_DEFAULT,
             recursive: 0,
         }
     }

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -42,6 +42,9 @@ extern void test_thread_local(void);
 // Tests if pthread attributes can be initialized and destroyed.
 extern void test_pthread_attr_init_destroy(void);
 
+// Tests if the mutex type attribute can be set and retrieved.
+extern void test_pthread_mutexattr_settype(void);
+
 // Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
 extern void test_pthread_getattr_np_destroy(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -115,6 +115,7 @@ int main(int argc, const char *argv[])
     test_pthread_create_join();
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();
+    test_pthread_mutexattr_settype();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
     test_pthread_rwlock_static_init();

--- a/src/tests/integration/test-c-thread/mutexattr_settype.c
+++ b/src/tests/integration/test-c-thread/mutexattr_settype.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// A mutex type that is not supported by the implementation.
+#define INVALID_MUTEX_TYPE 1000
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Asserts that a mutex type can be set and read back from a mutex attributes object.
+static void assert_roundtrip(pthread_mutexattr_t *attr, int wanted)
+{
+    int got = -1;
+    int ret = pthread_mutexattr_settype(attr, wanted);
+    assert(ret == 0);
+    ret = pthread_mutexattr_gettype(attr, &got);
+    assert(ret == 0);
+    assert(got == wanted);
+
+    // Setting the type must mirror PTHREAD_MUTEX_RECURSIVE onto the recursive flag.
+    assert(attr->recursive == (wanted == PTHREAD_MUTEX_RECURSIVE));
+}
+
+// Tests if the mutex type attribute can be set and retrieved.
+void test_pthread_mutexattr_settype(void)
+{
+    fprintf(stderr, "testing pthread_mutexattr_settype() and pthread_mutexattr_gettype() ... ");
+
+    // Initialize the mutex attributes object and assert operation.
+    pthread_mutexattr_t attr = {
+        .type = INVALID_MUTEX_TYPE,
+        .recursive = 1,
+    };
+    int ret = pthread_mutexattr_init(&attr);
+    assert(ret == 0);
+
+    // Initialization must overwrite caller-provided storage with default values.
+    assert(attr.is_initialized != 0);
+    assert(attr.recursive == 0);
+
+    int type = -1;
+    ret = pthread_mutexattr_gettype(&attr, &type);
+    assert(ret == 0);
+    assert(type == PTHREAD_MUTEX_DEFAULT);
+
+    // Each supported mutex type must round-trip through set/get.
+    assert_roundtrip(&attr, PTHREAD_MUTEX_NORMAL);
+    assert_roundtrip(&attr, PTHREAD_MUTEX_RECURSIVE);
+    assert_roundtrip(&attr, PTHREAD_MUTEX_ERRORCHECK);
+    assert_roundtrip(&attr, PTHREAD_MUTEX_DEFAULT);
+
+    // An unsupported type must be rejected and must leave the stored type unchanged.
+    ret = pthread_mutexattr_settype(&attr, INVALID_MUTEX_TYPE);
+    assert(ret != 0);
+    ret = pthread_mutexattr_gettype(&attr, &type);
+    assert(ret == 0);
+    assert(type == PTHREAD_MUTEX_DEFAULT);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_mutexattr_init(NULL);
+    assert(ret != 0);
+    ret = pthread_mutexattr_settype(NULL, PTHREAD_MUTEX_NORMAL);
+    assert(ret != 0);
+    ret = pthread_mutexattr_gettype(NULL, &type);
+    assert(ret != 0);
+    ret = pthread_mutexattr_gettype(&attr, NULL);
+    assert(ret != 0);
+
+    // Destroy the mutex attributes object and assert operation.
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## What

Implements the POSIX mutex type attribute accessors and wires them through
the `sysapi`/libc surface:

- **libc_pthread:** add `pthread_mutexattr_settype()` and
  `pthread_mutexattr_gettype()` FFI entry points. `settype()` validates the
  requested type and stores it (mirroring it onto the recursive flag);
  `gettype()` reads it back. Both reject invalid pointers.
  `pthread_mutexattr_init()` now actually initializes the object with
  default values instead of being a no-op.
- **sysapi:** add `type_()` / `set_type()` accessors on
  `pthread_mutexattr_t`, and change the default mutex type from
  `PTHREAD_MUTEX_NORMAL` to `PTHREAD_MUTEX_DEFAULT`.
- **Headers:** declare the two new functions in `pthread.toml` and
  regenerate `include/pthread.h`.

## Why

The mutex attribute object previously had no way to set or query its type,
and `pthread_mutexattr_init()` left caller-provided storage untouched.
These changes fill that gap and align default initialization with the
distinct `PTHREAD_MUTEX_DEFAULT` value.

## Tests

Adds `thread-c/mutexattr_settype.c` and registers it in the `thread-c`
suite. It covers set/get round-trips for every supported type, the default
type after `init()`, rejection of unsupported types, and invalid-pointer
handling.