### PR TITLE
[tests] Add dlfcn search-path acceptance test

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -22,6 +22,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \
 	test-c-dlfcn-pie \
+	test-c-dlfcn-searchpath \
 	test-c-dlfcn-selflink \
 	test-c-dlfcn-startup \
 	test-c-dlfcn-weak \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -147,6 +147,13 @@ POSIX_TEST_PIE_test-c-dlfcn-weak := yes
 # self-linker (syscall::dlfcn::dllink_executable) must bind the executable's own
 # GOT/PLT against the loaded library before main() runs.
 POSIX_TEST_PIE_test-c-dlfcn-selflink := yes
+# dlfcn-searchpath-c dlopen()s the REAL libc.so at run time. libc.so carries an
+# UNDEFINED `__nanvix_main` (the app entry symbol, normally supplied by the main
+# executable), which RTLD_NOW must resolve from the executable's exported global
+# scope. Linking PIE with --export-dynamic lands the executable's symbols
+# (including `__nanvix_main`) in `.dynsym` so dlinit() seeds the loader's global
+# symbol table and the dlopen("libc.so") relocation succeeds.
+POSIX_TEST_PIE_test-c-dlfcn-searchpath := yes
 
 # Per-suite hooks consumed by POSIX_TEST_RULE: extra link-time prerequisites and
 # extra linker arguments appended AFTER the libc/libm `--end-group`. Used by
@@ -272,6 +279,7 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini)
@@ -282,6 +290,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INITFINI_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_WEAK_SEED)
@@ -539,6 +548,32 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup): $(LIBRARIES_DIR)/libc.so $(LIBRARI
 	$(MKRAMFS) -o $@ $(POSIX_TEST_STARTUP_SEED)
 
 #---------------------------------------------------------------------------------------------------
+# dlfcn-searchpath-c: default search-path resolution of bare libc.so + libm.so.
+#---------------------------------------------------------------------------------------------------
+#
+# Like dlfcn-startup-c, this suite stages the ACTUAL shared libraries produced by
+# nanvix-libc-bundle (libc.so + libm.so) under lib/. The difference is in how the
+# suite reaches them: instead of linking the executable against them (DT_NEEDED +
+# startup auto-load), dlfcn-searchpath-c dlopen()s the BARE names "libc.so" and
+# "libm.so" at run time, so the loader's default lib/ search path
+# (syscall::dlfcn::resolve_library_path -> LIBRARY_SEARCH_PATHS) is what locates
+# them. This is the acceptance test for the runtime layout + default search path
+# work (issue #2775). The suite links PIE + --export-dynamic (see POSIX_TEST_PIE_*
+# above) so that libc.so's undefined `__nanvix_main` resolves from the
+# executable's exported global scope when RTLD_NOW relocates it; the per-suite
+# RAMFS below stages the libraries under lib/.
+POSIX_TEST_SEARCHPATH_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-searchpath-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-searchpath.img
+
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath): $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_SEARCHPATH_SEED)/lib
+	$(CP_CMD) $(LIBRARIES_DIR)/libc.so $(POSIX_TEST_SEARCHPATH_SEED)/lib/
+	$(CP_CMD) $(LIBRARIES_DIR)/libm.so $(POSIX_TEST_SEARCHPATH_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_SEARCHPATH_SEED)
+
+#---------------------------------------------------------------------------------------------------
 # dlfcn-initfini-c: startup DT_NEEDED constructor/destructor ordering fixture.
 #---------------------------------------------------------------------------------------------------
 #
@@ -572,6 +607,7 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini): $(POSIX_TEST_INITFINI_DIR)/libini
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini)

--- a/src/tests/integration/test-c-dlfcn-searchpath/main.c
+++ b/src/tests/integration/test-c-dlfcn-searchpath/main.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-searchpath-c: Validate that the loader's DEFAULT library search path
+ * resolves a BARE shared-library name (no '/'), locating the REAL Nanvix shared
+ * libraries libc.so and libm.so shipped under lib/.
+ *
+ * This is the acceptance test for the runtime layout + default search path work
+ * (issue #2775). Unlike dlfcn-c (which dlopen()s an EXPLICIT relative path,
+ * "lib/libmul.so", that bypasses the search path) and dlfcn-startup-c (which
+ * links the executable against libc.so/libm.so via DT_NEEDED and lets the
+ * crt0 startup loader auto-load them), this suite calls dlopen() at run time
+ * with the BARE names "libc.so" and "libm.so". With no path separator,
+ * syscall::dlfcn::resolve_library_path() must search the default
+ * LIBRARY_SEARCH_PATHS ("lib/") and find lib/libc.so and lib/libm.so.
+ * dlopen("libm.so") additionally exercises the default search path
+ * transitively: libm.so carries a DT_NEEDED on libc.so (its allocator / mem*
+ * surface), which the loader resolves through the same "lib/" search path and
+ * consolidates onto the libc.so instance opened below.
+ *
+ * Runtime layout / standalone limitation: in standalone single-process mode the
+ * UserVM has no shared rootfs, so each suite ships the libraries it needs in its
+ * own per-suite RAMFS (handed to nanvixd via -ramfs), staged under lib/. The
+ * multi-daemon / rootfs deployments instead ship libc.so/libm.so once in the
+ * system image; either way the loader finds them through the same default lib/
+ * search path exercised here.
+ *
+ * The suite is linked PIE + --export-dynamic (see the build wiring): libc.so
+ * carries an UNDEFINED `__nanvix_main` (the app entry symbol, normally supplied
+ * by the main executable), which the RTLD_NOW relocation of dlopen("libc.so")
+ * resolves from this executable's exported global symbol scope.
+ *
+ * Only leaf / pure symbols are called from the freshly dlopen()ed copies
+ * (strlen from libc.so, cos from libm.so): the executable is also statically
+ * linked against libc.a, so calling a stateful symbol (e.g. malloc) from the
+ * second in-memory libc would split the heap. Pass/fail is signalled by the
+ * exit code (0 = pass), which nanvixd propagates; the "ok" write mirrors the
+ * other suites' magic marker.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /*
+     * Bare name (no '/') -> resolve_library_path() searches the default
+     * LIBRARY_SEARCH_PATHS ("lib/") and must find lib/libc.so. RTLD_GLOBAL keeps
+     * libc's symbols in the global scope so libm.so's imports (loaded below)
+     * bind to this instance.
+     */
+    void *libc = dlopen("libc.so", RTLD_NOW | RTLD_GLOBAL);
+    assert(libc != NULL);
+
+    /* strlen is a leaf libc symbol: safe to call from the second libc copy. */
+    size_t (*p_strlen)(const char *) = NULL;
+    *(void **)(&p_strlen) = dlsym(libc, "strlen");
+    assert(p_strlen != NULL);
+    assert(p_strlen("nanvix") == 6);
+
+    /*
+     * Bare name again -> the default search path finds lib/libm.so; libm.so's
+     * DT_NEEDED libc.so is resolved through the same "lib/" search path and
+     * consolidated onto the instance opened above.
+     */
+    void *libm = dlopen("libm.so", RTLD_NOW);
+    assert(libm != NULL);
+
+    /* cos is pure: cos(0.0) == 1.0 exactly, so no floating-point tolerance. */
+    double (*p_cos)(double) = NULL;
+    *(void **)(&p_cos) = dlsym(libm, "cos");
+    assert(p_cos != NULL);
+    assert(p_cos(0.0) == 1.0);
+
+    assert(dlclose(libm) == 0);
+    assert(dlclose(libc) == 0);
+
+    /* Write magic string to signal that the test passed. */
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -114,6 +114,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-searchpath"
+program = "./bin/test-c-dlfcn-searchpath.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-selflink"
 program = "./bin/test-c-dlfcn-selflink.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-selflink.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -114,6 +114,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-searchpath"
+program = "./bin/test-c-dlfcn-searchpath.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-selflink"
 program = "./bin/test-c-dlfcn-selflink.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-selflink.img"


### PR DESCRIPTION
## Summary

Adds `test-c-dlfcn-searchpath`, the acceptance test for the runtime layout +
default library search path work (issue #2775). It `dlopen()`s the **real**
`libc.so` and `libm.so` by **bare** name (no `/`), so the loader's default
`lib/` search path (`resolve_library_path` -> `LIBRARY_SEARCH_PATHS`) is what
locates them — distinct from `test-c-dlfcn` (explicit `lib/libmul.so`) and
`test-c-dlfcn-startup` (DT_NEEDED startup auto-load).

The default-search-path implementation already exists; this suite is the
acceptance test that validates issue #2775's criteria and documents the
standalone single-process limitation.

## Changes

**Tests**
- New `src/tests/integration/test-c-dlfcn-searchpath/main.c`:
  `dlopen("libc.so", RTLD_NOW | RTLD_GLOBAL)` then `dlopen("libm.so", RTLD_NOW)`;
  calls only leaf symbols (`strlen`, `cos`) through `dlsym` pointers so the
  second in-memory libc never splits the statically linked `libc.a` heap.
  Pass/fail is the propagated exit code (`0` = pass).

**Build and harness wiring**
- Register the suite in `ALL_POSIX_TESTS` (`build/make/lists/guest-posix-tests.mk`).
- Link PIE + `--export-dynamic` so libc.so's undefined `__nanvix_main` resolves
  from the executable's exported global scope at RTLD_NOW relocation time
  (`POSIX_TEST_PIE_test-c-dlfcn-searchpath`).
- Per-suite RAMFS rule staging the real `libc.so`/`libm.so` under `lib/`
  (mirrors `dlfcn-startup`); wired into `POSIX_TEST_SOLIB_IMGS` and the clean
  target.
- `[[tests]]` entries in `test/test-posix.toml` and `test/test-posix-windows.toml`
  (debug + release, expected exit code `0`).

## Validation
- Debug run via the harness passes (guest exit `0`).
- `codespell` clean on the changed files.

Closes #2775.
