### PR TITLE
[sysapi] Add sys/statvfs.h Header

### DIFF
--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_STATVFS_H
+#define _NANVIX_SYS_STATVFS_H
+
+/**
+ * @file sys/statvfs.h
+ * @brief File-system information.
+ *
+ * Declares the statvfs()/fstatvfs() interfaces and the struct statvfs they
+ * populate. Nanvix does not yet expose per-file-system statistics, so the backing
+ * implementations are stubs that fail with ENOSYS; the declarations exist so that
+ * portable software which queries file-system geometry compiles and links.
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * File-System Information
+ *==================================================================================================*/
+
+/** @brief File-system information. */
+struct statvfs {
+    unsigned long f_bsize;   /**< File-system block size.                 */
+    unsigned long f_frsize;  /**< Fundamental file-system block size.     */
+    fsblkcnt_t    f_blocks;  /**< Total blocks (in f_frsize units).       */
+    fsblkcnt_t    f_bfree;   /**< Total free blocks.                      */
+    fsblkcnt_t    f_bavail;  /**< Free blocks available to non-superuser.  */
+    fsfilcnt_t    f_files;   /**< Total file nodes (inodes).              */
+    fsfilcnt_t    f_ffree;   /**< Total free file nodes (inodes).         */
+    fsfilcnt_t    f_favail;  /**< Free file nodes for non-superuser.      */
+    unsigned long f_fsid;    /**< File-system identifier.                 */
+    unsigned long f_flag;    /**< Bitwise-or of ST_* mount flags.         */
+    unsigned long f_namemax; /**< Maximum filename length.                */
+};
+
+/* f_flag bits. */
+#define ST_RDONLY 1 /**< Read-only file system. */
+#define ST_NOSUID 2 /**< Set-user/group-ID bits ignored on exec. */
+
+extern int statvfs(const char *path, struct statvfs *buf);
+extern int fstatvfs(int fd, struct statvfs *buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_STATVFS_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -50,6 +50,8 @@ typedef int ssize_t;
 /* File-system and process types. */
 typedef long long blkcnt_t;          /**< File block counts.              */
 typedef long long blksize_t;         /**< Block sizes.                    */
+typedef unsigned long fsblkcnt_t;    /**< File-system block counts.       */
+typedef unsigned long fsfilcnt_t;    /**< File-system file counts.        */
 typedef unsigned long long dev_t;    /**< Device IDs.                     */
 typedef unsigned int gid_t;          /**< Group IDs.                      */
 typedef unsigned long long ino_t;    /**< File serial numbers.            */

--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -519,3 +519,38 @@ pub unsafe extern "C" fn glob(
 pub unsafe extern "C" fn globfree(_pglob: *mut c_void) {
     ::syslog::debug!("globfree(): not implemented");
 }
+
+///
+/// # Description
+///
+/// Retrieves file-system statistics for the file system that contains the open file
+/// referred to by `fd` and stores them in the `statvfs` structure pointed to by `buf`.
+///
+/// # Parameters
+///
+/// - `fd`: An open file descriptor referring to any file within the queried file system.
+/// - `buf`: Pointer to a `struct statvfs` to be filled in on success.
+///
+/// # Returns
+///
+/// On success returns `0` and populates `*buf`. On failure returns `-1` and sets `errno`.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not
+/// implemented). It mirrors [`statvfs()`] and exists so that portable software which
+/// references the symbol compiles and links; such callers treat the `-1`/`errno` failure
+/// as "information unavailable". A future implementation should query the backing
+/// file-system daemon.
+///
+/// # Safety
+///
+/// This function is safe to call with any arguments; it ignores `fd` and `buf`.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn fstatvfs(_fd: c_int, _buf: *mut c_void) -> c_int {
+    ::syslog::debug!("fstatvfs(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}

--- a/src/libs/sysapi/headers/sys_statvfs.toml
+++ b/src/libs/sysapi/headers/sys_statvfs.toml
@@ -1,0 +1,40 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/statvfs.h.
+
+file = "sys/statvfs.h"
+brief = "File-system information."
+description = '''
+Declares the statvfs()/fstatvfs() interfaces and the struct statvfs they
+populate. Nanvix does not yet expose per-file-system statistics, so the backing
+implementations are stubs that fail with ENOSYS; the declarations exist so that
+portable software which queries file-system geometry compiles and links.'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_STATVFS_H"
+content_order = ["raw:0"]
+
+[[raw_sections]]
+title = "File-System Information"
+text = '''
+/** @brief File-system information. */
+struct statvfs {
+    unsigned long f_bsize;   /**< File-system block size.                 */
+    unsigned long f_frsize;  /**< Fundamental file-system block size.     */
+    fsblkcnt_t    f_blocks;  /**< Total blocks (in f_frsize units).       */
+    fsblkcnt_t    f_bfree;   /**< Total free blocks.                      */
+    fsblkcnt_t    f_bavail;  /**< Free blocks available to non-superuser.  */
+    fsfilcnt_t    f_files;   /**< Total file nodes (inodes).              */
+    fsfilcnt_t    f_ffree;   /**< Total free file nodes (inodes).         */
+    fsfilcnt_t    f_favail;  /**< Free file nodes for non-superuser.      */
+    unsigned long f_fsid;    /**< File-system identifier.                 */
+    unsigned long f_flag;    /**< Bitwise-or of ST_* mount flags.         */
+    unsigned long f_namemax; /**< Maximum filename length.                */
+};
+
+/* f_flag bits. */
+#define ST_RDONLY 1 /**< Read-only file system. */
+#define ST_NOSUID 2 /**< Set-user/group-ID bits ignored on exec. */
+
+extern int statvfs(const char *path, struct statvfs *buf);
+extern int fstatvfs(int fd, struct statvfs *buf);'''

--- a/src/libs/sysapi/headers/sys_types.toml
+++ b/src/libs/sysapi/headers/sys_types.toml
@@ -41,6 +41,8 @@ typedef int ssize_t;
 /* File-system and process types. */
 typedef long long blkcnt_t;          /**< File block counts.              */
 typedef long long blksize_t;         /**< Block sizes.                    */
+typedef unsigned long fsblkcnt_t;    /**< File-system block counts.       */
+typedef unsigned long fsfilcnt_t;    /**< File-system file counts.        */
 typedef unsigned long long dev_t;    /**< Device IDs.                     */
 typedef unsigned int gid_t;          /**< Group IDs.                      */
 typedef unsigned long long ino_t;    /**< File serial numbers.            */

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -17,6 +17,7 @@ use crate::{
         c_long,
         c_longlong,
         c_uint,
+        c_ulong,
         c_ulonglong,
         c_ushort,
         c_void,
@@ -54,6 +55,12 @@ pub type clockid_t = c_int;
 
 /// Used for device IDs.
 pub type dev_t = c_ulonglong;
+
+/// Used for file-system block counts.
+pub type fsblkcnt_t = c_ulong;
+
+/// Used for file-system file (node) counts.
+pub type fsfilcnt_t = c_ulong;
 
 /// Used for group IDs.
 pub type gid_t = c_uint;


### PR DESCRIPTION
## Summary

Adds a bundled `<sys/statvfs.h>` header so that portable software which queries file-system geometry compiles and links against Nanvix. The header declares `struct statvfs`, the `ST_RDONLY`/`ST_NOSUID` mount-flag macros, and the `statvfs()`/`fstatvfs()` interfaces.

Nanvix does not yet expose per-file-system statistics, so the backing implementations are dummy stubs that fail with `ENOSYS`; callers treat the `-1`/`errno` failure as "information unavailable". `statvfs()` already existed in the POSIX layer — this change adds the companion `fstatvfs()` stub.

To match the POSIX definition of `struct statvfs`, the `fsblkcnt_t` and `fsfilcnt_t` typedefs are added to `<sys/types.h>` and used for the block/file count members, so that conforming source referencing those types compiles.

## Changes

- `src/libs/sysapi/headers/sys_statvfs.toml` *(new)* — spec rendered into `include/sys/statvfs.h`.
- `src/libs/sysapi/headers/sys_types.toml` — add `fsblkcnt_t`/`fsfilcnt_t` typedefs (rendered into `include/sys/types.h`).
- `src/libs/posix/src/dummy.rs` — add the `fstatvfs()` dummy stub.
- `include/sys/statvfs.h`, `include/sys/types.h` *(generated)*.

## Review changes vs. the original branch

The original branch also added `statfs()`/`fstatfs()` stubs. These were **dropped**: they are non-POSIX (Linux-specific), no header declared them, and they referenced a `struct statfs` that exists in no Nanvix header — i.e. an unusable "half API". Code-review (below) flagged this; the result is a focused, coherent POSIX `statvfs` change. `statfs`/`fstatfs` can be added later with a proper `<sys/vfs.h>` and `struct statfs`.

## Validation

- `gen-headers --check` → **all headers up to date**.
- `codespell` on changed files → **clean**.
- `./z build -- run-unit-tests run-kernel-tests run-nanvix-tests` → **pass** (unit, in-kernel, integration).
- Pre-commit hooks (format/lint/spell across standalone, single-process, multi-process) → **3/3 passed**.

## Review

Reviewed with **Claude Opus 4.8** (max effort) and **GPT-5.5** (xhigh effort) code-review subagents. Findings addressed:
- **(Medium)** `statfs`/`fstatfs` undeclared + undefined `struct statfs` → **dropped** the stubs (both reviewers endorsed drop-or-add-header; dropping keeps the change POSIX-focused).
- **(Medium/should-fix)** `struct statvfs` should use `fsblkcnt_t`/`fsfilcnt_t` → **added** the typedefs and used them.
- **(Low)** `fstatvfs` `# Safety` doc claimed a dereference it never performs → **corrected** to match the no-op contract.
