### PR TITLE
[libc_sys_ioctl] Add ioctl encoding macros

### DIFF
--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -43,6 +43,41 @@ struct winsize {
 #define FIONREAD 0x541b
 
 /*==================================================================================================
+ * Request Encoding
+ *==================================================================================================*/
+
+/*
+ * Request-number encoding macros, compatible with the Linux/i386 `_IOC`
+ * scheme. Nanvix device drivers use the fixed request numbers above; these
+ * macros are provided so that portable software (which constructs request
+ * numbers with `_IO`/`_IOR`/`_IOW`/`_IOWR`) compiles and links. Requests built
+ * this way that Nanvix does not recognize are ignored: `ioctl()` returns 0
+ * without acting on the device.
+ */
+#define _IOC_NRBITS   8
+#define _IOC_TYPEBITS 8
+#define _IOC_SIZEBITS 14
+#define _IOC_DIRBITS  2
+
+#define _IOC_NRSHIFT   0
+#define _IOC_TYPESHIFT (_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_SIZESHIFT (_IOC_TYPESHIFT + _IOC_TYPEBITS)
+#define _IOC_DIRSHIFT  (_IOC_SIZESHIFT + _IOC_SIZEBITS)
+
+#define _IOC_NONE  0U
+#define _IOC_WRITE 1U
+#define _IOC_READ  2U
+
+#define _IOC(dir, type, nr, size) \
+    (((dir) << _IOC_DIRSHIFT) | ((type) << _IOC_TYPESHIFT) | \
+     ((nr) << _IOC_NRSHIFT) | ((size) << _IOC_SIZESHIFT))
+
+#define _IO(type, nr)         _IOC(_IOC_NONE, (type), (nr), 0)
+#define _IOR(type, nr, size)  _IOC(_IOC_READ, (type), (nr), sizeof(size))
+#define _IOW(type, nr, size)  _IOC(_IOC_WRITE, (type), (nr), sizeof(size))
+#define _IOWR(type, nr, size) _IOC(_IOC_READ | _IOC_WRITE, (type), (nr), sizeof(size))
+
+/*==================================================================================================
  * Functions
  *==================================================================================================*/
 

--- a/src/libs/sysapi/headers/sys_ioctl.toml
+++ b/src/libs/sysapi/headers/sys_ioctl.toml
@@ -12,7 +12,7 @@ ports. In standalone mode the terminal-attribute and window-size requests
 backend; hosted deployments have no guest terminal device and ignore them.'''
 guard = "_NANVIX_SYS_IOCTL_H"
 scan_crates = ["libc_sys_ioctl"]
-content_order = ["raw:0", "raw:1", "section:0"]
+content_order = ["raw:0", "raw:1", "raw:2", "section:0"]
 
 [[raw_sections]]
 title = "Structures"
@@ -33,6 +33,40 @@ text = '''
 #define TIOCGWINSZ 0x5413
 #define TIOCSWINSZ 0x5414
 #define FIONREAD 0x541b'''
+
+[[raw_sections]]
+title = "Request Encoding"
+text = '''
+/*
+ * Request-number encoding macros, compatible with the Linux/i386 `_IOC`
+ * scheme. Nanvix device drivers use the fixed request numbers above; these
+ * macros are provided so that portable software (which constructs request
+ * numbers with `_IO`/`_IOR`/`_IOW`/`_IOWR`) compiles and links. Requests built
+ * this way that Nanvix does not recognize are ignored: `ioctl()` returns 0
+ * without acting on the device.
+ */
+#define _IOC_NRBITS   8
+#define _IOC_TYPEBITS 8
+#define _IOC_SIZEBITS 14
+#define _IOC_DIRBITS  2
+
+#define _IOC_NRSHIFT   0
+#define _IOC_TYPESHIFT (_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_SIZESHIFT (_IOC_TYPESHIFT + _IOC_TYPEBITS)
+#define _IOC_DIRSHIFT  (_IOC_SIZESHIFT + _IOC_SIZEBITS)
+
+#define _IOC_NONE  0U
+#define _IOC_WRITE 1U
+#define _IOC_READ  2U
+
+#define _IOC(dir, type, nr, size) \
+    (((dir) << _IOC_DIRSHIFT) | ((type) << _IOC_TYPESHIFT) | \
+     ((nr) << _IOC_NRSHIFT) | ((size) << _IOC_SIZESHIFT))
+
+#define _IO(type, nr)         _IOC(_IOC_NONE, (type), (nr), 0)
+#define _IOR(type, nr, size)  _IOC(_IOC_READ, (type), (nr), sizeof(size))
+#define _IOW(type, nr, size)  _IOC(_IOC_WRITE, (type), (nr), sizeof(size))
+#define _IOWR(type, nr, size) _IOC(_IOC_READ | _IOC_WRITE, (type), (nr), sizeof(size))'''
 
 [[sections]]
 title = "Functions"


### PR DESCRIPTION
## What

Add the Linux/i386-compatible `_IOC` request-number encoding macros to
`sys/ioctl.h` so portable software that constructs request numbers with
`_IO`/`_IOR`/`_IOW`/`_IOWR` compiles and links against Nanvix.

## Why

Nanvix device drivers use a fixed set of request numbers, but third-party
POSIX software commonly builds request codes through the `_IOC` family of
macros. Without these macros such code fails to compile. Requests built this
way that Nanvix does not recognize are ignored: `ioctl()` returns `0` without
acting on the device, preserving the existing permissive behavior.

## Changes

- **Libraries:** Extend `src/libs/sysapi/headers/sys_ioctl.toml` with a
  "Request Encoding" raw section defining the `_IOC_*` bit/shift/direction
  constants and the `_IOC`/`_IO`/`_IOR`/`_IOW`/`_IOWR` macros, and register it
  in `content_order`.
- **Build:** Regenerate `include/sys/ioctl.h` from the spec.

## Validation

- `gen-headers-check`, unit, in-kernel, integration, smoke, and POSIX tests pass.
- C syntax check of `#include <sys/ioctl.h>` exercising `_IO`/`_IOR`/`_IOW`/`_IOWR`.