### PR TITLE
[syscall] Bind Executable GOT/PLT at Startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-weak test-c-echo test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-inet test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
+ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-selflink test-c-dlfcn-weak test-c-echo test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-inet test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -140,6 +140,23 @@ POSIX_TEST_PIE_test-c-dlfcn-init-runpath := yes
 # `main_callback`/`weak_data` globals land in `.dynsym`; the loader resolves the
 # helper `.so` files' weak undefined references against that global scope.
 POSIX_TEST_PIE_test-c-dlfcn-weak := yes
+# dlfcn-selflink-c links PIE against libprovider.so (-lprovider) so the main
+# executable carries a DT_NEEDED entry plus an R_386_GLOB_DAT (data) and an
+# R_386_JMP_SLOT (function) relocation against the provider's symbols. This is
+# the forward direction the other dlfcn suites do not cover: nvx-crt0's
+# self-linker (syscall::dlfcn::dllink_executable) must bind the executable's own
+# GOT/PLT against the loaded library before main() runs.
+POSIX_TEST_PIE_test-c-dlfcn-selflink := yes
+
+# Per-suite hooks consumed by POSIX_TEST_RULE: extra link-time prerequisites and
+# extra linker arguments appended AFTER the libc/libm `--end-group`. Used by
+# dlfcn-selflink-c to link the suite ELF against its libprovider.so fixture
+# (recording the DT_NEEDED entry and the GOT/PLT relocations) with eager binding
+# (`-z now`), since Nanvix has no lazy PLT resolver. These must be set before the
+# POSIX_TEST_RULE foreach below expands each suite's link rule.
+POSIX_TEST_SELFLINK_DIR := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-selflink/libs
+POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-selflink := $(POSIX_TEST_SELFLINK_DIR)/libprovider.so
+POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-selflink := -L$(POSIX_TEST_SELFLINK_DIR) -lprovider -z now
 
 define POSIX_TEST_RULE
 POSIX_TEST_SRCROOT_$(1) := $$(if $$(POSIX_TEST_STRESS_$(1)),$$(POSIX_TESTS_STRESS_SRCDIR),$$(POSIX_TESTS_SRCDIR))
@@ -150,11 +167,13 @@ ifeq ($$(POSIX_TEST_PIE_$(1)),yes)
 $$(POSIX_TEST_OBJS_$(1)): POSIX_TEST_EXTRA_CFLAGS := -fPIE
 endif
 $$(BINARIES_DIR)/$(1).$$(EXEC_FORMAT): $$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
-		$$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) $$(LIBNVX_CRT0) $$(GUEST_C_APP_LD_SCRIPT)
+		$$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) $$(LIBNVX_CRT0) $$(GUEST_C_APP_LD_SCRIPT) \
+		$$(POSIX_TEST_EXTRA_LD_DEPS_$(1))
 	@echo "[posix-test] linking $(1) against libc.a + libm.a$$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))), (PIE))"
 	$$(GUEST_C_APP_LD) $$(GUEST_C_APP_LDFLAGS) $$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))),$$(POSIX_TEST_PIE_LDFLAGS)) \
 		$$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
-		--start-group $$(LIBNVX_CRT0) $$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) --end-group -o $$@
+		--start-group $$(LIBNVX_CRT0) $$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) --end-group \
+		$$(POSIX_TEST_EXTRA_LDLIBS_$(1)) -o $$@
 	@echo "[posix-test] built $$@"
 endef
 
@@ -211,11 +230,13 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
 
@@ -383,9 +404,43 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond): $(POSIX_TEST_DIAMOND_DIR)/libbase.
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libdiamond.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_DIAMOND_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-selflink-c: main-executable GOT/PLT self-linking fixture.
+#---------------------------------------------------------------------------------------------------
+#
+# Unlike the suites above (which dlopen() shared libraries at runtime), this
+# suite exercises the FORWARD direction: the main executable itself is linked
+# against libprovider.so (-lprovider, see POSIX_TEST_EXTRA_LDLIBS_* above), so
+# it carries a DT_NEEDED entry plus an R_386_GLOB_DAT (data) and an
+# R_386_JMP_SLOT (function) relocation against the provider's symbols. nvx-crt0's
+# self-linker (syscall::dlfcn::dllink_executable) must load libprovider.so into
+# the global scope and bind both slots before main() runs. libprovider.so plays
+# the role of a "libc.so" and is staged at lib/libprovider.so, reached through
+# the loader's default lib/ search path. Built with the same i686 freestanding
+# toolchain as the fixtures above; an explicit -soname pins the bare DT_NEEDED
+# name regardless of linker (GNU ld vs ld.lld).
+POSIX_TEST_SELFLINK_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-selflink-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-selflink.img
+
+# Provider: self-contained (zero undefined symbols), exporting one data symbol
+# (-> R_386_GLOB_DAT in the executable) and one function (-> R_386_JMP_SLOT).
+$(POSIX_TEST_SELFLINK_DIR)/libprovider.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-selflink/libs/provider.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building test-c-dlfcn-selflink/libprovider.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libprovider.so $@.o -o $@
+
+# Per-suite RAMFS image carrying libprovider.so under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink): $(POSIX_TEST_SELFLINK_DIR)/libprovider.so \
+		all-host-binaries-mkramfs
+	@$(MKDIR_CMD) $(POSIX_TEST_SELFLINK_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_SELFLINK_DIR)/libprovider.so $(POSIX_TEST_SELFLINK_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_SELFLINK_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
-	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-init-runpath-c: constructor/destructor + DT_RUNPATH fixtures.

--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -33,6 +33,25 @@ SECTIONS
 		*(.data*)
 	}
 
+	/*
+	 * Dynamic section.
+	 *
+	 * Holds the DT_* entries (DT_NEEDED dependencies and the addresses/sizes of
+	 * the dynamic relocation and symbol tables). The bounding symbols are
+	 * provided HERE — mirroring `.dynsym`/`.dynstr` below — so the dlfcn
+	 * self-linker (`syscall::dlfcn::dllink_executable`) can find `.dynamic` at
+	 * runtime: the ELF header and program headers are not mapped at the image's
+	 * load address, so they cannot be parsed in-process. The boundaries collapse
+	 * to an empty range for statically linked images (no `.dynamic`), making the
+	 * self-linker a no-op there.
+	 */
+	.dynamic : ALIGN(4)
+	{
+		PROVIDE(__dynamic_start = .);
+		*(.dynamic)
+		PROVIDE(__dynamic_end = .);
+	}
+
 	/* Global constructors. */
 	.ctors : ALIGN(4)
 	{

--- a/build/user/linker/x86_64/user.ld
+++ b/build/user/linker/x86_64/user.ld
@@ -34,6 +34,25 @@ SECTIONS
 	}
 
 	/*
+	 * Dynamic section.
+	 *
+	 * Holds the DT_* entries (DT_NEEDED dependencies and the addresses/sizes of
+	 * the dynamic relocation and symbol tables). The bounding symbols are
+	 * provided HERE — mirroring `.dynsym`/`.dynstr` below — so the dlfcn
+	 * self-linker (`syscall::dlfcn::dllink_executable`) can find `.dynamic` at
+	 * runtime: the ELF header and program headers are not mapped at the image's
+	 * load address, so they cannot be parsed in-process. The boundaries collapse
+	 * to an empty range for statically linked images (no `.dynamic`), making the
+	 * self-linker a no-op there.
+	 */
+	.dynamic : ALIGN(8)
+	{
+		PROVIDE(__dynamic_start = .);
+		*(.dynamic)
+		PROVIDE(__dynamic_end = .);
+	}
+
+	/*
 	 * Constructor / destructor arrays (the primary ctor/dtor mechanism).
 	 *
 	 * `__nanvix_libc_start_main` (libposix start.rs) walks `.preinit_array`

--- a/src/libs/elf/src/elf32.rs
+++ b/src/libs/elf/src/elf32.rs
@@ -141,6 +141,10 @@ pub const PT_HIPROC: u32 = 0x7fffffff;
 
 /// Marks end of dynamic section.
 pub const DT_NULL: i32 = 0;
+/// String-table offset of the name of a needed shared object (DT_NEEDED).
+pub const DT_NEEDED: i32 = 1;
+/// Address of the dynamic symbol table (DT_SYMTAB).
+pub const DT_SYMTAB: i32 = 6;
 /// Address of relocation table.
 pub const DT_REL: i32 = 17;
 /// Size of relocation table in bytes.

--- a/src/libs/nanvix_libc/src/start.rs
+++ b/src/libs/nanvix_libc/src/start.rs
@@ -45,10 +45,7 @@
 
 #![cfg(all(feature = "allocator", feature = "syscall"))]
 use ::alloc::vec::Vec;
-use ::config::memory_layout::{
-    USER_BASE_RAW,
-    USER_HEAP_CAPACITY,
-};
+use ::config::memory_layout::USER_HEAP_CAPACITY;
 use ::core::ffi::c_char;
 
 //==================================================================================================
@@ -157,11 +154,6 @@ pub static mut environ: *mut *mut c_char = ::core::ptr::null_mut();
 pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut c_char) -> ! {
     ::syslog::trace!("__nanvix_libc_start_main(): argp={:?}, envp={:?}", argp, envp);
 
-    // Suppress unused-import warning when neither USER_BASE_RAW nor any
-    // other consumer needs it; it is referenced only by the `_start`
-    // documentation cross-reference in `nvx-crt0`.
-    let _ = USER_BASE_RAW;
-
     // Bring up the stateful runtime (heap, TDA).  All `sysalloc` state
     // lives in this compilation unit (libc); no other static
     // archive in the final link may depend on `sysalloc`.
@@ -212,6 +204,23 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
     // those descriptors, so the cache — rebuilt lazily on first use — observes the
     // post-close-on-exec table. In run modes without a guest `vfsd`, this is a no-op.
     ::syscall::unistd::exec_startup_barrier();
+
+    // Bind the executable's own symbol-based GOT/PLT relocations
+    // (`R_386_GLOB_DAT` / `R_386_JMP_SLOT`) against the global symbol table,
+    // loading any `DT_NEEDED` shared libraries into the global scope first.
+    // This complements the early `R_386_RELATIVE` pass performed by
+    // `nvx::pie::relocate_pie_binary` before the heap was up, and must run
+    // before any application code (`.init_array` constructors or `main`) so the
+    // bound slots are valid on first use. A no-op for executables that declare
+    // no shared-library dependencies.
+    //
+    // A failure here leaves GOT/PLT slots unbound, so entering `.init_array` or
+    // `main` would fault on the first call through an unbound PLT slot or read of
+    // an unbound GOT slot. Like the other `runtime_init()` startup failures, this
+    // is unrecoverable and must abort the process.
+    if let Err(e) = unsafe { ::syscall::dlfcn::dllink_executable() } {
+        panic!("__nanvix_libc_start_main(): failed to bind executable symbols: {e:?}");
+    }
 
     // Run global constructors before entering `main`.  `.preinit_array` runs
     // first, then `.init_array` (relibc's `relibc_start` pattern).  Done after

--- a/src/libs/nvx/src/pie.rs
+++ b/src/libs/nvx/src/pie.rs
@@ -34,6 +34,15 @@ use ::elf::elf32::{
 /// If the binary is not ET_DYN, has no PT_DYNAMIC segment, or was loaded at its link-time
 /// address (delta = 0), this function returns without modification.
 ///
+/// # Note
+///
+/// This pass intentionally handles only the symbol-less `R_386_RELATIVE` fixups, which is all
+/// that can be done this early: it runs from `nvx-crt0::_start` before the heap, VFS, and dlfcn
+/// runtime are available. Symbol-based GOT/PLT relocations (`R_386_GLOB_DAT` / `R_386_JMP_SLOT`)
+/// — including those bound against `DT_NEEDED` shared libraries — are resolved later by the
+/// dlfcn self-linker (`syscall::dlfcn::dllink_executable`), which libposix invokes from
+/// `__nanvix_libc_start_main` once the heap is up and before any application code runs.
+///
 /// # Parameters
 ///
 /// - `base_address`: The address at which the PIE binary was loaded. The ELF header must be

--- a/src/libs/syscall/src/dlfcn/mod.rs
+++ b/src/libs/syscall/src/dlfcn/mod.rs
@@ -24,6 +24,7 @@ cfg_if::cfg_if! {
         pub use syscall::dlsym;
         pub use syscall::dladdr;
         pub use syscall::dlinit;
+        pub use syscall::dllink_executable;
     }
 }
 

--- a/src/libs/syscall/src/dlfcn/syscall/exe_link.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/exe_link.rs
@@ -1,0 +1,408 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::vec::Vec;
+use ::elf::{
+    elf32::{
+        Elf32Dyn,
+        DT_JMPREL,
+        DT_NEEDED,
+        DT_NULL,
+        DT_PLTRELSZ,
+        DT_REL,
+        DT_RELSZ,
+        DT_SYMTAB,
+    },
+    RelocationEntry,
+    RelocationTable,
+    RelocationType,
+    StringTable,
+    Symbol,
+    SymbolTable,
+};
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Binds the main executable's symbol-based relocations (`R_386_JMP_SLOT` /
+/// `R_386_GLOB_DAT`, plus `R_386_32` / `R_386_PC32`) against the global symbol
+/// table at process startup. This complements [`nvx::pie::relocate_pie_binary`],
+/// which runs earlier (before the heap is up) and applies only the
+/// symbol-less `R_386_RELATIVE` fixups.
+///
+/// The routine is a no-op unless the executable carries a dynamic section
+/// (`.dynamic`) that declares at least one `DT_NEEDED` shared-library
+/// dependency. For such images it:
+///
+/// 1. Loads every `DT_NEEDED` dependency into the global scope (the equivalent
+///    of `dlopen(name, RTLD_GLOBAL | RTLD_NOW)`), making the dependency's
+///    exported symbols resolvable.
+/// 2. Walks the executable's `.rel.dyn` and `.rel.plt` tables and resolves each
+///    symbol-based relocation, reusing the dlfcn resolver's symbol logic (the
+///    global symbol table and the System V weak-undefined-resolves-to-zero
+///    rule).
+///
+/// The dynamic section is located through the `__dynamic_start`/`__dynamic_end`
+/// linker-script symbols rather than by parsing the ELF header: on Nanvix the
+/// first `PT_LOAD` segment begins at a non-zero file offset, so the ELF header
+/// and program headers are *not* mapped at the image's load address and cannot
+/// be read at runtime.
+///
+/// This must run after the heap is available (it allocates while loading
+/// dependencies) and before any application code (`.init_array` constructors or
+/// `main`) executes, so the executable's GOT/PLT slots are bound before first
+/// use.
+///
+/// # Returns
+///
+/// `Ok(())` on success (including the no-op cases). Returns an error if one or
+/// more required (non-weak) symbols could not be resolved; the successfully
+/// resolved relocations are still applied.
+///
+/// # Safety
+///
+/// Must be called once, on the main executable's own thread of control, while
+/// the dynamic section, relocation tables and dynamic symbol/string tables of
+/// the loaded image are mapped in memory (they always are once the image is
+/// running).
+///
+pub unsafe fn dllink_executable() -> Result<(), Error> {
+    // The relocation logic below is hard-wired to ELF32/i386 (`Elf32Dyn`,
+    // `R_386_*`, 32-bit addends). On any other target the `.dynamic` array has a
+    // different layout (ELF64), so parsing it as `Elf32Dyn` would mis-read memory
+    // and corrupt GOT/PLT slots. Until an ELF64/x86_64 self-linker exists, this is
+    // a safe no-op on unsupported targets.
+    if !cfg!(target_arch = "x86") {
+        return Ok(());
+    }
+
+    // Locate the dynamic array via the `__dynamic_start`/`__dynamic_end`
+    // linker-script symbols. A statically linked image (no dynamic section) has
+    // an empty range and there is nothing to bind.
+    let dyn_entries: &[Elf32Dyn] = match dynamic_section() {
+        Some(entries) => entries,
+        None => return Ok(()),
+    };
+
+    // Parse the relocation-table descriptors and the DT_NEEDED list.
+    let mut dt_rel: Option<u32> = None;
+    let mut dt_relsz: Option<u32> = None;
+    let mut dt_jmprel: Option<u32> = None;
+    let mut dt_pltrelsz: Option<u32> = None;
+    let mut dt_symtab: Option<u32> = None;
+    let mut needed: Vec<u32> = Vec::new();
+
+    for entry in dyn_entries {
+        match entry.d_tag {
+            DT_NEEDED => needed.push(entry.d_val),
+            DT_REL => dt_rel = Some(entry.d_val),
+            DT_RELSZ => dt_relsz = Some(entry.d_val),
+            DT_JMPREL => dt_jmprel = Some(entry.d_val),
+            DT_PLTRELSZ => dt_pltrelsz = Some(entry.d_val),
+            DT_SYMTAB => dt_symtab = Some(entry.d_val),
+            _ => {},
+        }
+    }
+
+    // An executable that declares no shared-library dependencies has no
+    // externally-provided symbols to bind; the earlier R_386_RELATIVE pass
+    // already covered everything. Nothing to do.
+    if needed.is_empty() {
+        return Ok(());
+    }
+
+    // Locate the executable's own dynamic symbol/string tables (the same
+    // linker-script boundaries that `dlinit()` consumes).
+    let (dynsym_start, dynsym, dynstr) = match exe_dynsym_dynstr() {
+        Some(tables) => tables,
+        None => {
+            ::syslog::warn!(
+                "dllink_executable(): executable has no .dynsym/.dynstr; cannot bind symbols"
+            );
+            return Ok(());
+        },
+    };
+
+    // Relocation delta (actual load address minus link-time base). The dynamic
+    // symbol table is reachable both at its runtime address (the `__dynsym_start`
+    // linker symbol) and at its link-time address (`DT_SYMTAB`); their difference
+    // is the load bias. On Nanvix the main executable loads at its link base, so
+    // this is zero, but computing it keeps the resolver correct regardless.
+    let delta: u32 = match dt_symtab {
+        Some(link_vaddr) => (dynsym_start as u32).wrapping_sub(link_vaddr),
+        None => 0,
+    };
+
+    // Publish the executable's own exported symbols into the global table, then
+    // load each DT_NEEDED dependency into the global scope so its exported
+    // symbols become resolvable.
+    super::dlinit();
+    for off in &needed {
+        let name: &str = match dynstr.get_name(*off as usize) {
+            Ok(name) if !name.is_empty() => name,
+            _ => continue,
+        };
+        match super::dlopen(name, true) {
+            Ok(_) => ::syslog::trace!("dllink_executable(): loaded DT_NEEDED {}", name),
+            Err(e) => ::syslog::warn!(
+                "dllink_executable(): failed to load DT_NEEDED {} (error={:?})",
+                name,
+                e
+            ),
+        }
+    }
+
+    // Resolve the executable's symbol-based relocations from .rel.dyn and
+    // .rel.plt.
+    let mut unresolved: usize = 0;
+    if let (Some(vaddr), Some(size)) = (dt_rel, dt_relsz) {
+        unresolved += resolve_table(vaddr, size, delta, &dynsym, &dynstr);
+    }
+    if let (Some(vaddr), Some(size)) = (dt_jmprel, dt_pltrelsz) {
+        unresolved += resolve_table(vaddr, size, delta, &dynsym, &dynstr);
+    }
+
+    if unresolved > 0 {
+        ::syslog::warn!("dllink_executable(): {} unresolved executable relocations", unresolved);
+        return Err(Error::new(ErrorCode::NoSuchEntry, "unresolved executable relocations"));
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the executable's dynamic array (`.dynamic`) as a slice bounded by the
+/// `__dynamic_start` / `__dynamic_end` linker-script symbols, truncated at its
+/// `DT_NULL` terminator. Returns `None` when the image carries no dynamic
+/// section (the boundaries collapse to an empty range, as for a statically
+/// linked image).
+///
+/// The dynamic array lives in a loaded segment and is therefore mapped at
+/// runtime, unlike the ELF header. The boundary symbols are provided by the
+/// linker script (`PROVIDE`, mirroring `__dynsym_start`/`__dynstr_start`), so the
+/// reference resolves in every image — empty when there is no `.dynamic`.
+///
+/// # Safety
+///
+/// The `__dynamic_*` boundary symbols must delimit a valid, in-memory
+/// `.dynamic` section of the loaded executable image.
+///
+unsafe fn dynamic_section() -> Option<&'static [Elf32Dyn]> {
+    extern "C" {
+        static __dynamic_start: u8;
+        static __dynamic_end: u8;
+    }
+
+    let start: usize = &__dynamic_start as *const u8 as usize;
+    let end: usize = &__dynamic_end as *const u8 as usize;
+
+    let size: usize = end.saturating_sub(start);
+    let capacity: usize = size / core::mem::size_of::<Elf32Dyn>();
+    if capacity == 0 {
+        return None;
+    }
+
+    // Truncate at the DT_NULL terminator (the entries past it are padding).
+    let base: *const Elf32Dyn = start as *const Elf32Dyn;
+    let mut len: usize = 0;
+    while len < capacity {
+        if (*base.add(len)).d_tag == DT_NULL {
+            break;
+        }
+        len += 1;
+    }
+
+    Some(core::slice::from_raw_parts(base, len))
+}
+
+///
+/// # Description
+///
+/// Returns the executable's dynamic symbol and string tables, together with the
+/// runtime start address of the symbol table, bounded by the `__dynsym_*` /
+/// `__dynstr_*` linker-script symbols. Returns `None` when the executable was
+/// linked without `--export-dynamic` (the boundaries collapse to an empty
+/// range).
+///
+/// # Safety
+///
+/// The linker-script boundary symbols must delimit valid, in-memory `.dynsym` /
+/// `.dynstr` sections of the loaded executable image.
+///
+unsafe fn exe_dynsym_dynstr() -> Option<(usize, SymbolTable, StringTable)> {
+    extern "C" {
+        static __dynsym_start: u8;
+        static __dynsym_end: u8;
+        static __dynstr_start: u8;
+        static __dynstr_end: u8;
+    }
+
+    let dynsym_start: usize = &__dynsym_start as *const u8 as usize;
+    let dynsym_end: usize = &__dynsym_end as *const u8 as usize;
+    let dynstr_start: usize = &__dynstr_start as *const u8 as usize;
+    let dynstr_end: usize = &__dynstr_end as *const u8 as usize;
+
+    let dynsym_size: usize = dynsym_end.saturating_sub(dynsym_start);
+    let dynstr_size: usize = dynstr_end.saturating_sub(dynstr_start);
+    if dynsym_size == 0 || dynstr_size == 0 {
+        return None;
+    }
+
+    let sym_count: usize = dynsym_size / core::mem::size_of::<Symbol>();
+    let dynsym: SymbolTable = SymbolTable::from_raw_parts(dynsym_start as *mut Symbol, sym_count);
+    let dynstr: StringTable = StringTable::from_raw_parts(dynstr_start as *const u8, dynstr_size);
+
+    Some((dynsym_start, dynsym, dynstr))
+}
+
+///
+/// # Description
+///
+/// Resolves all symbol-based relocations in a single relocation table, returning
+/// the number that could not be resolved.
+///
+/// # Safety
+///
+/// `rel_vaddr + delta` must point to a valid relocation table of `rel_size`
+/// bytes whose targets are writable, and `dynsym` / `dynstr` must describe the
+/// executable's dynamic symbol/string tables.
+///
+unsafe fn resolve_table(
+    rel_vaddr: u32,
+    rel_size: u32,
+    delta: u32,
+    dynsym: &SymbolTable,
+    dynstr: &StringTable,
+) -> usize {
+    let rel_addr: usize = rel_vaddr as usize + delta as usize;
+    let count: usize = rel_size as usize / core::mem::size_of::<RelocationEntry>();
+    let table: RelocationTable =
+        RelocationTable::from_raw_parts(rel_addr as *mut RelocationEntry, count);
+
+    let mut unresolved: usize = 0;
+    for rel in table.iter() {
+        let typ: RelocationType = match rel.typ() {
+            Ok(typ) => typ,
+            // Unknown / processor-specific relocation: leave the slot untouched.
+            Err(_) => continue,
+        };
+
+        match typ {
+            // Already applied by `nvx::pie::relocate_pie_binary` (a no-op when
+            // the load delta is zero); nothing to bind here.
+            RelocationType::R_386_RELATIVE | RelocationType::R_386_NONE => {},
+
+            RelocationType::R_386_GLOB_DAT
+            | RelocationType::R_386_JMP_SLOT
+            | RelocationType::R_386_32
+            | RelocationType::R_386_PC32 => {
+                if !apply_symbol_relocation(rel, &typ, delta, dynsym, dynstr) {
+                    unresolved += 1;
+                }
+            },
+
+            other => {
+                ::syslog::warn!("dllink_executable(): unsupported relocation type {:?}", other);
+            },
+        }
+    }
+
+    unresolved
+}
+
+///
+/// # Description
+///
+/// Resolves a single symbol-based relocation, writing the resolved value into
+/// the relocation target. Returns `false` if the referenced symbol could not be
+/// resolved (and is not a weak undefined symbol, which legally resolves to
+/// zero).
+///
+/// # Safety
+///
+/// `rel` must reference a valid symbol index into `dynsym`, and its target
+/// (`rel.offset() + delta`) must be writable.
+///
+unsafe fn apply_symbol_relocation(
+    rel: &RelocationEntry,
+    typ: &RelocationType,
+    delta: u32,
+    dynsym: &SymbolTable,
+    dynstr: &StringTable,
+) -> bool {
+    let index: usize = rel.symbol_index() as usize;
+    let sym: &Symbol = match dynsym.get(index) {
+        Some(sym) => sym,
+        None => {
+            ::syslog::warn!("dllink_executable(): invalid symbol index {}", index);
+            return false;
+        },
+    };
+
+    let name: &str = match dynstr.get_name(sym.name_offset()) {
+        Ok(name) => name,
+        Err(_) => return false,
+    };
+
+    // Resolve the symbol to an absolute runtime address.
+    let value: u32 = if !sym.is_undefined() {
+        // Defined within the executable itself.
+        sym.value().wrapping_add(delta)
+    } else {
+        match super::global_symbol_lookup(name) {
+            Some(addr) => addr as u32,
+            None => {
+                // System V ABI: an unresolved weak undefined symbol is taken to
+                // have the value zero. Every other unresolved symbol is an error.
+                if sym.is_weak() {
+                    0
+                } else {
+                    ::syslog::warn!("dllink_executable(): symbol not found: {}", name);
+                    return false;
+                }
+            },
+        }
+    };
+
+    let target: *mut u32 = (rel.offset() as usize + delta as usize) as *mut u32;
+    match typ {
+        // GOT/PLT slots take the symbol value directly (the implicit addend is
+        // zero for these types).
+        RelocationType::R_386_JMP_SLOT | RelocationType::R_386_GLOB_DAT => {
+            target.write_unaligned(value);
+        },
+        // S + A, with wrapping 32-bit ELF arithmetic.
+        RelocationType::R_386_32 => {
+            let addend: u32 = target.read_unaligned();
+            target.write_unaligned(value.wrapping_add(addend));
+        },
+        // S + A - P, with wrapping 32-bit ELF arithmetic.
+        RelocationType::R_386_PC32 => {
+            let addend: u32 = target.read_unaligned();
+            let place: u32 = target as u32;
+            target.write_unaligned(value.wrapping_add(addend).wrapping_sub(place));
+        },
+        // Unreachable: callers only dispatch the four types handled above.
+        _ => return false,
+    }
+
+    true
+}

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -17,6 +17,7 @@ mod dlclose;
 mod dlopen;
 mod dlsym;
 mod dynlib;
+mod exe_link;
 
 //==================================================================================================
 // Imports
@@ -382,3 +383,4 @@ pub use dladdr::dladdr;
 pub use dlclose::dlclose;
 pub use dlopen::dlopen;
 pub use dlsym::dlsym;
+pub use exe_link::dllink_executable;

--- a/src/tests/integration/test-c-dlfcn-selflink/libs/provider.c
+++ b/src/tests/integration/test-c-dlfcn-selflink/libs/provider.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libprovider.so - Self-contained shared library that plays the role of
+ * "libc.so" for the crt0 self-linking test.
+ *
+ * It exports one data symbol and one function symbol with ZERO undefined
+ * symbols of its own, so it always loads successfully. The main executable
+ * references both as undefined externs, which makes the static linker emit:
+ *   - R_386_GLOB_DAT for selflink_provider_value (a GOT data slot), and
+ *   - R_386_JMP_SLOT for selflink_provider_func  (a PLT entry),
+ * plus a DT_NEEDED entry on libprovider.so. nvx-crt0's self-linker
+ * (syscall::dlfcn::dllink_executable) must bind both before main() runs.
+ */
+
+/* Distinctive sentinel so a failure to bind the GOT slot is obvious. */
+int selflink_provider_value = 0xC0DE;
+
+int selflink_provider_func(int x)
+{
+    return x + 1;
+}

--- a/src/tests/integration/test-c-dlfcn-selflink/main.c
+++ b/src/tests/integration/test-c-dlfcn-selflink/main.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-selflink-c: Validate that crt0 binds the MAIN EXECUTABLE's own
+ * symbol-based GOT/PLT relocations against a DT_NEEDED shared library before
+ * main() runs.
+ *
+ * Unlike the other dlfcn suites, this test never calls dlopen(): the binding
+ * happens implicitly at process startup. The executable is linked PIE and
+ * against libprovider.so (-lprovider), so the static linker records a
+ * DT_NEEDED entry and emits:
+ *   - R_386_GLOB_DAT for `selflink_provider_value` (read through the GOT), and
+ *   - R_386_JMP_SLOT for `selflink_provider_func`  (called through the PLT).
+ *
+ * Historically nvx-crt0 only applied R_386_RELATIVE fixups, leaving these two
+ * slots unbound; reading the value or calling the function would observe an
+ * unrelocated slot (wrong value / faulting indirect jump). With the self-linker
+ * (syscall::dlfcn::dllink_executable), both slots are bound before main() and
+ * the references below resolve to libprovider.so.
+ *
+ * Pass/fail is signalled by the exit code (0 = pass), which nanvixd propagates;
+ * the "ok" write mirrors the other suites' magic marker.
+ */
+
+#include <unistd.h>
+
+/*
+ * Defined in libprovider.so. The executable references these as undefined
+ * externs, which drives the GOT/PLT relocations the self-linker must bind.
+ */
+extern int selflink_provider_value;
+extern int selflink_provider_func(int x);
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* R_386_GLOB_DAT: the GOT slot must point at libprovider.so's data. */
+    int value = selflink_provider_value;
+
+    /* R_386_JMP_SLOT: the PLT slot must point at libprovider.so's code. */
+    int result = selflink_provider_func(41);
+
+    if (value == 0xC0DE && result == 42) {
+        write(STDOUT_FILENO, "ok", 2);
+        return 0;
+    }
+
+    return 1;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -106,6 +106,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-selflink"
+program = "./bin/test-c-dlfcn-selflink.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-selflink.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-weak"
 program = "./bin/test-c-dlfcn-weak.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-weak.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -106,6 +106,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-selflink"
+program = "./bin/test-c-dlfcn-selflink.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-selflink.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-weak"
 program = "./bin/test-c-dlfcn-weak.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-weak.img"


### PR DESCRIPTION
## Summary

Resolve the main executable's own symbol-based GOT/PLT relocations at process
startup, so undefined externs bound to a `DT_NEEDED` shared library are usable
before `main()` runs. Previously `nvx-crt0` applied only the symbol-less
`R_386_RELATIVE` fixups, leaving `R_386_GLOB_DAT` / `R_386_JMP_SLOT` slots
unbound — reading such a GOT entry or calling through such a PLT entry observed
an unrelocated slot.

## What changed

**Implementation — `[syscall] F: Bind Executable GOT/PLT at Startup`**
- New `syscall::dlfcn::dllink_executable()` self-linker: loads each `DT_NEEDED`
  dependency into the global scope (`RTLD_GLOBAL | RTLD_NOW`), then walks
  `.rel.dyn` / `.rel.plt` and resolves `GLOB_DAT`/`JMP_SLOT` (plus `R_386_32`/
  `R_386_PC32`) via the existing dlfcn resolver. Locates `.dynamic` through
  linker-script bounds rather than the (unmapped) ELF header.
- `posix`: invokes it from `__nanvix_libc_start_main()` after heap init and
  before `.init_array`/`main`.
- `elf`: adds `DT_NEEDED` / `DT_SYMTAB` constants. `nvx`: documents that the
  early pass intentionally handles only `R_386_RELATIVE`.
- Build: emits a `.dynamic` section bounded by `__dynamic_start`/`__dynamic_end`
  in the x86 and x86_64 user linker scripts (collapses to a no-op for static
  images).

**Test — `[tests] E: Add dlfcn selflink GOT/PLT suite`**
- New `test-c-dlfcn-selflink` POSIX suite: a PIE linked directly against
  `libprovider.so` reads a `GLOB_DAT` data symbol and calls a `JMP_SLOT`
  function, asserting both bind before `main()`. Fails without the self-linker;
  passes with it.

## Validation

Full standalone build; POSIX suite (incl. selflink) all exit 0; unit tests
(1928 passed); standalone integration suite passes; format / spell / clippy
gates pass.

closes #2772