### PR TITLE
[sysapi] Add Default Paths Header

### DIFF
--- a/include/paths.h
+++ b/include/paths.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_PATHS_H
+#define _NANVIX_PATHS_H
+
+/**
+ * @file paths.h
+ * @brief Default path prefixes for system files and directories.
+ *
+ * Defines the `_PATH_*` string constants that name the conventional locations of
+ * system files and directories and the default executable search paths.
+ */
+
+#define _PATH_DEFPATH "/usr/bin:/bin"
+#define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
+#define _PATH_BSHELL "/bin/sh"
+#define _PATH_CSHELL "/bin/csh"
+#define _PATH_CONSOLE "/dev/console"
+#define _PATH_DEVNULL "/dev/null"
+#define _PATH_TTY "/dev/tty"
+#define _PATH_DEV "/dev/"
+#define _PATH_TMP "/tmp/"
+#define _PATH_MOUNTED "/etc/mtab"
+#define _PATH_MNTTAB "/etc/fstab"
+#define _PATH_NOLOGIN "/etc/nologin"
+#define _PATH_SHELLS "/etc/shells"
+#define _PATH_WTMP "/var/log/wtmp"
+#define _PATH_UTMP "/var/run/utmp"
+#define _PATH_LASTLOG "/var/log/lastlog"
+
+#endif /* _NANVIX_PATHS_H */

--- a/src/libs/sysapi/headers/paths.toml
+++ b/src/libs/sysapi/headers/paths.toml
@@ -1,0 +1,35 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for paths.h.
+
+file = "paths.h"
+brief = "Default path prefixes for system files and directories."
+description = '''
+Defines the `_PATH_*` string constants that name the conventional locations of
+system files and directories and the default executable search paths.'''
+guard = "_NANVIX_PATHS_H"
+extern_c = false
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#define _PATH_DEFPATH "/usr/bin:/bin"
+#define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
+#define _PATH_BSHELL "/bin/sh"
+#define _PATH_CSHELL "/bin/csh"
+#define _PATH_CONSOLE "/dev/console"
+#define _PATH_DEVNULL "/dev/null"
+#define _PATH_TTY "/dev/tty"
+#define _PATH_DEV "/dev/"
+#define _PATH_TMP "/tmp/"
+#define _PATH_MOUNTED "/etc/mtab"
+#define _PATH_MNTTAB "/etc/fstab"
+#define _PATH_NOLOGIN "/etc/nologin"
+#define _PATH_SHELLS "/etc/shells"
+#define _PATH_WTMP "/var/log/wtmp"
+#define _PATH_UTMP "/var/run/utmp"
+#define _PATH_LASTLOG "/var/log/lastlog"'''


### PR DESCRIPTION
## Summary

Adds a bundled libc `<paths.h>` (the BSD-style header of `_PATH_*` default-location string constants) so that portable software compiles against Nanvix.

The header is specified in `src/libs/sysapi/headers/paths.toml` and rendered to `include/paths.h` by `gen-headers`. It defines the conventional `_PATH_*` macros for the default executable search paths, the shells, common `/dev` nodes, the temporary directory, the `/etc` mount/login tables, and the `/var` accounting logs:

`_PATH_DEFPATH`, `_PATH_STDPATH`, `_PATH_BSHELL`, `_PATH_CSHELL`, `_PATH_CONSOLE`, `_PATH_DEVNULL`, `_PATH_TTY`, `_PATH_DEV`, `_PATH_TMP`, `_PATH_MOUNTED`, `_PATH_MNTTAB`, `_PATH_NOLOGIN`, `_PATH_SHELLS`, `_PATH_WTMP`, `_PATH_UTMP`, `_PATH_LASTLOG`.

All values follow the conventional glibc/BSD definitions (including the trailing slashes on `_PATH_DEV` and `_PATH_TMP`, and the BSD `_PATH_MNTTAB`=`/etc/fstab` / `_PATH_MOUNTED`=`/etc/mtab` distinction). The header exists so portable software compiles and links; whether a given path resolves at runtime is the consumer's concern, matching how glibc ships `<paths.h>` regardless of which files exist.

## Reviews

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents. Both verified all values against the canonical glibc `<paths.h>`. Acting on their feedback that the initial subset omitted some high-value constants, the set was expanded to add `_PATH_CSHELL`, `_PATH_TMP`, `_PATH_NOLOGIN`, and `_PATH_SHELLS` for broader compile-compatibility.

## Testing

- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` — all unit, in-kernel, and integration tests pass.
- `gen-headers-check` confirms `include/paths.h` is in sync with `paths.toml`.
- Pre-commit hooks (format-check, lint-check, spellcheck across standalone, single-process, and multi-process configurations) pass.