### PR TITLE
[libc_mntent] Add Mntent Library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc_mntent"
+version = "0.17.74"
+dependencies = [
+ "sysapi",
+]
+
+[[package]]
 name = "libc_netdb"
 version = "0.17.74"
 dependencies = [
@@ -2179,6 +2186,7 @@ dependencies = [
  "libc_langinfo",
  "libc_libgen",
  "libc_locale",
+ "libc_mntent",
  "libc_regex",
  "libc_setjmp",
  "libc_signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
         "src/libs/libc_langinfo",
         "src/libs/libc_libgen",
         "src/libs/libc_locale",
+        "src/libs/libc_mntent",
         "src/libs/libc_setjmp",
         "src/libs/libc_signal",
         "src/libs/libc_stdio",
@@ -283,6 +284,7 @@ libc_inttypes = { path = "src/libs/libc_inttypes", default-features = false }
 libc_langinfo = { path = "src/libs/libc_langinfo", default-features = false }
 libc_libgen = { path = "src/libs/libc_libgen", default-features = false }
 libc_locale = { path = "src/libs/libc_locale", default-features = false }
+libc_mntent = { path = "src/libs/libc_mntent", default-features = false }
 libc_setjmp = { path = "src/libs/libc_setjmp", default-features = false }
 libc_math = { path = "src/libs/libc_math", default-features = false }
 libc_regex = { path = "src/libs/libc_regex", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ ALL_GUEST_RUST_LIBS := \
 	koptions nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi \
 	syscall sysalloc syslog-macros syslog sys \
 	libc_arpa_inet libc_assert libc_ctype libc_dlfcn libc_errno libc_fnmatch \
-	libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_netdb \
+	libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_mntent libc_netdb \
 	libc_poll libc_pthread libc_pwd libc_regex libc_setjmp libc_signal \
 	libc_stdio libc_stdlib libc_string libc_sys_ioctl libc_sys_resource \
 	libc_sys_stat libc_sys_time libc_sys_times libc_sys_un libc_sys_uio \
@@ -392,7 +392,7 @@ ALL_GUEST_RUST_LIBS := \
 ALL_GUEST_RUST_LIBS_TEST_LIST := \
 	arch bitmap bump-allocator cache cmdline config elf error fat32 type-safe \
 	koptions proc raw-array nanvix-slab sorted-vec static_assert \
-	libc_assert libc_ctype libc_fnmatch libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_regex \
+	libc_assert libc_ctype libc_fnmatch libc_inttypes libc_langinfo libc_libgen libc_locale libc_math libc_mntent libc_regex \
 	libc_setjmp libc_signal libc_stdio libc_stdlib libc_string libc_time \
 	libc_wchar libc_wctype \
 	syslog-macros syslog sys mmio-tag syscall vfs

--- a/include/mntent.h
+++ b/include/mntent.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_MNTENT_H
+#define _NANVIX_MNTENT_H
+
+/**
+ * @file mntent.h
+ * @brief Filesystem table (fstab/mtab) access.
+ *
+ * Declares the structure and functions used to read and write the filesystem
+ * description files (/etc/fstab and /etc/mtab), implemented by the libc_mntent
+ * Rust crate as thin parsers layered on top of <stdio.h>.
+ */
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Paths and Options
+ *==================================================================================================*/
+
+#define MNTTAB  "/etc/fstab"
+#define MOUNTED "/etc/mtab"
+
+#define MNTTYPE_IGNORE "ignore"
+#define MNTTYPE_NFS    "nfs"
+#define MNTTYPE_SWAP   "swap"
+
+#define MNTOPT_DEFAULTS "defaults"
+#define MNTOPT_RO       "ro"
+#define MNTOPT_RW       "rw"
+#define MNTOPT_SUID     "suid"
+#define MNTOPT_NOSUID   "nosuid"
+#define MNTOPT_NOAUTO   "noauto"
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Filesystem table entry. */
+struct mntent {
+    char *mnt_fsname; /**< Device or remote filesystem.  */
+    char *mnt_dir;    /**< Mount point.                  */
+    char *mnt_type;   /**< Filesystem type.              */
+    char *mnt_opts;   /**< Comma-separated mount options.*/
+    int mnt_freq;     /**< Dump frequency in days.       */
+    int mnt_passno;   /**< Pass number on parallel fsck. */
+};
+
+/*==================================================================================================
+ * Filesystem Table Access
+ *==================================================================================================*/
+
+extern FILE *setmntent(const char *filename, const char *type);
+extern struct mntent *getmntent(FILE *stream);
+extern struct mntent *getmntent_r(FILE *stream, struct mntent *result, char *buffer, int bufsize);
+extern int addmntent(FILE *stream, const struct mntent *mnt);
+extern int endmntent(FILE *stream);
+extern char *hasmntopt(const struct mntent *mnt, const char *opt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_MNTENT_H */

--- a/src/libs/libc_mntent/Cargo.toml
+++ b/src/libs/libc_mntent/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "libc_mntent"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+sysapi = { workspace = true }
+
+[features]
+default = []
+# Enables the use of the Rust Standard Library.
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/libc_mntent/header.toml
+++ b/src/libs/libc_mntent/header.toml
@@ -1,0 +1,68 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for mntent.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/mntent.h.
+
+file = "mntent.h"
+brief = "Filesystem table (fstab/mtab) access."
+description = """
+Declares the structure and functions used to read and write the filesystem
+description files (/etc/fstab and /etc/mtab), implemented by the libc_mntent
+Rust crate as thin parsers layered on top of <stdio.h>."""
+includes = ["stdio.h"]
+guard = "_NANVIX_MNTENT_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+    "section:0",
+]
+
+[[raw_sections]]
+title = "Paths and Options"
+text = '''
+#define MNTTAB  "/etc/fstab"
+#define MOUNTED "/etc/mtab"
+
+#define MNTTYPE_IGNORE "ignore"
+#define MNTTYPE_NFS    "nfs"
+#define MNTTYPE_SWAP   "swap"
+
+#define MNTOPT_DEFAULTS "defaults"
+#define MNTOPT_RO       "ro"
+#define MNTOPT_RW       "rw"
+#define MNTOPT_SUID     "suid"
+#define MNTOPT_NOSUID   "nosuid"
+#define MNTOPT_NOAUTO   "noauto"'''
+
+[[raw_sections]]
+title = "Types"
+text = '''
+/** @brief Filesystem table entry. */
+struct mntent {
+    char *mnt_fsname; /**< Device or remote filesystem.  */
+    char *mnt_dir;    /**< Mount point.                  */
+    char *mnt_type;   /**< Filesystem type.              */
+    char *mnt_opts;   /**< Comma-separated mount options.*/
+    int mnt_freq;     /**< Dump frequency in days.       */
+    int mnt_passno;   /**< Pass number on parallel fsck. */
+};'''
+
+[[sections]]
+title = "Filesystem Table Access"
+functions = ["setmntent", "getmntent", "getmntent_r", "addmntent", "endmntent", "hasmntopt"]
+
+[overrides]
+setmntent = '''
+extern FILE *setmntent(const char *filename, const char *type);'''
+getmntent = '''
+extern struct mntent *getmntent(FILE *stream);'''
+getmntent_r = '''
+extern struct mntent *getmntent_r(FILE *stream, struct mntent *result, char *buffer, int bufsize);'''
+addmntent = '''
+extern int addmntent(FILE *stream, const struct mntent *mnt);'''
+endmntent = '''
+extern int endmntent(FILE *stream);'''
+hasmntopt = '''
+extern char *hasmntopt(const struct mntent *mnt, const char *opt);'''

--- a/src/libs/libc_mntent/src/lib.rs
+++ b/src/libs/libc_mntent/src/lib.rs
@@ -1,0 +1,425 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Crate Configuration
+//==================================================================================================
+
+// Attributes
+#![cfg_attr(not(feature = "std"), no_std)]
+// Lints
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod parse;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Opaque standard I/O stream, defined by `<stdio.h>`. Only ever handled through a pointer.
+#[repr(C)]
+pub struct CFile {
+    _opaque: [u8; 0],
+}
+
+/// A filesystem table entry, mirroring the C `struct mntent`.
+#[repr(C)]
+pub struct Mntent {
+    /// Device or remote filesystem.
+    pub mnt_fsname: *mut c_char,
+    /// Mount point.
+    pub mnt_dir: *mut c_char,
+    /// Filesystem type.
+    pub mnt_type: *mut c_char,
+    /// Comma-separated mount options.
+    pub mnt_opts: *mut c_char,
+    /// Dump frequency in days.
+    pub mnt_freq: c_int,
+    /// Pass number on parallel fsck.
+    pub mnt_passno: c_int,
+}
+
+//==================================================================================================
+// `<stdio.h>` Backend
+//==================================================================================================
+
+// These are provided by `libc_stdio` and resolved when the libc archive is linked.
+#[cfg(not(test))]
+extern "C" {
+    fn fopen(pathname: *const c_char, mode: *const c_char) -> *mut CFile;
+    fn fclose(stream: *mut CFile) -> c_int;
+    fn fgets(s: *mut c_char, size: c_int, stream: *mut CFile) -> *mut c_char;
+    fn fputc(c: c_int, stream: *mut CFile) -> c_int;
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Capacity of the static line buffer used by the non-reentrant [`getmntent`].
+#[cfg(not(test))]
+const LINE_CAPACITY: usize = 4096;
+/// Capacity of the static line buffer expressed as a C `int`.
+#[cfg(not(test))]
+const LINE_CAPACITY_INT: c_int = 4096;
+
+/// ASCII space, as a C `int` for [`fputc`].
+#[cfg(not(test))]
+const SPACE: c_int = b' ' as c_int;
+/// ASCII newline, as a C `int` for [`fputc`].
+#[cfg(not(test))]
+const NEWLINE: c_int = b'\n' as c_int;
+/// ASCII minus sign, as a C `int` for [`fputc`].
+#[cfg(not(test))]
+const MINUS: c_int = b'-' as c_int;
+/// ASCII digit zero, as a C `int` for [`fputc`].
+#[cfg(not(test))]
+const DIGIT_ZERO: c_int = b'0' as c_int;
+/// ASCII backslash, as a C `int` for [`fputc`].
+#[cfg(not(test))]
+const BACKSLASH: c_int = b'\\' as c_int;
+
+//==================================================================================================
+// Non-Reentrant State
+//==================================================================================================
+
+/// Line buffer backing the non-reentrant [`getmntent`].
+#[cfg(not(test))]
+static mut LINE_BUFFER: [c_char; LINE_CAPACITY] = [0; LINE_CAPACITY];
+
+/// Entry storage backing the non-reentrant [`getmntent`].
+#[cfg(not(test))]
+static mut STATIC_ENTRY: Mntent = Mntent {
+    mnt_fsname: core::ptr::null_mut(),
+    mnt_dir: core::ptr::null_mut(),
+    mnt_type: core::ptr::null_mut(),
+    mnt_opts: core::ptr::null_mut(),
+    mnt_freq: 0,
+    mnt_passno: 0,
+};
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Opens the filesystem description file `filename` for reading or writing, returning a stream
+/// suitable for use with [`getmntent`], [`addmntent`], and [`endmntent`].
+///
+/// # Parameters
+///
+/// - `filename`: Path to the filesystem description file (e.g. `/etc/fstab`).
+/// - `type`: Access mode, as understood by `fopen()` (e.g. `"r"` or `"a"`).
+///
+/// # Return Value
+///
+/// A stream pointer on success, or a null pointer on error.
+///
+/// # Safety
+///
+/// `filename` and `type` must be valid null-terminated C strings.
+///
+#[cfg(not(test))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn setmntent(filename: *const c_char, r#type: *const c_char) -> *mut CFile {
+    fopen(filename, r#type)
+}
+
+///
+/// # Description
+///
+/// Closes the filesystem description file stream opened by [`setmntent`].
+///
+/// # Parameters
+///
+/// - `stream`: Stream returned by [`setmntent`].
+///
+/// # Return Value
+///
+/// Always returns `1`, as mandated by the interface.
+///
+/// # Safety
+///
+/// `stream` must be null or a stream previously returned by [`setmntent`].
+///
+#[cfg(not(test))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn endmntent(stream: *mut CFile) -> c_int {
+    if !stream.is_null() {
+        fclose(stream);
+    }
+    1
+}
+
+///
+/// # Description
+///
+/// Reads the next entry from a filesystem description file stream, storing the result in a
+/// statically allocated structure that is overwritten on each call.
+///
+/// # Parameters
+///
+/// - `stream`: Stream returned by [`setmntent`].
+///
+/// # Return Value
+///
+/// A pointer to a [`Mntent`] on success, or a null pointer at end of file.
+///
+/// # Safety
+///
+/// `stream` must be a stream previously returned by [`setmntent`]. The returned pointer aliases
+/// shared static storage and must not be used across threads or concurrent calls.
+///
+#[cfg(not(test))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getmntent(stream: *mut CFile) -> *mut Mntent {
+    let entry: *mut Mntent = core::ptr::addr_of_mut!(STATIC_ENTRY);
+    let buffer: *mut c_char = core::ptr::addr_of_mut!(LINE_BUFFER).cast::<c_char>();
+    getmntent_r(stream, entry, buffer, LINE_CAPACITY_INT)
+}
+
+///
+/// # Description
+///
+/// Reentrant variant of [`getmntent`]: reads the next entry into the caller-provided structure,
+/// using `buffer` to hold the parsed field strings.
+///
+/// # Parameters
+///
+/// - `stream`: Stream returned by [`setmntent`].
+/// - `result`: Destination structure.
+/// - `buffer`: Scratch buffer that backs the field strings in `result`.
+/// - `bufsize`: Size of `buffer`, in bytes.
+///
+/// # Return Value
+///
+/// `result` on success, or a null pointer at end of file or on invalid arguments.
+///
+/// # Safety
+///
+/// All pointers must be valid, and `buffer` must be writable for `bufsize` bytes.
+///
+#[cfg(not(test))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getmntent_r(
+    stream: *mut CFile,
+    result: *mut Mntent,
+    buffer: *mut c_char,
+    bufsize: c_int,
+) -> *mut Mntent {
+    if stream.is_null() || result.is_null() || buffer.is_null() || bufsize <= 1 {
+        return core::ptr::null_mut();
+    }
+
+    loop {
+        if fgets(buffer, bufsize, stream).is_null() {
+            return core::ptr::null_mut();
+        }
+        if parse::parse_line(buffer, result) {
+            return result;
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Appends a filesystem table entry to a stream opened for writing by [`setmntent`].
+///
+/// # Parameters
+///
+/// - `stream`: Stream opened for appending.
+/// - `mnt`: Entry to write.
+///
+/// # Return Value
+///
+/// `0` on success, or `1` on error. It is an error for any of the four mandatory string fields
+/// (`mnt_fsname`, `mnt_dir`, `mnt_type`, `mnt_opts`) to be null or empty, as such an entry could not
+/// be read back by [`getmntent`].
+///
+/// # Safety
+///
+/// `stream` must be writable, and `mnt` must point to a valid [`Mntent`] whose string fields are
+/// valid null-terminated C strings (or null).
+///
+#[cfg(not(test))]
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn addmntent(stream: *mut CFile, mnt: *const Mntent) -> c_int {
+    if stream.is_null() || mnt.is_null() {
+        return 1;
+    }
+    let entry: &Mntent = &*mnt;
+    if field_is_empty(entry.mnt_fsname)
+        || field_is_empty(entry.mnt_dir)
+        || field_is_empty(entry.mnt_type)
+        || field_is_empty(entry.mnt_opts)
+    {
+        return 1;
+    }
+    if write_field(stream, entry.mnt_fsname) != 0
+        || fputc(SPACE, stream) < 0
+        || write_field(stream, entry.mnt_dir) != 0
+        || fputc(SPACE, stream) < 0
+        || write_field(stream, entry.mnt_type) != 0
+        || fputc(SPACE, stream) < 0
+        || write_field(stream, entry.mnt_opts) != 0
+        || fputc(SPACE, stream) < 0
+        || write_int(stream, entry.mnt_freq) != 0
+        || fputc(SPACE, stream) < 0
+        || write_int(stream, entry.mnt_passno) != 0
+        || fputc(NEWLINE, stream) < 0
+    {
+        return 1;
+    }
+    0
+}
+
+///
+/// # Description
+///
+/// Searches the option list of `mnt` for the option named `opt`.
+///
+/// # Parameters
+///
+/// - `mnt`: Entry whose `mnt_opts` field is searched.
+/// - `opt`: Null-terminated option name to look for.
+///
+/// # Return Value
+///
+/// A pointer to the matching option within `mnt_opts`, or a null pointer when absent.
+///
+/// # Safety
+///
+/// `mnt` must be null or valid, and `opt` must be a valid null-terminated C string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn hasmntopt(mnt: *const Mntent, opt: *const c_char) -> *mut c_char {
+    if mnt.is_null() {
+        return core::ptr::null_mut();
+    }
+    parse::option_search((*mnt).mnt_opts, opt)
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns `true` when `field` is null or points to an empty string, i.e. when it is not a valid
+/// mandatory field value for [`addmntent`].
+#[cfg(not(test))]
+unsafe fn field_is_empty(field: *const c_char) -> bool {
+    field.is_null() || *field == 0
+}
+
+/// Writes a single (possibly null) field to `stream`, octal-escaping the characters that are
+/// significant to the line format (space, tab, newline, and backslash) as glibc does, so that the
+/// entry can be read back by [`getmntent`]. Returns `0` on success or `1` on error.
+#[cfg(not(test))]
+unsafe fn write_field(stream: *mut CFile, field: *const c_char) -> c_int {
+    if field.is_null() {
+        return 0;
+    }
+    let mut i: usize = 0;
+    loop {
+        let c: c_char = *field.add(i);
+        if c == 0 {
+            return 0;
+        }
+        let byte: u8 = u8::from_ne_bytes(c.to_ne_bytes());
+        if matches!(byte, b' ' | b'\t' | b'\n' | b'\\') {
+            if write_octal_escape(stream, byte) != 0 {
+                return 1;
+            }
+        } else if fputc(c_int::from(byte), stream) < 0 {
+            return 1;
+        }
+        i += 1;
+    }
+}
+
+/// Writes `byte` as a three-digit octal escape sequence (`\NNN`) to `stream`, returning `0` on
+/// success or `1` on error.
+#[cfg(not(test))]
+unsafe fn write_octal_escape(stream: *mut CFile, byte: u8) -> c_int {
+    let d0: c_int = c_int::from((byte >> 6) & 0o7);
+    let d1: c_int = c_int::from((byte >> 3) & 0o7);
+    let d2: c_int = c_int::from(byte & 0o7);
+    if fputc(BACKSLASH, stream) < 0
+        || fputc(DIGIT_ZERO + d0, stream) < 0
+        || fputc(DIGIT_ZERO + d1, stream) < 0
+        || fputc(DIGIT_ZERO + d2, stream) < 0
+    {
+        return 1;
+    }
+    0
+}
+
+/// Writes the decimal representation of `value` to `stream`, returning `0` on success or `1` on
+/// error.
+#[cfg(not(test))]
+unsafe fn write_int(stream: *mut CFile, value: c_int) -> c_int {
+    // i32 has at most 10 decimal digits; the sign is emitted separately.
+    let mut digits: [c_int; 10] = [0; 10];
+    // Widen to i64 so that negating i32::MIN cannot overflow.
+    let mut remaining: i64 = i64::from(value);
+    if remaining < 0 {
+        if fputc(MINUS, stream) < 0 {
+            return 1;
+        }
+        remaining = -remaining;
+    }
+
+    let mut count: usize = 0;
+    if remaining == 0 {
+        digits[0] = 0;
+        count = 1;
+    } else {
+        while remaining > 0 && count < digits.len() {
+            // `remaining % 10` is in `0..=9`, which always fits in a C `int`.
+            digits[count] = c_int::try_from(remaining % 10).unwrap_or(0);
+            count += 1;
+            remaining /= 10;
+        }
+    }
+
+    // Digits were collected least-significant first; emit them in reverse.
+    let mut index: usize = count;
+    while index > 0 {
+        index -= 1;
+        if fputc(DIGIT_ZERO + digits[index], stream) < 0 {
+            return 1;
+        }
+    }
+    0
+}

--- a/src/libs/libc_mntent/src/parse.rs
+++ b/src/libs/libc_mntent/src/parse.rs
@@ -1,0 +1,438 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::Mntent;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// ASCII `#`, compared in `i32` space to avoid `c_char` sign-dependent casts.
+const HASH: i32 = b'#' as i32;
+/// ASCII `-`.
+const MINUS: i32 = b'-' as i32;
+/// ASCII `,`.
+const COMMA: i32 = b',' as i32;
+/// ASCII `=`.
+const EQUALS: i32 = b'=' as i32;
+/// ASCII `0`.
+const ZERO: i32 = b'0' as i32;
+/// ASCII `7`, the largest octal digit.
+const SEVEN: i32 = b'7' as i32;
+/// ASCII `9`.
+const NINE: i32 = b'9' as i32;
+/// ASCII `\`.
+const BACKSLASH: i32 = b'\\' as i32;
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+/// Returns `true` if `c` is an ASCII blank or line-separator character.
+fn is_space(c: c_char) -> bool {
+    matches!(i32::from(c), 0x20 | 0x09 | 0x0a | 0x0d | 0x0b | 0x0c)
+}
+
+/// Returns `true` if `c` is an ASCII octal digit (`0`–`7`).
+fn is_octal(c: c_char) -> bool {
+    (ZERO..=SEVEN).contains(&i32::from(c))
+}
+
+/// Decodes glibc-style octal escapes (`\NNN`) in the null-terminated string `s`, in place.
+///
+/// A backslash followed by exactly three octal digits encoding a byte value (`0..=255`) is replaced
+/// by that byte; any other backslash is kept verbatim. This mirrors how `mount(8)`/glibc store
+/// whitespace and backslashes in `mnt_*` fields (e.g. a space as `\040`). Decoding never lengthens
+/// the string, so the rewrite always stays within the original buffer.
+///
+/// # Safety
+///
+/// `s` must be a writable, null-terminated C string.
+unsafe fn unescape_in_place(s: *mut c_char) {
+    let mut read: usize = 0;
+    let mut write: usize = 0;
+    loop {
+        let c: c_char = *s.add(read);
+        if c == 0 {
+            break;
+        }
+        // A backslash followed by three octal digits is decoded to a single byte. The `&&`
+        // short-circuits before reading past the terminator, since a null byte is not octal.
+        if i32::from(c) == BACKSLASH
+            && is_octal(*s.add(read + 1))
+            && is_octal(*s.add(read + 2))
+            && is_octal(*s.add(read + 3))
+        {
+            let d0: i32 = i32::from(*s.add(read + 1)) - ZERO;
+            let d1: i32 = i32::from(*s.add(read + 2)) - ZERO;
+            let d2: i32 = i32::from(*s.add(read + 3)) - ZERO;
+            let value: i32 = d0 * 64 + d1 * 8 + d2;
+            if let Ok(byte) = u8::try_from(value) {
+                *s.add(write) = c_char::from_ne_bytes(byte.to_ne_bytes());
+                write += 1;
+                read += 4;
+                continue;
+            }
+        }
+        *s.add(write) = c;
+        write += 1;
+        read += 1;
+    }
+    *s.add(write) = 0;
+}
+
+/// Returns the length of the null-terminated C string `s`, excluding the terminator.
+///
+/// # Safety
+///
+/// `s` must be a valid null-terminated C string.
+unsafe fn c_strlen(s: *const c_char) -> usize {
+    let mut n: usize = 0;
+    while *s.add(n) != 0 {
+        n += 1;
+    }
+    n
+}
+
+/// Returns `true` if the first `n` bytes at `a` and `b` are equal.
+///
+/// # Safety
+///
+/// `a` and `b` must be readable for at least `n` bytes.
+unsafe fn bytes_equal(a: *const c_char, b: *const c_char, n: usize) -> bool {
+    let mut i: usize = 0;
+    while i < n {
+        if *a.add(i) != *b.add(i) {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Extracts the next whitespace-delimited token from `*p`, null-terminating it in place and
+/// advancing `*p` past it.
+///
+/// # Return Value
+///
+/// A pointer to the token, or null if no token remains.
+///
+/// # Safety
+///
+/// `*p` must point into a writable, null-terminated buffer.
+unsafe fn take_token(p: &mut *mut c_char) -> *mut c_char {
+    while is_space(**p) {
+        *p = (*p).add(1);
+    }
+    if **p == 0 {
+        return core::ptr::null_mut();
+    }
+    let start: *mut c_char = *p;
+    while **p != 0 && !is_space(**p) {
+        *p = (*p).add(1);
+    }
+    if **p != 0 {
+        **p = 0;
+        *p = (*p).add(1);
+    }
+    start
+}
+
+/// Extracts the next token and parses it as a base-10 integer, defaulting to `0` when the token is
+/// absent or malformed.
+///
+/// # Safety
+///
+/// `*p` must point into a writable, null-terminated buffer.
+unsafe fn take_int(p: &mut *mut c_char) -> c_int {
+    let token: *mut c_char = take_token(p);
+    if token.is_null() {
+        return 0;
+    }
+
+    let mut index: usize = 0;
+    let negative: bool = i32::from(*token) == MINUS;
+    if negative {
+        index = 1;
+    }
+
+    // Accumulate the magnitude in `i64` so that `i32::MIN` — whose magnitude exceeds `c_int::MAX`,
+    // and which `write_int` is able to emit — round-trips correctly. Saturate, then clamp into the
+    // `c_int` range.
+    let mut magnitude: i64 = 0;
+    loop {
+        let digit: i32 = i32::from(*token.add(index));
+        if !(ZERO..=NINE).contains(&digit) {
+            break;
+        }
+        magnitude = magnitude
+            .saturating_mul(10)
+            .saturating_add(i64::from(digit - ZERO));
+        index += 1;
+    }
+
+    let signed: i64 = if negative { -magnitude } else { magnitude };
+    let clamped: i64 = signed.clamp(i64::from(c_int::MIN), i64::from(c_int::MAX));
+    c_int::try_from(clamped).unwrap_or(0)
+}
+
+//==================================================================================================
+// Crate-Visible Functions
+//==================================================================================================
+
+/// Parses one `fstab`/`mtab` line in place, filling `ent` with pointers into `line`.
+///
+/// # Return Value
+///
+/// `true` when a populated entry was parsed, `false` for blank or comment lines or lines that lack
+/// the four mandatory string fields.
+///
+/// # Safety
+///
+/// `line` must be a writable, null-terminated buffer and `ent` must be valid for writes.
+pub(crate) unsafe fn parse_line(line: *mut c_char, ent: *mut Mntent) -> bool {
+    let mut p: *mut c_char = line;
+
+    // Detect blank and comment lines.
+    while is_space(*p) {
+        p = p.add(1);
+    }
+    if *p == 0 || i32::from(*p) == HASH {
+        return false;
+    }
+
+    let fsname: *mut c_char = take_token(&mut p);
+    let dir: *mut c_char = take_token(&mut p);
+    let typ: *mut c_char = take_token(&mut p);
+    let opts: *mut c_char = take_token(&mut p);
+    if fsname.is_null() || dir.is_null() || typ.is_null() || opts.is_null() {
+        return false;
+    }
+
+    // Decode glibc-style octal escapes in the four string fields (e.g. `\040` -> space). This is
+    // safe to do after tokenizing because escaped whitespace contains no literal separator, so the
+    // fields were not split on it.
+    unescape_in_place(fsname);
+    unescape_in_place(dir);
+    unescape_in_place(typ);
+    unescape_in_place(opts);
+
+    let freq: c_int = take_int(&mut p);
+    let passno: c_int = take_int(&mut p);
+
+    (*ent).mnt_fsname = fsname;
+    (*ent).mnt_dir = dir;
+    (*ent).mnt_type = typ;
+    (*ent).mnt_opts = opts;
+    (*ent).mnt_freq = freq;
+    (*ent).mnt_passno = passno;
+    true
+}
+
+/// Searches the comma-separated option list `opts` for an option named `opt`.
+///
+/// # Return Value
+///
+/// A pointer to the matching option within `opts`, or null when not present.
+///
+/// # Safety
+///
+/// `opts` and `opt` must be null or valid null-terminated C strings.
+pub(crate) unsafe fn option_search(opts: *const c_char, opt: *const c_char) -> *mut c_char {
+    if opts.is_null() || opt.is_null() {
+        return core::ptr::null_mut();
+    }
+    let optlen: usize = c_strlen(opt);
+    if optlen == 0 {
+        return core::ptr::null_mut();
+    }
+
+    let mut p: *const c_char = opts;
+    loop {
+        // Skip separators.
+        while i32::from(*p) == COMMA {
+            p = p.add(1);
+        }
+        if *p == 0 {
+            return core::ptr::null_mut();
+        }
+
+        let token: *const c_char = p;
+        while *p != 0 && i32::from(*p) != COMMA {
+            p = p.add(1);
+        }
+        let tokenlen: usize = usize::try_from(p.offset_from(token)).unwrap_or(0);
+
+        // Match the option name, requiring a whole-token (or `name=value`) match.
+        if tokenlen >= optlen && bytes_equal(token, opt, optlen) {
+            let trailing: i32 = i32::from(*token.add(optlen));
+            if trailing == 0 || trailing == COMMA || trailing == EQUALS {
+                return token.cast_mut();
+            }
+        }
+
+        if *p == 0 {
+            return core::ptr::null_mut();
+        }
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        option_search,
+        parse_line,
+    };
+    use crate::Mntent;
+    use ::std::vec::Vec;
+    use ::sysapi::ffi::{
+        c_char,
+        c_int,
+    };
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0);
+        v
+    }
+
+    fn c_str_to_bytes(p: *const c_char) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::new();
+        let mut i: usize = 0;
+        unsafe {
+            while *p.add(i) != 0 {
+                v.push(u8::from_ne_bytes((*p.add(i)).to_ne_bytes()));
+                i += 1;
+            }
+        }
+        v
+    }
+
+    fn empty_entry() -> Mntent {
+        Mntent {
+            mnt_fsname: core::ptr::null_mut(),
+            mnt_dir: core::ptr::null_mut(),
+            mnt_type: core::ptr::null_mut(),
+            mnt_opts: core::ptr::null_mut(),
+            mnt_freq: 0,
+            mnt_passno: 0,
+        }
+    }
+
+    #[test]
+    fn parses_a_full_entry() {
+        let mut line: Vec<c_char> = make_c_string(b"/dev/sda1 / ext4 rw,relatime 1 2");
+        let mut ent: Mntent = empty_entry();
+        let ok: bool = unsafe { parse_line(line.as_mut_ptr(), &mut ent) };
+        assert!(ok);
+        assert_eq!(c_str_to_bytes(ent.mnt_fsname), b"/dev/sda1");
+        assert_eq!(c_str_to_bytes(ent.mnt_dir), b"/");
+        assert_eq!(c_str_to_bytes(ent.mnt_type), b"ext4");
+        assert_eq!(c_str_to_bytes(ent.mnt_opts), b"rw,relatime");
+        assert_eq!(ent.mnt_freq, 1);
+        assert_eq!(ent.mnt_passno, 2);
+    }
+
+    #[test]
+    fn defaults_missing_dump_and_pass_fields() {
+        let mut line: Vec<c_char> = make_c_string(b"\tproc   /proc\tproc  defaults\n");
+        let mut ent: Mntent = empty_entry();
+        let ok: bool = unsafe { parse_line(line.as_mut_ptr(), &mut ent) };
+        assert!(ok);
+        assert_eq!(c_str_to_bytes(ent.mnt_fsname), b"proc");
+        assert_eq!(c_str_to_bytes(ent.mnt_dir), b"/proc");
+        assert_eq!(c_str_to_bytes(ent.mnt_type), b"proc");
+        assert_eq!(c_str_to_bytes(ent.mnt_opts), b"defaults");
+        assert_eq!(ent.mnt_freq, 0);
+        assert_eq!(ent.mnt_passno, 0);
+    }
+
+    #[test]
+    fn rejects_comment_and_blank_lines() {
+        let mut comment: Vec<c_char> = make_c_string(b"   # a comment");
+        let mut blank: Vec<c_char> = make_c_string(b"   \t  ");
+        let mut partial: Vec<c_char> = make_c_string(b"only two");
+        let mut ent: Mntent = empty_entry();
+        unsafe {
+            assert!(!parse_line(comment.as_mut_ptr(), &mut ent));
+            assert!(!parse_line(blank.as_mut_ptr(), &mut ent));
+            assert!(!parse_line(partial.as_mut_ptr(), &mut ent));
+        }
+    }
+
+    #[test]
+    fn finds_whole_options_only() {
+        let opts: Vec<c_char> = make_c_string(b"rw,noexec,nosuid");
+        unsafe {
+            // Whole-token matches succeed.
+            assert!(!option_search(opts.as_ptr(), make_c_string(b"rw").as_ptr()).is_null());
+            assert!(!option_search(opts.as_ptr(), make_c_string(b"noexec").as_ptr()).is_null());
+            assert!(!option_search(opts.as_ptr(), make_c_string(b"nosuid").as_ptr()).is_null());
+            // A substring of an option is not a match ("exec" in "noexec", "suid" in "nosuid").
+            assert!(option_search(opts.as_ptr(), make_c_string(b"exec").as_ptr()).is_null());
+            assert!(option_search(opts.as_ptr(), make_c_string(b"suid").as_ptr()).is_null());
+            assert!(option_search(opts.as_ptr(), make_c_string(b"ro").as_ptr()).is_null());
+        }
+    }
+
+    #[test]
+    fn matches_option_with_value() {
+        let opts: Vec<c_char> = make_c_string(b"rw,uid=1000,gid=1000");
+        unsafe {
+            let hit: *mut c_char = option_search(opts.as_ptr(), make_c_string(b"uid").as_ptr());
+            assert!(!hit.is_null());
+            assert_eq!(c_str_to_bytes(hit), b"uid=1000,gid=1000");
+            assert!(option_search(opts.as_ptr(), make_c_string(b"id").as_ptr()).is_null());
+        }
+    }
+
+    #[test]
+    fn decodes_octal_escapes_in_fields() {
+        // `/mnt/my\040drive` (space), type `a\011b` (tab), opts `x\134y` (backslash).
+        let mut line: Vec<c_char> =
+            make_c_string(b"/dev/sda1 /mnt/my\\040drive a\\011b x\\134y 0 0");
+        let mut ent: Mntent = empty_entry();
+        let ok: bool = unsafe { parse_line(line.as_mut_ptr(), &mut ent) };
+        assert!(ok);
+        assert_eq!(c_str_to_bytes(ent.mnt_fsname), b"/dev/sda1");
+        assert_eq!(c_str_to_bytes(ent.mnt_dir), b"/mnt/my drive");
+        assert_eq!(c_str_to_bytes(ent.mnt_type), b"a\tb");
+        assert_eq!(c_str_to_bytes(ent.mnt_opts), b"x\\y");
+    }
+
+    #[test]
+    fn keeps_lone_backslash_verbatim() {
+        // A backslash not followed by three octal digits is preserved as-is.
+        let mut line: Vec<c_char> = make_c_string(b"a\\b /mnt ext4 rw 0 0");
+        let mut ent: Mntent = empty_entry();
+        let ok: bool = unsafe { parse_line(line.as_mut_ptr(), &mut ent) };
+        assert!(ok);
+        assert_eq!(c_str_to_bytes(ent.mnt_fsname), b"a\\b");
+    }
+
+    #[test]
+    fn parses_extreme_dump_and_pass_values() {
+        // i32::MIN must round-trip the value written by write_int; large values saturate.
+        let mut line: Vec<c_char> = make_c_string(b"none none none none -2147483648 2147483647");
+        let mut ent: Mntent = empty_entry();
+        let ok: bool = unsafe { parse_line(line.as_mut_ptr(), &mut ent) };
+        assert!(ok);
+        assert_eq!(ent.mnt_freq, c_int::MIN);
+        assert_eq!(ent.mnt_passno, c_int::MAX);
+    }
+}

--- a/src/libs/nanvix_libc/Cargo.toml
+++ b/src/libs/nanvix_libc/Cargo.toml
@@ -21,6 +21,7 @@ libc_inttypes = { workspace = true }
 libc_langinfo = { workspace = true }
 libc_libgen = { workspace = true }
 libc_locale = { workspace = true }
+libc_mntent = { workspace = true }
 libc_regex = { workspace = true }
 # NOTE: the math routines (`libc_math`) are deliberately NOT pulled in here — they
 # are shipped as the separate `libm.a` archive (the `nanvix_libm` crate), mirroring

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -23,6 +23,7 @@ extern crate libc_inttypes;
 extern crate libc_langinfo;
 extern crate libc_libgen;
 extern crate libc_locale;
+extern crate libc_mntent;
 extern crate libc_regex;
 extern crate libc_setjmp;
 extern crate libc_signal;


### PR DESCRIPTION
## Summary

Adds a new bundled-libc crate, **`libc_mntent`**, implementing the glibc
`<mntent.h>` interface for reading and writing the filesystem description files
(`/etc/fstab` and `/etc/mtab`).

### API

- `setmntent()` / `endmntent()` — open/close a table stream over the bundled `<stdio.h>` (`fopen`/`fclose`).
- `getmntent()` / `getmntent_r()` — read the next entry, skipping blank and comment lines. `getmntent()` uses a static buffer; `getmntent_r()` is the reentrant variant.
- `addmntent()` — append an entry to a stream opened for writing.
- `hasmntopt()` — whole-token search of an entry's option list (matches `name` and `name=value`).
- `struct mntent` plus the standard `MNTTAB`/`MOUNTED`, `MNTTYPE_*`, and `MNTOPT_*` macros.

### Notable details

- **glibc round-trip fidelity:** the four string fields are octal-escaped on write and decoded on read. `addmntent()` emits spaces, tabs, newlines, and backslashes as `\NNN`; `getmntent()` decodes `\NNN` back to the original byte. This prevents fields containing whitespace (e.g. `/mnt/my\040drive`) from being mis-split into separate columns.
- **Full `c_int` range:** the dump/pass numeric parser accumulates in `i64` and clamps, so the entire `c_int` range — including `i32::MIN` — round-trips with what `addmntent()` writes.
- The parser is a thin in-place tokenizer storing pointers into the caller's buffer; pure-parsing functions are compiled and unit-tested on the host.

## Files changed

- `src/libs/libc_mntent/` — new crate (`Cargo.toml`, `src/lib.rs`, `src/parse.rs`) + C header spec (`header.toml`).
- `include/mntent.h` — generated by `gen-headers`.
- `Cargo.toml`, `Cargo.lock` — register the crate as workspace member + dependency.
- `Makefile` — add to the guest and test library lists.
- `src/libs/nanvix_libc/` — depend on and link the new crate.

## Validation

- `gen-headers-check`: headers up to date.
- `format-check` + `lint-check` (clippy): clean.
- Full suite — `run-unit-tests run-kernel-tests run-nanvix-tests`: **pass** (111 `ok`, 8 `libc_mntent` parser unit tests incl. octal-escape and extreme-value round-trip cases).
- Pre-commit hook: all 3 configurations (standalone, single-process, multi-process) passed; commit hooks **not** bypassed.

## Reviews

Reviewed with both **Claude Opus 4.8 (max effort)** and **GPT-5.5 (xhigh effort)** code-review subagents. Findings addressed:

- **Octal escaping/unescaping** of the string fields (both reviewers) — implemented per glibc.
- **`INT_MIN` parsing** (GPT-5.5) — `take_int` now accumulates in `i64` and clamps to the `c_int` range.
- **`MNTTYPE_NFS "nfs"` macro** (GPT-5.5) — added.

Two Claude nits (over-long-line handling, `addmntent` `fseek`) were consciously skipped as explicitly non-blocking.
