### PR TITLE
[libc_unistd] Honor _PC_* pathconf selectors

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -39,6 +39,7 @@ ALL_POSIX_TESTS := \
 	test-c-misc \
 	test-c-network \
 	test-c-noop \
+	test-c-pathconf \
 	test-c-regex \
 	test-c-setjmp \
 	test-c-stdio \

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -62,6 +62,28 @@ extern "C" {
 #define _SC_PHYS_PAGES 11 /**< Total number of physical pages. */
 #define _SC_AVPHYS_PAGES 12 /**< Number of available physical pages. */
 
+/* pathconf()/fpathconf() name selectors. */
+#define _PC_LINK_MAX 0 /**< Maximum number of links to a file. */
+#define _PC_MAX_CANON 1 /**< Maximum bytes in a terminal canonical input line. */
+#define _PC_MAX_INPUT 2 /**< Maximum bytes in a terminal input queue. */
+#define _PC_NAME_MAX 3 /**< Maximum length of a filename component. */
+#define _PC_PATH_MAX 4 /**< Maximum length of a relative pathname. */
+#define _PC_PIPE_BUF 5 /**< Maximum atomic write size to a pipe. */
+#define _PC_CHOWN_RESTRICTED 6 /**< Whether chown() is restricted. */
+#define _PC_NO_TRUNC 7 /**< Whether over-long pathname components error. */
+#define _PC_VDISABLE 8 /**< Terminal special-character disable value. */
+#define _PC_SYNC_IO 9 /**< Whether synchronized I/O is supported. */
+#define _PC_ASYNC_IO 10 /**< Whether asynchronous I/O is supported. */
+#define _PC_PRIO_IO 11 /**< Whether prioritized I/O is supported. */
+#define _PC_FILESIZEBITS 12 /**< Number of bits to represent a file's size. */
+#define _PC_ALLOC_SIZE_MIN 13 /**< Minimum allocation unit of a file. */
+#define _PC_REC_INCR_XFER_SIZE 14 /**< Recommended transfer size increment. */
+#define _PC_REC_MAX_XFER_SIZE 15 /**< Maximum recommended transfer size. */
+#define _PC_REC_MIN_XFER_SIZE 16 /**< Minimum recommended transfer size. */
+#define _PC_REC_XFER_ALIGN 17 /**< Recommended transfer buffer alignment. */
+#define _PC_SYMLINK_MAX 18 /**< Maximum length of a symbolic-link target. */
+#define _PC_2_SYMLINKS 19 /**< Whether the file system supports symbolic links. */
+
 /*==================================================================================================
  * File and Process Operations
  *==================================================================================================*/

--- a/src/libs/libc_unistd/src/bindings.rs
+++ b/src/libs/libc_unistd/src/bindings.rs
@@ -5,14 +5,94 @@
 // Imports
 //==================================================================================================
 
-use ::sys::error::ErrorCode;
-use ::sysapi::ffi::{
-    c_char,
-    c_int,
-    c_long,
+use ::sysapi::{
+    errno::{
+        EBADF,
+        EFAULT,
+        EINVAL,
+    },
+    ffi::{
+        c_char,
+        c_int,
+        c_long,
+    },
+    limits::{
+        NAME_MAX,
+        PATH_MAX,
+    },
 };
 use ::syscall::errno::__errno_location;
 use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// pathconf()/fpathconf() name selectors. These MUST mirror the `_PC_*` `#define`s emitted into
+// <unistd.h> by src/libs/sysapi/headers/unistd.toml.
+const _PC_LINK_MAX: c_int = 0;
+const _PC_MAX_CANON: c_int = 1;
+const _PC_MAX_INPUT: c_int = 2;
+const _PC_NAME_MAX: c_int = 3;
+const _PC_PATH_MAX: c_int = 4;
+const _PC_PIPE_BUF: c_int = 5;
+const _PC_CHOWN_RESTRICTED: c_int = 6;
+const _PC_NO_TRUNC: c_int = 7;
+const _PC_VDISABLE: c_int = 8;
+const _PC_SYNC_IO: c_int = 9;
+const _PC_ASYNC_IO: c_int = 10;
+const _PC_PRIO_IO: c_int = 11;
+const _PC_FILESIZEBITS: c_int = 12;
+const _PC_ALLOC_SIZE_MIN: c_int = 13;
+const _PC_REC_INCR_XFER_SIZE: c_int = 14;
+const _PC_REC_MAX_XFER_SIZE: c_int = 15;
+const _PC_REC_MIN_XFER_SIZE: c_int = 16;
+const _PC_REC_XFER_ALIGN: c_int = 17;
+const _PC_SYMLINK_MAX: c_int = 18;
+const _PC_2_SYMLINKS: c_int = 19;
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Shared limit lookup for `pathconf()`/`fpathconf()`. The values are system-global on Nanvix today
+/// (there are no per-file-system overrides yet), so the path/descriptor argument is unused.
+///
+/// Returns the configured limit for a known selector, `-1` **without modifying `errno`** for an
+/// option that has no determinate limit (so callers take the "no limit -> fall back" branch), and
+/// `-1` with `errno = EINVAL` for an unrecognized selector (per POSIX, not `ENOSYS`).
+///
+/// # Safety
+///
+/// Writes to the thread-local `errno` via `__errno_location()` for the unknown-selector case.
+unsafe fn pathconf_value(name: c_int) -> c_long {
+    match name {
+        // Selectors with determinate limits (mirroring <limits.h>).
+        _PC_PATH_MAX | _PC_SYMLINK_MAX => PATH_MAX as c_long, // 1024
+        _PC_NAME_MAX => NAME_MAX as c_long,                   // 255
+        _PC_LINK_MAX => 32767,                                // implementation-defined upper bound
+        _PC_MAX_CANON | _PC_MAX_INPUT => 255,                 // _POSIX_MAX_CANON / _POSIX_MAX_INPUT
+        _PC_PIPE_BUF => 4096,
+        _PC_FILESIZEBITS => 64,
+        _PC_CHOWN_RESTRICTED | _PC_NO_TRUNC | _PC_2_SYMLINKS => 1,
+        _PC_VDISABLE => 0,
+        // Options with no determinate limit: return -1 WITHOUT touching errno so callers (e.g.
+        // libc++ <filesystem>) take the "no limit -> fall back" branch.
+        _PC_SYNC_IO
+        | _PC_ASYNC_IO
+        | _PC_PRIO_IO
+        | _PC_ALLOC_SIZE_MIN
+        | _PC_REC_INCR_XFER_SIZE
+        | _PC_REC_MAX_XFER_SIZE
+        | _PC_REC_MIN_XFER_SIZE
+        | _PC_REC_XFER_ALIGN => -1,
+        // Unrecognized selector: POSIX mandates EINVAL (not ENOSYS).
+        _ => {
+            *__errno_location() = EINVAL;
+            -1
+        },
+    }
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -32,19 +112,15 @@ use ::syslog::trace_libcall;
 ///
 /// # Returns
 ///
-/// On success a non-negative limit value, or `-1` (with `errno` unchanged) when the
-/// queried option has no determinate limit. On failure returns `-1` and sets `errno`.
+/// On success the configured limit for `name`; `-1` (with `errno` unchanged) when the queried
+/// option has no determinate limit; `-1` with `errno = EFAULT` when `path` is NULL; or `-1` with
+/// `errno = EINVAL` for an unrecognized selector.
 ///
 /// # Notes
 ///
-/// This is a dummy implementation that always returns `-1` with `errno = ENOSYS`,
-/// matching the convention used by the other "not implemented" stubs in this module.
-/// Callers (notably libstdc++'s `std::filesystem`) treat `-1` as "no limit known" and
-/// fall back to compile-time defaults such as `PATH_MAX`, so this stub is sufficient
-/// to satisfy the libstdc++ link without changing behaviour. A future implementation
-/// should return real limits for the selectors it knows about (e.g. `_PC_PATH_MAX`,
-/// `_PC_NAME_MAX`, `_PC_LINK_MAX`), and only set `errno = EINVAL` for genuinely
-/// unrecognised selectors per the POSIX contract.
+/// The limits are system-global on Nanvix today, so `path` is not consulted beyond a NULL check; it
+/// is only required to be a valid pointer. A future implementation could consult the VFS for
+/// per-file-system limits.
 ///
 /// # Safety
 ///
@@ -54,10 +130,12 @@ use ::syslog::trace_libcall;
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn pathconf(_path: *const c_char, _name: c_int) -> c_long {
-    ::syslog::debug!("pathconf(): not implemented");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
-    -1
+pub unsafe extern "C" fn pathconf(path: *const c_char, name: c_int) -> c_long {
+    if path.is_null() {
+        *__errno_location() = EFAULT;
+        return -1;
+    }
+    pathconf_value(name)
 }
 
 ///
@@ -74,24 +152,25 @@ pub unsafe extern "C" fn pathconf(_path: *const c_char, _name: c_int) -> c_long 
 ///
 /// # Returns
 ///
-/// On success a non-negative limit value, or `-1` (with `errno` unchanged) when the
-/// queried option has no determinate limit. On failure returns `-1` and sets `errno`.
+/// On success the configured limit for `name`; `-1` (with `errno` unchanged) when the queried
+/// option has no determinate limit; `-1` with `errno = EBADF` when `fd` is invalid; or `-1` with
+/// `errno = EINVAL` for an unrecognized selector.
 ///
 /// # Notes
 ///
-/// This is a dummy implementation that always returns `-1` with `errno = ENOSYS`.
-/// See `pathconf()` for the rationale on why this stub is acceptable for the current
-/// libstdc++ link requirements.
+/// The limits are system-global on Nanvix today, so `fd` is not consulted beyond a validity check.
+/// Behaves identically to `pathconf()` for the same selector.
 ///
 /// # Safety
 ///
-/// This function is safe to call with any integer; passing a descriptor that is not
-/// currently open does not change the (stub) behaviour.
+/// This function is safe to call with any integer; a negative descriptor is rejected with `EBADF`.
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn fpathconf(_fd: c_int, _name: c_int) -> c_long {
-    ::syslog::debug!("fpathconf(): not implemented");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
-    -1
+pub unsafe extern "C" fn fpathconf(fd: c_int, name: c_int) -> c_long {
+    if fd < 0 {
+        *__errno_location() = EBADF;
+        return -1;
+    }
+    pathconf_value(name)
 }

--- a/src/libs/sysapi/headers/unistd.toml
+++ b/src/libs/sysapi/headers/unistd.toml
@@ -51,7 +51,29 @@ text = '''
 #define _SC_NPROCESSORS_CONF 9 /**< Number of configured processors. */
 #define _SC_NPROCESSORS_ONLN 10 /**< Number of online processors. */
 #define _SC_PHYS_PAGES 11 /**< Total number of physical pages. */
-#define _SC_AVPHYS_PAGES 12 /**< Number of available physical pages. */'''
+#define _SC_AVPHYS_PAGES 12 /**< Number of available physical pages. */
+
+/* pathconf()/fpathconf() name selectors. */
+#define _PC_LINK_MAX 0 /**< Maximum number of links to a file. */
+#define _PC_MAX_CANON 1 /**< Maximum bytes in a terminal canonical input line. */
+#define _PC_MAX_INPUT 2 /**< Maximum bytes in a terminal input queue. */
+#define _PC_NAME_MAX 3 /**< Maximum length of a filename component. */
+#define _PC_PATH_MAX 4 /**< Maximum length of a relative pathname. */
+#define _PC_PIPE_BUF 5 /**< Maximum atomic write size to a pipe. */
+#define _PC_CHOWN_RESTRICTED 6 /**< Whether chown() is restricted. */
+#define _PC_NO_TRUNC 7 /**< Whether over-long pathname components error. */
+#define _PC_VDISABLE 8 /**< Terminal special-character disable value. */
+#define _PC_SYNC_IO 9 /**< Whether synchronized I/O is supported. */
+#define _PC_ASYNC_IO 10 /**< Whether asynchronous I/O is supported. */
+#define _PC_PRIO_IO 11 /**< Whether prioritized I/O is supported. */
+#define _PC_FILESIZEBITS 12 /**< Number of bits to represent a file's size. */
+#define _PC_ALLOC_SIZE_MIN 13 /**< Minimum allocation unit of a file. */
+#define _PC_REC_INCR_XFER_SIZE 14 /**< Recommended transfer size increment. */
+#define _PC_REC_MAX_XFER_SIZE 15 /**< Maximum recommended transfer size. */
+#define _PC_REC_MIN_XFER_SIZE 16 /**< Minimum recommended transfer size. */
+#define _PC_REC_XFER_ALIGN 17 /**< Recommended transfer buffer alignment. */
+#define _PC_SYMLINK_MAX 18 /**< Maximum length of a symbolic-link target. */
+#define _PC_2_SYMLINKS 19 /**< Whether the file system supports symbolic links. */'''
 
 [[raw_sections]]
 title = "File and Process Operations"

--- a/src/tests/integration/test-c-pathconf/main.c
+++ b/src/tests/integration/test-c-pathconf/main.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Tests that pathconf() returns the configured limit for selectors with a determinate value, and
+// leaves errno untouched. The values must match <limits.h> (PATH_MAX, NAME_MAX).
+static void test_pathconf_known_limits(void)
+{
+    errno = 0;
+    assert(pathconf("/", _PC_PATH_MAX) == PATH_MAX);
+    assert(pathconf("/", _PC_NAME_MAX) == NAME_MAX);
+    assert(pathconf("/", _PC_SYMLINK_MAX) == PATH_MAX);
+    assert(pathconf("/", _PC_LINK_MAX) == 32767);
+    assert(pathconf("/", _PC_MAX_CANON) == 255);
+    assert(pathconf("/", _PC_MAX_INPUT) == 255);
+    assert(pathconf("/", _PC_PIPE_BUF) == 4096);
+    assert(pathconf("/", _PC_FILESIZEBITS) == 64);
+    assert(pathconf("/", _PC_CHOWN_RESTRICTED) == 1);
+    assert(pathconf("/", _PC_NO_TRUNC) == 1);
+    assert(pathconf("/", _PC_2_SYMLINKS) == 1);
+    assert(pathconf("/", _PC_VDISABLE) == 0);
+    assert(errno == 0);
+}
+
+// Tests that fpathconf() behaves identically to pathconf() (the limits are system-global, so the
+// descriptor is not consulted).
+static void test_fpathconf_matches_pathconf(void)
+{
+    errno = 0;
+    assert(fpathconf(STDOUT_FILENO, _PC_PATH_MAX) == PATH_MAX);
+    assert(fpathconf(STDOUT_FILENO, _PC_NAME_MAX) == NAME_MAX);
+    assert(fpathconf(STDIN_FILENO, _PC_NAME_MAX) == NAME_MAX);
+    assert(errno == 0);
+}
+
+// Tests that selectors with no determinate limit return -1 WITHOUT modifying errno, so callers
+// (e.g. libc++'s <filesystem>) take the "no limit -> fall back" branch rather than reporting an
+// error. A nonzero sentinel is installed in errno first to prove it is left untouched (not merely
+// observed as zero).
+static void test_no_limit_selectors_leave_errno(void)
+{
+    const int no_limit_selectors[] = {
+        _PC_SYNC_IO,
+        _PC_ASYNC_IO,
+        _PC_PRIO_IO,
+        _PC_ALLOC_SIZE_MIN,
+        _PC_REC_INCR_XFER_SIZE,
+        _PC_REC_MAX_XFER_SIZE,
+        _PC_REC_MIN_XFER_SIZE,
+        _PC_REC_XFER_ALIGN,
+    };
+    const int sentinel = 0x5A5A;
+
+    for (size_t i = 0; i < sizeof(no_limit_selectors) / sizeof(no_limit_selectors[0]); i++) {
+        errno = sentinel;
+        assert(pathconf("/", no_limit_selectors[i]) == -1);
+        assert(errno == sentinel);
+
+        errno = sentinel;
+        assert(fpathconf(STDOUT_FILENO, no_limit_selectors[i]) == -1);
+        assert(errno == sentinel);
+    }
+}
+
+// Tests that an unrecognized selector returns -1 and sets errno to EINVAL (per POSIX), not ENOSYS.
+static void test_unknown_selector_sets_einval(void)
+{
+    errno = 0;
+    assert(pathconf("/", 9999) == -1);
+    assert(errno == EINVAL);
+
+    errno = 0;
+    assert(fpathconf(STDOUT_FILENO, -1) == -1);
+    assert(errno == EINVAL);
+}
+
+// Tests that pathconf() rejects a NULL path with -1 and errno = EFAULT (per POSIX, an invalid
+// pointer must not be treated as success).
+static void test_pathconf_null_path_sets_efault(void)
+{
+    errno = 0;
+    assert(pathconf(NULL, _PC_PATH_MAX) == -1);
+    assert(errno == EFAULT);
+}
+
+// Tests that fpathconf() rejects an invalid (negative) descriptor with -1 and errno = EBADF (per
+// POSIX, an invalid file descriptor must not be treated as success).
+static void test_fpathconf_bad_fd_sets_ebadf(void)
+{
+    errno = 0;
+    assert(fpathconf(-1, _PC_PATH_MAX) == -1);
+    assert(errno == EBADF);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests pathconf()/fpathconf() and the `_PC_*` selector constants.
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv List of command-line arguments.
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    // Assert command-line arguments.
+    assert(argc == 1);
+    assert(argv[0] != NULL);
+    assert(argv[1] == NULL);
+    assert(strcmp(argv[0], "test-c-pathconf.elf") == 0);
+
+    test_pathconf_known_limits();
+    test_fpathconf_matches_pathconf();
+    test_no_limit_selectors_leave_errno();
+    test_unknown_selector_sets_einval();
+    test_pathconf_null_path_sets_efault();
+    test_fpathconf_bad_fd_sets_ebadf();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -279,3 +279,10 @@ executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/test-c-pathconf"
+program = "./bin/test-c-pathconf.initrd"
+expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -279,3 +279,10 @@ executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
 expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
+name = "posix/test-c-pathconf"
+program = "./bin/test-c-pathconf.initrd"
+expected_exit_code = 0


### PR DESCRIPTION
## Summary

Fixes #2799. libc++'s `<filesystem>` (`operations.cpp`) failed to compile because the `_PC_*` `pathconf` selector constants were **undefined** in `<unistd.h>`, and `pathconf`/`fpathconf` were unconditional ENOSYS stubs. libc++ probes `pathconf(".", _PC_PATH_MAX)` and only treats a `-1` result as *"no limit → fall back to `PATH_MAX`"* when `errno == 0`; the stub set `errno = ENOSYS`, so libc++ took the `errno != 0` branch and reported a **hard error**.

## Changes

- **`src/libs/sysapi/headers/unistd.toml`**: define the 20 `_PC_*` selectors (values `0..19`) in the raw "Constants" block, mirroring the existing `_SC_*` style (the spec's `content_order` has no `"macros"` token, so the raw-text mechanism is correct). Regenerated `include/unistd.h`.
- **`src/libs/libc_unistd/src/bindings.rs`**: `pathconf`/`fpathconf` now delegate to a shared `pathconf_value(name)` that:
  - returns real limits for known selectors — `_PC_PATH_MAX`/`_PC_SYMLINK_MAX` → `1024`, `_PC_NAME_MAX` → `255` (both matching `<limits.h>`), `_PC_LINK_MAX` → `32767`, `_PC_MAX_CANON`/`_PC_MAX_INPUT` → `255`, `_PC_PIPE_BUF` → `4096`, `_PC_FILESIZEBITS` → `64`, the boolean-ish ones → `1`, `_PC_VDISABLE` → `0`;
  - returns `-1` **without touching `errno`** for options with no determinate limit (so callers fall back);
  - returns `-1` with `errno = EINVAL` (per POSIX, not `ENOSYS`) for unknown selectors.

  The limits are system-global today, so the path/fd argument is unused. The private Rust `_PC_*` constants mirror the `unistd.toml` `#define` values.

## Tests

- **New POSIX C suite `test-c-pathconf`** (wired into `Makefile` + both test tomls): asserts the known-limit values (incl. `== PATH_MAX`/`== NAME_MAX` from `<limits.h>`), that `fpathconf` matches `pathconf`, that **all** no-limit selectors return `-1` with `errno` unchanged (verified against a nonzero sentinel, not just `== 0`), and that an unknown selector returns `-1` with `errno == EINVAL`.

## Validation
- `make gen-headers-check` passes; `grep _PC_PATH_MAX include/unistd.h` etc. succeed.
- `make rust-lint-check-guest-rlibs` passes (`libc_unistd` is guest-only — it uses `__errno_location` — so the C suite is the runtime validation). The C suite compiles cleanly with `-Wall -Wextra`; rustfmt + codespell clean.
- Pre-commit hook passed all three deployment configurations.

## Notes / scope
- The `_PC_*` numeric values are implementation-defined; the Rust selector table mirrors the `unistd.toml` `#define`s.
- Follow-ups (out of this issue's scope): `_PC_TIMESTAMP_RESOLUTION` (POSIX.1-2017, not needed by libc++ `<filesystem>`); a real `statvfs`/`fstatvfs` implementation; and per-file-system limits via the VFS.

## Unblocks (ordering)
This is the primary low-risk libc fix. Re-enabling libc++ `<filesystem>` (`-DLIBCXX_ENABLE_FILESYSTEM=ON`) must happen **after** localization (#2798), because `copy_file`'s `<fstream>` fallback needs iostreams.
