### PR TITLE
[syscall] Keep libraries loaded during dlclose

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -17,6 +17,7 @@ ALL_POSIX_TESTS := \
 	test-c-ctor \
 	test-c-dlfcn \
 	test-c-dlfcn-diamond \
+	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \
 	test-c-dlfcn-hello \
 	test-c-dlfcn-init-runpath \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -132,6 +132,11 @@ POSIX_TEST_PIE_test-c-dlfcn-pie := yes
 POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+# dlfcn-dtor-reentry-c links PIE + --export-dynamic so the main executable's
+# `dtor_probe` helper (and its witness globals) land in `.dynsym`; libreentry.so's
+# destructor then resolves its `extern void dtor_probe(void)` reference from the
+# loader's global symbol table while it is being torn down.
+POSIX_TEST_PIE_test-c-dlfcn-dtor-reentry := yes
 # dlfcn-init-runpath-c links PIE with --export-dynamic so the main executable's
 # `g_dtor_ran` global lands in `.dynsym`; the loader's global symbol table then
 # satisfies libctor.so's `extern volatile int g_dtor_ran` reference at load time.
@@ -294,6 +299,7 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
@@ -305,6 +311,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
@@ -642,9 +649,60 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini): $(POSIX_TEST_INITFINI_DIR)/libini
 	$(CP_CMD) $(POSIX_TEST_INITFINI_DIR)/libinitfini.so $(POSIX_TEST_INITFINI_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_INITFINI_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-dtor-reentry-c: destructor-time loader re-entrancy fixtures (issue #2538).
+#---------------------------------------------------------------------------------------------------
+#
+# Ships TWO shared libraries (built with the same i686 freestanding toolchain as
+# the fixtures above):
+#   * libdep.so     - self-contained dependency (zero undefined symbols),
+#                     exporting dep_value(). An explicit -soname pins the bare
+#                     DT_NEEDED name recorded in libreentry.so to `libdep.so`
+#                     regardless of linker (GNU ld vs ld.lld), so the loader
+#                     resolves it through the default lib/ search path.
+#   * libreentry.so - DT_NEEDED=libdep.so (it references dep_value via -ldep).
+#                     Carries a `.fini_array` destructor that calls the main
+#                     executable's dtor_probe() -- left UNDEFINED and resolved
+#                     from the global scope at load time (the suite ELF is PIE +
+#                     --export-dynamic, see POSIX_TEST_PIE_* above).
+# Both are staged under lib/, where main.c dlopen()s libreentry.so. A correct
+# dlclose() keeps both entries (and the libreentry.so -> libdep.so edge) in the
+# registry until the destructors finish, so the destructor-time probe re-resolves
+# them instead of mapping a second copy.
+POSIX_TEST_DTOR_REENTRY_SUITE  := test-c-dlfcn-dtor-reentry
+POSIX_TEST_DTOR_REENTRY_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_DTOR_REENTRY_SUITE)/libs
+POSIX_TEST_DTOR_REENTRY_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_DTOR_REENTRY_SUITE)-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_DTOR_REENTRY_SUITE).img
+
+# libdep.so: self-contained dependency with SONAME=libdep.so.
+$(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libdep.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_DTOR_REENTRY_SUITE)/libs/dep.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_DTOR_REENTRY_SUITE)/libdep.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libdep.so $@.o -o $@
+
+# libreentry.so: DT_NEEDED=libdep.so; `.fini_array` destructor calls dtor_probe.
+$(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libreentry.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_DTOR_REENTRY_SUITE)/libs/reentry.c \
+		$(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libdep.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_DTOR_REENTRY_SUITE)/libreentry.so (DT_NEEDED libdep.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o \
+		-L$(POSIX_TEST_DTOR_REENTRY_LIBDIR) -ldep -o $@
+
+# Per-suite RAMFS image carrying both fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry): $(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libdep.so \
+		$(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libreentry.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libdep.so $(POSIX_TEST_DTOR_REENTRY_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libreentry.so $(POSIX_TEST_DTOR_REENTRY_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_DTOR_REENTRY_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \

--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -11,7 +11,10 @@ use crate::dlfcn::syscall::{
     DYNAMIC_LIBRARY_REGISTRY,
 };
 use ::alloc::{
-    collections::btree_map::BTreeMap,
+    collections::{
+        btree_map::BTreeMap,
+        btree_set::BTreeSet,
+    },
     string::String,
     sync::Arc,
     vec::Vec,
@@ -33,102 +36,106 @@ use ::sys::error::{
 pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
     ::syslog::trace!("dlclose(): handle={:?}", handle);
 
-    // Order in which `.fini_array` destructors must run: the closing library
-    // first, then its dependencies (the reverse of constructor order). The
-    // libraries are removed from the registry while `DYNAMIC_LIBRARY_REGISTRY`
-    // is held, but their destructors run *after* the lock is released so a
-    // destructor may legally call back into `dlsym`/`dlopen`/`dlclose` without
-    // self-deadlocking on the registry mutex.
+    // Phase 1: determine, WITHOUT mutating the registry, the set of libraries
+    // that become unreferenced when `handle` is closed, ordered dependents-
+    // first (the reverse of constructor order). Entries are left in the
+    // registry and their dependency edges left intact: while the `.fini_array`
+    // destructors run below (phase 2), the libraries therefore stay
+    // discoverable -- a re-entrant `dlopen` of one of them returns the existing
+    // entry instead of mapping a second copy, and `dlsym(handle, ...)` keeps
+    // resolving symbols across the still-connected dependency graph. The
+    // registry removal is deferred to phase 3, after every destructor has run.
     let fini_order: Vec<Arc<Mutex<DynamicLibrary>>> = {
-        let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
+        let registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
             DYNAMIC_LIBRARY_REGISTRY.lock();
 
-        // Check if dynamic library file is opened.
-        if !registry.contains_key(handle) {
-            let reason: &str = "dynamic library file not open";
-            ::syslog::warn!("dlclose(): {}", reason);
-            return Err(Error::new(ErrorCode::BadFile, reason));
-        }
-
-        // Remove the closing library from the registry, but only if this is the
-        // last reference to it (i.e., no other loaded library still depends on
-        // it). If it is still referenced, there is nothing to unload yet.
-        let mut extracted: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
-            .extract_if(.., |dlhandle, dlfile| handle == dlhandle && Arc::strong_count(dlfile) == 1)
-            .collect();
-
-        // A handle is unique, so at most one entry can match.
-        debug_assert!(extracted.len() <= 1);
-
-        // Dynamic library file is still in use.
-        let root: Arc<Mutex<DynamicLibrary>> = match extracted.pop() {
-            Some((_, root)) => root,
-            None => return Ok(()),
+        // Check if the dynamic library file is open.
+        let root: &Arc<Mutex<DynamicLibrary>> = match registry.get(handle) {
+            Some(root) => root,
+            None => {
+                let reason: &str = "dynamic library file not open";
+                ::syslog::warn!("dlclose(): {}", reason);
+                return Err(Error::new(ErrorCode::BadFile, reason));
+            },
         };
 
-        // Walk the dependency graph, removing every library that becomes
-        // unreferenced once its dependents are removed, recording the unload
-        // order (dependents before dependencies). `take_dependencies` detaches
-        // a library's dependency edges, so recording a library here drops its
-        // hold on its dependencies; a dependency is only unloaded once *all* of
-        // its dependents -- inside and outside this `dlclose` call -- have
-        // released it.
-        let mut fini_order: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
-        let mut worklist: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::new();
-
-        for (_dlname, dep) in root.lock().take_dependencies() {
-            worklist.push(dep);
+        // The closing library can only be unloaded if the registry holds the
+        // last reference to it. A higher count means another loaded library
+        // still depends on it, or it is pinned in the global scope
+        // (`RTLD_GLOBAL`): there is nothing to unload yet.
+        if Arc::strong_count(root) != 1 {
+            return Ok(());
         }
-        fini_order.push(root);
 
-        while let Some(candidate) = worklist.pop() {
-            let candidate_handle: DlHandle = candidate.lock().handle();
+        // Reference-count peel over the dependency graph. `remaining[h]` is the
+        // number of references to `h` that will survive once every library
+        // already placed in the unload set is torn down; a library joins the
+        // set when that count falls to just the registry's own reference (`1`).
+        // Neither the registry nor any dependency edge is mutated here, and the
+        // owning `Arc`s are cloned only afterwards, below. A live
+        // `Arc::strong_count` may still change concurrently (e.g. another
+        // thread completing a dlopen/dlclose), so this peel only computes a
+        // candidate unload set; phase 3 re-checks ownership before removing any
+        // entry.
+        let mut remaining: BTreeMap<DlHandle, usize> = BTreeMap::new();
+        let mut visited: BTreeSet<DlHandle> = BTreeSet::new();
+        let mut order: Vec<DlHandle> = Vec::new();
+        let mut stack: Vec<DlHandle> = Vec::new();
 
-            // Remove the candidate from the registry only if the registry and
-            // this worklist entry hold the last two references to it. A higher
-            // count means another not-yet-removed dependent (e.g., the other
-            // arm of a diamond dependency) or a library outside this unload set
-            // still references it: skip it now and let the remaining dependent
-            // re-enqueue it once that dependent is removed. An empty result
-            // means the candidate was already unloaded via another path.
-            let mut extracted: Vec<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = registry
-                .extract_if(.., |dlhandle, dlfile| {
-                    *dlhandle == candidate_handle && Arc::strong_count(dlfile) == 2
-                })
-                .collect();
+        visited.insert(*handle);
+        order.push(*handle);
+        stack.push(*handle);
 
-            // A handle is unique, so at most one entry can match.
-            debug_assert!(extracted.len() <= 1);
-
-            let dep: Arc<Mutex<DynamicLibrary>> = match extracted.pop() {
-                Some((_, dep)) => dep,
+        while let Some(parent) = stack.pop() {
+            // Snapshot the parent's bound dependency handles under a short lock.
+            let dependencies: Vec<DlHandle> = match registry.get(&parent) {
+                Some(dlfile) => dlfile.lock().dependency_handles(),
                 None => continue,
             };
 
-            {
-                let mut lib: MutexGuard<'_, DynamicLibrary> = dep.lock();
-                for (_dlname, dlfile) in lib.take_dependencies() {
-                    worklist.push(dlfile);
+            for dependency in dependencies {
+                // Seed `remaining` from the dependency's live reference count
+                // the first time it is reached, then release the edge that
+                // `parent` -- now in the unload set -- holds on it.
+                let count: &mut usize = remaining.entry(dependency).or_insert_with(|| {
+                    registry
+                        .get(&dependency)
+                        .map(Arc::strong_count)
+                        .unwrap_or(1)
+                });
+                *count = count.saturating_sub(1);
+
+                // Once only the registry still references the dependency, it too
+                // becomes part of the unload set. A dependency shared with a
+                // library outside the set (or pinned in the global scope) never
+                // reaches `1` and is correctly left loaded.
+                if *count == 1 && visited.insert(dependency) {
+                    order.push(dependency);
+                    stack.push(dependency);
                 }
-                ::syslog::debug!(
-                    "dlclose(): unloading dependency (name={:?}, registry.len={:?})",
-                    lib.name(),
-                    registry.len()
-                );
             }
-            fini_order.push(dep);
         }
 
-        fini_order
+        // Collect owning references in dependents-first order. Cloning here
+        // (after the peel) keeps every library alive across the destructor
+        // phase and, crucially, bumps each `strong_count` above `1`, so a
+        // destructor that re-enters `dlclose` for one of these handles sees it
+        // as still referenced and does not unload it a second time.
+        order
+            .iter()
+            .filter_map(|handle| registry.get(handle).cloned())
+            .collect()
     };
 
-    // The registry lock is now released. Run `.fini_array` destructors in
-    // dependents-first order with no dlfcn locks held.
+    // Phase 2: the registry lock is released. Run `.fini_array` destructors in
+    // dependents-first order with no dlfcn locks held, so a destructor may
+    // legally call back into `dlsym`/`dlopen`/`dlclose`.
     for dlfile in fini_order.iter() {
         // Snapshot the destructor descriptor and name under a short per-library
         // lock, then drop the lock before invoking destructors. Holding the
         // per-library lock during destructor execution would deadlock any
-        // destructor that re-enters the same library's libposix/alloc paths.
+        // destructor that re-enters the same library's libposix/alloc paths, or
+        // that calls `dlsym(self_handle, ...)`.
         let (descriptor, name): (Option<(usize, usize)>, String) = {
             let lib: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
             (lib.fini_array_descriptor(), String::from(lib.name()))
@@ -143,8 +150,50 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
         }
     }
 
-    // Drop the libraries now that all destructors have run, unmapping their
-    // segments and releasing their file descriptors.
+    // Phase 3: every destructor has run. Re-acquire the registry lock and remove
+    // the unloaded libraries that are still owned only by the registry and this
+    // `fini_order` snapshot, detaching their dependency edges so the owning
+    // `Arc`s are released. A destructor may have re-entered `dlopen` and added a
+    // new real reference to one of these libraries (for example by loading a new
+    // dependent or promoting it to `RTLD_GLOBAL`); such libraries must remain in
+    // the registry with their dependency edges intact. Detaching a shared
+    // dependency's edge that is kept alive by a library OUTSIDE the unload set
+    // correctly decrements that dependency's reference count without unloading
+    // it. The actual unmap happens when `fini_order` is dropped below, with the
+    // registry lock NOT held (segment teardown issues kernel calls).
+    {
+        let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
+            DYNAMIC_LIBRARY_REGISTRY.lock();
+        for dlfile in fini_order.iter() {
+            let handle: DlHandle = dlfile.lock().handle();
+            if !registry.contains_key(&handle) {
+                continue;
+            }
+
+            let strong_count: usize = Arc::strong_count(dlfile);
+            if strong_count != 2 {
+                ::syslog::debug!(
+                    "dlclose(): keeping library loaded (handle={:?}, references={:?})",
+                    handle,
+                    strong_count
+                );
+                continue;
+            }
+
+            if registry.remove(&handle).is_some() {
+                ::syslog::debug!(
+                    "dlclose(): unloading library (handle={:?}, registry.len={:?})",
+                    handle,
+                    registry.len()
+                );
+                dlfile.lock().take_dependencies();
+            }
+        }
+    }
+
+    // Drop the libraries now that all destructors have run and they have been
+    // removed from the registry, unmapping their segments and releasing their
+    // file descriptors. The registry lock is not held here.
     drop(fini_order);
 
     Ok(())

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -1142,13 +1142,15 @@ impl DynamicLibrary {
     ///
     /// This function must be called with **no** dlfcn locks held -- neither
     /// `DYNAMIC_LIBRARY_REGISTRY` nor the per-library mutex of the
-    /// originating library. The current `dlclose()` caller removes every
-    /// library it is going to unload from the registry and then releases
+    /// originating library. The `dlclose()` caller releases
     /// `DYNAMIC_LIBRARY_REGISTRY` before invoking any destructor, so a
     /// destructor may legally call back into `dlopen`/`dlclose`/`dlsym`
-    /// without deadlocking. One caveat remains: `dlsym(self_handle, ...)`
-    /// fails with `NoSuchEntry` rather than succeeding, because the closing
-    /// library has already been removed from the registry.
+    /// without deadlocking. The libraries being unloaded are left in the
+    /// registry, with their dependency edges intact, until *every* destructor
+    /// has run (see `dlclose`); therefore `dlsym(self_handle, ...)` and a
+    /// re-entrant `dlopen` of the closing library (or of one of its
+    /// still-loaded dependencies) resolve correctly during teardown instead
+    /// of failing or mapping a second copy.
     ///
     /// # Safety
     ///

--- a/src/tests/integration/test-c-dlfcn-dtor-reentry/libs/dep.c
+++ b/src/tests/integration/test-c-dlfcn-dtor-reentry/libs/dep.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libdep.so - dependency fixture for dlfcn-dtor-reentry-c.
+ *
+ * A self-contained shared library (zero undefined symbols) that exports a
+ * single value function. libreentry.so DT_NEEDEDs it, and the suite resolves
+ * dep_value() through libreentry.so's handle WHILE libreentry.so is being torn
+ * down, proving the dependency edge stays intact until destructors finish.
+ */
+
+int dep_value(void)
+{
+    return 4321;
+}

--- a/src/tests/integration/test-c-dlfcn-dtor-reentry/libs/reentry.c
+++ b/src/tests/integration/test-c-dlfcn-dtor-reentry/libs/reentry.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libreentry.so - primary fixture for dlfcn-dtor-reentry-c.
+ *
+ * Carries a `.fini_array` destructor that runs during dlclose() teardown and
+ * delegates to the main executable's dtor_probe(), which re-enters the loader
+ * to prove this library and its dependency stay discoverable until destructors
+ * finish. The library DT_NEEDEDs libdep.so (reentry_dep_value() references
+ * dep_value(), so the linker records the edge), leaves dtor_probe() UNDEFINED
+ * (resolved from the main executable's exported global scope at load time, as
+ * the suite ELF is PIE + --export-dynamic), and exports reentry_value() so the
+ * destructor-time probe can resolve it via dlsym().
+ */
+
+/* Defined in libdep.so; referenced here so the linker records a DT_NEEDED entry
+ * on libdep.so and the loader keeps the edge to resolve during teardown. */
+extern int dep_value(void);
+
+/* Defined in the main executable and exported via --export-dynamic; resolved
+ * from the loader's global symbol table at load time. Called from this
+ * library's destructor while dlclose() is unloading it. */
+extern void dtor_probe(void);
+
+/* Exported so the destructor-time probe can resolve it via dlsym(). */
+int reentry_value(void)
+{
+    return 1234;
+}
+
+/* Exported helper that references the dependency, forcing the DT_NEEDED edge on
+ * libdep.so (and giving the probe a dependency symbol to resolve). */
+int reentry_dep_value(void)
+{
+    return dep_value();
+}
+
+/* Runs from `.fini_array` during dlclose() teardown. */
+static void __attribute__((destructor)) reentry_dtor(void)
+{
+    dtor_probe();
+}

--- a/src/tests/integration/test-c-dlfcn-dtor-reentry/main.c
+++ b/src/tests/integration/test-c-dlfcn-dtor-reentry/main.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-dtor-reentry-c: Validate that a library stays discoverable, with its
+ * dependency graph intact, until its `.fini_array` destructors have finished
+ * running.
+ *
+ * Before the fix, dlclose() removed a library (and any dependency that became
+ * unreferenced) from the loader registry, and detached its dependency edges,
+ * *before* running the `.fini_array` destructors. A destructor that re-entered
+ * the loader therefore observed a half-dismantled state: dlopen() of the
+ * library being unloaded mapped a SECOND copy (new file descriptor -> new
+ * handle) instead of returning the existing one, and dlsym() against the
+ * library's own handle (or a dependency's symbol) failed because the entry /
+ * edge was already gone.
+ *
+ * Fixtures (staged under lib/ by the per-suite RAMFS image):
+ *   - libdep.so:     exports dep_value() == 4321. Self-contained.
+ *   - libreentry.so: DT_NEEDED libdep.so; exports reentry_value() == 1234; its
+ *                    `.fini_array` destructor calls dtor_probe() (below,
+ *                    resolved from the main executable's exported global scope,
+ *                    which the suite ELF publishes via PIE + --export-dynamic).
+ *
+ * Flow: main() dlopen()s libreentry.so, records the handle, then dlclose()s it.
+ * dlclose() runs libreentry.so's destructor, which calls back into
+ * dtor_probe(). While that destructor is on the stack -- i.e. WHILE the library
+ * is being torn down -- dtor_probe() re-enters the loader and checks that:
+ *   (1) dlopen("lib/libreentry.so") returns the SAME handle (no second copy);
+ *   (2) dlsym(handle, "reentry_value") resolves the library's own symbol;
+ *   (3) dlsym(handle, "dep_value") resolves a STILL-LOADED dependency's symbol;
+ *   (4) dlsym(original_handle, "reentry_value") -- the handle main() still holds
+ *       -- resolves too.
+ *
+ * Pass/fail is the guest exit code (the harness discards stdout in standalone
+ * mode): main() returns 0 only when the destructor ran AND all four checks
+ * passed.
+ */
+
+#include <dlfcn.h>
+#include <stddef.h>
+#include <unistd.h>
+
+/* Sentinel proving the destructor (hence dtor_probe) actually ran. */
+#define PROBE_SENTINEL 0x2538
+
+/* Per-check result bits recorded by dtor_probe(). */
+#define BIT_REOPEN_SAME_HANDLE 0x1 /* (1) dlopen returns the existing handle   */
+#define BIT_SELF_SYM_OK        0x2 /* (2) dlsym resolves the library's symbol  */
+#define BIT_DEP_SYM_OK         0x4 /* (3) dlsym resolves a dependency's symbol */
+#define BIT_ORIG_SYM_OK        0x8 /* (4) the original handle still resolves   */
+#define PROBE_EXPECTED \
+    (BIT_REOPEN_SAME_HANDLE | BIT_SELF_SYM_OK | BIT_DEP_SYM_OK | BIT_ORIG_SYM_OK)
+
+/*
+ * Witnesses owned by the executable and exported via --export-dynamic so the
+ * fixture's destructor can resolve `dtor_probe` from the loader's global scope.
+ * `volatile` keeps the optimizer from assuming their values across the
+ * cross-module write performed by the destructor.
+ */
+volatile int g_probe_ran = 0;
+volatile int g_probe_result = 0;
+volatile void *g_original_handle = NULL;
+
+/*
+ * Invoked from libreentry.so's `.fini_array` destructor, i.e. while dlclose()
+ * is tearing libreentry.so down. Re-enters the loader to confirm the library
+ * (and its dependency) are still discoverable during teardown, recording the
+ * outcome in `g_probe_result` for main() to check after dlclose() returns.
+ */
+void dtor_probe(void)
+{
+    int result = 0;
+
+    g_probe_ran = PROBE_SENTINEL;
+
+    /*
+     * (1) dlopen() of the library currently being unloaded must return the
+     *     EXISTING registry entry (same handle), not map a second copy. A
+     *     second copy would open a new file descriptor and hand back a
+     *     different handle.
+     */
+    void *reopened = dlopen("lib/libreentry.so", RTLD_NOW);
+    if (reopened != NULL) {
+        if (reopened == (void *)g_original_handle) {
+            result |= BIT_REOPEN_SAME_HANDLE;
+        }
+
+        /* (2) The library's own exported symbol resolves during teardown. */
+        int (*rv)(void) = NULL;
+        *(void **)(&rv) = dlsym(reopened, "reentry_value");
+        if (rv != NULL && rv() == 1234) {
+            result |= BIT_SELF_SYM_OK;
+        }
+
+        /*
+         * (3) A symbol of a STILL-LOADED dependency resolves through the library's
+         *     handle: libreentry.so -> libdep.so's edge must remain intact until
+         *     the destructors finish.
+         */
+        int (*dv)(void) = NULL;
+        *(void **)(&dv) = dlsym(reopened, "dep_value");
+        if (dv != NULL && dv() == 4321) {
+            result |= BIT_DEP_SYM_OK;
+        }
+    }
+
+    /* (4) The original handle main() still holds also resolves symbols. */
+    int (*rv2)(void) = NULL;
+    *(void **)(&rv2) = dlsym((void *)g_original_handle, "reentry_value");
+    if (rv2 != NULL && rv2() == 1234) {
+        result |= BIT_ORIG_SYM_OK;
+    }
+
+    g_probe_result = result;
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* Load the fixture and remember its handle for the destructor-time probe. */
+    void *handle = dlopen("lib/libreentry.so", RTLD_NOW);
+    if (handle == NULL) {
+        return 1;
+    }
+    g_original_handle = handle;
+
+    /* Closing the library runs its destructor, which calls dtor_probe(). */
+    if (dlclose(handle) != 0) {
+        return 2;
+    }
+
+    /* The destructor must have run at all. */
+    if (g_probe_ran != PROBE_SENTINEL) {
+        return 3;
+    }
+
+    /* Every re-entrancy check must have passed. Encode the failing checks into
+     * the exit code (bit set == check that did NOT pass) to aid post-mortem. */
+    if (g_probe_result != PROBE_EXPECTED) {
+        return 16 | (PROBE_EXPECTED & ~g_probe_result);
+    }
+
+    /* Success: emit the magic string some harnesses expect, then return 0. */
+    const char *magic = "ok";
+    write(STDOUT_FILENO, magic, 2);
+
+    return 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-dtor-reentry"
+program = "./bin/test-c-dlfcn-dtor-reentry.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dtor-reentry.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-global"
 program = "./bin/test-c-dlfcn-global.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-global.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-dtor-reentry"
+program = "./bin/test-c-dlfcn-dtor-reentry.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dtor-reentry.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-global"
 program = "./bin/test-c-dlfcn-global.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-global.img"


### PR DESCRIPTION
## Summary

Fixes a `dlclose()` teardown bug where a library and its dependencies were
removed from `DYNAMIC_LIBRARY_REGISTRY` (and their dependency edges detached)
*before* their `.fini_array` destructors ran. A destructor that re-entered the
loader therefore observed a half-dismantled state: `dlopen()` of the unloading
library mapped a **second copy**, and `dlsym(self_handle, ...)` failed. This
keeps the library and its dependency graph discoverable throughout teardown.

Closes #2538.

## What changed

**Loader (`syscall`):**
- Rework `dlclose()` into three phases: (1) compute the dependents-first unload
  set with a non-destructive reference-count peel that leaves the registry and
  all dependency edges intact; (2) run `.fini_array` destructors with no dlfcn
  locks held; (3) re-acquire the registry and remove only entries still owned
  solely by the registry and the fini-order snapshot.
- Guard phase 3 with an `Arc::strong_count` check so a destructor that re-enters
  `dlopen` (adding a real dependent or an `RTLD_GLOBAL` pin) leaves the revived
  library loaded with its edges intact.
- Update `DynamicLibrary::invoke_fini_array()` locking docs to reflect that
  in-destructor `dlsym`/`dlopen` of the unloading library now resolve correctly.

**Acceptance test + wiring (`tests`, `build`):**
- Add the `test-c-dlfcn-dtor-reentry` POSIX suite: `main.c` `dlopen`s
  `libreentry.so` and `dlclose`s it; the destructor calls back into main''s
  exported `dtor_probe()`, which re-enters the loader and verifies the reopened
  handle matches (no second copy) and that the library''s own and its
  still-loaded dependency''s symbols resolve via `dlsym()`.
- Fixtures: `libdep.so` (self-contained, `SONAME=libdep.so`) and `libreentry.so`
  (`DT_NEEDED libdep.so`, `.fini_array` destructor).
- Register the suite in `ALL_POSIX_TESTS`, build it PIE + `--export-dynamic`, add
  make rules for the shared libraries and a per-suite RAMFS image, wire cleanup,
  and register it in `test-posix.toml` / `test-posix-windows.toml` (expected
  exit code 0).

## Validation

- `./z build -- check`, `./z build -- all-posix-tests`, and `./z build -- test`
  pass; the new `posix/test-c-dlfcn-dtor-reentry` case exits 0.