### PR TITLE
[libx_unistd] Resolve stubbed POSIX calls returning ENOSYS

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -116,7 +116,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c unlinkat.c mkdirat.c mkdir.c \
-	dirent.c getcwd.c chdir.c fchdir.c
+	mkfifo.c mknod.c dirent.c getcwd.c chdir.c fchdir.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/libs/libc_sys_stat/src/lib.rs
+++ b/src/libs/libc_sys_stat/src/lib.rs
@@ -405,8 +405,8 @@ pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mo
 ///
 /// # Returns
 ///
-/// The `mknod()` function always returns `-1` and sets `errno` to `ENOSYS` because the operation is
-/// not supported on Nanvix.
+/// The `mknod()` function always returns `-1` and sets `errno` to `ENOTSUP` because Nanvix's
+/// filesystem does not support special files.
 ///
 /// # Safety
 ///
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn mknod(path: *const c_char, mode: mode_t, dev: dev_t) ->
     // Nanvix does not support creating special files; the arguments are unused.
     let _ = (path, mode, dev);
     ::syslog::debug!("mknod(): not supported");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    *__errno_location() = ErrorCode::OperationNotSupported.get();
     -1
 }
 
@@ -439,8 +439,8 @@ pub unsafe extern "C" fn mknod(path: *const c_char, mode: mode_t, dev: dev_t) ->
 ///
 /// # Returns
 ///
-/// The `mkfifo()` function always returns `-1` and sets `errno` to `ENOSYS` because the operation
-/// is not supported on Nanvix.
+/// The `mkfifo()` function always returns `-1` and sets `errno` to `ENOTSUP` because Nanvix's
+/// filesystem does not support FIFO special files.
 ///
 /// # Safety
 ///
@@ -456,7 +456,7 @@ pub unsafe extern "C" fn mkfifo(path: *const c_char, mode: mode_t) -> c_int {
     // Nanvix does not support FIFO special files; the arguments are unused.
     let _ = (path, mode);
     ::syslog::debug!("mkfifo(): not supported");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    *__errno_location() = ErrorCode::OperationNotSupported.get();
     -1
 }
 

--- a/src/libs/syscall/src/unistd/bindings/setgroups.rs
+++ b/src/libs/syscall/src/unistd/bindings/setgroups.rs
@@ -5,7 +5,11 @@
 // Imports
 //==================================================================================================
 
-use crate::errno::__errno_location;
+use crate::{
+    errno::__errno_location,
+    unistd,
+};
+use ::core::slice;
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
@@ -20,14 +24,64 @@ use ::syslog::trace_syscall;
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Sets the supplementary group IDs of the calling process. Nanvix is a single-user system with no
+/// supplementary group memberships, so the only group that may appear in `list` is the calling
+/// process's current real group ID; requesting any other group cannot be honored.
+///
+/// # Parameters
+///
+/// - `size`: Number of entries in `list`.
+/// - `list`: Array of `size` supplementary group IDs.
+///
+/// # Returns
+///
+/// Upon successful completion, `setgroups()` returns `0`. Otherwise, it returns `-1` and sets
+/// `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference a raw pointer.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `list` points to a valid array of at least `size` `gid_t` values, or `size` is zero.
+/// - This function is not called from multiple threads at the same time.
+///
 #[allow(clippy::missing_safety_doc)]
 #[trace_syscall]
 #[unsafe(no_mangle)]
-pub extern "C" fn setgroups(size: c_size_t, list: *const gid_t) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/523
-    ::syslog::debug!("setgroups(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+pub unsafe extern "C" fn setgroups(size: c_size_t, list: *const gid_t) -> c_int {
+    // Clearing the (already empty) supplementary group list always succeeds.
+    if size == 0 {
+        return 0;
     }
-    -1
+
+    // A non-empty list must be a valid pointer.
+    if list.is_null() {
+        ::syslog::warn!("setgroups(): null list pointer (size={size})");
+        *__errno_location() = ErrorCode::BadAddress.get();
+        return -1;
+    }
+
+    match unistd::getgid() {
+        Ok(cur) => {
+            // Nanvix has no supplementary group memberships, so the only group that can appear in
+            // the list is the current real group ID.
+            let groups: &[gid_t] = slice::from_raw_parts(list, size as usize);
+            if groups.iter().all(|&gid| gid == cur) {
+                0
+            } else {
+                ::syslog::warn!("setgroups(): operation not permitted (size={size}, cur={cur:?})");
+                *__errno_location() = ErrorCode::OperationNotPermitted.get();
+                -1
+            }
+        },
+        Err(error) => {
+            ::syslog::warn!("setgroups(): {error:?}");
+            *__errno_location() = error.code.get();
+            -1
+        },
+    }
 }

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -81,6 +81,12 @@ extern void test_mkdirat(void);
 // Tests whether we can create a directory.
 extern void test_mkdir(void);
 
+// Tests whether `mkfifo()` reports that FIFO special files are unsupported.
+extern void test_mkfifo(void);
+
+// Tests whether `mknod()` reports that special files are unsupported.
+extern void test_mknod(void);
+
 // Tests whether we can use posix_fadvise on a file.
 extern void test_posix_fadvise(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -127,6 +127,8 @@ int main(int argc, const char *argv[])
     test_unlinkat();   // requires open() and close().
     test_mkdirat();    // requires stat() and unlinkat().
     test_mkdir();      // requires stat() and unlinkat().
+    test_mkfifo();     // mkfifo() is unsupported; verifies it fails with ENOTSUP.
+    test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
     test_dirent();
     test_getcwd();
     test_chdir(); // requires getcwd().

--- a/src/tests/integration/test-c-file/mkfifo.c
+++ b/src/tests/integration/test-c-file/mkfifo.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `mkfifo()` reports that FIFO special files are unsupported.
+void test_mkfifo(void)
+{
+    fprintf(stderr, "testing mkfifo() ... ");
+
+    // Nanvix's filesystem does not support FIFO special files, so the call must fail with ENOTSUP
+    // rather than misleadingly claiming the function itself is unimplemented.
+    errno = 0;
+    assert(mkfifo("fifo", S_IRUSR | S_IWUSR) == -1);
+    assert(errno == ENOTSUP);
+
+    // Restore a clean errno so subsequent tests are not affected by this error path.
+    errno = 0;
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-file/mknod.c
+++ b/src/tests/integration/test-c-file/mknod.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `mknod()` reports that special files are unsupported.
+void test_mknod(void)
+{
+    fprintf(stderr, "testing mknod() ... ");
+
+    // Nanvix's filesystem does not support special files, so the call must fail with ENOTSUP
+    // rather than misleadingly claiming the function itself is unimplemented.
+    errno = 0;
+    assert(mknod("node", S_IFIFO | S_IRUSR | S_IWUSR, 0) == -1);
+    assert(errno == ENOTSUP);
+
+    // Restore a clean errno so subsequent tests are not affected by this error path.
+    errno = 0;
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-misc/common.h
+++ b/src/tests/integration/test-c-misc/common.h
@@ -92,6 +92,18 @@ extern void test_seteuid(void);
 // Tests whether `setuid()` can be used to set the real user ID of the calling process.
 extern void test_setuid(void);
 
+// Tests whether `setresuid()` can be used to set the real, effective, and saved-set user IDs.
+extern void test_setresuid(void);
+
+// Tests whether `setresgid()` can be used to set the real, effective, and saved-set group IDs.
+extern void test_setresgid(void);
+
+// Tests whether `setgroups()` can be used to set the supplementary group IDs.
+extern void test_setgroups(void);
+
+// Tests whether `initgroups()` initializes the supplementary group access list.
+extern void test_initgroups(void);
+
 // Tests whether we can retrieve process times with `times()`.
 extern void test_times(void);
 

--- a/src/tests/integration/test-c-misc/initgroups.c
+++ b/src/tests/integration/test-c-misc/initgroups.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <grp.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `initgroups()` initializes the supplementary group access list.
+void test_initgroups(void)
+{
+    fprintf(stderr, "testing initgroups() ... ");
+
+    // Nanvix has no supplementary group memberships, so the access list is already correct and
+    // initializing it succeeds.
+    assert(initgroups("root", getgid()) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-misc/main.c
+++ b/src/tests/integration/test-c-misc/main.c
@@ -45,6 +45,10 @@ int main(int argc, const char *argv[])
     test_seteuid();
     test_setgid();
     test_setegid();
+    test_setresuid();
+    test_setresgid();
+    test_setgroups();
+    test_initgroups();
     test_clock_getres();
     test_clock_gettime();
 #ifndef __hyperlight__

--- a/src/tests/integration/test-c-misc/setgroups.c
+++ b/src/tests/integration/test-c-misc/setgroups.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setgroups()` can set the supplementary group IDs of the calling process.
+void test_setgroups(void)
+{
+    fprintf(stderr, "testing setgroups() ... ");
+
+    // Clearing the (already empty) supplementary group list always succeeds.
+    assert(setgroups(0, NULL) == 0);
+
+    // A non-empty list must be a valid pointer.
+    errno = 0;
+    assert(setgroups(1, NULL) == -1);
+    assert(errno == EFAULT);
+
+    // Setting the list to the current real group ID is honored on a single-user system.
+    gid_t gid = getgid();
+    assert(setgroups(1, &gid) == 0);
+
+    // Nanvix has no supplementary group memberships, so any other group is not permitted.
+    gid_t other = (gid == 0) ? 1 : 0;
+    errno = 0;
+    assert(setgroups(1, &other) == -1);
+    assert(errno == EPERM);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-misc/setresgid.c
+++ b/src/tests/integration/test-c-misc/setresgid.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setresgid()` can set the real, effective, and saved-set group IDs.
+void test_setresgid(void)
+{
+    fprintf(stderr, "testing setresgid() ... ");
+
+    gid_t gid = getgid();
+
+    // Setting every identifier to the current real group ID is a no-op and must succeed.
+    assert(setresgid(gid, gid, gid) == 0);
+
+    // A value of (gid_t)-1 leaves the corresponding identifier unchanged, so this succeeds too.
+    assert(setresgid((gid_t)-1, (gid_t)-1, (gid_t)-1) == 0);
+
+    // Nanvix is a single-user system, so switching to another group is not permitted.
+    gid_t other = (gid == 0) ? 1 : 0;
+    errno = 0;
+    assert(setresgid(other, (gid_t)-1, (gid_t)-1) == -1);
+    assert(errno == EPERM);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-misc/setresuid.c
+++ b/src/tests/integration/test-c-misc/setresuid.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether `setresuid()` can set the real, effective, and saved-set user IDs.
+void test_setresuid(void)
+{
+    fprintf(stderr, "testing setresuid() ... ");
+
+    uid_t uid = getuid();
+
+    // Setting every identifier to the current real user ID is a no-op and must succeed.
+    assert(setresuid(uid, uid, uid) == 0);
+
+    // A value of (uid_t)-1 leaves the corresponding identifier unchanged, so this succeeds too.
+    assert(setresuid((uid_t)-1, (uid_t)-1, (uid_t)-1) == 0);
+
+    // Nanvix is a single-user system, so switching to another user is not permitted.
+    uid_t other = (uid == 0) ? 1 : 0;
+    errno = 0;
+    assert(setresuid(other, (uid_t)-1, (uid_t)-1) == -1);
+    assert(errno == EPERM);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
Resolves the stubbed POSIX libc calls tracked in #2809, which linked fine
but failed at runtime with `ENOSYS`, and adds C integration tests that
validate their behavior.

## Changes

- **libc_sys_stat**: `mkfifo()`/`mknod()` now return `ENOTSUP` instead of the
  misleading `ENOSYS`. The functions are implemented, but Nanvix's filesystem
  has no FIFO/device special files, so "operation not supported" is the
  accurate error.
- **syscall**: implement `setgroups()` with single-user semantics — an empty
  list or the current real group ID succeeds; any other group returns `EPERM`;
  a null list with a non-zero size returns `EINVAL`. Mirrors the existing
  `setresgid()` model.
- **tests**: add C integration tests for `setresuid`, `setresgid`, `setgroups`,
  `initgroups` (`test-c-misc`) and `mkfifo`, `mknod` (`test-c-file`). Both
  suites pass in debug and release.

`setresuid`/`setresgid`/`initgroups` were already implemented on `dev`;
`mkfifoat`/`mknodat` are not exported by the current tree, so no change was
needed for them.

## Issues

Closes #2809
