### PR TITLE
[nanvix_libc] Add cfsetspeed/cfmakeraw/tcgetsid

### DIFF
--- a/include/termios.h
+++ b/include/termios.h
@@ -237,10 +237,13 @@ extern int tcsendbreak(int fd, int duration);
 extern int tcdrain(int fd);
 extern int tcflush(int fd, int queue_selector);
 extern int tcflow(int fd, int action);
+extern pid_t tcgetsid(int fd);
 extern speed_t cfgetispeed(const struct termios *termios_p);
 extern speed_t cfgetospeed(const struct termios *termios_p);
 extern int cfsetispeed(struct termios *termios_p, speed_t speed);
 extern int cfsetospeed(struct termios *termios_p, speed_t speed);
+extern int cfsetspeed(struct termios *termios_p, speed_t speed);
+extern void cfmakeraw(struct termios *termios_p);
 
 #ifdef __cplusplus
 }

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -67,7 +67,10 @@ use ::sysapi::{
         c_uint,
         c_void,
     },
-    sys_types::c_size_t,
+    sys_types::{
+        c_size_t,
+        pid_t,
+    },
 };
 
 /// Thread-local errno storage (single-threaded: a plain static suffices).
@@ -381,6 +384,75 @@ pub extern "C" fn cfsetispeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int 
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub extern "C" fn cfsetospeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
     0
+}
+
+/// Stub `cfsetspeed` — sets both input and output line speed. No terminal hardware, so this is a
+/// no-op success.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn cfsetspeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
+    0
+}
+
+/// `cfmakeraw` — places the terminal attributes pointed to by `termios_p` in "raw" mode.
+///
+/// Unlike line-speed configuration, this is a pure in-memory transformation of the caller's
+/// `struct termios` and requires no terminal hardware. It clears canonical input (`ICANON`), echo
+/// (`ECHO`), signal generation (`ISIG`), extended input processing (`IEXTEN`), CR-to-NL mapping
+/// (`ICRNL`), start/stop output control (`IXON`), and output post-processing (`OPOST`), then sets a
+/// one-byte, no-timeout non-canonical read (`VMIN = 1`, `VTIME = 0`) — the flags honored by the
+/// vfsd console line discipline. A null pointer is ignored.
+///
+/// # Safety
+///
+/// `termios_p` must be null or point to a valid, writable `struct termios`; a non-null pointer is
+/// dereferenced and overwritten.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfmakeraw(termios_p: *mut c_void) {
+    use ::sysapi::termios::{
+        Termios,
+        ECHO,
+        ICANON,
+        ICRNL,
+        IEXTEN,
+        ISIG,
+        IXON,
+        OPOST,
+        VMIN,
+        VTIME,
+    };
+
+    if termios_p.is_null() {
+        return;
+    }
+
+    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
+    let termios: &mut Termios = unsafe { &mut *(termios_p as *mut Termios) };
+    termios.c_iflag &= !(ICRNL | IXON);
+    termios.c_oflag &= !OPOST;
+    termios.c_lflag &= !(ICANON | ECHO | ISIG | IEXTEN);
+    termios.c_cc[VMIN] = 1;
+    termios.c_cc[VTIME] = 0;
+}
+
+/// `tcgetsid` — returns the session ID of the terminal referred to by `fd`.
+///
+/// Nanvix has no sessions or process groups, so a process is treated as its own session leader:
+/// when `fd` refers to a terminal, the returned session ID is the caller's process ID. If `fd` does
+/// not refer to a terminal, returns `-1` with `errno` set, as reported by `isatty`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcgetsid(fd: c_int) -> pid_t {
+    extern "C" {
+        fn isatty(fd: c_int) -> c_int;
+        fn getpid() -> pid_t;
+    }
+
+    // SAFETY: FFI to the runtime `isatty`, which validates `fd` and sets `errno` on error.
+    if unsafe { isatty(fd) } == 0 {
+        return -1 as pid_t;
+    }
+
+    // SAFETY: FFI to the runtime `getpid`, which has no preconditions.
+    unsafe { getpid() }
 }
 
 //==================================================================================================

--- a/src/libs/sysapi/headers/termios.toml
+++ b/src/libs/sysapi/headers/termios.toml
@@ -230,10 +230,13 @@ functions = [
     "tcdrain",
     "tcflush",
     "tcflow",
+    "tcgetsid",
     "cfgetispeed",
     "cfgetospeed",
     "cfsetispeed",
     "cfsetospeed",
+    "cfsetspeed",
+    "cfmakeraw",
 ]
 
 [overrides]
@@ -257,3 +260,9 @@ cfsetispeed = '''
 extern int cfsetispeed(struct termios *termios_p, speed_t speed);'''
 cfsetospeed = '''
 extern int cfsetospeed(struct termios *termios_p, speed_t speed);'''
+cfsetspeed = '''
+extern int cfsetspeed(struct termios *termios_p, speed_t speed);'''
+cfmakeraw = '''
+extern void cfmakeraw(struct termios *termios_p);'''
+tcgetsid = '''
+extern pid_t tcgetsid(int fd);'''


### PR DESCRIPTION
## Summary

Extends the bundled `<termios.h>` with three more terminal-control functions so that portable
software which configures terminals compiles, links, and behaves correctly on Nanvix:

- **`cfsetspeed()`** — sets both input and output line speed. Nanvix's console has no configurable
  baud rate, so this is a no-op returning success, mirroring the existing
  `cfsetispeed()`/`cfsetospeed()` stubs.
- **`cfmakeraw()`** — places the caller's `struct termios` in raw mode. This is a pure in-memory
  transformation of the structure and needs no terminal hardware, so it is implemented for real:
  it clears `ICANON`, `ECHO`, `ISIG`, `IEXTEN`, `ICRNL`, `IXON`, and `OPOST` and sets
  `VMIN=1`/`VTIME=0`. These are exactly the flags honored by the vfsd console line discipline, so
  the standard `tcgetattr()` → `cfmakeraw()` → `tcsetattr()` sequence now actually switches the
  console out of canonical mode. A null pointer is ignored.
- **`tcgetsid()`** — returns the session ID of the terminal referred to by `fd`. The descriptor is
  validated with `isatty()`; a non-terminal descriptor yields `-1` with `errno` set. Nanvix has no
  sessions or process groups, so on success the calling process is treated as its own session
  leader and its process ID (`getpid()`) is returned.

## Changes

- `src/libs/nanvix_libc/src/lib.rs`: add the three implementations and import `pid_t`.
- `src/libs/sysapi/headers/termios.toml`: add the functions and their explicit prototype overrides.
- `include/termios.h`: regenerated by `gen-headers`.

## Validation

- `gen-headers-check`: all headers up to date.
- `format-check`, `lint-check` (clippy `-D warnings`, all three deployment configs): clean.
- Pre-commit hook passed for all 3 configurations (standalone, single-process, multi-process).
- `run-unit-tests run-kernel-tests run-nanvix-tests`: all pass (109 `test result: ok`).

## Review

Reviewed with Claude Opus 4.8 (max effort) and GPT-5.5 (xhigh effort) code-review subagents.
Both findings were addressed:

- **`cfmakeraw` was a no-op** (GPT, medium): since `tcgetattr`/`tcsetattr` genuinely `ioctl` the
  vfsd console in standalone mode, an empty `cfmakeraw` left the console in canonical mode. It now
  performs the real in-memory raw-mode transformation. The `unsafe` qualifier and `# Safety` note
  are now accurate (the function dereferences the pointer).
- **`tcgetsid` ignored `fd`** (GPT, medium): it now validates the descriptor with `isatty()` and
  returns `-1`/`errno` for non-terminals.
- **Unwarranted `unsafe`** (Claude, low): `tcgetsid` no longer dereferences pointers, so its
  function-level `unsafe` was dropped (inner `unsafe` blocks wrap the FFI calls), matching the
  non-`unsafe` `cf*` siblings and the `pid_seed` precedent.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
