### PR TITLE
[kernel] Flush Klog in Single Block Transfer

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -47,7 +47,7 @@ default = ["microvm"]
 # Machine Types
 microvm = [
     "arch/microvm",
-    "putb",
+    "puts",
     "stdio",
     "pit",
     "dep:config",

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -251,8 +251,77 @@ pub(super) unsafe fn wait_for_interrupt() {
 /// - It assumes that the standard output device was properly initialized.
 /// - It does not prevent concurrent access to the standard output device.
 ///
+#[cfg(feature = "putb")]
 pub unsafe fn putb(b: u8) {
     ::arch::io::out8(::config::microvm::DEFAULT_STDOUT_PORT, b);
+}
+
+///
+/// # Description
+///
+/// Writes the string `s` to the platform's standard output device in a single block transfer.
+///
+/// The kernel log buffer flushes through this path. Instead of emitting one `out8` per byte on
+/// [`DEFAULT_STDOUT_PORT`](::config::microvm::DEFAULT_STDOUT_PORT) — which traps once per byte on a
+/// virtual machine — it builds a [`VmBusMessage`] envelope describing the buffer and writes the
+/// envelope address with a single `out32` to
+/// [`DEFAULT_KLOG_PORT`](::config::microvm::DEFAULT_KLOG_PORT). The host then reads the whole buffer
+/// from guest memory in one shot, so a full `KlogBuffer` flush costs one VM exit rather than one per
+/// byte.
+///
+/// # Parameters
+///
+/// - `s`: String to write.
+///
+/// # Safety
+///
+/// This function is unsafe for multiple reasons:
+/// - It assumes that the standard output device is present.
+/// - It assumes that the standard output device was properly initialized.
+/// - It does not prevent concurrent access to the standard output device.
+///
+#[cfg(feature = "puts")]
+pub unsafe fn puts(s: &str) {
+    use ::core::hint;
+    use ::sys::{
+        ipc::{
+            VmBusMessage,
+            VmBusMessageKind,
+        },
+        mm::{
+            Address,
+            VirtualAddress,
+        },
+    };
+
+    // Nothing to do for an empty flush.
+    if s.is_empty() {
+        return;
+    }
+
+    // Resolve the guest virtual address of the buffer. On the 32-bit kernel this never fails;
+    // drop the output on the (unreachable) error rather than making the log path fallible.
+    let buffer_addr: u32 =
+        match VirtualAddress::try_from_ptr(s.as_ptr(), "klog buffer address exceeds u32") {
+            Ok(addr) => addr.into_raw_value() as u32,
+            Err(_) => return,
+        };
+
+    // Build an envelope describing the buffer. The dedicated `DEFAULT_KLOG_PORT` plus the
+    // `KlogBlock` kind let the host validate that this is a raw console-block transfer rather than
+    // an application IKC message.
+    let envelope: VmBusMessage =
+        VmBusMessage::new(s.len() as u32, VmBusMessageKind::KlogBlock, buffer_addr);
+
+    crate::PERF_KLOG_BLOCK_WRITES.fetch_add(1, ::core::sync::atomic::Ordering::Relaxed);
+    crate::PERF_KLOG_BYTES.fetch_add(s.len(), ::core::sync::atomic::Ordering::Relaxed);
+
+    // NOTE: we assume that page is tagged as writethrough-enabled and cache-disabled.
+    #[allow(clippy::unit_arg)]
+    hint::black_box(::arch::io::out32(
+        ::config::microvm::DEFAULT_KLOG_PORT,
+        &envelope as *const VmBusMessage as u32,
+    ));
 }
 
 ///

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -188,6 +188,14 @@ static PERF_IKC_MESSAGES_SENT: AtomicUsize = AtomicUsize::new(0);
 /// Number of IKC messages received.
 static PERF_IKC_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
 
+/// Number of block kernel-log flushes emitted via `DEFAULT_KLOG_PORT` (one VM exit each).
+static PERF_KLOG_BLOCK_WRITES: AtomicUsize = AtomicUsize::new(0);
+
+/// Total number of kernel-log bytes flushed to the host console. Under the legacy per-byte path
+/// this equals the number of VM exits; with block flushing it is amortized across
+/// [`PERF_KLOG_BLOCK_WRITES`] exits.
+static PERF_KLOG_BYTES: AtomicUsize = AtomicUsize::new(0);
+
 /// Whether the guest is entitled to take a VM snapshot.
 /// Set to `true` during boot when the `snapshot` kernel option is present.
 /// Consumed (set to `false`) on the first successful snapshot request.
@@ -642,6 +650,14 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     info!("- No. Times VMBus Write Was Called: {:?}", PERF_VMBUS_WRITE.load(Ordering::Relaxed));
     info!("- No. IKC Messages Sent: {:?}", PERF_IKC_MESSAGES_SENT.load(Ordering::Relaxed));
     info!("- No. IKC Messages Received: {:?}", PERF_IKC_MESSAGES_RECEIVED.load(Ordering::Relaxed));
+    info!(
+        "- No. Klog Block Writes (out32 exits): {:?}",
+        PERF_KLOG_BLOCK_WRITES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Klog Bytes Flushed (== legacy per-byte exits): {:?}",
+        PERF_KLOG_BYTES.load(Ordering::Relaxed)
+    );
 
     trace!("the system will shutdown now!");
     kernel_magic_string(status);

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -281,6 +281,12 @@ pub mod microvm {
     /// I/O port that is connected to the standard input of the virtual machine.
     pub const DEFAULT_STDIN_PORT: u16 = 0xea;
 
+    /// I/O port used by the kernel to flush its log buffer to the host console in a single block
+    /// transfer (Dword width). The guest writes the address of a [`VmBusMessage`] envelope
+    /// describing the buffer, so a whole `KlogBuffer` flush costs one VM exit instead of one exit
+    /// per byte on [`DEFAULT_STDOUT_PORT`].
+    pub const DEFAULT_KLOG_PORT: u16 = 0xeb;
+
     /// Timer period in microseconds, derived from the kernel timer frequency.
     pub const TIMER_PERIOD_US: u64 =
         (crate::constants::MICROSECONDS_PER_SECOND as u64) / (crate::kernel::TIMER_FREQ as u64);

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -322,6 +322,10 @@ pub enum VmBusMessageKind {
     Ikc = 1,
     /// Guest scatter/gather bulk transfer descriptor.
     GuestSgBulk = 2,
+    /// Kernel-log block. Carries a contiguous run of console bytes flushed by the kernel log
+    /// buffer in a single transfer (delivered on `DEFAULT_KLOG_PORT`), so a whole buffer flush
+    /// costs one VM exit instead of one per byte.
+    KlogBlock = 3,
 }
 
 impl TryFrom<u64> for VmBusMessageKind {
@@ -334,6 +338,7 @@ impl TryFrom<u64> for VmBusMessageKind {
             value if value == Self::LegacyBulk as u64 => Ok(Self::LegacyBulk),
             value if value == Self::Ikc as u64 => Ok(Self::Ikc),
             value if value == Self::GuestSgBulk as u64 => Ok(Self::GuestSgBulk),
+            value if value == Self::KlogBlock as u64 => Ok(Self::KlogBlock),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid vmbus message kind")),
         }
     }

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -1291,6 +1291,16 @@ fn output_fn(
                     },
                 }
             },
+            VmBusMessageKind::KlogBlock => {
+                // Kernel-log blocks are delivered on `DEFAULT_KLOG_PORT` and handled by the console
+                // path, never the application stdout path. Receiving one here means a guest or port
+                // mix-up, so fail loudly rather than misrouting kernel log bytes into application
+                // output.
+                let reason: String =
+                    "unexpected KlogBlock envelope on the application stdout port".to_string();
+                error!("output(): {reason}");
+                anyhow::bail!(reason);
+            },
         }
 
         Ok(())

--- a/src/uservm/src/vmm/microvm/emulator.rs
+++ b/src/uservm/src/vmm/microvm/emulator.rs
@@ -40,7 +40,10 @@ use ::std::{
     io::Write,
     sync::Arc,
 };
-use ::sys::ipc::VmBusMessage;
+use ::sys::ipc::{
+    VmBusMessage,
+    VmBusMessageKind,
+};
 use ::tokio::sync::Mutex;
 
 //==================================================================================================
@@ -245,6 +248,34 @@ impl Emulator {
                         width.into(),
                     )?;
                 },
+                // Block kernel-log flush. The guest writes the address of a `VmBusMessage`
+                // envelope describing its whole log buffer, so the host drains the buffer to the
+                // console sink in a single `write_all`. This collapses what used to be one VM exit
+                // per logged byte (per-byte `out8` on `DEFAULT_STDOUT_PORT`) into a single exit per
+                // buffer flush -- the source-level cure for the debug/trace large-image slowness.
+                ::config::microvm::DEFAULT_KLOG_PORT => {
+                    if *width != PmioWidth::Dword {
+                        warn!("handle_pmio_access(): invalid klog write size (size={width:?})");
+                    } else {
+                        let envelope: VmBusMessage = self.read_envelope(*data)?;
+                        // The port is dedicated to kernel-log blocks; reject anything else rather
+                        // than silently treating a stray envelope as console output.
+                        if matches!(envelope.kind(), Ok(VmBusMessageKind::KlogBlock)) {
+                            let bytes: Vec<u8> = read_console_block(&envelope, |addr, buf| {
+                                self.vmem.blocking_lock().read_bytes(addr, buf)
+                            })?;
+                            if !bytes.is_empty() {
+                                self.stderr_fn.write_all(&bytes)?;
+                            }
+                        } else {
+                            warn!(
+                                "handle_pmio_access(): unexpected envelope kind on klog port \
+                                 (kind={:?}), dropping",
+                                envelope.kind()
+                            );
+                        }
+                    }
+                },
                 // Write to the virtual machine monitor port.
                 ::config::microvm::DEFAULT_VMM_PORT => match (*data >> 16) as u16 {
                     ::config::microvm::DEFAULT_VMM_SHUTDOWN_CMD => {
@@ -321,5 +352,127 @@ impl Emulator {
         }
 
         Ok(None)
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Decodes a kernel-log block envelope into the bytes that should be forwarded to the console sink.
+///
+/// The declared length is clamped to the guest's kernel-log buffer size
+/// ([`::config::kernel::KLOG_BUFFER_SIZE`]) so a guest-provided size can never drive an unbounded
+/// host allocation; any excess is dropped (the console path is best-effort). The payload itself is
+/// read through `read_payload`, which the caller wires to guest memory.
+///
+/// # Parameters
+///
+/// - `envelope`: Envelope describing the block (its `size` and `message_addr`).
+/// - `read_payload`: Reads `buf.len()` bytes from guest memory at the given address into `buf`.
+///
+/// # Return Value
+///
+/// On success, returns the bytes to write to the console sink (possibly truncated, possibly empty).
+/// Returns an error if `read_payload` fails.
+///
+fn read_console_block(
+    envelope: &VmBusMessage,
+    read_payload: impl FnOnce(u64, &mut [u8]) -> Result<()>,
+) -> Result<Vec<u8>> {
+    let declared: usize = envelope.size() as usize;
+    let cap: usize = ::config::kernel::KLOG_BUFFER_SIZE;
+    let len: usize = declared.min(cap);
+    if declared > cap {
+        warn!(
+            "read_console_block(): klog block exceeds cap, truncating (declared={declared}, \
+             cap={cap})"
+        );
+    }
+
+    let mut bytes: Vec<u8> = vec![0u8; len];
+    if len > 0 {
+        read_payload(envelope.message_addr() as u64, &mut bytes)?;
+    }
+    Ok(bytes)
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::read_console_block;
+    use ::config::kernel::KLOG_BUFFER_SIZE;
+    use ::sys::ipc::{
+        VmBusMessage,
+        VmBusMessageKind,
+    };
+
+    /// A normal block returns exactly the declared bytes read from the simulated guest memory.
+    #[test]
+    fn read_console_block_returns_declared_payload() {
+        let guest_memory: &[u8] = b"[INFO][kernel] hello, klog";
+        let envelope: VmBusMessage =
+            VmBusMessage::new(guest_memory.len() as u32, VmBusMessageKind::KlogBlock, 0);
+
+        let bytes: Vec<u8> = read_console_block(&envelope, |addr, buf| {
+            let start: usize = addr as usize;
+            buf.copy_from_slice(&guest_memory[start..start + buf.len()]);
+            Ok(())
+        })
+        .expect("decoding a valid block must succeed");
+
+        assert_eq!(bytes, guest_memory, "the whole declared payload must be returned");
+    }
+
+    /// A zero-length block is a no-op: it never reads guest memory and yields no bytes.
+    #[test]
+    fn read_console_block_empty_does_not_read() {
+        let envelope: VmBusMessage = VmBusMessage::new(0, VmBusMessageKind::KlogBlock, 0xdead_beef);
+
+        let bytes: Vec<u8> = read_console_block(&envelope, |_addr, _buf| {
+            // A zero-length transfer must not touch guest memory.
+            Err(::anyhow::anyhow!("read_payload must not be called for an empty block"))
+        })
+        .expect("an empty block must succeed without reading");
+
+        assert!(bytes.is_empty(), "an empty block must produce no bytes");
+    }
+
+    /// An oversized declared length is clamped to the cap, bounding the host allocation.
+    #[test]
+    fn read_console_block_clamps_oversized_length() {
+        let oversized: u32 = (KLOG_BUFFER_SIZE as u32) + 4096;
+        let envelope: VmBusMessage = VmBusMessage::new(oversized, VmBusMessageKind::KlogBlock, 0);
+
+        let mut requested: usize = 0;
+        let bytes: Vec<u8> = read_console_block(&envelope, |_addr, buf| {
+            requested = buf.len();
+            for byte in buf.iter_mut() {
+                *byte = b'x';
+            }
+            Ok(())
+        })
+        .expect("a clamped block must still succeed");
+
+        assert_eq!(requested, KLOG_BUFFER_SIZE, "the read must be clamped to the cap");
+        assert_eq!(bytes.len(), KLOG_BUFFER_SIZE, "the output must be clamped to the cap");
+    }
+
+    /// A propagated read error surfaces to the caller rather than being swallowed.
+    #[test]
+    fn read_console_block_propagates_read_error() {
+        let envelope: VmBusMessage = VmBusMessage::new(8, VmBusMessageKind::KlogBlock, 0x1000);
+
+        let result = read_console_block(&envelope, |_addr, _buf| {
+            Err(::anyhow::anyhow!("simulated out-of-bounds guest read"))
+        });
+
+        assert!(result.is_err(), "a failing payload read must produce an error");
     }
 }


### PR DESCRIPTION
## What

Replace the per-byte kernel-log path with a single block transfer so a whole `KlogBuffer` flush costs one VM exit instead of one trap per byte.

## Why

Under the legacy path the kernel emitted one `out8` per logged byte on `DEFAULT_STDOUT_PORT`, trapping once per byte on a virtual machine. On large debug/trace images this produced a flood of VM exits and noticeable slowness. Block flushing amortizes a full buffer flush into a single exit.

## How

- **Kernel:** Add a microvm `puts()` that builds a `VmBusMessage` envelope describing the log buffer and writes the envelope address with a single `out32` to a new dedicated klog port. The microvm feature swaps `putb` for `puts`. New `PERF_KLOG_BLOCK_WRITES` / `PERF_KLOG_BYTES` counters are reported at shutdown to compare exits against the legacy per-byte path.
- **Libraries:** `config` defines `DEFAULT_KLOG_PORT` (0xeb); `sys` adds `VmBusMessageKind::KlogBlock` plus its `TryFrom` decoding.
- **UserVM:** The emulator handles `DEFAULT_KLOG_PORT`, validating the Dword width and `KlogBlock` kind, then decodes via `read_console_block()`, clamping the declared length to `config::kernel::KLOG_BUFFER_SIZE` to bound host allocation and dropping any excess. Unexpected `KlogBlock` envelopes on the application stdout port are rejected.
- **Tests:** Cover `read_console_block()` for normal, empty, oversized-clamped, and read-error cases.

## Issues

Closes #2805 