### PR TITLE
[nanvix_libc] Add POSIX/glibc compat shims

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -65,6 +65,7 @@ extern DIR *opendir(const char *dirname);
 extern DIR *fdopendir(int fd);
 extern struct dirent *readdir(DIR *dirp);
 extern int closedir(DIR *dirp);
+extern void rewinddir(DIR *dirp);
 
 #ifdef __cplusplus
 }

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -45,6 +45,7 @@ extern "C" {
 #define AT_EACCESS 1 /**< Check access using effective IDs. */
 #define AT_SYMLINK_NOFOLLOW 2 /**< Do not follow symbolic links. */
 #define AT_REMOVEDIR 8 /**< Remove a directory instead of a file. */
+#define AT_SYMLINK_FOLLOW 0x400 /**< Follow symbolic links. */
 #define POSIX_FADV_NORMAL 0 /**< No advice. */
 #define POSIX_FADV_SEQUENTIAL 1 /**< Sequential access. */
 #define POSIX_FADV_RANDOM 2 /**< Random access. */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -46,6 +46,11 @@ extern "C" {
  * Types
  *==================================================================================================*/
 
+/* glibc compatibility: expose alloca() via <stdlib.h> under _GNU_SOURCE. */
+#ifdef _GNU_SOURCE
+#include <alloca.h>
+#endif
+
 /** @brief Structure type returned by the div() function. */
 typedef struct {
     int quot; /**< Quotient.  */
@@ -86,7 +91,7 @@ extern long atol(const char *nptr);
 extern long long atoll(const char *nptr);
 extern double strtod(const char *restrict nptr, char **restrict endptr);
 extern float strtof(const char *restrict nptr, char **restrict endptr);
-extern double strtold(const char *restrict nptr, char **restrict endptr);
+extern long double strtold(const char *restrict nptr, char **restrict endptr);
 extern long strtol(const char *restrict nptr, char **restrict endptr, int base);
 extern long long strtoll(const char *restrict nptr, char **restrict endptr, int base);
 extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);

--- a/src/libs/libc_dirent/src/bindings.rs
+++ b/src/libs/libc_dirent/src/bindings.rs
@@ -52,3 +52,20 @@ pub unsafe extern "C" fn fdopendir(_fd: c_int) -> *mut c_void {
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
 }
+
+///
+/// # Description
+///
+/// Resets the position of the directory stream `dirp` to the beginning. Minimal stub: the
+/// underlying getdents-backed stream cannot be re-seeked, so this is a no-op kept so consumers
+/// (e.g. CPython's posixmodule) link successfully.
+///
+/// # Safety
+///
+/// Safe to call with any pointer; the value is not dereferenced.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn rewinddir(_dirp: *mut c_void) {
+    ::syslog::debug!("rewinddir(): not implemented");
+}

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -55,6 +55,13 @@ guard = "MB_CUR_MAX"
 
 [[types]]
 text = """
+/* glibc compatibility: expose alloca() via <stdlib.h> under _GNU_SOURCE. */
+#ifdef _GNU_SOURCE
+#include <alloca.h>
+#endif"""
+
+[[types]]
+text = """
 /** @brief Structure type returned by the div() function. */
 typedef struct {
     int quot; /**< Quotient.  */
@@ -170,7 +177,7 @@ extern double strtod(const char *restrict nptr, char **restrict endptr);'''
 strtof = '''
 extern float strtof(const char *restrict nptr, char **restrict endptr);'''
 strtold = '''
-extern double strtold(const char *restrict nptr, char **restrict endptr);'''
+extern long double strtold(const char *restrict nptr, char **restrict endptr);'''
 strtol = '''
 extern long strtol(const char *restrict nptr, char **restrict endptr, int base);'''
 strtoll = '''

--- a/src/libs/libc_stdlib/src/strtold.rs
+++ b/src/libs/libc_stdlib/src/strtold.rs
@@ -16,10 +16,11 @@ use ::sysapi::ffi::c_char;
 ///
 /// Converts the initial portion of the string pointed to by `nptr` to a floating-point value.
 ///
-/// Nanvix computes the result at `double` precision and the generated C declaration returns
-/// `double` to match. This keeps the implementation and the C prototype in agreement on the
-/// return-value ABI (a `long double` prototype would expect the value in the x87 register on the
-/// supported targets, corrupting callers).
+/// The C prototype returns `long double` to match POSIX. The conversion is computed at `double`
+/// precision and delegated to [`crate::strtod`]. This is ABI-correct on the supported i686 target,
+/// where the cdecl convention returns `float`, `double`, and `long double` alike in the x87 `st0`
+/// register; the `f64` result is promoted to the 80-bit extended representation on return, so the
+/// value the caller pops as `long double` is exactly the converted number.
 ///
 /// # Parameters
 ///

--- a/src/libs/sysapi/headers/dirent.toml
+++ b/src/libs/sysapi/headers/dirent.toml
@@ -79,7 +79,7 @@ struct posix_dent {
 
 [[sections]]
 title = "Directory Operations"
-functions = ["opendir", "fdopendir", "readdir", "closedir"]
+functions = ["opendir", "fdopendir", "readdir", "closedir", "rewinddir"]
 
 # opendir's Rust binding spells its path argument `*const i8`; declare the
 # standard POSIX prototype so C callers can pass a `const char *`.
@@ -88,3 +88,4 @@ functions = ["opendir", "fdopendir", "readdir", "closedir"]
 [overrides]
 opendir = "extern DIR *opendir(const char *dirname);"
 fdopendir = "extern DIR *fdopendir(int fd);"
+rewinddir = "extern void rewinddir(DIR *dirp);"

--- a/src/libs/sysapi/headers/fcntl.toml
+++ b/src/libs/sysapi/headers/fcntl.toml
@@ -36,6 +36,7 @@ text = '''
 #define AT_EACCESS 1 /**< Check access using effective IDs. */
 #define AT_SYMLINK_NOFOLLOW 2 /**< Do not follow symbolic links. */
 #define AT_REMOVEDIR 8 /**< Remove a directory instead of a file. */
+#define AT_SYMLINK_FOLLOW 0x400 /**< Follow symbolic links. */
 #define POSIX_FADV_NORMAL 0 /**< No advice. */
 #define POSIX_FADV_SEQUENTIAL 1 /**< Sequential access. */
 #define POSIX_FADV_RANDOM 2 /**< Random access. */

--- a/src/libs/sysapi/src/fcntl.rs
+++ b/src/libs/sysapi/src/fcntl.rs
@@ -102,6 +102,8 @@ pub mod atflags {
     pub const AT_EACCESS: c_int = 1;
     /// Remove directory instead of file.
     pub const AT_REMOVEDIR: c_int = 8;
+    /// Follow symbolic links.
+    pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
     /// Do not follow symbolic links.
     pub const AT_SYMLINK_NOFOLLOW: c_int = 2;
 }


### PR DESCRIPTION
## Summary

Adds POSIX/glibc compatibility shims to `nanvix_libc` so common consumers (e.g. CPython, libstdc++) link and compile cleanly.

## Changes

- **`rewinddir()`** — minimal `dirent` stub (no-op) so consumers linking against the symbol succeed.
- **`AT_SYMLINK_FOLLOW`** — added to `sysapi` fcntl atflags and the generated `fcntl.h`.
- **`alloca()`** — exposed via `<stdlib.h>` under `_GNU_SOURCE` for glibc compatibility.
- **`strtold()`** — prototype restored to POSIX `long double`. The conversion stays at `double` precision; this is ABI-correct on i686 where cdecl returns `float`/`double`/`long double` alike in the x87 `st0` register.

## Validation

- `./z build -- run-unit-tests` passes.
- Pre-commit hook checks pass for all three CI configurations.