### PR TITLE
[tests] Add dlfcn startup DT_NEEDED suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,6 +405,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-needed \
 	test-c-dlfcn-pie \
 	test-c-dlfcn-selflink \
+	test-c-dlfcn-startup \
 	test-c-dlfcn-weak \
 	test-c-echo \
 	test-c-execvp \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -158,6 +158,26 @@ POSIX_TEST_SELFLINK_DIR := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-selflink/libs
 POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-selflink := $(POSIX_TEST_SELFLINK_DIR)/libprovider.so
 POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-selflink := -L$(POSIX_TEST_SELFLINK_DIR) -lprovider -z now
 
+# dlfcn-startup-c is the acceptance test for the startup DT_NEEDED loader (issue
+# #2773): it links the executable PIE against the REAL toolchain-shipped shared
+# libraries libc.so and libm.so (via `-l:libc.so -l:libm.so`) instead of the
+# static libm.a, so the executable carries DT_NEEDED entries for both plus
+# R_386_JMP_SLOT relocations against libm.so's math symbols. The self-linker
+# (syscall::dlfcn::dllink_executable) must auto-load libc.so and then libm.so
+# into the global scope and bind the executable's GOT/PLT before main() runs,
+# with NO dlopen() call. libm.so's allocator / mem* imports resolve from libc.so
+# (loaded first, in DT_NEEDED order); the executable's statically linked libc.a
+# stays the single heap owner because the loader's global scope is first-wins.
+# `-z now` forces eager binding (Nanvix has no lazy PLT resolver). The bare
+# DT_NEEDED names (`-l:` with no SONAME on the .so) are resolved through the
+# loader's default lib/ search path, where the per-suite RAMFS stages them.
+POSIX_TEST_PIE_test-c-dlfcn-startup := yes
+# Drop the static libm.a from the link group so the math symbols stay undefined
+# and bind to libm.so at startup instead of being pulled in statically.
+POSIX_TEST_NO_STATIC_LIBM_test-c-dlfcn-startup := yes
+POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-startup := $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so
+POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-startup := -L$(LIBRARIES_DIR) -l:libc.so -l:libm.so -z now
+
 define POSIX_TEST_RULE
 POSIX_TEST_SRCROOT_$(1) := $$(if $$(POSIX_TEST_STRESS_$(1)),$$(POSIX_TESTS_STRESS_SRCDIR),$$(POSIX_TESTS_SRCDIR))
 POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TEST_SRCROOT_$(1))/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TEST_SRCROOT_$(1))/$(1)/*.c))
@@ -169,10 +189,10 @@ endif
 $$(BINARIES_DIR)/$(1).$$(EXEC_FORMAT): $$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
 		$$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) $$(LIBNVX_CRT0) $$(GUEST_C_APP_LD_SCRIPT) \
 		$$(POSIX_TEST_EXTRA_LD_DEPS_$(1))
-	@echo "[posix-test] linking $(1) against libc.a + libm.a$$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))), (PIE))"
+	@echo "[posix-test] linking $(1) against libc.a$$(if $$(POSIX_TEST_NO_STATIC_LIBM_$(1)),, + libm.a)$$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))), (PIE))"
 	$$(GUEST_C_APP_LD) $$(GUEST_C_APP_LDFLAGS) $$(if $$(filter yes,$$(POSIX_TEST_PIE_$(1))),$$(POSIX_TEST_PIE_LDFLAGS)) \
 		$$(POSIX_TEST_OBJS_$(1)) $$(POSIX_TEST_CRT_OBJ) \
-		--start-group $$(LIBNVX_CRT0) $$(GUEST_C_APP_LIBC) $$(GUEST_C_APP_LIBM) --end-group \
+		--start-group $$(LIBNVX_CRT0) $$(GUEST_C_APP_LIBC) $$(if $$(POSIX_TEST_NO_STATIC_LIBM_$(1)),,$$(GUEST_C_APP_LIBM)) --end-group \
 		$$(POSIX_TEST_EXTRA_LDLIBS_$(1)) -o $$@
 	@echo "[posix-test] built $$@"
 endef
@@ -231,6 +251,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
 	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
 	$(RM_CMD) $(POSIX_TEST_EXECVP_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
@@ -238,6 +259,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_EXECVP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
@@ -439,10 +461,32 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink): $(POSIX_TEST_SELFLINK_DIR)/libpro
 	$(CP_CMD) $(POSIX_TEST_SELFLINK_DIR)/libprovider.so $(POSIX_TEST_SELFLINK_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_SELFLINK_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-startup-c: real libc.so + libm.so startup auto-load fixture.
+#---------------------------------------------------------------------------------------------------
+#
+# Unlike the fixtures above (purpose-built .so files), this suite stages the
+# ACTUAL shared libraries produced by nanvix-libc-bundle (libc.so + libm.so)
+# under lib/, reached through the loader's default lib/ search path. The
+# executable links against them via DT_NEEDED (see the per-suite hooks above) and
+# the startup loader auto-loads them before main(); see
+# test-c-dlfcn-startup/main.c.
+POSIX_TEST_STARTUP_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-startup-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-startup.img
+
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup): $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_STARTUP_SEED)/lib
+	$(CP_CMD) $(LIBRARIES_DIR)/libc.so $(POSIX_TEST_STARTUP_SEED)/lib/
+	$(CP_CMD) $(LIBRARIES_DIR)/libm.so $(POSIX_TEST_STARTUP_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_STARTUP_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
-	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-init-runpath-c: constructor/destructor + DT_RUNPATH fixtures.

--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -80,28 +80,37 @@ SECTIONS
 	 * These sections hold relocated function pointers, so they must live in the
 	 * writable LOAD segment (with .data/.ctors/.dtors) where the PIE relocator
 	 * fixes them up.
+	 *
+	 * The boundary symbols use `PROVIDE` (default visibility) rather than the
+	 * customary `PROVIDE_HIDDEN`, mirroring the `__dynamic_*` / `__dynsym_*` /
+	 * `__dynstr_*` bounds above, so they are emitted into `.dynsym` under
+	 * `--export-dynamic`. A dynamically linked `libc.so` references these section
+	 * bounds as undefined symbols (its own `__nanvix_libc_start_main` walks the
+	 * arrays), and the startup DT_NEEDED loader
+	 * (`syscall::dlfcn::dllink_executable`) resolves them from the executable's
+	 * exported global scope when it auto-loads `libc.so`.
 	 */
 	.preinit_array : ALIGN(4)
 	{
-		PROVIDE_HIDDEN(__preinit_array_start = .);
+		PROVIDE(__preinit_array_start = .);
 		KEEP(*(.preinit_array))
-		PROVIDE_HIDDEN(__preinit_array_end = .);
+		PROVIDE(__preinit_array_end = .);
 	}
 
 	.init_array : ALIGN(4)
 	{
-		PROVIDE_HIDDEN(__init_array_start = .);
+		PROVIDE(__init_array_start = .);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*)))
 		KEEP(*(.init_array))
-		PROVIDE_HIDDEN(__init_array_end = .);
+		PROVIDE(__init_array_end = .);
 	}
 
 	.fini_array : ALIGN(4)
 	{
-		PROVIDE_HIDDEN(__fini_array_start = .);
+		PROVIDE(__fini_array_start = .);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
 		KEEP(*(.fini_array))
-		PROVIDE_HIDDEN(__fini_array_end = .);
+		PROVIDE(__fini_array_end = .);
 	}
 
 	/* Uninitialized data section. */

--- a/build/user/linker/x86_64/user.ld
+++ b/build/user/linker/x86_64/user.ld
@@ -61,28 +61,37 @@ SECTIONS
 	 * GCC crtbegin/crtend — because Nanvix ships no crti/crtn/crtbegin/crtend.
 	 * These sections hold relocated function pointers, so they must live in the
 	 * writable LOAD segment (with .data) where the PIE relocator fixes them up.
+	 *
+	 * The boundary symbols use `PROVIDE` (default visibility) rather than the
+	 * customary `PROVIDE_HIDDEN`, mirroring the `__dynamic_*` / `__dynsym_*` /
+	 * `__dynstr_*` bounds above, so they are emitted into `.dynsym` under
+	 * `--export-dynamic`. A dynamically linked `libc.so` references these section
+	 * bounds as undefined symbols (its own `__nanvix_libc_start_main` walks the
+	 * arrays), and the startup DT_NEEDED loader
+	 * (`syscall::dlfcn::dllink_executable`) resolves them from the executable's
+	 * exported global scope when it auto-loads `libc.so`.
 	 */
 	.preinit_array : ALIGN(8)
 	{
-		PROVIDE_HIDDEN(__preinit_array_start = .);
+		PROVIDE(__preinit_array_start = .);
 		KEEP(*(.preinit_array))
-		PROVIDE_HIDDEN(__preinit_array_end = .);
+		PROVIDE(__preinit_array_end = .);
 	}
 
 	.init_array : ALIGN(8)
 	{
-		PROVIDE_HIDDEN(__init_array_start = .);
+		PROVIDE(__init_array_start = .);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*)))
 		KEEP(*(.init_array))
-		PROVIDE_HIDDEN(__init_array_end = .);
+		PROVIDE(__init_array_end = .);
 	}
 
 	.fini_array : ALIGN(8)
 	{
-		PROVIDE_HIDDEN(__fini_array_start = .);
+		PROVIDE(__fini_array_start = .);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.fini_array.*)))
 		KEEP(*(.fini_array))
-		PROVIDE_HIDDEN(__fini_array_end = .);
+		PROVIDE(__fini_array_end = .);
 	}
 
 	/* Uninitialized data section. */

--- a/src/tests/integration/test-c-dlfcn-startup/main.c
+++ b/src/tests/integration/test-c-dlfcn-startup/main.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-startup-c: Validate that crt0's startup DT_NEEDED loader auto-loads the
+ * REAL Nanvix shared libraries (libc.so and libm.so) before main() runs, with
+ * NO dlopen() call.
+ *
+ * Unlike dlfcn-selflink-c (which links the executable against a self-contained
+ * libprovider.so fixture), this suite links against the actual shared libraries
+ * shipped by the toolchain. The executable is linked PIE and against libm.so
+ * (-l:libm.so) instead of the static libm.a, so the math symbols below are left
+ * UNDEFINED in the executable and recorded as a DT_NEEDED entry plus
+ * R_386_JMP_SLOT relocations. libm.so in turn imports libc.so's allocator and
+ * mem* surface, so the executable also carries a DT_NEEDED on libc.so.
+ *
+ * At process startup, syscall::dlfcn::dllink_executable() walks the executable's
+ * DT_NEEDED list and loads libc.so and then libm.so into the global scope (the
+ * equivalent of dlopen(RTLD_GLOBAL | RTLD_NOW)), binding the executable's GOT/PLT
+ * slots against them before .init_array / main(). libm.so's own imports resolve
+ * from libc.so (loaded first); the executable's statically linked libc.a remains
+ * the single heap owner, because the loader's global scope is first-wins. No
+ * dlopen() is called by the test.
+ *
+ * Pass/fail is signalled by the exit code (0 = pass), which nanvixd propagates;
+ * the "ok" write mirrors the other suites' magic marker.
+ */
+
+#include <math.h>
+#include <unistd.h>
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /*
+     * `volatile` inputs stop the optimizer (release builds compile at -O3) from
+     * constant-folding these math calls away: the calls must survive as real
+     * PLT references into libm.so so the startup loader has GOT/PLT slots to
+     * bind. The chosen arguments yield exact results, so the equality checks
+     * below need no floating-point tolerance.
+     */
+    volatile double zero = 0.0;
+    volatile double base = 2.0;
+    volatile double exponent = 10.0;
+
+    /* R_386_JMP_SLOT relocations against libm.so, auto-bound before main(). */
+    double c = cos(zero);           /* cos(0)    == 1    */
+    double p = pow(base, exponent); /* pow(2, 10) == 1024 */
+    double e = exp(zero);           /* exp(0)    == 1    */
+
+    if (c == 1.0 && p == 1024.0 && e == 1.0) {
+        write(STDOUT_FILENO, "ok", 2);
+        return 0;
+    }
+
+    return 1;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -114,6 +114,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-startup"
+program = "./bin/test-c-dlfcn-startup.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-startup.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-weak"
 program = "./bin/test-c-dlfcn-weak.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-weak.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -114,6 +114,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-startup"
+program = "./bin/test-c-dlfcn-startup.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-startup.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-weak"
 program = "./bin/test-c-dlfcn-weak.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-weak.img"


### PR DESCRIPTION
## Summary

Adds the acceptance test for the startup `DT_NEEDED` loader (issue #2773): an
executable linked against the **real** `libc.so` / `libm.so` runs with its
shared-library dependencies auto-loaded before `main()`, with no `dlopen()` call.

The startup loader (`syscall::dlfcn::dllink_executable`) and its exe-GOT/PLT
binding already landed in #2786 (validated against a fixture `libprovider.so`).
This PR exercises that machinery against the actual toolchain-shipped shared
libraries.

## What changed

**`[tests]` — new `test-c-dlfcn-startup` suite**
- A PIE executable that statically links `libc.a` (bootstrap) and carries
  `DT_NEEDED` on the real `libc.so` and `libm.so`. It calls `cos`/`pow`/`exp`
  (left undefined → `R_386_JMP_SLOT`) through `volatile` inputs so the calls
  survive `-O3` and stay real PLT references into `libm.so`. `main` returns 0
  only if the loader auto-loaded both `.so` and bound the slots before `main`.
- `posix-tests.mk`: links the suite against `-l:libc.so -l:libm.so -z now` and
  drops the static `libm.a` via a new per-suite `POSIX_TEST_NO_STATIC_LIBM` hook;
  stages both `.so` in a per-suite RAMFS reached through the loader's default
  `lib/` search path.
- Registered in `ALL_POSIX_TESTS` and the Linux + Windows POSIX test configs.

**`[build]` — export init/fini array bounds**
- The `.preinit_array` / `.init_array` / `.fini_array` boundary symbols in both
  guest linker scripts change from `PROVIDE_HIDDEN` to `PROVIDE`, so they land in
  `.dynsym` under `--export-dynamic`. A dynamically loaded `libc.so` references
  these section bounds as undefined symbols; exporting them lets the startup
  loader resolve them from the executable's global scope. Inert for static guests
  (no `.dynsym`); only PIE `--export-dynamic` binaries (the dlfcn suites) are
  affected.

## Validation

- New suite boots and passes (`VM exit_status=0`); logs show `libm.so` symbols
  resolved at load and `libc.so` auto-loaded.
- No regressions: all 7 existing PIE dlfcn suites (`selflink`, `init-runpath`,
  `pie`, `weak`, `global`, `needed`, `diamond`) still pass under the changed
  linker scripts.
- `-O3` (release) compile keeps the PLT references + `DT_NEEDED`; `format-check`
  and `spellcheck` pass.

closes #2773