### PR TITLE
[sysapi] Advertise POSIX timers in <unistd.h>

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -40,6 +40,7 @@ ALL_POSIX_TESTS := \
 	test-c-network \
 	test-c-noop \
 	test-c-pathconf \
+	test-c-posix-timers \
 	test-c-regex \
 	test-c-setjmp \
 	test-c-stdio \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -33,6 +33,12 @@ extern "C" {
 #ifndef _POSIX_THREADS
 #define _POSIX_THREADS 200809L
 #endif
+#ifndef _POSIX_TIMERS
+#define _POSIX_TIMERS 200809L
+#endif
+#ifndef _POSIX_MONOTONIC_CLOCK
+#define _POSIX_MONOTONIC_CLOCK 200809L
+#endif
 
 #define STDIN_FILENO 0 /**< File descriptor of standard input. */
 #define STDOUT_FILENO 1 /**< File descriptor of standard output. */

--- a/src/libs/sysapi/headers/unistd.toml
+++ b/src/libs/sysapi/headers/unistd.toml
@@ -24,6 +24,12 @@ text = '''
 #ifndef _POSIX_THREADS
 #define _POSIX_THREADS 200809L
 #endif
+#ifndef _POSIX_TIMERS
+#define _POSIX_TIMERS 200809L
+#endif
+#ifndef _POSIX_MONOTONIC_CLOCK
+#define _POSIX_MONOTONIC_CLOCK 200809L
+#endif
 
 #define STDIN_FILENO 0 /**< File descriptor of standard input. */
 #define STDOUT_FILENO 1 /**< File descriptor of standard output. */

--- a/src/tests/integration/test-c-posix-timers/main.c
+++ b/src/tests/integration/test-c-posix-timers/main.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+// <unistd.h> is included first and on its own so the feature-test-macro checks below attribute the
+// macros specifically to <unistd.h>, not to any later header.
+#include <unistd.h>
+
+//==================================================================================================
+// Compile-Time Checks
+//==================================================================================================
+
+// <unistd.h> must advertise the POSIX timers and monotonic-clock options. Portable software (e.g.
+// libc++'s chrono.cpp) gates the clock_gettime(CLOCK_MONOTONIC) path on `_POSIX_TIMERS > 0`, so a
+// missing or non-positive macro is a hard regression.
+#if !defined(_POSIX_TIMERS) || (_POSIX_TIMERS <= 0)
+#error "_POSIX_TIMERS is not advertised by <unistd.h>"
+#endif
+
+#if !defined(_POSIX_MONOTONIC_CLOCK) || (_POSIX_MONOTONIC_CLOCK <= 0)
+#error "_POSIX_MONOTONIC_CLOCK is not advertised by <unistd.h>"
+#endif
+
+//==================================================================================================
+// Remaining Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Confirms, at run time, that the feature-test macros are positive (mirroring the compile-time
+// guard above so the check is also exercised at run time).
+static void test_macros_advertised(void)
+{
+    assert(_POSIX_TIMERS > 0);
+    assert(_POSIX_MONOTONIC_CLOCK > 0);
+}
+
+// Confirms the advertisement is truthful: CLOCK_MONOTONIC is actually serviced by clock_gettime()
+// and clock_getres(), and successive reads are non-decreasing.
+static void test_monotonic_clock_works(void)
+{
+    struct timespec res = {0};
+    struct timespec first = {0};
+    struct timespec second = {0};
+
+    assert(clock_getres(CLOCK_MONOTONIC, &res) == 0);
+    assert(res.tv_sec >= 0);
+    assert(res.tv_nsec >= 0);
+
+    assert(clock_gettime(CLOCK_MONOTONIC, &first) == 0);
+    assert(first.tv_sec >= 0);
+    assert(first.tv_nsec >= 0);
+
+    assert(clock_gettime(CLOCK_MONOTONIC, &second) == 0);
+
+    // The monotonic clock must never run backwards.
+    assert(second.tv_sec > first.tv_sec ||
+           (second.tv_sec == first.tv_sec && second.tv_nsec >= first.tv_nsec));
+}
+
+// Confirms nanosleep(), part of the advertised POSIX timers subset, suspends and returns success.
+static void test_nanosleep_works(void)
+{
+#ifndef __hyperlight__
+    struct timespec request = {0};
+    request.tv_sec = 0;
+    request.tv_nsec = 1000000; // 1 ms.
+    assert(nanosleep(&request, NULL) == 0);
+#endif
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests that <unistd.h> advertises the POSIX timers options and that the advertised
+ * monotonic-clock functionality is implemented.
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv List of command-line arguments.
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert command-line arguments.
+    assert(argc == 1);
+    assert(argv[0] != NULL);
+    assert(argv[1] == NULL);
+    assert(strcmp(argv[0], "test-c-posix-timers.elf") == 0);
+
+    test_macros_advertised();
+    test_monotonic_clock_works();
+    test_nanosleep_works();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -276,6 +276,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-posix-timers"
+program = "./bin/test-c-posix-timers.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -276,6 +276,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-posix-timers"
+program = "./bin/test-c-posix-timers.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Fixes #2797. Advertises the POSIX feature-test macros `_POSIX_TIMERS` and `_POSIX_MONOTONIC_CLOCK` in `<unistd.h>`. Nanvix already services `CLOCK_MONOTONIC` via `clock_gettime`/`clock_getres` and implements `nanosleep`, but without these macros portable software (e.g. libc++'s `chrono.cpp`, which gates `_LIBCPP_HAS_CLOCK_GETTIME` on `_POSIX_TIMERS > 0`) could not detect the implemented functionality and failed with *"Monotonic clock not implemented on this platform"*.

## Changes

- **`src/libs/sysapi/headers/unistd.toml`**: add `_POSIX_TIMERS 200809L` and `_POSIX_MONOTONIC_CLOCK 200809L` (both `#ifndef`-guarded) to the raw "Constants" block, matching the existing `_POSIX_VERSION`/`_POSIX_THREADS` style. The raw-text mechanism is correct here because the spec's `content_order` has no `"macros"` token.
- **`include/unistd.h`**: regenerated.

This is a **header/spec-only** change — no Rust changes, because the clock and `nanosleep` symbols already exist and are exported as `extern "C"`.

## Deliberate caveat (advertised on purpose)

Strict `_POSIX_TIMERS` also implies the `timer_create`/`timer_settime`/… interval-timer family, which Nanvix does **not** implement, and `clock_settime` is a privileged stub (`EPERM`). The macro is advertised anyway because it is exactly the signal consumers test to enable the implemented `clock_gettime(CLOCK_MONOTONIC)` subset. `_POSIX_CPUTIME`, `_POSIX_THREAD_CPUTIME`, and `_POSIX_CLOCK_SELECTION` are intentionally **not** advertised (their backing functionality is unsupported / absent).

## Tests

- **New POSIX C suite `test-c-posix-timers`** (wired into `Makefile` + both test tomls): a compile-time `#if`/`#error` guard (with `<unistd.h>` included first/alone, so the macros are attributed specifically to it) that both macros are defined and `> 0`; plus runtime checks that `clock_getres`/`clock_gettime(CLOCK_MONOTONIC)` succeed, the monotonic clock is non-decreasing across two reads, and `nanosleep` returns 0.

## Validation
- `make gen-headers-check` passes; `include/unistd.h` contains both guarded macros.
- The C suite compiles cleanly with `-Wall -Wextra`; a negative build with `-D_POSIX_TIMERS=0` correctly trips the `#error`.
- codespell clean. Pre-commit hook passed all three deployment configurations.

## Unblocks
Once the toolchain picks up the regenerated `<unistd.h>`, the `defined(__nanvix__)` special-case in libc++'s `chrono.cpp` can be removed (the generic `_POSIX_TIMERS` branch covers Nanvix).
