### PR TITLE
[sysapi] Add byteswap.h header

### DIFF
--- a/include/byteswap.h
+++ b/include/byteswap.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_BYTESWAP_H
+#define _NANVIX_BYTESWAP_H
+
+/**
+ * @file byteswap.h
+ * @brief Byte-order swapping macros.
+ *
+ * `bswap_16()`, `bswap_32()`, and `bswap_64()` reverse the byte order of a 16-,
+ * 32-, or 64-bit integer. They map directly to the compiler's `__builtin_bswap*`
+ * intrinsics.
+ */
+
+#define bswap_16(x) __builtin_bswap16(x)
+#define bswap_32(x) __builtin_bswap32(x)
+#define bswap_64(x) __builtin_bswap64(x)
+
+#endif /* _NANVIX_BYTESWAP_H */

--- a/src/libs/sysapi/headers/byteswap.toml
+++ b/src/libs/sysapi/headers/byteswap.toml
@@ -1,0 +1,23 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for byteswap.h.
+
+file = "byteswap.h"
+brief = "Byte-order swapping macros."
+description = '''
+`bswap_16()`, `bswap_32()`, and `bswap_64()` reverse the byte order of a 16-,
+32-, or 64-bit integer. They map directly to the compiler's `__builtin_bswap*`
+intrinsics.'''
+guard = "_NANVIX_BYTESWAP_H"
+extern_c = false
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#define bswap_16(x) __builtin_bswap16(x)
+#define bswap_32(x) __builtin_bswap32(x)
+#define bswap_64(x) __builtin_bswap64(x)'''


### PR DESCRIPTION
## Summary

Adds a bundled C library `<byteswap.h>` header exposing the `bswap_16()`, `bswap_32()`, and `bswap_64()` macros, mirroring the glibc interface. Each macro forwards to the corresponding `__builtin_bswap*` intrinsic, so the byte-order reversal is emitted inline by the compiler and remains usable in integer constant expressions.

## Details

- `src/libs/sysapi/headers/byteswap.toml` — new header specification.
- `include/byteswap.h` — rendered from the spec by the `gen-headers` tool; kept in sync (verified with `gen-headers-check`).

## Validation

- Rebased on the latest `dev`.
- Reviewed by two independent AI reviewers (Claude Opus 4.8, GPT-5.5); no issues found.
- `run-unit-tests`, `run-kernel-tests`, and `run-nanvix-tests` pass.
- Pre-commit checks (format/lint/spell across all deployment configs) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>