### PR TITLE
[libc_wchar] Implement wcspbrk

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -42,4 +42,5 @@ ALL_POSIX_TESTS := \
 	test-c-setjmp \
 	test-c-stdio \
 	test-c-termios \
-	test-c-thread
+	test-c-thread \
+	test-c-wchar

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -93,6 +93,7 @@ extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);
 
 extern wchar_t *wcschr(const wchar_t *s, wchar_t c);
 extern wchar_t *wcsrchr(const wchar_t *s, wchar_t c);
+extern wchar_t *wcspbrk(const wchar_t *ws1, const wchar_t *ws2);
 extern wchar_t *wcsstr(const wchar_t *haystack, const wchar_t *needle);
 extern wchar_t *wcstok(wchar_t *ws, const wchar_t *delim, wchar_t **ptr);
 

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -77,7 +77,7 @@ functions = ["wcscmp", "wcsncmp", "wcscoll", "wcsxfrm"]
 
 [[sections]]
 title = "Search"
-functions = ["wcschr", "wcsrchr", "wcsstr", "wcstok"]
+functions = ["wcschr", "wcsrchr", "wcspbrk", "wcsstr", "wcstok"]
 
 [[sections]]
 title = "Numeric Conversions"

--- a/src/libs/libc_wchar/src/lib.rs
+++ b/src/libs/libc_wchar/src/lib.rs
@@ -44,6 +44,7 @@ pub mod wcsftime;
 pub mod wcslen;
 pub mod wcsncmp;
 pub mod wcsncpy;
+pub mod wcspbrk;
 pub mod wcsrchr;
 pub mod wcsstr;
 pub mod wcstod;

--- a/src/libs/libc_wchar/src/wcspbrk.rs
+++ b/src/libs/libc_wchar/src/wcspbrk.rs
@@ -1,0 +1,118 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::wchar_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Locates the first occurrence in the wide string `ws1` of any wide character from the wide string
+/// `ws2`.
+///
+/// # Parameters
+///
+/// - `ws1`: Pointer to the null-terminated wide string to search.
+/// - `ws2`: Pointer to a null-terminated wide string containing the set of wide characters to
+///   match.
+///
+/// # Return Value
+///
+/// Returns a pointer to the first wide character in `ws1` that matches any wide character in
+/// `ws2`, or a null pointer if no such wide character is found.
+///
+/// # Safety
+///
+/// Behavior is undefined if `ws1` or `ws2` is null or does not point to a valid null-terminated
+/// wide string.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcspbrk(ws1: *const wchar_t, ws2: *const wchar_t) -> *mut wchar_t {
+    debug_assert!(!ws1.is_null(), "wcspbrk(): null ws1 pointer");
+    debug_assert!(!ws2.is_null(), "wcspbrk(): null ws2 pointer");
+
+    let mut s: *const wchar_t = ws1;
+    while unsafe { *s } != 0 {
+        let ch: wchar_t = unsafe { *s };
+        let mut a: *const wchar_t = ws2;
+        while unsafe { *a } != 0 {
+            if ch == unsafe { *a } {
+                return s.cast_mut();
+            }
+            a = unsafe { a.add(1) };
+        }
+        s = unsafe { s.add(1) };
+    }
+
+    ::core::ptr::null_mut()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcspbrk_found() {
+        // ws1 = "hello world", ws2 = "ow" -> first match is 'o' at index 4.
+        let ws1: [wchar_t; 12] = [
+            0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F, 0x72, 0x6C, 0x64, 0,
+        ];
+        let ws2: [wchar_t; 3] = [0x6F, 0x77, 0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert_eq!(result.cast_const(), unsafe { ws1.as_ptr().add(4) });
+    }
+
+    #[test]
+    fn test_wcspbrk_not_found() {
+        let ws1: [wchar_t; 6] = [0x68, 0x65, 0x6C, 0x6C, 0x6F, 0];
+        let ws2: [wchar_t; 4] = [0x78, 0x79, 0x7A, 0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcspbrk_empty_set() {
+        // An empty match set never matches.
+        let ws1: [wchar_t; 6] = [0x68, 0x65, 0x6C, 0x6C, 0x6F, 0];
+        let ws2: [wchar_t; 1] = [0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcspbrk_first_char_matches() {
+        let ws1: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let ws2: [wchar_t; 2] = [0x61, 0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert_eq!(result.cast_const(), ws1.as_ptr());
+    }
+
+    #[test]
+    fn test_wcspbrk_empty_haystack() {
+        // An empty haystack never matches, regardless of the set.
+        let ws1: [wchar_t; 1] = [0];
+        let ws2: [wchar_t; 2] = [0x61, 0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_wcspbrk_duplicate_set() {
+        // Duplicate characters in the set do not change the leftmost-match result.
+        let ws1: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let ws2: [wchar_t; 4] = [0x7A, 0x7A, 0x62, 0];
+        let result: *mut wchar_t = unsafe { wcspbrk(ws1.as_ptr(), ws2.as_ptr()) };
+        assert_eq!(result.cast_const(), unsafe { ws1.as_ptr().add(1) });
+    }
+}

--- a/src/tests/integration/test-c-wchar/main.c
+++ b/src/tests/integration/test-c-wchar/main.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+#include <wchar.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Tests wcspbrk(), the wide-character "search for any of a set" function.
+static void test_wcspbrk(void)
+{
+    // A match exists: the first wide character of "hello world" that is in "ow" is the 'o' at
+    // index 4.
+    {
+        const wchar_t *ws1 = L"hello world";
+        const wchar_t *result = wcspbrk(ws1, L"ow");
+        assert(result == ws1 + 4);
+        assert(*result == L'o');
+    }
+
+    // No wide character of the haystack is in the match set.
+    assert(wcspbrk(L"hello", L"xyz") == NULL);
+
+    // An empty match set never matches.
+    assert(wcspbrk(L"hello", L"") == NULL);
+
+    // The very first wide character matches.
+    {
+        const wchar_t *ws1 = L"abc";
+        assert(wcspbrk(ws1, L"a") == ws1);
+    }
+
+    // A later wide character matches; ensure the leftmost is returned.
+    {
+        const wchar_t *ws1 = L"abcdef";
+        const wchar_t *result = wcspbrk(ws1, L"fc");
+        assert(result == ws1 + 2);
+        assert(*result == L'c');
+    }
+
+    // An empty haystack never matches.
+    assert(wcspbrk(L"", L"a") == NULL);
+    assert(wcspbrk(L"", L"") == NULL);
+
+    // Duplicate wide characters in the match set do not change the leftmost match.
+    {
+        const wchar_t *ws1 = L"abc";
+        const wchar_t *result = wcspbrk(ws1, L"zzb");
+        assert(result == ws1 + 1);
+        assert(*result == L'b');
+    }
+}
+
+// Sanity-checks the rest of the const-correct wide-search surface alongside wcspbrk so the whole
+// group is covered together.
+static void test_wide_search_siblings(void)
+{
+    const wchar_t *ws = L"hello world";
+
+    assert(wcslen(ws) == 11);
+    assert(wcschr(ws, L'o') == ws + 4);
+    assert(wcsrchr(ws, L'o') == ws + 7);
+    assert(wcschr(ws, L'z') == NULL);
+    assert(wcsstr(ws, L"world") == ws + 6);
+    assert(wcsstr(ws, L"absent") == NULL);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests wide-character search functions in the Nanvix C library.
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv List of command-line arguments.
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert command-line arguments.
+    assert(argc == 1);
+    assert(argv[0] != NULL);
+    assert(argv[1] == NULL);
+    assert(strcmp(argv[0], "test-c-wchar.elf") == 0);
+
+    test_wcspbrk();
+    test_wide_search_siblings();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -265,3 +265,10 @@ executor = "terminal"
 name = "posix/test-c-thread"
 program = "./bin/test-c-thread.initrd"
 expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/test-c-wchar"
+program = "./bin/test-c-wchar.initrd"
+expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -265,3 +265,10 @@ executor = "terminal"
 name = "posix/test-c-thread"
 program = "./bin/test-c-thread.initrd"
 expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/test-c-wchar"
+program = "./bin/test-c-wchar.initrd"
+expected_exit_code = 0


### PR DESCRIPTION
## Summary

Fixes #2796. Implements `wcspbrk`, the only wide-character symbol missing from the const-correct wide-search set (`wcschr`, `wcsrchr`, `wcsstr`, `wmemchr` already exist). libc++'s `<wchar.h>` const-correct overload block unconditionally references `::wcspbrk`, so building libc++ with `LIBCXX_ENABLE_WIDE_CHARACTERS=ON` failed with `use of undeclared identifier 'wcspbrk'`. `wcspbrk` is the single strict blocker for re-enabling wide characters.

## Changes

- **`src/libs/libc_wchar/src/wcspbrk.rs`** (new): `pub unsafe extern "C" fn wcspbrk(ws1, ws2) -> *mut wchar_t`, the wide analog of `strpbrk` — a two-pointer scan returning the leftmost position in `ws1` whose wide character appears in `ws2`, else null. Mirrors the existing `wcsstr.rs`. Includes unit tests.
- **`src/libs/libc_wchar/src/lib.rs`**: `pub mod wcspbrk;`.
- **`src/libs/libc_wchar/header.toml`**: add `wcspbrk` to the "Search" section. No `[overrides]` is needed — the generator auto-emits `extern wchar_t *wcspbrk(const wchar_t *ws1, const wchar_t *ws2);`, identical in shape to `wcsstr`.
- **`include/wchar.h`**: regenerated (adds the declaration).

## Tests

- **Unit tests** (`make test-guest-rlib-libc_wchar`): found / not-found / empty-set / empty-haystack / first-char / duplicate-set / leftmost — all pass (121 total).
- **New POSIX C suite `test-c-wchar`** (wired into `Makefile`, `test/test-posix.toml`, `test/test-posix-windows.toml`): exercises `wcspbrk` from C and sanity-checks the sibling wide-search functions. `L"..."` literals are valid here — the toolchain `wchar_t` is `int` (4 bytes), matching the libc `wchar_t` (`i32`).

## Validation
- `make gen-headers-check` passes; `include/wchar.h` declares the expected prototype.
- C suite compiles cleanly against the real i686 headers with `-Wall -Wextra`.
- `cargo clippy -p libc_wchar --features std -- -D warnings`, rustfmt, codespell all clean.
- Pre-commit hook passed all three deployment configurations.

## Unblocks
Once merged, `-DLIBCXX_ENABLE_WIDE_CHARACTERS=OFF` can be removed from the `nanvix/llvm-project` toolchain bootstrap.
