### PR TITLE
[libc_wchar] Add Wide Character Stream I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
 name = "libc_wchar"
 version = "0.18.36"
 dependencies = [
+ "libc_stdio",
  "sysapi",
 ]
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -77,10 +77,11 @@ extern "C" {
  * Fields should not be accessed directly; use the accessor functions below.
  */
 typedef struct {
-    int fd;         /**< Underlying file descriptor. */
-    int eof;        /**< End-of-file indicator.      */
-    int error;      /**< Error indicator.             */
-    int ungetc_buf; /**< Push-back character buffer.  */
+    int fd;          /**< Underlying file descriptor.       */
+    int eof;         /**< End-of-file indicator.            */
+    int error;       /**< Error indicator.                  */
+    int ungetc_buf;  /**< Push-back character buffer.       */
+    int orientation; /**< 0 unoriented, >0 wide, <0 byte.   */
 } FILE;
 
 /*==================================================================================================

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -134,6 +134,30 @@ extern int wctob(wint_t c);
 
 extern int swprintf(wchar_t *ws, size_t n, const wchar_t *format, ...);
 extern int vswprintf(wchar_t *ws, size_t n, const wchar_t *format, va_list ap);
+extern int fwprintf(FILE *stream, const wchar_t *format, ...);
+extern int wprintf(const wchar_t *format, ...);
+extern int vfwprintf(FILE *stream, const wchar_t *format, va_list ap);
+extern int vwprintf(const wchar_t *format, va_list ap);
+
+/*==================================================================================================
+ * Wide Character Stream I/O
+ *==================================================================================================*/
+
+extern wint_t fgetwc(FILE *stream);
+extern wint_t getwc(FILE *stream);
+extern wint_t getwchar(void);
+extern wint_t fputwc(wchar_t wc, FILE *stream);
+extern wint_t putwc(wchar_t wc, FILE *stream);
+extern wint_t putwchar(wchar_t wc);
+extern wchar_t *fgetws(wchar_t *ws, int n, FILE *stream);
+extern int fputws(const wchar_t *ws, FILE *stream);
+extern wint_t ungetwc(wint_t wc, FILE *stream);
+
+/*==================================================================================================
+ * Stream Orientation
+ *==================================================================================================*/
+
+extern int fwide(FILE *stream, int mode);
 
 /*==================================================================================================
  * Restartable Multibyte / Wide Conversion

--- a/src/libs/libc_stdio/header.toml
+++ b/src/libs/libc_stdio/header.toml
@@ -36,10 +36,11 @@ text = '''
  * Fields should not be accessed directly; use the accessor functions below.
  */
 typedef struct {
-    int fd;         /**< Underlying file descriptor. */
-    int eof;        /**< End-of-file indicator.      */
-    int error;      /**< Error indicator.             */
-    int ungetc_buf; /**< Push-back character buffer.  */
+    int fd;          /**< Underlying file descriptor.       */
+    int eof;         /**< End-of-file indicator.            */
+    int error;       /**< Error indicator.                  */
+    int ungetc_buf;  /**< Push-back character buffer.       */
+    int orientation; /**< 0 unoriented, >0 wide, <0 byte.   */
 } FILE;'''
 
 [[raw_sections]]

--- a/src/libs/libc_stdio/src/fdopen.rs
+++ b/src/libs/libc_stdio/src/fdopen.rs
@@ -74,6 +74,7 @@ pub unsafe extern "C" fn fdopen(fd: c_int, mode: *const c_char) -> *mut FILE {
     (*file).eof = 0;
     (*file).error = 0;
     (*file).ungetc_buf = -1;
+    (*file).orientation = 0;
 
     file
 }

--- a/src/libs/libc_stdio/src/fopen.rs
+++ b/src/libs/libc_stdio/src/fopen.rs
@@ -108,6 +108,7 @@ pub unsafe extern "C" fn fopen(pathname: *const c_char, mode: *const c_char) -> 
     (*file).eof = 0;
     (*file).error = 0;
     (*file).ungetc_buf = -1;
+    (*file).orientation = 0;
 
     file
 }

--- a/src/libs/libc_stdio/src/format_engine.rs
+++ b/src/libs/libc_stdio/src/format_engine.rs
@@ -671,6 +671,55 @@ fn format_string<W: WriteTarget>(
     Ok(())
 }
 
+/// Formats a wide-string specifier (`%ls`) and writes to the target.
+///
+/// The argument is a pointer to an array of wide characters (`wchar_t`, i.e. `i32`). In the
+/// single-byte C/POSIX locale each wide character maps to one output byte, so a wide character
+/// outside `0..=0xff` is not representable and terminates the conversion.
+fn format_wide_string<W: WriteTarget>(
+    writer: &mut W,
+    ws: *const i32,
+    flags: &FormatFlags,
+    width: usize,
+    has_precision: bool,
+    precision: usize,
+) -> Result<(), ()> {
+    // A null pointer is rendered exactly like the narrow `%s` conversion.
+    if ws.is_null() {
+        return format_string(writer, core::ptr::null(), flags, width, has_precision, precision);
+    }
+
+    // Count the leading representable wide characters, honoring any precision cap.
+    let mut slen: usize = 0;
+    loop {
+        if has_precision && slen >= precision {
+            break;
+        }
+        // SAFETY: ws is non-null and NUL-terminated, so `slen` stays within the string.
+        let wc: i32 = unsafe { *ws.add(slen) };
+        if wc == 0 || (wc as u32) > 0xff {
+            break;
+        }
+        slen += 1;
+    }
+
+    let pad_len: usize = width.saturating_sub(slen);
+
+    if !flags.left_align {
+        write_padding(writer, b' ', pad_len)?;
+    }
+    for i in 0..slen {
+        // SAFETY: `i < slen`, so the wide character is within the string and representable.
+        let wc: i32 = unsafe { *ws.add(i) };
+        writer.write_byte((wc as u32 & 0xff) as u8)?;
+    }
+    if flags.left_align {
+        write_padding(writer, b' ', pad_len)?;
+    }
+
+    Ok(())
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -815,17 +864,35 @@ pub(crate) fn format_core<W: WriteTarget, A: ArgSource>(
                 let _ = format_unsigned_spec(writer, val, &params);
             },
             b's' => {
-                let s: *const c_char = args.next_str();
-                let _ = format_string(writer, s, &flags, width, has_precision, precision);
+                if matches!(length, LengthMod::Long) {
+                    // `%ls` consumes a `wchar_t *`; render it as bytes for the C/POSIX locale.
+                    let ws: *const i32 = args.next_str().cast::<i32>();
+                    let _ = format_wide_string(writer, ws, &flags, width, has_precision, precision);
+                } else {
+                    let s: *const c_char = args.next_str();
+                    let _ = format_string(writer, s, &flags, width, has_precision, precision);
+                }
             },
             b'c' => {
-                let c: u8 = args.next_int() as u8;
-                if width > 1 && !flags.left_align {
-                    let _ = write_padding(writer, b' ', width - 1);
+                // `%lc` consumes a `wint_t`; a wide character outside `0..=0xff` is not
+                // representable in the single-byte C/POSIX locale and yields no output byte.
+                // Plain `%c` truncates its `int` argument to a byte as usual.
+                let raw: c_int = args.next_int();
+                let byte: Option<u8> = if matches!(length, LengthMod::Long) && (raw as u32) > 0xff {
+                    Option::None
+                } else {
+                    Some(raw as u8)
+                };
+                let out_len: usize = if byte.is_some() { 1 } else { 0 };
+                let pad_len: usize = width.saturating_sub(out_len);
+                if !flags.left_align {
+                    let _ = write_padding(writer, b' ', pad_len);
                 }
-                let _ = writer.write_byte(c);
-                if width > 1 && flags.left_align {
-                    let _ = write_padding(writer, b' ', width - 1);
+                if let Some(b) = byte {
+                    let _ = writer.write_byte(b);
+                }
+                if flags.left_align {
+                    let _ = write_padding(writer, b' ', pad_len);
                 }
             },
             b'p' => {
@@ -1079,6 +1146,51 @@ mod test {
         let mut args: TestArgs = TestArgs::new();
         args.ints.push(b'A' as c_int);
         assert_eq!(fmt(b"%c\0", &mut args), "A");
+    }
+
+    #[test]
+    fn test_percent_ls() {
+        let mut args: TestArgs = TestArgs::new();
+        // A wide string is an array of wchar_t (i32); %ls renders it as bytes in the C locale.
+        let ws: [i32; 6] = [
+            b'w' as i32,
+            b'o' as i32,
+            b'r' as i32,
+            b'l' as i32,
+            b'd' as i32,
+            0,
+        ];
+        args.strs.push(ws.as_ptr().cast::<c_char>());
+        assert_eq!(fmt(b"hi %ls\0", &mut args), "hi world");
+    }
+
+    #[test]
+    fn test_percent_ls_null() {
+        let mut args: TestArgs = TestArgs::new();
+        args.strs.push(core::ptr::null());
+        assert_eq!(fmt(b"%ls\0", &mut args), "(null)");
+    }
+
+    #[test]
+    fn test_percent_ls_precision() {
+        let mut args: TestArgs = TestArgs::new();
+        let ws: [i32; 6] = [
+            b'w' as i32,
+            b'o' as i32,
+            b'r' as i32,
+            b'l' as i32,
+            b'd' as i32,
+            0,
+        ];
+        args.strs.push(ws.as_ptr().cast::<c_char>());
+        assert_eq!(fmt(b"%.3ls\0", &mut args), "wor");
+    }
+
+    #[test]
+    fn test_percent_lc() {
+        let mut args: TestArgs = TestArgs::new();
+        args.ints.push(b'A' as c_int);
+        assert_eq!(fmt(b"%lc\0", &mut args), "A");
     }
 
     #[test]

--- a/src/libs/libc_stdio/src/freopen.rs
+++ b/src/libs/libc_stdio/src/freopen.rs
@@ -136,6 +136,7 @@ pub unsafe extern "C" fn freopen(
     (*stream).eof = 0;
     (*stream).error = 0;
     (*stream).ungetc_buf = -1;
+    (*stream).orientation = 0;
 
     stream
 }

--- a/src/libs/libc_stdio/src/streams.rs
+++ b/src/libs/libc_stdio/src/streams.rs
@@ -22,6 +22,8 @@ pub struct FILE {
     pub error: c_int,
     /// One-character push-back buffer for [`ungetc`](`crate::ungetc::ungetc`) (-1 = empty).
     pub ungetc_buf: c_int,
+    /// Stream orientation (0 = unoriented, >0 = wide, <0 = byte).
+    pub orientation: c_int,
 }
 
 //==================================================================================================
@@ -34,6 +36,7 @@ static mut STDIN_FILE: FILE = FILE {
     eof: 0,
     error: 0,
     ungetc_buf: -1,
+    orientation: 0,
 };
 /// Standard output stream.
 static mut STDOUT_FILE: FILE = FILE {
@@ -41,6 +44,7 @@ static mut STDOUT_FILE: FILE = FILE {
     eof: 0,
     error: 0,
     ungetc_buf: -1,
+    orientation: 0,
 };
 /// Standard error stream.
 static mut STDERR_FILE: FILE = FILE {
@@ -48,6 +52,7 @@ static mut STDERR_FILE: FILE = FILE {
     eof: 0,
     error: 0,
     ungetc_buf: -1,
+    orientation: 0,
 };
 
 //==================================================================================================
@@ -131,13 +136,14 @@ mod test {
     }
 
     #[test]
-    fn standard_streams_start_without_errors_or_pushback() {
+    fn standard_streams_start_without_errors_pushback_or_orientation() {
         // SAFETY: the accessors return valid pointers to the static standard streams.
         unsafe {
             let s: *mut super::FILE = stdin();
             assert_eq!((*s).eof, 0);
             assert_eq!((*s).error, 0);
             assert_eq!((*s).ungetc_buf, -1);
+            assert_eq!((*s).orientation, 0);
         }
     }
 

--- a/src/libs/libc_stdio/src/ungetc.rs
+++ b/src/libs/libc_stdio/src/ungetc.rs
@@ -80,6 +80,7 @@ mod test {
             eof: 1,
             error: 0,
             ungetc_buf: -1,
+            orientation: 0,
         }
     }
 

--- a/src/libs/libc_wchar/Cargo.toml
+++ b/src/libs/libc_wchar/Cargo.toml
@@ -13,12 +13,13 @@ homepage.workspace = true
 crate-type = ["lib"]
 
 [dependencies]
+libc_stdio = { workspace = true }
 sysapi = { workspace = true }
 
 [features]
 default = []
 # Enables the use of the Rust Standard Library.
-std = []
+std = ["libc_stdio/std"]
 
 [lints]
 workspace = true

--- a/src/libs/libc_wchar/header.toml
+++ b/src/libs/libc_wchar/header.toml
@@ -21,6 +21,8 @@ content_order = [
     "section:4",
     "section:5",
     "section:6",
+    "section:9",
+    "section:10",
     "section:7",
     "section:8",
 ]
@@ -108,7 +110,14 @@ functions = ["btowc", "wctob"]
 
 [[sections]]
 title = "Wide Character Formatted Output"
-functions = ["swprintf", "vswprintf"]
+functions = [
+    "swprintf",
+    "vswprintf",
+    "fwprintf",
+    "wprintf",
+    "vfwprintf",
+    "vwprintf",
+]
 
 [[sections]]
 title = "Restartable Multibyte / Wide Conversion"
@@ -126,6 +135,24 @@ functions = [
 [[sections]]
 title = "Wide Character Time"
 functions = ["wcsftime"]
+
+[[sections]]
+title = "Wide Character Stream I/O"
+functions = [
+    "fgetwc",
+    "getwc",
+    "getwchar",
+    "fputwc",
+    "putwc",
+    "putwchar",
+    "fgetws",
+    "fputws",
+    "ungetwc",
+]
+
+[[sections]]
+title = "Stream Orientation"
+functions = ["fwide"]
 
 [overrides]
 wcscoll = '''

--- a/src/libs/libc_wchar/src/fgetwc.rs
+++ b/src/libs/libc_wchar/src/fgetwc.rs
@@ -1,0 +1,120 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::{
+    wint_t,
+    WEOF,
+};
+use ::libc_stdio::{
+    fgetc::fgetc,
+    stdin,
+    FILE,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// End-of-file value returned by the byte-oriented stream functions.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads the next wide character from the given file stream. In the C/POSIX locale a wide character
+/// is encoded as a single byte, so one byte is read and returned as a wide character.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Return Value
+///
+/// The next wide character as a [`wint_t`], or `WEOF` on end-of-file or a read error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fgetwc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fgetwc(stream: *mut FILE) -> wint_t {
+    if stream.is_null() {
+        return WEOF;
+    }
+
+    if (*stream).orientation == 0 {
+        (*stream).orientation = 1;
+    }
+
+    // The C/POSIX locale is single-byte, so one byte read yields exactly one wide character.
+    let c: c_int = unsafe { fgetc(stream) };
+    if c == EOF {
+        return WEOF;
+    }
+
+    // `fgetc` returns the byte as an `unsigned char` in 0..=255; that value is the wide character.
+    c
+}
+
+///
+/// # Description
+///
+/// Reads the next wide character from the given file stream. Equivalent to [`fgetwc`].
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Return Value
+///
+/// The next wide character as a [`wint_t`], or `WEOF` on end-of-file or a read error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getwc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getwc(stream: *mut FILE) -> wint_t {
+    unsafe { fgetwc(stream) }
+}
+
+///
+/// # Description
+///
+/// Reads the next wide character from the standard input stream. Equivalent to `fgetwc(stdin)`.
+///
+/// # Return Value
+///
+/// The next wide character as a [`wint_t`], or `WEOF` on end-of-file or a read error.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses the standard input stream through a raw pointer.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getwchar.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn getwchar() -> wint_t {
+    unsafe { fgetwc(stdin()) }
+}

--- a/src/libs/libc_wchar/src/fgetws.rs
+++ b/src/libs/libc_wchar/src/fgetws.rs
@@ -1,0 +1,92 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    fgetwc::fgetwc,
+    wchar_t::{
+        wchar_t,
+        wint_t,
+        WEOF,
+    },
+};
+use ::libc_stdio::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Wide newline character (`L'\n'`), which terminates a line read.
+const NEWLINE: wint_t = 0x0A;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads wide characters from `stream` into the array `ws` until `n - 1` wide characters have been
+/// read, a newline is read (which is retained), or end-of-file is reached. A null wide character is
+/// written after the last wide character stored.
+///
+/// # Parameters
+///
+/// - `ws`: Destination buffer for at least `n` wide characters.
+/// - `n`: Maximum number of wide characters to store, including the terminating null.
+/// - `stream`: Pointer to the source [`FILE`] stream.
+///
+/// # Return Value
+///
+/// Returns `ws` on success. Returns a null pointer if end-of-file is reached before any wide
+/// character is read, or if a read error occurs.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that `ws`
+/// points to storage for at least `n` wide characters and that `stream` points to a valid, open
+/// [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fgetws.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fgetws(ws: *mut wchar_t, n: c_int, stream: *mut FILE) -> *mut wchar_t {
+    if ws.is_null() || stream.is_null() || n <= 0 {
+        return ::core::ptr::null_mut();
+    }
+
+    // Room for at most `n - 1` wide characters plus the terminating null.
+    let limit: usize = usize::try_from(n - 1).unwrap_or(0);
+    if limit == 0 {
+        // The buffer only has room for the terminator.
+        unsafe { *ws = 0 };
+        return ws;
+    }
+
+    let mut i: usize = 0;
+    while i < limit {
+        let wc: wint_t = unsafe { fgetwc(stream) };
+        if wc == WEOF {
+            break;
+        }
+        unsafe { *ws.add(i) = wc };
+        i += 1;
+        if wc == NEWLINE {
+            break;
+        }
+    }
+
+    // End-of-file or a read error before any wide character was read.
+    if i == 0 {
+        return ::core::ptr::null_mut();
+    }
+
+    unsafe { *ws.add(i) = 0 };
+    ws
+}

--- a/src/libs/libc_wchar/src/fputwc.rs
+++ b/src/libs/libc_wchar/src/fputwc.rs
@@ -1,0 +1,151 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::{
+    wchar_t,
+    wint_t,
+    WEOF,
+};
+use ::libc_stdio::{
+    fputc::fputc,
+    stdout,
+    FILE,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EILSEQ,
+    },
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// End-of-file value returned by the byte-oriented stream functions.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Sets `errno` to `code`.
+fn set_errno(code: c_int) {
+    // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
+    unsafe {
+        *__errno_location() = code;
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the wide character `wc` to the given file stream. In the C/POSIX locale a wide character
+/// is encoded as a single byte, so only wide characters in the range `0..=255` are representable.
+///
+/// # Parameters
+///
+/// - `wc`: The wide character to write.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Return Value
+///
+/// The wide character written as a [`wint_t`], or `WEOF` on error. On an encoding error `errno` is
+/// set to `EILSEQ`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fputwc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fputwc(wc: wchar_t, stream: *mut FILE) -> wint_t {
+    if stream.is_null() {
+        return WEOF;
+    }
+
+    if (*stream).orientation == 0 {
+        (*stream).orientation = 1;
+    }
+
+    // The C/POSIX locale is single-byte: only wide characters in 0..=255 have a representation.
+    let cp: u32 = u32::from_ne_bytes(wc.to_ne_bytes());
+    if cp > 0xff {
+        set_errno(EILSEQ);
+        return WEOF;
+    }
+
+    let byte: c_int = c_int::from(u8::try_from(cp).unwrap_or(0));
+    if unsafe { fputc(byte, stream) } == EOF {
+        return WEOF;
+    }
+
+    wc
+}
+
+///
+/// # Description
+///
+/// Writes the wide character `wc` to the given file stream. Equivalent to [`fputwc`].
+///
+/// # Parameters
+///
+/// - `wc`: The wide character to write.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Return Value
+///
+/// The wide character written as a [`wint_t`], or `WEOF` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/putwc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn putwc(wc: wchar_t, stream: *mut FILE) -> wint_t {
+    unsafe { fputwc(wc, stream) }
+}
+
+///
+/// # Description
+///
+/// Writes the wide character `wc` to the standard output stream. Equivalent to `fputwc(wc, stdout)`.
+///
+/// # Parameters
+///
+/// - `wc`: The wide character to write.
+///
+/// # Return Value
+///
+/// The wide character written as a [`wint_t`], or `WEOF` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it accesses the standard output stream through a raw pointer.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/putwchar.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn putwchar(wc: wchar_t) -> wint_t {
+    unsafe { fputwc(wc, stdout()) }
+}

--- a/src/libs/libc_wchar/src/fputws.rs
+++ b/src/libs/libc_wchar/src/fputws.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    fputwc::fputwc,
+    wchar_t::{
+        wchar_t,
+        WEOF,
+    },
+};
+use ::libc_stdio::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes the null-terminated wide string `ws` to the given file stream. The terminating null wide
+/// character is not written.
+///
+/// # Parameters
+///
+/// - `ws`: Pointer to a null-terminated wide string to write.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Return Value
+///
+/// A non-negative value on success, or `-1` on a write error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that `ws`
+/// points to a valid, null-terminated wide string and that `stream` points to a valid, open
+/// [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fputws.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fputws(ws: *const wchar_t, stream: *mut FILE) -> c_int {
+    if ws.is_null() || stream.is_null() {
+        return -1;
+    }
+
+    let mut i: usize = 0;
+    loop {
+        let wc: wchar_t = unsafe { *ws.add(i) };
+        if wc == 0 {
+            break;
+        }
+        if unsafe { fputwc(wc, stream) } == WEOF {
+            return -1;
+        }
+        i += 1;
+    }
+
+    0
+}

--- a/src/libs/libc_wchar/src/fwide.rs
+++ b/src/libs/libc_wchar/src/fwide.rs
@@ -1,0 +1,111 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::libc_stdio::FILE;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reports, and possibly sets, the orientation of the stream `stream`. A positive `mode` attempts
+/// to make an unoriented stream wide-oriented, a negative `mode` attempts to make it byte-oriented,
+/// and a zero `mode` only queries the current orientation. Once a stream is oriented, subsequent
+/// calls do not change its orientation.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the [`FILE`] stream to query.
+/// - `mode`: Requested orientation: `> 0` for wide, `< 0` for byte, `0` to query.
+///
+/// # Return Value
+///
+/// A value greater than zero if the stream is wide-oriented, less than zero if it is byte-oriented,
+/// and zero if it has no orientation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` is either null or points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fwide.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fwide(stream: *mut FILE, mode: c_int) -> c_int {
+    if stream.is_null() {
+        return 0;
+    }
+
+    if (*stream).orientation == 0 {
+        if mode > 0 {
+            (*stream).orientation = 1;
+        } else if mode < 0 {
+            (*stream).orientation = -1;
+        }
+    }
+
+    (*stream).orientation
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::fwide;
+    use ::libc_stdio::FILE;
+
+    fn make_file() -> FILE {
+        FILE {
+            fd: 0,
+            eof: 0,
+            error: 0,
+            ungetc_buf: -1,
+            orientation: 0,
+        }
+    }
+
+    #[test]
+    fn sets_wide_orientation_for_positive_mode() {
+        let mut stream: FILE = make_file();
+
+        unsafe {
+            assert_eq!(fwide(&raw mut stream, 0), 0);
+            assert!(fwide(&raw mut stream, 1) > 0);
+            assert!(fwide(&raw mut stream, -1) > 0);
+            assert!(fwide(&raw mut stream, 0) > 0);
+        }
+    }
+
+    #[test]
+    fn sets_byte_orientation_for_negative_mode() {
+        let mut stream: FILE = make_file();
+
+        unsafe {
+            assert_eq!(fwide(&raw mut stream, 0), 0);
+            assert!(fwide(&raw mut stream, -1) < 0);
+            assert!(fwide(&raw mut stream, 1) < 0);
+            assert!(fwide(&raw mut stream, 0) < 0);
+        }
+    }
+
+    #[test]
+    fn reports_undetermined_orientation_for_zero_mode() {
+        let mut stream: FILE = make_file();
+
+        unsafe {
+            assert_eq!(fwide(&raw mut stream, 0), 0);
+            assert_eq!(stream.orientation, 0);
+        }
+    }
+}

--- a/src/libs/libc_wchar/src/fwprintf.rs
+++ b/src/libs/libc_wchar/src/fwprintf.rs
@@ -1,0 +1,189 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    multibyte::wcstombs,
+    wchar_t::wchar_t,
+    wcslen::wcslen,
+};
+use ::core::ffi::VaList;
+use ::libc_stdio::{
+    stdout,
+    vfprintf::vfprintf,
+    FILE,
+};
+use ::sysapi::{
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+//==================================================================================================
+// External Symbols
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes formatted wide output to the given file stream, taking the conversion arguments from the
+/// variable-argument list `ap`.
+///
+/// The wide format string is converted to a narrow (multibyte) format string and rendered with the
+/// byte-oriented `vfprintf` engine. For every conversion specifier the wide and narrow `printf`
+/// families consume identical argument types: plain `%s`/`%c` take a `char *`/`int`, while
+/// `%ls`/`%lc` take a `wchar_t *`/`wint_t`. The shared formatting engine performs the wide-to-byte
+/// conversion for the `%ls`/`%lc` cases, and in the single-byte C/POSIX locale one output byte
+/// equals one wide character, so this produces exactly the wide output and character count while
+/// reusing the single, well-tested formatting implementation.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `format`: Null-terminated wide format string.
+/// - `ap`: Variable-argument list supplying the conversion arguments.
+///
+/// # Return Value
+///
+/// The number of wide characters written, or a negative value on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers and consumes a variadic argument
+/// list. The caller must ensure that `stream` is a valid, open [`FILE`], that `format` is a valid
+/// wide format string, and that `ap` matches the conversions in `format`.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vfwprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vfwprintf(
+    stream: *mut FILE,
+    format: *const wchar_t,
+    ap: VaList<'_>,
+) -> c_int {
+    if stream.is_null() || format.is_null() {
+        return -1;
+    }
+
+    if (*stream).orientation == 0 {
+        (*stream).orientation = 1;
+    }
+
+    // Convert the wide format string to a narrow (multibyte) format string.
+    let flen: c_size_t = unsafe { wcslen(format) };
+    let nfmt_size: c_size_t = flen.saturating_add(1);
+    let nfmt: *mut c_char = unsafe { malloc(nfmt_size) }.cast::<c_char>();
+    if nfmt.is_null() {
+        return -1;
+    }
+
+    let nmax: usize = usize::try_from(nfmt_size).unwrap_or(0);
+    // On an encoding error `wcstombs` returns `(size_t)-1`; fail and release the buffer.
+    if unsafe { wcstombs(nfmt, format, nmax) } == usize::MAX {
+        unsafe { free(nfmt.cast::<c_void>()) };
+        return -1;
+    }
+
+    let ret: c_int = unsafe { vfprintf(stream, nfmt, ap) };
+    unsafe { free(nfmt.cast::<c_void>()) };
+    ret
+}
+
+///
+/// # Description
+///
+/// Writes formatted wide output to the given file stream.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer to the target [`FILE`] stream.
+/// - `format`: Null-terminated wide format string.
+///
+/// # Return Value
+///
+/// The number of wide characters written, or a negative value on error.
+///
+/// # Safety
+///
+/// See [`vfwprintf`].
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fwprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn fwprintf(stream: *mut FILE, format: *const wchar_t, args: ...) -> c_int {
+    unsafe { vfwprintf(stream, format, args) }
+}
+
+///
+/// # Description
+///
+/// Writes formatted wide output to the standard output stream, taking the conversion arguments from
+/// the variable-argument list `ap`. Equivalent to `vfwprintf(stdout, format, ap)`.
+///
+/// # Parameters
+///
+/// - `format`: Null-terminated wide format string.
+/// - `ap`: Variable-argument list supplying the conversion arguments.
+///
+/// # Return Value
+///
+/// The number of wide characters written, or a negative value on error.
+///
+/// # Safety
+///
+/// See [`vfwprintf`].
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/vwprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn vwprintf(format: *const wchar_t, ap: VaList<'_>) -> c_int {
+    unsafe { vfwprintf(stdout(), format, ap) }
+}
+
+///
+/// # Description
+///
+/// Writes formatted wide output to the standard output stream. Equivalent to
+/// `fwprintf(stdout, format, ...)`.
+///
+/// # Parameters
+///
+/// - `format`: Null-terminated wide format string.
+///
+/// # Return Value
+///
+/// The number of wide characters written, or a negative value on error.
+///
+/// # Safety
+///
+/// See [`vfwprintf`].
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wprintf.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn wprintf(format: *const wchar_t, args: ...) -> c_int {
+    unsafe { vwprintf(format, args) }
+}

--- a/src/libs/libc_wchar/src/lib.rs
+++ b/src/libs/libc_wchar/src/lib.rs
@@ -7,6 +7,8 @@
 
 // Attributes
 #![cfg_attr(not(feature = "std"), no_std)]
+// Features
+#![feature(c_variadic)]
 // Lints
 #![forbid(clippy::unwrap_used)]
 #![forbid(clippy::cast_possible_truncation)]
@@ -30,9 +32,16 @@
 //==================================================================================================
 
 pub mod btowc;
+pub mod fgetwc;
+pub mod fgetws;
+pub mod fputwc;
+pub mod fputws;
+pub mod fwide;
+pub mod fwprintf;
 pub mod locale;
 pub mod mbstate;
 pub mod multibyte;
+pub mod ungetwc;
 pub mod utf8;
 pub mod wchar_t;
 pub mod wcs_narrow;

--- a/src/libs/libc_wchar/src/ungetwc.rs
+++ b/src/libs/libc_wchar/src/ungetwc.rs
@@ -1,0 +1,98 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::wchar_t::{
+    wint_t,
+    WEOF,
+};
+use ::libc_stdio::{
+    ungetc::ungetc,
+    FILE,
+};
+use ::sysapi::{
+    errno::{
+        __errno_location,
+        EILSEQ,
+    },
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// End-of-file value returned by the byte-oriented stream functions.
+const EOF: c_int = -1;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Sets `errno` to `code`.
+fn set_errno(code: c_int) {
+    // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
+    unsafe {
+        *__errno_location() = code;
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Pushes the wide character `wc` back onto the input stream `stream`, where it will be returned by
+/// the next read. Only one wide character of push-back is guaranteed. In the C/POSIX locale a wide
+/// character is encoded as a single byte, so only wide characters in the range `0..=255` can be
+/// pushed back.
+///
+/// # Parameters
+///
+/// - `wc`: The wide character to push back.
+/// - `stream`: Pointer to the target [`FILE`] stream.
+///
+/// # Return Value
+///
+/// The wide character pushed back as a [`wint_t`], or `WEOF` on error. On an encoding error (a wide
+/// character that is not representable in the single-byte C/POSIX locale) `errno` is set to
+/// `EILSEQ`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller must ensure that
+/// `stream` points to a valid, open [`FILE`] structure.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ungetwc.html>
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn ungetwc(wc: wint_t, stream: *mut FILE) -> wint_t {
+    if stream.is_null() || wc == WEOF {
+        return WEOF;
+    }
+
+    // The C/POSIX locale is single-byte: only wide characters in 0..=255 can be pushed back.
+    let cp: u32 = u32::from_ne_bytes(wc.to_ne_bytes());
+    if cp > 0xff {
+        set_errno(EILSEQ);
+        return WEOF;
+    }
+
+    let byte: c_int = c_int::from(u8::try_from(cp).unwrap_or(0));
+    if unsafe { ungetc(byte, stream) } == EOF {
+        return WEOF;
+    }
+
+    if (*stream).orientation == 0 {
+        (*stream).orientation = 1;
+    }
+
+    wc
+}

--- a/src/tests/integration/test-c-wchar/main.c
+++ b/src/tests/integration/test-c-wchar/main.c
@@ -10,7 +10,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <locale.h>
+#include <stdarg.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
@@ -300,6 +302,108 @@ static void test_wcsnrtombs(void)
     }
 }
 
+// Calls vfwprintf() with a freshly built variable argument list.
+static int call_vfwprintf(FILE *stream, const wchar_t *format, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, format);
+    ret = vfwprintf(stream, format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+// Calls vwprintf() with a freshly built variable argument list.
+static int call_vwprintf(const wchar_t *format, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, format);
+    ret = vwprintf(format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+// Tests the wide-character stream I/O functions by writing to a temporary file with the output
+// helpers and reading the data back with the input helpers. Nanvix uses the single-byte C/POSIX
+// locale, so each wide character round-trips through one byte.
+static void test_wide_stream_io(void)
+{
+    const char *filename = "wchar-stdio-c.tmp";
+    FILE *stream;
+    wchar_t buf[16];
+
+    stream = fopen(filename, "w+");
+    assert(stream != NULL);
+
+    // fwide() sets the stream orientation once and reports the persistent orientation after that.
+    assert(fwide(stream, 0) == 0);
+    assert(fwide(stream, 1) > 0);
+    assert(fwide(stream, -1) > 0);
+    assert(fwide(stream, 0) > 0);
+
+    // Write "abcd7-xyZ[wq]" using each of the wide output functions. Plain %s/%c take narrow
+    // char*/int arguments, while %ls/%lc take wide wchar_t*/wint_t arguments; both paths are
+    // exercised so the wide-argument conversions are validated too.
+    assert(fputwc(L'a', stream) == L'a');
+    assert(putwc(L'b', stream) == L'b');
+    assert(fputws(L"cd", stream) >= 0);
+    assert(fwprintf(stream, L"%d", 7) == 1);
+    assert(call_vfwprintf(stream, L"-%s", "xy") == 3);
+    assert(fwprintf(stream, L"%lc", (wint_t)L'Z') == 1);
+    assert(call_vfwprintf(stream, L"[%ls]", L"wq") == 4);
+
+    // Rewind and read the data back.
+    assert(fseeko(stream, 0, SEEK_SET) == 0);
+
+    assert(fgetwc(stream) == L'a');
+    assert(getwc(stream) == L'b');
+
+    // Push the last wide character back and read it again.
+    assert(ungetwc(L'b', stream) == L'b');
+    assert(fgetwc(stream) == L'b');
+
+    // Read the remaining wide characters as a string. No newline is present, so the read stops at
+    // end-of-file.
+    assert(fgetws(buf, 16, stream) == buf);
+    assert(wcscmp(buf, L"cd7-xyZ[wq]") == 0);
+
+    // A subsequent read reports end-of-file.
+    assert(fgetwc(stream) == WEOF);
+
+    assert(fclose(stream) == 0);
+    assert(remove(filename) == 0);
+
+    // A wide character outside the single-byte range cannot be written or pushed back.
+    {
+        FILE *reject = fopen(filename, "w+");
+        assert(reject != NULL);
+        errno = 0;
+        assert(fputwc((wchar_t)0x100, reject) == WEOF);
+        assert(errno == EILSEQ);
+        assert(ungetwc((wint_t)0x100, reject) == WEOF);
+        assert(fclose(reject) == 0);
+        assert(remove(filename) == 0);
+    }
+}
+
+// Tests the wide output functions that target the standard output stream. Only the return values
+// are asserted; the emitted bytes are harmless because the harness validates the exit code.
+static void test_wide_stdout(void)
+{
+    assert(putwchar(L'[') == L'[');
+    assert(wprintf(L"%d", 42) == 2);
+    assert(call_vwprintf(L":%s", "ok") == 3);
+    assert(wprintf(L"%lc", (wint_t)L'#') == 1);
+    assert(call_vwprintf(L"<%ls>", L"ok") == 4);
+    assert(putwchar(L']') == L']');
+    assert(putwchar(L'\n') == L'\n');
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -330,6 +434,8 @@ int main(int argc, const char *argv[])
     test_wcs_collation_l();
     test_mbsnrtowcs();
     test_wcsnrtombs();
+    test_wide_stream_io();
+    test_wide_stdout();
 
     // Write magic string to signal that the test passed.
     {

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -323,6 +323,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
 expected_exit_code = 0
 
 [[tests]]

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -323,6 +323,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-wchar"
 program = "./bin/test-c-wchar.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
 expected_exit_code = 0
 
 [[tests]]


### PR DESCRIPTION
## Summary

Implements the POSIX wide-character stream I/O and stream-orientation functions in `libc_wchar`, backed by the byte-oriented `libc_stdio` engine in the single-byte C/POSIX locale. This lets wide-oriented C programs read, write, push back, and format wide characters against Nanvix streams.

## What changed

**Libraries (`libc_wchar`):**
- Add `fgetwc`/`getwc`/`getwchar`, `fputwc`/`putwc`/`putwchar`, `fgetws`, `fputws`, and `ungetwc`, mapping each wide character to one byte and reporting `WEOF`/`EILSEQ` on end-of-file and unrepresentable characters.
- Add `fwprintf`/`wprintf`/`vfwprintf`/`vwprintf`, converting the wide format string to multibyte and rendering through `vfprintf`.
- Add `fwide()` with persistent per-stream orientation: an unoriented stream is set once by the first orienting call, and the wide I/O entry points mark a stream wide-oriented on first use.
- Depend on `libc_stdio` (forward its `std` feature) and enable `c_variadic` for the wide `printf` family.

**Libraries (`libc_stdio`):**
- Extend `FILE` with an `orientation` field (`0` unoriented, `>0` wide, `<0` byte) and initialize/reset it in `fopen`, `fdopen`, `freopen`, and the standard streams.

**Headers:**
- Declare the new wide stream I/O and stream-orientation sections and regenerate `stdio.h` and `wchar.h`.

**Tests and harness wiring:**
- Extend `test-c-wchar` with `test_wide_stream_io()` (temp-file round trip of the write/read/push-back/format functions, `fwide()` orientation, `WEOF` at EOF, `EILSEQ` for out-of-range characters) and `test_wide_stdout()`.
- Mount the shared writable RAMFS for `posix/test-c-wchar` in `test-posix.toml` and `test-posix-windows.toml` so `fopen(path, "w+")` succeeds.

## Validation

- Unit tests for `libc_stdio` and `libc_wchar`, generated-header check, in-kernel tests, `run-nanvix-tests`, and `run-posix-tests` all pass on Windows/WHP standalone.

Closes #2827
