### PR TITLE
[kernel] Add SIGCHLD and Stop/Cont job control

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -124,7 +124,12 @@ use ::sys::{
         SigSet,
         ThreadCreateArgs,
         ThreadIdentifier,
+        SIGCONT,
         SIGKILL,
+        SIGSTOP,
+        SIGTSTP,
+        SIGTTIN,
+        SIGTTOU,
         SIG_MAX,
     },
     time::SystemTime,
@@ -177,9 +182,9 @@ enum PostAction {
     /// A caught signal was posted: interrupt a blocked candidate thread so its blocking call reports
     /// `EINTR` (or restarts) and the handler is delivered at the return-to-user checkpoint.
     Interrupt,
-    /// A job-control stop/continue signal was posted: wake a candidate thread (full semantics arrive
-    /// in a later phase).
-    Wake,
+    /// A job-control stop signal with the default disposition was posted: suspend the target
+    /// process (`SIGSTOP`/`SIGTSTP`/`SIGTTIN`/`SIGTTOU`).
+    Stop,
 }
 
 //==================================================================================================
@@ -429,15 +434,26 @@ impl ProcessManager {
         // NOTE: if we fail beyond this point we need to page mappings.
         //==============================================================
 
+        // A new thread inherits the creating (running) thread's blocked-signal mask, as POSIX
+        // requires; the signal dispositions are process-wide and therefore already shared.
+        let inherited_blocked: SigSet = self
+            .get_running_mut()
+            .running_mut()
+            .thread_state()
+            .blocked();
+
         Ok(no_fail!(ThreadIdentifier, {
             // Create a new thread.
-            let ready_thread: ReadyThread = self.tm.create_thread(
+            let mut ready_thread: ReadyThread = self.tm.create_thread(
                 tid,
                 Some(kernel_stack),
                 None,
                 thread_create_args.user_tda,
                 context,
             );
+            ready_thread
+                .thread_state_mut()
+                .set_blocked(inherited_blocked);
 
             // Commit the next thread identifier now that all fallible operations have succeeded.
             self.tm.commit_next_tid(next_tid);
@@ -849,12 +865,13 @@ impl ProcessManager {
                         PostAction::Terminate
                     },
                     DefaultAction::Ignore => PostAction::None,
-                    DefaultAction::Stop | DefaultAction::Continue => {
-                        // Job-control stop/continue semantics arrive in a later phase; for now the
-                        // signal is recorded as pending and a candidate thread is woken.
-                        signals.post(signum);
-                        PostAction::Wake
-                    },
+                    // Job-control stop suspends the target. The effect is applied directly to the
+                    // target's scheduling state below, so the signal is consumed rather than left
+                    // pending.
+                    DefaultAction::Stop => PostAction::Stop,
+                    // The continue effect is applied unconditionally for SIGCONT above (it must
+                    // resume a stopped target regardless of disposition), so nothing remains here.
+                    DefaultAction::Continue => PostAction::None,
                 },
                 None => {
                     let reason: &str = "invalid signal number";
@@ -864,10 +881,18 @@ impl ProcessManager {
             }
         };
 
+        // SIGCONT's continue effect is unconditional (POSIX): it resumes a stopped target
+        // regardless of the target's disposition, so it is applied here rather than only on the
+        // default path. An installed handler still runs — that delivery is driven by the
+        // disposition-derived action below.
+        if signum == SIGCONT {
+            self.continue_process(target)?;
+        }
+
         match action {
             PostAction::Terminate => return self.kill_terminate(caller, target),
             PostAction::Interrupt => self.interrupt_signal_candidate(target, signum),
-            PostAction::Wake => self.wakeup_signal_candidate(target),
+            PostAction::Stop => self.stop_process(target)?,
             PostAction::None => {},
         }
         Ok(KillOutcome::Done)
@@ -905,29 +930,63 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Wakes a candidate thread of a process to which a signal was posted, so that the thread can
-    /// evaluate delivery at its return-to-user checkpoint.
+    /// Stops (suspends) a process in response to a job-control stop signal whose default action is
+    /// *stop* (`SIGSTOP`/`SIGTSTP`/`SIGTTIN`/`SIGTTOU`).
     ///
-    /// Only a fully-suspended process needs an explicit wake; a process that still has a ready or
-    /// interrupted thread is already schedulable. The wakeup is best-effort: the candidate thread
-    /// may already have been woken by another notifier.
+    /// The process is marked stopped, which makes the scheduler skip it — none of its threads run —
+    /// regardless of whether they are currently ready, running, suspended, or interrupted. The
+    /// threads keep their underlying state, so a later `SIGCONT` resumes them from where they were.
+    /// Any pending `SIGCONT` is discarded, mirroring the POSIX rule that a stop supersedes a
+    /// not-yet-acted-upon continue.
+    ///
+    /// The target is never the running process here: cross-process posting is relayed through the
+    /// process-manager daemon (which is the running process during the kernel call). A process that
+    /// stops *itself* marks its own running state and is descheduled and skipped at the next
+    /// scheduling opportunity (its next blocking call or preemption).
     ///
     /// # Parameters
     ///
-    /// - `pid`: Identifier of the process whose candidate thread should be woken.
+    /// - `pid`: Identifier of the process to stop.
     ///
-    fn wakeup_signal_candidate(&mut self, pid: ProcessIdentifier) {
-        let candidate: Option<ThreadIdentifier> = match self
-            .suspended
-            .iter()
-            .find(|process| process.state().pid() == pid)
-        {
-            Some(process) => process.candidate_tid(),
-            None => return,
-        };
-        if let Some(tid) = candidate {
-            let _ = self.do_wakeup(tid);
+    fn stop_process(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {
+        // The kernel/idle process underpins the scheduler's always-runnable invariant (a stopped
+        // process is skipped by `take_earliest_ready`, which relies on the kernel process always
+        // being selectable), so it must never be stopped.
+        if pid == ProcessIdentifier::KERNEL {
+            let reason: &str = "cannot stop the kernel process";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
+        let mut process: ProcessRefMut = self.find_process_mut(pid)?;
+        // A stop discards a pending continue and vice versa.
+        process.state_mut().signals_mut().clear_pending(SIGCONT);
+        process.state_mut().set_stopped(true);
+        trace!("stopped process (pid={pid:?})");
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Continues a process in response to `SIGCONT`, clearing its stopped flag so the scheduler
+    /// considers it runnable again. A process that was suspended in a blocking kernel call when it
+    /// was stopped stays suspended and resumes that call when it next wakes; a process that was
+    /// ready or running resumes execution at the next scheduling opportunity. Continuing a process
+    /// that is not stopped is a no-op. Any pending stop signals are discarded, mirroring the POSIX
+    /// rule that a continue supersedes a not-yet-acted-upon stop.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process to continue.
+    ///
+    fn continue_process(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {
+        let mut process: ProcessRefMut = self.find_process_mut(pid)?;
+        for stop_signum in [SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU] {
+            process.state_mut().signals_mut().clear_pending(stop_signum);
+        }
+        process.state_mut().set_stopped(false);
+        trace!("continued process (pid={pid:?})");
+        Ok(())
     }
 
     ///
@@ -1539,17 +1598,35 @@ impl ProcessManager {
         // NOTE: if we fail beyond this point we leak page mappings.
         //==============================================================
 
+        // Capture the parent's signal state to inherit into the child. POSIX requires a forked child
+        // to inherit the parent's signal dispositions and the calling thread's blocked-signal mask,
+        // while starting with an empty pending set. The dispositions (and restorer) are captured
+        // here and installed into the child below; the blocked mask is applied to the child's main
+        // thread.
+        let inherited_signals: SignalControl =
+            self.get_running().state().signals().inherited_for_fork();
+        let inherited_blocked: SigSet = self
+            .get_running_mut()
+            .running_mut()
+            .thread_state()
+            .blocked();
+
         Ok(no_fail!(ProcessIdentifier, {
-            let thread: ReadyThread =
+            let mut thread: ReadyThread =
                 self.tm
                     .create_thread(child_tid, Some(kernel_stack), None, args.user_tda, context);
+            // The child's main thread inherits the calling thread's blocked-signal mask.
+            thread.thread_state_mut().set_blocked(inherited_blocked);
 
             // Commit reserved identifiers now that all fallible operations succeeded.
             self.next_pid = next_pid;
             self.tm.commit_next_tid(next_tid);
             self.live_count += 1;
 
-            let process: RunnableProcess = RunnableProcess::new(child_pid, pid, thread, vmem);
+            // Install the dispositions and restorer inherited from the parent into the freshly
+            // created child before it is enqueued; its pending set stays empty.
+            let mut process: RunnableProcess = RunnableProcess::new(child_pid, pid, thread, vmem);
+            process.set_signals(inherited_signals);
             self.ready.push_back(process);
 
             // Record the creation so the kernel main loop can publish a process-creation
@@ -2207,6 +2284,13 @@ impl ProcessManager {
         // counterpart threads that would otherwise block forever.
         self.cleanup_rendezvous(pid, "terminate");
 
+        // Clear any job-control stopped flag so the doomed process is schedulable again and can run
+        // its own termination; a stopped process is otherwise skipped by the scheduler and could
+        // never complete its exit. The flag is harmless to clear when it was not set.
+        if let Ok(mut process) = self.find_process_mut(pid) {
+            process.state_mut().set_stopped(false);
+        }
+
         // Check if target process is ready.
         if let Some(process) = self.ready.iter().position(|p| p.state().pid() == pid) {
             let process: RunnableProcess = self.ready.remove(process);
@@ -2588,25 +2672,28 @@ impl ProcessManager {
     }
 
     fn take_earliest_ready(&mut self) -> RunnableProcess {
-        // SAFETY: As the kernel process is always runnable, the following statement will never panic.
-        let mut selected: (usize, SystemTime) = (
-            0,
-            self.ready
-                .front()
-                .expect("there should always be a process ready to run")
-                .earliest_admission_time(),
-        );
-
-        // Select process with the earliest admission time.
+        // Select the ready process with the earliest admission time, skipping job-control *stopped*
+        // processes (which remain on the ready list but must not run until continued by `SIGCONT`).
+        // The kernel process is never stopped and is always runnable, so a non-stopped candidate
+        // always exists.
+        let mut selected: Option<(usize, SystemTime)> = None;
         for (i, process) in self.ready.iter().enumerate() {
+            if process.state().is_stopped() {
+                continue;
+            }
             let process_admission_time: SystemTime = process.earliest_admission_time();
-            if process_admission_time < selected.1 {
-                selected = (i, process_admission_time);
+            match selected {
+                Some((_, earliest)) if earliest <= process_admission_time => {},
+                _ => selected = Some((i, process_admission_time)),
             }
         }
 
+        let index: usize = selected
+            .expect("there should always be a non-stopped process ready to run")
+            .0;
+
         // Remove the selected process from the list of ready processes.
-        self.ready.remove(selected.0)
+        self.ready.remove(index)
     }
 
     ///

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -235,6 +235,11 @@ pub struct ProcessState {
     ///
     /// Holds the process-wide signal dispositions installed via `sigaction()`.
     signals: SignalControl,
+    /// Job-control stopped flag. Set when a stop signal (`SIGSTOP`/`SIGTSTP`/`SIGTTIN`/`SIGTTOU`)
+    /// suspends the process and cleared when `SIGCONT` resumes it. A stopped process is skipped by
+    /// the scheduler — none of its threads run — until it is continued, modelling the POSIX
+    /// *stopped* state without a dedicated scheduling list.
+    stopped: bool,
 }
 
 impl ProcessState {
@@ -252,6 +257,7 @@ impl ProcessState {
             conditions: BTreeMap::new(),
             pending_exit_status: None,
             signals: SignalControl::default(),
+            stopped: false,
         }
     }
 
@@ -331,6 +337,66 @@ impl ProcessState {
     ///
     pub fn signals_mut(&mut self) -> &mut SignalControl {
         &mut self.signals
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns an immutable reference to the per-process signal control block.
+    ///
+    /// # Returns
+    ///
+    /// An immutable reference to the [`SignalControl`] of this process.
+    ///
+    pub fn signals(&self) -> &SignalControl {
+        &self.signals
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces the per-process signal control block.
+    ///
+    /// Used by `fork()` to install the dispositions and restorer inherited from the parent into the
+    /// freshly created child.
+    ///
+    /// # Parameters
+    ///
+    /// - `signals`: The signal control block to install.
+    ///
+    pub fn set_signals(&mut self, signals: SignalControl) {
+        self.signals = signals;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports whether the process is job-control *stopped*.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the process is stopped (and therefore not schedulable until continued), `false`
+    /// otherwise.
+    ///
+    pub fn is_stopped(&self) -> bool {
+        self.stopped
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets or clears the job-control *stopped* flag of the process.
+    ///
+    /// While set, the scheduler skips the process so none of its threads run; clearing it (on
+    /// `SIGCONT`) makes the process schedulable again, resuming its threads from where they were
+    /// suspended.
+    ///
+    /// # Parameters
+    ///
+    /// - `stopped`: `true` to stop the process, `false` to continue it.
+    ///
+    pub fn set_stopped(&mut self, stopped: bool) {
+        self.stopped = stopped;
     }
 
     ///

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -12,6 +12,7 @@ use crate::{
         clock,
         process::state::{
             interrupted::interrupt,
+            signal::SignalControl,
             InterruptedProcess,
             ProcessState,
             RunningProcess,
@@ -99,6 +100,22 @@ impl RunnableProcess {
 
     pub(super) fn state_mut(&mut self) -> &mut ProcessState {
         &mut self.state
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs the per-process signal control block into this process.
+    ///
+    /// Used by `fork()` to install the dispositions and restorer inherited from the parent into
+    /// the freshly created child before it is enqueued onto the ready list.
+    ///
+    /// # Parameters
+    ///
+    /// - `signals`: The signal control block to install.
+    ///
+    pub fn set_signals(&mut self, signals: SignalControl) {
+        self.state.set_signals(signals);
     }
 
     ///

--- a/src/kernel/src/pm/process/state/signal.rs
+++ b/src/kernel/src/pm/process/state/signal.rs
@@ -63,7 +63,7 @@ pub const UNBLOCKABLE: SigSet = (1u64 << (SIGKILL - 1)) | (1u64 << (SIGSTOP - 1)
 // Boxed by [`SignalDisposition::Handler`] so that a disposition is only pointer-sized. Storing this
 // payload inline in every one of the 64 disposition slots would push the per-process table past the
 // kernel heap's maximum slab size (512 bytes); see [`crate::mm::kheap`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SignalHandler {
     /// Entry point of the user-space handler.
     pub entry: VirtualAddress,
@@ -80,7 +80,7 @@ pub struct SignalHandler {
 ///
 /// Disposition of a single signal.
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SignalDisposition {
     /// Take the default action for the signal.
     Default,
@@ -452,6 +452,29 @@ impl SignalControl {
     ///
     pub fn set_restorer(&mut self, restorer: Option<VirtualAddress>) {
         self.restorer = restorer;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Produces the signal control block a forked child inherits from this (the parent's) one.
+    ///
+    /// The signal dispositions are copied verbatim, as POSIX requires, and the restorer is inherited
+    /// because the child shares the parent's address space (the trampoline lives at the same
+    /// address). The pending set is *not* inherited: a freshly forked child starts with no pending
+    /// signals.
+    ///
+    /// # Returns
+    ///
+    /// A [`SignalControl`] carrying the inherited dispositions and restorer with an empty pending
+    /// set.
+    ///
+    pub fn inherited_for_fork(&self) -> Self {
+        Self {
+            dispositions: self.dispositions.clone(),
+            pending: 0,
+            restorer: self.restorer,
+        }
     }
 
     ///

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -71,23 +71,6 @@ impl SleepingProcess {
     ///
     /// # Description
     ///
-    /// Returns the identifier of a candidate thread to wake when a signal is posted to this
-    /// suspended process, so the thread can evaluate delivery at its return-to-user checkpoint.
-    ///
-    /// # Returns
-    ///
-    /// The identifier of one of the process's sleeping threads.
-    ///
-    pub fn candidate_tid(&self) -> Option<ThreadIdentifier> {
-        self.sleeping_threads
-            .iter()
-            .next()
-            .map(|thread| thread.id())
-    }
-
-    ///
-    /// # Description
-    ///
     /// Returns the identifier of a candidate thread that can take delivery of signal `signum`, i.e.
     /// a sleeping thread that does not currently block it.
     ///

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -53,6 +53,7 @@ use ::sys::{
         GroupIdentifier,
         ProcessIdentifier,
         UserIdentifier,
+        SIGCHLD,
     },
 };
 
@@ -519,6 +520,10 @@ impl ProcessDaemon {
                     record.zombie = Some(status);
                 }
                 self.wake_waiter(parent, pid, status)?;
+                // Notify the parent of the child's state change after servicing any blocked
+                // `waitpid()` waiter. This keeps the synchronous reap path stable while still
+                // generating the asynchronous `SIGCHLD` notification.
+                self.notify_parent_sigchld(parent);
             },
             // No live process can ever reap it: drop it rather than leak an unreapable zombie.
             None => {
@@ -694,6 +699,22 @@ impl ProcessDaemon {
         }
 
         Ok(())
+    }
+
+    /// Posts `SIGCHLD` to `parent` to notify it of a child's state change (here, termination), as
+    /// required by POSIX. `SIGCHLD` defaults to being ignored, so this is a no-op for a parent that
+    /// has not installed a handler; it complements, rather than replaces, the `waitpid()` flow. A
+    /// failure to post is logged but never propagated: the child's termination must still be
+    /// finalized (the zombie retained and any blocked waiter woken) even when the notification
+    /// cannot be delivered.
+    fn notify_parent_sigchld(&self, parent: ProcessIdentifier) {
+        if let Err(e) = ::sys::kcall::pm::__kcall_kill(parent, SIGCHLD as i32) {
+            ::syslog::warn!(
+                "notify_parent_sigchld(): failed to post SIGCHLD (parent={:?}, error={:?})",
+                parent,
+                e
+            );
+        }
     }
 
     /// Reaps a zombie `child` of `parent`, removing it from the registry and from the parent's list

--- a/src/tests/integration/test-rust-kill/src/tests/kill.rs
+++ b/src/tests/integration/test-rust-kill/src/tests/kill.rs
@@ -74,7 +74,10 @@ use ::sys::{
         SIG_BLOCK,
         SIG_MAX,
         SIG_SETMASK,
+        SIGCHLD,
+        SIGCONT,
         SIGKILL,
+        SIGSTOP,
         SIGTERM,
         SIGUSR1,
         SIGUSR2,
@@ -90,6 +93,7 @@ use ::sysapi::{
         time_t,
     },
     sys_wait::{
+        WNOHANG,
         wexitstatus,
         wifexited,
     },
@@ -758,6 +762,497 @@ fn test_sigpending_reports_blocked_pending() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Job Control (Stop/Continue)
+//==================================================================================================
+
+/// Exit status reported by a job-control child once it is continued and resumes past its gating
+/// receive. Observing it after a stop/continue cycle proves the child was suspended and then
+/// resumed rather than running straight through.
+const JOBCTL_RESUMED: c_int = 88;
+
+/// Number of non-blocking wait polls used to confirm a stopped child makes no progress. Each poll is
+/// a process-manager round-trip that yields the CPU, so a child that was *not* stopped would be
+/// scheduled, consume its go-message, and exit within these opportunities — turning a broken stop
+/// into a caught regression rather than a silent pass.
+const STOP_POLL_ATTEMPTS: usize = 16;
+
+/// Child entry point for the stop/continue test: notify the parent that it is about to block, then
+/// block in `recv()` for the parent's go-message. The receive can only complete once the child is
+/// scheduled, which a stopped child never is; on receiving the message the child exits with a
+/// sentinel that proves it resumed. This function never returns to the caller.
+fn run_jobctl_child() -> ! {
+    let parent: ProcessIdentifier = match pm::__kcall_getppid() {
+        Ok(parent) => parent,
+        // SAFETY: the freshly forked child holds no resources requiring cleanup.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+    if notify_ready(parent).is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    // Block until the parent's go-message arrives. While the child is stopped this cannot complete,
+    // because the child is never scheduled to receive it.
+    if ipc::__kcall_recv().is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    // SAFETY: as above.
+    unsafe { bindings::_exit::_exit(JOBCTL_RESUMED) };
+}
+
+/// Forks a job-control child. Returns the child's PID in the parent; the child never returns here.
+fn spawn_jobctl_child() -> Result<ProcessIdentifier, Error> {
+    let ret: pid_t = bindings::fork::fork();
+    if ret == 0 {
+        run_jobctl_child();
+    }
+    assert!(ret > 0, "fork() failed in parent (ret={})", ret);
+    Ok(ProcessIdentifier::from(ret))
+}
+
+/// Verifies that `SIGSTOP` suspends a process and `SIGCONT` resumes it. The parent stops the child,
+/// makes its go-message available, and confirms the child makes no progress (it never terminates
+/// despite the message being deliverable). It then continues the child, which consumes the message
+/// and exits with [`JOBCTL_RESUMED`], proving the suspension was lifted and the child resumed from
+/// exactly where it was stopped.
+fn test_sigstop_stops_and_sigcont_resumes() -> Result<(), Error> {
+    let child: ProcessIdentifier = spawn_jobctl_child()?;
+    // The child has reached (or is about to reach) its gating receive by the time its readiness
+    // notification arrives.
+    await_ready()?;
+
+    // Stop the child. The cross-process post is relayed through the process-manager daemon, so the
+    // stop is in effect by the time `kill()` returns.
+    post_signal(child, as_signum(SIGSTOP)?);
+
+    // Make the go-message available. A running child would consume it and exit; a stopped child
+    // cannot run, so the message stays buffered and the child stays alive.
+    send_empty(child)?;
+
+    // Confirm the stopped child makes no progress: across repeated scheduling opportunities it is
+    // never terminated, even though its go-message is already deliverable.
+    let mut status: c_int = 0;
+    for _ in 0..STOP_POLL_ATTEMPTS {
+        // SAFETY: `status` points to a valid `c_int`.
+        let polled: pid_t =
+            unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, WNOHANG) };
+        assert!(
+            polled == 0,
+            "a stopped child must not terminate (ret={}, errno={})",
+            polled,
+            read_errno()
+        );
+    }
+
+    // Continue the child. It is scheduled again, completes its gating receive, and exits.
+    post_signal(child, as_signum(SIGCONT)?);
+
+    // SAFETY: `status` points to a valid `c_int`.
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, 0) };
+    assert!(
+        reaped == i32::from(child),
+        "waitpid() must reap the continued child (ret={}, child={})",
+        reaped,
+        i32::from(child)
+    );
+    assert!(
+        wifexited(status),
+        "continued child must surface as a normal exit (status={:#x})",
+        status
+    );
+    assert!(
+        wexitstatus(status) == JOBCTL_RESUMED,
+        "continued child must exit with the resume sentinel (got={}, expected={})",
+        wexitstatus(status),
+        JOBCTL_RESUMED
+    );
+    Ok(())
+}
+
+/// Verifies that `SIGSTOP` is uncatchable: its disposition cannot be changed, so installing a
+/// handler for it is rejected.
+fn test_sigstop_is_uncatchable() -> Result<(), Error> {
+    let act: SigAction = SigAction {
+        sa_handler: sigusr1_handler_addr(),
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: 0,
+    };
+    // SAFETY: `act` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    let ret: Result<(), Error> =
+        unsafe { pm::__kcall_sigaction(as_signum(SIGSTOP)?, &raw const act, ptr::null_mut()) };
+    assert!(
+        matches!(&ret, Err(error) if error.code.get() == ErrorCode::InvalidArgument.get()),
+        "installing a handler for the uncatchable SIGSTOP must be rejected"
+    );
+    Ok(())
+}
+
+/// Records whether the child's `SIGCONT` handler ran.
+static CONT_HANDLER_RAN: AtomicBool = AtomicBool::new(false);
+
+/// Exit status reported by the caught-`SIGCONT` child when it resumed *and* its handler ran.
+const CONT_RESUMED_WITH_HANDLER: c_int = 99;
+/// Exit status reported by the caught-`SIGCONT` child when it resumed but its handler did not run.
+const CONT_RESUMED_NO_HANDLER: c_int = 98;
+
+/// Handler installed by the caught-`SIGCONT` child; records that the continue signal was delivered.
+extern "C" fn sigcont_handler(_signum: c_int) {
+    CONT_HANDLER_RAN.store(true, Ordering::SeqCst);
+}
+
+/// Returns the address of [`sigcont_handler`] for the `sa_handler` slot.
+#[allow(clippy::as_conversions)]
+fn sigcont_handler_addr() -> usize {
+    sigcont_handler as *const () as usize
+}
+
+/// Child entry point for the caught-`SIGCONT` test. Installs a `SIGCONT` handler, then blocks in a
+/// gating receive (retrying across an interruption by the continue signal itself). On resuming it
+/// reports, through its exit status, whether the handler ran — proving `SIGCONT` both resumed the
+/// stopped process and ran its handler. Never returns.
+fn run_jobctl_handler_child() -> ! {
+    CONT_HANDLER_RAN.store(false, Ordering::SeqCst);
+    let parent: ProcessIdentifier = match pm::__kcall_getppid() {
+        Ok(parent) => parent,
+        // SAFETY: the freshly forked child holds no resources requiring cleanup.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+
+    // Install a catching disposition for SIGCONT.
+    let act: SigAction = SigAction {
+        sa_handler: sigcont_handler_addr(),
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: 0,
+    };
+    let signum: c_int = match as_signum(SIGCONT) {
+        Ok(signum) => signum,
+        // SAFETY: as above.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+    // SAFETY: `act` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    if unsafe { pm::__kcall_sigaction(signum, &raw const act, ptr::null_mut()) }.is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+
+    if notify_ready(parent).is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+
+    // Block until the parent's go-message arrives. Continuing the stopped child with the caught
+    // SIGCONT may interrupt this receive (delivering the handler); retry until it completes.
+    loop {
+        match ipc::__kcall_recv() {
+            Ok(_) => break,
+            Err(error) if error.code.get() == ErrorCode::Interrupted.get() => continue,
+            // SAFETY: as above.
+            Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+        }
+    }
+
+    if CONT_HANDLER_RAN.load(Ordering::SeqCst) {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CONT_RESUMED_WITH_HANDLER) };
+    }
+    // SAFETY: as above.
+    unsafe { bindings::_exit::_exit(CONT_RESUMED_NO_HANDLER) };
+}
+
+/// Forks a caught-`SIGCONT` child. Returns the child's PID in the parent; the child never returns.
+fn spawn_jobctl_handler_child() -> Result<ProcessIdentifier, Error> {
+    let ret: pid_t = bindings::fork::fork();
+    if ret == 0 {
+        run_jobctl_handler_child();
+    }
+    assert!(ret > 0, "fork() failed in parent (ret={})", ret);
+    Ok(ProcessIdentifier::from(ret))
+}
+
+/// Verifies that `SIGCONT` resumes a stopped process *and* runs an installed handler — i.e. its
+/// continue effect is independent of its (catching) disposition. Without this, a stopped process
+/// that caught `SIGCONT` would never be continued and would hang forever. The child installs a
+/// `SIGCONT` handler, is stopped, and is then continued with `SIGCONT`; it exits with a sentinel
+/// only if it both resumed and observed its handler having run.
+fn test_caught_sigcont_continues_and_runs_handler() -> Result<(), Error> {
+    let child: ProcessIdentifier = spawn_jobctl_handler_child()?;
+    await_ready()?;
+
+    post_signal(child, as_signum(SIGSTOP)?);
+    send_empty(child)?;
+
+    // Confirm the child is stopped: it makes no progress despite its go-message being deliverable.
+    let mut status: c_int = 0;
+    for _ in 0..STOP_POLL_ATTEMPTS {
+        // SAFETY: `status` points to a valid `c_int`.
+        let polled: pid_t =
+            unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, WNOHANG) };
+        assert!(
+            polled == 0,
+            "a stopped child with a caught SIGCONT must not terminate (ret={}, errno={})",
+            polled,
+            read_errno()
+        );
+    }
+
+    // Continue the child with the caught SIGCONT. It must resume and run its handler.
+    post_signal(child, as_signum(SIGCONT)?);
+
+    // SAFETY: `status` points to a valid `c_int`.
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, 0) };
+    assert!(
+        reaped == i32::from(child),
+        "waitpid() must reap the continued child (ret={}, child={})",
+        reaped,
+        i32::from(child)
+    );
+    assert!(
+        wifexited(status),
+        "continued child must surface as a normal exit (status={:#x})",
+        status
+    );
+    assert!(
+        wexitstatus(status) == CONT_RESUMED_WITH_HANDLER,
+        "caught SIGCONT must both resume the stopped child and run its handler (exit={}, \
+         resumed-without-handler={})",
+        wexitstatus(status),
+        CONT_RESUMED_NO_HANDLER
+    );
+    Ok(())
+}
+
+//==================================================================================================
+// Fork Signal-State Inheritance
+//==================================================================================================
+
+/// Exit status reported by the fork-inheritance child when every inherited property is correct.
+const INHERIT_OK: c_int = 55;
+/// Exit status reported when the inherited `SIGUSR1` disposition is not the parent's handler.
+const INHERIT_BAD_DISPOSITION: c_int = 56;
+/// Exit status reported when the inherited blocked mask does not carry `SIGUSR2`.
+const INHERIT_BAD_MASK: c_int = 57;
+/// Exit status reported when the child's pending set was not cleared.
+const INHERIT_BAD_PENDING: c_int = 58;
+
+/// Child entry point for the fork-inheritance test. Confirms that the parent's signal state was
+/// inherited per POSIX: the caught `SIGUSR1` disposition and the blocked `SIGUSR2` mask carry over,
+/// while the pending set starts empty. Reports the outcome through its exit status. Never returns.
+fn run_fork_inherit_child() -> ! {
+    let signum: c_int = match as_signum(SIGUSR1) {
+        Ok(signum) => signum,
+        // SAFETY: the freshly forked child holds no resources requiring cleanup.
+        Err(_) => unsafe { bindings::_exit::_exit(CHILD_FAIL) },
+    };
+
+    // The caught SIGUSR1 disposition must be inherited as the parent's handler.
+    let mut old: SigAction = SigAction::default();
+    // SAFETY: `old` points to a valid `SigAction`; a null `act` requests only the current action.
+    if unsafe { pm::__kcall_sigaction(signum, ptr::null(), &raw mut old) }.is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    if old.sa_handler != sigusr1_handler_addr() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(INHERIT_BAD_DISPOSITION) };
+    }
+
+    // The blocked mask must be inherited with SIGUSR2 still blocked.
+    let mut mask: SigSet = 0;
+    // SAFETY: `mask` points to a valid `SigSet`; a null `set` requests only the current mask.
+    if unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, ptr::null(), &raw mut mask) }.is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    if mask & (1u64 << (SIGUSR2 - 1)) == 0 {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(INHERIT_BAD_MASK) };
+    }
+
+    // The pending set must start empty: pending signals are not inherited across fork.
+    let mut pending: SigSet = 0;
+    // SAFETY: `pending` points to a valid `SigSet`.
+    if unsafe { pm::__kcall_sigpending(&raw mut pending) }.is_err() {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(CHILD_FAIL) };
+    }
+    if pending != 0 {
+        // SAFETY: as above.
+        unsafe { bindings::_exit::_exit(INHERIT_BAD_PENDING) };
+    }
+
+    // SAFETY: as above.
+    unsafe { bindings::_exit::_exit(INHERIT_OK) };
+}
+
+/// Verifies that `fork()` honors POSIX signal-state inheritance: the child inherits the parent's
+/// signal dispositions and the calling thread's blocked mask, while its pending set starts empty.
+/// The parent installs a `SIGUSR1` handler, blocks `SIGUSR2`, forks, and confirms the child observes
+/// all three properties through its exit status.
+fn test_fork_inherits_signal_state() -> Result<(), Error> {
+    install_sigusr1_handler(0)?;
+
+    // Block SIGUSR2 in the parent so the child must inherit it as blocked.
+    let usr2_bit: SigSet = 1u64 << (SIGUSR2 - 1);
+    let mut saved_mask: SigSet = 0;
+    // SAFETY: `usr2_bit` and `saved_mask` point to valid `SigSet` values.
+    unsafe { pm::__kcall_sigprocmask(SIG_BLOCK, &raw const usr2_bit, &raw mut saved_mask) }?;
+
+    let ret: pid_t = bindings::fork::fork();
+    if ret == 0 {
+        run_fork_inherit_child();
+    }
+    assert!(ret > 0, "fork() failed in parent (ret={})", ret);
+    let child: ProcessIdentifier = ProcessIdentifier::from(ret);
+
+    let mut status: c_int = 0;
+    // SAFETY: `status` points to a valid `c_int`.
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, 0) };
+    assert!(
+        reaped == i32::from(child),
+        "waitpid() must reap the fork-inheritance child (ret={}, child={})",
+        reaped,
+        i32::from(child)
+    );
+    assert!(wifexited(status), "child must surface as a normal exit (status={:#x})", status);
+    assert!(
+        wexitstatus(status) == INHERIT_OK,
+        "forked child must inherit the parent's signal state (exit={}, expected={})",
+        wexitstatus(status),
+        INHERIT_OK
+    );
+
+    // Restore the parent's signal state so later tests are unaffected.
+    // SAFETY: `saved_mask` points to a valid `SigSet`; the old-mask output is not requested.
+    unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, &raw const saved_mask, ptr::null_mut()) }?;
+    let restore: SigAction = SigAction {
+        sa_handler: ::sys::pm::SIG_DFL,
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: 0,
+    };
+    // SAFETY: `restore` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    unsafe { pm::__kcall_sigaction(as_signum(SIGUSR1)?, &raw const restore, ptr::null_mut()) }?;
+
+    Ok(())
+}
+
+//==================================================================================================
+// Child-Status Signals (SIGCHLD)
+//==================================================================================================
+
+/// Counts how many times the `SIGCHLD` handler ran, so the test can confirm that the
+/// process-manager daemon posted `SIGCHLD` to the parent on a child's termination.
+static SIGCHLD_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Handler installed for `SIGCHLD`; records each delivery so the test can confirm the parent was
+/// notified of its child's termination.
+extern "C" fn sigchld_handler(_signum: c_int) {
+    SIGCHLD_COUNT.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Returns the address of [`sigchld_handler`] for the `sa_handler` slot.
+#[allow(clippy::as_conversions)]
+fn sigchld_handler_addr() -> usize {
+    sigchld_handler as *const () as usize
+}
+
+/// Forks a child that exits immediately with status zero. Returns the child's PID in the parent;
+/// the child never returns from this function.
+fn spawn_exiting_child() -> Result<ProcessIdentifier, Error> {
+    let ret: pid_t = bindings::fork::fork();
+    if ret == 0 {
+        // SAFETY: the freshly forked child holds no resources requiring cleanup.
+        unsafe { bindings::_exit::_exit(0) };
+    }
+    assert!(ret > 0, "fork() failed in parent (ret={})", ret);
+    Ok(ProcessIdentifier::from(ret))
+}
+
+/// Verifies that the process-manager daemon posts `SIGCHLD` to the parent when a child terminates,
+/// and that this notification integrates cleanly with `waitpid()`: the parent installs a `SIGCHLD`
+/// handler, forks a child that exits, reaps the child, and observes the handler having run.
+///
+/// `SIGCHLD` is blocked across the reap so the notification remains pending and can be observed
+/// deterministically after the synchronous `waitpid()` completes. This mirrors the POSIX-idiomatic
+/// pattern for combining a `SIGCHLD` handler with a direct wait: collect the child status first,
+/// then unblock the pending notification and run the handler.
+fn test_sigchld_delivered_on_child_exit() -> Result<(), Error> {
+    SIGCHLD_COUNT.store(0, Ordering::SeqCst);
+
+    // Install a catching disposition for SIGCHLD. Its default action is to ignore, so a handler is
+    // required to observe the notification at all.
+    let act: SigAction = SigAction {
+        sa_handler: sigchld_handler_addr(),
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: 0,
+    };
+    // SAFETY: `act` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    unsafe { pm::__kcall_sigaction(as_signum(SIGCHLD)?, &raw const act, ptr::null_mut()) }?;
+
+    // Block SIGCHLD across the reap so the daemon-relayed wait is not interrupted by the very
+    // notification it triggers; the signal stays pending and is observed deterministically below.
+    let bit: SigSet = 1u64 << (SIGCHLD - 1);
+    let mut old: SigSet = 0;
+    // SAFETY: `bit` and `old` point to valid `SigSet` values.
+    unsafe { pm::__kcall_sigprocmask(SIG_BLOCK, &raw const bit, &raw mut old) }?;
+
+    let child: ProcessIdentifier = spawn_exiting_child()?;
+
+    // Reap the child with a blocking wait. SIGCHLD is blocked, so the wait completes cleanly with
+    // the child collected rather than being interrupted by the notification its exit generates.
+    let mut status: c_int = 0;
+    // SAFETY: `status` points to a valid `c_int`.
+    let reaped: pid_t = unsafe { bindings::waitpid::waitpid(i32::from(child), &raw mut status, 0) };
+    assert!(
+        reaped == i32::from(child),
+        "waitpid() must reap the exiting child (ret={}, errno={})",
+        reaped,
+        read_errno()
+    );
+    assert!(wifexited(status), "exited child must surface as a normal exit (status={:#x})", status);
+    assert!(
+        wexitstatus(status) == 0,
+        "exited child must report exit status zero (got={})",
+        wexitstatus(status)
+    );
+
+    // The daemon must have posted SIGCHLD to the parent on the child's termination; with the signal
+    // blocked, the notification is pending rather than delivered.
+    let mut pending: SigSet = 0;
+    // SAFETY: `pending` points to a valid `SigSet`.
+    unsafe { pm::__kcall_sigpending(&raw mut pending) }?;
+    assert!(
+        pending & bit != 0,
+        "SIGCHLD must be pending on the parent after its child's termination (pending={:#x})",
+        pending
+    );
+
+    // Unblocking delivers the pending notification at this call's return-to-user boundary, running
+    // the handler.
+    // SAFETY: `old` points to a valid `SigSet`; the old-mask output is not requested.
+    unsafe { pm::__kcall_sigprocmask(SIG_SETMASK, &raw const old, ptr::null_mut()) }?;
+    assert!(
+        SIGCHLD_COUNT.load(Ordering::SeqCst) >= 1,
+        "unblocking a pending SIGCHLD must deliver it to the parent"
+    );
+
+    // Restore the default disposition so later code in this process is unaffected.
+    let restore: SigAction = SigAction {
+        sa_handler: ::sys::pm::SIG_DFL,
+        sa_mask: 0,
+        sa_flags: 0,
+        sa_sigaction: 0,
+    };
+    // SAFETY: `restore` is a valid, properly aligned `SigAction`; the old-action pointer is null.
+    unsafe { pm::__kcall_sigaction(as_signum(SIGCHLD)?, &raw const restore, ptr::null_mut()) }?;
+
+    Ok(())
+}
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
@@ -779,5 +1274,10 @@ pub fn run() -> Result<(), Error> {
     test_sigsuspend_returns_after_handler()?;
     test_sigsuspend_delivers_pending_unblocked_signal()?;
     test_sigpending_reports_blocked_pending()?;
+    test_sigstop_stops_and_sigcont_resumes()?;
+    test_sigstop_is_uncatchable()?;
+    test_caught_sigcont_continues_and_runs_handler()?;
+    test_fork_inherits_signal_state()?;
+    test_sigchld_delivered_on_child_exit()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Integrate signals with the process lifecycle and basic job control,
completing the job-control phase of the signals effort. Child
termination now notifies the parent via `SIGCHLD`, and a stopped
process state backs the `SIGSTOP`/`SIGCONT` default actions so suspended
processes are skipped by the scheduler until continued.

Part of #2690. Closes #2697.

## What changed

**Kernel**
- Add a job-control stopped flag to `ProcessState` with `is_stopped()`/
  `set_stopped()` accessors, and skip stopped processes in
  `take_earliest_ready()` so none of their threads run until continued.
- Replace the placeholder `PostAction::Wake` with `PostAction::Stop`;
  resolve `SIGSTOP`/`SIGTSTP`/`SIGTTIN`/`SIGTTOU` to `stop_process()` and
  apply `SIGCONT`'s continue effect unconditionally via
  `continue_process()`, discarding the superseded pending stop/continue.
- Reject stopping the kernel process and clear the stopped flag on
  `terminate()` so a doomed process can run its own exit.
- Inherit the creating thread's blocked mask on thread creation and the
  parent's dispositions/restorer on fork via `SignalControl` inheritance;
  derive `Clone` for `SignalHandler`/`SignalDisposition` and add
  `ProcessState::signals()`/`set_signals()`.
- Drop the now-unused `SleepingProcess::candidate_tid()`.

**Libraries**
- `proc`: post `SIGCHLD` to the parent on child termination, complementing
  the existing `waitpid()` flow (`SIGCHLD` defaults to `Ign`).

**Tests**
- Extend `test-rust-kill` with `SIGSTOP`/`SIGCONT` suspend-resume,
  uncatchable `SIGSTOP`, caught `SIGCONT` delivery, fork signal-state
  inheritance, and `SIGCHLD`-on-child-exit coverage.

## Validation

- `./z build -- run-nanvix-tests`
- `./z build -- run-unit-tests`
- `./z build -- run-kernel-tests MACHINE=microvm TARGET=x86`