### PR TITLE
[libc_wchar] Add wide xlocale and conversions

### DIFF
--- a/include/wchar.h
+++ b/include/wchar.h
@@ -85,7 +85,9 @@ extern wchar_t *wcscat(wchar_t *dest, const wchar_t *src);
 extern int wcscmp(const wchar_t *s1, const wchar_t *s2);
 extern int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
 extern int wcscoll(const wchar_t *s1, const wchar_t *s2);
+extern int wcscoll_l(const wchar_t *s1, const wchar_t *s2, locale_t locale);
 extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);
+extern size_t wcsxfrm_l(wchar_t *dest, const wchar_t *src, size_t n, locale_t locale);
 
 /*==================================================================================================
  * Search
@@ -142,7 +144,9 @@ extern size_t wcrtomb(char *s, wchar_t wc, mbstate_t *ps);
 extern size_t mbrlen(const char *s, size_t n, mbstate_t *ps);
 extern int mbsinit(const mbstate_t *ps);
 extern size_t mbsrtowcs(wchar_t *dest, const char **src, size_t n, mbstate_t *ps);
+extern size_t mbsnrtowcs(wchar_t *dest, const char **src, size_t nmc, size_t len, mbstate_t *ps);
 extern size_t wcsrtombs(char *dest, const wchar_t **src, size_t n, mbstate_t *ps);
+extern size_t wcsnrtombs(char *dest, const wchar_t **src, size_t nwc, size_t len, mbstate_t *ps);
 
 /*==================================================================================================
  * Wide Character Time

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -73,7 +73,14 @@ functions = ["wcslen", "wcscpy", "wcsncpy", "wcscat"]
 
 [[sections]]
 title = "Comparison"
-functions = ["wcscmp", "wcsncmp", "wcscoll", "wcsxfrm"]
+functions = [
+    "wcscmp",
+    "wcsncmp",
+    "wcscoll",
+    "wcscoll_l",
+    "wcsxfrm",
+    "wcsxfrm_l",
+]
 
 [[sections]]
 title = "Search"
@@ -111,7 +118,9 @@ functions = [
     "mbrlen",
     "mbsinit",
     "mbsrtowcs",
+    "mbsnrtowcs",
     "wcsrtombs",
+    "wcsnrtombs",
 ]
 
 [[sections]]
@@ -121,8 +130,12 @@ functions = ["wcsftime"]
 [overrides]
 wcscoll = '''
 extern int wcscoll(const wchar_t *s1, const wchar_t *s2);'''
+wcscoll_l = '''
+extern int wcscoll_l(const wchar_t *s1, const wchar_t *s2, locale_t locale);'''
 wcsxfrm = '''
 extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);'''
+wcsxfrm_l = '''
+extern size_t wcsxfrm_l(wchar_t *dest, const wchar_t *src, size_t n, locale_t locale);'''
 wcstok = '''
 extern wchar_t *wcstok(wchar_t *ws, const wchar_t *delim, wchar_t **ptr);'''
 wcsftime = '''
@@ -141,7 +154,11 @@ mbsinit = '''
 extern int mbsinit(const mbstate_t *ps);'''
 mbsrtowcs = '''
 extern size_t mbsrtowcs(wchar_t *dest, const char **src, size_t n, mbstate_t *ps);'''
+mbsnrtowcs = '''
+extern size_t mbsnrtowcs(wchar_t *dest, const char **src, size_t nmc, size_t len, mbstate_t *ps);'''
 wcsrtombs = '''
 extern size_t wcsrtombs(char *dest, const wchar_t **src, size_t n, mbstate_t *ps);'''
+wcsnrtombs = '''
+extern size_t wcsnrtombs(char *dest, const wchar_t **src, size_t nwc, size_t len, mbstate_t *ps);'''
 wcstold = '''
 extern long double wcstold(const wchar_t *nptr, wchar_t **endptr);'''

--- a/src/libs/libc_wchar/src/lib.rs
+++ b/src/libs/libc_wchar/src/lib.rs
@@ -30,6 +30,7 @@
 //==================================================================================================
 
 pub mod btowc;
+pub mod locale;
 pub mod mbstate;
 pub mod multibyte;
 pub mod utf8;

--- a/src/libs/libc_wchar/src/locale.rs
+++ b/src/libs/libc_wchar/src/locale.rs
@@ -1,0 +1,117 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    wchar_t::wchar_t,
+    wcscoll::wcscoll,
+    wcsxfrm::wcsxfrm,
+};
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Nanvix supports only the C/POSIX locale, so each `*_l` function ignores its `locale_t` argument
+// and delegates to its non-`_l` counterpart.
+
+/// # Description
+///
+/// Compares two wide-character strings using the collating sequence of the C/POSIX locale.
+///
+/// # Parameters
+///
+/// - `s1`: Pointer to the first null-terminated wide-character string.
+/// - `s2`: Pointer to the second null-terminated wide-character string.
+/// - `locale`: Locale to use (ignored; only the C/POSIX locale is supported).
+///
+/// # Returns
+///
+/// A negative, zero, or positive value if `s1` orders before, equal to, or after `s2`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `s1` and `s2`, which must point
+/// to valid null-terminated wide-character strings.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcscoll_l(
+    s1: *const wchar_t,
+    s2: *const wchar_t,
+    _locale: *mut c_void,
+) -> c_int {
+    unsafe { wcscoll(s1, s2) }
+}
+
+/// # Description
+///
+/// Transforms a wide-character string so that the result of `wcscmp()` on two transformed strings
+/// matches the result of `wcscoll()` on the originals. In the C/POSIX locale the transformation is
+/// the identity copy.
+///
+/// # Parameters
+///
+/// - `dest`: Destination buffer for the transformed wide-character string.
+/// - `src`: Pointer to the null-terminated source wide-character string.
+/// - `n`: Maximum number of wide characters to write to `dest`, including the null terminator.
+/// - `locale`: Locale to use (ignored; only the C/POSIX locale is supported).
+///
+/// # Returns
+///
+/// The length of the transformed wide-character string (excluding the null terminator).
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `dest` and `src`, which must be
+/// valid for the requested operation.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsxfrm_l(
+    dest: *mut wchar_t,
+    src: *const wchar_t,
+    n: c_size_t,
+    _locale: *mut c_void,
+) -> c_size_t {
+    unsafe { wcsxfrm(dest, src, n) }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wcscoll_l_orders_like_wcscmp() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let a: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let b: [wchar_t; 4] = [0x61, 0x62, 0x64, 0];
+
+        assert!(unsafe { wcscoll_l(a.as_ptr(), b.as_ptr(), locale) } < 0);
+        assert!(unsafe { wcscoll_l(b.as_ptr(), a.as_ptr(), locale) } > 0);
+        assert_eq!(unsafe { wcscoll_l(a.as_ptr(), a.as_ptr(), locale) }, 0);
+    }
+
+    #[test]
+    fn test_wcsxfrm_l_is_identity_in_c_locale() {
+        let locale: *mut c_void = ::core::ptr::null_mut();
+        let src: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let mut dest: [wchar_t; 8] = [-1; 8];
+        let capacity: c_size_t =
+            c_size_t::try_from(dest.len()).expect("destination length should fit in c_size_t");
+
+        let len: c_size_t = unsafe { wcsxfrm_l(dest.as_mut_ptr(), src.as_ptr(), capacity, locale) };
+        assert_eq!(len, 3);
+        assert_eq!(&dest[..4], &src[..4]);
+    }
+}

--- a/src/libs/libc_wchar/src/multibyte.rs
+++ b/src/libs/libc_wchar/src/multibyte.rs
@@ -487,6 +487,167 @@ pub unsafe extern "C" fn wcsrtombs(
     }
 }
 
+/// Restartable conversion of a multibyte string to a wide-character string, reading at most `nmc`
+/// bytes from the source.
+///
+/// Behaves like [`mbsrtowcs`] except that no more than `nmc` bytes are read from `*src`. As with
+/// [`mbsrtowcs`], conversion also stops once the terminating null byte is reached or, when `dst` is
+/// non-null, once `len` wide characters have been produced.
+///
+/// # Safety
+///
+/// `src` must point to a valid pointer to a multibyte string with at least `nmc` readable bytes.
+/// `dst` (when non-null) must have room for `len` wide characters.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn mbsnrtowcs(
+    dst: *mut wchar_t,
+    src: *mut *const c_char,
+    nmc: usize,
+    len: usize,
+    ps: *mut mbstate_t,
+) -> usize {
+    let mut state: mbstate_t = if ps.is_null() {
+        mbstate_t {
+            count: 0,
+            bytes: [0; 4],
+        }
+    } else {
+        unsafe { *ps }
+    };
+    let mut s: *const c_char = unsafe { *src };
+    let mut remaining: usize = nmc;
+    let mut count: usize = 0;
+
+    loop {
+        // Stop once the destination is full.
+        if !dst.is_null() && count >= len {
+            if !ps.is_null() {
+                unsafe { *ps = state };
+            }
+            unsafe { *src = s };
+            return count;
+        }
+
+        // Stop once the source byte budget is exhausted. Per POSIX, `*src` is updated only when
+        // `dst` is non-null.
+        if remaining == 0 {
+            if !ps.is_null() {
+                unsafe { *ps = state };
+            }
+            if !dst.is_null() {
+                unsafe { *src = s };
+            }
+            return count;
+        }
+
+        let mut wc: wchar_t = 0;
+        let res: usize = unsafe { mbrtowc_core(&mut wc, s, remaining, &mut state) };
+        if res == SIZE_ERR || res == SIZE_INCOMPLETE {
+            // Per POSIX, when `dst` is non-null the pointer object pointed to by `src` is updated
+            // to point at the byte that triggered the encoding error, so the caller can restart or
+            // diagnose. When `dst` is null the call merely measures and leaves `*src` untouched.
+            if !dst.is_null() {
+                unsafe { *src = s };
+            }
+            set_errno(EILSEQ);
+            return SIZE_ERR;
+        }
+        if wc == 0 {
+            // The terminating null was converted. Per POSIX, `*src` is nulled only when `dst` is
+            // non-null.
+            if !dst.is_null() {
+                unsafe { *dst.add(count) = 0 };
+                unsafe { *src = core::ptr::null() };
+            }
+            if !ps.is_null() {
+                unsafe { *ps = state };
+            }
+            return count;
+        }
+        if !dst.is_null() {
+            unsafe { *dst.add(count) = wc };
+        }
+        count += 1;
+        s = unsafe { s.add(res) };
+        remaining -= res;
+    }
+}
+
+/// Restartable conversion of a wide-character string to a multibyte string, reading at most `nwc`
+/// wide characters from the source.
+///
+/// Behaves like [`wcsrtombs`] except that no more than `nwc` wide characters are read from `*src`.
+/// As with [`wcsrtombs`], conversion also stops once the terminating null is reached or, when `dst`
+/// is non-null, once `len` bytes have been produced.
+///
+/// # Safety
+///
+/// `src` must point to a valid pointer to a wide string with at least `nwc` readable wide
+/// characters. `dst` (when non-null) must have room for `len` bytes.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wcsnrtombs(
+    dst: *mut c_char,
+    src: *mut *const wchar_t,
+    nwc: usize,
+    len: usize,
+    _ps: *mut mbstate_t,
+) -> usize {
+    let mut w: *const wchar_t = unsafe { *src };
+    let mut remaining: usize = nwc;
+    let mut count: usize = 0;
+
+    loop {
+        // Stop once the wide-character budget is exhausted. Per POSIX, `*src` is updated only when
+        // `dst` is non-null.
+        if remaining == 0 {
+            if !dst.is_null() {
+                unsafe { *src = w };
+            }
+            return count;
+        }
+
+        let wc: wchar_t = unsafe { *w };
+        if wc == 0 {
+            // Per POSIX, the pointer object pointed to by `src` is updated only when `dst` is
+            // non-null.
+            if !dst.is_null() {
+                if count < len {
+                    // There is room for the terminating null byte: store it and signal that
+                    // conversion stopped at the terminator by nulling `*src`.
+                    unsafe { *dst.add(count) = 0 };
+                    unsafe { *src = core::ptr::null() };
+                } else {
+                    // No room remains for the terminating null byte, so conversion stops early due
+                    // to the length limit. `*src` is left pointing at the terminator.
+                    unsafe { *src = w };
+                }
+            }
+            return count;
+        }
+
+        let cp: u32 = cp_of(wc);
+        if cp > 0xff {
+            if !dst.is_null() {
+                unsafe { *src = w };
+            }
+            set_errno(EILSEQ);
+            return SIZE_ERR;
+        }
+        if dst.is_null() {
+            count += 1;
+        } else {
+            if count >= len {
+                unsafe { *src = w };
+                return count;
+            }
+            unsafe { *dst.add(count) = cchar_of(u8::try_from(cp).unwrap_or(0)) };
+            count += 1;
+        }
+        w = unsafe { w.add(1) };
+        remaining -= 1;
+    }
+}
+
 //==================================================================================================
 // Unit Tests
 //==================================================================================================
@@ -498,8 +659,10 @@ mod test {
         mbrlen,
         mbrtowc,
         mbsinit,
+        mbsnrtowcs,
         mbsrtowcs,
         wcrtomb,
+        wcsnrtombs,
         wcsrtombs,
         SIZE_INCOMPLETE,
     };
@@ -712,5 +875,124 @@ mod test {
         assert_eq!(output[0], cchar_of(0x61));
         assert_eq!(output[1], cchar_of(0x62));
         assert_eq!(src, unsafe { input.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_mbsnrtowcs_stops_at_byte_budget() {
+        // Only the first two of the three available bytes may be read, so conversion stops with
+        // `*src` pointing just past the last converted byte and no null is written.
+        let input = as_chars(b"abc\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let mut output: [wchar_t; 4] = [-1; 4];
+        let ret: usize = unsafe {
+            mbsnrtowcs(output.as_mut_ptr(), &mut src, 2, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 2);
+        assert_eq!(output[0], 0x61);
+        assert_eq!(output[1], 0x62);
+        assert_eq!(src, unsafe { input.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_mbsnrtowcs_nulls_source_after_terminator_within_budget() {
+        // The terminator lies within the byte budget, so it is converted and `*src` is nulled.
+        let input = as_chars(b"ab\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let mut output: [wchar_t; 4] = [-1; 4];
+        let ret: usize = unsafe {
+            mbsnrtowcs(output.as_mut_ptr(), &mut src, 8, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 2);
+        assert_eq!(output[0], 0x61);
+        assert_eq!(output[1], 0x62);
+        assert_eq!(output[2], 0);
+        assert!(src.is_null());
+    }
+
+    #[test]
+    fn test_mbsnrtowcs_stops_when_destination_full() {
+        // The destination holds a single wide character, so conversion stops there even though more
+        // input and byte budget remain.
+        let input = as_chars(b"abc\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let mut output: [wchar_t; 1] = [0];
+        let ret: usize = unsafe {
+            mbsnrtowcs(output.as_mut_ptr(), &mut src, 8, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 1);
+        assert_eq!(output[0], 0x61);
+        assert_eq!(src, unsafe { input.as_ptr().add(1) });
+    }
+
+    #[test]
+    fn test_mbsnrtowcs_null_dst_leaves_source_unchanged() {
+        // In measuring mode (null `dst`) POSIX requires `*src` to be left untouched, while the byte
+        // budget still bounds the reported length.
+        let input = as_chars(b"abcd\0");
+        let mut src: *const ::sysapi::ffi::c_char = input.as_ptr();
+        let ret: usize =
+            unsafe { mbsnrtowcs(core::ptr::null_mut(), &mut src, 3, 0, core::ptr::null_mut()) };
+        assert_eq!(ret, 3);
+        assert_eq!(src, input.as_ptr());
+    }
+
+    #[test]
+    fn test_wcsnrtombs_stops_at_wide_char_budget() {
+        // Only the first two of the three available wide characters may be read, so conversion stops
+        // with `*src` pointing just past the last converted wide character.
+        let input: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 4] = [-1; 4];
+        let ret: usize = unsafe {
+            wcsnrtombs(output.as_mut_ptr(), &mut src, 2, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 2);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(output[1], cchar_of(0x62));
+        assert_eq!(src, unsafe { input.as_ptr().add(2) });
+    }
+
+    #[test]
+    fn test_wcsnrtombs_nulls_source_after_terminator_within_budget() {
+        // The terminator lies within the wide-character budget, so it is converted and `*src` is
+        // nulled.
+        let input: [wchar_t; 3] = [0x61, 0x62, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 4] = [-1; 4];
+        let ret: usize = unsafe {
+            wcsnrtombs(output.as_mut_ptr(), &mut src, 8, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, 2);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(output[1], cchar_of(0x62));
+        assert_eq!(output[2], 0);
+        assert!(src.is_null());
+    }
+
+    #[test]
+    fn test_wcsnrtombs_reports_error_on_unencodable_wide_char() {
+        // A wide character outside the single-byte range aborts conversion with `EILSEQ` and leaves
+        // `*src` pointing at the offending character.
+        let input: [wchar_t; 3] = [0x61, 0x100, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let mut output: [::sysapi::ffi::c_char; 4] = [-1; 4];
+        let ret: usize = unsafe {
+            wcsnrtombs(output.as_mut_ptr(), &mut src, 8, output.len(), core::ptr::null_mut())
+        };
+        assert_eq!(ret, usize::MAX);
+        assert_eq!(output[0], cchar_of(0x61));
+        assert_eq!(src, unsafe { input.as_ptr().add(1) });
+    }
+
+    #[test]
+    fn test_wcsnrtombs_null_dst_leaves_source_unchanged() {
+        // In measuring mode (null `dst`) POSIX requires `*src` to be left untouched, while the
+        // wide-character budget still bounds the reported length.
+        let input: [wchar_t; 4] = [0x61, 0x62, 0x63, 0];
+        let mut src: *const wchar_t = input.as_ptr();
+        let ret: usize =
+            unsafe { wcsnrtombs(core::ptr::null_mut(), &mut src, 2, 0, core::ptr::null_mut()) };
+        assert_eq!(ret, 2);
+        assert_eq!(src, input.as_ptr());
     }
 }

--- a/src/tests/integration/test-c-wchar/main.c
+++ b/src/tests/integration/test-c-wchar/main.c
@@ -8,6 +8,8 @@
 //==================================================================================================
 
 #include <assert.h>
+#include <errno.h>
+#include <locale.h>
 #include <stddef.h>
 #include <string.h>
 #include <unistd.h>
@@ -136,6 +138,168 @@ static void test_wcstold(void)
     assert(wcstold(L"10", NULL) == 10.0L);
 }
 
+// Tests wcscoll_l() and wcsxfrm_l(), the locale-aware wide comparison functions. Nanvix supports
+// only the C/POSIX locale, so collation follows wide code-point order and the transform is the
+// identity copy.
+static void test_wcs_collation_l(void)
+{
+    locale_t loc = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    assert(loc != (locale_t)0);
+
+    // wcscoll_l() orders like wcscmp() in the C/POSIX locale.
+    assert(wcscoll_l(L"abc", L"abc", loc) == 0);
+    assert(wcscoll_l(L"abc", L"abd", loc) < 0);
+    assert(wcscoll_l(L"abd", L"abc", loc) > 0);
+
+    // Lowercase code points sort after uppercase ones.
+    assert(wcscoll_l(L"a", L"A", loc) > 0);
+
+    // wcsxfrm_l() performs the identity transform: the returned length excludes the terminator and
+    // the destination equals the source.
+    {
+        wchar_t dest[8] = {L'?', L'?', L'?', L'?', L'?', L'?', L'?', L'?'};
+        size_t len = wcsxfrm_l(dest, L"abc", 8, loc);
+        assert(len == 3);
+        assert(wcscmp(dest, L"abc") == 0);
+    }
+
+    // The defining property of wcsxfrm_l(): comparing two transformed strings with wcscmp() yields
+    // the same ordering as comparing the originals with wcscoll_l().
+    {
+        wchar_t xa[8];
+        wchar_t xb[8];
+        assert(wcsxfrm_l(xa, L"abc", 8, loc) == 3);
+        assert(wcsxfrm_l(xb, L"abd", 8, loc) == 3);
+        assert(wcscmp(xa, xb) < 0);
+    }
+
+    // A zero-size destination writes nothing but still reports the required length.
+    assert(wcsxfrm_l(NULL, L"hello", 0, loc) == 5);
+
+    freelocale(loc);
+}
+
+// Tests mbsnrtowcs(), the bounded restartable multibyte-to-wide conversion. The C/POSIX locale maps
+// each byte directly to a wide character.
+static void test_mbsnrtowcs(void)
+{
+    // The byte budget bounds the conversion: only two of the three bytes are read, no terminator is
+    // written, and src is advanced past the last converted byte.
+    {
+        const char in[] = "abc";
+        const char *src = in;
+        wchar_t out[4] = {L'?', L'?', L'?', L'?'};
+        size_t n = mbsnrtowcs(out, &src, 2, 4, NULL);
+        assert(n == 2);
+        assert(out[0] == L'a');
+        assert(out[1] == L'b');
+        assert(src == in + 2);
+    }
+
+    // When the terminator falls within the budget it is converted and src is set to NULL.
+    {
+        const char in[] = "ab";
+        const char *src = in;
+        wchar_t out[4] = {L'?', L'?', L'?', L'?'};
+        size_t n = mbsnrtowcs(out, &src, 8, 4, NULL);
+        assert(n == 2);
+        assert(out[0] == L'a');
+        assert(out[1] == L'b');
+        assert(out[2] == L'\0');
+        assert(src == NULL);
+    }
+
+    // The destination length bounds the conversion even when byte budget remains.
+    {
+        const char in[] = "abc";
+        const char *src = in;
+        wchar_t out[1];
+        size_t n = mbsnrtowcs(out, &src, 8, 1, NULL);
+        assert(n == 1);
+        assert(out[0] == L'a');
+        assert(src == in + 1);
+    }
+
+    // A caller-supplied conversion state is accepted and round-trips to the initial state.
+    {
+        mbstate_t st;
+        memset(&st, 0, sizeof(st));
+        const char in[] = "hi";
+        const char *src = in;
+        wchar_t out[4] = {L'?', L'?', L'?', L'?'};
+        size_t n = mbsnrtowcs(out, &src, 8, 4, &st);
+        assert(n == 2);
+        assert(out[0] == L'h');
+        assert(out[1] == L'i');
+        assert(out[2] == L'\0');
+        assert(src == NULL);
+        assert(mbsinit(&st) != 0);
+    }
+
+    // A null destination measures the length (bounded by the byte budget) and leaves src unchanged.
+    {
+        const char in[] = "abcd";
+        const char *src = in;
+        size_t n = mbsnrtowcs(NULL, &src, 3, 0, NULL);
+        assert(n == 3);
+        assert(src == in);
+    }
+}
+
+// Tests wcsnrtombs(), the bounded restartable wide-to-multibyte conversion.
+static void test_wcsnrtombs(void)
+{
+    // The wide-character budget bounds the conversion: only two of the three wide characters are
+    // read, no terminator is written, and src is advanced past the last converted character.
+    {
+        const wchar_t in[] = L"abc";
+        const wchar_t *src = in;
+        char out[4] = {'?', '?', '?', '?'};
+        size_t n = wcsnrtombs(out, &src, 2, 4, NULL);
+        assert(n == 2);
+        assert(out[0] == 'a');
+        assert(out[1] == 'b');
+        assert(src == in + 2);
+    }
+
+    // When the terminator falls within the budget it is converted and src is set to NULL.
+    {
+        const wchar_t in[] = L"ab";
+        const wchar_t *src = in;
+        char out[4] = {'?', '?', '?', '?'};
+        size_t n = wcsnrtombs(out, &src, 8, 4, NULL);
+        assert(n == 2);
+        assert(out[0] == 'a');
+        assert(out[1] == 'b');
+        assert(out[2] == '\0');
+        assert(src == NULL);
+    }
+
+    // A wide character outside the single-byte range aborts with (size_t)-1, sets errno to EILSEQ,
+    // and leaves src pointing at the offending character.
+    {
+        const wchar_t in[] = {L'a', (wchar_t)0x100, L'\0'};
+        const wchar_t *src = in;
+        char out[4] = {'?', '?', '?', '?'};
+        errno = 0;
+        size_t n = wcsnrtombs(out, &src, 8, 4, NULL);
+        assert(n == (size_t)-1);
+        assert(errno == EILSEQ);
+        assert(out[0] == 'a');
+        assert(src == in + 1);
+    }
+
+    // A null destination measures the length (bounded by the wide-character budget) and leaves src
+    // unchanged.
+    {
+        const wchar_t in[] = L"abcd";
+        const wchar_t *src = in;
+        size_t n = wcsnrtombs(NULL, &src, 2, 0, NULL);
+        assert(n == 2);
+        assert(src == in);
+    }
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -163,6 +327,9 @@ int main(int argc, const char *argv[])
     test_wide_search_siblings();
     test_wcstof();
     test_wcstold();
+    test_wcs_collation_l();
+    test_mbsnrtowcs();
+    test_wcsnrtombs();
 
     // Write magic string to signal that the test passed.
     {


### PR DESCRIPTION
## Summary

Adds the wide-character locale collation and bounded restartable conversion
functions required to re-enable libc++ localization, so the LLVM toolchain port
can drop `-DLIBCXX_ENABLE_LOCALIZATION=OFF`. All new routines operate in the
C/POSIX locale, mapping bytes directly to wide values and treating collation as
code-point order.

## What changed

**Libraries (`libc_wchar`):**
- Add `wcscoll_l()` and `wcsxfrm_l()` in a new `locale` module; each ignores its
  `locale_t` argument and delegates to `wcscoll()`/`wcsxfrm()`.
- Add `mbsnrtowcs()` and `wcsnrtombs()`, the byte/wide-count-bounded restartable
  conversions, honoring POSIX rules for updating `*src` only when `dst` is
  non-null, the byte/wide budgets, terminator handling, and `EILSEQ` on
  unencodable wide characters.
- Register the new `locale` module in the crate root.

**Headers:**
- Declare `wcscoll_l`, `wcsxfrm_l`, `mbsnrtowcs`, and `wcsnrtombs` in `wchar.h`
  and add matching `header.toml` sections and signature overrides.

**Tests:**
- Add host unit tests covering collation ordering, the identity transform,
  budget limits, measuring mode, terminator nulling, caller-supplied state, and
  the `EILSEQ` path.
- Extend the `test-c-wchar` integration suite with guest coverage for the same
  functions end to end.

## Validation

- `cargo test -p libc_wchar --features std --lib`: 137 passed / 0 failed.
- Clippy clean for both `std` and `no_std` configurations.
- `test-c-wchar` POSIX integration suite passes in the microvm (guest exit 0,
  `ok` sentinel emitted).

Closes  #2819. Follow-up to #2798.