### PR TITLE
[tests] Add getenv cmdline-env system test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,6 +3760,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-rust-getenv-nostd"
+version = "0.17.82"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc_stdlib",
+ "libc_string",
+ "nvx",
+ "nvx-crt0",
+ "sys",
+ "sysalloc",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
 name = "test-rust-kernel"
 version = "0.17.82"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ members = [
         "src/tests/integration/test-rust-cmdline-env-nostd",
         "src/tests/integration/test-rust-dlfcn",
         "src/tests/integration/test-rust-env-nostd",
+        "src/tests/integration/test-rust-getenv-nostd",
         "src/tests/integration/test-rust-execv-big-target",
         "src/tests/integration/test-rust-execv-target",
         "src/tests/integration/test-rust-execv-test",

--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ ALL_GUEST_TESTS := \
 	test-rust-sigsegv \
 	test-rust-linux-app test-rust-arch test-rust-vfs-test test-rust-misc test-rust-memory test-rust-network \
 	test-rust-c-bindings test-rust-mount-test test-rust-mount-multipart-test test-rust-cmdline-len \
-	test-rust-env-nostd test-rust-cmdline-env-nostd test-rust-snapshot-test test-rust-execv-test test-rust-execv-target \
+	test-rust-env-nostd test-rust-cmdline-env-nostd test-rust-getenv-nostd test-rust-snapshot-test test-rust-execv-test test-rust-execv-target \
 	test-rust-execv-big-target test-rust-pipe-dup2 test-rust-fork-exec-vfsd-test test-rust-fork-exec-vfsd-target \
 	test-rust-fork-exec-write-test test-rust-fork-exec-write-target test-rust-thread-vfs-test \
 	test-rust-fork-exec-loop-test test-rust-fork-exec-loop-target test-rust-socket-fork \

--- a/src/libs/libc_stdlib/src/env_table.rs
+++ b/src/libs/libc_stdlib/src/env_table.rs
@@ -718,6 +718,45 @@ mod test {
         assert_eq!(value.to_bytes(), b"\xff\xfe");
     }
 
+    /// Tests that `init_from_raw` skips malformed entries (those lacking a `=`) while still
+    /// importing the well-formed entries that surround them.
+    #[test]
+    fn test_init_from_raw_skips_malformed() {
+        let _guard = setup();
+        let entries: [&[u8]; 4] = [b"GOOD=1\0", b"MALFORMED\0", b"ALSO=2\0", b"\0"];
+        let ptrs: [*const c_char; 4] = [
+            entries[0].as_ptr().cast::<c_char>(),
+            entries[1].as_ptr().cast::<c_char>(),
+            entries[2].as_ptr().cast::<c_char>(),
+            ::core::ptr::null(),
+        ];
+        unsafe {
+            init_from_raw(ptrs.as_ptr());
+        }
+        let good: *const c_char = get("GOOD");
+        assert!(!good.is_null());
+        let good_val: &ffi::CStr = unsafe { ffi::CStr::from_ptr(good) };
+        assert_eq!(good_val.to_str(), Ok("1"));
+        let also: *const c_char = get("ALSO");
+        assert!(!also.is_null());
+        let also_val: &ffi::CStr = unsafe { ffi::CStr::from_ptr(also) };
+        assert_eq!(also_val.to_str(), Ok("2"));
+        // The malformed token carried no `=`, so it must not become an environment entry.
+        assert!(get("MALFORMED").is_null());
+    }
+
+    /// Tests that `init_from_raw` with a non-null `envp` whose first element is the terminating
+    /// NULL produces an empty table (covers the non-null-pointer path distinct from `envp.is_null()`).
+    #[test]
+    fn test_init_from_raw_empty_array() {
+        let _guard = setup();
+        let ptrs: [*const c_char; 1] = [::core::ptr::null()];
+        unsafe {
+            init_from_raw(ptrs.as_ptr());
+        }
+        assert!(get("ANYTHING").is_null());
+    }
+
     /// Reads the [`ENVIRON_ARRAY`] back into owned `KEY=VALUE` strings, dereferencing each published
     /// pointer up to the terminating NULL. Mirrors how C code walks `char **environ`.
     fn environ_view() -> Vec<String> {

--- a/src/tests/integration/test-rust-getenv-nostd/Cargo.toml
+++ b/src/tests/integration/test-rust-getenv-nostd/Cargo.toml
@@ -1,0 +1,33 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "test-rust-getenv-nostd"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "Integration test that getenv() returns kernel-cmdline-provided environment variables"
+homepage.workspace = true
+
+[[bin]]
+name = "test-rust-getenv-nostd"
+
+[dependencies]
+nvx = { workspace = true }
+nvx-crt0 = { workspace = true, features = ["rust-main", "provides-allocator"] }
+sysalloc = { workspace = true }
+libc_stdlib = { workspace = true }
+libc_string = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
+syslog = { workspace = true, default-features = true }
+
+[build-dependencies]
+cc = { workspace = true }
+cfg-if = { workspace = true }
+
+[features]
+default = ["panic"]
+panic = ["nvx/panic", "nvx-crt0/panic"]

--- a/src/tests/integration/test-rust-getenv-nostd/build.rs
+++ b/src/tests/integration/test-rust-getenv-nostd/build.rs
@@ -1,0 +1,56 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use std::{
+    env,
+    fs::File,
+    io::Read,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+fn main() {
+    //==============================================================================================
+    // Test-Specific Environment Variables
+    //==============================================================================================
+
+    // Get CARGO_MANIFEST_DIR Environment Variable.
+    let manifest_dir: String = match env::var("CARGO_MANIFEST_DIR") {
+        Ok(mdir) => mdir,
+        Err(_) => panic!("failed to get CARGO_MANIFEST_DIR environment variable"),
+    };
+
+    let config_path: PathBuf = Path::new(&manifest_dir).join("config.json");
+    if config_path.exists() {
+        println!("cargo:rerun-if-changed=./config.json");
+        let mut file: File = File::open(&config_path).expect("Failed to open file");
+        let mut raw_content: String = String::new();
+        file.read_to_string(&mut raw_content)
+            .expect("Failed to read config.json");
+        let content = raw_content.replace("\n", "").replace(" ", "");
+        println!("cargo:rustc-env=CONFIG={content}");
+    }
+
+    //==============================================================================================
+    // Link Archive
+    //==============================================================================================
+
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
+}

--- a/src/tests/integration/test-rust-getenv-nostd/src/main.rs
+++ b/src/tests/integration/test-rust-getenv-nostd/src/main.rs
@@ -1,0 +1,104 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![no_main]
+#![deny(clippy::all)]
+#![deny(clippy::as_conversions)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+extern crate alloc;
+extern crate libc_string;
+extern crate nvx;
+extern crate nvx_crt0;
+
+use ::core::ffi::CStr;
+use ::sys::error::Error;
+use ::sysapi::{
+    ffi::c_char,
+    unistd::STDOUT_FILENO,
+};
+use ::syscall::unistd;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Environment variable names probed via `getenv()`, in deterministic output order.
+///
+/// Each entry is NUL-terminated so it can be passed straight to `getenv()`. `NVX_GETENV_MISSING`
+/// is never expected to resolve: the harness either omits it entirely (null-return path) or
+/// supplies it as a bare `KEY` token with no `=` (malformed-entry-skip path). Either way
+/// `getenv()` must return null for it.
+const KEYS: [&[u8]; 4] = [
+    b"HOME\0",
+    b"NVX_GETENV_A\0",
+    b"NVX_GETENV_B\0",
+    b"NVX_GETENV_MISSING\0",
+];
+
+/// Sentinel written in place of a value when `getenv()` returns a null pointer.
+const NULL_SENTINEL: &[u8] = b"(null)";
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Probes a fixed set of environment variables through `getenv()` and writes the results to stdout
+/// in a deterministic format the test harness can match:
+///
+/// ```text
+/// GETENV:HOME=<v> NVX_GETENV_A=<v> NVX_GETENV_B=<v> NVX_GETENV_MISSING=<v>
+/// ok
+/// ```
+///
+/// Each `<v>` is the value returned by `getenv()` for that key, or `(null)` when `getenv()` returns
+/// a null pointer. Because `getenv()` reads the process environment table populated at start-of-day
+/// from the kernel-provided env page, a non-null result proves the kernel-delivered variable made
+/// it all the way into the runtime environment API. The trailing `ok` lets the harness confirm the
+/// program ran to completion.
+///
+#[unsafe(no_mangle)]
+pub fn main() -> Result<(), Error> {
+    unistd::write(STDOUT_FILENO, b"GETENV:")?;
+
+    for (index, key) in KEYS.iter().enumerate() {
+        if index > 0 {
+            unistd::write(STDOUT_FILENO, b" ")?;
+        }
+
+        // Print the key name without its trailing NUL terminator.
+        let name: &[u8] = &key[..key.len() - 1];
+        unistd::write(STDOUT_FILENO, name)?;
+        unistd::write(STDOUT_FILENO, b"=")?;
+
+        // Look up the value through getenv(), which consults the environment table initialized at
+        // process start from the kernel-provided env page.
+        let value: *mut c_char = unsafe { ::libc_stdlib::getenv(key.as_ptr().cast::<c_char>()) };
+        if value.is_null() {
+            unistd::write(STDOUT_FILENO, NULL_SENTINEL)?;
+        } else {
+            // SAFETY: a non-null `getenv()` result points to a NUL-terminated C string that remains
+            // valid until the next environment mutation, and this test performs none.
+            let bytes: &[u8] = unsafe { CStr::from_ptr(value) }.to_bytes();
+            unistd::write(STDOUT_FILENO, bytes)?;
+        }
+    }
+
+    unistd::write(STDOUT_FILENO, b"\n")?;
+    unistd::write(STDOUT_FILENO, b"ok")?;
+
+    Ok(())
+}

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -381,3 +381,54 @@ program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello"
 program_env = "PATH=a;b"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
+
+#===================================================================================================
+# getenv() Environment Lookup Tests
+#===================================================================================================
+
+# getenv() returns kernel-cmdline-provided variables (including HOME); a key that was never
+# provided resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+input = "[]"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+# A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+input = "[]"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+# An empty environment produces an empty table, so every probed key resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+input = "[]"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -380,3 +380,54 @@ program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello"
 program_env = "PATH=a;b"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
+
+#===================================================================================================
+# getenv() Environment Lookup Tests
+#===================================================================================================
+
+# getenv() returns kernel-cmdline-provided variables (including HOME); a key that was never
+# provided resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+input = "[]"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+# A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+input = "[]"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+# An empty environment produces an empty table, so every probed key resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+input = "[]"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -170,6 +170,34 @@ program_args_padding_len = 4066
 expected_output = "ok"
 
 #===================================================================================================
+# getenv() Environment Lookup Tests
+#===================================================================================================
+
+# getenv() returns kernel-cmdline-provided variables (including HOME); a key that was never
+# provided resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+# A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+# An empty environment produces an empty table, so every probed key resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+#===================================================================================================
 # HTTP Executor Tests
 #
 # HTTP mode is supported on Windows in single-tenant standalone deployments. The guest stdio
@@ -284,6 +312,37 @@ program = "./bin/test-rust-cmdline-len.elf"
 program_args_padding_len = 4066
 input = "[]"
 expected_output = "ok"
+
+#===================================================================================================
+# getenv() Environment Lookup Tests
+#===================================================================================================
+
+# getenv() returns kernel-cmdline-provided variables (including HOME); a key that was never
+# provided resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+input = "[]"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+# A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+input = "[]"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+# An empty environment produces an empty table, so every probed key resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+input = "[]"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 #===================================================================================================
 # Host Mount Tests

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -633,6 +633,57 @@ program_env = "PATH=a;b"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 #===================================================================================================
+# getenv() Environment Lookup Tests
+#===================================================================================================
+
+# getenv() returns kernel-cmdline-provided variables (including HOME); a key that was never
+# provided resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+input = "[]"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
+expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
+
+# A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+input = "[]"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
+expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+# An empty environment produces an empty table, so every probed key resolves to null.
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "http"
+program = "./bin/test-rust-getenv-nostd.elf"
+input = "[]"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+program = "./bin/test-rust-getenv-nostd.elf"
+expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
+
+#===================================================================================================
 # Snapshot Save / Restore Tests
 #===================================================================================================
 


### PR DESCRIPTION
## Summary

Adds the missing end-to-end test for issue #2281. The kernel env-page
parsing at process init (`__nanvix_env_init` → `env_table::init_from_raw`)
was already implemented on `dev`; the gap was a test proving `getenv()`
actually returns variables delivered through the kernel command line.

## What changed

- **New guest integration crate** `test-rust-getenv-nostd` — probes
  `getenv()` for cmdline-provided keys (`HOME`, `NVX_GETENV_A`,
  `NVX_GETENV_B`, `NVX_GETENV_MISSING`) and prints the results in a
  print-and-match style (mirrors `test-rust-cmdline-env-nostd`).
- **Workspace registration** — root `Cargo.toml` members, `Makefile`
  `ALL_GUEST_TESTS`, `Cargo.lock`.
- **System-test cases** registered in all four configs
  (`test-standalone`, `test-single_process`, `test-multi_process`,
  `test-standalone-windows`) across **terminal** and **HTTP** executors,
  covering three scenarios:
  1. Provided env — all keys resolve to their cmdline values.
  2. Malformed entry (bare `KEY` with no `=`) — skipped, returns null.
  3. Empty env — every key returns null.
- **Unit tests** in `env_table.rs` for malformed and empty input.

## Validation

- `libc_stdlib` unit tests: 161 passed (incl. 2 new).
- Guest cross-compile + link: clean.
- `clippy -D warnings`, format-check, spellcheck: clean.
- Full `all-nanvix` build: success.
- End-to-end boot on Windows standalone: all 6 getenv cases passed
  (`EXIT=0`); captured guest stdout matches expected output.

Closes #2281
