### PR TITLE
[syscall] Add msync() Binding

### DIFF
--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -33,6 +33,9 @@ extern "C" {
 #define MAP_PRIVATE 0x02 /**< Changes are private. */
 #define MAP_FIXED 0x10 /**< Interpret the address exactly. */
 #define MAP_ANONYMOUS 0x20 /**< Anonymous mapping (not backed by a file). */
+#define MS_ASYNC 0x1 /**< Perform asynchronous writes. */
+#define MS_INVALIDATE 0x2 /**< Invalidate cached copies of mapped data. */
+#define MS_SYNC 0x4 /**< Perform synchronous writes. */
 
 /** @brief Returned by mmap() on failure. */
 #define MAP_FAILED ((void *)-1)
@@ -56,6 +59,12 @@ extern int mprotect(void *addr, size_t length, int prot);
 
 extern int mlock(const void *addr, size_t len);
 extern int munlock(const void *addr, size_t len);
+
+/*==================================================================================================
+ * Memory Synchronization
+ *==================================================================================================*/
+
+extern int msync(void *addr, size_t length, int flags);
 
 #ifdef __cplusplus
 }

--- a/src/libs/sysapi/headers/sys_mman.toml
+++ b/src/libs/sysapi/headers/sys_mman.toml
@@ -14,7 +14,7 @@ interfaces. Constants mirror the Rust definitions in the sysapi crate
 includes = ["sys/types.h"]
 guard = "_NANVIX_SYS_MMAN_H"
 scan_crates = ["syscall"]
-content_order = ["macros", "raw:0", "section:0", "section:1", "section:2"]
+content_order = ["macros", "raw:0", "section:0", "section:1", "section:2", "section:3"]
 
 [[macros]]
 name = "PROT_NONE"
@@ -56,6 +56,21 @@ name = "MAP_ANONYMOUS"
 value = "0x20"
 comment = "Anonymous mapping (not backed by a file)."
 
+[[macros]]
+name = "MS_ASYNC"
+value = "0x1"
+comment = "Perform asynchronous writes."
+
+[[macros]]
+name = "MS_INVALIDATE"
+value = "0x2"
+comment = "Invalidate cached copies of mapped data."
+
+[[macros]]
+name = "MS_SYNC"
+value = "0x4"
+comment = "Perform synchronous writes."
+
 [[raw_sections]]
 title = ""
 text = """
@@ -73,6 +88,7 @@ munmap = "extern int munmap(void *addr, size_t length);"
 mprotect = "extern int mprotect(void *addr, size_t length, int prot);"
 mlock = "extern int mlock(const void *addr, size_t len);"
 munlock = "extern int munlock(const void *addr, size_t len);"
+msync = "extern int msync(void *addr, size_t length, int flags);"
 
 [[sections]]
 title = "Memory Protection"
@@ -81,3 +97,7 @@ functions = ["mprotect"]
 [[sections]]
 title = "Memory Locking"
 functions = ["mlock", "munlock"]
+
+[[sections]]
+title = "Memory Synchronization"
+functions = ["msync"]

--- a/src/libs/sysapi/src/sys_mman.rs
+++ b/src/libs/sysapi/src/sys_mman.rs
@@ -33,3 +33,14 @@ pub mod flags {
 
 /// Used to indicate a failure in `mmap()`.
 pub const MAP_FAILED: *mut u8 = -1isize as *mut u8;
+
+pub mod msync_flags {
+    use crate::ffi::c_int;
+
+    /// Perform asynchronous writes.
+    pub const MS_ASYNC: c_int = 0x1;
+    /// Invalidate cached copies of mapped data.
+    pub const MS_INVALIDATE: c_int = 0x2;
+    /// Perform synchronous writes.
+    pub const MS_SYNC: c_int = 0x4;
+}

--- a/src/libs/syscall/src/sys/mman/bindings/mod.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/mod.rs
@@ -13,10 +13,11 @@ pub mod mprotect;
 #[cfg(feature = "syscall")]
 pub mod munmap;
 
-// `mlock()` and `munlock()` are no-ops after range validation. They share the host-testable helpers
-// below, so they are compiled under the relaxed module gate (see the parent module) rather than
-// being restricted to the `syscall` feature.
+// `mlock()`, `munlock()`, and `msync()` are no-ops after argument validation. They share the
+// host-testable helpers below, so they are compiled under the relaxed module gate (see the parent
+// module) rather than being restricted to the `syscall` feature.
 pub mod mlock;
+pub mod msync;
 pub mod munlock;
 
 //==================================================================================================

--- a/src/libs/syscall/src/sys/mman/bindings/msync.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/msync.rs
@@ -1,0 +1,185 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#[cfg(feature = "syscall")]
+use crate::{
+    errno::__errno_location,
+    sys::mman,
+};
+#[cfg(any(feature = "syscall", test))]
+use ::sys::error::ErrorCode;
+#[cfg(feature = "syscall")]
+use ::sys::mm::VirtualAddress;
+#[cfg(any(feature = "syscall", test))]
+use ::sysapi::ffi::c_int;
+#[cfg(feature = "syscall")]
+use ::sysapi::ffi::c_void;
+#[cfg(any(feature = "syscall", test))]
+use ::sysapi::sys_mman::msync_flags::{
+    MS_ASYNC,
+    MS_INVALIDATE,
+    MS_SYNC,
+};
+#[cfg(feature = "syscall")]
+use ::sysapi::sys_types::c_size_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Validates the flags supplied to the `msync()` binding.
+///
+/// POSIX requires `flags` to specify exactly one synchronization mode, `MS_ASYNC` or `MS_SYNC`,
+/// optionally combined with `MS_INVALIDATE`. Any other combination, including no synchronization
+/// mode at all or unknown bits, is rejected.
+///
+/// # Parameters
+///
+/// - `flags`: Synchronization flags supplied by the caller.
+///
+/// # Returns
+///
+/// Returns `Ok(())` if `flags` is a valid combination, otherwise the `ErrorCode` to report via
+/// `errno`.
+///
+#[cfg(any(feature = "syscall", test))]
+fn validate_msync_flags(flags: c_int) -> Result<(), ErrorCode> {
+    // Reject any bit outside the set of recognized flags.
+    const KNOWN: c_int = MS_ASYNC | MS_INVALIDATE | MS_SYNC;
+    if flags & !KNOWN != 0 {
+        return Err(ErrorCode::InvalidArgument);
+    }
+
+    // Exactly one synchronization mode must be requested.
+    let mode: c_int = flags & (MS_ASYNC | MS_SYNC);
+    if mode != MS_ASYNC && mode != MS_SYNC {
+        return Err(ErrorCode::InvalidArgument);
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Synchronizes the whole pages containing any part of the address range that starts at `addr` and
+/// spans `length` bytes with their backing store.
+///
+/// Nanvix backs every mapping with anonymous physical memory, so the in-memory contents are always
+/// the authoritative copy and there is nothing to write back. This function therefore validates its
+/// arguments and reports success without performing any I/O.
+///
+/// # Parameters
+///
+/// - `addr`: Start address of the region to synchronize.
+/// - `length`: Number of bytes to synchronize.
+/// - `flags`: Synchronization flags (`MS_ASYNC`, `MS_SYNC`, and optionally `MS_INVALIDATE`).
+///
+/// # Returns
+///
+/// On success, returns `0`. On failure, returns `-1` and sets `errno` to indicate the error:
+/// - `EINVAL`: `flags` is invalid, or `addr` is not a multiple of the page size.
+/// - `ENOMEM`: the range extends past the end of the address space, or some page in the range is
+///   not mapped.
+///
+/// # Safety
+///
+/// This function is unsafe because it may modify `errno`. It is safe to call provided that access
+/// to `errno` is synchronized with other threads that may modify it.
+///
+/// # Known Limitations (Nanvix)
+///
+/// - Synchronization is a no-op: mappings are anonymous and have no separate backing store.
+///
+#[cfg(feature = "syscall")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn msync(addr: *mut c_void, length: c_size_t, flags: c_int) -> c_int {
+    if let Err(code) = validate_msync_flags(flags) {
+        unsafe {
+            *__errno_location() = code.get();
+        }
+        return -1;
+    }
+
+    match super::validate_lock_range(addr as usize, length) {
+        Ok(None) => 0,
+        Ok(Some((addr, length))) => {
+            let addr: VirtualAddress = VirtualAddress::from_raw_value(addr);
+            match mman::msync(addr, length) {
+                Ok(()) => 0,
+                Err(error) => {
+                    unsafe {
+                        *__errno_location() = error.code.get();
+                    }
+                    -1
+                },
+            }
+        },
+        Err(code) => {
+            unsafe {
+                *__errno_location() = code.get();
+            }
+            -1
+        },
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::validate_msync_flags;
+    use ::sys::error::ErrorCode;
+    use ::sysapi::sys_mman::msync_flags::{
+        MS_ASYNC,
+        MS_INVALIDATE,
+        MS_SYNC,
+    };
+
+    /// A lone `MS_SYNC` flag is accepted.
+    #[test]
+    fn accepts_ms_sync() {
+        assert_eq!(validate_msync_flags(MS_SYNC), Ok(()));
+    }
+
+    /// A lone `MS_ASYNC` flag is accepted.
+    #[test]
+    fn accepts_ms_async() {
+        assert_eq!(validate_msync_flags(MS_ASYNC), Ok(()));
+    }
+
+    /// A synchronization mode combined with `MS_INVALIDATE` is accepted.
+    #[test]
+    fn accepts_mode_with_invalidate() {
+        assert_eq!(validate_msync_flags(MS_SYNC | MS_INVALIDATE), Ok(()));
+    }
+
+    /// Specifying no synchronization mode is rejected.
+    #[test]
+    fn rejects_no_mode() {
+        assert_eq!(validate_msync_flags(0), Err(ErrorCode::InvalidArgument));
+        assert_eq!(validate_msync_flags(MS_INVALIDATE), Err(ErrorCode::InvalidArgument));
+    }
+
+    /// Specifying both synchronization modes is rejected.
+    #[test]
+    fn rejects_both_modes() {
+        assert_eq!(validate_msync_flags(MS_ASYNC | MS_SYNC), Err(ErrorCode::InvalidArgument));
+    }
+
+    /// An unknown flag bit is rejected.
+    #[test]
+    fn rejects_unknown_bit() {
+        let unknown: ::sysapi::ffi::c_int = MS_ASYNC | MS_INVALIDATE | MS_SYNC | 0x100;
+        assert_eq!(validate_msync_flags(unknown), Err(ErrorCode::InvalidArgument));
+    }
+}

--- a/src/libs/syscall/src/sys/mman/mod.rs
+++ b/src/libs/syscall/src/sys/mman/mod.rs
@@ -34,6 +34,7 @@ cfg_if::cfg_if! {
             mmap::mmap,
             mmap_reserve,
             mprotect::mprotect,
+            msync::msync,
             munlock::munlock,
             munmap::munmap,
         };

--- a/src/libs/syscall/src/sys/mman/syscalls/mod.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mod.rs
@@ -30,6 +30,7 @@ use ::sys::{
 pub mod mlock;
 pub mod mmap;
 pub mod mprotect;
+pub mod msync;
 pub mod munlock;
 pub mod munmap;
 

--- a/src/libs/syscall/src/sys/mman/syscalls/msync.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/msync.rs
@@ -1,0 +1,39 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::sys::mman::syscalls::validate_mapped_lock_range;
+use ::sys::{
+    error::Error,
+    mm::VirtualAddress,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Synchronizes a mapped address range with its backing store.
+///
+/// Nanvix backs every mapping with anonymous physical memory and never caches mapped pages in a
+/// separate store, so the in-memory contents are always the authoritative copy. Synchronizing a
+/// range therefore has nothing to write back, and this function only validates that the requested
+/// range is currently mapped.
+///
+/// # Parameters
+///
+/// - `addr`: Page-aligned base address of the range to synchronize.
+/// - `length`: Page-rounded length of the range to synchronize.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+pub fn msync(addr: VirtualAddress, length: usize) -> Result<(), Error> {
+    validate_mapped_lock_range("msync", addr, length)
+}


### PR DESCRIPTION
## Summary

Adds the POSIX `msync()` function to the bundled libc (`<sys/mman.h>`), along with the `MS_ASYNC`, `MS_INVALIDATE`, and `MS_SYNC` flag macros, so that portable software that flushes memory-mapped regions compiles and links against Nanvix.

Nanvix backs every mapping with anonymous physical memory and never caches mapped pages in a separate store, so the in-memory contents are always the authoritative copy and there is nothing to write back. `msync()` therefore validates its flags and address range and reports success without performing any I/O — mirroring the existing `mlock()`/`munlock()` no-op bindings.

## Behavior

- **Flag validation (POSIX):** exactly one of `MS_ASYNC` or `MS_SYNC` must be requested, optionally combined with `MS_INVALIDATE`; any other combination (including no mode, `MS_INVALIDATE`-only, or unknown bits) is rejected with `EINVAL`.
- **Range validation:** uses the shared lock-range helpers, so misaligned, out-of-range, or unmapped requests fail with `EINVAL`/`ENOMEM` exactly like `mlock()`/`munlock()`.
- On success returns `0`; on failure returns `-1` and sets `errno`.

## Changes

- `src/libs/sysapi/src/sys_mman.rs` — new `msync_flags` module (`MS_ASYNC`/`MS_INVALIDATE`/`MS_SYNC`).
- `src/libs/syscall/src/sys/mman/bindings/msync.rs` *(new)* — C-ABI entry point + `validate_msync_flags` helper + unit tests.
- `src/libs/syscall/src/sys/mman/syscalls/msync.rs` *(new)* — inner implementation validating the mapped range.
- `src/libs/syscall/src/sys/mman/{mod.rs,bindings/mod.rs,syscalls/mod.rs}` — module wiring / re-export.
- `src/libs/sysapi/headers/sys_mman.toml` — macros, prototype, and "Memory Synchronization" section.
- `include/sys/mman.h` *(generated)* — `extern int msync(void *addr, size_t length, int flags);` + `MS_*` macros, rendered by `gen-headers`.

## Validation

- `gen-headers --check` → **all headers up to date**.
- `cargo clippy -p syscall` / `-p sysapi` (i686 guest + host `std` configs) → **clean** under `-D warnings`.
- New `validate_msync_flags` unit tests (accept async/sync/sync|invalidate; reject none/invalidate-only/both/unknown-bit) → **pass**.
- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` → **pass** (unit, in-kernel, integration).
- Pre-commit hooks (format/lint/spell across standalone, single-process, multi-process) → **3/3 passed**.

## Review

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents — both reported **no significant issues**; flag semantics, ABI, errno discipline, macro/const consistency, feature-gate hygiene, and module wiring independently verified across both CI configs.
