### PR TITLE
[libc_math] Fix libm special values and precision

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -38,6 +38,7 @@ ALL_POSIX_TESTS := \
 	test-c-inet \
 	test-c-libgen \
 	test-c-locale \
+	test-c-math \
 	test-c-memory \
 	test-c-misc \
 	test-c-network \

--- a/src/libs/libc_math/src/erf.rs
+++ b/src/libs/libc_math/src/erf.rs
@@ -1,9 +1,91 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// A tiny value used to raise the inexact flag and produce correctly-signed
+/// results in the saturated tails.
+pub(crate) const TINY_ERF: f64 = 1e-300;
+
+/// `erf(1)` rounded to 53 bits, the anchor for the `[0.84375, 1.25]` branch.
+pub(crate) const ERX: f64 = 8.450_629_115_104_675e-1;
+
+// Coefficients for the approximation of `erf` on `[0, 0.84375]`.
+pub(crate) const EFX8: f64 = 1.027_033_336_764_100_7;
+pub(crate) const PP0: f64 = 1.283_791_670_955_125_6e-1;
+pub(crate) const PP1: f64 = -3.250_421_072_470_015e-1;
+pub(crate) const PP2: f64 = -2.848_174_957_559_851e-2;
+pub(crate) const PP3: f64 = -5.770_270_296_489_442e-3;
+pub(crate) const PP4: f64 = -2.376_301_665_665_016_3e-5;
+pub(crate) const QQ1: f64 = 3.979_172_239_591_553_5e-1;
+pub(crate) const QQ2: f64 = 6.502_224_998_876_73e-2;
+pub(crate) const QQ3: f64 = 5.081_306_281_875_766e-3;
+pub(crate) const QQ4: f64 = 1.324_947_380_043_216_4e-4;
+pub(crate) const QQ5: f64 = -3.960_228_278_775_368e-6;
+
+// Coefficients for the approximation of `erf` on `[0.84375, 1.25]`.
+pub(crate) const PA0: f64 = -2.362_118_560_752_659_4e-3;
+pub(crate) const PA1: f64 = 4.148_561_186_837_483_3e-1;
+pub(crate) const PA2: f64 = -3.722_078_760_357_013e-1;
+pub(crate) const PA3: f64 = 3.183_466_199_011_617_5e-1;
+pub(crate) const PA4: f64 = -1.108_946_942_823_966_8e-1;
+pub(crate) const PA5: f64 = 3.547_830_432_561_823_6e-2;
+pub(crate) const PA6: f64 = -2.166_375_594_868_791e-3;
+pub(crate) const QA1: f64 = 1.064_208_804_008_442_3e-1;
+pub(crate) const QA2: f64 = 5.403_979_177_021_71e-1;
+pub(crate) const QA3: f64 = 7.182_865_441_419_627e-2;
+pub(crate) const QA4: f64 = 1.261_712_198_087_616_4e-1;
+pub(crate) const QA5: f64 = 1.363_708_391_202_905e-2;
+pub(crate) const QA6: f64 = 1.198_449_984_679_910_7e-2;
+
+// Coefficients for the approximation of `erfc` on `[1.25, 1/0.35]`.
+pub(crate) const RA0: f64 = -9.864_944_034_847_148e-3;
+pub(crate) const RA1: f64 = -6.938_585_727_071_818e-1;
+pub(crate) const RA2: f64 = -1.055_862_622_532_329_1e1;
+pub(crate) const RA3: f64 = -6.237_533_245_032_600_6e1;
+pub(crate) const RA4: f64 = -1.623_966_694_625_734_7e2;
+pub(crate) const RA5: f64 = -1.846_050_929_067_110_4e2;
+pub(crate) const RA6: f64 = -8.128_743_550_630_66e1;
+pub(crate) const RA7: f64 = -9.814_329_344_169_145;
+pub(crate) const SA1: f64 = 1.965_127_166_743_925_7e1;
+pub(crate) const SA2: f64 = 1.376_577_541_435_190_4e2;
+pub(crate) const SA3: f64 = 4.345_658_774_752_292_3e2;
+pub(crate) const SA4: f64 = 6.453_872_717_332_679e2;
+pub(crate) const SA5: f64 = 4.290_081_400_275_678_3e2;
+pub(crate) const SA6: f64 = 1.086_350_055_417_794_4e2;
+pub(crate) const SA7: f64 = 6.570_249_770_319_282;
+pub(crate) const SA8: f64 = -6.042_441_521_485_81e-2;
+
+// Coefficients for the approximation of `erfc` on `[1/0.35, 28]`.
+pub(crate) const RB0: f64 = -9.864_942_924_700_1e-3;
+pub(crate) const RB1: f64 = -7.992_832_376_805_23e-1;
+pub(crate) const RB2: f64 = -1.775_795_491_775_475_2e1;
+pub(crate) const RB3: f64 = -1.606_363_848_558_219_2e2;
+pub(crate) const RB4: f64 = -6.375_664_433_683_896e2;
+pub(crate) const RB5: f64 = -1.025_095_131_611_077_2e3;
+pub(crate) const RB6: f64 = -4.835_191_916_086_514e2;
+pub(crate) const SB1: f64 = 3.033_806_074_348_246e1;
+pub(crate) const SB2: f64 = 3.257_925_129_965_739e2;
+pub(crate) const SB3: f64 = 1.536_729_586_084_437e3;
+pub(crate) const SB4: f64 = 3.199_858_219_508_595_5e3;
+pub(crate) const SB5: f64 = 2.553_050_406_433_164_4e3;
+pub(crate) const SB6: f64 = 4.745_285_412_069_553_7e2;
+pub(crate) const SB7: f64 = -2.244_095_244_658_582e1;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
 /// Computes the error function of `x`.
 ///
-/// Uses the Abramowitz & Stegun 7.1.26 rational approximation.
+/// # Description
+///
+/// Uses the fdlibm piecewise rational approximations (accurate to within one unit
+/// in the last place): a direct polynomial near zero, an approximation anchored at
+/// `erf(1)` on `[0.84375, 1.25]`, and `erf(x) = 1 - erfc(x)` computed from a scaled
+/// exponential for larger arguments.
 ///
 /// # Parameters
 ///
@@ -13,19 +95,70 @@
 ///
 /// The value `erf(x)`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub extern "C" fn erf(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
+    let hx: i32 = (x.to_bits() >> 32) as i32;
+    let ix: i32 = hx & 0x7fff_ffff;
+    if ix >= 0x7ff0_0000 {
+        // erf(+/-inf) = +/-1, erf(NaN) = NaN.
+        let i: i32 = ((x.to_bits() >> 63) as i32) << 1;
+        return f64::from(1 - i) + 1.0 / x;
     }
-    let sign: f64 = if x < 0.0 { -1.0 } else { 1.0 };
-    let ax: f64 = x.abs();
-    let t: f64 = 1.0 / (1.0 + 0.3275911 * ax);
-    let poly: f64 =
-        ((((1.061_405_429 * t - 1.453_152_027) * t + 1.421_413_741) * t - 0.284_496_736) * t
-            + 0.254_829_592)
-            * t;
-    let y: f64 = 1.0 - poly * crate::exp::exp(-ax * ax);
-    sign * y
+
+    if ix < 0x3feb_0000 {
+        // |x| < 0.84375
+        if ix < 0x3e30_0000 {
+            // |x| < 2^-28: avoid underflow.
+            return 0.125 * (8.0 * x + EFX8 * x);
+        }
+        let z: f64 = x * x;
+        let r: f64 = PP0 + z * (PP1 + z * (PP2 + z * (PP3 + z * PP4)));
+        let s: f64 = 1.0 + z * (QQ1 + z * (QQ2 + z * (QQ3 + z * (QQ4 + z * QQ5))));
+        let y: f64 = r / s;
+        return x + x * y;
+    }
+    if ix < 0x3ff4_0000 {
+        // 0.84375 <= |x| < 1.25
+        let s: f64 = f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff) - 1.0;
+        let p: f64 = PA0 + s * (PA1 + s * (PA2 + s * (PA3 + s * (PA4 + s * (PA5 + s * PA6)))));
+        let q: f64 = 1.0 + s * (QA1 + s * (QA2 + s * (QA3 + s * (QA4 + s * (QA5 + s * QA6)))));
+        if hx >= 0 {
+            return ERX + p / q;
+        }
+        return -ERX - p / q;
+    }
+    if ix >= 0x4018_0000 {
+        // |x| >= 6
+        if hx >= 0 {
+            return 1.0 - TINY_ERF;
+        }
+        return TINY_ERF - 1.0;
+    }
+    let ax: f64 = f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff);
+    let s: f64 = 1.0 / (ax * ax);
+    let (r, big_s): (f64, f64) = if ix < 0x4006_db6d {
+        // |x| < 1/0.35
+        let r: f64 =
+            RA0 + s * (RA1 + s * (RA2 + s * (RA3 + s * (RA4 + s * (RA5 + s * (RA6 + s * RA7))))));
+        let big_s: f64 = 1.0
+            + s * (SA1
+                + s * (SA2 + s * (SA3 + s * (SA4 + s * (SA5 + s * (SA6 + s * (SA7 + s * SA8)))))));
+        (r, big_s)
+    } else {
+        // |x| >= 1/0.35
+        let r: f64 = RB0 + s * (RB1 + s * (RB2 + s * (RB3 + s * (RB4 + s * (RB5 + s * RB6)))));
+        let big_s: f64 =
+            1.0 + s * (SB1 + s * (SB2 + s * (SB3 + s * (SB4 + s * (SB5 + s * (SB6 + s * SB7))))));
+        (r, big_s)
+    };
+    let z: f64 = f64::from_bits(ax.to_bits() & 0xffff_ffff_0000_0000); // high word only
+    let r2: f64 =
+        crate::exp::exp(-z * z - 0.5625) * crate::exp::exp((z - ax) * (z + ax) + r / big_s);
+    if hx >= 0 {
+        1.0 - r2 / ax
+    } else {
+        r2 / ax - 1.0
+    }
 }
 
 //==================================================================================================
@@ -36,26 +169,41 @@ pub extern "C" fn erf(x: f64) -> f64 {
 mod tests {
     use super::*;
 
+    /// Reference values from a correctly-rounded erf (e.g. glibc / MPFR).
+    const CASES: [(f64, f64); 7] = [
+        (0.0, 0.0),
+        (0.1, 0.112_462_916_018_284_89),
+        (0.5, 0.520_499_877_813_046_5),
+        (1.0, 0.842_700_792_949_714_9),
+        (2.0, 0.995_322_265_018_952_7),
+        (3.0, 0.999_977_909_503_001_4),
+        (4.0, 0.999_999_984_582_742_1),
+    ];
+
+    #[test]
+    fn test_reference_values() {
+        for &(x, want) in &CASES {
+            let got: f64 = erf(x);
+            assert!(
+                (got - want).abs() <= want.abs() * 1e-14 + 1e-15,
+                "erf({x}) = {got}, want {want}"
+            );
+            // erf is odd.
+            let got_neg: f64 = erf(-x);
+            assert!((got_neg + want).abs() <= want.abs() * 1e-14 + 1e-15);
+        }
+    }
+
     #[test]
     fn test_zero() {
-        assert!((erf(0.0)).abs() < 1e-7);
+        assert_eq!(erf(0.0), 0.0);
+        assert_eq!(erf(-0.0).to_bits(), (-0.0_f64).to_bits());
     }
 
     #[test]
-    fn test_one() {
-        // The Abramowitz & Stegun approximation is accurate to about 1.5e-7.
-        assert!((erf(1.0) - 0.842_700_792_949_714_9).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_odd_symmetry() {
-        assert!((erf(-1.0) + erf(1.0)).abs() < 1e-12);
-    }
-
-    #[test]
-    fn test_large() {
-        assert!((erf(5.0) - 1.0).abs() < 1e-6);
-        assert!((erf(-5.0) + 1.0).abs() < 1e-6);
+    fn test_limits() {
+        assert_eq!(erf(f64::INFINITY), 1.0);
+        assert_eq!(erf(f64::NEG_INFINITY), -1.0);
     }
 
     #[test]

--- a/src/libs/libc_math/src/erfc.rs
+++ b/src/libs/libc_math/src/erfc.rs
@@ -1,7 +1,80 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::erf::{
+    ERX,
+    PA0,
+    PA1,
+    PA2,
+    PA3,
+    PA4,
+    PA5,
+    PA6,
+    PP0,
+    PP1,
+    PP2,
+    PP3,
+    PP4,
+    QA1,
+    QA2,
+    QA3,
+    QA4,
+    QA5,
+    QA6,
+    QQ1,
+    QQ2,
+    QQ3,
+    QQ4,
+    QQ5,
+    RA0,
+    RA1,
+    RA2,
+    RA3,
+    RA4,
+    RA5,
+    RA6,
+    RA7,
+    RB0,
+    RB1,
+    RB2,
+    RB3,
+    RB4,
+    RB5,
+    RB6,
+    SA1,
+    SA2,
+    SA3,
+    SA4,
+    SA5,
+    SA6,
+    SA7,
+    SA8,
+    SB1,
+    SB2,
+    SB3,
+    SB4,
+    SB5,
+    SB6,
+    SB7,
+    TINY_ERF,
+};
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
 /// Computes the complementary error function of `x`, `erfc(x) = 1 - erf(x)`.
+///
+/// # Description
+///
+/// Uses the fdlibm piecewise rational approximations. For larger arguments it
+/// evaluates the tail directly from a scaled exponential rather than as
+/// `1 - erf(x)`, avoiding the catastrophic cancellation that destroys precision in
+/// the tail. Accurate to within one unit in the last place.
 ///
 /// # Parameters
 ///
@@ -11,11 +84,81 @@
 ///
 /// The value `erfc(x)`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub extern "C" fn erfc(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
+    let hx: i32 = (x.to_bits() >> 32) as i32;
+    let ix: i32 = hx & 0x7fff_ffff;
+    if ix >= 0x7ff0_0000 {
+        // erfc(NaN) = NaN, erfc(+inf) = 0, erfc(-inf) = 2.
+        let i: i32 = ((x.to_bits() >> 63) as i32) << 1;
+        return f64::from(i) + 1.0 / x;
     }
-    1.0 - crate::erf::erf(x)
+
+    if ix < 0x3feb_0000 {
+        // |x| < 0.84375
+        if ix < 0x3c70_0000 {
+            // |x| < 2^-56
+            return 1.0 - x;
+        }
+        let z: f64 = x * x;
+        let r: f64 = PP0 + z * (PP1 + z * (PP2 + z * (PP3 + z * PP4)));
+        let s: f64 = 1.0 + z * (QQ1 + z * (QQ2 + z * (QQ3 + z * (QQ4 + z * QQ5))));
+        let y: f64 = r / s;
+        if hx < 0x3fd0_0000 {
+            // x < 1/4
+            return 1.0 - (x + x * y);
+        }
+        let r2: f64 = x * y + (x - 0.5);
+        return 0.5 - r2;
+    }
+    if ix < 0x3ff4_0000 {
+        // 0.84375 <= |x| < 1.25
+        let s: f64 = f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff) - 1.0;
+        let p: f64 = PA0 + s * (PA1 + s * (PA2 + s * (PA3 + s * (PA4 + s * (PA5 + s * PA6)))));
+        let q: f64 = 1.0 + s * (QA1 + s * (QA2 + s * (QA3 + s * (QA4 + s * (QA5 + s * QA6)))));
+        if hx >= 0 {
+            let z: f64 = 1.0 - ERX;
+            return z - p / q;
+        }
+        let z: f64 = ERX + p / q;
+        return 1.0 + z;
+    }
+    if ix < 0x403c_0000 {
+        // |x| < 28
+        let ax: f64 = f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff);
+        let s: f64 = 1.0 / (ax * ax);
+        let (r, big_s): (f64, f64) = if ix < 0x4006_db6d {
+            // |x| < 1/0.35 ~= 2.857
+            let r: f64 = RA0
+                + s * (RA1 + s * (RA2 + s * (RA3 + s * (RA4 + s * (RA5 + s * (RA6 + s * RA7))))));
+            let big_s: f64 = 1.0
+                + s * (SA1
+                    + s * (SA2
+                        + s * (SA3 + s * (SA4 + s * (SA5 + s * (SA6 + s * (SA7 + s * SA8)))))));
+            (r, big_s)
+        } else {
+            // |x| >= 1/0.35 ~= 2.857
+            if hx < 0 && ix >= 0x4018_0000 {
+                return 2.0 - TINY_ERF; // x < -6
+            }
+            let r: f64 = RB0 + s * (RB1 + s * (RB2 + s * (RB3 + s * (RB4 + s * (RB5 + s * RB6)))));
+            let big_s: f64 = 1.0
+                + s * (SB1 + s * (SB2 + s * (SB3 + s * (SB4 + s * (SB5 + s * (SB6 + s * SB7))))));
+            (r, big_s)
+        };
+        let z: f64 = f64::from_bits(ax.to_bits() & 0xffff_ffff_0000_0000); // high word only
+        let r2: f64 =
+            crate::exp::exp(-z * z - 0.5625) * crate::exp::exp((z - ax) * (z + ax) + r / big_s);
+        if hx > 0 {
+            r2 / ax
+        } else {
+            2.0 - r2 / ax
+        }
+    } else if hx > 0 {
+        TINY_ERF * TINY_ERF
+    } else {
+        2.0 - TINY_ERF
+    }
 }
 
 //==================================================================================================
@@ -26,19 +169,42 @@ pub extern "C" fn erfc(x: f64) -> f64 {
 mod tests {
     use super::*;
 
+    /// Reference values from a correctly-rounded erfc (e.g. glibc / MPFR). The
+    /// large-argument cases exercise the tail path where `1 - erf(x)` would cancel.
+    const CASES: [(f64, f64); 6] = [
+        (0.5, 0.479_500_122_186_953_5),
+        (1.0, 0.157_299_207_050_285_13),
+        (2.0, 4.677_734_981_047_266e-3),
+        (3.0, 2.209_049_699_858_544e-5),
+        (5.0, 1.537_459_794_428_035e-12),
+        (10.0, 2.088_487_583_762_544_7e-45),
+    ];
+
+    #[test]
+    fn test_reference_values() {
+        for &(x, want) in &CASES {
+            let got: f64 = erfc(x);
+            assert!((got - want).abs() <= want.abs() * 1e-13, "erfc({x}) = {got}, want {want}");
+        }
+    }
+
+    #[test]
+    fn test_erfc_plus_erf_is_one() {
+        for &x in &[-1.5_f64, -0.3, 0.0, 0.3, 0.9, 1.5, 2.5] {
+            assert!((erfc(x) + crate::erf::erf(x) - 1.0).abs() <= 1e-14);
+        }
+    }
+
     #[test]
     fn test_zero() {
-        assert!((erfc(0.0) - 1.0).abs() < 1e-7);
+        assert_eq!(erfc(0.0), 1.0);
     }
 
     #[test]
-    fn test_one() {
-        assert!((erfc(1.0) - 0.157_299_207_050_285_1).abs() < 1e-6);
-    }
-
-    #[test]
-    fn test_large() {
-        assert!((erfc(5.0)).abs() < 1e-6);
+    fn test_limits() {
+        assert_eq!(erfc(f64::INFINITY), 0.0);
+        assert_eq!(erfc(f64::NEG_INFINITY), 2.0);
+        assert_eq!(erfc(30.0), 0.0); // underflows to zero
     }
 
     #[test]

--- a/src/libs/libc_math/src/exp.rs
+++ b/src/libs/libc_math/src/exp.rs
@@ -5,25 +5,26 @@
 // Constants
 //==================================================================================================
 
-const LN2: f64 = core::f64::consts::LN_2;
-const LN2_INV: f64 = core::f64::consts::LOG2_E;
-
-/// Taylor series coefficients for e^r: 1/n! from n=12 down to n=0.
-const EXP_COEFFS: [f64; 13] = [
-    1.0 / 479_001_600.0,
-    1.0 / 39_916_800.0,
-    1.0 / 3_628_800.0,
-    1.0 / 362_880.0,
-    1.0 / 40_320.0,
-    1.0 / 5_040.0,
-    1.0 / 720.0,
-    1.0 / 120.0,
-    1.0 / 24.0,
-    1.0 / 6.0,
-    0.5,
-    1.0,
-    1.0,
-];
+/// `ln(2)` split into a leading part (exact in its high bits) and a low
+/// correction, indexed by the sign of the argument so the reduction stays exact.
+const LN2HI: [f64; 2] = [6.931_471_803_691_238e-1, -6.931_471_803_691_238e-1];
+const LN2LO: [f64; 2] = [1.908_214_929_270_587_7e-10, -1.908_214_929_270_587_7e-10];
+/// `+/-0.5`, added before truncation to round the reduction quotient.
+const HALF: [f64; 2] = [0.5, -0.5];
+/// `1 / ln(2)`.
+const INVLN2: f64 = 1.442_695_040_888_963_4;
+/// Overflow threshold: `exp(x)` overflows to `+inf` for `x > O_THRESHOLD`.
+const O_THRESHOLD: f64 = 7.097_827_128_933_84e2;
+/// Underflow threshold: `exp(x)` underflows to `0` for `x < U_THRESHOLD`.
+const U_THRESHOLD: f64 = -7.451_332_191_019_411e2;
+/// Minimax polynomial coefficients for the scaled remainder `x - r*R(r^2)`.
+const P1: f64 = 1.666_666_666_666_660_2e-1;
+const P2: f64 = -2.777_777_777_701_559_3e-3;
+const P3: f64 = 6.613_756_321_437_934e-5;
+const P4: f64 = -1.653_390_220_546_525_2e-6;
+const P5: f64 = 4.138_136_797_057_238_5e-8;
+/// `2^-1000`, used to defer final scaling for tiny results without underflow.
+const TWOM1000: f64 = f64::from_bits(0x0170_0000_0000_0000);
 
 //==================================================================================================
 // Public Functions
@@ -33,7 +34,10 @@ const EXP_COEFFS: [f64; 13] = [
 ///
 /// # Description
 ///
-/// Uses range reduction: `e^x = 2^k * e^r` where `r = x - k*ln(2)` and `|r| <= ln(2)/2`.
+/// Reduces the argument as `x = k*ln(2) + r` with `|r| <= 0.5*ln(2)`, evaluates
+/// `e^r` from a minimax polynomial in `r`, and reconstructs the result by scaling
+/// with `2^k`. This is the fdlibm algorithm and is accurate to within one unit in
+/// the last place.
 ///
 /// # Parameters
 ///
@@ -41,52 +45,77 @@ const EXP_COEFFS: [f64; 13] = [
 ///
 /// # Returns
 ///
-/// The value `e^x`.
+/// The value `e^x`. Overflow saturates to `+inf` and underflow to `0`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub extern "C" fn exp(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
-    }
+    let hx: u32 = (x.to_bits() >> 32) as u32;
+    let xsb: usize = ((hx >> 31) & 1) as usize; // sign bit of x
+    let ax: u32 = hx & 0x7fff_ffff; // high word of |x|
 
-    // Range reduction: x = k*ln(2) + r.
-    let k_f: f64 = crate::round::round(x * LN2_INV);
-    let r: f64 = x - k_f * LN2;
-
-    // Horner evaluation of degree-12 Taylor polynomial.
-    let mut poly: f64 = EXP_COEFFS[0];
-    let mut i: usize = 1;
-    while i < EXP_COEFFS.len() {
-        poly = poly * r + EXP_COEFFS[i];
-        i += 1;
-    }
-
-    // Multiply by 2^k.
-    #[allow(clippy::cast_possible_truncation)]
-    let k_i64: i64 = k_f as i64;
-
-    // The result is `poly * 2^k`. Inputs just below the overflow boundary
-    // (`ln(f64::MAX) ~= 709.7827`) reduce to `k == 1024`, whose result is still
-    // finite even though `2^1024` is not a representable exponent. Scale as
-    // `2^1023 * 2` so those values round correctly while true overflows saturate
-    // to `+inf`.
-    if k_i64 > 1024 {
-        return f64::from_bits(0x7FF0_0000_0000_0000);
-    }
-    if k_i64 == 1024 {
-        return poly * f64::from_bits(0x7FE0_0000_0000_0000) * 2.0;
-    }
-    if k_i64 < -1022 {
-        let scale: f64 = f64::from_bits(0x0010_0000_0000_0000);
-        let adj: i64 = k_i64 + 1022;
-        if adj < -1022 {
-            return 0.0;
+    // Filter out non-finite and out-of-range arguments.
+    if ax >= 0x4086_2E42 {
+        // |x| >= 709.78...
+        if ax >= 0x7ff0_0000 {
+            // x is +/-inf or NaN.
+            if x.is_nan() {
+                return x + x;
+            }
+            return if xsb == 0 { x } else { 0.0 }; // exp(+inf)=inf, exp(-inf)=0
         }
-        let biased: u64 = (adj + 1023) as u64;
-        return poly * scale * f64::from_bits(biased << 52);
+        if x > O_THRESHOLD {
+            return f64::INFINITY; // overflow
+        }
+        if x < U_THRESHOLD {
+            return 0.0; // underflow
+        }
     }
 
-    let biased: u64 = (k_i64 + 1023) as u64;
-    poly * f64::from_bits(biased << 52)
+    // Argument reduction: x = k*ln(2) + (hi - lo), with r = hi - lo the reduced value.
+    let mut k: i32 = 0;
+    let mut hi: f64 = 0.0;
+    let mut lo: f64 = 0.0;
+    let mut r: f64 = x;
+    if ax > 0x3fd6_2e42 {
+        // |x| > 0.5*ln2
+        if ax < 0x3FF0_A2B2 {
+            // |x| < 1.5*ln2: a single step of ln2 suffices.
+            hi = x - LN2HI[xsb];
+            lo = LN2LO[xsb];
+            k = 1 - (xsb as i32) - (xsb as i32);
+        } else {
+            k = (INVLN2 * x + HALF[xsb]) as i32;
+            let t: f64 = f64::from(k);
+            hi = x - t * LN2HI[0]; // t*LN2HI[0] is exact here
+            lo = t * LN2LO[0];
+        }
+        r = hi - lo;
+    } else if ax < 0x3e30_0000 {
+        // |x| < 2^-28: exp(x) rounds to 1 + x.
+        return 1.0 + x;
+    }
+
+    // Evaluate exp(r) on the reduced range and scale by 2^k.
+    let t: f64 = r * r;
+    let twopk: f64 = if k >= -1021 {
+        f64::from_bits(((0x3ff + k) as u64) << 52)
+    } else {
+        f64::from_bits(((0x3ff + k + 1000) as u64) << 52)
+    };
+    let c: f64 = r - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
+    if k == 0 {
+        return 1.0 - ((r * c) / (c - 2.0) - r);
+    }
+    let y: f64 = 1.0 - ((lo - (r * c) / (2.0 - c)) - hi);
+    if k >= -1021 {
+        if k == 1024 {
+            // 2^1024 is not representable; scale as 2^1023 * 2 instead.
+            return y * 2.0 * f64::from_bits(0x7fe0_0000_0000_0000);
+        }
+        y * twopk
+    } else {
+        y * twopk * TWOM1000
+    }
 }
 
 //==================================================================================================
@@ -114,7 +143,19 @@ mod tests {
 
     #[test]
     fn test_ln2() {
-        assert!((exp(LN2) - 2.0).abs() < 1e-10);
+        assert!((exp(core::f64::consts::LN_2) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_matches_std_over_range() {
+        // Compare against the host libm across the full finite range at <= a few ULP.
+        let mut x: f64 = -700.0;
+        while x <= 700.0 {
+            let got: f64 = exp(x);
+            let want: f64 = x.exp();
+            assert!((got - want).abs() <= want.abs() * 1e-14, "exp({x}) = {got}, want {want}");
+            x += 0.013;
+        }
     }
 
     #[test]

--- a/src/libs/libc_math/src/expm1.rs
+++ b/src/libs/libc_math/src/expm1.rs
@@ -1,7 +1,35 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Overflow threshold: `expm1(x)` overflows to `+inf` for `x > O_THRESHOLD`.
+const O_THRESHOLD: f64 = 7.097_827_128_933_84e2;
+/// `ln(2)` split into a leading part (exact in its high bits) and a low correction.
+const LN2_HI: f64 = 6.931_471_803_691_238e-1;
+const LN2_LO: f64 = 1.908_214_929_270_587_7e-10;
+/// `1 / ln(2)`.
+const INVLN2: f64 = 1.442_695_040_888_963_4;
+/// Minimax coefficients for the auxiliary rational used by the reduction.
+const Q1: f64 = -3.333_333_333_333_313e-2;
+const Q2: f64 = 1.587_301_587_254_814_6e-3;
+const Q3: f64 = -7.936_507_578_674_88e-5;
+const Q4: f64 = 4.008_217_827_329_362e-6;
+const Q5: f64 = -2.010_992_181_836_243_7e-7;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
 /// Computes `e^x - 1`.
+///
+/// # Description
+///
+/// Computes `e^x - 1` directly (rather than as `exp(x) - 1`) so that no
+/// significant digits are lost to cancellation when `x` is near zero. This is the
+/// fdlibm algorithm and is accurate to within one unit in the last place.
 ///
 /// # Parameters
 ///
@@ -9,13 +37,113 @@
 ///
 /// # Returns
 ///
-/// The value `expm1(x) = e^x - 1`.
+/// The value `expm1(x) = e^x - 1`. Overflow saturates to `+inf`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation)]
 pub extern "C" fn expm1(x: f64) -> f64 {
-    if x.is_nan() || x == 0.0 {
-        return x;
+    let hx_full: u32 = (x.to_bits() >> 32) as u32;
+    let xsb: u32 = hx_full & 0x8000_0000; // sign bit of x
+    let hx: u32 = hx_full & 0x7fff_ffff; // high word of |x|
+
+    let k: i32;
+    let c: f64;
+    let xr: f64;
+
+    // Filter out huge and non-finite arguments.
+    if hx >= 0x4043_687A {
+        // |x| >= 56*ln2
+        if hx >= 0x4086_2E42 {
+            // |x| >= 709.78...
+            if hx >= 0x7ff0_0000 {
+                if x.is_nan() {
+                    return x + x;
+                }
+                return if xsb == 0 { x } else { -1.0 }; // expm1(+inf)=inf, expm1(-inf)=-1
+            }
+            if x > O_THRESHOLD {
+                return f64::INFINITY; // overflow
+            }
+        }
+        if xsb != 0 {
+            // x < -56*ln2: expm1(x) rounds to -1.
+            return -1.0;
+        }
     }
-    crate::exp::exp(x) - 1.0
+
+    // Argument reduction: x = k*ln(2) + (hi - lo), with c the reduction round-off.
+    if hx > 0x3fd6_2e42 {
+        // |x| > 0.5*ln2
+        let hi: f64;
+        let lo: f64;
+        if hx < 0x3FF0_A2B2 {
+            // |x| < 1.5*ln2: a single step of ln2 suffices.
+            if xsb == 0 {
+                hi = x - LN2_HI;
+                lo = LN2_LO;
+                k = 1;
+            } else {
+                hi = x + LN2_HI;
+                lo = -LN2_LO;
+                k = -1;
+            }
+        } else {
+            k = (INVLN2 * x + if xsb == 0 { 0.5 } else { -0.5 }) as i32;
+            let t: f64 = f64::from(k);
+            hi = x - t * LN2_HI; // t*LN2_HI is exact here
+            lo = t * LN2_LO;
+        }
+        xr = hi - lo;
+        c = (hi - xr) - lo;
+    } else if hx < 0x3c90_0000 {
+        // |x| < 2^-54: expm1(x) rounds to x (preserving a signed zero).
+        return x;
+    } else {
+        k = 0;
+        xr = x;
+        c = 0.0;
+    }
+
+    // x is now in the primary range.
+    let hfx: f64 = 0.5 * xr;
+    let hxs: f64 = xr * hfx;
+    let r1: f64 = 1.0 + hxs * (Q1 + hxs * (Q2 + hxs * (Q3 + hxs * (Q4 + hxs * Q5))));
+    let t: f64 = 3.0 - r1 * hfx;
+    let mut e: f64 = hxs * ((r1 - t) / (6.0 - xr * t));
+    if k == 0 {
+        return xr - (xr * e - hxs);
+    }
+    let twopk: f64 = f64::from_bits(((1023 + k) as u64) << 52); // 2^k
+    e = xr * (e - c) - c;
+    e -= hxs;
+    if k == -1 {
+        return 0.5 * (xr - e) - 0.5;
+    }
+    if k == 1 {
+        if xr < -0.25 {
+            return -2.0 * (e - (xr + 0.5));
+        }
+        return 1.0 + 2.0 * (xr - e);
+    }
+    if k <= -2 || k > 56 {
+        // exp(x) - 1 is accurate enough here.
+        let mut y: f64 = 1.0 - (e - xr);
+        if k == 1024 {
+            y = y * 2.0 * f64::from_bits(0x7fe0_0000_0000_0000); // 2^1023
+        } else {
+            y *= twopk;
+        }
+        return y - 1.0;
+    }
+    if k < 20 {
+        let t2: f64 = 1.0 - f64::from_bits(((1023 - k) as u64) << 52); // 1 - 2^-k (exact)
+        let y: f64 = t2 - (e - xr);
+        y * twopk
+    } else {
+        let t2: f64 = f64::from_bits(((1023 - k) as u64) << 52); // 2^-k
+        let mut y: f64 = xr - (e + t2);
+        y += 1.0;
+        y * twopk
+    }
 }
 
 //==================================================================================================
@@ -44,5 +172,34 @@ mod tests {
     #[test]
     fn test_nan() {
         assert!(expm1(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        assert_eq!(expm1(0.0).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(expm1(-0.0).to_bits(), (-0.0_f64).to_bits());
+    }
+
+    #[test]
+    fn test_small_precision() {
+        // Near zero, expm1(x) must not lose precision the way exp(x) - 1 does.
+        for &x in &[1e-8_f64, -1e-8, 1e-5, -1e-5, 1e-12] {
+            let want: f64 = x.exp_m1();
+            assert!((expm1(x) - want).abs() <= want.abs() * 1e-14 + 1e-300);
+        }
+    }
+
+    #[test]
+    fn test_matches_std_over_range() {
+        let mut x: f64 = -40.0;
+        while x <= 700.0 {
+            let got: f64 = expm1(x);
+            let want: f64 = x.exp_m1();
+            assert!(
+                (got - want).abs() <= want.abs() * 1e-14 + 1e-300,
+                "expm1({x}) = {got}, want {want}"
+            );
+            x += 0.017;
+        }
     }
 }

--- a/src/libs/libc_math/src/fmod.rs
+++ b/src/libs/libc_math/src/fmod.rs
@@ -9,7 +9,14 @@
 ///
 /// # Description
 ///
-/// The result has the same sign as `x` and magnitude less than that of `y`.
+/// The result `r` has the same sign as `x` and magnitude less than that of `y`,
+/// and satisfies `x == n*y + r` for some integer `n`. The computation is exact:
+/// it is performed on the integer significands so no rounding error is
+/// introduced.
+///
+/// Special values follow IEEE-754 / C99: `fmod(±0, y) = ±0` for `y != 0`,
+/// `fmod(x, ±inf) = x` for finite `x`, and `fmod(x, 0)`, `fmod(±inf, y)` and any
+/// NaN operand yield NaN.
 ///
 /// # Parameters
 ///
@@ -18,17 +25,93 @@
 ///
 /// # Returns
 ///
-/// The floating-point remainder `x - n*y` where `n = trunc(x/y)`.
+/// The floating-point remainder of `x / y`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::eq_op
+)]
 pub extern "C" fn fmod(x: f64, y: f64) -> f64 {
-    if y == 0.0 || x.is_nan() || y.is_nan() {
-        return f64::from_bits(0x7FF8_0000_0000_0000); // NaN
+    let mut uxi: u64 = x.to_bits();
+    let mut uyi: u64 = y.to_bits();
+    let mut ex: i32 = ((uxi >> 52) & 0x7ff) as i32;
+    let mut ey: i32 = ((uyi >> 52) & 0x7ff) as i32;
+    let sx: u64 = uxi >> 63;
+
+    // y == 0, or x is non-finite (inf/NaN), or y is NaN: the result is NaN.
+    // `(x*y)/(x*y)` yields a quiet NaN and raises the invalid flag, matching libm.
+    if (uyi << 1) == 0 || y.is_nan() || ex == 0x7ff {
+        return (x * y) / (x * y);
     }
-    if x.to_bits() & 0x7FF0_0000_0000_0000 == 0x7FF0_0000_0000_0000 {
-        return f64::from_bits(0x7FF8_0000_0000_0000); // NaN for inf
+    // |x| <= |y|: either |x| < |y| (result is x, covering fmod(x, inf) = x and
+    // fmod(±0, y) = ±0) or |x| == |y| (result is a zero with the sign of x).
+    if (uxi << 1) <= (uyi << 1) {
+        if (uxi << 1) == (uyi << 1) {
+            return 0.0 * x;
+        }
+        return x;
     }
-    let n: f64 = crate::trunc::trunc(x / y);
-    x - n * y
+
+    // Normalize x into a 53-bit significand with the leading bit at position 52,
+    // tracking the (possibly subnormal) exponent in `ex`.
+    if ex == 0 {
+        let mut i: u64 = uxi << 12;
+        while (i >> 63) == 0 {
+            ex -= 1;
+            i <<= 1;
+        }
+        uxi <<= (1 - ex) as u32;
+    } else {
+        uxi &= u64::MAX >> 12;
+        uxi |= 1 << 52;
+    }
+    // Normalize y likewise.
+    if ey == 0 {
+        let mut i: u64 = uyi << 12;
+        while (i >> 63) == 0 {
+            ey -= 1;
+            i <<= 1;
+        }
+        uyi <<= (1 - ey) as u32;
+    } else {
+        uyi &= u64::MAX >> 12;
+        uyi |= 1 << 52;
+    }
+
+    // Compute the remainder of the significands via shift-and-subtract long division.
+    while ex > ey {
+        let i: u64 = uxi.wrapping_sub(uyi);
+        if (i >> 63) == 0 {
+            if i == 0 {
+                return 0.0 * x;
+            }
+            uxi = i;
+        }
+        uxi <<= 1;
+        ex -= 1;
+    }
+    let i: u64 = uxi.wrapping_sub(uyi);
+    if (i >> 63) == 0 {
+        if i == 0 {
+            return 0.0 * x;
+        }
+        uxi = i;
+    }
+    while (uxi >> 52) == 0 {
+        uxi <<= 1;
+        ex -= 1;
+    }
+
+    // Reassemble the floating-point result, restoring the sign of x.
+    if ex > 0 {
+        uxi -= 1 << 52;
+        uxi |= (ex as u64) << 52;
+    } else {
+        uxi >>= (1 - ex) as u32;
+    }
+    uxi |= sx << 63;
+    f64::from_bits(uxi)
 }
 
 //==================================================================================================
@@ -62,5 +145,47 @@ mod tests {
     #[test]
     fn test_nan() {
         assert!(fmod(f64::NAN, 2.0).is_nan());
+        assert!(fmod(2.0, f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_infinite_divisor_returns_x() {
+        // fmod(x, ±inf) == x for finite x.
+        assert_eq!(fmod(2.0, f64::INFINITY), 2.0);
+        assert_eq!(fmod(2.0, f64::NEG_INFINITY), 2.0);
+        assert_eq!(fmod(-3.5, f64::INFINITY), -3.5);
+        assert_eq!(fmod(1e300, f64::INFINITY), 1e300);
+    }
+
+    #[test]
+    fn test_infinite_dividend_is_nan() {
+        assert!(fmod(f64::INFINITY, 2.0).is_nan());
+        assert!(fmod(f64::NEG_INFINITY, 2.0).is_nan());
+    }
+
+    #[test]
+    fn test_signed_zero_dividend() {
+        // fmod(±0, y) == ±0, preserving the sign of zero.
+        assert_eq!(fmod(0.0, 3.0).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(fmod(-0.0, 3.0).to_bits(), (-0.0_f64).to_bits());
+    }
+
+    #[test]
+    fn test_exact_matches_rem_operator() {
+        // Rust's `%` on f64 is the C `fmod`; the result must be bit-identical.
+        let xs: [f64; 9] = [5.3, -5.3, 6.0, 1e300, -1e-300, 12345.678, -0.1, 3.0, 2.5];
+        let ys: [f64; 7] = [2.0, 3.0, 0.5, 1e-100, 7.0, -2.0, 1.25];
+        for &x in &xs {
+            for &y in &ys {
+                assert_eq!(fmod(x, y).to_bits(), (x % y).to_bits(), "fmod({x}, {y}) mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn test_subnormal_operands() {
+        let tiny: f64 = f64::from_bits(0x0000_0000_0000_0007); // subnormal
+        assert_eq!(fmod(tiny, tiny).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(fmod(1.0, tiny).to_bits(), (1.0_f64 % tiny).to_bits());
     }
 }

--- a/src/libs/libc_math/src/log.rs
+++ b/src/libs/libc_math/src/log.rs
@@ -5,7 +5,19 @@
 // Constants
 //==================================================================================================
 
-const LN2: f64 = core::f64::consts::LN_2;
+/// `ln(2)` split into a leading part (exact in its high bits) and a low correction.
+const LN2_HI: f64 = 6.931_471_803_691_238e-1;
+const LN2_LO: f64 = 1.908_214_929_270_587_7e-10;
+/// `2^54`, used to scale subnormal inputs up into the normal range.
+const TWO54: f64 = 1.801_439_850_948_198_4e16;
+/// Minimax coefficients for the log approximation on the reduced range.
+const LG1: f64 = 6.666_666_666_666_735e-1;
+const LG2: f64 = 3.999_999_999_940_942e-1;
+const LG3: f64 = 2.857_142_874_366_239e-1;
+const LG4: f64 = 2.222_219_843_214_978_4e-1;
+const LG5: f64 = 1.818_357_216_161_805e-1;
+const LG6: f64 = 1.531_383_769_920_937_3e-1;
+const LG7: f64 = 1.479_819_860_511_658_6e-1;
 
 //==================================================================================================
 // Public Functions
@@ -15,8 +27,11 @@ const LN2: f64 = core::f64::consts::LN_2;
 ///
 /// # Description
 ///
-/// Decomposes `x` into mantissa `m` and exponent `e`, then computes
-/// `log(x) = e * ln(2) + log(m)` using the substitution `s = (m-1)/(m+1)` for fast convergence.
+/// Writes `x = 2^k * (1 + f)` with `f` in `[-1/3, 1/3]` and evaluates
+/// `log(1 + f)` from an odd minimax polynomial in `s = f / (2 + f)`, then adds
+/// `k * ln(2)` using a two-part `ln(2)` so no precision is lost for large `k`.
+/// This is the fdlibm algorithm and is accurate to within one unit in the last
+/// place.
 ///
 /// # Parameters
 ///
@@ -24,62 +39,83 @@ const LN2: f64 = core::f64::consts::LN_2;
 ///
 /// # Returns
 ///
-/// The natural logarithm of `x`. Returns NaN for negative inputs, -inf for zero.
+/// The natural logarithm of `x`. Returns NaN for negative inputs and `-inf` for zero.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::eq_op
+)]
 pub extern "C" fn log(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
+    let mut xr: f64 = x;
+    let mut hx: i32 = (x.to_bits() >> 32) as i32; // signed high word
+    let lx: u32 = x.to_bits() as u32; // low word
+
+    let mut k: i32 = 0;
+    if hx < 0x0010_0000 {
+        // |x| < 2^-1022: zero, negative, or subnormal.
+        if (hx & 0x7fff_ffff) == 0 && lx == 0 {
+            return f64::NEG_INFINITY; // log(+/-0) = -inf
+        }
+        if hx < 0 {
+            return (x - x) / 0.0; // log(negative) = NaN
+        }
+        // Subnormal: scale up by 2^54 and adjust the exponent.
+        k -= 54;
+        xr = x * TWO54;
+        hx = (xr.to_bits() >> 32) as i32;
     }
-    if x < 0.0 {
-        return f64::from_bits(0x7FF8_0000_0000_0000);
+    if hx >= 0x7ff0_0000 {
+        return x + x; // log(+inf) = +inf, log(NaN) = NaN
     }
-    if x == 0.0 {
-        return f64::from_bits(0xFFF0_0000_0000_0000);
-    }
-    if x.to_bits() == 0x7FF0_0000_0000_0000 {
-        return x;
+    k += (hx >> 20) - 1023;
+    hx &= 0x000f_ffff;
+    let i: i32 = (hx + 0x9_5f64) & 0x10_0000;
+    // Normalize the significand to [1, 2) (i == 0) or [0.5, 1) (i != 0).
+    let new_hi: u64 = u64::from((hx | (i ^ 0x3ff0_0000)) as u32);
+    xr = f64::from_bits((new_hi << 32) | (xr.to_bits() & 0xffff_ffff));
+    k += i >> 20;
+    let f: f64 = xr - 1.0;
+
+    // Path for f very close to zero, avoiding cancellation.
+    if (0x000f_ffff & (2 + hx)) < 3 {
+        if f == 0.0 {
+            if k == 0 {
+                return 0.0;
+            }
+            let dk: f64 = f64::from(k);
+            return dk * LN2_HI + dk * LN2_LO;
+        }
+        let r: f64 = f * f * (0.5 - 0.333_333_333_333_333_3 * f);
+        if k == 0 {
+            return f - r;
+        }
+        let dk: f64 = f64::from(k);
+        return dk * LN2_HI - ((r - dk * LN2_LO) - f);
     }
 
-    let bits: u64 = x.to_bits();
-    let exp_raw: u64 = (bits >> 52) & 0x7FF;
-
-    // Handle subnormals by scaling up.
-    let (adj_bits, exp_adj): (u64, i64) = if exp_raw == 0 {
-        let scaled: f64 = x * 4_503_599_627_370_496.0; // 2^52
-        (scaled.to_bits(), -52)
+    let s: f64 = f / (2.0 + f);
+    let dk: f64 = f64::from(k);
+    let z: f64 = s * s;
+    let i2: i32 = hx - 0x6_147a;
+    let w: f64 = z * z;
+    let j: i32 = 0x6_b851 - hx;
+    let t1: f64 = w * (LG2 + w * (LG4 + w * LG6));
+    let t2: f64 = z * (LG1 + w * (LG3 + w * (LG5 + w * LG7)));
+    let r: f64 = t2 + t1;
+    if (i2 | j) > 0 {
+        let hfsq: f64 = 0.5 * f * f;
+        if k == 0 {
+            f - (hfsq - s * (hfsq + r))
+        } else {
+            dk * LN2_HI - ((hfsq - (s * (hfsq + r) + dk * LN2_LO)) - f)
+        }
+    } else if k == 0 {
+        f - s * (f - r)
     } else {
-        (bits, 0)
-    };
-
-    let exp_biased: u64 = (adj_bits >> 52) & 0x7FF;
-    #[allow(clippy::cast_possible_wrap)]
-    let mut e: i64 = (exp_biased as i64) - 1023 + exp_adj;
-
-    // Extract mantissa in [1, 2).
-    let m_bits: u64 = (adj_bits & 0x000F_FFFF_FFFF_FFFF) | 0x3FF0_0000_0000_0000;
-    let mut m: f64 = f64::from_bits(m_bits);
-
-    // Reduce m to [sqrt(2)/2, sqrt(2)] for better convergence.
-    if m > core::f64::consts::SQRT_2 {
-        m *= 0.5;
-        e += 1;
+        dk * LN2_HI - ((s * (f - r) - dk * LN2_LO) - f)
     }
-
-    // Use substitution s = (m-1)/(m+1), then log(m) = 2*(s + s^3/3 + s^5/5 + ...).
-    let s: f64 = (m - 1.0) / (m + 1.0);
-    let s2: f64 = s * s;
-
-    let log_m: f64 = 2.0
-        * s
-        * (1.0
-            + s2 * (1.0 / 3.0
-                + s2 * (0.2
-                    + s2 * (1.0 / 7.0
-                        + s2 * (1.0 / 9.0
-                            + s2 * (1.0 / 11.0 + s2 * (1.0 / 13.0 + s2 * (1.0 / 15.0))))))));
-
-    let e_f64: f64 = e as f64;
-    e_f64 * LN2 + log_m
 }
 
 //==================================================================================================
@@ -102,12 +138,33 @@ mod tests {
 
     #[test]
     fn test_two() {
-        assert!((log(2.0) - LN2).abs() < 1e-10);
+        assert!((log(2.0) - core::f64::consts::LN_2).abs() < 1e-10);
     }
 
     #[test]
     fn test_ten() {
         assert!((log(10.0) - 2.302_585_092_994_046).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_matches_std_over_range() {
+        // Multiplicative sweep across the exponent range, compared to the host libm.
+        let mut x: f64 = 1e-300;
+        while x < 1e300 {
+            let got: f64 = log(x);
+            let want: f64 = x.ln();
+            assert!(
+                (got - want).abs() <= want.abs() * 1e-14 + 1e-15,
+                "log({x}) = {got}, want {want}"
+            );
+            x *= 1.037;
+        }
+    }
+
+    #[test]
+    fn test_subnormal() {
+        let d: f64 = f64::from_bits(0x0000_0000_0000_1000); // subnormal
+        assert!((log(d) - d.ln()).abs() <= d.ln().abs() * 1e-14);
     }
 
     #[test]

--- a/src/libs/libc_math/src/tan.rs
+++ b/src/libs/libc_math/src/tan.rs
@@ -2,6 +2,131 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// `2 / pi`, for the argument reduction quotient.
+const INVPIO2: f64 = 6.366_197_723_675_814e-1;
+/// `pi/2` split into successively finer parts for an exact Cody-Waite reduction.
+const PIO2_1: f64 = 1.570_796_326_734_125_6;
+const PIO2_1T: f64 = 6.077_100_506_506_192e-11;
+const PIO2_2: f64 = 6.077_100_506_303_966e-11;
+const PIO2_2T: f64 = 2.022_266_248_795_950_6e-21;
+const PIO2_3: f64 = 2.022_266_248_711_166_5e-21;
+const PIO2_3T: f64 = 8.478_427_660_368_9e-32;
+
+/// `pi/4` split into a high part and a low correction, for the near-`pi/4` branch.
+const PIO4: f64 = 7.853_981_633_974_483e-1;
+const PIO4LO: f64 = 3.061_616_997_868_383e-17;
+
+/// Minimax coefficients for the tangent kernel on `[0, pi/4]`.
+const KT: [f64; 13] = [
+    3.333_333_333_333_341e-1,
+    1.333_333_333_332_012_4e-1,
+    5.396_825_397_622_605e-2,
+    2.186_948_829_485_954_2e-2,
+    8.863_239_823_599_3e-3,
+    3.592_079_107_591_312_4e-3,
+    1.456_209_454_325_290_3e-3,
+    5.880_412_408_202_641e-4,
+    2.464_631_348_184_699e-4,
+    7.817_944_429_395_571e-5,
+    7.140_724_913_826_082e-5,
+    -1.855_863_748_552_754_6e-5,
+    2.590_730_518_636_337e-5,
+];
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+/// Cody-Waite reduction of `x` (with high word `ix`) to `n*(pi/2) + (y0 + y1)`
+/// with `|y0 + y1| <= pi/4`, valid for `|x| < 2^20*(pi/2)`. Returns `(n, y0, y1)`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn rem_pio2_medium(x: f64, ix: u32) -> (i32, f64, f64) {
+    let fnn: f64 = crate::round::round(x * INVPIO2);
+    let n: i32 = fnn as i32;
+    let mut r: f64 = x - fnn * PIO2_1;
+    let mut w: f64 = fnn * PIO2_1T; // 1st round, good to 85 bits
+    let j: i32 = (ix >> 20) as i32;
+    let mut y0: f64 = r - w;
+    let mut high: u32 = (y0.to_bits() >> 32) as u32;
+    let mut i: i32 = j - (((high >> 20) & 0x7ff) as i32);
+    if i > 16 {
+        // 2nd iteration needed, good to 118 bits.
+        let t: f64 = r;
+        w = fnn * PIO2_2;
+        r = t - w;
+        w = fnn * PIO2_2T - ((t - r) - w);
+        y0 = r - w;
+        high = (y0.to_bits() >> 32) as u32;
+        i = j - (((high >> 20) & 0x7ff) as i32);
+        if i > 49 {
+            // 3rd iteration needed, good to 151 bits.
+            let t2: f64 = r;
+            w = fnn * PIO2_3;
+            r = t2 - w;
+            w = fnn * PIO2_3T - ((t2 - r) - w);
+            y0 = r - w;
+        }
+    }
+    let y1: f64 = (r - y0) - w;
+    (n, y0, y1)
+}
+
+/// Tangent kernel on the reduced argument `x + y` (with `|x| <= pi/4`). `iy` is
+/// `1` when `tan` is wanted and `-1` when `-1/tan` (an odd quadrant) is wanted.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn kernel_tan(mut x: f64, mut y: f64, iy: i32) -> f64 {
+    let hx: i32 = (x.to_bits() >> 32) as i32;
+    let ix: i32 = hx & 0x7fff_ffff;
+    if ix < 0x3e30_0000 {
+        // |x| < 2^-28.
+        if (x as i32) == 0 {
+            let low: u32 = x.to_bits() as u32;
+            if (((ix as u32) | low) | ((iy + 1) as u32)) == 0 {
+                // x == 0 and an odd quadrant: this is a pole, return +inf.
+                return 1.0 / f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff);
+            }
+            return if iy == 1 { x } else { -1.0 / x };
+        }
+    }
+    if ix >= 0x3FE5_9428 {
+        // |x| >= 0.6744: reflect about pi/4 for better polynomial accuracy.
+        if hx < 0 {
+            x = -x;
+            y = -y;
+        }
+        let z: f64 = PIO4 - x;
+        let w: f64 = PIO4LO - y;
+        x = z + w;
+        y = 0.0;
+    }
+    let z: f64 = x * x;
+    let w: f64 = z * z;
+    let r: f64 = KT[1] + w * (KT[3] + w * (KT[5] + w * (KT[7] + w * (KT[9] + w * KT[11]))));
+    let v: f64 = z * (KT[2] + w * (KT[4] + w * (KT[6] + w * (KT[8] + w * (KT[10] + w * KT[12])))));
+    let s: f64 = z * x;
+    let mut r: f64 = y + z * (s * (r + v) + y);
+    r += KT[0] * s;
+    let w: f64 = x + r;
+    if ix >= 0x3FE5_9428 {
+        let v: f64 = f64::from(iy);
+        return f64::from(1 - ((hx >> 30) & 2)) * (v - 2.0 * (x - (w * w / (w + v) - r)));
+    }
+    if iy == 1 {
+        return w;
+    }
+    // iy == -1: compute -1.0/(x+r) accurately.
+    let z: f64 = f64::from_bits(w.to_bits() & 0xffff_ffff_0000_0000); // high word of w only
+    let v: f64 = r - (z - x); // z + v = r + x
+    let a: f64 = -1.0 / w;
+    let t: f64 = f64::from_bits(a.to_bits() & 0xffff_ffff_0000_0000); // high word of a only
+    let s: f64 = 1.0 + t * z;
+    t + a * (s + t * v)
+}
+
+//==================================================================================================
 // Public Functions
 //==================================================================================================
 
@@ -9,7 +134,10 @@
 ///
 /// # Description
 ///
-/// Computed as `sin(x) / cos(x)`.
+/// Reduces `x` modulo `pi/2` with a Cody-Waite scheme and evaluates a minimax
+/// tangent kernel on the reduced argument. This is the fdlibm algorithm and is
+/// accurate to within one unit in the last place for `|x| < 2^20*(pi/2)`; larger
+/// arguments fall back to `sin(x)/cos(x)`.
 ///
 /// # Parameters
 ///
@@ -19,12 +147,27 @@
 ///
 /// The tangent of `x`.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::eq_op)]
 pub extern "C" fn tan(x: f64) -> f64 {
-    let s: f64 = crate::sin::sin(x);
-    let c: f64 = crate::cos::cos(x);
-    // Divide directly so IEEE-754 signed-zero semantics select the correct signed infinity at the
-    // poles, where cos(x) underflows to +0.0 or -0.0.
-    s / c
+    let ix: u32 = ((x.to_bits() >> 32) as u32) & 0x7fff_ffff;
+    if ix <= 0x3fe9_21fb {
+        // |x| <= pi/4.
+        if ix < 0x3e40_0000 {
+            // |x| < 2^-27: tan(x) rounds to x.
+            return x;
+        }
+        return kernel_tan(x, 0.0, 1);
+    }
+    if ix >= 0x7ff0_0000 {
+        return x - x; // tan(inf or NaN) is NaN
+    }
+    if ix >= 0x4139_21fb {
+        // |x| >= 2^20*(pi/2): fall back to sin/cos for these rare huge arguments.
+        return crate::sin::sin(x) / crate::cos::cos(x);
+    }
+    let (n, y0, y1) = rem_pio2_medium(x, ix);
+    // n even -> tan(reduced); n odd -> -1/tan(reduced).
+    kernel_tan(y0, y1, 1 - ((n & 1) << 1))
 }
 
 //==================================================================================================
@@ -60,5 +203,35 @@ mod tests {
     #[test]
     fn test_infinity() {
         assert!(tan(f64::INFINITY).is_nan());
+    }
+
+    #[test]
+    fn test_matches_std_over_range() {
+        // Sweep across many periods (within the Cody-Waite range) vs the host libm.
+        let mut x: f64 = -1000.0;
+        while x <= 1000.0 {
+            let got: f64 = tan(x);
+            let want: f64 = x.tan();
+            // Skip points extremely close to a pole, where the true value is huge
+            // and a relative comparison is dominated by reduction round-off.
+            if want.abs() < 1e6 {
+                assert!(
+                    (got - want).abs() <= want.abs() * 1e-13 + 1e-13,
+                    "tan({x}) = {got}, want {want}"
+                );
+            }
+            x += 0.1;
+        }
+    }
+
+    #[test]
+    fn test_large_argument() {
+        for &x in &[1.0e5_f64, 3.0e5, -7.0e5, 123456.789] {
+            let got: f64 = tan(x);
+            let want: f64 = x.tan();
+            if want.abs() < 1e6 {
+                assert!((got - want).abs() <= want.abs() * 1e-11 + 1e-11);
+            }
+        }
     }
 }

--- a/src/libs/libc_math/src/tanh.rs
+++ b/src/libs/libc_math/src/tanh.rs
@@ -3,6 +3,12 @@
 
 /// Computes the hyperbolic tangent of `x`.
 ///
+/// # Description
+///
+/// Evaluates `tanh` from `expm1` so precision is preserved near zero, and
+/// preserves the sign of a zero argument (`tanh(-0.0) == -0.0`). This is the musl
+/// algorithm and is accurate to within one unit in the last place.
+///
 /// # Parameters
 ///
 /// - `x`: Input value.
@@ -11,18 +17,39 @@
 ///
 /// The value `tanh(x)`, saturating to `+/-1` for large magnitudes.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+#[allow(clippy::cast_possible_truncation)]
 pub extern "C" fn tanh(x: f64) -> f64 {
-    if x.is_nan() {
-        return x;
+    let sign: bool = (x.to_bits() >> 63) != 0;
+    let ax: f64 = f64::from_bits(x.to_bits() & 0x7fff_ffff_ffff_ffff); // |x|
+    let w: u32 = (ax.to_bits() >> 32) as u32;
+
+    let t: f64;
+    if w > 0x3fe1_93ea {
+        // |x| > log(3)/2 ~= 0.5493, or NaN.
+        if w > 0x4034_0000 {
+            // |x| > 20, or NaN: tanh saturates (and propagates NaN).
+            t = 1.0 - 0.0 / ax;
+        } else {
+            let e: f64 = crate::expm1::expm1(2.0 * ax);
+            t = 1.0 - 2.0 / (e + 2.0);
+        }
+    } else if w > 0x3fd0_58ae {
+        // |x| > log(5/3)/2 ~= 0.2554
+        let e: f64 = crate::expm1::expm1(2.0 * ax);
+        t = e / (e + 2.0);
+    } else if w >= 0x0010_0000 {
+        // 2^-1022 <= |x| <= 0.2554: use the -2x form to preserve precision.
+        let e: f64 = crate::expm1::expm1(-2.0 * ax);
+        t = -e / (e + 2.0);
+    } else {
+        // |x| is zero or subnormal: tanh(x) rounds to x.
+        t = ax;
     }
-    if x > 20.0 {
-        return 1.0;
+    if sign {
+        -t
+    } else {
+        t
     }
-    if x < -20.0 {
-        return -1.0;
-    }
-    let e2: f64 = crate::exp::exp(2.0 * x);
-    (e2 - 1.0) / (e2 + 1.0)
 }
 
 //==================================================================================================
@@ -57,5 +84,26 @@ mod tests {
     #[test]
     fn test_nan() {
         assert!(tanh(f64::NAN).is_nan());
+    }
+
+    #[test]
+    fn test_signed_zero() {
+        // tanh must preserve the sign of zero.
+        assert_eq!(tanh(0.0).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(tanh(-0.0).to_bits(), (-0.0_f64).to_bits());
+    }
+
+    #[test]
+    fn test_matches_std_over_range() {
+        let mut x: f64 = -25.0;
+        while x <= 25.0 {
+            let got: f64 = tanh(x);
+            let want: f64 = x.tanh();
+            assert!(
+                (got - want).abs() <= want.abs() * 1e-14 + 1e-16,
+                "tanh({x}) = {got}, want {want}"
+            );
+            x += 0.011;
+        }
     }
 }

--- a/src/tests/integration/test-c-math/main.c
+++ b/src/tests/integration/test-c-math/main.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <math.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/**
+ * @brief Launders a value through a volatile store so the compiler cannot
+ * constant-fold a math call at its own (host) precision and must instead emit a
+ * real call into the bundled libm.
+ */
+static double vol(double x)
+{
+    volatile double v = x;
+    return v;
+}
+
+/**
+ * @brief Checks that @p got is within @p rel relative error of @p want (with a
+ * tiny absolute floor so exact-zero references still work).
+ */
+static int close_rel(double got, double want, double rel)
+{
+    double diff = got - want;
+    if (diff < 0.0) {
+        diff = -diff;
+    }
+    double magnitude = want < 0.0 ? -want : want;
+    return diff <= rel * magnitude + 1e-300;
+}
+
+//==================================================================================================
+// Subtests
+//==================================================================================================
+
+/**
+ * @brief Validates fmod() special values and a basic remainder.
+ */
+static void test_fmod(void)
+{
+    double inf = HUGE_VAL;
+
+    // fmod(x, +/-inf) == x for finite x (previously returned NaN).
+    assert(fmod(vol(2.0), inf) == 2.0);
+    assert(fmod(vol(2.0), -inf) == 2.0);
+    assert(fmod(vol(-3.5), inf) == -3.5);
+
+    // fmod(+/-0, y) preserves the sign of zero.
+    double z = fmod(vol(-0.0), vol(3.0));
+    assert(z == 0.0 && signbit(z));
+
+    // fmod(+/-inf, y) and fmod(x, 0) are NaN.
+    assert(isnan(fmod(inf, vol(2.0))));
+    assert(isnan(fmod(vol(5.0), vol(0.0))));
+
+    // Ordinary remainder.
+    assert(close_rel(fmod(vol(5.3), vol(2.0)), 1.3, 1e-12));
+}
+
+/**
+ * @brief Validates tanh() sign-of-zero handling and precision.
+ */
+static void test_tanh(void)
+{
+    // tanh(-0.0) must return -0.0 (previously returned +0.0).
+    double nz = tanh(vol(-0.0));
+    assert(nz == 0.0 && signbit(nz));
+
+    double pz = tanh(vol(0.0));
+    assert(pz == 0.0 && !signbit(pz));
+
+    assert(close_rel(tanh(vol(0.5)), 0.46211715726000974, 1e-12));
+    assert(close_rel(tanh(vol(1.0)), 0.7615941559557649, 1e-12));
+    assert(close_rel(tanh(vol(-2.0)), -0.9640275800758169, 1e-12));
+}
+
+/**
+ * @brief Validates exp() precision across a wide range.
+ */
+static void test_exp(void)
+{
+    assert(close_rel(exp(vol(1.0)), 2.718281828459045, 1e-12));
+    assert(close_rel(exp(vol(-0.5)), 0.6065306597126334, 1e-12));
+    assert(close_rel(exp(vol(2.0)), 7.38905609893065, 1e-12));
+    assert(close_rel(exp(vol(700.0)), 1.0142320547350045e304, 1e-12));
+    assert(exp(vol(1000.0)) == HUGE_VAL);
+    assert(exp(vol(-1000.0)) == 0.0);
+}
+
+/**
+ * @brief Validates that expm1() keeps precision near zero.
+ */
+static void test_expm1(void)
+{
+    assert(close_rel(expm1(vol(1.0)), 1.718281828459045, 1e-12));
+
+    // Near zero, expm1(x) - x must recover the x^2/2 term (~5e-17), which the
+    // naive exp(x) - 1 loses entirely.
+    double x = vol(1e-8);
+    double excess = expm1(x) - x;
+    assert(excess > 3e-17 && excess < 7e-17);
+}
+
+/**
+ * @brief Validates log() precision, including large arguments.
+ */
+static void test_log(void)
+{
+    assert(close_rel(log(vol(2.0)), 0.6931471805599453, 1e-12));
+    assert(close_rel(log(vol(10.0)), 2.302585092994046, 1e-12));
+    assert(close_rel(log(vol(1e100)), 230.25850929940458, 1e-13));
+    assert(log(vol(0.0)) == -HUGE_VAL);
+    assert(isnan(log(vol(-1.0))));
+}
+
+/**
+ * @brief Validates tan() precision, including a reduced large argument.
+ */
+static void test_tan(void)
+{
+    assert(close_rel(tan(vol(0.5)), 0.5463024898437905, 1e-12));
+    assert(close_rel(tan(vol(1.0)), 1.5574077246549023, 1e-12));
+    // Large argument exercises the Cody-Waite range reduction.
+    assert(close_rel(tan(vol(1000.0)), 1.4703241557027185, 1e-11));
+    assert(isnan(tan(vol(HUGE_VAL))));
+}
+
+/**
+ * @brief Validates erf() precision (the old approximation was only accurate to
+ * ~1.5e-7).
+ */
+static void test_erf(void)
+{
+    assert(close_rel(erf(vol(0.5)), 0.5204998778130465, 1e-12));
+    assert(close_rel(erf(vol(1.0)), 0.8427007929497149, 1e-12));
+    assert(close_rel(erf(vol(2.0)), 0.9953222650189527, 1e-12));
+    // erf is odd and saturates at the limits.
+    assert(close_rel(erf(vol(-1.0)), -0.8427007929497149, 1e-12));
+    assert(erf(vol(HUGE_VAL)) == 1.0);
+}
+
+/**
+ * @brief Validates erfc() precision in the tail, where the old `1 - erf(x)`
+ * form cancelled catastrophically.
+ */
+static void test_erfc(void)
+{
+    assert(close_rel(erfc(vol(1.0)), 0.15729920705028513, 1e-12));
+    // Tail values that 1 - erf(x) cannot represent.
+    assert(close_rel(erfc(vol(5.0)), 1.5374597944280349e-12, 1e-11));
+    assert(close_rel(erfc(vol(10.0)), 2.0884875837625447e-45, 1e-11));
+    assert(erfc(vol(HUGE_VAL)) == 0.0);
+    assert(erfc(vol(-HUGE_VAL)) == 2.0);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests the bundled math library (libm).
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    assert(argc >= 1);
+    assert(argv[0] != NULL);
+
+    test_fmod();
+    test_tanh();
+    test_exp();
+    test_expm1();
+    test_log();
+    test_tan();
+    test_erf();
+    test_erfc();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -299,6 +299,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-math"
+program = "./bin/test-c-math.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-posix-timers"
 program = "./bin/test-c-posix-timers.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -299,6 +299,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-math"
+program = "./bin/test-c-math.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-posix-timers"
 program = "./bin/test-c-posix-timers.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Fixes incorrect special values and precision loss in the bundled math library
(`libm.a`, from the `libc_math` crate). Guests link this libm exclusively, so its
accuracy is the single source of truth for floating-point math. The affected
routines are replaced with faithful fdlibm/musl ports, and a POSIX C test suite
is added to guard against regressions.

closes #2810

## What changed

**Libraries (`libc_math`):** rewrite `fmod`, `exp`, `expm1`, `log`, `tanh`, `tan`,
`erf`, and `erfc` as fdlibm/musl ports.

- `fmod`: `fmod(x, ±inf) == x` and `fmod(±0, y)` preserves the sign of zero, via
  exact integer-significand division (previously returned NaN).
- `tanh`: preserves the sign of a zero argument (`tanh(-0.0) == -0.0`) and is
  evaluated through `expm1` to stay accurate near zero.
- `erfc`: evaluates the tail from a scaled exponential instead of `1 - erf(x)`,
  avoiding the catastrophic cancellation that destroyed precision for large `x`.
- `exp`, `expm1`, `log`, `tan`, `erf`: use the fdlibm minimax reductions,
  restoring ~1-ULP accuracy across their ranges.

**Tests:** add the `test-c-math` POSIX C suite validating IEEE-754 special values
and ~1-ULP accuracy for each function. Each call is laundered through a `volatile`
store so clang cannot constant-fold it at host precision under `-O3` and must emit
a real call into `libm.a`.

**Build and harness wiring:** register `test-c-math` in the guest POSIX test list
and add the suite (debug + release, terminal executor, exit code 0) to
`test/test-posix.toml` and `test/test-posix-windows.toml`.

## Validation

- `libc_math` host unit tests pass (356) and `cargo clippy` is clean.
- `test-c-math` boots under nanvixd in standalone mode and passes in both debug
  (`-O0`) and release (`-O3`).
