### PR TITLE
[sysapi] Add Network Interface Header

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_NET_IF_H
+#define _NANVIX_NET_IF_H
+
+/**
+ * @file net/if.h
+ * @brief Network interface name limits.
+ *
+ * Defines `IF_NAMESIZE`/`IFNAMSIZ`, the maximum length of a network interface
+ * name including the terminating null byte, and `struct if_nameindex`, which
+ * pairs an interface index with its name.
+ */
+
+#define IF_NAMESIZE 16
+#define IFNAMSIZ IF_NAMESIZE
+
+struct if_nameindex {
+    unsigned int if_index;
+    char *if_name;
+};
+
+#endif /* _NANVIX_NET_IF_H */

--- a/src/libs/sysapi/headers/net_if.toml
+++ b/src/libs/sysapi/headers/net_if.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for net/if.h.
+
+file = "net/if.h"
+brief = "Network interface name limits."
+description = '''
+Defines `IF_NAMESIZE`/`IFNAMSIZ`, the maximum length of a network interface
+name including the terminating null byte, and `struct if_nameindex`, which
+pairs an interface index with its name.'''
+guard = "_NANVIX_NET_IF_H"
+extern_c = false
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#define IF_NAMESIZE 16
+#define IFNAMSIZ IF_NAMESIZE
+
+struct if_nameindex {
+    unsigned int if_index;
+    char *if_name;
+};'''


### PR DESCRIPTION
## Summary

Adds a bundled libc `<net/if.h>` so that portable software compiles against Nanvix.

The header is specified in `src/libs/sysapi/headers/net_if.toml` and rendered to `include/net/if.h` by `gen-headers`. It defines:

- `IF_NAMESIZE` (16) and its `IFNAMSIZ` alias — the maximum length of a network interface name including the terminating null byte (matches Linux).
- `struct if_nameindex { unsigned int if_index; char *if_name; }` — pairs an interface index with its name.

## Scope

The POSIX `if_nametoindex()` / `if_indextoname()` / `if_nameindex()` / `if_freenameindex()` functions are intentionally omitted: Nanvix has no networking back end for them, and declaring them without an implementation would turn consumer references into link errors rather than clearer compile-time diagnostics.

## Reviews

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents — both returned clean with no findings. Verified: `IF_NAMESIZE == 16` matches Linux; `struct if_nameindex` field order/types match POSIX; i686 layout is offset0=`if_index`(4B), offset4=`if_name`(4B), size 8 align 4 (no padding); include guard unique; no `#include` needed; `extern "C"` correctly omitted (consistent with other type/macro-only bundled headers).

## Testing

- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` — all unit, in-kernel, and integration tests pass.
- `gen-headers-check` confirms `include/net/if.h` is in sync with `net_if.toml`.
- Pre-commit hooks (format-check, lint-check, spellcheck across standalone, single-process, and multi-process configurations) pass.