### PR TITLE
Parallelize CI integration tests into disjoint shards

### DIFF
--- a/.github/actions/integration-test-extras/action.yml
+++ b/.github/actions/integration-test-extras/action.yml
@@ -1,0 +1,57 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Integration Test Extras"
+description: "Run the non-sharded integration checks (in-kernel and smoke tests)
+  for the microvm machine type"
+
+inputs:
+  build-type:
+    description: "Build type (debug or release)"
+    required: true
+  machine-type:
+    description: "Machine type"
+    required: true
+  deployment-type:
+    description: "Deployment type"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # In-kernel unit tests: build kernel with `test` feature, boot it, and verify
+    # tests pass by waiting for the magic string (tests run before the user binary).
+    - name: "In-Kernel Tests (${{ inputs.machine-type }})"
+      if: inputs.build-type == 'debug'
+      shell: bash
+      env:
+        RUST_LOG: debug
+      run: |
+        set -Eeuo pipefail
+
+        ./z build -- run-kernel-tests \
+            "MACHINE=${{ inputs.machine-type }}" \
+            TARGET=x86 \
+            LOG_LEVEL=trace
+
+        echo "In-kernel tests passed."
+
+    # Smoke test that boots nanvixd and checks for the kernel magic string,
+    # verifying the multibin initrd (procd, testd, memd, vfsd).
+    - name: "Smoke Test (${{ inputs.machine-type }})"
+      shell: bash
+      env:
+        RUST_LOG: debug
+      run: |
+        set -Eeuo pipefail
+
+        TIMEOUT=120
+        RELEASE_FLAG=""
+        if [[ "${{ inputs.build-type }}" == "release" ]]; then
+          RELEASE_FLAG="--release"
+        fi
+
+        ./z build ${RELEASE_FLAG} -- run-smoke-test \
+            "MACHINE=${{ inputs.machine-type }}" \
+            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}" \
+            "TIMEOUT=${TIMEOUT}"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 
 name: "Integration Test"
-description: "Run integration tests for microvm machine type"
+description: "Run a disjoint shard of the TOML-driven integration tests for the
+  microvm machine type"
 
 inputs:
   build-type:
@@ -14,49 +15,23 @@ inputs:
   deployment-type:
     description: "Deployment type"
     required: true
+  shard-index:
+    description: "1-based index of this shard (e.g. 1)"
+    required: true
+  shard-total:
+    description: "Total number of shards the tests are partitioned into (e.g. 4)"
+    required: true
 
 runs:
   using: "composite"
   steps:
-    # In-kernel unit tests: build kernel with `test` feature, boot it, and verify
-    # tests pass by waiting for the magic string (tests run before the user binary).
-    - name: "In-Kernel Tests (${{ inputs.machine-type }})"
-      if: inputs.build-type == 'debug'
-      shell: bash
-      env:
-        RUST_LOG: debug
-      run: |
-        set -Eeuo pipefail
-
-        ./z build -- run-kernel-tests \
-            "MACHINE=${{ inputs.machine-type }}" \
-            TARGET=x86 \
-            LOG_LEVEL=trace
-
-        echo "In-kernel tests passed."
-
-    # Smoke test that boots nanvixd and checks for the kernel magic string,
-    # verifying the multibin initrd (procd, testd, memd, vfsd).
-    - name: "Smoke Test (${{ inputs.machine-type }})"
-      shell: bash
-      env:
-        RUST_LOG: debug
-      run: |
-        set -Eeuo pipefail
-
-        TIMEOUT=120
-        RELEASE_FLAG=""
-        if [[ "${{ inputs.build-type }}" == "release" ]]; then
-          RELEASE_FLAG="--release"
-        fi
-
-        ./z build ${RELEASE_FLAG} -- run-smoke-test \
-            "MACHINE=${{ inputs.machine-type }}" \
-            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}" \
-            "TIMEOUT=${TIMEOUT}"
-
-    # Run test binary directly from downloaded artifacts.
-    - name: "Integration Test (${{ inputs.machine-type }})"
+    # Run this shard's slice of the deployment's integration suite directly from
+    # the downloaded artifacts. The harness selects a disjoint, round-robin
+    # subset via `-shard INDEX/TOTAL`, so new tests added to the TOML config are
+    # automatically distributed across shards with no workflow changes. The
+    # config path must be the last argument (the harness treats it positionally),
+    # so the `-shard` selector precedes it.
+    - name: "Integration Test (${{ inputs.machine-type }}, shard ${{ inputs.shard-index }}/${{ inputs.shard-total }})"
       shell: bash
       env:
         RUST_LOG: info
@@ -78,17 +53,19 @@ runs:
             ;;
         esac
 
-        echo "Running: ./bin/nanvix-test.elf ${TEST_CONFIG}"
-        ./bin/nanvix-test.elf "${TEST_CONFIG}"
+        SHARD="${{ inputs.shard-index }}/${{ inputs.shard-total }}"
+        echo "Running: ./bin/nanvix-test.elf -shard ${SHARD} ${TEST_CONFIG}"
+        ./bin/nanvix-test.elf -shard "${SHARD}" "${TEST_CONFIG}"
 
     # Ported POSIX C test suites. Standalone-only: the runner boots each suite
     # under nanvixd in standalone mode and uses the guest exit code as the
-    # pass/fail signal. This also exercises the freestanding guest C toolchain
-    # (build/make/guest-c-apps.mk) that no other CI step compiles.
-    - name: "POSIX C Suites (${{ inputs.machine-type }})"
+    # pass/fail signal. The SHARD selector partitions the suites round-robin so
+    # each runner executes a disjoint slice. This also exercises the freestanding
+    # guest C toolchain (build/make/guest-c-apps.mk) that no other CI step compiles.
+    - name: "POSIX C Suites (${{ inputs.machine-type }}, shard ${{ inputs.shard-index }}/${{ inputs.shard-total }})"
       if: inputs.deployment-type == 'standalone'
       shell: bash
-      # No RUST_LOG here (unlike the direct-invocation steps above): this step
+      # No RUST_LOG here (unlike the direct-invocation step above): this step
       # drives the harness through `./z build -- run-posix-tests`, whose recipe
       # sets RUST_LOG=$(LOG_LEVEL) on the harness command line, so a step-level
       # RUST_LOG would be overridden and have no effect.
@@ -103,4 +80,6 @@ runs:
         ./z build ${RELEASE_FLAG} -- run-posix-tests \
             "MACHINE=${{ inputs.machine-type }}" \
             TARGET=x86 \
-            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}"
+            "DEPLOYMENT_MODE=${{ inputs.deployment-type }}" \
+            "SHARD=${{ inputs.shard-index }}/${{ inputs.shard-total }}"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,83 @@ jobs:
 
   ci-test:
     name: "Test (${{ matrix.build-type }}, ${{ matrix.machine-type }}, ${{
+      matrix.deployment-type }}, shard ${{ matrix.shard }}/4)"
+    needs: [ ci-build ]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    if: ${{ !cancelled() && needs.ci-build.result == 'success' }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug","release"]' ||
+          github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
+          '["release"]') }}
+        machine-type: [ microvm ]
+        deployment-type: [ standalone, single-process, multi-process ]
+        # The TOML-driven integration suites are partitioned into disjoint shards
+        # that run on independent runners. The harness selects this shard's tests
+        # via `-shard INDEX/TOTAL` (round-robin), so tests added to the TOML
+        # configs are distributed automatically with no workflow changes. To
+        # change the shard count, update this list AND the `shard-total` input
+        # passed to the integration-test action below so they stay in sync.
+        shard: [ 1, 2, 3, 4 ]
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
+      options: --privileged
+    permissions:
+      contents: read
+      packages: read
+    env:
+      # The CI container runs as root without USER set; nanvixd uses it as
+      # fallback tenant-id and fails when the variable is missing.
+      USER: root
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Setup"
+        uses: ./.github/actions/native-setup
+
+      - name: "Setup KVM"
+        uses: ./.github/actions/setup-kvm
+
+      - name: "Prepare Test Artifacts"
+        uses: ./.github/actions/prepare-test-artifacts
+        with:
+          build-type: "${{ matrix.build-type }}"
+          machine-type: "${{ matrix.machine-type }}"
+          deployment-type: "${{ matrix.deployment-type }}"
+
+      - name: "Integration Test"
+        uses: ./.github/actions/integration-test
+        with:
+          build-type: "${{ matrix.build-type }}"
+          machine-type: "${{ matrix.machine-type }}"
+          deployment-type: "${{ matrix.deployment-type }}"
+          shard-index: "${{ matrix.shard }}"
+          shard-total: "4"
+
+      - name: "Upload logs in case of failures"
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nanvix-integration-logs-${{ github.event.pull_request.number ||
+            github.run_number }}-${{ matrix.build-type }}-${{
+            matrix.machine-type }}-${{ matrix.deployment-type }}-shard${{ matrix.shard }}
+          overwrite: "true"
+          path: |
+            logs/
+            **/*.log
+            **/*.out
+            **/*.err
+
+  # Non-sharded integration checks that should run once per configuration rather
+  # than per shard: in-kernel unit tests, the boot smoke test, and the shim
+  # integration test. Kept in a dedicated job so the sharded ci-test runners
+  # execute only disjoint slices of the TOML suites.
+  ci-test-extras:
+    name: "Test Extras (${{ matrix.build-type }}, ${{ matrix.machine-type }}, ${{
       matrix.deployment-type }})"
     needs: [ ci-build ]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
@@ -527,8 +604,8 @@ jobs:
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
 
-      - name: "Integration Test"
-        uses: ./.github/actions/integration-test
+      - name: "In-Kernel & Smoke Tests"
+        uses: ./.github/actions/integration-test-extras
         with:
           build-type: "${{ matrix.build-type }}"
           machine-type: "${{ matrix.machine-type }}"
@@ -548,7 +625,7 @@ jobs:
         if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
-          name: nanvix-integration-logs-${{ github.event.pull_request.number ||
+          name: nanvix-integration-extras-logs-${{ github.event.pull_request.number ||
             github.run_number }}-${{ matrix.build-type }}-${{
             matrix.machine-type }}-${{ matrix.deployment-type }}
           overwrite: "true"
@@ -557,6 +634,7 @@ jobs:
             **/*.log
             **/*.out
             **/*.err
+
 
   # ==========================================================================================
   # Windows CI (GitHub-Hosted Runners)
@@ -784,15 +862,14 @@ jobs:
   # mirroring the Linux CI integration-test stage.
   windows-integration-test:
     name: "Windows Integration Test (${{ matrix.machine-type }}, ${{
-      matrix.build-type }})"
+      matrix.build-type }}, shard ${{ matrix.shard }}/4)"
     needs: [ windows-ci-build ]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: ${{ !cancelled() && needs.windows-ci-build.result == 'success' }}
-    # Debug guests run ~15x slower than release under WHP, so the debug matrix
-    # variant (debug-only in-kernel tests + integration suite + POSIX C suites)
-    # routinely consumes 25-27 min, and grows as new suites are added. Allow
-    # generous headroom over the 30 min default.
-    timeout-minutes: 60
+    # Debug guests run ~15x slower than release under WHP. Partitioning the
+    # integration + POSIX suites into disjoint shards keeps each runner well
+    # under the timeout even for debug. Allow headroom over the 30 min default.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -800,6 +877,11 @@ jobs:
           github.event_name == 'workflow_dispatch' && '["debug","release"]' ||
           '["release"]') }}
         machine-type: [ microvm ]
+        # Integration tests are partitioned into disjoint shards via the harness
+        # `-shard INDEX/TOTAL` option (round-robin), so new tests distribute
+        # automatically. To change the shard count, update this list AND the
+        # `/4` divisors used in the test steps below so they stay in sync.
+        shard: [ 1, 2, 3, 4 ]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -876,9 +958,11 @@ jobs:
           Write-Host "WHP probe succeeded — hypervisor is functional."
           echo "whp_available=true" >> $env:GITHUB_OUTPUT
 
+      # In-kernel tests are deployment- and shard-agnostic, so run them only on
+      # the first shard to avoid redundant work across the parallel shard runners.
       - name: "In-Kernel Tests (${{ matrix.machine-type }})"
         if: steps.whp-check.outputs.whp_available == 'true' && matrix.build-type ==
-          'debug'
+          'debug' && matrix.shard == 1
         shell: pwsh
         env:
           RUST_LOG: debug
@@ -886,7 +970,7 @@ jobs:
           .\z.ps1 build -- run-kernel-tests "MACHINE=${{ matrix.machine-type }}" TARGET=x86 LOG_LEVEL=trace
           Write-Host "In-kernel tests passed."
 
-      - name: "Run Integration Tests"
+      - name: "Run Integration Tests (shard ${{ matrix.shard }}/4)"
         if: steps.whp-check.outputs.whp_available == 'true'
         shell: pwsh
         env:
@@ -895,13 +979,14 @@ jobs:
           # marked release-only via `build_modes`, which are too slow under a debug/trace build).
           BUILD_MODE: ${{ matrix.build-type }}
         run: |
-          & .\bin\nanvix-test.exe .\test\test-standalone-windows.toml
+          # The config path must be the last argument, so -shard precedes it.
+          & .\bin\nanvix-test.exe -shard "${{ matrix.shard }}/4" .\test\test-standalone-windows.toml
 
       # Ported POSIX C test suites. Boots the prebuilt <suite>.initrd images
       # (built by the Windows build job via all-posix-test-images and downloaded
       # with the artifact) directly under WHP through the nanvix-test harness,
       # asserting each guest exit code is 0. No rebuild is needed here.
-      - name: "POSIX C Suites (${{ matrix.machine-type }})"
+      - name: "POSIX C Suites (${{ matrix.machine-type }}, shard ${{ matrix.shard }}/4)"
         if: steps.whp-check.outputs.whp_available == 'true'
         shell: pwsh
         env:
@@ -909,7 +994,8 @@ jobs:
           # Forwarded to the harness so it can gate build-mode-restricted tests.
           BUILD_MODE: ${{ matrix.build-type }}
         run: |
-          & .\bin\nanvix-test.exe .\test\test-posix-windows.toml
+          # The config path must be the last argument, so -shard precedes it.
+          & .\bin\nanvix-test.exe -shard "${{ matrix.shard }}/4" .\test\test-posix-windows.toml
 
       - name: "Upload logs in case of failures"
         if: failure() || cancelled()
@@ -917,7 +1003,7 @@ jobs:
         with:
           name: nanvix-windows-integration-logs-${{ github.event.pull_request.number ||
             github.run_number }}-${{ matrix.machine-type }}-${{
-            matrix.build-type }}
+            matrix.build-type }}-shard${{ matrix.shard }}
           overwrite: "true"
           path: |
             logs/
@@ -1468,6 +1554,7 @@ jobs:
       ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
     needs:
       - ci-test
+      - ci-test-extras
       - benchmark-gate-linux
       - benchmark-gate-windows
       - benchmark-finalize
@@ -1482,6 +1569,7 @@ jobs:
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
+      needs.ci-test-extras.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
         needs.benchmark-gate-linux.outputs.should-run != 'true') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
@@ -1533,6 +1621,7 @@ jobs:
     needs:
       - windows-integration-test
       - ci-test
+      - ci-test-extras
       - benchmark-gate-linux
       - benchmark-gate-windows
       - benchmark-finalize
@@ -1547,6 +1636,7 @@ jobs:
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
+      needs.ci-test-extras.result == 'success' &&
       (needs.benchmark-finalize.result == 'success' ||
         needs.benchmark-gate-linux.outputs.should-run != 'true') &&
       (needs.windows-benchmark-finalize.result == 'success' ||
@@ -1631,6 +1721,7 @@ jobs:
         verify,
         ci-build,
         ci-test,
+        ci-test-extras,
         benchmark-gate-linux,
         benchmark-gate-windows,
         benchmark,

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -732,6 +732,13 @@ else
 POSIX_TEST_CONFIG := test/test-posix.toml
 endif
 
+# Optional test sharding. When SHARD is set to INDEX/TOTAL (e.g. SHARD=1/4), the
+# harness runs only that disjoint, round-robin slice of the suites via its
+# `-shard` option, letting CI partition the POSIX suites across independent
+# runners. The selector must precede the config path (the harness treats the
+# last argument as the config file). Leave SHARD empty to run every suite.
+POSIX_TEST_SHARD_FLAG := $(if $(strip $(SHARD)),-shard $(strip $(SHARD)))
+
 ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
@@ -741,8 +748,8 @@ run-posix-tests: $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(USERVM) || { echo "ERROR: $(USERVM) missing; run './z build -- all' first."; exit 1; }
-	@echo "Running ported POSIX C test suites with configuration: $(POSIX_TEST_CONFIG)"
-	RUST_LOG=$(LOG_LEVEL) $(NANVIX_TEST_BIN) $(POSIX_TEST_CONFIG)
+	@echo "Running ported POSIX C test suites with configuration: $(POSIX_TEST_CONFIG)$(if $(strip $(SHARD)), (shard $(strip $(SHARD))))"
+	RUST_LOG=$(LOG_LEVEL) $(NANVIX_TEST_BIN) $(POSIX_TEST_SHARD_FLAG) $(POSIX_TEST_CONFIG)
 else
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (DEPLOYMENT_MODE=$(DEPLOYMENT_MODE), requires standalone)."

--- a/src/utils/nanvix-test/src/args.rs
+++ b/src/utils/nanvix-test/src/args.rs
@@ -21,12 +21,74 @@ use ::std::process;
 ///
 /// # Description
 ///
+/// Partition selector that assigns a disjoint, round-robin subset of the filtered test list to a
+/// single parallel shard. Sharding is positional, so it is independent of test names and
+/// automatically distributes newly added tests across shards.
+#[derive(Clone, Copy)]
+pub struct Shard {
+    /// Zero-based index of this shard within `total`.
+    index: usize,
+    /// Total number of shards the test list is partitioned into.
+    total: usize,
+}
+
+impl Shard {
+    ///
+    /// # Description
+    ///
+    /// Determines whether the test at `position` (zero-based, within the filtered list) is assigned
+    /// to this shard. Round-robin assignment keeps shards balanced as tests are added.
+    ///
+    /// # Parameters
+    ///
+    /// - `position`: Zero-based index of the test within the filtered list.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` when the test belongs to this shard; otherwise returns `false`.
+    ///
+    pub fn selects(&self, position: usize) -> bool {
+        position % self.total == self.index
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the one-based index of this shard, suitable for display.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the one-based shard index.
+    ///
+    pub fn index(&self) -> usize {
+        self.index + 1
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the total number of shards.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the total shard count.
+    ///
+    pub fn total(&self) -> usize {
+        self.total
+    }
+}
+
+///
+/// # Description
+///
 /// CLI arguments resolved for the Nanvix test utility entrypoint.
 pub struct Args {
     /// Path to the Nanvix test configuration file supplied on the command line.
     config_file_path: String,
     /// Optional test filter to select specific tests to run.
     test_filter: Option<String>,
+    /// Optional shard selector that partitions the filtered tests across parallel runners.
+    shard: Option<Shard>,
     /// When true, list selected tests and exit without running them.
     list: bool,
 }
@@ -38,6 +100,7 @@ pub struct Args {
 impl Args {
     const OPT_HELP: &'static str = "-help";
     const OPT_TEST_SELECTOR: &'static str = "-test";
+    const OPT_SHARD: &'static str = "-shard";
     const OPT_LIST: &'static str = "-list";
 
     ///
@@ -65,6 +128,8 @@ Options:
     {help}                   Show this help message and exit.
     {filter} <pattern>         Specify a comma-separated list or a matching pattern of test(s) to \
              run (e.g., '-test http/*' to run all tests in the 'http' executor).
+    {shard} <INDEX/TOTAL>    Run only shard INDEX of TOTAL (1-based), partitioning the selected \
+             tests round-robin across parallel runners (e.g., '-shard 1/4').
     {list}                   List selected tests and exit without running them.
 
 Required positional arguments:
@@ -73,6 +138,7 @@ Required positional arguments:
             program_name = program_name,
             help = Self::OPT_HELP,
             filter = Self::OPT_TEST_SELECTOR,
+            shard = Self::OPT_SHARD,
             list = Self::OPT_LIST,
         );
     }
@@ -94,6 +160,7 @@ Required positional arguments:
     pub fn parse(args: Vec<String>) -> Result<Self> {
         let mut config_file_path: Option<String> = None;
         let mut test_filter_string: Option<String> = None;
+        let mut shard: Option<Shard> = None;
         let mut list: bool = false;
 
         let mut i: usize = 1;
@@ -113,6 +180,26 @@ Required positional arguments:
                     } else {
                         let reason: String = "missing argument for option '-test': expected a \
                                               comma-separated list of test names or a pattern"
+                            .to_string();
+                        Self::usage(args[0].as_str());
+                        eprintln!("parse(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    }
+                },
+                Self::OPT_SHARD => {
+                    if i + 1 < args.len() {
+                        match Self::parse_shard(args[i + 1].as_str()) {
+                            Ok(parsed_shard) => shard = Some(parsed_shard),
+                            Err(reason) => {
+                                Self::usage(args[0].as_str());
+                                eprintln!("parse(): {reason}");
+                                return Err(::anyhow::anyhow!(reason));
+                            },
+                        }
+                        i += 1; // Skip the next argument since it's the shard selector
+                    } else {
+                        let reason: String = "missing argument for option '-shard': expected \
+                                              INDEX/TOTAL (e.g. '1/4')"
                             .to_string();
                         Self::usage(args[0].as_str());
                         eprintln!("parse(): {reason}");
@@ -152,6 +239,7 @@ Required positional arguments:
         Ok(Self {
             config_file_path,
             test_filter,
+            shard,
             list,
         })
     }
@@ -185,6 +273,19 @@ Required positional arguments:
     ///
     /// # Description
     ///
+    /// Retrieves the shard selector specified via the CLI.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the shard selector when `-shard` was provided; otherwise returns `None`.
+    ///
+    pub fn shard(&self) -> Option<Shard> {
+        self.shard
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns whether the `-list` flag was specified on the command line.
     ///
     /// # Return Value
@@ -209,6 +310,51 @@ Required positional arguments:
         self.test_filter
             .as_ref()
             .map(|filter_str: &String| build_globset(filter_str))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Parses a `-shard` selector of the form `INDEX/TOTAL` (1-based index).
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: Raw selector string supplied on the command line.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the parsed `Shard` when the selector is well formed; otherwise returns an error
+    /// message describing the problem.
+    ///
+    fn parse_shard(value: &str) -> Result<Shard, String> {
+        let trimmed: &str = value.trim();
+        let (index_str, total_str) = trimmed.split_once('/').ok_or_else(|| {
+            format!("invalid '-shard' value '{trimmed}': expected INDEX/TOTAL (e.g. '1/4')")
+        })?;
+        let index: usize = index_str.trim().parse().map_err(|_| {
+            format!(
+                "invalid shard index '{}' in '-shard {trimmed}': expected a positive integer",
+                index_str.trim()
+            )
+        })?;
+        let total: usize = total_str.trim().parse().map_err(|_| {
+            format!(
+                "invalid shard total '{}' in '-shard {trimmed}': expected a positive integer",
+                total_str.trim()
+            )
+        })?;
+        if total == 0 {
+            return Err(format!("invalid '-shard {trimmed}': TOTAL must be greater than zero"));
+        }
+        if index == 0 || index > total {
+            return Err(format!(
+                "invalid '-shard {trimmed}': INDEX must be in the range 1..={total}"
+            ));
+        }
+        Ok(Shard {
+            index: index - 1,
+            total,
+        })
     }
 }
 
@@ -352,5 +498,81 @@ mod tests {
         let args = vec!["nanvix-test".to_string(), "test/test.toml".to_string()];
         let parsed = super::Args::parse(args).expect("Failed to parse args without -list");
         assert!(!parsed.list(), "list must default to false");
+    }
+    #[test]
+    fn shard_flag_parses_valid_value() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "2/4".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        let parsed = super::Args::parse(args).expect("Failed to parse -shard flag");
+        let shard = parsed.shard().expect("shard must be set");
+        assert_eq!(shard.index(), 2, "one-based shard index must be 2");
+        assert_eq!(shard.total(), 4, "shard total must be 4");
+        assert_eq!(parsed.config_file_path(), "test/test.toml");
+    }
+    #[test]
+    fn shard_flag_defaults_to_none() {
+        let args = vec!["nanvix-test".to_string(), "test/test.toml".to_string()];
+        let parsed = super::Args::parse(args).expect("Failed to parse args without -shard");
+        assert!(parsed.shard().is_none(), "shard must default to None");
+    }
+    #[test]
+    fn shard_selects_round_robin() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "1/4".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        let parsed = super::Args::parse(args).expect("Failed to parse -shard flag");
+        let shard = parsed.shard().expect("shard must be set");
+        // Shard 1 of 4 (zero-based index 0) selects positions 0, 4, 8, ...
+        assert!(shard.selects(0));
+        assert!(!shard.selects(1));
+        assert!(!shard.selects(3));
+        assert!(shard.selects(4));
+    }
+    #[test]
+    fn shard_flag_rejects_zero_total() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "1/0".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        assert!(super::Args::parse(args).is_err(), "zero TOTAL must be rejected");
+    }
+    #[test]
+    fn shard_flag_rejects_index_out_of_range() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "5/4".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        assert!(super::Args::parse(args).is_err(), "INDEX greater than TOTAL must be rejected");
+    }
+    #[test]
+    fn shard_flag_rejects_zero_index() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "0/4".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        assert!(super::Args::parse(args).is_err(), "zero INDEX must be rejected");
+    }
+    #[test]
+    fn shard_flag_rejects_malformed_value() {
+        let args = vec![
+            "nanvix-test".to_string(),
+            "-shard".to_string(),
+            "abc".to_string(),
+            "test/test.toml".to_string(),
+        ];
+        assert!(super::Args::parse(args).is_err(), "malformed shard value must be rejected");
     }
 }

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -267,10 +267,24 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
     // Select tests before preparing the environment to avoid unnecessary environment setup.
     let test_glob_filter: Option<GlobSet> = parsed_args.glob_filter();
     let total_tests: usize = tests.len();
-    let selected_tests: Vec<TestCaseConfig> = tests
+    let filtered_tests: Vec<TestCaseConfig> = tests
         .into_iter()
         .filter(|test_config| test_config.matches_filter(test_glob_filter.as_ref()))
         .collect();
+    let filtered_count: usize = filtered_tests.len();
+
+    // Partition the filtered tests across shards when a shard selector is provided. Sharding is
+    // positional (round-robin over the filtered, TOML-ordered list), so it is independent of test
+    // names and automatically distributes newly added tests across shards.
+    let selected_tests: Vec<TestCaseConfig> = match parsed_args.shard() {
+        Some(shard) => filtered_tests
+            .into_iter()
+            .enumerate()
+            .filter(|(position, _)| shard.selects(*position))
+            .map(|(_, test_config)| test_config)
+            .collect(),
+        None => filtered_tests,
+    };
     let selected_count: usize = selected_tests.len();
 
     // List mode: print selected tests and exit without executing.
@@ -307,6 +321,22 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
 
     // Fail early when no tests match the requested filter.
     if selected_tests.is_empty() {
+        // An empty shard is not an error: when TOTAL exceeds the number of filtered tests, some
+        // shards legitimately receive no work. Only treat an empty selection as success when the
+        // filtered test list is non-empty (i.e. the filter matched tests but this shard received
+        // none); an empty filtered list is still fatal, matching the non-sharded path.
+        if let (Some(shard), true) = (parsed_args.shard(), filtered_count > 0) {
+            info!(
+                "main(): no tests assigned to shard {}/{} (filter={})",
+                shard.index(),
+                shard.total(),
+                parsed_args
+                    .test_filter()
+                    .map(|f| format!("\"{}\"", f))
+                    .unwrap_or("None".to_string())
+            );
+            return Ok(());
+        }
         let reason: String = format!(
             "no tests selected (filter={})",
             parsed_args
@@ -319,10 +349,14 @@ async fn run(cancellation_token: CancellationToken) -> Result<()> {
     }
 
     info!(
-        "main(): selected {selected_count} of {total_tests} tests to run (filter={})",
+        "main(): selected {selected_count} of {total_tests} tests to run (filter={}, shard={})",
         parsed_args
             .test_filter()
             .map(|f| format!("\"{}\"", f))
+            .unwrap_or("None".to_string()),
+        parsed_args
+            .shard()
+            .map(|s| format!("{}/{}", s.index(), s.total()))
             .unwrap_or("None".to_string())
     );
 


### PR DESCRIPTION
## Summary

Decouples the integration test suites into **disjoint shards** that run on
independent runners, so the test stage scales horizontally and adding new tests
does not lengthen the critical path. The partitioning is **positional
round-robin**, so it is independent of test names and newly added tests are
distributed automatically with no workflow changes.

## What changed

### `nanvix-test` harness
- New `-shard INDEX/TOTAL` option (1-based). Selects a disjoint, round-robin
  slice of the filtered, TOML-ordered test list. Positional selection makes it
  robust to duplicate/auto-derived test names.
- `-list` honors the selector; empty shards (when `TOTAL` > test count) exit
  cleanly instead of erroring.
- Added unit tests for parsing and selection.

### Build
- `run-posix-tests` accepts an optional `SHARD=i/N`, forwarding `-shard` to the
  harness (placed before the config path, which must remain the last argument).

### CI (`.github/workflows/ci.yml`)
- `ci-test` (Linux) and `windows-integration-test` now fan out across a
  `shard: [1, 2, 3, 4]` matrix axis; each runner executes only its slice of the
  deployment integration suite plus the standalone POSIX suites.
- New `ci-test-extras` job runs the non-sharded checks once per configuration:
  in-kernel tests, the boot smoke test, and the shim integration test.
- Windows runs in-kernel tests only on shard 1 (deployment/shard-agnostic),
  avoiding a near-empty extra runner on release and duplicating the WHP probe.
- `integration-test` action refactored to be shard-aware; new
  `integration-test-extras` action holds the in-kernel + smoke steps.
- Updated downstream dependencies (`release-archive`, `windows-release-archive`,
  `notify-release-failure`).

### Changing the shard count
Update the `shard: [...]` matrix list **and** the matching total
(`shard-total` input / `/4` divisors) so they stay in sync.

## Validation (local, Windows / WHP, release build)
- Harness unit tests pass; `rust-lint-check` and `format-check` clean.
- Ran all four shards of both suites against a release build:
  - standalone: 15 + 15 + 15 + 14 = **59** (disjoint, complete) — all exit 0.
  - POSIX: 7 + 7 + 7 + 6 = **27** (disjoint, complete) — all exit 0.
- Verified via `-list` that the union of shards equals the full set with no
  overlap; the Makefile `SHARD` flag ordering was confirmed by dry-run.

## Note
On Linux, standalone shards still rebuild the POSIX images per runner (as today,
just parallelized) since those images are not in the build artifact. A future
optimization could publish `all-posix-test-images` as an artifact like the
Windows job does to eliminate the redundant builds.

Opened as a draft per `CONTRIBUTING.md`.
