### PR TITLE
[libc_sys_socket] Add AF_LOCAL and PF_* macros

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -29,6 +29,12 @@ extern "C" {
 #define AF_UNIX 1 /**< UNIX domain sockets. */
 #define AF_INET 2 /**< Internet domain sockets (IPv4). */
 #define AF_INET6 10 /**< Internet domain sockets (IPv6). */
+#define AF_LOCAL AF_UNIX /**< Synonym for AF_UNIX. */
+#define PF_UNSPEC AF_UNSPEC /**< Unspecified protocol family. */
+#define PF_UNIX AF_UNIX /**< UNIX domain protocol family. */
+#define PF_LOCAL AF_LOCAL /**< Synonym for PF_UNIX. */
+#define PF_INET AF_INET /**< Internet protocol family (IPv4). */
+#define PF_INET6 AF_INET6 /**< Internet protocol family (IPv6). */
 #define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
 #define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
 #define SOCK_RAW 3 /**< Raw protocol interface. */

--- a/src/libs/sysapi/headers/sys_socket.toml
+++ b/src/libs/sysapi/headers/sys_socket.toml
@@ -53,6 +53,12 @@ text = '''
 #define AF_UNIX 1 /**< UNIX domain sockets. */
 #define AF_INET 2 /**< Internet domain sockets (IPv4). */
 #define AF_INET6 10 /**< Internet domain sockets (IPv6). */
+#define AF_LOCAL AF_UNIX /**< Synonym for AF_UNIX. */
+#define PF_UNSPEC AF_UNSPEC /**< Unspecified protocol family. */
+#define PF_UNIX AF_UNIX /**< UNIX domain protocol family. */
+#define PF_LOCAL AF_LOCAL /**< Synonym for PF_UNIX. */
+#define PF_INET AF_INET /**< Internet protocol family (IPv4). */
+#define PF_INET6 AF_INET6 /**< Internet protocol family (IPv6). */
 #define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
 #define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
 #define SOCK_RAW 3 /**< Raw protocol interface. */


### PR DESCRIPTION
## Summary

Adds the standard protocol-family aliases and the `AF_LOCAL` synonym to the
`<sys/socket.h>` public header, improving POSIX source compatibility for code
that uses the `PF_*` constants.

## What changed

- Define `AF_LOCAL` as a synonym for `AF_UNIX`.
- Define `PF_UNSPEC`, `PF_UNIX`, `PF_LOCAL`, `PF_INET`, and `PF_INET6` as
  aliases of their corresponding `AF_*` values.
- Mirror the additions in `src/libs/sysapi/headers/sys_socket.toml` so the
  generated header stays in sync with `include/sys/socket.h`.

## Why

POSIX defines both the `AF_*` (address family) and `PF_*` (protocol family)
constant families. Providing the `PF_*` aliases and `AF_LOCAL` lets existing
portable code compile without modification.