### PR TITLE
[posix] Add glob() and globfree() stubs

### DIFF
--- a/include/glob.h
+++ b/include/glob.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_GLOB_H
+#define _NANVIX_GLOB_H
+
+/**
+ * @file glob.h
+ * @brief Pathname pattern matching.
+ *
+ * Declares the glob()/globfree() interfaces and the glob_t result structure.
+ * Nanvix does not yet implement pathname globbing, so the backing glob() always
+ * reports GLOB_NOMATCH; the declarations exist so that portable software (notably
+ * the hush shell) compiles and links.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Pathname Pattern Matching
+ *==================================================================================================*/
+
+/** @brief Result of a glob() call. */
+typedef struct {
+    size_t gl_pathc;  /**< Count of paths matched by pattern. */
+    char **gl_pathv;  /**< Null-terminated list of matched pathnames. */
+    size_t gl_offs;   /**< Reserved slots at the start of gl_pathv. */
+} glob_t;
+
+/* Flags for the glob() flags argument. */
+#define GLOB_ERR      0x0001 /**< Return on read errors. */
+#define GLOB_MARK     0x0002 /**< Append a slash to matched directories. */
+#define GLOB_NOSORT   0x0004 /**< Do not sort the matched pathnames. */
+#define GLOB_DOOFFS   0x0008 /**< Reserve gl_offs slots at the start. */
+#define GLOB_NOCHECK  0x0010 /**< Return the pattern itself on no match. */
+#define GLOB_APPEND   0x0020 /**< Append matches to an existing gl_pathv. */
+#define GLOB_NOESCAPE 0x0040 /**< Backslashes do not quote metacharacters. */
+
+/* Error returns from glob(). */
+#define GLOB_NOSPACE 1 /**< Ran out of memory. */
+#define GLOB_ABORTED 2 /**< Read error. */
+#define GLOB_NOMATCH 3 /**< No matches found. */
+#define GLOB_NOSYS   4 /**< Not implemented. */
+
+extern int glob(const char *pattern, int flags,
+                int (*errfunc)(const char *epath, int eerrno), glob_t *pglob);
+extern void globfree(glob_t *pglob);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_GLOB_H */

--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -412,3 +412,110 @@ pub unsafe extern "C" fn fdopendir(_fd: c_int) -> *mut c_void {
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
 }
+
+/// Subset of `GLOB_*` flag bits from `<glob.h>` consulted by the [`glob()`] stub.
+const GLOB_DOOFFS: c_int = 0x0008;
+const GLOB_APPEND: c_int = 0x0020;
+/// Return value from `<glob.h>` indicating that a pattern matched no paths.
+const GLOB_NOMATCH: c_int = 3;
+
+/// Mirror of the C `glob_t` result structure declared in `<glob.h>`.
+///
+/// The fields are written through a raw pointer to hand callers a well-defined empty result; they
+/// match the C ABI layout `{ size_t gl_pathc; char **gl_pathv; size_t gl_offs; }`.
+#[repr(C)]
+struct GlobT {
+    gl_pathc: usize,
+    gl_pathv: *mut *mut c_char,
+    gl_offs: usize,
+}
+
+///
+/// # Description
+///
+/// Searches for paths matching a shell wildcard pattern. Nanvix does not provide pathname globbing,
+/// so this stub reports that no paths matched.
+///
+/// # Parameters
+///
+/// - `pattern`: Null-terminated wildcard pattern (ignored).
+/// - `flags`: Bitwise-or of `GLOB_*` flags. `GLOB_APPEND` and `GLOB_DOOFFS` are honored when
+///   clearing `pglob`; all other flags are ignored.
+/// - `errfunc`: Optional error callback (ignored).
+/// - `pglob`: Pointer to a `glob_t` result structure. Cleared to an empty result when non-null
+///   and `GLOB_APPEND` is not set.
+///
+/// # Returns
+///
+/// `GLOB_NOMATCH` (3), indicating that the pattern matched no paths. Callers such as the hush shell
+/// then treat the pattern as a literal string.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always reports no match; behavioral flags such as
+/// `GLOB_NOCHECK` (which would otherwise return the pattern itself) are not honored. A future
+/// version should expand the pattern using `fnmatch()` over directory entries and populate
+/// `pglob->gl_pathv` / `pglob->gl_pathc`.
+///
+/// # Safety
+///
+/// `pglob` must be either null or a valid, writable pointer to a `glob_t`. When `GLOB_DOOFFS`
+/// is set (and `GLOB_APPEND` is not), the caller must also have initialized `gl_offs`, which is
+/// read before the structure is rewritten. `pattern` and `errfunc` are ignored.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn glob(
+    _pattern: *const c_char,
+    flags: c_int,
+    _errfunc: Option<extern "C" fn(epath: *const c_char, eerrno: c_int) -> c_int>,
+    pglob: *mut c_void,
+) -> c_int {
+    ::syslog::debug!("glob(): not implemented");
+
+    // glibc and the BSDs leave `gl_pathc`/`gl_pathv` in a well-defined empty state even on a
+    // no-match, so portable callers may inspect them without pre-zeroing the structure. Mirror
+    // that contract to avoid exposing uninitialized memory. An existing result list is preserved
+    // when GLOB_APPEND is set, and a caller-provided `gl_offs` is preserved under GLOB_DOOFFS.
+    if !pglob.is_null() && (flags & GLOB_APPEND) == 0 {
+        let pglob: *mut GlobT = pglob.cast();
+        let gl_offs: usize = if (flags & GLOB_DOOFFS) != 0 {
+            (*pglob).gl_offs
+        } else {
+            0
+        };
+        core::ptr::write(
+            pglob,
+            GlobT {
+                gl_pathc: 0,
+                gl_pathv: core::ptr::null_mut(),
+                gl_offs,
+            },
+        );
+    }
+
+    // Report that the pattern matched nothing so callers such as the hush shell fall back to
+    // treating the pattern as a literal string. Returning GLOB_NOSYS would instead be fatal for
+    // such callers, so GLOB_NOMATCH is intentional.
+    GLOB_NOMATCH
+}
+
+///
+/// # Description
+///
+/// Frees the dynamic storage allocated by a successful [`glob()`] call. Because [`glob()`] never
+/// allocates (it always reports no match), this is a no-op.
+///
+/// # Parameters
+///
+/// - `pglob`: Pointer to the `glob_t` structure to release (ignored).
+///
+/// # Safety
+///
+/// This function is safe to call with any argument; it does nothing.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn globfree(_pglob: *mut c_void) {
+    ::syslog::debug!("globfree(): not implemented");
+}

--- a/src/libs/sysapi/headers/glob.toml
+++ b/src/libs/sysapi/headers/glob.toml
@@ -1,0 +1,44 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for glob.h.
+
+file = "glob.h"
+brief = "Pathname pattern matching."
+description = '''
+Declares the glob()/globfree() interfaces and the glob_t result structure.
+Nanvix does not yet implement pathname globbing, so the backing glob() always
+reports GLOB_NOMATCH; the declarations exist so that portable software (notably
+the hush shell) compiles and links.'''
+includes = ["stddef.h"]
+guard = "_NANVIX_GLOB_H"
+content_order = ["raw:0"]
+
+[[raw_sections]]
+title = "Pathname Pattern Matching"
+text = '''
+/** @brief Result of a glob() call. */
+typedef struct {
+    size_t gl_pathc;  /**< Count of paths matched by pattern. */
+    char **gl_pathv;  /**< Null-terminated list of matched pathnames. */
+    size_t gl_offs;   /**< Reserved slots at the start of gl_pathv. */
+} glob_t;
+
+/* Flags for the glob() flags argument. */
+#define GLOB_ERR      0x0001 /**< Return on read errors. */
+#define GLOB_MARK     0x0002 /**< Append a slash to matched directories. */
+#define GLOB_NOSORT   0x0004 /**< Do not sort the matched pathnames. */
+#define GLOB_DOOFFS   0x0008 /**< Reserve gl_offs slots at the start. */
+#define GLOB_NOCHECK  0x0010 /**< Return the pattern itself on no match. */
+#define GLOB_APPEND   0x0020 /**< Append matches to an existing gl_pathv. */
+#define GLOB_NOESCAPE 0x0040 /**< Backslashes do not quote metacharacters. */
+
+/* Error returns from glob(). */
+#define GLOB_NOSPACE 1 /**< Ran out of memory. */
+#define GLOB_ABORTED 2 /**< Read error. */
+#define GLOB_NOMATCH 3 /**< No matches found. */
+#define GLOB_NOSYS   4 /**< Not implemented. */
+
+extern int glob(const char *pattern, int flags,
+                int (*errfunc)(const char *epath, int eerrno), glob_t *pglob);
+extern void globfree(glob_t *pglob);'''


### PR DESCRIPTION
## Summary

Adds a bundled libc `<glob.h>` and dummy `glob()`/`globfree()` implementations so that portable software — notably the busybox `hush` shell — compiles and links against Nanvix.

- The header is specified in `src/libs/sysapi/headers/glob.toml` and rendered to `include/glob.h` by `gen-headers`. It declares the `glob_t` result structure, the `GLOB_*` flag and error constants (values matching glibc), and the `glob()`/`globfree()` prototypes.
- `glob()` and `globfree()` are implemented as stubs in `src/libs/posix/src/dummy.rs`.

## Behavior

Nanvix does not yet implement pathname globbing, so `glob()` reports `GLOB_NOMATCH`; callers such as `hush` then treat the pattern as a literal string. (Returning `GLOB_NOSYS` would be fatal for such callers, so `GLOB_NOMATCH` is intentional.)

To honor the glibc/BSD contract and avoid exposing uninitialized memory, `glob()` clears the caller's `glob_t` to a well-defined empty result, preserving an existing list under `GLOB_APPEND` and the reserved `gl_offs` slots under `GLOB_DOOFFS`. `globfree()` is a no-op because `glob()` never allocates.

## Reviews

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents. Findings addressed:
- Zero-initialize `*pglob` on no-match to match the glibc/BSD empty-result contract (was previously left untouched).
- Documented the `gl_offs` initialization requirement under `GLOB_DOOFFS` in the `# Safety` section.
- Documented that behavioral flags such as `GLOB_NOCHECK` are not honored by the stub.

## Testing

- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` — all unit, in-kernel, and integration tests pass.
- `gen-headers-check` confirms `include/glob.h` is in sync with `glob.toml`.
- Pre-commit hooks (format-check, lint-check, spellcheck across standalone, single-process, and multi-process configurations) pass.