### PR TITLE
[syscall] Implement sleep()

### DIFF
--- a/src/libs/syscall/src/unistd/bindings/sleep.rs
+++ b/src/libs/syscall/src/unistd/bindings/sleep.rs
@@ -5,22 +5,90 @@
 // Imports
 //==================================================================================================
 
-use crate::errno::__errno_location;
-use ::sys::error::ErrorCode;
-use ::sysapi::ffi::c_uint;
+use ::core::time::Duration;
+use ::sys::{
+    error::ErrorCode,
+    kcall::pm,
+    time::SystemTime,
+};
+use ::sysapi::{
+    ffi::c_uint,
+    sys_types::time_t,
+    time::timespec,
+};
 use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Suspends the calling thread until either the number of real-time seconds specified by `seconds`
+/// has elapsed, or a signal whose action is to invoke a handler or to terminate the process is
+/// delivered to the calling thread.
+///
+/// # Parameters
+///
+/// - `seconds`: The number of seconds to sleep for.
+///
+/// # Returns
+///
+/// Returns `0` if the requested time has elapsed. If the sleep was interrupted by a signal, returns
+/// the unslept amount (the requested time minus the time actually slept) in seconds, rounded up to
+/// whole seconds so that a caller re-sleeping the returned value never sleeps for less than the
+/// originally requested time.
+///
 #[trace_libcall]
 #[unsafe(no_mangle)]
 pub extern "C" fn sleep(seconds: c_uint) -> c_uint {
-    // TODO: https://github.com/nanvix/nanvix/issues/453
-    ::syslog::debug!("sleep(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    // A zero-second request completes immediately, with no kernel round-trip.
+    if seconds == 0 {
+        return 0;
     }
-    0
+
+    let duration: Duration = Duration::from_secs(seconds as u64);
+    let req: timespec = timespec {
+        tv_sec: seconds as time_t,
+        tv_nsec: 0,
+    };
+
+    // Record the start time so that the unslept interval can be reported if a signal interrupts the
+    // sleep before the full duration elapses.
+    let mut start: SystemTime = SystemTime::default();
+    let measured: bool = pm::__kcall_gettime(&mut start).is_ok();
+
+    // Suspend the calling thread for the requested interval.
+    let mut rem: Option<&mut timespec> = None;
+    match crate::time::nanosleep(&req, &mut rem) {
+        // The full interval elapsed.
+        Ok(()) => return 0,
+        // A signal interrupted the sleep; fall through to report the unslept amount.
+        Err(e) if e.code == ErrorCode::Interrupted => {},
+        // Any other failure means that nothing was slept, so report the full interval as unslept.
+        Err(e) => {
+            ::syslog::warn!("sleep(): nanosleep() failed ({:?})", e.code);
+            return seconds;
+        },
+    }
+
+    // A signal interrupted the sleep. Report the unslept whole seconds when the elapsed time could
+    // be measured; otherwise report the full interval as unslept.
+    if !measured {
+        return seconds;
+    }
+
+    let mut now: SystemTime = SystemTime::default();
+    if pm::__kcall_gettime(&mut now).is_err() {
+        return seconds;
+    }
+
+    let elapsed: Duration = now.checked_sub(&start).unwrap_or(Duration::ZERO);
+
+    // Round the unslept interval up to whole seconds so that a caller re-sleeping the returned
+    // amount never sleeps for less than the originally requested time.
+    let remaining: Duration = duration.saturating_sub(elapsed);
+    let unslept: u64 = remaining.as_secs() + (remaining.subsec_nanos() > 0) as u64;
+    unslept as c_uint
 }

--- a/src/tests/integration/test-c-misc/common.h
+++ b/src/tests/integration/test-c-misc/common.h
@@ -77,6 +77,9 @@ extern void test_clock_gettime(void);
 // Tests whether we can sleep for a given amount of time with `nanosleep()`.
 extern void test_nanosleep(void);
 
+// Tests whether `sleep()` suspends the caller for the requested number of seconds.
+extern void test_sleep(void);
+
 // Tests whether `setegid()` can be used to set the effective group ID of the calling process.
 extern void test_setegid(void);
 

--- a/src/tests/integration/test-c-misc/main.c
+++ b/src/tests/integration/test-c-misc/main.c
@@ -49,6 +49,7 @@ int main(int argc, const char *argv[])
     test_clock_gettime();
 #ifndef __hyperlight__
     test_nanosleep();
+    test_sleep();
 #endif
     test_times();
     test_uname();

--- a/src/tests/integration/test-c-misc/sleep.c
+++ b/src/tests/integration/test-c-misc/sleep.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `sleep()` suspends the caller for the requested number of seconds.
+void test_sleep(void)
+{
+    fprintf(stderr, "testing sleep() ... ");
+
+    // A zero-second request returns immediately with nothing left unslept.
+    assert(sleep(0) == 0);
+
+    // A one-second request sleeps the full interval and reports no unslept time.
+    struct timespec before = {0, 0};
+    struct timespec after = {0, 0};
+    assert(clock_gettime(CLOCK_MONOTONIC, &before) == 0);
+    assert(sleep(1) == 0);
+    assert(clock_gettime(CLOCK_MONOTONIC, &after) == 0);
+
+    // The caller must have been suspended for about one second.
+    long long elapsed_ns = ((long long)after.tv_sec - (long long)before.tv_sec) * 1000000000LL +
+                           ((long long)after.tv_nsec - (long long)before.tv_nsec);
+    assert(elapsed_ns >= 900000000LL);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Implements the POSIX `sleep()` libc binding, which was previously a stub that always failed with `InvalidSysCall`.

## What changed

- **`syscall`**: Replace the `sleep()` stub with a working implementation. A zero-second request returns immediately; otherwise the calling thread is suspended for the requested interval via `nanosleep()`. When a signal interrupts the sleep, the unslept amount is computed from the measured elapsed time and returned, rounded **up** to whole seconds so a caller re-sleeping the result (e.g. `while ((rem = sleep(rem)))`) never sleeps for less than the originally requested time. The old `errno` write is dropped, matching POSIX (`sleep()` does not set `errno`).
- **`tests`**: Add `test_sleep()` to the `test-c-misc` suite covering the zero-second fast path and a full one-second sleep (validated against `CLOCK_MONOTONIC`), wired into `main()` and guarded out under hyperlight.

## Validation

- Build: OK
- Unit tests: pass
- In-kernel tests (`test-rust-kernel`): pass
- POSIX integration (`test-c-misc`, including the new `sleep` test): pass

closes #453