### PR TITLE
[sysapi] Add endian.h header

### DIFF
--- a/include/endian.h
+++ b/include/endian.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ENDIAN_H
+#define _NANVIX_ENDIAN_H
+
+/**
+ * @file endian.h
+ * @brief Byte-order macros.
+ *
+ * Defines the byte-order constants (`__LITTLE_ENDIAN`, `__BIG_ENDIAN`,
+ * `__PDP_ENDIAN`) together with `__BYTE_ORDER` for the target, plus the BSD-style
+ * unprefixed aliases. The active order is derived from the compiler's
+ * `__BYTE_ORDER__` intrinsic.
+ */
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __PDP_ENDIAN 3412
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) \
+    && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define __BYTE_ORDER __BIG_ENDIAN
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_PDP_ENDIAN__) \
+    && (__BYTE_ORDER__ == __ORDER_PDP_ENDIAN__)
+#define __BYTE_ORDER __PDP_ENDIAN
+#else
+#define __BYTE_ORDER __LITTLE_ENDIAN
+#endif
+
+/* BSD-style aliases. */
+#define LITTLE_ENDIAN __LITTLE_ENDIAN
+#define BIG_ENDIAN __BIG_ENDIAN
+#define PDP_ENDIAN __PDP_ENDIAN
+#define BYTE_ORDER __BYTE_ORDER
+
+#endif /* _NANVIX_ENDIAN_H */

--- a/src/libs/sysapi/headers/endian.toml
+++ b/src/libs/sysapi/headers/endian.toml
@@ -1,0 +1,38 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for endian.h.
+
+file = "endian.h"
+brief = "Byte-order macros."
+description = '''
+Defines the byte-order constants (`__LITTLE_ENDIAN`, `__BIG_ENDIAN`,
+`__PDP_ENDIAN`) together with `__BYTE_ORDER` for the target, plus the BSD-style
+unprefixed aliases. The active order is derived from the compiler's
+`__BYTE_ORDER__` intrinsic.'''
+guard = "_NANVIX_ENDIAN_H"
+extern_c = false
+content_order = ["raw:0"]
+
+[[raw_sections]]
+title = ""
+text = '''
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __PDP_ENDIAN 3412
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) \
+    && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define __BYTE_ORDER __BIG_ENDIAN
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_PDP_ENDIAN__) \
+    && (__BYTE_ORDER__ == __ORDER_PDP_ENDIAN__)
+#define __BYTE_ORDER __PDP_ENDIAN
+#else
+#define __BYTE_ORDER __LITTLE_ENDIAN
+#endif
+
+/* BSD-style aliases. */
+#define LITTLE_ENDIAN __LITTLE_ENDIAN
+#define BIG_ENDIAN __BIG_ENDIAN
+#define PDP_ENDIAN __PDP_ENDIAN
+#define BYTE_ORDER __BYTE_ORDER'''


### PR DESCRIPTION
## Summary

Adds a bundled C library `<endian.h>` header defining the byte-order constants `__LITTLE_ENDIAN`, `__BIG_ENDIAN`, and `__PDP_ENDIAN`, deriving `__BYTE_ORDER` for the target from the compiler's `__BYTE_ORDER__` intrinsic, and exposing the BSD-style unprefixed aliases (`LITTLE_ENDIAN`, `BIG_ENDIAN`, `PDP_ENDIAN`, `BYTE_ORDER`).

## Details

- `src/libs/sysapi/headers/endian.toml` — new header specification.
- `include/endian.h` — rendered from the spec by `gen-headers`; kept in sync (verified with `gen-headers-check`).

## Validation

- Rebased on the latest `dev`.
- Reviewed by two independent AI reviewers (Claude Opus 4.8, GPT-5.5); big-endian detection verified, no name clashes, no issues found.
- `run-unit-tests`, `run-kernel-tests`, and `run-nanvix-tests` pass.
- Pre-commit checks (format/lint/spell across all deployment configs) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>