### PR TITLE
[syscall] Run Dependency Destructors at Exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,6 +402,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-diamond \
 	test-c-dlfcn-global \
 	test-c-dlfcn-init-runpath \
+	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \
 	test-c-dlfcn-pie \
 	test-c-dlfcn-selflink \

--- a/Makefile
+++ b/Makefile
@@ -380,52 +380,10 @@ include build/make/lists/guest-daemons.mk
 include build/make/lists/guest-benchmarks.mk
 include build/make/lists/guest-applications.mk
 include build/make/lists/guest-tests.mk
+include build/make/lists/guest-posix-tests.mk
 
 ALL_GUEST_BINARIES := $(ALL_GUEST_DAEMONS) $(ALL_GUEST_BENCHMARKS) $(ALL_GUEST_APPLICATIONS)
 ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
-
-# Ported POSIX C test suites, compiled against the bundled libc by
-# build/make/posix-tests.mk and booted by `run-posix-tests`. Suites live under
-# src/tests/integration/<suite>/, except memory-c which lives under
-# src/tests/stress/<suite>/ (see POSIX_TEST_STRESS_* in posix-tests.mk).
-# `common/` holds shared crt0 scaffolding and is not a suite of its own. The
-# guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
-# (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
-# is gated on TARGET=x86 accordingly.
-#
-# One entry per line (with `\` continuations) so that adding a suite touches a
-# single line, minimizing merge conflicts between branches that each add a suite.
-ALL_POSIX_TESTS := \
-	test-c-bindings \
-	test-c-ctor \
-	test-c-dlfcn \
-	test-c-dlfcn-diamond \
-	test-c-dlfcn-global \
-	test-c-dlfcn-init-runpath \
-	test-c-dlfcn-initfini \
-	test-c-dlfcn-needed \
-	test-c-dlfcn-pie \
-	test-c-dlfcn-selflink \
-	test-c-dlfcn-startup \
-	test-c-dlfcn-weak \
-	test-c-echo \
-	test-c-execvp \
-	test-c-file \
-	test-c-fork-pid \
-	test-c-fork-pthread \
-	test-c-glob \
-	test-c-hello \
-	test-c-inet \
-	test-c-libgen \
-	test-c-memory \
-	test-c-misc \
-	test-c-network \
-	test-c-noop \
-	test-c-regex \
-	test-c-setjmp \
-	test-c-stdio \
-	test-c-termios \
-	test-c-thread
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 

--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -1,0 +1,45 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Ported POSIX C test suites, compiled against the bundled libc by
+# build/make/posix-tests.mk and booted by `run-posix-tests`. Suites live under
+# src/tests/integration/<suite>/, except memory-c which lives under
+# src/tests/stress/<suite>/ (see POSIX_TEST_STRESS_* in posix-tests.mk).
+# `common/` holds shared crt0 scaffolding and is not a suite of its own. The
+# guest C toolchain (build/make/guest-c-apps.mk) is pinned to the i686 ABI
+# (-m32 / -melf_i386), so the suites are i686-only; the `run-posix-tests` runner
+# is gated on TARGET=x86 accordingly.
+#
+# One entry per line (with `\` continuations) so that adding a suite touches a
+# single line, minimizing merge conflicts between branches that each add a suite.
+ALL_POSIX_TESTS := \
+	test-c-bindings \
+	test-c-ctor \
+	test-c-dlfcn \
+	test-c-dlfcn-diamond \
+	test-c-dlfcn-global \
+	test-c-dlfcn-init-runpath \
+	test-c-dlfcn-initfini \
+	test-c-dlfcn-needed \
+	test-c-dlfcn-pie \
+	test-c-dlfcn-selflink \
+	test-c-dlfcn-startup \
+	test-c-dlfcn-weak \
+	test-c-echo \
+	test-c-execvp \
+	test-c-file \
+	test-c-fork-pid \
+	test-c-fork-pthread \
+	test-c-glob \
+	test-c-hello \
+	test-c-inet \
+	test-c-libgen \
+	test-c-memory \
+	test-c-misc \
+	test-c-network \
+	test-c-noop \
+	test-c-regex \
+	test-c-setjmp \
+	test-c-stdio \
+	test-c-termios \
+	test-c-thread

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -158,6 +158,22 @@ POSIX_TEST_SELFLINK_DIR := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-selflink/libs
 POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-selflink := $(POSIX_TEST_SELFLINK_DIR)/libprovider.so
 POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-selflink := -L$(POSIX_TEST_SELFLINK_DIR) -lprovider -z now
 
+# dlfcn-initfini-c is the acceptance test for init/fini ordering across a
+# startup-loaded DT_NEEDED dependency: it links the executable PIE
+# + --export-dynamic against a purpose-built libinitfini.so (-linitfini) that the
+# executable references by NO symbol, so the dependency is auto-loaded at startup
+# purely for its `.init_array` constructor (run before main) and `.fini_array`
+# destructor (run at exit by syscall::dlfcn::dlfini_executable), with NO dlopen()
+# call. `--no-as-needed` forces the DT_NEEDED entry even though the executable
+# references none of libinitfini.so's symbols; `-z now` forces eager binding
+# (Nanvix has no lazy PLT resolver). The bare DT_NEEDED name (pinned by the
+# fixture's -soname) is resolved through the loader's default lib/ search path,
+# where the per-suite RAMFS stages libinitfini.so.
+POSIX_TEST_PIE_test-c-dlfcn-initfini := yes
+POSIX_TEST_INITFINI_DIR := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-initfini/libs
+POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-initfini := $(POSIX_TEST_INITFINI_DIR)/libinitfini.so
+POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-initfini := -L$(POSIX_TEST_INITFINI_DIR) --no-as-needed -linitfini -z now
+
 # dlfcn-startup-c is the acceptance test for the startup DT_NEEDED loader (issue
 # #2773): it links the executable PIE against the REAL toolchain-shipped shared
 # libraries libc.so and libm.so (via `-l:libc.so -l:libm.so`) instead of the
@@ -252,6 +268,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini)
 	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
 	$(RM_CMD) $(POSIX_TEST_EXECVP_IMG)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
@@ -260,6 +277,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_INITFINI_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_EXECVP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TESTS_OBJDIR)
@@ -482,11 +500,43 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup): $(LIBRARIES_DIR)/libc.so $(LIBRARI
 	$(CP_CMD) $(LIBRARIES_DIR)/libm.so $(POSIX_TEST_STARTUP_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_STARTUP_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-initfini-c: startup DT_NEEDED constructor/destructor ordering fixture.
+#---------------------------------------------------------------------------------------------------
+#
+# Ships ONE shared library, libinitfini.so, built with the same i686 freestanding
+# toolchain as the fixtures above. It carries a `.init_array` constructor and a
+# `.fini_array` destructor and leaves three symbols UNDEFINED — `g_ctor_ran`,
+# `g_main_ran` (data) and `test_dtor_finish` (function) — which the loader
+# resolves from the main executable's exported global scope at load time (the
+# suite ELF is PIE + --export-dynamic, see POSIX_TEST_PIE_* above). The executable
+# DT_NEEDEDs it but references none of its symbols, so the startup loader
+# auto-loads it for its constructor/destructor side effects alone (no dlopen).
+# An explicit -soname pins the bare DT_NEEDED name regardless of linker. Staged
+# at lib/libinitfini.so, reached through the loader's default lib/ search path.
+POSIX_TEST_INITFINI_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-initfini-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-initfini.img
+
+$(POSIX_TEST_INITFINI_DIR)/libinitfini.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-initfini/libs/initfini.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building test-c-dlfcn-initfini/libinitfini.so (.init_array/.fini_array)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libinitfini.so $@.o -o $@
+
+# Per-suite RAMFS image carrying libinitfini.so under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini): $(POSIX_TEST_INITFINI_DIR)/libinitfini.so \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_INITFINI_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_INITFINI_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_INITFINI_DIR)/libinitfini.so $(POSIX_TEST_INITFINI_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_INITFINI_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \
-	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-init-runpath-c: constructor/destructor + DT_RUNPATH fixtures.

--- a/src/libs/nanvix_libc/src/start.rs
+++ b/src/libs/nanvix_libc/src/start.rs
@@ -252,6 +252,23 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
         run_fini_array(&raw const __fini_array_start, &raw const __fini_array_end);
     }
 
+    // Run the `.fini_array` destructors of the startup-loaded shared-library
+    // dependencies (those auto-loaded by `dllink_executable` above, plus any
+    // promoted to the global scope via `dlopen(RTLD_GLOBAL)`), newest first —
+    // the reverse of the construction order `dllink_executable` established
+    // before `main`. Those dependencies are pinned for the lifetime of the
+    // process, so `dlclose` never drives their destructors; this is the
+    // process-exit counterpart that does. Done after the executable's own
+    // `.fini_array` (the executable was constructed last, so it is destroyed
+    // first) and before `runtime_cleanup` tears down the heap, because a
+    // destructor may still allocate or free. Unlike the executable's own
+    // arrays, this is NOT gated on the `init-array` feature: the dependencies'
+    // constructors ran through `dlopen` regardless of it, so their destructors
+    // must too. A no-op for executables with no shared-library dependencies.
+    unsafe {
+        ::syscall::dlfcn::dlfini_executable();
+    }
+
     // Tear down the runtime.  `argv` / `env` are leaked above (see the
     // comment at their declaration) so no Vec destructors run here
     // that would touch the heap after `runtime_cleanup` releases it.

--- a/src/libs/syscall/src/dlfcn/mod.rs
+++ b/src/libs/syscall/src/dlfcn/mod.rs
@@ -25,6 +25,7 @@ cfg_if::cfg_if! {
         pub use syscall::dladdr;
         pub use syscall::dlinit;
         pub use syscall::dllink_executable;
+        pub use syscall::dlfini_executable;
     }
 }
 

--- a/src/libs/syscall/src/dlfcn/syscall/exe_link.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/exe_link.rs
@@ -182,6 +182,44 @@ pub unsafe fn dllink_executable() -> Result<(), Error> {
     Ok(())
 }
 
+///
+/// # Description
+///
+/// Runs the `.fini_array` destructors of the executable's startup-loaded
+/// shared-library dependencies, in the reverse of their load order. This is the
+/// process-exit counterpart of [`dllink_executable`]: that routine loads the
+/// executable's `DT_NEEDED` dependencies into the global scope and runs their
+/// `.preinit_array` / `.init_array` constructors (via `dlopen`) before `main`;
+/// this runs their `.fini_array` destructors after `main` returns.
+///
+/// The startup dependencies are loaded with `RTLD_GLOBAL` and are therefore
+/// pinned for the lifetime of the process — `dlclose` never unloads them — so
+/// their destructors are not driven by the normal `dlclose` teardown path.
+/// This routine drives them at process exit instead, newest dependency first,
+/// as required by the System V gABI.
+///
+/// The walk covers every library currently in the global scope (the startup
+/// `DT_NEEDED` dependencies plus anything later promoted with
+/// `dlopen(RTLD_GLOBAL)`); libraries loaded `RTLD_LOCAL` and already torn down
+/// through `dlclose` are unaffected.
+///
+/// # Returns
+///
+/// Nothing. Destructors that panic propagate as usual; a library with no
+/// `.fini_array` is skipped.
+///
+/// # Safety
+///
+/// Must be called once, on the main executable's own thread of control, after
+/// `main` (and the executable's own `.fini_array`) has returned and while the
+/// heap is still up — a destructor may allocate or free. The destructors are
+/// the loaded libraries' own trusted teardown routines. Repeated calls are a
+/// no-op (guarded by a `Once`).
+///
+pub unsafe fn dlfini_executable() {
+    super::run_global_destructors();
+}
+
 //==================================================================================================
 // Private Functions
 //==================================================================================================

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -82,6 +82,9 @@ static LIBRARY_SEARCH_PATHS: Lazy<Mutex<Vec<String>>> =
 /// Ensures `dlinit` runs at most once.
 static DLINIT_ONCE: Once = Once::new();
 
+/// Ensures the global-scope `.fini_array` destructors run at most once.
+static GLOBAL_FINI_ONCE: Once = Once::new();
+
 /// Resolves a library filename to a canonical path.
 ///
 /// If `filename` contains a path separator (`/`), it is treated as an explicit
@@ -375,6 +378,59 @@ pub(super) fn register_library_in_global_scope(lib_arc: &Arc<Mutex<DynamicLibrar
     pinned.push(lib_arc.clone());
 }
 
+/// Runs the `.fini_array` destructors of every shared library that was loaded
+/// into the global scope (`RTLD_GLOBAL`) in the reverse of their load order.
+///
+/// This is the process-exit counterpart of the `.init_array` constructors that
+/// [`dlopen`] runs when a library is loaded. The startup `DT_NEEDED` loader
+/// ([`dllink_executable`](exe_link::dllink_executable)) loads the executable's
+/// dependencies with `RTLD_GLOBAL`, so each one is pinned in
+/// [`GLOBAL_PINNED_LIBRARIES`] in load order and its constructors run before
+/// `main`. Those pinned libraries are never unloaded by `dlclose` (the extra
+/// pin reference keeps their reference count above the unload threshold), so
+/// their destructors would otherwise never run. This routine closes that gap
+/// by invoking them at process teardown, newest-loaded first — the reverse of
+/// construction order, as required by the System V gABI.
+///
+/// Idempotent: a [`Once`] guard ensures the destructors run at most once even
+/// if this is called more than once (e.g. from multiple exit paths).
+///
+/// # Locking
+///
+/// The pinned-library list is snapshotted under its lock and the lock is
+/// released before any destructor runs, so a destructor may legally re-enter
+/// the loader (`dlsym`/`dlopen`/`dlclose`) without self-deadlocking. The
+/// snapshot's `Arc`s keep every library — and therefore its mapped segments —
+/// alive for the duration of the walk.
+pub(super) fn run_global_destructors() {
+    GLOBAL_FINI_ONCE.call_once(|| {
+        // Snapshot the pinned libraries in reverse load order, then release the
+        // lock before invoking any destructor.
+        let libraries: Vec<Arc<Mutex<DynamicLibrary>>> = {
+            let pinned: spin::MutexGuard<'_, Vec<Arc<Mutex<DynamicLibrary>>>> =
+                GLOBAL_PINNED_LIBRARIES.lock();
+            pinned.iter().rev().cloned().collect()
+        };
+
+        for lib_arc in libraries.iter() {
+            // Snapshot the destructor descriptor and library name under a short
+            // per-library lock, then drop the lock before invoking destructors
+            // so a destructor that re-enters the loader cannot deadlock.
+            let (descriptor, name): (Option<(usize, usize)>, String) = {
+                let lib: spin::MutexGuard<'_, DynamicLibrary> = lib_arc.lock();
+                (lib.fini_array_descriptor(), String::from(lib.name()))
+            };
+            // SAFETY: `descriptor` was produced under the per-library lock for a
+            // library still held alive by `libraries`'s `Arc`; pinned libraries
+            // are never unloaded, so its segments remain mapped; and no dlfcn
+            // locks are held across this call.
+            unsafe {
+                DynamicLibrary::invoke_fini_array(descriptor, &name);
+            }
+        }
+    });
+}
+
 //==================================================================================================
 // Exports
 //==================================================================================================
@@ -383,4 +439,7 @@ pub use dladdr::dladdr;
 pub use dlclose::dlclose;
 pub use dlopen::dlopen;
 pub use dlsym::dlsym;
-pub use exe_link::dllink_executable;
+pub use exe_link::{
+    dlfini_executable,
+    dllink_executable,
+};

--- a/src/tests/integration/test-c-dlfcn-initfini/libs/initfini.c
+++ b/src/tests/integration/test-c-dlfcn-initfini/libs/initfini.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libinitfini.so - constructor/destructor witness for the startup DT_NEEDED
+ * init/fini ordering test.
+ *
+ * The executable carries a DT_NEEDED entry on this library but references none
+ * of its symbols, so the startup loader (syscall::dlfcn::dllink_executable)
+ * auto-loads it purely for its `.init_array` / `.fini_array` side effects, with
+ * NO dlopen() call. All three symbols referenced below are UNDEFINED here and
+ * resolved from the executable's exported global scope at load time (the
+ * executable is linked --export-dynamic), exactly like
+ * test-c-dlfcn-init-runpath's libctor.so resolves `g_dtor_ran`:
+ *
+ *   - `g_ctor_ran`     : data witness the constructor sets before main().
+ *   - `g_main_ran`     : data witness main() sets, read by the destructor to
+ *                        confirm it runs AFTER main().
+ *   - `test_dtor_finish`: executable-side helper the destructor calls to make
+ *                        destructor-at-exit observable through the exit code.
+ */
+
+/* Witness sentinels. Must match the executable's main.c. */
+#define CTOR_SENTINEL 0xC70A
+#define MAIN_SENTINEL 0x3A14
+
+/* Witnesses owned by the executable, resolved from the loader's global scope. */
+extern volatile int g_ctor_ran;
+extern volatile int g_main_ran;
+
+/* Executable-side exit helper; `ok` selects the process exit code. */
+extern void test_dtor_finish(int ok);
+
+/*
+ * Constructor: must run before main(). Records the sentinel so main() can
+ * confirm the dependency's `.init_array` ran first.
+ */
+static void __attribute__((constructor)) initfini_ctor(void)
+{
+    g_ctor_ran = CTOR_SENTINEL;
+}
+
+/*
+ * Destructor: must run at process exit, after main() returned. Validates the
+ * full ctor -> main -> dtor ordering and hands the verdict to the executable's
+ * exit helper. Reaching here at all proves the dependency's `.fini_array` ran
+ * on exit; the witness checks additionally pin down the ordering.
+ */
+static void __attribute__((destructor)) initfini_dtor(void)
+{
+    int ordered = (g_ctor_ran == CTOR_SENTINEL) && (g_main_ran == MAIN_SENTINEL);
+    test_dtor_finish(ordered);
+}

--- a/src/tests/integration/test-c-dlfcn-initfini/main.c
+++ b/src/tests/integration/test-c-dlfcn-initfini/main.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-initfini-c: Validate init/fini ordering across a startup-loaded
+ * DT_NEEDED dependency.
+ *
+ * The executable is linked PIE + --export-dynamic against libinitfini.so
+ * (-linitfini), so the static linker records a DT_NEEDED entry on it. NO
+ * dlopen() is called: at process startup syscall::dlfcn::dllink_executable()
+ * auto-loads libinitfini.so into the global scope and runs its `.init_array`
+ * constructor BEFORE main(); at process exit __nanvix_libc_start_main() runs
+ * its `.fini_array` destructor (via syscall::dlfcn::dlfini_executable()), the
+ * reverse direction this suite exercises and that the other dlfcn suites do
+ * not cover for the startup path.
+ *
+ * libinitfini.so is a "pure" side-effect dependency: the executable references
+ * none of its symbols. Instead the fixture reaches back into this executable's
+ * exported globals/helper (resolved from the loader's global scope, the same
+ * mechanism as test-c-dlfcn-init-runpath's g_dtor_ran):
+ *
+ *   - its constructor writes CTOR_SENTINEL into `g_ctor_ran`, and
+ *   - its destructor calls `test_dtor_finish()` (below) to decide the process
+ *     exit code.
+ *
+ * Pass/fail is the guest exit code (the harness discards stdout in standalone
+ * mode). The flow makes BOTH halves of the ordering observable through it:
+ *
+ *   1. main() fails fast with _exit(1) if the constructor did not run before
+ *      it (g_ctor_ran unset).
+ *   2. Otherwise main() records MAIN_SENTINEL in `g_main_ran` and returns a
+ *      non-zero sentinel (EXIT_DTOR_DID_NOT_RUN). The fixture's destructor must
+ *      OVERRIDE that sentinel with _exit(0) at exit. If the destructor never
+ *      runs (init/fini ordering across the dependency not implemented), the
+ *      sentinel propagates and the suite fails.
+ *
+ * So the suite returns 0 only when the constructor ran before main AND the
+ * destructor ran at exit, in that order.
+ */
+
+#include <unistd.h>
+
+/* Witness sentinels. Duplicated in libs/initfini.c — keep the two in sync. */
+#define CTOR_SENTINEL 0xC70A
+#define MAIN_SENTINEL 0x3A14
+
+/* Exit codes propagated to the harness (only reached when the destructor did
+ * NOT override the result with _exit(0)). */
+#define EXIT_CTOR_DID_NOT_RUN 1
+#define EXIT_DTOR_DID_NOT_RUN 42
+
+/*
+ * Witnesses owned by the executable and exported via --export-dynamic so the
+ * DT_NEEDED fixture can resolve and update them from the loader's global scope.
+ * `volatile` keeps the optimizer from assuming their values across the
+ * cross-module writes performed by the fixture's constructor and by main().
+ */
+volatile int g_ctor_ran = 0;
+volatile int g_main_ran = 0;
+
+/*
+ * Exit helper exported to the fixture's destructor. Centralizing the _exit()
+ * here keeps the fixture from having to resolve libc's _exit from the global
+ * scope: `test_dtor_finish` is defined in the executable's own translation
+ * unit, so --export-dynamic is guaranteed to place it in .dynsym, and the
+ * _exit it references is pulled into the executable.
+ *
+ * `ok` is non-zero when the destructor observed a correctly ordered
+ * ctor -> main -> dtor sequence. _exit() makes the chosen code the authoritative
+ * process exit status, overriding main()'s EXIT_DTOR_DID_NOT_RUN sentinel.
+ */
+void test_dtor_finish(int ok)
+{
+    _exit(ok ? 0 : 3);
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* The DT_NEEDED fixture's constructor must have run before main(). */
+    if (g_ctor_ran != CTOR_SENTINEL) {
+        _exit(EXIT_CTOR_DID_NOT_RUN);
+    }
+
+    /* Record that main() ran, so the destructor can confirm it runs AFTER. */
+    g_main_ran = MAIN_SENTINEL;
+
+    /*
+     * Return a non-zero sentinel. The fixture's destructor must override it
+     * with test_dtor_finish(1) -> _exit(0) at exit; if it never runs, this
+     * sentinel is the process exit code and the suite fails.
+     */
+    return EXIT_DTOR_DID_NOT_RUN;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -90,6 +90,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-initfini"
+program = "./bin/test-c-dlfcn-initfini.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-initfini.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-needed"
 program = "./bin/test-c-dlfcn-needed.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-needed.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -90,6 +90,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-initfini"
+program = "./bin/test-c-dlfcn-initfini.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-initfini.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-needed"
 program = "./bin/test-c-dlfcn-needed.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-needed.img"


### PR DESCRIPTION
## Summary

Completes init/fini ordering across startup-loaded `DT_NEEDED` dependencies, as required by the System V gABI. Dependency constructors already ran before `main()` via the startup loader's `dlopen` path, but pinned `RTLD_GLOBAL` libraries were never `dlclose`'d, so their `.fini_array` destructors never ran. This PR runs those destructors at process exit and adds an acceptance suite covering the full ordering.

## Changes

- **`[syscall] E: Run dependency destructors at exit`** — Adds `syscall::dlfcn::run_global_destructors()` (exposed as `dlfini_executable()`), a `Once`-guarded walk that invokes each pinned global library's `.fini_array` in reverse load order. `nanvix_libc` start calls it after `main()` and the executable's own `.fini_array`, but before `runtime_cleanup()` tears down the heap.
- **`[tests] E: Add dlfcn init/fini ordering suite`** — Adds the `test-c-dlfcn-initfini` suite: a PIE executable auto-loads a purpose-built `libinitfini.so` purely for its constructor/destructor (referenced by no symbol). Pass/fail is the guest exit code: 0 only when the constructor ran before `main` AND the destructor ran at exit.

## Related

- Part of #2774
- Closes #2774