### PR TITLE
[tests] Add dlfcn dynamic-hello suite

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -18,6 +18,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn \
 	test-c-dlfcn-diamond \
 	test-c-dlfcn-global \
+	test-c-dlfcn-hello \
 	test-c-dlfcn-init-runpath \
 	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -201,6 +201,21 @@ POSIX_TEST_NO_STATIC_LIBM_test-c-dlfcn-startup := yes
 POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-startup := $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so
 POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-startup := -L$(LIBRARIES_DIR) -l:libc.so -l:libm.so -z now
 
+# dlfcn-hello-c is the "dynamic hello" acceptance test: the capstone
+# that boots a plain hello-world executable linked against the REAL shared
+# libraries libc.so and libm.so and lets the crt0 startup loader auto-resolve them
+# before main(), with NO dlopen() call. Its link wiring is identical to
+# dlfcn-startup-c above — PIE, static libm.a dropped so the math symbols bind to
+# libm.so (R_386_JMP_SLOT), DT_NEEDED on the bare libc.so/libm.so names, `-z now`
+# for eager binding — but main.c folds the dynamically-resolved cos/pow/exp
+# results into a single printed "value=42" instead of asserting each math result
+# separately. The bare DT_NEEDED names are resolved through the loader's default
+# lib/ search path, where the per-suite RAMFS stages libc.so and libm.so.
+POSIX_TEST_PIE_test-c-dlfcn-hello := yes
+POSIX_TEST_NO_STATIC_LIBM_test-c-dlfcn-hello := yes
+POSIX_TEST_EXTRA_LD_DEPS_test-c-dlfcn-hello := $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so
+POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-hello := -L$(LIBRARIES_DIR) -l:libc.so -l:libm.so -z now
+
 define POSIX_TEST_RULE
 POSIX_TEST_SRCROOT_$(1) := $$(if $$(POSIX_TEST_STRESS_$(1)),$$(POSIX_TESTS_STRESS_SRCDIR),$$(POSIX_TESTS_SRCDIR))
 POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TEST_SRCROOT_$(1))/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TEST_SRCROOT_$(1))/$(1)/*.c))
@@ -279,6 +294,7 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
@@ -290,6 +306,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INITFINI_SEED)
@@ -548,6 +565,27 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup): $(LIBRARIES_DIR)/libc.so $(LIBRARI
 	$(MKRAMFS) -o $@ $(POSIX_TEST_STARTUP_SEED)
 
 #---------------------------------------------------------------------------------------------------
+# dlfcn-hello-c: "dynamic hello" startup auto-load of real libc.so + libm.so.
+#---------------------------------------------------------------------------------------------------
+#
+# Like dlfcn-startup-c, this suite stages the ACTUAL shared libraries produced by
+# nanvix-libc-bundle (libc.so + libm.so) under lib/, reached through the loader's
+# default lib/ search path. The executable links against them via DT_NEEDED (see
+# the per-suite hooks above) and the startup loader auto-loads them before main();
+# see test-c-dlfcn-hello/main.c, which computes and prints "value=42" through that
+# dynamic linkage.
+POSIX_TEST_HELLO_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-hello-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-hello.img
+
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello): $(LIBRARIES_DIR)/libc.so $(LIBRARIES_DIR)/libm.so \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_HELLO_SEED)/lib
+	$(CP_CMD) $(LIBRARIES_DIR)/libc.so $(POSIX_TEST_HELLO_SEED)/lib/
+	$(CP_CMD) $(LIBRARIES_DIR)/libm.so $(POSIX_TEST_HELLO_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_HELLO_SEED)
+
+#---------------------------------------------------------------------------------------------------
 # dlfcn-searchpath-c: default search-path resolution of bare libc.so + libm.so.
 #---------------------------------------------------------------------------------------------------
 #
@@ -607,6 +645,7 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini): $(POSIX_TEST_INITFINI_DIR)/libini
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup) \

--- a/src/tests/integration/test-c-dlfcn-hello/main.c
+++ b/src/tests/integration/test-c-dlfcn-hello/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-hello-c: The "dynamic hello" acceptance test.
+ *
+ * This is the capstone of the startup dynamic-linking work: a plain, hello-world
+ * style executable that is linked against the REAL Nanvix shared libraries
+ * libc.so and libm.so (via `-l:libc.so -l:libm.so`, see the build wiring) and
+ * relies on the crt0 startup loader to auto-resolve them before main(), with NO
+ * dlopen() call. It ties together two behaviors it builds on:
+ *   - init/fini ordering: libc.so's constructors run before main;
+ *   - runtime layout + search path: the bare DT_NEEDED names are located
+ *     through the loader's default lib/ search path.
+ *
+ * Because the executable is linked PIE against libm.so instead of the static
+ * libm.a, the math symbols below are left UNDEFINED in the executable and
+ * recorded as DT_NEEDED entries plus R_386_JMP_SLOT relocations. libm.so in turn
+ * imports libc.so's allocator and mem* surface, so the executable also carries a
+ * DT_NEEDED on libc.so. At process startup, syscall::dlfcn::dllink_executable()
+ * walks the executable's DT_NEEDED list, loads libc.so then libm.so into the
+ * global scope, and binds the executable's GOT/PLT slots before main() runs.
+ * The executable's statically linked libc.a remains the single heap owner (the
+ * loader's global scope is first-wins), so printf() below is served by the
+ * static libc.a while cos/pow/exp are served by the auto-loaded libm.so.
+ *
+ * cos/pow/exp are used (rather than sqrt, which the compiler lowers to a
+ * hardware instruction / a local compiler_builtins symbol and so never becomes a
+ * dynamic import) precisely because they stay undefined in the executable and
+ * bind to libm.so at startup. The test computes a value of 42 THROUGH that
+ * dynamic linkage and prints it, the canonical "value=42 from a dynamically
+ * linked exe" acceptance signal. Pass/fail is signalled by the exit code
+ * (0 = pass), which nanvixd propagates; the "ok" write mirrors the other suites'
+ * magic marker.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /*
+     * `volatile` inputs stop the optimizer (release builds compile at -O3) from
+     * constant-folding these libm calls away: each must survive as a real PLT
+     * reference (R_386_JMP_SLOT) into libm.so so the startup loader has GOT/PLT
+     * slots to bind before main(). The chosen arguments yield exact results, so
+     * the arithmetic below needs no floating-point tolerance.
+     */
+    volatile double zero = 0.0;
+    volatile double base = 2.0;
+    volatile double exponent = 10.0;
+
+    /* R_386_JMP_SLOT relocations against libm.so, auto-bound before main(). */
+    double c = cos(zero);           /* cos(0)     == 1    */
+    double p = pow(base, exponent); /* pow(2, 10) == 1024 */
+    double e = exp(zero);           /* exp(0)     == 1    */
+
+    /*
+     * Derive the answer THROUGH the dynamically-resolved results so a wrong
+     * binding of cos/pow/exp would change it: cos(0) == exp(0) == 1 act as unit
+     * factors and pow(2, 10) == 1024 as its own normalizer, leaving the classic
+     * 6 * 7 == 42 exactly.
+     */
+    int value = (int)(6.0 * 7.0 * c * e * (p / 1024.0));
+
+    /* The "hello" line: prints "value=42" via the statically linked libc.a. */
+    printf("value=%d\n", value);
+    fflush(stdout);
+
+    if (value == 42) {
+        write(STDOUT_FILENO, "ok", 2);
+        return 0;
+    }
+
+    return 1;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -82,6 +82,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-hello"
+program = "./bin/test-c-dlfcn-hello.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-hello.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-init-runpath"
 program = "./bin/test-c-dlfcn-init-runpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-runpath.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -82,6 +82,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-hello"
+program = "./bin/test-c-dlfcn-hello.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-hello.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-init-runpath"
 program = "./bin/test-c-dlfcn-init-runpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-runpath.img"


### PR DESCRIPTION
## What

Adds a "dynamic hello" acceptance suite (`test-c-dlfcn-hello`) — the capstone of the startup dynamic-linking work. It boots a hello-world executable that is dynamically linked against the **real** `libc.so` and `libm.so`, with **no `dlopen()`**:

- The executable is linked PIE against `libc.so`/`libm.so` (`-l:libc.so -l:libm.so`, `-z now`), and the static `libm.a` is dropped so `cos`/`pow`/`exp` stay **undefined** in the exe and are recorded as `DT_NEEDED` + `R_386_JMP_SLOT`.
- At startup, the crt0 loader (`dllink_executable`) walks `DT_NEEDED`, auto-loads `libc.so` then `libm.so`, and binds the GOT/PLT before `main()`.
- `main()` folds the dynamically-bound results into a single printed **`value=42`** — so a mis-bound `libm.so` would change the result — and signals pass via the propagated exit code (0).

## Why

Delivers the "value=42 from a dynamically linked exe; integration green" acceptance for the dynamic-hello work, and wires it into CI.

## Changes

- **Test:** `src/tests/integration/test-c-dlfcn-hello/main.c`.
- **Build:** register the suite in `ALL_POSIX_TESTS`; PIE + `DT_NEEDED` link hooks; per-suite RAMFS staging `libc.so`/`libm.so` under `lib/` (found via the loader's default search path); aggregate-image and clean rules.
- **Harness/CI:** register the suite in `test/test-posix.toml` and `test/test-posix-windows.toml` (terminal executor, `-ramfs` image, expected exit code 0), giving it coverage in the existing POSIX C suites step.

## Validation

Builds clean; boots under nanvixd and prints `value=42` + `ok`, `VM exited (exit_status=0)`; the harness now enumerates 37 suites (was 36). `readelf` confirms `DT_NEEDED [libc.so] [libm.so]` and `JUMP_SLOT` for `cos`/`pow`/`exp`.

Closes #2776