### PR TITLE
[libc_termios] Implement termios line control

### DIFF
--- a/src/libs/libc_termios/src/bindings.rs
+++ b/src/libs/libc_termios/src/bindings.rs
@@ -6,9 +6,13 @@
 //==================================================================================================
 
 use ::sys::error::ErrorCode;
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uint,
+        c_void,
+    },
+    sys_types::pid_t,
 };
 use ::syscall::errno::__errno_location;
 use ::syslog::trace_libcall;
@@ -137,4 +141,307 @@ pub unsafe extern "C" fn tcsetattr(
         }
         -1
     }
+}
+
+//==================================================================================================
+// Terminal line-control and line-speed helpers
+//==================================================================================================
+//
+// These terminal helpers complement `tcgetattr` / `tcsetattr` above. The `tc*` line-control calls
+// validate that `fd` is a terminal (via `isatty`) and then complete as no-ops on the queueless vfsd
+// console, while the `cf*` accessors read and write the caller's `struct termios` directly.
+
+/// Returns whether `fd` refers to a terminal.
+///
+/// On a non-terminal or invalid descriptor this sets `errno` (`ENOTTY` or `EBADF`, respectively) as
+/// a side effect of `isatty`, so the terminal-control calls below can simply propagate the failure.
+/// Works in both standalone and hosted deployments, since `isatty` resolves the descriptor against
+/// whichever backend is active.
+fn fd_is_terminal(fd: c_int) -> bool {
+    extern "C" {
+        fn isatty(fd: c_int) -> c_int;
+    }
+
+    // SAFETY: FFI to the runtime `isatty`, which validates `fd` and sets `errno` on failure.
+    unsafe { isatty(fd) == 1 }
+}
+
+/// Returns whether `speed` is one of the encoded `Bxxx` baud-rate constants.
+///
+/// Valid encodings are the contiguous low range `B0..=B38400` and the extended range
+/// `B57600..=B4000000`. The bare `CBAUDEX` bit (which falls in the gap between the two ranges) and
+/// every other value are not baud rates. The bounds are named against `include/termios.h` so the
+/// accepted set stays auditable and does not drift from the header encoding.
+fn is_baud_rate(speed: c_uint) -> bool {
+    use ::sysapi::termios::{
+        B0,
+        B38400,
+        B4000000,
+        B57600,
+    };
+
+    matches!(speed, B0..=B38400 | B57600..=B4000000)
+}
+
+/// `tcsendbreak` — sends a break on the terminal referred to by `fd`.
+///
+/// The vfsd console has no serial line to signal, so once `fd` is confirmed to be a terminal the
+/// break request completes as a successful no-op regardless of `duration`. If `fd` does not refer to
+/// a terminal, returns `-1` with `errno` set (`EBADF` or `ENOTTY`), as reported by `isatty`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcsendbreak(fd: c_int, _duration: c_int) -> c_int {
+    if !fd_is_terminal(fd) {
+        return -1;
+    }
+    0
+}
+
+/// `tcdrain` — waits until all output written to the terminal referred to by `fd` is transmitted.
+///
+/// The vfsd console keeps no output queue to drain, so once `fd` is confirmed to be a terminal the
+/// call completes immediately with success. If `fd` does not refer to a terminal, returns `-1` with
+/// `errno` set (`EBADF` or `ENOTTY`), as reported by `isatty`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcdrain(fd: c_int) -> c_int {
+    if !fd_is_terminal(fd) {
+        return -1;
+    }
+    0
+}
+
+/// `tcflush` — discards queued terminal data selected by `queue_selector`.
+///
+/// The descriptor is validated first: if `fd` does not refer to a terminal, returns `-1` with
+/// `errno` set (`EBADF` or `ENOTTY`), as reported by `isatty`. Otherwise `queue_selector` must be
+/// `TCIFLUSH`, `TCOFLUSH`, or `TCIOFLUSH`; any other value is rejected with `errno = EINVAL`. The
+/// vfsd console keeps no output queue and delivers input eagerly, so a valid flush on a terminal is
+/// a successful no-op.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcflush(fd: c_int, queue_selector: c_int) -> c_int {
+    use ::sysapi::termios::{
+        TCIFLUSH,
+        TCIOFLUSH,
+        TCOFLUSH,
+    };
+
+    if !fd_is_terminal(fd) {
+        return -1;
+    }
+
+    match queue_selector {
+        TCIFLUSH | TCOFLUSH | TCIOFLUSH => {},
+        _ => {
+            // SAFETY: writes to the process-global errno location.
+            unsafe {
+                *__errno_location() = ::sysapi::errno::EINVAL;
+            }
+            return -1;
+        },
+    }
+
+    0
+}
+
+/// `tcflow` — suspends or resumes terminal input/output as selected by `action`.
+///
+/// The descriptor is validated first: if `fd` does not refer to a terminal, returns `-1` with
+/// `errno` set (`EBADF` or `ENOTTY`), as reported by `isatty`. Otherwise `action` must be `TCOOFF`,
+/// `TCOON`, `TCIOFF`, or `TCION`; any other value is rejected with `errno = EINVAL`. The vfsd
+/// console applies no software flow control, so a valid action on a terminal is a successful no-op.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcflow(fd: c_int, action: c_int) -> c_int {
+    use ::sysapi::termios::{
+        TCIOFF,
+        TCION,
+        TCOOFF,
+        TCOON,
+    };
+
+    if !fd_is_terminal(fd) {
+        return -1;
+    }
+
+    match action {
+        TCOOFF | TCOON | TCIOFF | TCION => {},
+        _ => {
+            // SAFETY: writes to the process-global errno location.
+            unsafe {
+                *__errno_location() = ::sysapi::errno::EINVAL;
+            }
+            return -1;
+        },
+    }
+
+    0
+}
+
+/// `cfgetispeed` — returns the input baud rate stored in `*termios_p`.
+///
+/// Pure accessor over the caller's `struct termios`: no descriptor, no I/O, and no `errno` contract.
+///
+/// # Safety
+///
+/// `termios_p` must point to a valid, readable `struct termios`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfgetispeed(termios_p: *const c_void) -> c_uint {
+    // SAFETY: the caller guarantees `termios_p` points to a valid, readable `struct termios`.
+    let termios: &::sysapi::termios::Termios =
+        unsafe { &*(termios_p as *const ::sysapi::termios::Termios) };
+    termios.c_ispeed
+}
+
+/// `cfgetospeed` — returns the output baud rate stored in `*termios_p`.
+///
+/// Pure accessor over the caller's `struct termios`: no descriptor, no I/O, and no `errno` contract.
+///
+/// # Safety
+///
+/// `termios_p` must point to a valid, readable `struct termios`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfgetospeed(termios_p: *const c_void) -> c_uint {
+    // SAFETY: the caller guarantees `termios_p` points to a valid, readable `struct termios`.
+    let termios: &::sysapi::termios::Termios =
+        unsafe { &*(termios_p as *const ::sysapi::termios::Termios) };
+    termios.c_ospeed
+}
+
+/// `cfsetispeed` — sets the input baud rate stored in `*termios_p`.
+///
+/// The change is purely in memory and takes effect only when the struct is later handed to
+/// `tcsetattr`. `speed` must be one of the `Bxxx` baud-rate constants (`B0` inclusive); any other
+/// value is rejected with `errno = EINVAL` and the struct is left unchanged.
+///
+/// # Safety
+///
+/// `termios_p` must point to a valid, writable `struct termios`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfsetispeed(termios_p: *mut c_void, speed: c_uint) -> c_int {
+    if !is_baud_rate(speed) {
+        // SAFETY: writes to the process-global errno location.
+        unsafe {
+            *__errno_location() = ::sysapi::errno::EINVAL;
+        }
+        return -1;
+    }
+
+    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
+    let termios: &mut ::sysapi::termios::Termios =
+        unsafe { &mut *(termios_p as *mut ::sysapi::termios::Termios) };
+    termios.c_ispeed = speed;
+    0
+}
+
+/// `cfsetospeed` — sets the output baud rate stored in `*termios_p`.
+///
+/// The change is purely in memory and takes effect only when the struct is later handed to
+/// `tcsetattr`. `speed` must be one of the `Bxxx` baud-rate constants (`B0` inclusive); any other
+/// value is rejected with `errno = EINVAL` and the struct is left unchanged.
+///
+/// # Safety
+///
+/// `termios_p` must point to a valid, writable `struct termios`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfsetospeed(termios_p: *mut c_void, speed: c_uint) -> c_int {
+    if !is_baud_rate(speed) {
+        // SAFETY: writes to the process-global errno location.
+        unsafe {
+            *__errno_location() = ::sysapi::errno::EINVAL;
+        }
+        return -1;
+    }
+
+    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
+    let termios: &mut ::sysapi::termios::Termios =
+        unsafe { &mut *(termios_p as *mut ::sysapi::termios::Termios) };
+    termios.c_ospeed = speed;
+    0
+}
+
+/// `cfsetspeed` — sets both the input and output baud rates stored in `*termios_p`.
+///
+/// The change is purely in memory and takes effect only when the struct is later handed to
+/// `tcsetattr`. `speed` must be one of the `Bxxx` baud-rate constants (`B0` inclusive); any other
+/// value is rejected with `errno = EINVAL` and the struct is left unchanged.
+///
+/// # Safety
+///
+/// `termios_p` must point to a valid, writable `struct termios`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfsetspeed(termios_p: *mut c_void, speed: c_uint) -> c_int {
+    if !is_baud_rate(speed) {
+        // SAFETY: writes to the process-global errno location.
+        unsafe {
+            *__errno_location() = ::sysapi::errno::EINVAL;
+        }
+        return -1;
+    }
+
+    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
+    let termios: &mut ::sysapi::termios::Termios =
+        unsafe { &mut *(termios_p as *mut ::sysapi::termios::Termios) };
+    termios.c_ispeed = speed;
+    termios.c_ospeed = speed;
+    0
+}
+
+/// `cfmakeraw` — places the terminal attributes pointed to by `termios_p` in "raw" mode.
+///
+/// Unlike line-speed configuration, this is a pure in-memory transformation of the caller's
+/// `struct termios` and requires no terminal hardware. It clears canonical input (`ICANON`), echo
+/// (`ECHO`), signal generation (`ISIG`), extended input processing (`IEXTEN`), CR-to-NL mapping
+/// (`ICRNL`), start/stop output control (`IXON`), and output post-processing (`OPOST`), then sets a
+/// one-byte, no-timeout non-canonical read (`VMIN = 1`, `VTIME = 0`) — the flags honored by the
+/// vfsd console line discipline. A null pointer is ignored.
+///
+/// # Safety
+///
+/// `termios_p` must be null or point to a valid, writable `struct termios`; a non-null pointer is
+/// dereferenced and overwritten.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn cfmakeraw(termios_p: *mut c_void) {
+    use ::sysapi::termios::{
+        Termios,
+        ECHO,
+        ICANON,
+        ICRNL,
+        IEXTEN,
+        ISIG,
+        IXON,
+        OPOST,
+        VMIN,
+        VTIME,
+    };
+
+    if termios_p.is_null() {
+        return;
+    }
+
+    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
+    let termios: &mut Termios = unsafe { &mut *(termios_p as *mut Termios) };
+    termios.c_iflag &= !(ICRNL | IXON);
+    termios.c_oflag &= !OPOST;
+    termios.c_lflag &= !(ICANON | ECHO | ISIG | IEXTEN);
+    termios.c_cc[VMIN] = 1;
+    termios.c_cc[VTIME] = 0;
+}
+
+/// `tcgetsid` — returns the session ID of the terminal referred to by `fd`.
+///
+/// Nanvix has no sessions or process groups, so a process is treated as its own session leader:
+/// when `fd` refers to a terminal, the returned session ID is the caller's process ID. If `fd` does
+/// not refer to a terminal, returns `-1` with `errno` set, as reported by `isatty`.
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn tcgetsid(fd: c_int) -> pid_t {
+    extern "C" {
+        fn isatty(fd: c_int) -> c_int;
+        fn getpid() -> pid_t;
+    }
+
+    // SAFETY: FFI to the runtime `isatty`, which validates `fd` and sets `errno` on error.
+    if unsafe { isatty(fd) } == 0 {
+        return -1 as pid_t;
+    }
+
+    // SAFETY: FFI to the runtime `getpid`, which has no preconditions.
+    unsafe { getpid() }
 }

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -141,13 +141,9 @@ use ::sysapi::{
         c_char,
         c_int,
         c_long,
-        c_uint,
         c_void,
     },
-    sys_types::{
-        c_size_t,
-        pid_t,
-    },
+    sys_types::c_size_t,
 };
 
 /// Thread-local errno storage (single-threaded: a plain static suffices).
@@ -392,130 +388,6 @@ unsafe impl Sync for SyncPtr {}
 /// C++ ABI: DSO handle symbol required by __cxa_atexit.
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub static __dso_handle: SyncPtr = SyncPtr(core::ptr::null_mut());
-
-//==================================================================================================
-// Terminal interface stubs (no interactive terminal in standalone mode)
-//==================================================================================================
-//
-// `tcgetattr`/`tcsetattr` are provided by the `libc_termios` crate; the
-// remaining terminal helpers below are not, so they live here.
-
-/// Stub `tcsendbreak` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn tcsendbreak(_fd: c_int, _duration: c_int) -> c_int {
-    0
-}
-
-/// Stub `tcdrain` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn tcdrain(_fd: c_int) -> c_int {
-    0
-}
-
-/// Stub `tcflush` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn tcflush(_fd: c_int, _queue_selector: c_int) -> c_int {
-    0
-}
-
-/// Stub `tcflow` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn tcflow(_fd: c_int, _action: c_int) -> c_int {
-    0
-}
-
-/// Stub `cfgetispeed` — returns the default `B9600` line speed.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn cfgetispeed(_termios_p: *const c_void) -> c_uint {
-    13
-}
-
-/// Stub `cfgetospeed` — returns the default `B9600` line speed.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn cfgetospeed(_termios_p: *const c_void) -> c_uint {
-    13
-}
-
-/// Stub `cfsetispeed` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn cfsetispeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
-    0
-}
-
-/// Stub `cfsetospeed` — no terminal hardware, so this is a no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn cfsetospeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
-    0
-}
-
-/// Stub `cfsetspeed` — sets both input and output line speed. No terminal hardware, so this is a
-/// no-op success.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn cfsetspeed(_termios_p: *mut c_void, _speed: c_uint) -> c_int {
-    0
-}
-
-/// `cfmakeraw` — places the terminal attributes pointed to by `termios_p` in "raw" mode.
-///
-/// Unlike line-speed configuration, this is a pure in-memory transformation of the caller's
-/// `struct termios` and requires no terminal hardware. It clears canonical input (`ICANON`), echo
-/// (`ECHO`), signal generation (`ISIG`), extended input processing (`IEXTEN`), CR-to-NL mapping
-/// (`ICRNL`), start/stop output control (`IXON`), and output post-processing (`OPOST`), then sets a
-/// one-byte, no-timeout non-canonical read (`VMIN = 1`, `VTIME = 0`) — the flags honored by the
-/// vfsd console line discipline. A null pointer is ignored.
-///
-/// # Safety
-///
-/// `termios_p` must be null or point to a valid, writable `struct termios`; a non-null pointer is
-/// dereferenced and overwritten.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn cfmakeraw(termios_p: *mut c_void) {
-    use ::sysapi::termios::{
-        Termios,
-        ECHO,
-        ICANON,
-        ICRNL,
-        IEXTEN,
-        ISIG,
-        IXON,
-        OPOST,
-        VMIN,
-        VTIME,
-    };
-
-    if termios_p.is_null() {
-        return;
-    }
-
-    // SAFETY: the caller guarantees `termios_p` points to a valid, writable `struct termios`.
-    let termios: &mut Termios = unsafe { &mut *(termios_p as *mut Termios) };
-    termios.c_iflag &= !(ICRNL | IXON);
-    termios.c_oflag &= !OPOST;
-    termios.c_lflag &= !(ICANON | ECHO | ISIG | IEXTEN);
-    termios.c_cc[VMIN] = 1;
-    termios.c_cc[VTIME] = 0;
-}
-
-/// `tcgetsid` — returns the session ID of the terminal referred to by `fd`.
-///
-/// Nanvix has no sessions or process groups, so a process is treated as its own session leader:
-/// when `fd` refers to a terminal, the returned session ID is the caller's process ID. If `fd` does
-/// not refer to a terminal, returns `-1` with `errno` set, as reported by `isatty`.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub extern "C" fn tcgetsid(fd: c_int) -> pid_t {
-    extern "C" {
-        fn isatty(fd: c_int) -> c_int;
-        fn getpid() -> pid_t;
-    }
-
-    // SAFETY: FFI to the runtime `isatty`, which validates `fd` and sets `errno` on error.
-    if unsafe { isatty(fd) } == 0 {
-        return -1 as pid_t;
-    }
-
-    // SAFETY: FFI to the runtime `getpid`, which has no preconditions.
-    unsafe { getpid() }
-}
 
 //==================================================================================================
 // Time zone globals (fixed UTC; Nanvix has no time-zone database)

--- a/src/libs/sysapi/src/termios.rs
+++ b/src/libs/sysapi/src/termios.rs
@@ -115,8 +115,16 @@ pub const VEOL2: usize = 16;
 // Baud rates
 //==================================================================================================
 
-/// 38400 baud (the default console line speed).
+/// Hang up (zero baud); lowest baud in the contiguous low range.
+pub const B0: speed_t = 0x0000;
+/// 38400 baud (the default console line speed); highest baud in the contiguous low range.
 pub const B38400: speed_t = 0x000f;
+/// Extended baud-rate flag, set by every speed above `B38400`; not itself a valid baud rate.
+pub const CBAUDEX: speed_t = 0x1000;
+/// 57600 baud; lowest baud in the extended range.
+pub const B57600: speed_t = 0x1001;
+/// 4000000 baud; highest baud in the extended range.
+pub const B4000000: speed_t = 0x100f;
 
 //==================================================================================================
 // Optional actions for tcsetattr()
@@ -128,6 +136,30 @@ pub const TCSANOW: i32 = 0;
 pub const TCSADRAIN: i32 = 1;
 /// Apply the change after queued output is transmitted and pending input is discarded.
 pub const TCSAFLUSH: i32 = 2;
+
+//==================================================================================================
+// Queue selectors for tcflush()
+//==================================================================================================
+
+/// Flush pending input.
+pub const TCIFLUSH: i32 = 0;
+/// Flush untransmitted output.
+pub const TCOFLUSH: i32 = 1;
+/// Flush both pending input and untransmitted output.
+pub const TCIOFLUSH: i32 = 2;
+
+//==================================================================================================
+// Actions for tcflow()
+//==================================================================================================
+
+/// Suspend output.
+pub const TCOOFF: i32 = 0;
+/// Resume suspended output.
+pub const TCOON: i32 = 1;
+/// Transmit a STOP character to suspend input.
+pub const TCIOFF: i32 = 2;
+/// Transmit a START character to resume input.
+pub const TCION: i32 = 3;
 
 //==================================================================================================
 // Structures

--- a/src/tests/integration/test-c-termios/main.c
+++ b/src/tests/integration/test-c-termios/main.c
@@ -179,8 +179,218 @@ static void test_tc_attr_enotty(void)
     fprintf(stderr, "passed\n");
 }
 
+// Tests tcdrain(): succeeds on a terminal (the console has no output queue to drain) and fails with
+// EBADF / ENOTTY on invalid / non-terminal descriptors.
+static void test_tcdrain(void)
+{
+    fprintf(stderr, "testing tcdrain() ... ");
+
+    // A terminal descriptor drains successfully.
+    assert(tcdrain(STDIN_FILENO) == 0);
+
+    // -1 is never a valid descriptor, so it deterministically yields EBADF.
+    errno = 0;
+    assert(tcdrain(-1) == -1);
+    assert(errno == EBADF);
+
+    // A pipe end is a valid descriptor that is not a terminal.
+    int fds[2];
+    assert(pipe(fds) == 0);
+    errno = 0;
+    assert(tcdrain(fds[0]) == -1);
+    assert(errno == ENOTTY);
+    assert(close(fds[0]) == 0);
+    assert(close(fds[1]) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests tcsendbreak(): succeeds on a terminal (the console has no serial line to signal) regardless
+// of the duration argument, and fails with EBADF / ENOTTY on invalid / non-terminal descriptors.
+static void test_tcsendbreak(void)
+{
+    fprintf(stderr, "testing tcsendbreak() ... ");
+
+    // A terminal descriptor accepts a break request; the duration is ignored.
+    assert(tcsendbreak(STDIN_FILENO, 0) == 0);
+    assert(tcsendbreak(STDIN_FILENO, 100) == 0);
+
+    errno = 0;
+    assert(tcsendbreak(-1, 0) == -1);
+    assert(errno == EBADF);
+
+    int fds[2];
+    assert(pipe(fds) == 0);
+    errno = 0;
+    assert(tcsendbreak(fds[0], 0) == -1);
+    assert(errno == ENOTTY);
+    assert(close(fds[0]) == 0);
+    assert(close(fds[1]) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests tcflush(): accepts the three POSIX queue selectors on a terminal, rejects any other
+// selector with EINVAL, and fails with EBADF / ENOTTY on invalid / non-terminal descriptors.
+static void test_tcflush(void)
+{
+    fprintf(stderr, "testing tcflush() ... ");
+
+    // All three POSIX queue selectors are accepted on a terminal descriptor.
+    assert(tcflush(STDIN_FILENO, TCIFLUSH) == 0);
+    assert(tcflush(STDIN_FILENO, TCOFLUSH) == 0);
+    assert(tcflush(STDIN_FILENO, TCIOFLUSH) == 0);
+
+    // An unrecognized selector is rejected with EINVAL, even on a valid terminal.
+    errno = 0;
+    assert(tcflush(STDIN_FILENO, 0x7fff) == -1);
+    assert(errno == EINVAL);
+
+    // A valid selector on an invalid descriptor yields EBADF.
+    errno = 0;
+    assert(tcflush(-1, TCIFLUSH) == -1);
+    assert(errno == EBADF);
+
+    // The descriptor is validated before the selector: an invalid descriptor paired with an
+    // invalid selector still reports EBADF, not EINVAL.
+    errno = 0;
+    assert(tcflush(-1, 0x7fff) == -1);
+    assert(errno == EBADF);
+
+    // A valid selector on a non-terminal descriptor yields ENOTTY.
+    int fds[2];
+    assert(pipe(fds) == 0);
+    errno = 0;
+    assert(tcflush(fds[0], TCIFLUSH) == -1);
+    assert(errno == ENOTTY);
+    assert(close(fds[0]) == 0);
+    assert(close(fds[1]) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests tcflow(): accepts the four POSIX actions on a terminal, rejects any other action with
+// EINVAL, and fails with EBADF / ENOTTY on invalid / non-terminal descriptors.
+static void test_tcflow(void)
+{
+    fprintf(stderr, "testing tcflow() ... ");
+
+    // All four POSIX actions are accepted on a terminal descriptor.
+    assert(tcflow(STDIN_FILENO, TCOOFF) == 0);
+    assert(tcflow(STDIN_FILENO, TCOON) == 0);
+    assert(tcflow(STDIN_FILENO, TCIOFF) == 0);
+    assert(tcflow(STDIN_FILENO, TCION) == 0);
+
+    // An unrecognized action is rejected with EINVAL, even on a valid terminal.
+    errno = 0;
+    assert(tcflow(STDIN_FILENO, 0x7fff) == -1);
+    assert(errno == EINVAL);
+
+    // A valid action on an invalid descriptor yields EBADF.
+    errno = 0;
+    assert(tcflow(-1, TCOON) == -1);
+    assert(errno == EBADF);
+
+    // The descriptor is validated before the action: an invalid descriptor paired with an
+    // invalid action still reports EBADF, not EINVAL.
+    errno = 0;
+    assert(tcflow(-1, 0x7fff) == -1);
+    assert(errno == EBADF);
+
+    // A valid action on a non-terminal descriptor yields ENOTTY.
+    int fds[2];
+    assert(pipe(fds) == 0);
+    errno = 0;
+    assert(tcflow(fds[0], TCOON) == -1);
+    assert(errno == ENOTTY);
+    assert(close(fds[0]) == 0);
+    assert(close(fds[1]) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests the cfgetispeed()/cfgetospeed()/cfsetispeed()/cfsetospeed() line-speed accessors. These
+// operate purely on the caller's struct termios: the getters read the stored fields, the setters
+// store a requested baud independently per direction, and an unsupported baud is rejected with
+// EINVAL without disturbing the struct.
+static void test_cfspeed_getset(void)
+{
+    fprintf(stderr, "testing cfget/cfset i/o speed ... ");
+
+    struct termios tio;
+    memset(&tio, 0, sizeof(tio));
+
+    // The getters return the actual stored fields, not a hardcoded constant. Distinct values for
+    // the two directions catch a getter that reads the wrong field.
+    tio.c_ispeed = B38400;
+    tio.c_ospeed = B19200;
+    assert(cfgetispeed(&tio) == (speed_t)B38400);
+    assert(cfgetospeed(&tio) == (speed_t)B19200);
+
+    // The setters store the requested baud and round-trip through the getters.
+    assert(cfsetispeed(&tio, B9600) == 0);
+    assert(cfsetospeed(&tio, B115200) == 0);
+    assert(cfgetispeed(&tio) == (speed_t)B9600);
+    assert(cfgetospeed(&tio) == (speed_t)B115200);
+
+    // B0 (hang up) is a valid baud rate.
+    assert(cfsetispeed(&tio, B0) == 0);
+    assert(cfgetispeed(&tio) == (speed_t)B0);
+
+    // Setting one direction must not disturb the other.
+    assert(cfsetispeed(&tio, B2400) == 0);
+    assert(cfgetospeed(&tio) == (speed_t)B115200);
+    assert(cfsetospeed(&tio, B4800) == 0);
+    assert(cfgetispeed(&tio) == (speed_t)B2400);
+
+    // An unsupported baud value is rejected with EINVAL and leaves the struct untouched.
+    errno = 0;
+    assert(cfsetispeed(&tio, 0x1234) == -1);
+    assert(errno == EINVAL);
+    assert(cfgetispeed(&tio) == (speed_t)B2400);
+
+    // The bare CBAUDEX bit is not itself a baud rate.
+    errno = 0;
+    assert(cfsetospeed(&tio, CBAUDEX) == -1);
+    assert(errno == EINVAL);
+    assert(cfgetospeed(&tio) == (speed_t)B4800);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests cfsetspeed(): stores the requested baud in both directions at once, rejects a non-baud
+// value with EINVAL, and leaves the struct untouched on rejection.
+static void test_cfsetspeed(void)
+{
+    fprintf(stderr, "testing cfsetspeed() ... ");
+
+    struct termios tio;
+    memset(&tio, 0, sizeof(tio));
+
+    // A valid baud is written to both the input and output directions in a single call.
+    assert(cfsetspeed(&tio, B9600) == 0);
+    assert(cfgetispeed(&tio) == (speed_t)B9600);
+    assert(cfgetospeed(&tio) == (speed_t)B9600);
+
+    // A later call overwrites both directions, including B0 (hang up).
+    assert(cfsetspeed(&tio, B0) == 0);
+    assert(cfgetispeed(&tio) == (speed_t)B0);
+    assert(cfgetospeed(&tio) == (speed_t)B0);
+
+    // A non-baud value is rejected with EINVAL and leaves both directions untouched.
+    assert(cfsetspeed(&tio, B38400) == 0);
+    errno = 0;
+    assert(cfsetspeed(&tio, 0x1234) == -1);
+    assert(errno == EINVAL);
+    assert(cfgetispeed(&tio) == (speed_t)B38400);
+    assert(cfgetospeed(&tio) == (speed_t)B38400);
+
+    fprintf(stderr, "passed\n");
+}
+
 /**
- * @brief Tests the terminal-attribute interfaces tcgetattr() and tcsetattr().
+ * @brief Tests the terminal-control interfaces: tcgetattr()/tcsetattr(), the line-control calls
+ * tcdrain()/tcsendbreak()/tcflush()/tcflow(), and the cfget/cfset line-speed accessors.
  *
  * @param argc Number of command-line arguments (unused).
  * @param argv List of command-line arguments (unused).
@@ -198,6 +408,12 @@ int main(int argc, const char *argv[])
     test_tcsetattr_optional_actions();
     test_tc_attr_ebadf();
     test_tc_attr_enotty();
+    test_tcdrain();
+    test_tcsendbreak();
+    test_tcflush();
+    test_tcflow();
+    test_cfspeed_getset();
+    test_cfsetspeed();
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Implements the previously missing POSIX terminal line-control calls and
line-speed accessors so they are exported from `libc.a` with correct return
and `errno` semantics, and moves the terminal helper surface into the
`libc_termios` crate. These functions were only stubs (no-ops or a constant
`B9600` / dropped speed), which surfaced as link failures when enabling the
CPython `termios` stdlib module.

Closes #2220, closes #2221, closes #2222, closes #2223, closes #2224,
closes #2225, closes #2226, closes #2227.

## What changed

**Libraries**
- `libc_termios`: implement `tcdrain` / `tcflush` / `tcflow` / `tcsendbreak`,
  which validate the descriptor via `isatty` (propagating `EBADF` / `ENOTTY`)
  and reject invalid `tcflush` queue selectors and `tcflow` actions with
  `EINVAL`, completing as no-ops on the queueless vfsd console.
- `libc_termios`: implement `cfgetispeed` / `cfgetospeed` / `cfsetispeed` /
  `cfsetospeed` against the caller's `struct termios`, reading/writing
  `c_ispeed` / `c_ospeed` per direction and rejecting non-baud speeds with
  `EINVAL`. Relocate `cfsetspeed` / `cfmakeraw` / `tcgetsid` and the private
  `fd_is_terminal` / `is_baud_rate` helpers here as well.
- `nanvix_libc`: drop the relocated terminal stubs; the surface now flows in
  via the existing `extern crate libc_termios`.
- `sysapi::termios`: add the `TCIFLUSH` / `TCOFLUSH` / `TCIOFLUSH` queue
  selectors and the `TCOOFF` / `TCOON` / `TCIOFF` / `TCION` flow-action
  constants.

**Tests**
- Extend `test-c-termios` to cover success, `EBADF`, `ENOTTY`, and `EINVAL`
  contracts for the line-control calls, plus per-direction round-trips,
  `B0`, direction independence, and non-baud rejection (including bare
  `CBAUDEX`) for the speed accessors.

## Validation

- `./z build -- rust-lint-check-guest-rlib-libc_termios rust-lint-check-guest-staticlib-nanvix_libc`
- `nm -g --defined-only lib/libc.a` confirms all eight symbols are exported.
- `./z build -- run-unit-tests`, `run-kernel-tests`, `run-smoke-test`,
  `run-nanvix-tests`, and `run-posix-tests DEPLOYMENT_MODE=standalone` all
  pass (including `posix/test-c-termios`).