### PR TITLE
[arpa_init] Implement POSIX inet_ntop(), inet_pton(), and inet_ntoa()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-weak test-c-echo test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
+ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-weak test-c-echo test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-inet test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/src/libs/libc_arpa_inet/src/lib.rs
+++ b/src/libs/libc_arpa_inet/src/lib.rs
@@ -11,6 +11,7 @@
 // Imports
 //==================================================================================================
 
+use ::core::ptr;
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::{
@@ -22,10 +23,28 @@ use ::sysapi::{
         in_addr,
         in_addr_t,
     },
-    sys_socket::socklen_t,
+    sys_socket::{
+        socket_address_family::{
+            AF_INET,
+            AF_INET6,
+        },
+        socklen_t,
+    },
 };
 use ::syscall::errno::__errno_location;
 use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Size of the buffer required to hold the longest IPv4 address string, including the terminating
+/// NUL (`"255.255.255.255"`).
+const INET_ADDRSTRLEN: usize = 16;
+
+/// Size of the buffer required to hold the longest IPv6 address string, including the terminating
+/// NUL (`"ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"`).
+const INET6_ADDRSTRLEN: usize = 46;
 
 //==================================================================================================
 // Standalone Functions
@@ -86,9 +105,31 @@ pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn inet_ntoa(addr: in_addr) -> *const c_char {
-    // TODO: https://github.com/nanvix/nanvix/issues/595.
-    ::syslog::debug!("inet_ntoa(): not implemented");
-    core::ptr::null()
+    // POSIX permits the result to point at static storage that subsequent calls overwrite. The
+    // buffer is sized for the longest IPv4 dotted-decimal string plus its terminating NUL.
+    static mut BUFFER: [u8; INET_ADDRSTRLEN] = [0; INET_ADDRSTRLEN];
+
+    // `s_addr` is held in network byte order; recover the host-order value so the octets can be
+    // extracted most-significant first.
+    let host: u32 = u32::from_be(addr.s_addr);
+    let octets: [u8; 4] = [
+        (host >> 24) as u8,
+        (host >> 16) as u8,
+        (host >> 8) as u8,
+        host as u8,
+    ];
+
+    // Format into a local buffer first, then publish to the static through a raw pointer.
+    // Raw-pointer access avoids constructing a reference to the mutable static (see
+    // `static_mut_refs`).
+    let mut scratch: [u8; INET_ADDRSTRLEN] = [0; INET_ADDRSTRLEN];
+    let len: usize = format_ipv4(octets, &mut scratch).unwrap_or(0);
+    let buffer: *mut u8 = ptr::addr_of_mut!(BUFFER) as *mut u8;
+    // SAFETY: `len < INET_ADDRSTRLEN`, so copying `len + 1` bytes (string plus NUL) stays within
+    // the bounds of `BUFFER`; the source and destination do not overlap.
+    ptr::copy_nonoverlapping(scratch.as_ptr(), buffer, len + 1);
+
+    buffer as *const c_char
 }
 
 ///
@@ -124,10 +165,38 @@ pub unsafe extern "C" fn inet_ntop(
     dst: *mut c_char,
     size: socklen_t,
 ) -> *const c_char {
-    // TODO: https://github.com/nanvix/nanvix/issues/592.
-    ::syslog::debug!("inet_ntop(): not implemented");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
-    core::ptr::null()
+    // Format into a scratch buffer large enough for any supported family, then copy it out only
+    // when the caller's buffer can hold the whole string.
+    let mut tmp: [u8; INET6_ADDRSTRLEN] = [0; INET6_ADDRSTRLEN];
+    let result: Option<usize> = match af {
+        AF_INET => format_in_addr(src, &mut tmp),
+        AF_INET6 => format_ipv6(src as *const u8, &mut tmp),
+        _ => {
+            *__errno_location() = ErrorCode::AddressFamilyNotSupported.get();
+            return ptr::null();
+        },
+    };
+
+    let len: usize = match result {
+        Some(len) => len,
+        None => {
+            *__errno_location() = ErrorCode::NoSpaceOnDevice.get();
+            return ptr::null();
+        },
+    };
+
+    // The full string plus its terminating NUL must fit within the caller's buffer.
+    if len + 1 > size as usize {
+        *__errno_location() = ErrorCode::NoSpaceOnDevice.get();
+        return ptr::null();
+    }
+
+    // Copy the formatted string, including its terminating NUL, into the caller's buffer.
+    for (i, &byte) in tmp[..=len].iter().enumerate() {
+        *dst.add(i) = byte as c_char;
+    }
+
+    dst
 }
 
 ///
@@ -157,10 +226,32 @@ pub unsafe extern "C" fn inet_ntop(
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn inet_pton(af: c_int, src: *const c_char, dst: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/593.
-    ::syslog::debug!("inet_pton(): not implemented");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
-    -1
+    match af {
+        AF_INET => match parse_ipv4(src) {
+            Some(octets) => {
+                let out: *mut u8 = dst as *mut u8;
+                for (i, &byte) in octets.iter().enumerate() {
+                    *out.add(i) = byte;
+                }
+                1
+            },
+            None => 0,
+        },
+        AF_INET6 => match parse_ipv6(src) {
+            Some(bytes) => {
+                let out: *mut u8 = dst as *mut u8;
+                for (i, &byte) in bytes.iter().enumerate() {
+                    *out.add(i) = byte;
+                }
+                1
+            },
+            None => 0,
+        },
+        _ => {
+            *__errno_location() = ErrorCode::AddressFamilyNotSupported.get();
+            -1
+        },
+    }
 }
 
 ///
@@ -314,4 +405,461 @@ pub unsafe extern "C" fn inet_aton(cp: *const c_char, inp: *mut in_addr) -> c_in
     }
 
     1
+}
+
+//==================================================================================================
+// Private Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the dotted-decimal representation of the four IPv4 `octets` into `dst`, starting at byte
+/// offset `start`. No terminating NUL is written.
+///
+/// # Parameters
+///
+/// - `octets`: The four address bytes, most-significant first.
+/// - `dst`: Destination byte buffer.
+/// - `start`: Offset into `dst` at which to begin writing.
+///
+/// # Returns
+///
+/// The offset just past the last byte written on success, or [`None`] if `dst` is too small.
+///
+fn write_ipv4(octets: [u8; 4], dst: &mut [u8], start: usize) -> Option<usize> {
+    let mut len: usize = start;
+    for (i, &octet) in octets.iter().enumerate() {
+        if i != 0 {
+            *dst.get_mut(len)? = b'.';
+            len += 1;
+        }
+        if octet >= 100 {
+            *dst.get_mut(len)? = b'0' + octet / 100;
+            len += 1;
+        }
+        if octet >= 10 {
+            *dst.get_mut(len)? = b'0' + (octet / 10) % 10;
+            len += 1;
+        }
+        *dst.get_mut(len)? = b'0' + octet % 10;
+        len += 1;
+    }
+    Some(len)
+}
+
+///
+/// # Description
+///
+/// Writes the dotted-decimal representation of the four IPv4 `octets` into `dst`, followed by a
+/// terminating NUL.
+///
+/// # Parameters
+///
+/// - `octets`: The four address bytes, most-significant first.
+/// - `dst`: Destination byte buffer.
+///
+/// # Returns
+///
+/// The length of the string (excluding the NUL) on success, or [`None`] if `dst` is too small.
+///
+fn format_ipv4(octets: [u8; 4], dst: &mut [u8]) -> Option<usize> {
+    let len: usize = write_ipv4(octets, dst, 0)?;
+    *dst.get_mut(len)? = 0;
+    Some(len)
+}
+
+///
+/// # Description
+///
+/// Writes the lowercase hexadecimal representation of a 16-bit IPv6 group `value` into `dst`
+/// starting at offset `start`, omitting leading zeros but always emitting at least one digit.
+///
+/// # Parameters
+///
+/// - `value`: The 16-bit group value.
+/// - `dst`: Destination byte buffer.
+/// - `start`: Offset into `dst` at which to begin writing.
+///
+/// # Returns
+///
+/// The offset just past the last byte written on success, or [`None`] if `dst` is too small.
+///
+fn write_hex16(value: u16, dst: &mut [u8], start: usize) -> Option<usize> {
+    let mut len: usize = start;
+    let mut started: bool = false;
+    for shift in [12u32, 8, 4, 0] {
+        let nibble: u8 = ((value >> shift) & 0xf) as u8;
+        if nibble != 0 || started || shift == 0 {
+            *dst.get_mut(len)? = if nibble < 10 {
+                b'0' + nibble
+            } else {
+                b'a' + nibble - 10
+            };
+            len += 1;
+            started = true;
+        }
+    }
+    Some(len)
+}
+
+///
+/// # Description
+///
+/// Finds the longest run of consecutive zero groups in an eight-group IPv6 address, which is the
+/// run eligible for `::` compression. Runs shorter than two groups are not reported, matching the
+/// canonical text representation rules.
+///
+/// # Parameters
+///
+/// - `words`: The eight 16-bit address groups.
+///
+/// # Returns
+///
+/// A tuple `(base, len)` giving the index and length of the longest qualifying zero run, or
+/// `(-1, 0)` when there is none.
+///
+fn longest_zero_run(words: &[u16; 8]) -> (isize, usize) {
+    let mut best_base: isize = -1;
+    let mut best_len: usize = 0;
+    let mut cur_base: isize = -1;
+    let mut cur_len: usize = 0;
+
+    for (i, &word) in words.iter().enumerate() {
+        if word == 0 {
+            if cur_base < 0 {
+                cur_base = i as isize;
+                cur_len = 1;
+            } else {
+                cur_len += 1;
+            }
+        } else if cur_base >= 0 {
+            if best_base < 0 || cur_len > best_len {
+                best_base = cur_base;
+                best_len = cur_len;
+            }
+            cur_base = -1;
+        }
+    }
+    if cur_base >= 0 && (best_base < 0 || cur_len > best_len) {
+        best_base = cur_base;
+        best_len = cur_len;
+    }
+
+    // A single zero group is written verbatim rather than compressed.
+    if best_base >= 0 && best_len < 2 {
+        return (-1, 0);
+    }
+
+    (best_base, best_len)
+}
+
+///
+/// # Description
+///
+/// Formats the sixteen-byte IPv6 address at `src` into `dst` using `::` zero-run compression and
+/// the trailing dotted-decimal form for IPv4-compatible and IPv4-mapped addresses, followed by a
+/// terminating NUL.
+///
+/// # Parameters
+///
+/// - `src`: Pointer to the sixteen address bytes in network byte order.
+/// - `dst`: Destination byte buffer.
+///
+/// # Returns
+///
+/// The length of the string (excluding the NUL) on success, or [`None`] if `dst` is too small.
+///
+/// # Safety
+///
+/// The caller must ensure that `src` points to at least sixteen readable bytes.
+///
+unsafe fn format_ipv6(src: *const u8, dst: &mut [u8]) -> Option<usize> {
+    // Combine the sixteen bytes into eight 16-bit groups (network byte order).
+    let mut words: [u16; 8] = [0; 8];
+    for (i, word) in words.iter_mut().enumerate() {
+        *word = ((*src.add(i * 2) as u16) << 8) | (*src.add(i * 2 + 1) as u16);
+    }
+
+    let (best_base, best_len) = longest_zero_run(&words);
+
+    let mut len: usize = 0;
+    let mut i: usize = 0;
+    while i < 8 {
+        // Inside the compressed run of zero groups?
+        if best_base >= 0 && i >= best_base as usize && i < best_base as usize + best_len {
+            if i == best_base as usize {
+                *dst.get_mut(len)? = b':';
+                len += 1;
+            }
+            i += 1;
+            continue;
+        }
+
+        // Emit a separator before each group other than the first.
+        if i != 0 {
+            *dst.get_mut(len)? = b':';
+            len += 1;
+        }
+
+        // IPv4-compatible and IPv4-mapped addresses end in dotted-decimal form.
+        if i == 6 && best_base == 0 && (best_len == 6 || (best_len == 5 && words[5] == 0xffff)) {
+            let octets: [u8; 4] = [*src.add(12), *src.add(13), *src.add(14), *src.add(15)];
+            len = write_ipv4(octets, dst, len)?;
+            break;
+        }
+
+        len = write_hex16(words[i], dst, len)?;
+        i += 1;
+    }
+
+    // A zero run that extends to the final group needs a closing colon.
+    if best_base >= 0 && best_base as usize + best_len == 8 {
+        *dst.get_mut(len)? = b':';
+        len += 1;
+    }
+
+    *dst.get_mut(len)? = 0;
+    Some(len)
+}
+
+///
+/// # Description
+///
+/// Formats the IPv4 address held in the [`in_addr`] structure at `src` into `dst`, followed by a
+/// terminating NUL.
+///
+/// # Parameters
+///
+/// - `src`: Pointer to an [`in_addr`] in network byte order.
+/// - `dst`: Destination byte buffer.
+///
+/// # Returns
+///
+/// The length of the string (excluding the NUL) on success, or [`None`] if `dst` is too small.
+///
+/// # Safety
+///
+/// The caller must ensure that `src` points to a readable [`in_addr`].
+///
+unsafe fn format_in_addr(src: *const c_void, dst: &mut [u8]) -> Option<usize> {
+    let bytes: *const u8 = src as *const u8;
+    let octets: [u8; 4] = [*bytes, *bytes.add(1), *bytes.add(2), *bytes.add(3)];
+    format_ipv4(octets, dst)
+}
+
+///
+/// # Description
+///
+/// Returns the value of a single hexadecimal digit, or [`None`] if `ch` is not one.
+///
+fn hex_value(ch: u8) -> Option<u8> {
+    match ch {
+        b'0'..=b'9' => Some(ch - b'0'),
+        b'a'..=b'f' => Some(ch - b'a' + 10),
+        b'A'..=b'F' => Some(ch - b'A' + 10),
+        _ => None,
+    }
+}
+
+///
+/// # Description
+///
+/// Parses a strict dotted-decimal IPv4 address (`"a.b.c.d"`, each field in the range `0..=255`
+/// with no leading zeros, octal, or hexadecimal). This is the form accepted by `inet_pton()`,
+/// which is stricter than `inet_aton()`.
+///
+/// # Parameters
+///
+/// - `src`: Pointer to a null-terminated candidate string.
+///
+/// # Returns
+///
+/// The four address bytes in network order on success, or [`None`] if the input is not a valid
+/// strict dotted-decimal address.
+///
+/// # Safety
+///
+/// The caller must ensure that `src` is null or points to a valid null-terminated string.
+///
+unsafe fn parse_ipv4(src: *const c_char) -> Option<[u8; 4]> {
+    if src.is_null() {
+        return None;
+    }
+
+    let mut octets: [u8; 4] = [0; 4];
+    let mut noctets: usize = 0;
+    let mut saw_digit: bool = false;
+    let mut i: usize = 0;
+
+    loop {
+        let ch: u8 = *src.add(i) as u8;
+        if ch == 0 {
+            break;
+        }
+        i += 1;
+
+        if ch.is_ascii_digit() {
+            let digit: u8 = ch - b'0';
+            if saw_digit {
+                // A leading zero (for example "01") is not a valid field.
+                if octets[noctets - 1] == 0 {
+                    return None;
+                }
+                let value: u16 = octets[noctets - 1] as u16 * 10 + digit as u16;
+                if value > 255 {
+                    return None;
+                }
+                octets[noctets - 1] = value as u8;
+            } else {
+                if noctets >= 4 {
+                    return None;
+                }
+                octets[noctets] = digit;
+                noctets += 1;
+                saw_digit = true;
+            }
+        } else if ch == b'.' && saw_digit {
+            if noctets == 4 {
+                return None;
+            }
+            saw_digit = false;
+        } else {
+            return None;
+        }
+    }
+
+    if noctets != 4 {
+        return None;
+    }
+
+    Some(octets)
+}
+
+///
+/// # Description
+///
+/// Parses an IPv6 address in any of its canonical textual forms, including `::` zero compression
+/// and a trailing embedded IPv4 address.
+///
+/// # Parameters
+///
+/// - `src`: Pointer to a null-terminated candidate string.
+///
+/// # Returns
+///
+/// The sixteen address bytes in network order on success, or [`None`] if the input is not a valid
+/// IPv6 address.
+///
+/// # Safety
+///
+/// The caller must ensure that `src` is null or points to a valid null-terminated string.
+///
+unsafe fn parse_ipv6(src: *const c_char) -> Option<[u8; 16]> {
+    if src.is_null() {
+        return None;
+    }
+
+    let mut tmp: [u8; 16] = [0; 16];
+    let mut tp: usize = 0;
+    let mut colonp: Option<usize> = None;
+    let mut seen_xdigits: u32 = 0;
+    let mut val: u32 = 0;
+    let mut i: usize = 0;
+
+    // Only a leading "::" may begin with a colon.
+    if *src.add(i) as u8 == b':' {
+        i += 1;
+        if *src.add(i) as u8 != b':' {
+            return None;
+        }
+    }
+
+    let mut curtok: usize = i;
+    loop {
+        let ch: u8 = *src.add(i) as u8;
+        if ch == 0 {
+            break;
+        }
+        i += 1;
+
+        if let Some(hexval) = hex_value(ch) {
+            val = (val << 4) | hexval as u32;
+            seen_xdigits += 1;
+            if seen_xdigits > 4 {
+                return None;
+            }
+            continue;
+        }
+
+        if ch == b':' {
+            curtok = i;
+            if seen_xdigits == 0 {
+                // Record the single permitted "::"; a second one is invalid.
+                if colonp.is_some() {
+                    return None;
+                }
+                colonp = Some(tp);
+                continue;
+            }
+            // A colon may not terminate the address.
+            if *src.add(i) as u8 == 0 {
+                return None;
+            }
+            if tp + 2 > 16 {
+                return None;
+            }
+            tmp[tp] = (val >> 8) as u8;
+            tmp[tp + 1] = val as u8;
+            tp += 2;
+            seen_xdigits = 0;
+            val = 0;
+            continue;
+        }
+
+        // A trailing dotted-decimal IPv4 address fills the final four bytes.
+        if ch == b'.' && tp + 4 <= 16 {
+            if let Some(octets) = parse_ipv4(src.add(curtok)) {
+                tmp[tp] = octets[0];
+                tmp[tp + 1] = octets[1];
+                tmp[tp + 2] = octets[2];
+                tmp[tp + 3] = octets[3];
+                tp += 4;
+                seen_xdigits = 0;
+                break;
+            }
+            return None;
+        }
+
+        return None;
+    }
+
+    // Flush a pending group of hex digits.
+    if seen_xdigits > 0 {
+        if tp + 2 > 16 {
+            return None;
+        }
+        tmp[tp] = (val >> 8) as u8;
+        tmp[tp + 1] = val as u8;
+        tp += 2;
+    }
+
+    // Expand "::" by shifting the groups that follow it to the end of the address.
+    if let Some(colon) = colonp {
+        if tp == 16 {
+            return None;
+        }
+        let n: usize = tp - colon;
+        for j in 1..=n {
+            tmp[16 - j] = tmp[colon + n - j];
+            tmp[colon + n - j] = 0;
+        }
+        tp = 16;
+    }
+
+    if tp != 16 {
+        return None;
+    }
+
+    Some(tmp)
 }

--- a/src/tests/integration/test-c-inet/main.c
+++ b/src/tests/integration/test-c-inet/main.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Asserts that inet_ntoa() renders the given host-order address as the expected string.
+static void check_ntoa(uint32_t host_addr, const char *expected)
+{
+    struct in_addr in;
+    in.s_addr = htonl(host_addr);
+
+    char *got = inet_ntoa(in);
+    assert(got != NULL);
+    assert(strcmp(got, expected) == 0);
+}
+
+// Asserts that inet_ntop() renders the given host-order IPv4 address as the expected string and
+// returns the caller's buffer.
+static void check_ntop4(uint32_t host_addr, const char *expected)
+{
+    struct in_addr in;
+    in.s_addr = htonl(host_addr);
+
+    char buf[INET_ADDRSTRLEN];
+    memset(buf, 0x55, sizeof(buf));
+
+    const char *got = inet_ntop(AF_INET, &in, buf, sizeof(buf));
+    assert(got == buf);
+    assert(strcmp(buf, expected) == 0);
+}
+
+// Asserts that inet_ntop() renders the given 16-byte IPv6 address as the expected string.
+static void check_ntop6(const uint8_t bytes[16], const char *expected)
+{
+    struct in6_addr in6;
+    memcpy(in6.s6_addr, bytes, 16);
+
+    char buf[INET6_ADDRSTRLEN];
+    memset(buf, 0x55, sizeof(buf));
+
+    const char *got = inet_ntop(AF_INET6, &in6, buf, sizeof(buf));
+    assert(got == buf);
+    assert(strcmp(buf, expected) == 0);
+}
+
+// Asserts that inet_pton() accepts a valid IPv4 string and stores it in network byte order.
+static void check_pton4_ok(const char *src, uint32_t expect_host)
+{
+    struct in_addr in;
+    memset(&in, 0xAA, sizeof(in));
+
+    int ret = inet_pton(AF_INET, src, &in);
+    assert(ret == 1);
+    assert(in.s_addr == htonl(expect_host));
+}
+
+// Asserts that inet_pton() rejects an invalid IPv4 string (returns 0, leaves errno unchanged).
+static void check_pton4_bad(const char *src)
+{
+    struct in_addr in;
+    memset(&in, 0xAA, sizeof(in));
+
+    errno = 0;
+    int ret = inet_pton(AF_INET, src, &in);
+    assert(ret == 0);
+    assert(errno == 0);
+}
+
+// Asserts that inet_pton() accepts a valid IPv6 string and stores the expected 16 bytes.
+static void check_pton6_ok(const char *src, const uint8_t expect[16])
+{
+    struct in6_addr in6;
+    memset(&in6, 0xAA, sizeof(in6));
+
+    int ret = inet_pton(AF_INET6, src, &in6);
+    assert(ret == 1);
+    assert(memcmp(in6.s6_addr, expect, 16) == 0);
+}
+
+// Asserts that inet_pton() rejects an invalid IPv6 string (returns 0, leaves errno unchanged).
+static void check_pton6_bad(const char *src)
+{
+    struct in6_addr in6;
+    memset(&in6, 0xAA, sizeof(in6));
+
+    errno = 0;
+    int ret = inet_pton(AF_INET6, src, &in6);
+    assert(ret == 0);
+    assert(errno == 0);
+}
+
+//==================================================================================================
+// inet_ntoa() (#595)
+//==================================================================================================
+
+// Tests inet_ntoa() across representative IPv4 addresses.
+static void test_inet_ntoa(void)
+{
+    check_ntoa(0x00000000, "0.0.0.0");
+    check_ntoa(0x7f000001, "127.0.0.1");
+    check_ntoa(0xc0a80101, "192.168.1.1");
+    check_ntoa(0x08080808, "8.8.8.8");
+    check_ntoa(0xffffffff, "255.255.255.255");
+    check_ntoa(0x01020304, "1.2.3.4");
+}
+
+// Tests that inet_ntoa() reuses static storage that later calls overwrite, as POSIX permits.
+static void test_inet_ntoa_static_storage(void)
+{
+    struct in_addr a = {.s_addr = htonl(0x0a000001)};
+    char *first = inet_ntoa(a);
+    assert(strcmp(first, "10.0.0.1") == 0);
+
+    struct in_addr b = {.s_addr = htonl(0xac100001)};
+    char *second = inet_ntoa(b);
+    assert(strcmp(second, "172.16.0.1") == 0);
+
+    // POSIX allows the buffer to be reused; the earlier pointer must now observe the newer value.
+    assert(first == second);
+    assert(strcmp(first, "172.16.0.1") == 0);
+}
+
+//==================================================================================================
+// inet_ntop() (#592)
+//==================================================================================================
+
+// Tests inet_ntop() for IPv4 addresses.
+static void test_inet_ntop_ipv4(void)
+{
+    check_ntop4(0x00000000, "0.0.0.0");
+    check_ntop4(0x7f000001, "127.0.0.1");
+    check_ntop4(0xc0a80101, "192.168.1.1");
+    check_ntop4(0xffffffff, "255.255.255.255");
+    check_ntop4(0x01020304, "1.2.3.4");
+}
+
+// Tests inet_ntop() for IPv6 addresses, including zero-run compression and embedded IPv4.
+static void test_inet_ntop_ipv6(void)
+{
+    const uint8_t unspecified[16] = {0};
+    check_ntop6(unspecified, "::");
+
+    const uint8_t loopback[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    check_ntop6(loopback, "::1");
+
+    const uint8_t full[16] = {0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8};
+    check_ntop6(full, "1:2:3:4:5:6:7:8");
+
+    const uint8_t doc[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01};
+    check_ntop6(doc, "2001:db8::1");
+
+    const uint8_t linklocal[16] = {0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01};
+    check_ntop6(linklocal, "fe80::1");
+
+    // The first (leftmost) longest zero run is the one compressed.
+    const uint8_t two_runs[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1};
+    check_ntop6(two_runs, "2001:db8::1:0:0:1");
+
+    // A single zero group is written verbatim rather than compressed.
+    const uint8_t single_zero[16] = {0, 1, 0, 0, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7};
+    check_ntop6(single_zero, "1:0:2:3:4:5:6:7");
+
+    // IPv4-mapped address uses the trailing dotted-decimal form.
+    const uint8_t mapped[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1};
+    check_ntop6(mapped, "::ffff:192.168.1.1");
+}
+
+// Tests that inet_ntop() fails with ENOSPC when the output buffer is too small.
+static void test_inet_ntop_enospc(void)
+{
+    struct in_addr in;
+    in.s_addr = htonl(0x7f000001); // "127.0.0.1" requires 10 bytes including NUL.
+
+    // One byte short of the required size must fail.
+    char small[9];
+    errno = 0;
+    assert(inet_ntop(AF_INET, &in, small, sizeof(small)) == NULL);
+    assert(errno == ENOSPC);
+
+    // The exact required size must succeed.
+    char exact[10];
+    assert(inet_ntop(AF_INET, &in, exact, sizeof(exact)) == exact);
+    assert(strcmp(exact, "127.0.0.1") == 0);
+
+    // IPv6 with a tiny buffer must also fail with ENOSPC.
+    struct in6_addr in6;
+    memset(in6.s6_addr, 0, 16);
+    in6.s6_addr[15] = 1;
+    char tiny[2];
+    errno = 0;
+    assert(inet_ntop(AF_INET6, &in6, tiny, sizeof(tiny)) == NULL);
+    assert(errno == ENOSPC);
+}
+
+//==================================================================================================
+// inet_pton() (#593)
+//==================================================================================================
+
+// Tests inet_pton() for valid and invalid IPv4 strings.
+static void test_inet_pton_ipv4(void)
+{
+    check_pton4_ok("0.0.0.0", 0x00000000);
+    check_pton4_ok("127.0.0.1", 0x7f000001);
+    check_pton4_ok("192.168.1.1", 0xc0a80101);
+    check_pton4_ok("255.255.255.255", 0xffffffff);
+    check_pton4_ok("1.2.3.4", 0x01020304);
+
+    // Out-of-range octet.
+    check_pton4_bad("256.0.0.1");
+    // Too few components (inet_pton() does not accept short forms).
+    check_pton4_bad("1.2.3");
+    check_pton4_bad("1");
+    // Too many components.
+    check_pton4_bad("1.2.3.4.5");
+    // Leading zeros are rejected (no octal interpretation).
+    check_pton4_bad("01.2.3.4");
+    check_pton4_bad("1.2.3.04");
+    // Hexadecimal is not accepted.
+    check_pton4_bad("0x7f.0.0.1");
+    // Trailing and malformed input.
+    check_pton4_bad("1.2.3.4.");
+    check_pton4_bad("1.2.3.4 ");
+    check_pton4_bad(".1.2.3");
+    check_pton4_bad("1..2.3");
+    check_pton4_bad("");
+    check_pton4_bad("abc");
+}
+
+// Tests inet_pton() for valid and invalid IPv6 strings.
+static void test_inet_pton_ipv6(void)
+{
+    const uint8_t unspecified[16] = {0};
+    check_pton6_ok("::", unspecified);
+
+    const uint8_t loopback[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    check_pton6_ok("::1", loopback);
+
+    const uint8_t full[16] = {0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8};
+    check_pton6_ok("1:2:3:4:5:6:7:8", full);
+
+    const uint8_t doc[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01};
+    check_pton6_ok("2001:db8::1", doc);
+    // Uppercase hexadecimal digits are accepted.
+    check_pton6_ok("2001:DB8::1", doc);
+
+    const uint8_t linklocal[16] = {0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01};
+    check_pton6_ok("fe80::1", linklocal);
+
+    const uint8_t leading[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12, 0x34};
+    check_pton6_ok("::1234", leading);
+
+    const uint8_t trailing[16] = {0x12, 0x34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    check_pton6_ok("1234::", trailing);
+
+    // IPv4-mapped address with an embedded dotted-decimal tail.
+    const uint8_t mapped[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1};
+    check_pton6_ok("::ffff:192.168.1.1", mapped);
+
+    // Invalid forms.
+    check_pton6_bad("");
+    check_pton6_bad(":");
+    check_pton6_bad(":::");
+    check_pton6_bad("1::2::3");    // More than one "::".
+    check_pton6_bad("12345::");    // Group with more than four hex digits.
+    check_pton6_bad("1:2:3:4:5:6:7:8:9"); // Too many groups.
+    check_pton6_bad("1:2:3:4:5:6:7");     // Too few groups without "::".
+    check_pton6_bad("g::1");       // Non-hexadecimal digit.
+    check_pton6_bad("1:2:3:4:5:6:7:8:"); // Trailing single colon.
+    check_pton6_bad("::ffff:256.1.1.1"); // Invalid embedded IPv4.
+}
+
+//==================================================================================================
+// Cross-cutting behavior
+//==================================================================================================
+
+// Tests that an unsupported address family is reported with EAFNOSUPPORT.
+static void test_unsupported_family(void)
+{
+    struct in_addr in;
+    in.s_addr = 0;
+    char buf[INET6_ADDRSTRLEN];
+
+    errno = 0;
+    assert(inet_ntop(AF_UNIX, &in, buf, sizeof(buf)) == NULL);
+    assert(errno == EAFNOSUPPORT);
+
+    uint8_t dst[16];
+    errno = 0;
+    assert(inet_pton(AF_UNIX, "1.2.3.4", dst) == -1);
+    assert(errno == EAFNOSUPPORT);
+}
+
+// Tests that inet_pton() writes exactly the address bytes and nothing beyond them.
+static void test_pton_no_overflow(void)
+{
+    uint8_t buf4[8];
+    memset(buf4, 0xAA, sizeof(buf4));
+    assert(inet_pton(AF_INET, "1.2.3.4", buf4) == 1);
+    assert(buf4[0] == 1 && buf4[1] == 2 && buf4[2] == 3 && buf4[3] == 4);
+    assert(buf4[4] == 0xAA && buf4[5] == 0xAA && buf4[6] == 0xAA && buf4[7] == 0xAA);
+
+    uint8_t buf6[20];
+    memset(buf6, 0xAA, sizeof(buf6));
+    assert(inet_pton(AF_INET6, "::1", buf6) == 1);
+    for (int i = 0; i < 15; i++) {
+        assert(buf6[i] == 0);
+    }
+    assert(buf6[15] == 1);
+    assert(buf6[16] == 0xAA && buf6[17] == 0xAA && buf6[18] == 0xAA && buf6[19] == 0xAA);
+}
+
+// Tests that inet_pton() followed by inet_ntop() reproduces the canonical text form.
+static void test_round_trip(void)
+{
+    static const char *const ipv4[] = {
+        "0.0.0.0", "127.0.0.1", "192.168.1.1", "255.255.255.255", "8.8.4.4"};
+    for (size_t i = 0; i < sizeof(ipv4) / sizeof(ipv4[0]); i++) {
+        struct in_addr in;
+        assert(inet_pton(AF_INET, ipv4[i], &in) == 1);
+        char buf[INET_ADDRSTRLEN];
+        assert(inet_ntop(AF_INET, &in, buf, sizeof(buf)) == buf);
+        assert(strcmp(buf, ipv4[i]) == 0);
+    }
+
+    static const char *const ipv6[] = {
+        "::", "::1", "1:2:3:4:5:6:7:8", "2001:db8::1", "fe80::1", "::ffff:192.168.1.1"};
+    for (size_t i = 0; i < sizeof(ipv6) / sizeof(ipv6[0]); i++) {
+        struct in6_addr in6;
+        assert(inet_pton(AF_INET6, ipv6[i], &in6) == 1);
+        char buf[INET6_ADDRSTRLEN];
+        assert(inet_ntop(AF_INET6, &in6, buf, sizeof(buf)) == buf);
+        assert(strcmp(buf, ipv6[i]) == 0);
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests POSIX Internet address conversion calls exposed by <arpa/inet.h>.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_inet_ntoa();
+    test_inet_ntoa_static_storage();
+    test_inet_ntop_ipv4();
+    test_inet_ntop_ipv6();
+    test_inet_ntop_enospc();
+    test_inet_pton_ipv4();
+    test_inet_pton_ipv6();
+    test_unsupported_family();
+    test_pton_no_overflow();
+    test_round_trip();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -158,6 +158,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-inet"
+program = "./bin/test-c-inet.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-libgen"
 program = "./bin/test-c-libgen.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -158,6 +158,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-inet"
+program = "./bin/test-c-inet.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-libgen"
 program = "./bin/test-c-libgen.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Implements the POSIX Internet address conversion functions `inet_ntop()`, `inet_pton()`, and `inet_ntoa()` in the `libc_arpa_inet` crate, replacing the previous stubs.

## Changes

- **`inet_ntoa()`** (#595): renders a `struct in_addr` to a dotted-decimal string in POSIX-permitted static storage.
- **`inet_ntop()`** (#592): supports `AF_INET` and `AF_INET6`, with RFC 5952-style `::` zero-run compression and embedded-IPv4 tails. Reports `ENOSPC` when the output buffer is too small and `EAFNOSUPPORT` for unsupported families.
- **`inet_pton()`** (#593): supports `AF_INET` (strict dotted-decimal — no leading zeros, octal, hex, or short forms) and `AF_INET6` (`::` expansion and embedded IPv4). Returns `1`/`0`/`-1` per the specification.

## Tests

Adds the `test-c-inet` POSIX C integration suite covering all three functions for IPv4 and IPv6, including zero-run compression, embedded IPv4, error paths (`ENOSPC`, `EAFNOSUPPORT`), write-overflow guards, and `inet_pton()` → `inet_ntop()` round trips. Registered in the `Makefile` and both POSIX test configurations.

Validated locally: `clippy -D warnings`, `rustfmt --check`, and `codespell` pass; the suite passes in both debug and release.

Closes #592
Closes #593
Closes #595