### PR TITLE
[sysapi] Add features.h header

### DIFF
--- a/include/features.h
+++ b/include/features.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_FEATURES_H
+#define _NANVIX_FEATURES_H
+
+/**
+ * @file features.h
+ * @brief Feature-test macro gateway.
+ *
+ * Reserved for feature-test macro definitions. The Nanvix libc exposes its full
+ * interface unconditionally, so this header currently defines no macros; it
+ * exists so that translation units which include <features.h> compile cleanly.
+ */
+
+#endif /* _NANVIX_FEATURES_H */

--- a/src/libs/sysapi/headers/features.toml
+++ b/src/libs/sysapi/headers/features.toml
@@ -1,0 +1,13 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for features.h.
+
+file = "features.h"
+brief = "Feature-test macro gateway."
+description = '''
+Reserved for feature-test macro definitions. The Nanvix libc exposes its full
+interface unconditionally, so this header currently defines no macros; it
+exists so that translation units which include <features.h> compile cleanly.'''
+guard = "_NANVIX_FEATURES_H"
+extern_c = false


### PR DESCRIPTION
## Summary

Adds a bundled C library `<features.h>` header as a feature-test-macro gateway. The Nanvix libc exposes its full interface unconditionally, so the header defines no macros; it exists so that translation units which `#include <features.h>` compile cleanly.

## Details

- `src/libs/sysapi/headers/features.toml` — new header specification (body-less).
- `include/features.h` — rendered from the spec by `gen-headers`; kept in sync (verified with `gen-headers-check`).

## Validation

- Rebased on the latest `dev`.
- Reviewed by two independent AI reviewers (Claude Opus 4.8, GPT-5.5); confirmed nothing in-tree relies on `<features.h>` defining macros, header renders byte-for-byte; no issues found.
- `run-unit-tests`, `run-kernel-tests`, and `run-nanvix-tests` pass.
- Pre-commit checks (format/lint/spell across all deployment configs) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>