### PR TITLE
[kernel] Reject oversized frame ranges

### DIFF
--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -151,8 +151,8 @@ impl Inner {
         // Reject impossible requests before delegating to the bitmap range allocator.
         if count > self.bitmap.number_of_bits() {
             let reason: &str = "requested range exceeds bitmap size";
-            error!("{reason} (count={count})");
-            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            error!("{reason} (count={count}, bitmap_bits={})", self.bitmap.number_of_bits());
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
         let frame_number: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -148,6 +148,12 @@ impl Inner {
     /// an error is returned instead.
     ///
     fn alloc_contiguous(&mut self, count: usize) -> Result<FrameAddress, Error> {
+        // Reject impossible requests before delegating to the bitmap range allocator.
+        if count > self.bitmap.number_of_bits() {
+            let reason: &str = "requested range exceeds bitmap size";
+            error!("{reason} (count={count})");
+            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        }
         let frame_number: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,
             Err(error) => {


### PR DESCRIPTION
Reject contiguous frame allocation requests that exceed the allocator capacity.