### PR TITLE
[syscall] Support sendto() and recvfrom()

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,numer,pendin,abd
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,numer,pendin,abd,tolen

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -46,10 +46,14 @@ use ::syscall::{
             GetSockNameResponse,
             ListenSocketRequest,
             ListenSocketResponse,
+            ReceiveFromSocketRequest,
+            ReceiveFromSocketResponse,
             ReceiveSocketRequest,
             ReceiveSocketResponse,
             SendSocketRequest,
             SendSocketResponse,
+            SendToSocketRequest,
+            SendToSocketResponse,
             ShutdownSocketRequest,
             ShutdownSocketResponse,
         },
@@ -86,7 +90,9 @@ pub fn is_networking_header(header: &SystemCallMessageHeader) -> bool {
             | SystemCallMessageHeader::GetSockNameRequest
             | SystemCallMessageHeader::ListenSocketRequest
             | SystemCallMessageHeader::ReceiveSocketRequest
+            | SystemCallMessageHeader::ReceiveFromSocketRequest
             | SystemCallMessageHeader::SendSocketRequest
+            | SystemCallMessageHeader::SendToSocketRequest
             | SystemCallMessageHeader::ShutdownSocketRequest
     )
 }
@@ -174,6 +180,63 @@ pub fn dispatch_message(
         },
         _ => None,
     }
+}
+
+///
+/// # Description
+///
+/// Dispatches a `sendto()` request whose datagram payload was delivered out-of-band via a
+/// scatter/gather push.
+///
+/// # Parameters
+///
+/// - `backend`: Reference to the networking backend.
+/// - `filter`: Host egress filter applied to the destination address.
+/// - `source`: The message source (identifies the calling thread).
+/// - `syscall_msg`: The parsed `SendToSocketRequest` system call message.
+/// - `data`: The datagram payload pulled from the caller.
+///
+/// # Returns
+///
+/// The response message to send back to the guest.
+///
+pub fn dispatch_sendto(
+    backend: &NetBackend,
+    filter: &HostFilter,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    data: &[u8],
+) -> Message {
+    let tid: ThreadIdentifier = source.tid;
+    let request: SendToSocketRequest = SendToSocketRequest::from_bytes(syscall_msg.payload);
+    do_sendto(backend, filter, tid, request, data)
+}
+
+///
+/// # Description
+///
+/// Dispatches a `recvfrom()` request whose datagram payload is delivered out-of-band via a
+/// scatter/gather pull.
+///
+/// # Parameters
+///
+/// - `backend`: Reference to the networking backend.
+/// - `source`: The message source (identifies the calling thread).
+/// - `syscall_msg`: The parsed `ReceiveFromSocketRequest` system call message.
+///
+/// # Returns
+///
+/// A tuple with the response message and the datagram payload to push back to the guest.
+///
+pub fn dispatch_recvfrom(
+    backend: &NetBackend,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+) -> (Message, Vec<u8>) {
+    let tid: ThreadIdentifier = source.tid;
+    let request: ReceiveFromSocketRequest =
+        ReceiveFromSocketRequest::from_bytes(syscall_msg.payload);
+    do_recvfrom(backend, tid, request)
 }
 
 //==================================================================================================
@@ -366,5 +429,63 @@ fn do_send(backend: &NetBackend, tid: ThreadIdentifier, request: SendSocketReque
         Ok(count) => SendSocketResponse::build(tid, count as i32),
         Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
         Err(NetError::Errno(code)) => build_error(tid, code),
+    }
+}
+
+fn do_sendto(
+    backend: &NetBackend,
+    filter: &HostFilter,
+    tid: ThreadIdentifier,
+    request: SendToSocketRequest,
+    data: &[u8],
+) -> Message {
+    trace!("networkd::sendto(): tid={tid:?}, request={request:?}, data.len={}", data.len());
+    // Enforce host egress policy before sending to an explicit destination. This mirrors the
+    // check performed by `do_connect()`: a `sendto()` to an arbitrary address is equivalent to a
+    // `connect()` followed by a `send()`, so the same unbypassable boundary applies. IPv4
+    // destinations are matched against the filter; any non-IPv4 or unparsable destination is
+    // permitted only under `AllowAll`.
+    let permitted: bool = match SocketAddr::try_from(&request.sockaddr) {
+        Ok(SocketAddr::V4(addr)) => filter.permits_connection(addr.addr().octets(), addr.port()),
+        _ => filter.is_allow_all(),
+    };
+    if !permitted {
+        trace!("networkd::sendto(): destination denied by host egress filter");
+        return build_error(tid, ErrorCode::PermissionDenied);
+    }
+    match backend.sendto(
+        to_host_fd(request.sockfd),
+        data,
+        data.len(),
+        request.flags,
+        &request.sockaddr,
+    ) {
+        Ok(count) => SendToSocketResponse::build(tid, count as i32),
+        Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
+        Err(NetError::Errno(code)) => build_error(tid, code),
+    }
+}
+
+fn do_recvfrom(
+    backend: &NetBackend,
+    tid: ThreadIdentifier,
+    request: ReceiveFromSocketRequest,
+) -> (Message, Vec<u8>) {
+    trace!("networkd::recvfrom(): tid={tid:?}, request={request:?}");
+    let recv_len: usize =
+        core::cmp::min(ReceiveFromSocketResponse::MAX_DATA_SIZE, request.count as usize);
+    let mut buffer: Vec<u8> = vec![0u8; recv_len];
+    match backend.recvfrom(to_host_fd(request.sockfd), &mut buffer, recv_len, request.flags) {
+        Ok((count, addr)) => {
+            // Report the actual address length supplied by the host rather than the fixed
+            // struct size.
+            let addrlen: u32 = u32::from(addr.sa_len);
+            // Trim the buffer to the bytes actually received so the bulk transfer carries only
+            // the datagram payload.
+            buffer.truncate(count as usize);
+            (ReceiveFromSocketResponse::build(tid, count as u32, addrlen, &addr), buffer)
+        },
+        Err(NetError::Interrupted) => (build_error(tid, ErrorCode::Interrupted), Vec::new()),
+        Err(NetError::Errno(code)) => (build_error(tid, code), Vec::new()),
     }
 }

--- a/src/daemons/networkd/src/lib.rs
+++ b/src/daemons/networkd/src/lib.rs
@@ -16,7 +16,10 @@ use ::net_backend::{
     HostFilter,
     NetBackend,
 };
-use ::sys::ipc::Message;
+use ::sys::ipc::{
+    Message,
+    MessageSender,
+};
 use ::syscall::{
     SystemCallMessage,
     SystemCallMessageHeader,
@@ -85,6 +88,54 @@ impl NetworkDaemon {
         };
 
         dispatch::dispatch_message(&self.backend, &self.filter, msg.source, syscall_msg)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Processes a `sendto()` request whose datagram payload was delivered out-of-band via a
+    /// scatter/gather push.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Identifies the calling thread.
+    /// - `syscall_msg`: The parsed `SendToSocketRequest` system call message.
+    /// - `data`: The datagram payload pulled from the caller.
+    ///
+    /// # Returns
+    ///
+    /// The response message to send back to the guest.
+    ///
+    pub fn handle_sendto(
+        &self,
+        source: MessageSender,
+        syscall_msg: SystemCallMessage,
+        data: &[u8],
+    ) -> Message {
+        dispatch::dispatch_sendto(&self.backend, &self.filter, source, syscall_msg, data)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Processes a `recvfrom()` request whose datagram payload is delivered out-of-band via a
+    /// scatter/gather pull.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Identifies the calling thread.
+    /// - `syscall_msg`: The parsed `ReceiveFromSocketRequest` system call message.
+    ///
+    /// # Returns
+    ///
+    /// A tuple with the response message and the datagram payload to push back to the guest.
+    ///
+    pub fn handle_recvfrom(
+        &self,
+        source: MessageSender,
+        syscall_msg: SystemCallMessage,
+    ) -> (Message, Vec<u8>) {
+        dispatch::dispatch_recvfrom(&self.backend, source, syscall_msg)
     }
 
     ///

--- a/src/libs/net-backend/src/io.rs
+++ b/src/libs/net-backend/src/io.rs
@@ -13,17 +13,26 @@ use crate::{
         last_socket_error,
         normalize_errno,
         raw_recv,
+        raw_recvfrom,
         raw_send,
+        raw_sendto,
+        sa_data_to_u8,
+        SocklenT,
         MAX_IO_LEN,
     },
-    types::LibcMessageFlags,
+    types::{
+        LibcMessageFlags,
+        LibcSocketAddress,
+    },
     NetBackend,
 };
+use ::core::mem;
 use ::log::{
     debug,
     error,
 };
 use ::sys::error::ErrorCode;
+use ::sysapi::sys_socket::sockaddr;
 
 //==================================================================================================
 // I/O Operations
@@ -120,6 +129,139 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::recv(): failed with errno={errno:?}");
+            let error: ErrorCode =
+                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            Err(NetError::Errno(error))
+        }
+    }
+
+    /// Sends a datagram on a socket to an explicit destination address.
+    ///
+    /// Returns the number of bytes sent.
+    pub fn sendto(
+        &self,
+        sockfd: i32,
+        buf: &[u8],
+        count: usize,
+        flags: i32,
+        addr: &sockaddr,
+    ) -> Result<isize, NetError> {
+        // Validate that count does not exceed buffer length to prevent out-of-bounds reads.
+        if count > buf.len() {
+            error!("sendto(): count ({count}) exceeds buffer length ({})", buf.len());
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        // On Windows, Winsock sendto() takes a c_int length; reject oversized counts.
+        // On Unix MAX_IO_LEN is usize::MAX so the comparison is trivially false;
+        // allow the lint so the check stays for Windows.
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if count > MAX_IO_LEN {
+            error!("sendto(): count ({count}) exceeds platform maximum ({MAX_IO_LEN})");
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        let flags: LibcMessageFlags =
+            LibcMessageFlags::try_from_nanvix(flags).map_err(|e| NetError::Errno(e.code))?;
+
+        let sockaddr: LibcSocketAddress =
+            LibcSocketAddress::try_from(*addr).map_err(|e| NetError::Errno(e.code))?;
+        let inner: libc::sockaddr = sockaddr.inner();
+        let socklen: SocklenT = mem::size_of_val(&inner) as SocklenT;
+
+        debug!(
+            "libc::sendto(): sockfd={sockfd:?}, count={count:?}, flags={:?}, \
+             sockaddr.sa_family={:?}",
+            flags.inner(),
+            inner.sa_family,
+        );
+
+        let raw = i32_to_raw(sockfd);
+        let result = unsafe {
+            raw_sendto(
+                raw,
+                buf.as_ptr(),
+                count,
+                flags.inner(),
+                &inner as *const libc::sockaddr,
+                socklen,
+            )
+        };
+
+        if result >= 0 {
+            debug!("libc::sendto(): count={result:?}");
+            Ok(result)
+        } else {
+            let errno: i32 = last_socket_error();
+            if is_interrupted(errno) {
+                return Err(NetError::Interrupted);
+            }
+            error!("libc::sendto(): failed with errno={errno:?}");
+            let error: ErrorCode =
+                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            Err(NetError::Errno(error))
+        }
+    }
+
+    /// Receives a datagram on a socket and reports the source address.
+    ///
+    /// Returns the number of bytes received and the source address.
+    pub fn recvfrom(
+        &self,
+        sockfd: i32,
+        buf: &mut [u8],
+        count: usize,
+        flags: i32,
+    ) -> Result<(isize, sockaddr), NetError> {
+        // Validate that count does not exceed buffer length to prevent out-of-bounds writes.
+        if count > buf.len() {
+            error!("recvfrom(): count ({count}) exceeds buffer length ({})", buf.len());
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        // On Windows, Winsock recvfrom() takes a c_int length; reject oversized counts.
+        // On Unix MAX_IO_LEN is usize::MAX so the comparison is trivially false;
+        // allow the lint so the check stays for Windows.
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if count > MAX_IO_LEN {
+            error!("recvfrom(): count ({count}) exceeds platform maximum ({MAX_IO_LEN})");
+            return Err(NetError::Errno(ErrorCode::InvalidArgument));
+        }
+
+        let flags: LibcMessageFlags =
+            LibcMessageFlags::try_from_nanvix(flags).map_err(|e| NetError::Errno(e.code))?;
+
+        debug!("libc::recvfrom(): sockfd={sockfd:?}, len={count:?}, flags={:?}", flags.inner());
+
+        let mut address: libc::sockaddr = unsafe { mem::zeroed() };
+        let mut address_len: SocklenT = mem::size_of::<libc::sockaddr>() as SocklenT;
+
+        let raw = i32_to_raw(sockfd);
+        let result = unsafe {
+            raw_recvfrom(
+                raw,
+                buf.as_mut_ptr(),
+                count,
+                flags.inner(),
+                &mut address as *mut libc::sockaddr,
+                &mut address_len as *mut SocklenT,
+            )
+        };
+
+        if result >= 0 {
+            debug!("libc::recvfrom(): count={result:?}");
+            let addr: sockaddr = sockaddr {
+                sa_len: address_len as u8,
+                sa_family: address.sa_family as u8,
+                sa_data: sa_data_to_u8(address.sa_data),
+            };
+            Ok((result, addr))
+        } else {
+            let errno: i32 = last_socket_error();
+            if is_interrupted(errno) {
+                return Err(NetError::Interrupted);
+            }
+            error!("libc::recvfrom(): failed with errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
             Err(NetError::Errno(error))

--- a/src/libs/net-backend/src/platform/unix.rs
+++ b/src/libs/net-backend/src/platform/unix.rs
@@ -163,6 +163,32 @@ pub(crate) unsafe fn raw_recv(
     libc::recv(fd, buf as *mut libc::c_void, count as _, flags) as isize
 }
 
+/// Raw sendto operation.
+#[inline]
+pub(crate) unsafe fn raw_sendto(
+    fd: RawSocket,
+    buf: *const u8,
+    count: usize,
+    flags: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: SocklenT,
+) -> isize {
+    libc::sendto(fd, buf as *const libc::c_void, count as _, flags, addr, addrlen) as isize
+}
+
+/// Raw recvfrom operation.
+#[inline]
+pub(crate) unsafe fn raw_recvfrom(
+    fd: RawSocket,
+    buf: *mut u8,
+    count: usize,
+    flags: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut SocklenT,
+) -> isize {
+    libc::recvfrom(fd, buf as *mut libc::c_void, count as _, flags, addr, addrlen) as isize
+}
+
 /// Raw shutdown operation.
 #[inline]
 pub(crate) unsafe fn raw_shutdown(fd: RawSocket, how: libc::c_int) -> libc::c_int {

--- a/src/libs/net-backend/src/platform/windows.rs
+++ b/src/libs/net-backend/src/platform/windows.rs
@@ -234,6 +234,46 @@ pub(crate) unsafe fn raw_recv(
     winsock::recv(fd, buf as *mut libc::c_char, count as libc::c_int, flags) as isize
 }
 
+/// Raw sendto operation (calls Winsock `sendto`).
+///
+/// # Safety
+///
+/// `buf` must point to at least `count` readable bytes. `count` must not exceed
+/// `libc::c_int::MAX`; the caller is responsible for validating this. `addr` must point to a
+/// valid socket address of `addrlen` bytes.
+#[inline]
+pub(crate) unsafe fn raw_sendto(
+    fd: RawSocket,
+    buf: *const u8,
+    count: usize,
+    flags: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: SocklenT,
+) -> isize {
+    winsock::sendto(fd, buf as *const libc::c_char, count as libc::c_int, flags, addr, addrlen)
+        as isize
+}
+
+/// Raw recvfrom operation (calls Winsock `recvfrom`).
+///
+/// # Safety
+///
+/// `buf` must point to at least `count` writable bytes. `count` must not exceed
+/// `libc::c_int::MAX`; the caller is responsible for validating this. `addr` and `addrlen` must
+/// point to a valid socket address buffer and its length.
+#[inline]
+pub(crate) unsafe fn raw_recvfrom(
+    fd: RawSocket,
+    buf: *mut u8,
+    count: usize,
+    flags: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut SocklenT,
+) -> isize {
+    winsock::recvfrom(fd, buf as *mut libc::c_char, count as libc::c_int, flags, addr, addrlen)
+        as isize
+}
+
 /// Raw shutdown operation (calls Winsock `shutdown`).
 #[inline]
 pub(crate) unsafe fn raw_shutdown(fd: RawSocket, how: libc::c_int) -> libc::c_int {
@@ -302,6 +342,7 @@ pub(crate) mod winsock {
     use libc::{
         c_char,
         c_int,
+        sockaddr,
         SOCKET,
     };
 
@@ -369,6 +410,22 @@ pub(crate) mod winsock {
         pub fn shutdown(s: SOCKET, how: c_int) -> c_int;
         pub fn send(s: SOCKET, buf: *const c_char, len: c_int, flags: c_int) -> c_int;
         pub fn recv(s: SOCKET, buf: *mut c_char, len: c_int, flags: c_int) -> c_int;
+        pub fn sendto(
+            s: SOCKET,
+            buf: *const c_char,
+            len: c_int,
+            flags: c_int,
+            to: *const sockaddr,
+            tolen: c_int,
+        ) -> c_int;
+        pub fn recvfrom(
+            s: SOCKET,
+            buf: *mut c_char,
+            len: c_int,
+            flags: c_int,
+            from: *mut sockaddr,
+            fromlen: *mut c_int,
+        ) -> c_int;
     }
 }
 

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -329,6 +329,12 @@ pub enum SystemCallMessageHeader {
     // request is transported as a `*Part` stream (see `SelectRequest`). Appended here to preserve
     // the on-the-wire discriminants of existing variants.
     SelectRequestPart,
+    // Datagram socket I/O carrying an explicit peer address (`sendto()`/`recvfrom()`). Appended
+    // here to preserve the on-the-wire discriminants of existing variants.
+    SendToSocketRequest,
+    SendToSocketResponse,
+    ReceiveFromSocketRequest,
+    ReceiveFromSocketResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -500,6 +506,10 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == TtyControlRequest as u16 => Ok(TtyControlRequest),
             x if x == TtyControlResponse as u16 => Ok(TtyControlResponse),
             x if x == SelectRequestPart as u16 => Ok(SelectRequestPart),
+            x if x == SendToSocketRequest as u16 => Ok(SendToSocketRequest),
+            x if x == SendToSocketResponse as u16 => Ok(SendToSocketResponse),
+            x if x == ReceiveFromSocketRequest as u16 => Ok(ReceiveFromSocketRequest),
+            x if x == ReceiveFromSocketResponse as u16 => Ok(ReceiveFromSocketResponse),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
@@ -6,6 +6,13 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
+#[cfg(feature = "standalone")]
+use crate::sys::socket;
+#[cfg(feature = "standalone")]
+use ::core::{
+    mem,
+    slice,
+};
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::{
@@ -70,7 +77,6 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
-#[allow(unreachable_code)]
 pub unsafe extern "C" fn recvfrom(
     sockfd: c_int,
     buf: *mut c_void,
@@ -81,15 +87,113 @@ pub unsafe extern "C" fn recvfrom(
 ) -> c_ssize_t {
     #[cfg(feature = "standalone")]
     {
-        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
-        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
-        return -1;
+        // Check if `buf` is valid.
+        if buf.is_null() {
+            ::syslog::warn!(
+                "recvfrom(): invalid buffer (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                 flags={flags:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Check if `len` is valid.
+        if len == 0 {
+            ::syslog::warn!(
+                "recvfrom(): invalid buffer length (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                 flags={flags:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Check if `flags` is valid.
+        if flags != 0 {
+            ::syslog::warn!(
+                "recvfrom(): unsupported flags (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                 flags={flags:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Attempt to convert `len` to `usize`.
+        let len: usize = match len.try_into() {
+            Ok(len) => len,
+            Err(_error) => {
+                ::syslog::warn!(
+                    "recvfrom(): failed to convert length (sockfd={sockfd:?}, buf={buf:?}, \
+                     len={len:?}, flags={flags:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            },
+        };
+
+        // Attempt to convert buffer.
+        let buf: &mut [u8] = unsafe { slice::from_raw_parts_mut(buf as *mut u8, len) };
+
+        // When no source address is requested, `recvfrom()` behaves like `recv()`.
+        if sockaddr.is_null() {
+            return match socket::syscall::recv(sockfd, buf, flags) {
+                Ok(bytes_received) => match bytes_received.try_into() {
+                    Ok(bytes_received) => bytes_received,
+                    Err(_error) => {
+                        *__errno_location() = ErrorCode::ValueOutOfRange.get();
+                        -1
+                    },
+                },
+                Err(error) => {
+                    ::syslog::warn!(
+                        "recvfrom(): {error:?} (sockfd={sockfd:?}, len={len:?}, flags={flags:?})"
+                    );
+                    *__errno_location() = error.code.get();
+                    -1
+                },
+            };
+        }
+
+        // A source address was requested, so `addrlen` must be valid too.
+        if addrlen.is_null() || *addrlen < mem::size_of::<sockaddr>() as socklen_t {
+            ::syslog::warn!(
+                "recvfrom(): invalid socket address length (sockfd={sockfd:?}, \
+                 sockaddr={sockaddr:?}, addrlen={addrlen:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        match socket::syscall::recvfrom(sockfd, buf, flags) {
+            Ok((bytes_received, source)) => match bytes_received.try_into() {
+                Ok(bytes_received) => {
+                    let (source, source_len): (sockaddr, socklen_t) = source.into();
+                    *sockaddr = source;
+                    *addrlen = source_len;
+                    bytes_received
+                },
+                Err(_error) => {
+                    *__errno_location() = ErrorCode::ValueOutOfRange.get();
+                    -1
+                },
+            },
+            Err(error) => {
+                ::syslog::warn!(
+                    "recvfrom(): {error:?} (sockfd={sockfd:?}, len={len:?}, flags={flags:?})"
+                );
+                *__errno_location() = error.code.get();
+                -1
+            },
+        }
     }
 
     // TODO: https://github.com/nanvix/nanvix/issues/590
-    ::syslog::debug!("recvfrom(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    #[cfg(not(feature = "standalone"))]
+    {
+        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
+        ::syslog::debug!("recvfrom(): not implemented");
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidSysCall.get();
+        }
+        -1
     }
-    -1
 }

--- a/src/libs/syscall/src/sys/socket/bindings/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendto.rs
@@ -6,6 +6,13 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
+#[cfg(feature = "standalone")]
+use crate::sys::{
+    socket,
+    socket::SocketAddr,
+};
+#[cfg(feature = "standalone")]
+use ::core::slice;
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::{
@@ -71,7 +78,6 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
-#[allow(unreachable_code)]
 pub unsafe extern "C" fn sendto(
     sockfd: c_int,
     buf: *const c_void,
@@ -82,15 +88,108 @@ pub unsafe extern "C" fn sendto(
 ) -> c_ssize_t {
     #[cfg(feature = "standalone")]
     {
-        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
-        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
-        return -1;
+        // Check if `buf` is valid.
+        if buf.is_null() {
+            ::syslog::warn!(
+                "sendto(): invalid buffer (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                 flags={flags:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // NOTE: `len` is not validated here. POSIX permits zero-length datagrams, but the
+        // standalone syscall path (`send`/`sendto`) currently rejects empty buffers with EINVAL.
+
+        // Check if `flags` is valid.
+        if flags != 0 {
+            ::syslog::warn!(
+                "sendto(): unsupported flags (sockfd={sockfd:?}, buf={buf:?}, len={len:?}, \
+                 flags={flags:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Attempt to convert `len` to `usize`.
+        let len: usize = match len.try_into() {
+            Ok(len) => len,
+            Err(_error) => {
+                ::syslog::warn!(
+                    "sendto(): failed to convert length (sockfd={sockfd:?}, buf={buf:?}, \
+                     len={len:?}, flags={flags:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            },
+        };
+
+        // Attempt to convert buffer.
+        let buf: &[u8] = unsafe { slice::from_raw_parts(buf as *const u8, len) };
+
+        // When no destination address is supplied, `sendto()` behaves like `send()`.
+        let result: Result<usize, ::sys::error::Error> = if sockaddr.is_null() {
+            socket::syscall::send(sockfd, buf, flags)
+        } else {
+            // Validate that `addrlen` covers a full `sockaddr` before dereferencing the pointer.
+            // A non-NULL pointer with a too-small `addrlen` would otherwise cause an
+            // out-of-bounds read when the address is dereferenced below.
+            if (addrlen as usize) < ::core::mem::size_of::<sockaddr>() {
+                ::syslog::warn!(
+                    "sendto(): invalid socket address length (sockfd={sockfd:?}, \
+                     sockaddr={sockaddr:?}, addrlen={addrlen:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            }
+
+            // Attempt to convert socket address.
+            let sockaddr: SocketAddr = match TryFrom::<&sockaddr>::try_from(&*sockaddr) {
+                Ok(sockaddr) => sockaddr,
+                Err(error) => {
+                    ::syslog::warn!(
+                        "sendto(): {error:?} (sockfd={sockfd:?}, sockaddr={sockaddr:?}, \
+                         addrlen={addrlen:?})"
+                    );
+                    *__errno_location() = error.code.get();
+                    return -1;
+                },
+            };
+
+            socket::syscall::sendto(sockfd, buf, flags, &sockaddr)
+        };
+
+        // Check for errors.
+        match result {
+            Ok(bytes_sent) => match bytes_sent.try_into() {
+                Ok(bytes_sent) => bytes_sent,
+                Err(_error) => {
+                    ::syslog::warn!(
+                        "sendto(): failed to convert bytes sent (sockfd={sockfd:?}, buf={buf:?}, \
+                         len={len:?}, flags={flags:?})"
+                    );
+                    *__errno_location() = ErrorCode::ValueOutOfRange.get();
+                    -1
+                },
+            },
+            Err(error) => {
+                ::syslog::warn!(
+                    "sendto(): {error:?} (sockfd={sockfd:?}, len={len:?}, flags={flags:?})"
+                );
+                *__errno_location() = error.code.get();
+                -1
+            },
+        }
     }
 
     // TODO: https://github.com/nanvix/nanvix/issues/589
-    ::syslog::debug!("sendto(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    #[cfg(not(feature = "standalone"))]
+    {
+        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
+        ::syslog::debug!("sendto(): not implemented");
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidSysCall.get();
+        }
+        -1
     }
-    -1
 }

--- a/src/libs/syscall/src/sys/socket/message/mod.rs
+++ b/src/libs/syscall/src/sys/socket/message/mod.rs
@@ -12,7 +12,9 @@ mod getpeername;
 mod getsockname;
 mod listen;
 mod recv;
+mod recvfrom;
 mod send;
+mod sendto;
 mod shutdown;
 mod socket;
 mod socketpair;
@@ -50,9 +52,17 @@ pub use self::{
         ReceiveSocketRequest,
         ReceiveSocketResponse,
     },
+    recvfrom::{
+        ReceiveFromSocketRequest,
+        ReceiveFromSocketResponse,
+    },
     send::{
         SendSocketRequest,
         SendSocketResponse,
+    },
+    sendto::{
+        SendToSocketRequest,
+        SendToSocketResponse,
     },
     shutdown::{
         ShutdownSocketRequest,

--- a/src/libs/syscall/src/sys/socket/message/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/message/recvfrom.rs
@@ -1,0 +1,162 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    sys::socket::sockaddr,
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::{
+    fmt::Debug,
+    mem,
+};
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::{
+    sys_socket::socklen_t,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// ReceiveFromSocketRequest
+//==================================================================================================
+
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct ReceiveFromSocketRequest {
+    pub sockfd: i32,
+    pub count: u32,
+    pub flags: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(ReceiveFromSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl ReceiveFromSocketRequest {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<i32>()
+        - mem::size_of::<u32>()
+        - mem::size_of::<i32>();
+
+    pub fn new(sockfd: i32, count: u32, flags: i32) -> Self {
+        Self {
+            sockfd,
+            count,
+            flags,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, count: u32, flags: i32) -> Message {
+        let message: ReceiveFromSocketRequest = ReceiveFromSocketRequest::new(sockfd, count, flags);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ReceiveFromSocketRequest,
+            message.into_bytes(),
+        );
+        let message: Message = Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+        message
+    }
+}
+
+//==================================================================================================
+// ReceiveFromSocketResponse
+//==================================================================================================
+
+#[repr(C, packed)]
+pub struct ReceiveFromSocketResponse {
+    pub count: c_size_t,
+    pub addrlen: socklen_t,
+    pub sockaddr: sockaddr,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(ReceiveFromSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl ReceiveFromSocketResponse {
+    /// Maximum number of payload bytes a single `recvfrom()` datagram may carry. The data travels
+    /// out-of-band via a scatter/gather pull, so it is bounded by a single page rather than by the
+    /// IPC message payload.
+    pub const MAX_DATA_SIZE: usize = ::arch::mem::PAGE_SIZE;
+
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<c_size_t>()
+        - mem::size_of::<socklen_t>()
+        - mem::size_of::<sockaddr>();
+
+    pub fn new(count: c_size_t, addrlen: socklen_t, sockaddr: &sockaddr) -> Self {
+        Self {
+            count,
+            addrlen,
+            sockaddr: *sockaddr,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        count: c_size_t,
+        addrlen: socklen_t,
+        sockaddr: &sockaddr,
+    ) -> Message {
+        let message: ReceiveFromSocketResponse =
+            ReceiveFromSocketResponse::new(count, addrlen, sockaddr);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ReceiveFromSocketResponse,
+            message.into_bytes(),
+        );
+        let message: Message = Message::new(
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+        message
+    }
+}
+
+impl Debug for ReceiveFromSocketResponse {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(
+            f,
+            "ReceiveFromSocketResponse {{ count: {}, addrlen: {}, sockaddr: {:?} }}",
+            { self.count },
+            { self.addrlen },
+            self.sockaddr
+        )
+    }
+}

--- a/src/libs/syscall/src/sys/socket/message/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/message/sendto.rs
@@ -1,0 +1,161 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    sys::socket::sockaddr,
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::{
+    fmt::Debug,
+    mem,
+};
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::sys_types::{
+    c_size_t,
+    c_ssize_t,
+};
+
+//==================================================================================================
+// SendToSocketRequest
+//==================================================================================================
+
+#[repr(C, packed)]
+pub struct SendToSocketRequest {
+    pub sockfd: i32,
+    pub count: u32,
+    pub flags: i32,
+    pub sockaddr: sockaddr,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(SendToSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl SendToSocketRequest {
+    /// Maximum number of payload bytes a single `sendto()` datagram may carry. The data travels
+    /// out-of-band via a scatter/gather push, so it is bounded by a single page rather than by the
+    /// IPC message payload.
+    pub const MAX_DATA_SIZE: usize = ::arch::mem::PAGE_SIZE;
+
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<i32>()
+        - mem::size_of::<u32>()
+        - mem::size_of::<i32>()
+        - mem::size_of::<sockaddr>();
+
+    pub fn new(sockfd: i32, count: c_size_t, flags: i32, sockaddr: &sockaddr) -> Self {
+        Self {
+            sockfd,
+            count,
+            flags,
+            sockaddr: *sockaddr,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        sockfd: i32,
+        count: c_size_t,
+        flags: i32,
+        sockaddr: &sockaddr,
+    ) -> Message {
+        let message: SendToSocketRequest = SendToSocketRequest::new(sockfd, count, flags, sockaddr);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::SendToSocketRequest,
+            message.into_bytes(),
+        );
+        let message: Message = Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+
+        message
+    }
+}
+
+impl Debug for SendToSocketRequest {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(
+            f,
+            "SendToSocketRequest {{ sockfd: {}, count: {}, flags: {}, sockaddr: {:?} }}",
+            { self.sockfd },
+            { self.count },
+            { self.flags },
+            self.sockaddr
+        )
+    }
+}
+
+//==================================================================================================
+// SendToSocketResponse
+//==================================================================================================
+
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct SendToSocketResponse {
+    pub count: i32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(SendToSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl SendToSocketResponse {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
+
+    pub fn new(count: c_ssize_t) -> Self {
+        Self {
+            count,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    pub fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
+        let message: SendToSocketResponse = SendToSocketResponse::new(count);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::SendToSocketResponse,
+            message.into_bytes(),
+        );
+        let message: Message = Message::new(
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+
+        message
+    }
+}

--- a/src/libs/syscall/src/sys/socket/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/mod.rs
@@ -12,7 +12,9 @@ mod getpeername;
 mod getsockname;
 mod listen;
 mod recv;
+mod recvfrom;
 mod send;
+mod sendto;
 mod shutdown;
 mod socket;
 mod socketpair;
@@ -29,7 +31,9 @@ pub use self::{
     getsockname::getsockname,
     listen::listen,
     recv::recv,
+    recvfrom::recvfrom,
     send::send,
+    sendto::sendto,
     shutdown::shutdown,
     socket::socket,
     socketpair::socketpair,

--- a/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
@@ -1,0 +1,129 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    sys::socket::{
+        message::{
+            ReceiveFromSocketRequest,
+            ReceiveFromSocketResponse,
+        },
+        SocketAddr,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::cmp;
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::Message,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Receives a datagram on a socket and reports the source address.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `buffer`: Buffer that stores the received message.
+/// - `flags`: Type of message reception.
+///
+/// # Returns
+///
+/// On success, a tuple with the number of bytes received and the source address is returned. On
+/// error, an error is returned.
+///
+pub fn recvfrom(
+    sockfd: c_int,
+    buffer: &mut [u8],
+    flags: c_int,
+) -> Result<(usize, SocketAddr), Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd: c_int = crate::fdtable::resolve_socket(sockfd, "recvfrom")?;
+
+    // Check if count is invalid.
+    if buffer.is_empty() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));
+    }
+
+    // A datagram cannot be reassembled across transfers, so cap the request at a single
+    // page-bounded pull.
+    let recv_len: usize = cmp::min(ReceiveFromSocketResponse::MAX_DATA_SIZE, buffer.len());
+
+    // Build metadata-only request and send it via IPC message.
+    let request: Message = ReceiveFromSocketRequest::build(tid, sockfd, recv_len as u32, flags);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    // Pull the datagram payload via data chunk transfer.
+    let bytes_pulled: usize = ::sys::kcall::ipc::__kcall_pull(
+        ProcessIdentifier::KERNEL,
+        ThreadIdentifier::KERNEL,
+        &mut buffer[..recv_len],
+    )?;
+
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+
+    // Check whether system call succeeded or not.
+    if response.status != 0 {
+        // System call failed, parse error code and return it.
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        Err(Error::new(error_code, "failed to receive data on socket"))
+    } else {
+        // System call succeeded, parse response.
+        match SystemCallMessage::try_from_bytes(response.payload) {
+            Ok(message) => match message.header {
+                SystemCallMessageHeader::ReceiveFromSocketResponse => {
+                    let response: ReceiveFromSocketResponse =
+                        ReceiveFromSocketResponse::from_bytes(message.payload);
+
+                    let count: usize = response.count as usize;
+
+                    // Validate the reported count against the requested length to avoid
+                    // out-of-bounds slicing on a malformed or buggy response.
+                    if count > recv_len {
+                        return Err(Error::new(
+                            ErrorCode::InvalidMessage,
+                            "response count exceeds requested length",
+                        ));
+                    }
+
+                    // The bulk data was already delivered into the user buffer by the pull above,
+                    // so the metadata count must match the bytes actually pulled.
+                    if count != bytes_pulled {
+                        return Err(Error::new(
+                            ErrorCode::InvalidMessage,
+                            "response count does not match bytes pulled",
+                        ));
+                    }
+
+                    // Convert source address.
+                    let sockaddr: SocketAddr = SocketAddr::try_from(&response.sockaddr)?;
+
+                    Ok((count, sockaddr))
+                },
+                _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
+            },
+            Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
+        }
+    }
+}

--- a/src/libs/syscall/src/sys/socket/syscall/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/sendto.rs
@@ -1,0 +1,113 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    sys::socket::{
+        message::{
+            SendToSocketRequest,
+            SendToSocketResponse,
+        },
+        sockaddr,
+        socklen_t,
+        SocketAddr,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::Message,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sends a datagram on a socket to an explicit destination address.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `buffer`: Buffer that holds the message to send.
+/// - `flags`: Type of message transmission.
+/// - `sockaddr`: Destination address of the message.
+///
+/// # Returns
+///
+/// On success, the number of bytes sent is returned. On error, an error is returned.
+///
+pub fn sendto(
+    sockfd: c_int,
+    buffer: &[u8],
+    flags: c_int,
+    sockaddr: &SocketAddr,
+) -> Result<usize, Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+
+    let (sockaddr, _socklen): (sockaddr, socklen_t) = From::<&SocketAddr>::from(sockaddr);
+
+    // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
+    let sockfd: c_int = crate::fdtable::resolve_socket(sockfd, "sendto")?;
+
+    // Check if count is invalid.
+    if buffer.is_empty() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));
+    }
+
+    // A datagram cannot be split across transfers, so it must fit in a single page-bounded push.
+    if buffer.len() > SendToSocketRequest::MAX_DATA_SIZE {
+        return Err(Error::new(
+            ErrorCode::MessageTooLong,
+            "datagram is too large for a single message",
+        ));
+    }
+
+    // Build metadata-only request and send it via IPC message.
+    let request: Message =
+        SendToSocketRequest::build(tid, sockfd, buffer.len() as c_size_t, flags, &sockaddr);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    // Push the datagram payload via data chunk transfer.
+    ::sys::kcall::ipc::__kcall_push(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buffer)?;
+
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+
+    // Check whether system call succeeded or not.
+    if response.status != 0 {
+        // System call failed, parse error code and return it.
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        Err(Error::new(error_code, "failed to send data through socket"))
+    } else {
+        // System call succeeded, parse response.
+        match SystemCallMessage::try_from_bytes(response.payload) {
+            Ok(message) => match message.header {
+                SystemCallMessageHeader::SendToSocketResponse => {
+                    let response: SendToSocketResponse =
+                        SendToSocketResponse::from_bytes(message.payload);
+                    Ok(response.count as usize)
+                },
+                _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
+            },
+            Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
+        }
+    }
+}

--- a/src/tests/integration/test-c-network/inet.c
+++ b/src/tests/integration/test-c-network/inet.c
@@ -13,7 +13,101 @@
 #include <netinet/in.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Creates a datagram socket bound to an ephemeral port on the supplied address and reports the
+// address that the system assigned to it.
+static int new_bound_dgram_socket(struct in_addr addr, struct sockaddr_in *assigned)
+{
+    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    assert(sockfd >= 0);
+
+    struct sockaddr_in bindaddr = {
+        .sin_len = sizeof(bindaddr),
+        .sin_family = AF_INET,
+        .sin_port = htons(0),
+        .sin_addr = addr,
+    };
+    int ret = bind(sockfd, (const struct sockaddr *)&bindaddr, sizeof(bindaddr));
+    assert(ret == 0);
+
+    // Learn the address/port that the system assigned to the socket.
+    socklen_t assigned_len = sizeof(*assigned);
+    ret = getsockname(sockfd, (struct sockaddr *)assigned, &assigned_len);
+    assert(ret == 0);
+    assert(assigned_len == sizeof(*assigned));
+    assert(assigned->sin_family == AF_INET);
+
+    return sockfd;
+}
+
+// Tests datagram `sendto()`/`recvfrom()` with an explicit destination address. A datagram is sent
+// to the socket's own address and received back, validating both the payload and the reported
+// source address.
+static void test_inet_dgram_sendto_recvfrom(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Send a datagram to our own address.
+    const char message[] = "hello";
+    const size_t message_len = sizeof(message) - 1;
+    ssize_t sent =
+        sendto(sockfd, message, message_len, 0, (const struct sockaddr *)&self, sizeof(self));
+    assert(sent == (ssize_t)message_len);
+
+    // Receive the datagram and capture the source address.
+    char buffer[16];
+    memset(buffer, 0, sizeof(buffer));
+    struct sockaddr_in source;
+    memset(&source, 0, sizeof(source));
+    socklen_t source_len = sizeof(source);
+    ssize_t received =
+        recvfrom(sockfd, buffer, sizeof(buffer), 0, (struct sockaddr *)&source, &source_len);
+    assert(received == (ssize_t)message_len);
+    assert(memcmp(buffer, message, message_len) == 0);
+
+    // The reported source must match the socket's own address (loopback self-send).
+    assert(source.sin_family == AF_INET);
+    assert(source.sin_addr.s_addr == self.sin_addr.s_addr);
+    assert(source.sin_port == self.sin_port);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+}
+
+// Tests datagram `sendto()`/`recvfrom()` with a NULL address on a connected socket. When no address
+// is supplied, the calls must behave like `send()`/`recv()`.
+static void test_inet_dgram_null_address(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Connect the datagram socket to its own address so a NULL destination is valid.
+    int ret = connect(sockfd, (const struct sockaddr *)&self, sizeof(self));
+    assert(ret == 0);
+
+    // With a NULL address, `sendto()` behaves like `send()`.
+    const char message[] = "world";
+    const size_t message_len = sizeof(message) - 1;
+    ssize_t sent = sendto(sockfd, message, message_len, 0, NULL, 0);
+    assert(sent == (ssize_t)message_len);
+
+    // With a NULL address, `recvfrom()` behaves like `recv()`.
+    char buffer[16];
+    memset(buffer, 0, sizeof(buffer));
+    ssize_t received = recvfrom(sockfd, buffer, sizeof(buffer), 0, NULL, NULL);
+    assert(received == (ssize_t)message_len);
+    assert(memcmp(buffer, message, message_len) == 0);
+
+    ret = close(sockfd);
+    assert(ret == 0);
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -39,4 +133,8 @@ void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr)
     test_listen_socket(
         domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
     test_get_sockname(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    // Exercise datagram sendto()/recvfrom() over loopback.
+    test_inet_dgram_sendto_recvfrom(sin_addr);
+    test_inet_dgram_null_address(sin_addr);
 }

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -622,6 +622,28 @@ async fn standalone_io_handler(
                         )
                         .await;
                     },
+                    SystemCallMessageHeader::SendToSocketRequest => {
+                        handle_sendto_request(
+                            &mut vm_stdout_rx,
+                            &vm_stdin_tx,
+                            &network_daemon,
+                            msg.source,
+                            syscall_msg,
+                            &counters,
+                        )
+                        .await;
+                    },
+                    SystemCallMessageHeader::ReceiveFromSocketRequest => {
+                        handle_recvfrom_request(
+                            &mut vm_stdout_rx,
+                            &vm_stdin_tx,
+                            &network_daemon,
+                            msg.source,
+                            syscall_msg,
+                            &counters,
+                        )
+                        .await;
+                    },
                     header if header.is_hostfs() => {
                         // For multi-part long requests, vfsd allocates a single pending
                         // entry keyed on the logical op_id but emits N SystemCallMessagePart
@@ -1211,5 +1233,256 @@ async fn handle_read_request(
     );
     if vm_stdin_tx.send(IkcFrame::Message(response)).await.is_err() {
         error!("standalone io_handler: failed to send ReadResponse (VM input channel closed)");
+    }
+}
+
+///
+/// # Description
+///
+/// Handles a guest `SendToSocketRequest` by consuming the subsequent push data frame and
+/// forwarding the datagram to networkd on a blocking task, which sends the response back to the
+/// guest.
+///
+/// The push data frame must always be drained — even when networking is disabled — otherwise the
+/// IKC frame stream desynchronizes and subsequent requests are misinterpreted.
+///
+async fn handle_sendto_request(
+    vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    network_daemon: &Option<Arc<NetworkDaemon>>,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    counters: &MessageCounters,
+) {
+    let tid: ThreadIdentifier = extract_tid(source);
+    trace!("standalone io_handler: handling SendToSocketRequest (tid={tid:?})");
+
+    // Wait for the push data frame that the guest's `ipc::push()` emits after the request.
+    let data: Vec<u8> = match vm_stdout_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => bulk.into_data(),
+        other => {
+            error!(
+                "standalone io_handler: expected bulk frame after SendToSocketRequest, got {:?}",
+                other.as_ref().map(|f| f.frame_type_byte())
+            );
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    let network_daemon: Arc<NetworkDaemon> = match network_daemon {
+        Some(nd) => nd.clone(),
+        None => {
+            warn!("standalone io_handler: networking not allowed, rejecting sendto (tid={tid:?})");
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    // Run the (potentially blocking) backend call on its own thread so it does not stall the I/O
+    // handler loop, mirroring `spawn_networking_task`.
+    let vm_stdin_tx: mpsc::Sender<IkcFrame> = vm_stdin_tx.clone();
+    let counters: MessageCounters = counters.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        let response: Message = network_daemon.handle_sendto(source, syscall_msg, &data);
+        counters.increment_io_thread_messages_received();
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Message(response))
+            .is_err()
+        {
+            error!(
+                "standalone io_handler: failed to send sendto response (VM input channel closed)"
+            );
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            error!("standalone io_handler: sendto task panicked: {e}");
+        }
+    });
+}
+
+///
+/// # Description
+///
+/// Handles a guest `ReceiveFromSocketRequest` by consuming the pull-header bulk frame and
+/// forwarding the request to networkd on a blocking task, which pushes the received datagram back
+/// to the guest followed by the response message.
+///
+async fn handle_recvfrom_request(
+    vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    network_daemon: &Option<Arc<NetworkDaemon>>,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    counters: &MessageCounters,
+) {
+    let tid: ThreadIdentifier = extract_tid(source);
+    trace!("standalone io_handler: handling ReceiveFromSocketRequest (tid={tid:?})");
+
+    // Wait for the pull-header bulk frame that the guest's `ipc::pull()` emits after the request.
+    // It carries the bulk location the received datagram must be written to.
+    let pull_header: DataChunkHeader = match vm_stdout_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
+        other => {
+            error!(
+                "standalone io_handler: expected bulk frame after ReceiveFromSocketRequest, got \
+                 {:?}",
+                other.as_ref().map(|f| f.frame_type_byte())
+            );
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    let network_daemon: Arc<NetworkDaemon> = match network_daemon {
+        Some(nd) => nd.clone(),
+        None => {
+            warn!(
+                "standalone io_handler: networking not allowed, rejecting recvfrom (tid={tid:?})"
+            );
+            // Release the guest blocked in `ipc::pull()` with an empty transfer before reporting
+            // the error so it does not deadlock.
+            send_empty_pull_response(vm_stdin_tx, &pull_header, counters).await;
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    // Run the blocking `recvfrom()` on its own thread so a waiting socket does not stall the I/O
+    // handler loop.
+    let vm_stdin_tx: mpsc::Sender<IkcFrame> = vm_stdin_tx.clone();
+    let counters: MessageCounters = counters.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        let (response, data): (Message, Vec<u8>) =
+            network_daemon.handle_recvfrom(source, syscall_msg);
+
+        // The datagram payload is bounded by a single page, so its length normally fits in u32.
+        // Guard the conversion anyway, releasing the guest's pull with an empty transfer and an
+        // error on the unexpected overflow so it does not deadlock.
+        let actual_len: u32 = match u32::try_from(data.len()) {
+            Ok(n) => n,
+            Err(_) => {
+                error!("standalone io_handler: recvfrom size overflows u32 (len={})", data.len());
+                let empty_header: DataChunkHeader = DataChunkHeader::new(
+                    pull_header.source_pid(),
+                    pull_header.source_tid(),
+                    pull_header.destination_pid(),
+                    pull_header.destination_tid(),
+                    pull_header.data_addr(),
+                    0,
+                );
+                counters.increment_io_thread_messages_received();
+                counters.increment_io_thread_messages_received();
+                let _ = vm_stdin_tx
+                    .blocking_send(IkcFrame::Bulk(DataChunk::new(empty_header, Vec::new())));
+                let err: Message = Message::new(
+                    MessageSender::NETWORKD,
+                    MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+                    MessageType::Ikc,
+                    Some(ErrorCode::InvalidMessage),
+                    [0u8; Message::PAYLOAD_SIZE],
+                );
+                let _ = vm_stdin_tx.blocking_send(IkcFrame::Message(err));
+                return;
+            },
+        };
+        let response_header: DataChunkHeader = DataChunkHeader::new(
+            pull_header.source_pid(),
+            pull_header.source_tid(),
+            pull_header.destination_pid(),
+            pull_header.destination_tid(),
+            pull_header.data_addr(),
+            actual_len,
+        );
+        let response_bulk: DataChunk = DataChunk::new(response_header, data);
+
+        // Increment once for the bulk frame and once for the message response that follow.
+        counters.increment_io_thread_messages_received();
+        counters.increment_io_thread_messages_received();
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Bulk(response_bulk))
+            .is_err()
+        {
+            error!(
+                "standalone io_handler: failed to send recvfrom bulk response (VM input channel \
+                 closed)"
+            );
+            return;
+        }
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Message(response))
+            .is_err()
+        {
+            error!(
+                "standalone io_handler: failed to send recvfrom response (VM input channel closed)"
+            );
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            error!("standalone io_handler: recvfrom task panicked: {e}");
+        }
+    });
+}
+
+///
+/// # Description
+///
+/// Sends a networking error response addressed to `tid`, releasing a guest blocked in
+/// `ipc::recv()` after a sendto/recvfrom request when the operation cannot proceed.
+///
+async fn send_networking_error(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    tid: ThreadIdentifier,
+    counters: &MessageCounters,
+) {
+    let error_response: Message = Message::new(
+        MessageSender::NETWORKD,
+        MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+        MessageType::Ikc,
+        Some(ErrorCode::OperationNotSupported),
+        [0u8; Message::PAYLOAD_SIZE],
+    );
+    counters.increment_io_thread_messages_received();
+    if vm_stdin_tx
+        .send(IkcFrame::Message(error_response))
+        .await
+        .is_err()
+    {
+        error!(
+            "standalone io_handler: failed to send networking error response (VM input channel \
+             closed)"
+        );
+    }
+}
+
+///
+/// # Description
+///
+/// Pushes an empty bulk transfer back to the guest to release a thread blocked in `ipc::pull()`
+/// when a `recvfrom()` cannot be served.
+///
+async fn send_empty_pull_response(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    pull_header: &DataChunkHeader,
+    counters: &MessageCounters,
+) {
+    let header: DataChunkHeader = DataChunkHeader::new(
+        pull_header.source_pid(),
+        pull_header.source_tid(),
+        pull_header.destination_pid(),
+        pull_header.destination_tid(),
+        pull_header.data_addr(),
+        0,
+    );
+    let bulk: DataChunk = DataChunk::new(header, Vec::new());
+    counters.increment_io_thread_messages_received();
+    if vm_stdin_tx.send(IkcFrame::Bulk(bulk)).await.is_err() {
+        error!(
+            "standalone io_handler: failed to send empty pull response (VM input channel closed)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements POSIX `sendto()` (#589) and `recvfrom()` (#590) for the **standalone** deployment mode, plus C integration tests.

The new datagram path is wired end-to-end through the existing socket layering:

`C app → libc binding → syscall IPC client → networkd dispatch → net-backend → host libc`

### Behavior
- **NULL peer address** → delegates to the existing `send()`/`recv()` paths (POSIX-equivalent), reusing the chunked stream transport.
- **Explicit address** → new single-message datagram path (atomic, capped at the IPC payload `BUFFER_SIZE`).
- `networkd` enforces the host egress filter on `sendto()`, mirroring `connect()` (a `sendto(addr)` is equivalent to `connect()` + `send()`).

### Changes
- **message**: new `SendToSocket{Request,Response}` and `ReceiveFromSocket{Request,Response}` IPC types.
- **lib.rs**: 4 new `SystemCallMessageHeader` variants appended at the end (wire-stable discriminants) + `TryFrom<u16>` arms.
- **syscall clients** and **C ABI bindings** (`sendto.rs` / `recvfrom.rs`).
- **net-backend**: `sendto`/`recvfrom` (`io.rs`) and `raw_sendto`/`raw_recvfrom` for unix + windows (winsock externs).
- **networkd**: `do_sendto` (egress filter) / `do_recvfrom` + dispatch routing.
- **tests**: UDP loopback cases in `test-c-network` (explicit address and NULL/connected delegation).
- `.codespellrc`: ignore `tolen` (winsock parameter name).

### Scope / follow-up
Only **standalone** is implemented. The non-standalone (linuxd) path remains a stub returning `InvalidSysCall`; issues #589 and #590 stay open to track that work.

## Validation
- `./z build -- all` and `all-posix-tests` succeed.
- `lint-check`, `format-check`, and `spellcheck` pass across `standalone`, `single-process`, and `multi-process` (pre-commit hook green).
- Full POSIX C suite (27 suites incl. `test-c-network`) passes — no regressions.
- A negative-control run (corrupted assertion → non-zero exit) confirms the new test actually exercises and validates the implementation.

## Issues
Closes #589 
Closes #590
