### PR TITLE
[libc_sys_stat] Add mkfifo() Stub

### DIFF
--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -98,6 +98,7 @@ extern int fstat(int fd, struct stat *buf);
 extern int lstat(const char *pathname, struct stat *statbuf);
 extern int mkdir(const char *pathname, mode_t mode);
 extern int mkdirat(int dirfd, const char *pathname, mode_t mode);
+extern int mkfifo(const char *path, mode_t mode);
 extern mode_t umask(mode_t mask);
 extern int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags);
 extern int lchmod(const char *pathname, mode_t mode);

--- a/src/libs/libc_sys_stat/src/lib.rs
+++ b/src/libs/libc_sys_stat/src/lib.rs
@@ -439,6 +439,40 @@ pub unsafe extern "C" fn mknod(path: *const c_char, mode: mode_t, dev: dev_t) ->
 ///
 /// # Description
 ///
+/// Creates a new FIFO special file named `path`. Nanvix does not support FIFO special files, so
+/// the call always fails.
+///
+/// # Parameters
+///
+/// - `path`: Pathname of the FIFO to create.
+/// - `mode`: Permission bits of the new FIFO.
+///
+/// # Returns
+///
+/// The `mkfifo()` function always returns `-1` and sets `errno` to `ENOSYS` because the operation
+/// is not supported on Nanvix.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference a raw pointer.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `path` points to a valid null-terminated C string.
+///
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[trace_syscall]
+pub unsafe extern "C" fn mkfifo(path: *const c_char, mode: mode_t) -> c_int {
+    // Nanvix does not support FIFO special files; the arguments are unused.
+    let _ = (path, mode);
+    ::syslog::debug!("mkfifo(): not supported");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
 /// Sets the calling process's file mode creation mask (umask).
 ///
 /// # Parameters

--- a/src/libs/sysapi/headers/sys_stat.toml
+++ b/src/libs/sysapi/headers/sys_stat.toml
@@ -86,6 +86,7 @@ functions = [
     "lstat",
     "mkdir",
     "mkdirat",
+    "mkfifo",
     "umask",
     "fchmodat",
     "lchmod",


### PR DESCRIPTION
## Summary

Adds the POSIX `mkfifo()` function to the bundled libc so that portable software that creates FIFO special files compiles and links against Nanvix.

Nanvix does not provide FIFO special files and has no `mkfifo` system call, so this is a **stub** modeled on the adjacent `mknod()` stub: it logs that the operation is not supported, sets `errno` to `ENOSYS` (`ErrorCode::InvalidSysCall`), and returns `-1`.

## Changes

- **`src/libs/libc_sys_stat/src/lib.rs`** — new `#[no_mangle] extern "C" fn mkfifo(path: *const c_char, mode: mode_t) -> c_int` stub, faithfully mirroring `mknod` (tracing, doc comments, errno/return behavior).
- **`src/libs/sysapi/headers/sys_stat.toml`** — adds `"mkfifo"` to the `functions` list (no override needed; the scanned Rust signature is already canonical).
- **`include/sys/stat.h`** *(generated)* — `gen-headers` renders `extern int mkfifo(const char *path, mode_t mode);` from the new Rust signature.

> Note: the original branch declared `mkfifo` in the header/toml but shipped **no implementation**, leaving `gen-headers --check` failing with an unresolved placeholder. This PR supplies the missing stub so the header generator resolves the prototype and the tree is back in sync.

## Validation

- `gen-headers --check` → **all headers up to date**.
- `cargo clippy -p libc_sys_stat` (i686, `no_std`) → **clean** under `-D warnings`.
- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` → **pass** (unit, in-kernel, integration).
- Pre-commit hooks (format/lint/spell across standalone, single-process, multi-process) → **3/3 passed**.

## Review

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents — both reported **no significant issues**; signature/ABI, stub correctness, and header/symbol wiring independently verified.
