### PR TITLE
[nanvix-test] Fix Flaky Broken-Pipe Test Failures

### DIFF
--- a/doc/host-mount.md
+++ b/doc/host-mount.md
@@ -259,7 +259,6 @@ The test entry in `test/test-standalone-windows.toml`:
 executor = "terminal"
 program = "./bin/mount-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img -mount ./bin/mount-test-data"
-input = "[]"
 expected_output = "ok"
 expected_exit_code = 0
 runs_on = ["microvm"]

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -219,14 +219,31 @@ pub(crate) async fn test_with_http_executor(
 ///
 /// # Return Value
 ///
-/// Returns `Ok(())` after the bytes are written successfully; returns an error on socket write
-/// failures.
+/// Returns `Ok(())` after the bytes are written successfully. A `BrokenPipe` or `ConnectionReset`
+/// error is treated as success because it means the guest closed the gateway before consuming its
+/// input (for example, a workload that exits or faults before reading stdin); the workload's real
+/// expectations are validated later via the collected output and exit code. Any other write
+/// failure is returned as an error.
 ///
 async fn send_payload(user_vm: &mut UserVm, payload: &[u8]) -> Result<()> {
     trace!("send_payload(): payload_len={}, payload={:?}", payload.len(), payload);
     if let Err(error) = user_vm.gateway_stream().write_all(payload).await {
-        error!("send_payload(): failed to send payload (error={error})");
-        return Err(error.into());
+        match error.kind() {
+            // The guest closed the gateway before consuming its input. Mirror the read path
+            // (collect_uservm_payload) and the terminal executor (send_interactive_input),
+            // which also tolerate a peer that closes early.
+            ErrorKind::BrokenPipe | ErrorKind::ConnectionReset => {
+                warn!(
+                    "send_payload(): gateway closed before payload was sent (error_kind={:?}, \
+                     error={error})",
+                    error.kind()
+                );
+            },
+            _ => {
+                error!("send_payload(): failed to send payload (error={error})");
+                return Err(error.into());
+            },
+        }
     }
 
     Ok(())
@@ -239,14 +256,29 @@ async fn send_payload(user_vm: &mut UserVm, payload: &[u8]) -> Result<()> {
 ///
 /// # Return Value
 ///
-/// Returns `Ok(())` when the shutdown succeeds; returns an error if the gateway cannot be closed.
+/// Returns `Ok(())` when the shutdown succeeds. A `BrokenPipe` or `ConnectionReset` error is
+/// treated as success because the guest already closed the gateway (for example, a workload that
+/// exits or faults before reading stdin). Any other shutdown failure is returned as an error.
 ///
 async fn close_gateway_input(user_vm: &mut UserVm) -> Result<()> {
     if let Err(error) = user_vm.gateway_stream().shutdown_write().await {
-        let reason: String =
-            format!("failed to shutdown uservm gateway write half (error={error})");
-        error!("close_gateway_input(): {reason}");
-        return Err(::anyhow::anyhow!(reason));
+        match error.kind() {
+            // The guest already closed the gateway, so shutting down the write half is a no-op
+            // from the test's perspective. Tolerate it like send_payload and the read path.
+            ErrorKind::BrokenPipe | ErrorKind::ConnectionReset => {
+                warn!(
+                    "close_gateway_input(): gateway already closed (error_kind={:?}, \
+                     error={error})",
+                    error.kind()
+                );
+            },
+            _ => {
+                let reason: String =
+                    format!("failed to shutdown uservm gateway write half (error={error})");
+                error!("close_gateway_input(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+        }
     }
 
     Ok(())

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -46,7 +46,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -55,7 +54,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 runs_on = ["microvm"]
@@ -65,7 +63,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -81,40 +78,34 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-memory.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-misc.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.elf"
-input = "[]"
 expected_output = "ok"

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -46,7 +46,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -55,7 +54,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -64,7 +62,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -79,49 +76,42 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-file.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-stress.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-misc.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-memory.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -129,14 +119,12 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.elf"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-dlfcn.elf"
-input = "[]"
 expected_output = "ok"
 
 #===================================================================================================
@@ -148,7 +136,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -157,7 +144,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -166,7 +152,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -250,7 +235,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "TEST_VAR=hello"
-input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
@@ -266,7 +250,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
-input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
@@ -282,7 +265,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
-input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
@@ -303,7 +285,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -320,7 +301,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
@@ -336,7 +316,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -353,7 +332,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "a;b"
 program_env = "X=1"
-input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
@@ -371,7 +349,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello"
 program_env = "PATH=a;b"
-input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
@@ -393,7 +370,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
-input = "[]"
 expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -409,7 +385,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
-input = "[]"
 expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -424,7 +399,6 @@ expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
-input = "[]"
 expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -45,7 +45,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -54,7 +53,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -63,7 +61,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -78,49 +75,42 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-file.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-stress.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-misc.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-memory.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -128,14 +118,12 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.elf"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-dlfcn.elf"
-input = "[]"
 expected_output = "ok"
 
 #===================================================================================================
@@ -147,7 +135,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -156,7 +143,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -165,7 +151,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -249,7 +234,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "TEST_VAR=hello"
-input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
@@ -265,7 +249,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
-input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
@@ -281,7 +264,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
-input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
@@ -302,7 +284,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -319,7 +300,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
@@ -335,7 +315,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -352,7 +331,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "a;b"
 program_env = "X=1"
-input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
@@ -370,7 +348,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello"
 program_env = "PATH=a;b"
-input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
@@ -392,7 +369,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
-input = "[]"
 expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -408,7 +384,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
-input = "[]"
 expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -423,7 +398,6 @@ expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
-input = "[]"
 expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -57,7 +57,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 runs_on = ["microvm"]
@@ -67,7 +66,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 runs_on = ["microvm"]
@@ -77,7 +75,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -87,7 +84,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-vfs-test.img"
-input = "[]"
 expect_empty_output = true
 runs_on = ["microvm"]
 
@@ -219,7 +215,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 runs_on = ["microvm"]
@@ -229,7 +224,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 runs_on = ["microvm"]
@@ -239,7 +233,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -249,7 +242,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-vfs-test.img"
-input = "[]"
 expect_empty_output = true
 runs_on = ["microvm"]
 
@@ -257,7 +249,6 @@ runs_on = ["microvm"]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -271,42 +262,36 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-waitpid.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kill.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-job-control.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-setenv.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-stress.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -314,7 +299,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -323,7 +307,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-len.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 25 (filename) - 1 (space separator) = 4066.
 program_args_padding_len = 4066
-input = "[]"
 expected_output = "ok"
 
 #===================================================================================================
@@ -337,7 +320,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
-input = "[]"
 expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
 
 # A malformed entry (a bare KEY token with no '=') is skipped, so getenv() returns null for it.
@@ -346,7 +328,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
-input = "[]"
 expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 # An empty environment produces an empty table, so every probed key resolves to null.
@@ -354,7 +335,6 @@ expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
-input = "[]"
 expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 #===================================================================================================
@@ -366,7 +346,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mount-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img -mount ./bin/mount-test-data"
-input = "[]"
 expected_output = "ok"
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -376,7 +355,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-fork-hostfs.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img -mount ./bin/test-fork-hostfs-data"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 runs_on = ["microvm"]
@@ -386,7 +364,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mount-multipart-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
-input = "[]"
 expected_output = "ok"
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -400,7 +377,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.initrd"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -414,7 +390,6 @@ expected_output = "ok"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-pipe-dup2.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -422,7 +397,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-vfsd-test.img"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -430,7 +404,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-write-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for file-descriptor inheritance across fork()+execv(): a
@@ -444,7 +417,6 @@ build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-loop-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for execv() arguments containing spaces: an argument with an
@@ -457,7 +429,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-argv-space-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-argv-space-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for bulk pipe data integrity across fork()+execv(): a large
@@ -472,7 +443,6 @@ build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-pipe-bulk-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-pipe-bulk-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for repeated pipe-capture reliability across fork()+execv(): a
@@ -485,7 +455,6 @@ expected_output = "ok"
 executor = "http"
 program = "./bin/test-rust-fork-exec-pipe-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-pipe-loop-test.img"
-input = "[]"
 expected_output = "ok"
 build_modes = ["release"]
 
@@ -505,7 +474,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-thread-vfs-test.img"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -532,7 +500,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-socket-fork.initrd"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -45,7 +45,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -54,7 +53,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -63,7 +61,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -72,7 +69,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-vfs-test.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -87,14 +83,12 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-kcall.initrd"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -103,7 +97,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-guestfs.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-guestfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -111,42 +104,36 @@ expected_exit_code = 13
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-waitpid.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kill.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-job-control.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-setenv.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-stress.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -154,7 +141,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.initrd"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
-input = "[]"
 expected_output = "ok"
 
 #===================================================================================================
@@ -166,7 +152,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -175,7 +160,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 
@@ -184,7 +168,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -193,7 +176,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-vfs-test.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 
@@ -294,7 +276,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-len.elf"
 # 4092 (MAX_CMDLINE_ARGS_LEN) - 25 (filename) - 1 (space separator) = 4066.
 program_args_padding_len = 4066
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -315,7 +296,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mount-test.initrd"
 extra_nanvixd_args = "-mount ./bin/mount-test-data"
-input = "[]"
 expected_output = "ok"
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -325,7 +305,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-fork-hostfs.initrd"
 extra_nanvixd_args = "-mount ./bin/test-fork-hostfs-data"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 runs_on = ["microvm"]
@@ -334,7 +313,6 @@ runs_on = ["microvm"]
 build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mount-multipart-test.initrd"
-input = "[]"
 expected_output = "ok"
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -348,7 +326,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.initrd"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -362,7 +339,6 @@ expected_output = "ok"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-pipe-dup2.initrd"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -370,7 +346,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-vfsd-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-vfsd-test.img"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -378,7 +353,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-write-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-write-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for file-descriptor inheritance across fork()+execv(): a
@@ -392,7 +366,6 @@ build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-loop-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for execv() arguments containing spaces: an argument with an
@@ -405,7 +378,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-argv-space-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-argv-space-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for bulk pipe data integrity across fork()+execv(): a large
@@ -420,7 +392,6 @@ build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-fork-exec-pipe-bulk-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-pipe-bulk-test.img"
-input = "[]"
 expected_output = "ok"
 
 # Acceptance test for repeated pipe-capture reliability across fork()+execv(): a
@@ -433,7 +404,6 @@ expected_output = "ok"
 executor = "http"
 program = "./bin/test-rust-fork-exec-pipe-loop-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-fork-exec-pipe-loop-test.img"
-input = "[]"
 expected_output = "ok"
 build_modes = ["release"]
 
@@ -453,7 +423,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread-vfs-test.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-rust-thread-vfs-test.img"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -480,7 +449,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-socket-fork.initrd"
 extra_nanvixd_args = "-allow-host-networking"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
@@ -513,7 +481,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "TEST_VAR=hello"
-input = "[]"
 expected_output = "TEST_VAR=hello\nok"
 
 [[tests]]
@@ -529,7 +496,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "FOO=bar BAZ=qux"
-input = "[]"
 expected_output = "FOO=bar\nBAZ=qux\nok"
 
 [[tests]]
@@ -545,7 +511,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-env-nostd.elf"
 program_env = "SPECIAL=a/b:c-d_e.f"
-input = "[]"
 expected_output = "SPECIAL=a/b:c-d_e.f\nok"
 
 [[tests]]
@@ -566,7 +531,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -583,7 +547,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello world"
-input = "[]"
 expected_output = "ARGS:hello world\nENV:\nok"
 
 [[tests]]
@@ -599,7 +562,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_env = "FOO=bar"
-input = "[]"
 expected_output = "ARGS:\nENV:FOO=bar\nok"
 
 [[tests]]
@@ -616,7 +578,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "a;b"
 program_env = "X=1"
-input = "[]"
 expected_output = "ARGS:a;b\nENV:X=1\nok"
 
 [[tests]]
@@ -634,7 +595,6 @@ executor = "http"
 program = "./bin/test-rust-cmdline-env-nostd.elf"
 program_args = "hello"
 program_env = "PATH=a;b"
-input = "[]"
 expected_output = "ARGS:hello\nENV:PATH=a;b\nok"
 
 [[tests]]
@@ -656,7 +616,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta"
-input = "[]"
 expected_output = "GETENV:HOME=/scratch NVX_GETENV_A=alpha NVX_GETENV_B=beta NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -672,7 +631,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
 program_env = "HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B"
-input = "[]"
 expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]
@@ -687,7 +645,6 @@ expected_output = "GETENV:HOME=/data NVX_GETENV_A=alpha NVX_GETENV_B=(null) NVX_
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-getenv-nostd.elf"
-input = "[]"
 expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NVX_GETENV_MISSING=(null)\nok"
 
 [[tests]]

--- a/test/test.toml
+++ b/test/test.toml
@@ -45,7 +45,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -54,7 +53,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 runs_on = ["microvm"]
@@ -64,7 +62,6 @@ build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 runs_on = ["microvm"]
@@ -80,63 +77,54 @@ expected_output = "hello world!"
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-linux-app.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-file.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-thread.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-stress.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-arch.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-misc.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["release"]
 executor = "http"
 program = "./bin/test-rust-memory.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-network.elf"
-input = "[]"
 expected_output = "ok"
 
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
 program = "./bin/test-rust-dlfcn.elf"
-input = "[]"
 expected_output = "ok"
 runs_on = ["microvm"]
 
@@ -149,7 +137,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-kernel.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -158,7 +145,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-mmio-fault.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 4
 runs_on = ["microvm"]
@@ -168,7 +154,6 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 program = "./bin/test-rust-sigsegv.elf"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
-input = "[]"
 expect_empty_output = true
 expected_exit_code = 0
 runs_on = ["microvm"]


### PR DESCRIPTION
## What & Why

The HTTP integration-test executor could fail intermittently with
`Broken pipe (os error 32)` under CI load. Workloads that exit or fault
before reading their stdin (for example the fault-injection tests such
as `test-rust-mmio-fault`) close the gateway first, so the harness raced
the guest when writing input and hard-errored — even though the real
expectations (collected output and exit code) were still valid. This
surfaced as flaky `Test (...)` job failures.

This PR removes the race in two complementary ways:

### Harness (`src/utils/nanvix-test`)
- `send_payload()` now treats `BrokenPipe` / `ConnectionReset` on the
  gateway write as success (warn and return `Ok`); other errors still
  propagate.
- `close_gateway_input()` applies the same tolerance when shutting down
  the gateway write half.
- Mirrors the existing read path (`collect_uservm_payload`) and the
  terminal executor (`send_interactive_input`), which already tolerate a
  peer that closes early.

### Test configs
- Drop the `input = "[]"` entries (152 lines across 6 configs). The
  value was sent to the guest verbatim as a literal two-byte payload;
  removing it leaves stdin empty so no payload is written and the race
  window disappears. Non-empty inputs are preserved.

## Validation
- `cargo clippy` and `cargo fmt --check` clean on `nanvix-test`.
- Representative HTTP tests pass (fault tests now input-less; the
  real-input echo test still passes).
- Deterministic race reproduction (forced delay + non-empty send) now
  passes with a tolerated `BrokenPipe` warning instead of failing.

closes #2825