### PR TITLE
[libc_locale] Implement the POSIX xlocale API

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -34,6 +34,7 @@ ALL_POSIX_TESTS := \
 	test-c-hello \
 	test-c-inet \
 	test-c-libgen \
+	test-c-locale \
 	test-c-memory \
 	test-c-misc \
 	test-c-network \

--- a/include/ctype.h
+++ b/include/ctype.h
@@ -15,6 +15,8 @@
  * the libc_ctype Rust crate.
  */
 
+#include <locale.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,6 +38,18 @@ extern int ispunct(int c);
 extern int iscntrl(int c);
 extern int isxdigit(int c);
 extern int isascii(int c);
+extern int isalnum_l(int c, locale_t locale);
+extern int isalpha_l(int c, locale_t locale);
+extern int isblank_l(int c, locale_t locale);
+extern int iscntrl_l(int c, locale_t locale);
+extern int isdigit_l(int c, locale_t locale);
+extern int isgraph_l(int c, locale_t locale);
+extern int islower_l(int c, locale_t locale);
+extern int isprint_l(int c, locale_t locale);
+extern int ispunct_l(int c, locale_t locale);
+extern int isspace_l(int c, locale_t locale);
+extern int isupper_l(int c, locale_t locale);
+extern int isxdigit_l(int c, locale_t locale);
 
 /*==================================================================================================
  * Conversion
@@ -44,6 +58,8 @@ extern int isascii(int c);
 extern int toupper(int c);
 extern int tolower(int c);
 extern int toascii(int c);
+extern int tolower_l(int c, locale_t locale);
+extern int toupper_l(int c, locale_t locale);
 
 #ifdef __cplusplus
 }

--- a/include/locale.h
+++ b/include/locale.h
@@ -21,18 +21,6 @@ extern "C" {
 #endif
 
 /*==================================================================================================
- * Constants
- *==================================================================================================*/
-
-#define LC_CTYPE 0
-#define LC_NUMERIC 1
-#define LC_TIME 2
-#define LC_COLLATE 3
-#define LC_MONETARY 4
-#define LC_MESSAGES 5
-#define LC_ALL 6
-
-/*==================================================================================================
  * Types
  *==================================================================================================*/
 
@@ -64,11 +52,40 @@ struct lconv {
 };
 
 /*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define LC_CTYPE 0
+#define LC_NUMERIC 1
+#define LC_TIME 2
+#define LC_COLLATE 3
+#define LC_MONETARY 4
+#define LC_MESSAGES 5
+#define LC_ALL 6
+#define LC_CTYPE_MASK (1 << LC_CTYPE)
+#define LC_NUMERIC_MASK (1 << LC_NUMERIC)
+#define LC_TIME_MASK (1 << LC_TIME)
+#define LC_COLLATE_MASK (1 << LC_COLLATE)
+#define LC_MONETARY_MASK (1 << LC_MONETARY)
+#define LC_MESSAGES_MASK (1 << LC_MESSAGES)
+#define LC_ALL_MASK (LC_CTYPE_MASK | LC_NUMERIC_MASK | LC_TIME_MASK | LC_COLLATE_MASK | LC_MONETARY_MASK | LC_MESSAGES_MASK)
+#define LC_GLOBAL_LOCALE ((locale_t) -1)
+
+/*==================================================================================================
  * Functions
  *==================================================================================================*/
 
 extern char *setlocale(int category, const char *locale);
 extern struct lconv *localeconv(void);
+
+/*==================================================================================================
+ * Locale Management
+ *==================================================================================================*/
+
+extern locale_t newlocale(int category_mask, const char *locale, locale_t base);
+extern locale_t duplocale(locale_t locobj);
+extern void freelocale(locale_t locobj);
+extern locale_t uselocale(locale_t newloc);
 
 #ifdef __cplusplus
 }

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include <sys/wait.h>
+#include <locale.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,6 +97,13 @@ extern long strtol(const char *restrict nptr, char **restrict endptr, int base);
 extern long long strtoll(const char *restrict nptr, char **restrict endptr, int base);
 extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);
 extern unsigned long long strtoull(const char *restrict nptr, char **restrict endptr, int base);
+extern double strtod_l(const char *restrict nptr, char **restrict endptr, locale_t locale);
+extern float strtof_l(const char *restrict nptr, char **restrict endptr, locale_t locale);
+extern long double strtold_l(const char *restrict nptr, char **restrict endptr, locale_t locale);
+extern long strtol_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);
+extern long long strtoll_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);
+extern unsigned long strtoul_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);
+extern unsigned long long strtoull_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);
 
 /*==================================================================================================
  * Integer Arithmetic

--- a/include/string.h
+++ b/include/string.h
@@ -15,6 +15,7 @@
  */
 
 #include <stddef.h>
+#include <locale.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,6 +71,8 @@ extern char *strtok(char *s, const char *delim);
 extern char *strtok_r(char *s, const char *delim, char **saveptr);
 extern int strverscmp(const char *s1, const char *s2);
 extern size_t strxfrm(char *dest, const char *src, size_t n);
+extern int strcoll_l(const char *s1, const char *s2, locale_t locale);
+extern size_t strxfrm_l(char *dest, const char *src, size_t n, locale_t locale);
 
 #ifdef __cplusplus
 }

--- a/include/time.h
+++ b/include/time.h
@@ -15,6 +15,7 @@
  */
 
 #include <stddef.h>
+#include <locale.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,6 +109,8 @@ extern char *ctime(const time_t *timep);
 extern char *ctime_r(const time_t *timep, char *buf);
 extern size_t strftime(char *s, size_t max, const char *format,
                        const struct tm *timeptr);
+extern size_t strftime_l(char *s, size_t max, const char *format,
+                         const struct tm *timeptr, locale_t locale);
 
 /*==================================================================================================
  * Clocks

--- a/include/xlocale.h
+++ b/include/xlocale.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_XLOCALE_H
+#define _NANVIX_XLOCALE_H
+
+/**
+ * @file xlocale.h
+ * @brief Compatibility shim for the POSIX xlocale API.
+ *
+ * Re-includes the headers that declare the locale-management functions and the
+ * per-locale `*_l` functions. Provided for toolchains and sources that include
+ * <xlocale.h> directly; Nanvix declares each symbol in its primary header.
+ */
+
+#include <locale.h>
+#include <ctype.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+
+#endif /* _NANVIX_XLOCALE_H */

--- a/src/libs/libc_ctype/header.toml
+++ b/src/libs/libc_ctype/header.toml
@@ -11,7 +11,7 @@ description = """
 Declares functions for testing and mapping characters. All functions operate
 on values representable as unsigned char or the value EOF. Implemented by
 the libc_ctype Rust crate."""
-includes = []
+includes = ["locale.h"]
 guard = "_NANVIX_CTYPE_H"
 
 [[sections]]
@@ -30,8 +30,36 @@ functions = [
     "iscntrl",
     "isxdigit",
     "isascii",
+    "isalnum_l",
+    "isalpha_l",
+    "isblank_l",
+    "iscntrl_l",
+    "isdigit_l",
+    "isgraph_l",
+    "islower_l",
+    "isprint_l",
+    "ispunct_l",
+    "isspace_l",
+    "isupper_l",
+    "isxdigit_l",
 ]
 
 [[sections]]
 title = "Conversion"
-functions = ["toupper", "tolower", "toascii"]
+functions = ["toupper", "tolower", "toascii", "tolower_l", "toupper_l"]
+
+[overrides]
+isalnum_l = "extern int isalnum_l(int c, locale_t locale);"
+isalpha_l = "extern int isalpha_l(int c, locale_t locale);"
+isblank_l = "extern int isblank_l(int c, locale_t locale);"
+iscntrl_l = "extern int iscntrl_l(int c, locale_t locale);"
+isdigit_l = "extern int isdigit_l(int c, locale_t locale);"
+isgraph_l = "extern int isgraph_l(int c, locale_t locale);"
+islower_l = "extern int islower_l(int c, locale_t locale);"
+isprint_l = "extern int isprint_l(int c, locale_t locale);"
+ispunct_l = "extern int ispunct_l(int c, locale_t locale);"
+isspace_l = "extern int isspace_l(int c, locale_t locale);"
+isupper_l = "extern int isupper_l(int c, locale_t locale);"
+isxdigit_l = "extern int isxdigit_l(int c, locale_t locale);"
+tolower_l = "extern int tolower_l(int c, locale_t locale);"
+toupper_l = "extern int toupper_l(int c, locale_t locale);"

--- a/src/libs/libc_ctype/src/lib.rs
+++ b/src/libs/libc_ctype/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ispunct;
 pub mod isspace;
 pub mod isupper;
 pub mod isxdigit;
+pub mod locale;
 pub mod toascii;
 pub mod tolower;
 pub mod toupper;

--- a/src/libs/libc_ctype/src/locale.rs
+++ b/src/libs/libc_ctype/src/locale.rs
@@ -1,0 +1,148 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    isalnum::isalnum,
+    isalpha::isalpha,
+    isblank::isblank,
+    iscntrl::iscntrl,
+    isdigit::isdigit,
+    isgraph::isgraph,
+    islower::islower,
+    isprint::isprint,
+    ispunct::ispunct,
+    isspace::isspace,
+    isupper::isupper,
+    isxdigit::isxdigit,
+    tolower::tolower,
+    toupper::toupper,
+};
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Nanvix supports only the C/POSIX locale, so every `*_l` function ignores its `locale_t` argument
+// and delegates to its non-`_l` counterpart, mirroring the wide-character precedent in
+// `libc_wctype::locale`.
+
+/// Tests whether a character is alphanumeric in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isalnum_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isalnum(c)
+}
+
+/// Tests whether a character is alphabetic in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isalpha_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isalpha(c)
+}
+
+/// Tests whether a character is blank in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isblank_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isblank(c)
+}
+
+/// Tests whether a character is a control character in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn iscntrl_l(c: c_int, _locale: *mut c_void) -> c_int {
+    iscntrl(c)
+}
+
+/// Tests whether a character is a decimal digit in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isdigit_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isdigit(c)
+}
+
+/// Tests whether a character has a graphical representation in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isgraph_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isgraph(c)
+}
+
+/// Tests whether a character is lowercase in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn islower_l(c: c_int, _locale: *mut c_void) -> c_int {
+    islower(c)
+}
+
+/// Tests whether a character is printable in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isprint_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isprint(c)
+}
+
+/// Tests whether a character is punctuation in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn ispunct_l(c: c_int, _locale: *mut c_void) -> c_int {
+    ispunct(c)
+}
+
+/// Tests whether a character is white space in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isspace_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isspace(c)
+}
+
+/// Tests whether a character is uppercase in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isupper_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isupper(c)
+}
+
+/// Tests whether a character is a hexadecimal digit in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn isxdigit_l(c: c_int, _locale: *mut c_void) -> c_int {
+    isxdigit(c)
+}
+
+/// Converts a character to lowercase in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tolower_l(c: c_int, _locale: *mut c_void) -> c_int {
+    tolower(c)
+}
+
+/// Converts a character to uppercase in the C/POSIX locale.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn toupper_l(c: c_int, _locale: *mut c_void) -> c_int {
+    toupper(c)
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_classification_l_delegates() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        assert_ne!(isdigit_l(i32::from(b'7'), locale), 0);
+        assert_eq!(isdigit_l(i32::from(b'a'), locale), 0);
+        assert_ne!(isalpha_l(i32::from(b'a'), locale), 0);
+        assert_ne!(isupper_l(i32::from(b'A'), locale), 0);
+        assert_ne!(islower_l(i32::from(b'a'), locale), 0);
+        assert_ne!(isspace_l(i32::from(b' '), locale), 0);
+        assert_ne!(isxdigit_l(i32::from(b'f'), locale), 0);
+        assert_eq!(isxdigit_l(i32::from(b'g'), locale), 0);
+    }
+
+    #[test]
+    fn test_conversion_l_delegates() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        assert_eq!(tolower_l(i32::from(b'A'), locale), i32::from(b'a'));
+        assert_eq!(toupper_l(i32::from(b'a'), locale), i32::from(b'A'));
+    }
+}

--- a/src/libs/libc_locale/header.toml
+++ b/src/libs/libc_locale/header.toml
@@ -12,6 +12,9 @@ Declares functions and types for locale-specific formatting. Only the
 C/POSIX locale is supported. Implemented by the libc_locale Rust crate."""
 includes = ["stddef.h"]
 guard = "_NANVIX_LOCALE_H"
+# Emit the type block (which defines `locale_t`) before the constants so that the
+# `LC_GLOBAL_LOCALE` macro, whose value casts to `locale_t`, follows the typedef.
+content_order = ["types", "macros", "section:0", "section:1"]
 
 [[macros]]
 name = "LC_CTYPE"
@@ -40,6 +43,38 @@ value = "5"
 [[macros]]
 name = "LC_ALL"
 value = "6"
+
+[[macros]]
+name = "LC_CTYPE_MASK"
+value = "(1 << LC_CTYPE)"
+
+[[macros]]
+name = "LC_NUMERIC_MASK"
+value = "(1 << LC_NUMERIC)"
+
+[[macros]]
+name = "LC_TIME_MASK"
+value = "(1 << LC_TIME)"
+
+[[macros]]
+name = "LC_COLLATE_MASK"
+value = "(1 << LC_COLLATE)"
+
+[[macros]]
+name = "LC_MONETARY_MASK"
+value = "(1 << LC_MONETARY)"
+
+[[macros]]
+name = "LC_MESSAGES_MASK"
+value = "(1 << LC_MESSAGES)"
+
+[[macros]]
+name = "LC_ALL_MASK"
+value = "(LC_CTYPE_MASK | LC_NUMERIC_MASK | LC_TIME_MASK | LC_COLLATE_MASK | LC_MONETARY_MASK | LC_MESSAGES_MASK)"
+
+[[macros]]
+name = "LC_GLOBAL_LOCALE"
+value = "((locale_t) -1)"
 
 [[types]]
 text = """
@@ -74,3 +109,13 @@ struct lconv {
 [[sections]]
 title = "Functions"
 functions = ["setlocale", "localeconv"]
+
+[[sections]]
+title = "Locale Management"
+functions = ["newlocale", "duplocale", "freelocale", "uselocale"]
+
+[overrides]
+newlocale = "extern locale_t newlocale(int category_mask, const char *locale, locale_t base);"
+duplocale = "extern locale_t duplocale(locale_t locobj);"
+freelocale = "extern void freelocale(locale_t locobj);"
+uselocale = "extern locale_t uselocale(locale_t newloc);"

--- a/src/libs/libc_locale/src/lib.rs
+++ b/src/libs/libc_locale/src/lib.rs
@@ -32,3 +32,4 @@
 
 pub mod localeconv;
 pub mod setlocale;
+pub mod xlocale;

--- a/src/libs/libc_locale/src/xlocale.rs
+++ b/src/libs/libc_locale/src/xlocale.rs
@@ -1,0 +1,213 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::sync::atomic::{
+    AtomicPtr,
+    Ordering,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Currently installed locale handle.
+///
+/// A null pointer denotes the global locale managed by `setlocale()` (POSIX `LC_GLOBAL_LOCALE`),
+/// which is also the initial state. Nanvix supports only the C/POSIX locale, so the stored value is
+/// purely bookkeeping for `uselocale()`'s query/swap contract.
+///
+/// # Caveat
+///
+/// POSIX specifies `uselocale()` state as **per-thread**. This uses a single process-global atomic
+/// instead (consistent with `setlocale()`'s existing global state). That is sound while only the
+/// C/POSIX locale exists — every `*_l` function ignores the handle — but switching to true
+/// thread-local storage would be required before adding genuine multi-locale support.
+static CURRENT_LOCALE: AtomicPtr<c_void> = AtomicPtr::new(::core::ptr::null_mut());
+
+/// A single stable, non-null object whose address is the one and only `locale_t`.
+///
+/// Only the C/POSIX locale exists, so every locale handle aliases this object. It is never
+/// dereferenced; only its address is used as an opaque, non-null sentinel.
+static C_LOCALE_OBJECT: u8 = 0;
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Returns the canonical, non-null handle for the C/POSIX locale.
+fn c_locale_handle() -> *mut c_void {
+    (&raw const C_LOCALE_OBJECT).cast::<c_void>().cast_mut()
+}
+
+/// Returns POSIX `LC_GLOBAL_LOCALE`, i.e. `(locale_t) -1`.
+fn lc_global_locale() -> *mut c_void {
+    ::core::ptr::without_provenance_mut(usize::MAX)
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// # Description
+///
+/// Creates a locale object. Nanvix supports only the C/POSIX locale, so the canonical handle is
+/// returned regardless of the requested categories, locale name, or base object.
+///
+/// # Parameters
+///
+/// - `category_mask`: Bitwise OR of `LC_*_MASK` categories to set (ignored).
+/// - `locale`: Name of the locale to load (ignored; not dereferenced).
+/// - `base`: An existing locale object to modify (ignored; not dereferenced).
+///
+/// # Returns
+///
+/// The canonical, non-null C/POSIX locale handle.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn newlocale(
+    _category_mask: c_int,
+    _locale: *const c_char,
+    _base: *mut c_void,
+) -> *mut c_void {
+    c_locale_handle()
+}
+
+/// # Description
+///
+/// Releases a locale object. The single C/POSIX handle is static, so this is a no-op.
+///
+/// # Parameters
+///
+/// - `locobj`: The locale object to release (ignored; never freed).
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn freelocale(_locobj: *mut c_void) {}
+
+/// # Description
+///
+/// Installs `newloc` as the current locale and returns the previously installed one. A null
+/// argument queries the current locale without changing it (POSIX `uselocale((locale_t) 0)`).
+///
+/// # Parameters
+///
+/// - `newloc`: The locale to install, `LC_GLOBAL_LOCALE` to restore the global locale, or a null
+///   pointer to query the current locale without changing it.
+///
+/// # Returns
+///
+/// The locale that was installed before the call, or `LC_GLOBAL_LOCALE` if the global locale was
+/// active.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn uselocale(newloc: *mut c_void) -> *mut c_void {
+    // A null argument is a pure query of the current locale.
+    if newloc.is_null() {
+        let current: *mut c_void = CURRENT_LOCALE.load(Ordering::Relaxed);
+        return if current.is_null() {
+            lc_global_locale()
+        } else {
+            current
+        };
+    }
+
+    // `LC_GLOBAL_LOCALE` is stored internally as null so that a later query reports it correctly.
+    let to_store: *mut c_void = if newloc == lc_global_locale() {
+        ::core::ptr::null_mut()
+    } else {
+        newloc
+    };
+    let previous: *mut c_void = CURRENT_LOCALE.swap(to_store, Ordering::Relaxed);
+    if previous.is_null() {
+        lc_global_locale()
+    } else {
+        previous
+    }
+}
+
+/// # Description
+///
+/// Duplicates a locale object. Every handle aliases the single C/POSIX locale, so the canonical
+/// handle is returned.
+///
+/// # Parameters
+///
+/// - `locobj`: The locale object to duplicate (ignored; not dereferenced).
+///
+/// # Returns
+///
+/// The canonical, non-null C/POSIX locale handle.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn duplocale(_locobj: *mut c_void) -> *mut c_void {
+    c_locale_handle()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use ::std::sync::{
+        Mutex,
+        MutexGuard,
+    };
+
+    /// Serializes tests that observe the process-global current locale. They mutate and query the
+    /// shared `CURRENT_LOCALE`, so they must not run concurrently with one another.
+    static USELOCALE_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Acquires the serialization guard, recovering from poisoning so that a failing test does not
+    /// cascade into unrelated ones.
+    fn guard() -> MutexGuard<'static, ()> {
+        USELOCALE_GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn test_newlocale_returns_non_null() {
+        let handle: *mut c_void = newlocale(0, ::core::ptr::null(), ::core::ptr::null_mut());
+        assert!(!handle.is_null());
+    }
+
+    #[test]
+    fn test_duplocale_returns_non_null() {
+        let handle: *mut c_void = duplocale(::core::ptr::null_mut());
+        assert!(!handle.is_null());
+    }
+
+    #[test]
+    fn test_uselocale_query_is_pure() {
+        let _guard: MutexGuard<'static, ()> = guard();
+
+        // Querying must not change the current locale and, initially, reports the global locale.
+        let first: *mut c_void = uselocale(::core::ptr::null_mut());
+        let second: *mut c_void = uselocale(::core::ptr::null_mut());
+        assert_eq!(first, second);
+        assert_eq!(first, lc_global_locale());
+    }
+
+    #[test]
+    fn test_uselocale_round_trips_a_handle() {
+        let _guard: MutexGuard<'static, ()> = guard();
+
+        let handle: *mut c_void = newlocale(0, ::core::ptr::null(), ::core::ptr::null_mut());
+
+        // Installing a handle returns the previous (global) locale.
+        let previous: *mut c_void = uselocale(handle);
+        assert_eq!(previous, lc_global_locale());
+
+        // The installed handle is now reported by a query.
+        assert_eq!(uselocale(::core::ptr::null_mut()), handle);
+
+        // Restoring the global locale returns the handle we installed.
+        let restored: *mut c_void = uselocale(lc_global_locale());
+        assert_eq!(restored, handle);
+        assert_eq!(uselocale(::core::ptr::null_mut()), lc_global_locale());
+    }
+}

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -11,7 +11,7 @@ description = """
 Declares memory allocation, string conversion, integer arithmetic, searching
 and sorting, pseudo-random sequence generation, environment, and process
 control interfaces implemented by the libc_stdlib Rust crate."""
-includes = ["stddef.h", "sys/wait.h"]
+includes = ["stddef.h", "sys/wait.h", "locale.h"]
 guard = "_NANVIX_STDLIB_H"
 content_order = [
     "macros",
@@ -110,6 +110,13 @@ functions = [
     "strtoll",
     "strtoul",
     "strtoull",
+    "strtod_l",
+    "strtof_l",
+    "strtold_l",
+    "strtol_l",
+    "strtoll_l",
+    "strtoul_l",
+    "strtoull_l",
 ]
 
 [[sections]]
@@ -186,6 +193,13 @@ strtoul = '''
 extern unsigned long strtoul(const char *restrict nptr, char **restrict endptr, int base);'''
 strtoull = '''
 extern unsigned long long strtoull(const char *restrict nptr, char **restrict endptr, int base);'''
+strtod_l = "extern double strtod_l(const char *restrict nptr, char **restrict endptr, locale_t locale);"
+strtof_l = "extern float strtof_l(const char *restrict nptr, char **restrict endptr, locale_t locale);"
+strtold_l = "extern long double strtold_l(const char *restrict nptr, char **restrict endptr, locale_t locale);"
+strtol_l = "extern long strtol_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);"
+strtoll_l = "extern long long strtoll_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);"
+strtoul_l = "extern unsigned long strtoul_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);"
+strtoull_l = "extern unsigned long long strtoull_l(const char *restrict nptr, char **restrict endptr, int base, locale_t locale);"
 qsort_r = '''
 extern void qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *arg);'''
 mbtowc = '''

--- a/src/libs/libc_stdlib/src/lib.rs
+++ b/src/libs/libc_stdlib/src/lib.rs
@@ -89,6 +89,7 @@ mod labs;
 mod ldiv;
 mod llabs;
 mod lldiv;
+pub mod locale;
 mod malloc;
 mod malloc_usable_size;
 mod memalign;

--- a/src/libs/libc_stdlib/src/locale.rs
+++ b/src/libs/libc_stdlib/src/locale.rs
@@ -1,0 +1,179 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    strtod::strtod,
+    strtof::strtof,
+    strtol::strtol,
+    strtold::strtold,
+    strtoll::strtoll,
+    strtoul::strtoul,
+    strtoull::strtoull,
+};
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_long,
+    c_longlong,
+    c_ulong,
+    c_ulonglong,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Nanvix supports only the C/POSIX locale, so each `*_l` function ignores its `locale_t` argument
+// and delegates to its non-`_l` counterpart.
+
+/// Converts the initial portion of a string to a `double` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtod_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _locale: *mut c_void,
+) -> f64 {
+    unsafe { strtod(nptr, endptr) }
+}
+
+/// Converts the initial portion of a string to a `float` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtof_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _locale: *mut c_void,
+) -> f32 {
+    unsafe { strtof(nptr, endptr) }
+}
+
+/// Converts the initial portion of a string to a `long double` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtold_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _locale: *mut c_void,
+) -> f64 {
+    unsafe { strtold(nptr, endptr) }
+}
+
+/// Converts the initial portion of a string to a `long` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtol_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+    _locale: *mut c_void,
+) -> c_long {
+    unsafe { strtol(nptr, endptr, base) }
+}
+
+/// Converts the initial portion of a string to a `long long` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoll_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+    _locale: *mut c_void,
+) -> c_longlong {
+    unsafe { strtoll(nptr, endptr, base) }
+}
+
+/// Converts the initial portion of a string to an `unsigned long` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoul_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+    _locale: *mut c_void,
+) -> c_ulong {
+    unsafe { strtoul(nptr, endptr, base) }
+}
+
+/// Converts the initial portion of a string to an `unsigned long long` using the C/POSIX locale.
+///
+/// # Safety
+///
+/// This function dereferences the raw pointers `nptr` and `endptr`, which must be valid.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strtoull_l(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+    _locale: *mut c_void,
+) -> c_ulonglong {
+    unsafe { strtoull(nptr, endptr, base) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_floating_l_delegates() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let nptr: *const c_char = c"3.5".as_ptr();
+        let null_end: *mut *mut c_char = ::core::ptr::null_mut();
+
+        assert_eq!(unsafe { strtod_l(nptr, null_end, locale) }, 3.5);
+        assert_eq!(unsafe { strtof_l(nptr, null_end, locale) }, 3.5f32);
+        assert_eq!(unsafe { strtold_l(nptr, null_end, locale) }, 3.5);
+    }
+
+    #[test]
+    fn test_integer_l_delegates() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let signed: *const c_char = c"-42".as_ptr();
+        let unsigned: *const c_char = c"100".as_ptr();
+        let null_end: *mut *mut c_char = ::core::ptr::null_mut();
+
+        assert_eq!(unsafe { strtol_l(signed, null_end, 10, locale) }, -42);
+        assert_eq!(unsafe { strtoll_l(signed, null_end, 10, locale) }, -42);
+        assert_eq!(unsafe { strtoul_l(unsigned, null_end, 10, locale) }, 100);
+        assert_eq!(unsafe { strtoull_l(unsigned, null_end, 10, locale) }, 100);
+    }
+
+    #[test]
+    fn test_endptr_is_updated() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let nptr: *const c_char = c"42rest".as_ptr();
+        let mut end: *mut c_char = ::core::ptr::null_mut();
+
+        let value: c_long = unsafe { strtol_l(nptr, &mut end, 10, locale) };
+        assert_eq!(value, 42);
+        // The parse consumes "42" and stops at the 'r' (index 2).
+        assert_eq!(end.cast_const(), unsafe { nptr.add(2) });
+    }
+}

--- a/src/libs/libc_string/header.toml
+++ b/src/libs/libc_string/header.toml
@@ -10,7 +10,7 @@ brief = "String and memory operations."
 description = """
 Declares byte-string length and memory manipulation routines implemented by
 the libc_string Rust crate."""
-includes = ["stddef.h"]
+includes = ["stddef.h", "locale.h"]
 guard = "_NANVIX_STRING_H"
 
 [[sections]]
@@ -62,4 +62,10 @@ functions = [
     "strtok_r",
     "strverscmp",
     "strxfrm",
+    "strcoll_l",
+    "strxfrm_l",
 ]
+
+[overrides]
+strcoll_l = "extern int strcoll_l(const char *s1, const char *s2, locale_t locale);"
+strxfrm_l = "extern size_t strxfrm_l(char *dest, const char *src, size_t n, locale_t locale);"

--- a/src/libs/libc_string/src/lib.rs
+++ b/src/libs/libc_string/src/lib.rs
@@ -33,6 +33,7 @@ pub mod bcmp;
 pub mod bcopy;
 pub mod bzero;
 pub mod ffs;
+pub mod locale;
 pub mod memccpy;
 pub mod memchr;
 pub mod memcmp;

--- a/src/libs/libc_string/src/locale.rs
+++ b/src/libs/libc_string/src/locale.rs
@@ -1,0 +1,126 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    strcoll::strcoll,
+    strxfrm::strxfrm,
+};
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Nanvix supports only the C/POSIX locale, so each `*_l` function ignores its `locale_t` argument
+// and delegates to its non-`_l` counterpart.
+
+/// # Description
+///
+/// Compares two strings using the collating sequence of the C/POSIX locale.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated string.
+/// - `s2`: Pointer to the second null-terminated string.
+/// - `locale`: Locale to use (ignored; only the C/POSIX locale is supported).
+///
+/// # Returns
+///
+/// A negative, zero, or positive value if `s1` orders before, equal to, or after `s2`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `s1` and `s2`, which must point
+/// to valid null-terminated strings.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strcoll_l(
+    s1: *const c_char,
+    s2: *const c_char,
+    _locale: *mut c_void,
+) -> c_int {
+    unsafe { strcoll(s1, s2) }
+}
+
+/// # Description
+///
+/// Transforms a string so that the result of `strcmp()` on two transformed strings matches the
+/// result of `strcoll()` on the originals. In the C/POSIX locale the transformation is the identity
+/// copy.
+///
+/// # Parameters
+///
+/// - `dest`: Destination buffer for the transformed string.
+/// - `src`: Pointer to the null-terminated source string.
+/// - `n`: Maximum number of bytes to write to `dest`, including the null terminator.
+/// - `locale`: Locale to use (ignored; only the C/POSIX locale is supported).
+///
+/// # Returns
+///
+/// The length of the transformed string (excluding the null terminator).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `dest` and `src`, which must be
+/// valid for the requested operation.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strxfrm_l(
+    dest: *mut c_char,
+    src: *const c_char,
+    n: c_size_t,
+    _locale: *mut c_void,
+) -> c_size_t {
+    unsafe { strxfrm(dest, src, n) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use ::std::vec::Vec;
+
+    fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
+        v.push(0);
+        v
+    }
+
+    #[test]
+    fn test_strcoll_l_orders_like_strcmp() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let a: Vec<c_char> = make_c_string(b"abc");
+        let b: Vec<c_char> = make_c_string(b"abd");
+
+        assert!(unsafe { strcoll_l(a.as_ptr(), b.as_ptr(), locale) } < 0);
+        assert!(unsafe { strcoll_l(b.as_ptr(), a.as_ptr(), locale) } > 0);
+        assert_eq!(unsafe { strcoll_l(a.as_ptr(), a.as_ptr(), locale) }, 0);
+    }
+
+    #[test]
+    fn test_strxfrm_l_is_identity_in_c_locale() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let src: Vec<c_char> = make_c_string(b"abc");
+        let mut dest: [c_char; 8] = [0; 8];
+        let capacity: c_size_t = c_size_t::try_from(dest.len()).expect("capacity fits");
+
+        let len: c_size_t = unsafe { strxfrm_l(dest.as_mut_ptr(), src.as_ptr(), capacity, locale) };
+        assert_eq!(len, 3);
+        assert_eq!(&dest[..4], &src[..4]);
+    }
+}

--- a/src/libs/libc_time/header.toml
+++ b/src/libs/libc_time/header.toml
@@ -8,7 +8,7 @@ brief = "Date and time."
 description = '''
 Declares functions for calendar time manipulation and conversion.
 Implemented by the libc_time Rust crate.'''
-includes = ["stddef.h"]
+includes = ["stddef.h", "locale.h"]
 guard = "_NANVIX_TIME_H"
 content_order = ["types", "section:0", "section:1", "raw:0", "raw:1", "raw:2", "raw:3"]
 
@@ -77,7 +77,9 @@ extern char *asctime_r(const struct tm *timeptr, char *buf);
 extern char *ctime(const time_t *timep);
 extern char *ctime_r(const time_t *timep, char *buf);
 extern size_t strftime(char *s, size_t max, const char *format,
-                       const struct tm *timeptr);'''
+                       const struct tm *timeptr);
+extern size_t strftime_l(char *s, size_t max, const char *format,
+                         const struct tm *timeptr, locale_t locale);'''
 
 # Implemented by the syscall crate; declared here so callers of time.h can use them.
 [[raw_sections]]

--- a/src/libs/libc_time/src/lib.rs
+++ b/src/libs/libc_time/src/lib.rs
@@ -39,6 +39,7 @@ pub mod ctime_r;
 pub mod difftime;
 pub mod gmtime;
 pub mod gmtime_r;
+pub mod locale;
 pub mod localtime;
 pub mod localtime_r;
 pub mod mktime;

--- a/src/libs/libc_time/src/locale.rs
+++ b/src/libs/libc_time/src/locale.rs
@@ -1,0 +1,94 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    strftime::strftime,
+    tm_struct::tm,
+};
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// # Description
+///
+/// Formats a broken-down time according to `format` using the C/POSIX locale. Nanvix supports only
+/// the C/POSIX locale, so this delegates to `strftime()` and ignores the `locale_t` argument.
+///
+/// # Parameters
+///
+/// - `s`: Destination buffer for the formatted string.
+/// - `max`: Maximum number of bytes to write to `s`, including the null terminator.
+/// - `format`: Pointer to the null-terminated format string.
+/// - `timeptr`: Pointer to the broken-down time to format.
+/// - `locale`: Locale to use (ignored; only the C/POSIX locale is supported).
+///
+/// # Returns
+///
+/// The number of bytes written to `s` (excluding the null terminator), or `0` if the result would
+/// not fit.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `s`, `format`, and `timeptr`,
+/// which must be valid for the requested operation.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn strftime_l(
+    s: *mut c_char,
+    max: c_size_t,
+    format: *const c_char,
+    timeptr: *const tm,
+    _locale: *mut c_void,
+) -> c_size_t {
+    unsafe { strftime(s, max, format, timeptr) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+    use ::std::{
+        ffi::CString,
+        string::String,
+        vec,
+    };
+
+    #[test]
+    fn test_strftime_l_delegates_to_strftime() {
+        let mut time: tm = tm::new();
+        time.tm_year = 2021 - 1900;
+        time.tm_mon = 3 - 1;
+        time.tm_mday = 14;
+
+        let format: CString = CString::new("%Y-%m-%d").unwrap_or_else(|_| CString::default());
+        let mut buffer: vec::Vec<u8> = vec![0u8; 64];
+        let capacity: c_size_t = c_size_t::try_from(buffer.len()).expect("capacity fits");
+        let locale: *mut c_void = ::core::ptr::null_mut();
+
+        let written: c_size_t = unsafe {
+            strftime_l(
+                buffer.as_mut_ptr().cast::<c_char>(),
+                capacity,
+                format.as_ptr(),
+                &time,
+                locale,
+            )
+        };
+
+        assert_eq!(String::from_utf8_lossy(&buffer[..written as usize]), "2021-03-14");
+    }
+}

--- a/src/libs/sysapi/headers/xlocale.toml
+++ b/src/libs/sysapi/headers/xlocale.toml
@@ -1,0 +1,14 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for xlocale.h.
+
+file = "xlocale.h"
+brief = "Compatibility shim for the POSIX xlocale API."
+description = '''
+Re-includes the headers that declare the locale-management functions and the
+per-locale `*_l` functions. Provided for toolchains and sources that include
+<xlocale.h> directly; Nanvix declares each symbol in its primary header.'''
+includes = ["locale.h", "ctype.h", "string.h", "time.h", "stdlib.h"]
+guard = "_NANVIX_XLOCALE_H"
+extern_c = false

--- a/src/tests/integration/test-c-locale/main.c
+++ b/src/tests/integration/test-c-locale/main.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <ctype.h>
+#include <locale.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Tests the locale-management functions. Nanvix is single-locale ("C"/POSIX), so the handles are
+// opaque non-null sentinels and uselocale() implements the query/swap contract.
+static void test_locale_management(void)
+{
+    // newlocale() and duplocale() hand out non-null handles.
+    locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    assert(loc != (locale_t)0);
+    locale_t dup = duplocale(loc);
+    assert(dup != (locale_t)0);
+
+    // Querying the current locale must not change it; initially it is the global locale.
+    locale_t before = uselocale((locale_t)0);
+    assert(uselocale((locale_t)0) == before);
+
+    // Installing a locale returns the previous one; querying then reports the installed one.
+    locale_t previous = uselocale(loc);
+    assert(previous == before);
+    assert(uselocale((locale_t)0) == loc);
+
+    // Restoring the global locale returns the handle we installed.
+    locale_t restored = uselocale(LC_GLOBAL_LOCALE);
+    assert(restored == loc);
+    assert(uselocale((locale_t)0) == LC_GLOBAL_LOCALE);
+
+    // freelocale() accepts the handle (no-op for the static C locale).
+    freelocale(dup);
+    freelocale(loc);
+}
+
+// Tests the narrow per-locale ctype functions; each must agree with its non-`_l` counterpart in the
+// C/POSIX locale.
+static void test_ctype_l(void)
+{
+    locale_t loc = newlocale(LC_CTYPE_MASK, "C", (locale_t)0);
+
+    assert(isalnum_l('a', loc) && isalnum_l('5', loc) && !isalnum_l('!', loc));
+    assert(isalpha_l('z', loc) && !isalpha_l('0', loc));
+    assert(isblank_l(' ', loc) && !isblank_l('x', loc));
+    assert(iscntrl_l('\n', loc) && !iscntrl_l('x', loc));
+    assert(isdigit_l('7', loc) && !isdigit_l('a', loc));
+    assert(isgraph_l('A', loc) && !isgraph_l(' ', loc));
+    assert(islower_l('a', loc) && !islower_l('A', loc));
+    assert(isprint_l(' ', loc) && !isprint_l('\n', loc));
+    assert(ispunct_l('!', loc) && !ispunct_l('a', loc));
+    assert(isspace_l(' ', loc) && !isspace_l('a', loc));
+    assert(isupper_l('A', loc) && !isupper_l('a', loc));
+    assert(isxdigit_l('f', loc) && !isxdigit_l('g', loc));
+
+    assert(tolower_l('A', loc) == 'a');
+    assert(tolower_l('a', loc) == 'a');
+    assert(toupper_l('a', loc) == 'A');
+    assert(toupper_l('A', loc) == 'A');
+
+    freelocale(loc);
+}
+
+// Tests the per-locale string functions strcoll_l() and strxfrm_l().
+static void test_string_l(void)
+{
+    locale_t loc = newlocale(LC_COLLATE_MASK, "C", (locale_t)0);
+
+    assert(strcoll_l("abc", "abd", loc) < 0);
+    assert(strcoll_l("abd", "abc", loc) > 0);
+    assert(strcoll_l("abc", "abc", loc) == 0);
+
+    // In the C locale strxfrm is the identity copy and returns the source length.
+    char buffer[16];
+    memset(buffer, 0, sizeof(buffer));
+    size_t length = strxfrm_l(buffer, "hello", sizeof(buffer), loc);
+    assert(length == 5);
+    assert(strcmp(buffer, "hello") == 0);
+
+    freelocale(loc);
+}
+
+// Tests the per-locale time-formatting function strftime_l().
+static void test_time_l(void)
+{
+    locale_t loc = newlocale(LC_TIME_MASK, "C", (locale_t)0);
+
+    struct tm broken = {0};
+    broken.tm_year = 2021 - 1900;
+    broken.tm_mon = 3 - 1;
+    broken.tm_mday = 14;
+
+    char buffer[32];
+    memset(buffer, 0, sizeof(buffer));
+    size_t written = strftime_l(buffer, sizeof(buffer), "%Y-%m-%d", &broken, loc);
+    assert(written == strlen("2021-03-14"));
+    assert(strcmp(buffer, "2021-03-14") == 0);
+
+    freelocale(loc);
+}
+
+// Tests the per-locale string-to-number conversions.
+static void test_stdlib_l(void)
+{
+    locale_t loc = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+    char *end;
+
+    assert(strtod_l("3.5rest", &end, loc) == 3.5);
+    assert(*end == 'r');
+    assert(strtof_l("1.25", NULL, loc) == 1.25f);
+    assert(strtold_l("0.5", NULL, loc) == (long double)0.5);
+
+    assert(strtol_l("-42stop", &end, 10, loc) == -42L);
+    assert(*end == 's');
+    assert(strtoll_l("9001", NULL, 10, loc) == 9001LL);
+    assert(strtoul_l("100", NULL, 10, loc) == 100UL);
+    assert(strtoull_l("0xff", NULL, 16, loc) == 255ULL);
+
+    freelocale(loc);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests the POSIX xlocale API (locale management plus the narrow `*_l` functions).
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv List of command-line arguments.
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert command-line arguments.
+    assert(argc == 1);
+    assert(argv[0] != NULL);
+    assert(argv[1] == NULL);
+    assert(strcmp(argv[0], "test-c-locale.elf") == 0);
+
+    test_locale_management();
+    test_ctype_l();
+    test_string_l();
+    test_time_l();
+    test_stdlib_l();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -269,6 +269,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-locale"
+program = "./bin/test-c-locale.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -269,6 +269,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-locale"
+program = "./bin/test-c-locale.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Fixes #2798. Implements the **narrow POSIX xlocale API** so libc++ localization can be re-enabled. Nanvix already had `locale_t`, `setlocale`/`localeconv`, and the *wide* `_l` ctype functions, but was missing the locale-management functions, the narrow `*_l` ctype functions, and the `*_l` string/time/stdlib functions. libc++'s localization layer falls back to `bsd_locale_fallbacks.h` (built on `uselocale()` + the `*_l` functions), so it was being built with `-DLIBCXX_ENABLE_LOCALIZATION=OFF` (dropping `<iostream>`, `<locale>`, `<regex>`).

## Design

Single-locale ("C"/POSIX), mirroring the existing wide-`_l` precedent (`libc_wctype/src/locale.rs`): each `*_l` ignores its `locale_t` argument and delegates to its non-`_l` counterpart; the management functions hand out an opaque, **non-null** sentinel handle; `uselocale` swaps a process-global atomic.

## Changes (28 symbols across 5 crates)

| Crate | New file | Symbols |
|---|---|---|
| `libc_locale` | `src/xlocale.rs` | `newlocale`, `duplocale`, `freelocale`, `uselocale` + `LC_*_MASK` / `LC_GLOBAL_LOCALE` macros |
| `libc_ctype` | `src/locale.rs` | 14 narrow `_l` (`isalnum_l`…`isxdigit_l`, `tolower_l`, `toupper_l`); `<ctype.h>` now `#include <locale.h>` |
| `libc_string` | `src/locale.rs` | `strcoll_l`, `strxfrm_l` |
| `libc_time` | `src/locale.rs` | `strftime_l` |
| `libc_stdlib` | `src/locale.rs` | `strtod_l`, `strtof_l`, `strtold_l`, `strtol_l`, `strtoll_l`, `strtoul_l`, `strtoull_l` |

Regenerated `include/{locale,ctype,string,time,stdlib}.h`.

## Tests

- Per-crate unit tests for `_l` delegation and the `uselocale` query/swap round-trip (the latter serialized with a mutex to avoid host parallel-test races, matching `setlocale`'s tests).
- **New POSIX C suite `test-c-locale`** (wired into `Makefile` + both test tomls) exercising locale management plus all 28 `_l` symbols from C.

## Validation
- `make gen-headers-check` passes; all 28 symbols declared in the right headers.
- Per-crate unit tests pass; `make rust-lint-check-guest-rlibs` passes (guest no_std + host std clippy, `-D warnings`).
- The C suite compiles cleanly (`-Wall -Wextra`); `locale.h`/`ctype.h`/`string.h`/`time.h` parse as C++.

## Notes / scope
- **Process-global `uselocale`:** POSIX specifies per-thread state; this uses a process-global atomic (consistent with `setlocale`'s existing global state). Sound while only the C/POSIX locale exists; documented in-code as requiring TLS before genuine multi-locale support.
- **`stdlib.h` and C++:** its `strto*_l` overrides use the bare C99 `restrict` keyword (matching the existing `strtod` etc.). `stdlib.h` is only C++-safe once #2795 lands — consistent with the recommended landing order (A=#2795 before D=#2798).
- **Follow-ups (out of this issue's 28-symbol scope):** additional `_l` variants such as `wcscoll_l`/`wcsxfrm_l` (wide; tied to wide-character support, #2796), `nl_langinfo_l`, `strcasecmp_l`/`strncasecmp_l`, and `strerror_l` may be added if libc++'s enabled feature set surfaces them.

## Unblocks
Once merged (after #2795), `-DLIBCXX_ENABLE_LOCALIZATION=OFF` can be removed from the `nanvix/llvm-project` bootstrap, restoring `<iostream>`, `<locale>`, `<regex>`, and locale-aware `<format>`/`<chrono>`.
