### PR TITLE
[syscall] Implement execvp() PATH Search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 # guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
 # (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
 # is gated on TARGET=x86 accordingly.
-ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-selflink test-c-dlfcn-weak test-c-echo test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-inet test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
+ALL_POSIX_TESTS := test-c-bindings test-c-ctor test-c-dlfcn test-c-dlfcn-diamond test-c-dlfcn-global test-c-dlfcn-init-runpath test-c-dlfcn-needed test-c-dlfcn-pie test-c-dlfcn-selflink test-c-dlfcn-weak test-c-echo test-c-execvp test-c-file test-c-fork-pid test-c-fork-pthread test-c-glob test-c-hello test-c-inet test-c-libgen test-c-memory test-c-misc test-c-network test-c-noop test-c-regex test-c-setjmp test-c-stdio test-c-thread
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -232,12 +232,14 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
+	$(RM_CMD) $(POSIX_TEST_EXECVP_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_EXECVP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
 
 #---------------------------------------------------------------------------------------------------
@@ -569,6 +571,30 @@ $(POSIX_TEST_WEAK_IMG): $(foreach lib,$(POSIX_TEST_WEAK_LIBS),$(POSIX_TEST_WEAK_
 		$(POSIX_TEST_WEAK_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_WEAK_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# execvp-c: PATH-search fixture.
+#---------------------------------------------------------------------------------------------------
+#
+# test-c-execvp validates execvp()'s PATH search. The suite is a dual-role ELF:
+# booted as the driver it fork()s and execvp()s a copy of itself, and that copy
+# (re-exec'd with argv[1]=="execvp-child") plays the target role. The target must
+# be reachable through PATH, so the suite ELF is staged a second time in this
+# per-suite RAMFS image as /bin/prog; the driver sets PATH=/bin and asserts the
+# child it execvp()s exits with the target's sentinel code. /bin/prog IS the
+# suite ELF, so no extra build step is needed beyond copying it into the seed.
+
+POSIX_TEST_EXECVP_SUITE := test-c-execvp
+POSIX_TEST_EXECVP_SEED  := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_EXECVP_SUITE)-seed
+POSIX_TEST_EXECVP_IMG   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_EXECVP_SUITE).img
+
+$(POSIX_TEST_EXECVP_IMG): $(BINARIES_DIR)/$(POSIX_TEST_EXECVP_SUITE).$(EXEC_FORMAT) \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_EXECVP_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_EXECVP_SEED)/bin
+	$(CP_CMD) $(BINARIES_DIR)/$(POSIX_TEST_EXECVP_SUITE).$(EXEC_FORMAT) \
+		$(POSIX_TEST_EXECVP_SEED)/bin/prog
+	$(MKRAMFS) -o $@ $(POSIX_TEST_EXECVP_SEED)
+
 # The per-suite boot arguments that pair each suite with its RAMFS image
 # (`-ramfs <img>`) or enable host networking (`-allow-host-networking`) now live
 # in the nanvix-test harness configs (test/test-posix.toml and
@@ -590,7 +616,8 @@ all-posix-test-images: $(POSIX_TEST_INITRDS) \
 		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
 		$(POSIX_TEST_SOLIB_IMGS) \
 		$(POSIX_TEST_RUNPATH_IMG) \
-		$(POSIX_TEST_WEAK_IMG)
+		$(POSIX_TEST_WEAK_IMG) \
+		$(POSIX_TEST_EXECVP_IMG)
 	@echo "All POSIX C test-suite images built."
 
 .PHONY: run-posix-tests
@@ -615,7 +642,7 @@ ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
 else ifeq ($(DEPLOYMENT_MODE),standalone)
-run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG) $(POSIX_TEST_WEAK_IMG)
+run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG) $(POSIX_TEST_WEAK_IMG) $(POSIX_TEST_EXECVP_IMG)
 	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }

--- a/src/libs/syscall/src/unistd/bindings/execvp.rs
+++ b/src/libs/syscall/src/unistd/bindings/execvp.rs
@@ -20,22 +20,23 @@ use ::syslog::trace_syscall;
 /// # Description
 ///
 /// Executes a program by replacing the current process image. The `execvp()` function replaces the
-/// current process image with a new process image specified by `file`. Per POSIX, if `file`
-/// contains a slash it is used as a pathname; otherwise the directories listed in the `PATH`
-/// environment variable are searched for an executable of that name (see the Notes section for the
-/// current limitation). The `argv` argument is an array of character pointers to
-/// null-terminated strings that represent the argument list available to the new program. The
-/// first argument, by convention, points to the filename associated with the file being executed.
-/// The array of pointers must be terminated by a null pointer. This function is one of the exec
-/// family of functions that provide different interfaces for program execution and process
-/// replacement. Per POSIX, the new program inherits the calling process's environment.
+/// current process image with a new process image. Per POSIX, if `file` contains a slash it is used
+/// as a pathname; otherwise the directories listed in the `PATH` environment variable are searched
+/// in order for an executable of that name, and the first match is executed. The `argv` argument is
+/// an array of character pointers to null-terminated strings that represent the argument list
+/// available to the new program. The first argument, by convention, points to the filename
+/// associated with the file being executed. The array of pointers must be terminated by a null
+/// pointer. This function is one of the exec family of functions that provide different interfaces
+/// for program execution and process replacement. Per POSIX, the new program inherits the calling
+/// process's environment.
 ///
 /// # Parameters
 ///
 /// - `file`: Name of the executable file to execute. This must be a valid null-terminated string.
 ///   If it contains a slash, it is treated as a pathname (absolute or relative to the current
-///   working directory); otherwise POSIX locates it as a bare program name through the `PATH`
-///   environment variable (not yet implemented; see the Notes section). The file must have
+///   working directory); otherwise it is located as a bare program name by searching the
+///   directories in the `PATH` environment variable. When `PATH` is unset, a default search path is
+///   used, and an empty `PATH` entry denotes the current working directory. The file must have
 ///   appropriate execute permissions for the calling process.
 /// - `argv`: Argument vector for the new program. This is an array of pointers to null-terminated
 ///   strings that represent the command-line arguments to be passed to the new program. By
@@ -50,12 +51,6 @@ use ::syslog::trace_syscall;
 /// to indicate the error. The calling process continues execution at the point of the failed
 /// `execvp()` call. Common error conditions include file not found, permission denied, invalid
 /// executable format, insufficient memory, or invalid argument pointers.
-///
-/// # Notes
-///
-/// `PATH` search is not yet implemented: `file` is currently treated as a literal path and the
-/// call is delegated directly to the `execv()` path. A future implementation should search the
-/// directories listed in the `PATH` environment variable when `file` does not contain a slash.
 ///
 /// # Safety
 ///
@@ -73,10 +68,11 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
-    // `PATH` search is not implemented; treat `file` as a literal path and delegate to the
-    // environment-inheriting `execv()` path. `execv_inherit_env_from_c` returns only on failure; on
-    // success the process image is replaced and control does not return here.
-    let error: ::sys::error::Error = unsafe { crate::unistd::execv_inherit_env_from_c(file, argv) };
+    // Locate `file` per POSIX `execvp()` rules (direct path when it contains a slash, otherwise a
+    // `PATH` search) and replace the image, inheriting the caller's environment.
+    // `execvp_from_c` returns only on failure; on success the process image is replaced and control
+    // does not return here.
+    let error: ::sys::error::Error = unsafe { crate::unistd::execvp_from_c(file, argv) };
     unsafe {
         *__errno_location() = error.code.get();
     }

--- a/src/libs/syscall/src/unistd/exec/mod.rs
+++ b/src/libs/syscall/src/unistd/exec/mod.rs
@@ -39,6 +39,17 @@ use ::sysapi::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Separator between directory entries in the `PATH` environment variable. POSIX uses a colon.
+const PATH_SEPARATOR: char = ':';
+
+/// Search path used by `execvp()` when `PATH` is absent from the environment. POSIX leaves this
+/// value implementation-defined; a minimal, sensible default is used here.
+const DEFAULT_PATH: &str = "/bin:/usr/bin";
+
+//==================================================================================================
 // Private Standalone Functions
 //==================================================================================================
 
@@ -155,6 +166,61 @@ fn validate_exec_token(token: &str) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+///
+/// # Description
+///
+/// Reads the value of the `PATH` environment variable from the calling process's environment table
+/// (the same table that backs `getenv`/`setenv`).
+///
+/// # Returns
+///
+/// The value of `PATH` as an owned string if it is set and is valid UTF-8, otherwise `None`.
+///
+fn read_env_path() -> Option<String> {
+    let value: *const c_char = ::libc_stdlib::env_table::get("PATH");
+    if value.is_null() {
+        return None;
+    }
+    // SAFETY: `env_table::get` returned a non-null pointer (checked above) to a NUL-terminated C
+    // string that stays valid until the next `set`/`unset` of `PATH`. No such mutation happens
+    // before the value is copied into an owned `String` here, so the borrow is sound and the result
+    // does not depend on the table's storage afterward.
+    unsafe { ::core::ffi::CStr::from_ptr(value) }
+        .to_str()
+        .ok()
+        .map(String::from)
+}
+
+///
+/// # Description
+///
+/// Joins a single `PATH` directory prefix and a bare program name into one candidate path.
+///
+/// # Parameters
+///
+/// - `dir`: A single directory entry taken from `PATH`. Per POSIX, an empty entry denotes the
+///   current working directory; in that case `file` is returned unprefixed so it resolves relative
+///   to the current working directory.
+/// - `file`: The bare program name (the caller guarantees it contains no slash).
+///
+/// # Returns
+///
+/// The constructed candidate path.
+///
+fn join_search_path(dir: &str, file: &str) -> String {
+    if dir.is_empty() {
+        return String::from(file);
+    }
+
+    let mut candidate: String = String::with_capacity(dir.len() + 1 + file.len());
+    candidate.push_str(dir);
+    if !dir.ends_with('/') {
+        candidate.push('/');
+    }
+    candidate.push_str(file);
+    candidate
 }
 
 //==================================================================================================
@@ -384,14 +450,15 @@ pub unsafe fn execv_from_c(
 ///
 /// # Description
 ///
-/// C-ABI adapter for the environment-inheriting members of the `execv` family (`execv`, `execvp`):
-/// parses the `path` and `argv` C strings, snapshots the calling process's current environment, and
-/// replaces the calling process's image via [`do_execv`].
+/// C-ABI adapter for the environment-inheriting `execv()`: parses the `path` and `argv` C strings,
+/// snapshots the calling process's current environment, and replaces the calling process's image via
+/// [`do_execv`].
 ///
 /// Unlike [`execv_from_c`], which takes an explicit environment, this adapter inherits the caller's
-/// environment to honor POSIX `execv()`/`execvp()` semantics. The environment is read from the
-/// process-local environment table that also backs `getenv`/`setenv`, and is flattened into the
-/// kernel's NUL-separated `KEY=VALUE` form.
+/// environment to honor POSIX `execv()` semantics. The environment is read from the process-local
+/// environment table that also backs `getenv`/`setenv`, and is flattened into the kernel's
+/// NUL-separated `KEY=VALUE` form. (`execvp()` shares these semantics but performs a `PATH` search
+/// first; see [`execvp_from_c`].)
 ///
 /// # Parameters
 ///
@@ -421,6 +488,90 @@ pub unsafe fn execv_inherit_env_from_c(path: *const c_char, argv: *const *const 
     let env_tokens: Vec<&str> = env_owned.iter().map(String::as_str).collect();
 
     do_execv(path, &argv_vec, &env_tokens)
+}
+
+///
+/// # Description
+///
+/// C-ABI adapter for `execvp()`: parses the `file` and `argv` C strings, locates the executable
+/// following POSIX `execvp()` rules, and replaces the calling process's image via [`do_execv`],
+/// inheriting the caller's environment.
+///
+/// If `file` contains a slash it is used directly as a path, with no search. Otherwise the
+/// directories listed in the `PATH` environment variable are searched in order for an executable
+/// named `file`, and the first candidate that can be executed replaces the image. When `PATH` is
+/// unset, the default path [`DEFAULT_PATH`] is searched instead. An empty `PATH` entry denotes the
+/// current working directory.
+///
+/// During the search a candidate that does not exist ([`ErrorCode::NoSuchEntry`]) or whose prefix is
+/// not a directory ([`ErrorCode::InvalidDirectory`]) is skipped. A candidate that exists but cannot
+/// be accessed ([`ErrorCode::PermissionDenied`]) is remembered and reported only if no later
+/// candidate succeeds, mirroring the POSIX requirement to surface `EACCES`. Any other failure is
+/// reported immediately. If the search exhausts every entry, [`ErrorCode::NoSuchEntry`] is returned.
+///
+/// # Parameters
+///
+/// - `file`: NUL-terminated name or path of the program image to execute.
+/// - `argv`: NUL-pointer-terminated array of argument C strings.
+///
+/// # Returns
+///
+/// This function returns only on failure, yielding the error that prevented the replacement; on
+/// success the process image is replaced and control does not return.
+///
+/// # Safety
+///
+/// The caller must ensure that `file` points to a valid, NUL-terminated C string and that `argv` is
+/// non-null and points to a NUL-pointer-terminated array of valid, NUL-terminated C strings.
+///
+pub unsafe fn execvp_from_c(file: *const c_char, argv: *const *const c_char) -> Error {
+    // SAFETY: the caller upholds the documented C-string and array invariants.
+    let (file, argv_vec): (&str, Vec<&str>) = match unsafe { parse_path_and_argv(file, argv) } {
+        Ok(parsed) => parsed,
+        Err(error) => return error,
+    };
+
+    // An empty file name can never name an executable; fail fast before any search.
+    if file.is_empty() {
+        return Error::new(ErrorCode::NoSuchEntry, "execvp file name is empty");
+    }
+
+    // Snapshot the caller's environment so the new image inherits it (POSIX `execvp()` semantics).
+    // The owned strings outlive the borrowed token slice handed to `do_execv`.
+    let env_owned: Vec<String> = ::libc_stdlib::env_table::snapshot();
+    let env_tokens: Vec<&str> = env_owned.iter().map(String::as_str).collect();
+
+    // A file name that contains a slash is used as a path directly, with no `PATH` search (POSIX).
+    if file.contains('/') {
+        return do_execv(file, &argv_vec, &env_tokens);
+    }
+
+    // Otherwise, search each directory listed in `PATH` (or the default path when `PATH` is unset).
+    let path_value: Option<String> = read_env_path();
+    let search_path: &str = path_value.as_deref().unwrap_or(DEFAULT_PATH);
+
+    // Remember a `PermissionDenied` failure so it can be reported if nothing else executes, matching
+    // the POSIX requirement to surface `EACCES` when a candidate was found but could not be run.
+    let mut deferred: Option<Error> = None;
+    for dir in search_path.split(PATH_SEPARATOR) {
+        let candidate: String = join_search_path(dir, file);
+
+        // `do_execv` returns only on failure; on success the image is replaced and this never
+        // returns.
+        let error: Error = do_execv(&candidate, &argv_vec, &env_tokens);
+        match error.code {
+            // Not present in this directory: keep searching.
+            ErrorCode::NoSuchEntry | ErrorCode::InvalidDirectory => continue,
+            // Found but not accessible: remember it and keep searching.
+            ErrorCode::PermissionDenied => deferred = Some(error),
+            // Any other failure (e.g. a malformed executable) is reported immediately.
+            _ => return error,
+        }
+    }
+
+    // No candidate could be executed: report the remembered access error, if any, otherwise that
+    // the file was not found anywhere on the search path.
+    deferred.unwrap_or_else(|| Error::new(ErrorCode::NoSuchEntry, "execvp: file not found in PATH"))
 }
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/mod.rs
+++ b/src/libs/syscall/src/unistd/mod.rs
@@ -38,6 +38,7 @@ cfg_if::cfg_if! {
             exec_startup_barrier,
             execv_from_c,
             execv_inherit_env_from_c,
+            execvp_from_c,
         };
         pub use self::syscall::{
             faccessat,

--- a/src/tests/integration/test-c-execvp/main.c
+++ b/src/tests/integration/test-c-execvp/main.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Acceptance test for execvp(): the PATH search must locate a bare program name
+ * (one with no slash) in the directories listed in the PATH environment
+ * variable, while a name that contains a slash must be used as a path directly.
+ *
+ * Background
+ * ----------
+ * execvp() differs from execv() in how it resolves the program: if `file`
+ * contains a slash it is used verbatim, otherwise the directories in PATH are
+ * searched in order and the first executable found is run (POSIX). A stub that
+ * merely forwards to execv() (treating `file` as a literal path) cannot run a
+ * bare program name, which is what this test guards against.
+ *
+ * How it works (single ELF, two roles)
+ * ------------------------------------
+ * This program is bundled into the test ramfs a second time as `/bin/prog` and
+ * plays two roles selected by argv:
+ *   - Target role: when re-exec'd with argv[1] == "execvp-child", it returns the
+ *     sentinel exit code 42 and nothing else. Only the program at `/bin/prog`
+ *     does this, so observing 42 proves execvp() resolved to it.
+ *   - Driver role (argc < 2): it sets PATH and exercises execvp() through
+ *     fork()+waitpid(), asserting each child exits with 42.
+ *
+ * Sub-tests (all must pass)
+ * -------------------------
+ *   PATH-SEARCH-OK   execvp("prog") with PATH=/bin runs /bin/prog       (core).
+ *   PATH-MULTI-OK    execvp("prog") with PATH=/nonexistent:/bin skips
+ *                    the missing dir and runs /bin/prog.
+ *   SLASH-DIRECT-OK  execvp("/bin/prog") runs it directly even though
+ *                    PATH points elsewhere (slash bypasses PATH).
+ *   DEFAULT-PATH-OK  execvp("prog") with PATH unset falls back to the
+ *                    implementation default path and still runs /bin/prog.
+ *   NOTFOUND-OK      execvp() of a name absent from PATH returns -1 with
+ *                    errno == ENOENT.
+ *
+ * Pass/fail (standalone): guest stdout is discarded, so the propagated exit code
+ * is authoritative -- main() returns 0 on success and non-zero on the first
+ * failure. The emit() markers are diagnostic only.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/* Directory the target is staged in (added to PATH by the driver). */
+#define TARGET_DIR "/bin"
+/* Bare program name resolved through PATH. */
+#define TARGET_NAME "prog"
+/* Full path to the target, used by the slash-bypasses-PATH sub-test. */
+#define TARGET_PATH (TARGET_DIR "/" TARGET_NAME)
+/* argv[1] sentinel that selects the target role of this dual-role ELF. */
+#define CHILD_MARKER "execvp-child"
+/* Exit code the target returns; the driver asserts the child reports exactly this. */
+#define CHILD_EXIT_CODE 42
+/* Exit code a child reports if execvp() returned at all (i.e. it failed). */
+#define EXEC_FAILED_CODE 127
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/* Writes a NUL-terminated diagnostic string to standard output. */
+static void emit(const char *s)
+{
+    const char *p = s;
+    while (*p) {
+        p++;
+    }
+    (void)write(STDOUT_FILENO, s, (size_t)(p - s));
+}
+
+/*
+ * Forks a child that execvp()s `file` (handing it the CHILD_MARKER so the
+ * re-exec'd image takes the target role) and waits for it. Returns 0 only if the
+ * child exited with CHILD_EXIT_CODE -- i.e. execvp() located and ran /bin/prog.
+ * Returns -1 on any failure (fork, waitpid, execvp returning, or a wrong code).
+ */
+static int expect_exec_ok(const char *file)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        return (-1);
+    }
+
+    if (pid == 0) {
+        /* Child: replace the image with the program execvp() resolves. argv[0]
+           is conventional; argv[1] selects the target role. */
+        char *const cargv[] = {(char *)TARGET_NAME, (char *)CHILD_MARKER, NULL};
+        (void)execvp(file, cargv);
+        /* Only reached if execvp() failed; report a distinct, non-sentinel code. */
+        _exit(EXEC_FAILED_CODE);
+    }
+
+    /* Parent: reap the child and require the target's sentinel exit code. */
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid) {
+        return (-1);
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != CHILD_EXIT_CODE) {
+        return (-1);
+    }
+    return (0);
+}
+
+int main(int argc, char *argv[])
+{
+    /* Target role: this image was re-exec'd by the driver via execvp(). Report
+       the sentinel and do nothing else. Checked first so the re-exec'd image
+       short-circuits before any driver work. */
+    if (argc >= 2 && strcmp(argv[1], CHILD_MARKER) == 0) {
+        return (CHILD_EXIT_CODE);
+    }
+
+    emit("EXECVP-START\n");
+
+    /* 1. A bare name is resolved through PATH. */
+    if (setenv("PATH", TARGET_DIR, 1) != 0) {
+        emit("SETENV-FAILED\n");
+        return (1);
+    }
+    if (expect_exec_ok(TARGET_NAME) != 0) {
+        emit("PATH-SEARCH-FAILED\n");
+        return (1);
+    }
+    emit("PATH-SEARCH-OK\n");
+
+    /* 2. The search walks PATH in order, skipping a missing leading directory. */
+    if (setenv("PATH", "/nonexistent:" TARGET_DIR, 1) != 0) {
+        emit("SETENV-FAILED\n");
+        return (1);
+    }
+    if (expect_exec_ok(TARGET_NAME) != 0) {
+        emit("PATH-MULTI-FAILED\n");
+        return (1);
+    }
+    emit("PATH-MULTI-OK\n");
+
+    /* 3. A name with a slash is used directly and ignores PATH (set to a bogus
+          directory here to prove no PATH search happens). */
+    if (setenv("PATH", "/nonexistent", 1) != 0) {
+        emit("SETENV-FAILED\n");
+        return (1);
+    }
+    if (expect_exec_ok(TARGET_PATH) != 0) {
+        emit("SLASH-DIRECT-FAILED\n");
+        return (1);
+    }
+    emit("SLASH-DIRECT-OK\n");
+
+    /* 4. With PATH unset, the search falls back to the implementation default
+          path (which includes TARGET_DIR), so a bare name still resolves. */
+    if (unsetenv("PATH") != 0) {
+        emit("UNSETENV-FAILED\n");
+        return (1);
+    }
+    if (expect_exec_ok(TARGET_NAME) != 0) {
+        emit("DEFAULT-PATH-FAILED\n");
+        return (1);
+    }
+    emit("DEFAULT-PATH-OK\n");
+
+    /* 5. A bare name absent from every PATH directory fails with ENOENT. This
+          call runs in the driver because execvp() returns on failure. */
+    if (setenv("PATH", TARGET_DIR, 1) != 0) {
+        emit("SETENV-FAILED\n");
+        return (1);
+    }
+    errno = 0;
+    char *const nargv[] = {(char *)"definitely-not-here", NULL};
+    if (execvp("definitely-not-here", nargv) != -1) {
+        emit("NOTFOUND-RETURN\n");
+        return (1);
+    }
+    if (errno != ENOENT) {
+        emit("NOTFOUND-ERRNO\n");
+        return (1);
+    }
+    emit("NOTFOUND-OK\n");
+
+    emit("ok\n");
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -129,6 +129,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-execvp"
+program = "./bin/test-c-execvp.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-execvp.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-file"
 program = "./bin/test-c-file.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -129,6 +129,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-execvp"
+program = "./bin/test-c-execvp.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-execvp.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-file"
 program = "./bin/test-c-file.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"


### PR DESCRIPTION
Implements POSIX `execvp()` `PATH` search in the guest libc and adds a C acceptance suite that proves it.

Previously `execvp()` was a stub that forwarded to `execv()` and treated `file` as a literal path, so a bare program name could not be resolved. This PR makes `execvp()` follow POSIX: a name containing a slash is exec'd directly, otherwise each `PATH` entry is searched in order (inheriting the caller's environment), `ENOENT`/`ENOTDIR` candidates are skipped, an `EACCES` candidate is surfaced only if nothing else runs, an empty entry denotes the current directory, an unset `PATH` falls back to a default, and an exhausted search returns `ENOENT`.

**Library (`syscall`)**
- Add `execvp_from_c` plus `read_env_path`/`join_search_path` helpers and the `PATH_SEPARATOR`/`DEFAULT_PATH` constants.
- Point the `execvp()` C binding at `execvp_from_c`; `execv_inherit_env_from_c` now backs `execv()` only.

**Tests and build wiring**
- Add `src/tests/integration/test-c-execvp`, a dual-role ELF that fork()s/execvp()s a copy of itself and checks PATH search, multi-entry skip, slash-bypasses-PATH, and not-found (`errno == ENOENT`).
- Stage the suite ELF a second time as `/bin/prog` in a per-suite RAMFS; register the suite in the Makefile, `posix-tests.mk`, and both `test-posix*.toml` harness configs.

Validated on Windows standalone: the suite passes in both debug and release, `syscall` unit tests pass (88), and clippy/format are clean.

Closes #368