### PR TITLE
[ci] Build only 256MB images by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,11 +397,7 @@ jobs:
           '["release"]') }}
         machine-type: [ microvm ]
         deployment-type: [ standalone, single-process, multi-process ]
-        memory-size: ${{ fromJSON(github.event_name == 'pull_request' && '[128]' || '[128, 256]') }}
-        # 256MB images are release-only; exclude them from debug builds.
-        exclude:
-          - build-type: debug
-            memory-size: 256
+        memory-size: [ 256 ]
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nanvix/ci:ubuntu-24.04
@@ -510,6 +506,9 @@ jobs:
       # The CI container runs as root without USER set; nanvixd uses it as
       # fallback tenant-id and fails when the variable is missing.
       USER: root
+      # Single source of truth for the memory size (MB) whose build artifacts
+      # this job consumes. Must match the ci-build matrix memory-size.
+      MEMORY_SIZE: "256"
 
     steps:
       - uses: actions/checkout@v7
@@ -526,6 +525,7 @@ jobs:
           build-type: "${{ matrix.build-type }}"
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
+          memory-size: "${{ env.MEMORY_SIZE }}"
 
       - name: "Integration Test"
         uses: ./.github/actions/integration-test
@@ -715,11 +715,7 @@ jobs:
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
-        memory-size: ${{ fromJSON(github.event_name == 'pull_request' && '[128]' || '[128, 256]') }}
-        # 256MB images are release-only; exclude them from debug builds.
-        exclude:
-          - build-type: debug
-            memory-size: 256
+        memory-size: [ 256 ]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -802,6 +798,10 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+    env:
+      # Single source of truth for the memory size (MB) whose build artifacts
+      # this job consumes. Must match the windows-ci-build matrix memory-size.
+      MEMORY_SIZE: "256"
 
     steps:
       - uses: actions/checkout@v7
@@ -809,7 +809,7 @@ jobs:
       - name: "Download Build Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}-128mb
+          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}-${{ env.MEMORY_SIZE }}mb
           path: bin
 
       - name: "Exclude bin/ from Windows Defender"
@@ -1477,7 +1477,7 @@ jobs:
         target-arch: [ x86 ]
         machine-type: [ microvm ]
         deployment-type: [ standalone, single-process, multi-process ]
-        memory-size: [ 128, 256 ]
+        memory-size: [ 256 ]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -1542,7 +1542,7 @@ jobs:
       matrix:
         target-arch: [ x86 ]
         machine-type: [ microvm ]
-        memory-size: [ 128, 256 ]
+        memory-size: [ 256 ]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ export WHP ?= no
 
 # Memory size in megabytes. Exported as MEMORY_SIZE_BYTES for build.rs scripts.
 # Example: make all MEMORY_SIZE=256
-export MEMORY_SIZE ?= 128
+export MEMORY_SIZE ?= 256
 
 #===================================================================================================
 # OS Detection


### PR DESCRIPTION
## Summary

Standardize Nanvix on a single 256MB memory configuration so that `MEMORY_SIZE`
defaults to 256MB and the debug and release pipelines build, test, and release
only 256MB images.

## Changes

- **Makefile**: `MEMORY_SIZE` default `128` → `256` (also updates the derived
  `MEMORY_SIZE_BYTES` and the `make help` text automatically).
- **.github/workflows/ci.yml**:
  - `ci-build` and `windows-ci-build`: replace the PR-conditional
    `[128] / [128, 256]` matrix and the `debug → exclude 256` rules with a single
    `memory-size: [ 256 ]`, so debug builds at 256MB too.
  - `release-archive` and `windows-release-archive`: `[ 128, 256 ]` → `[ 256 ]`.
  - Update downstream artifact downloads to match the 256MB-only builds:
    - `windows-integration-test`: hardcoded `…-128mb` → `…-256mb`.
    - Linux `ci-test`: pass `memory-size: "256"` to `prepare-test-artifacts`
      (previously relied on the action's `128` default).

## Validation

- `ci.yml` parses as valid YAML.
- Makefile parses and reports `MEMORY_SIZE=256` (`MEMORY_SIZE_BYTES=268435456`).
- No `128` memory references remain in either file.
- pre-commit and commit-msg hooks passed locally.

> Note: `prepare-test-artifacts`' documented `default: "128"` is now always
> overridden from `ci.yml`. Left untouched to keep this change scoped to the two
> files; happy to update it to `256` if preferred.