### PR TITLE
[sys] E: Add Copy trait bound to Address types

### DIFF
--- a/src/kernel/src/hal/mem/types/region.rs
+++ b/src/kernel/src/hal/mem/types/region.rs
@@ -164,7 +164,7 @@ impl<T: Address> MemoryRegion<T> {
         }
 
         // Check if memory region is too big.
-        let start_raw_addr: usize = start.clone().into_raw_value();
+        let start_raw_addr: usize = start.into_raw_value();
         let end_raw_addr: usize = match start_raw_addr.checked_add(size - 1) {
             Some(end_raw_addr) => end_raw_addr,
             None => {
@@ -196,7 +196,7 @@ impl<T: Address> MemoryRegion<T> {
 
     /// Returns the first valid address that lies in the target memory region.
     pub fn start(&self) -> T {
-        self.start.clone()
+        self.start
     }
 
     /// Returns the size of the target memory region.

--- a/src/libs/sys/src/sys/mm/address/mod.rs
+++ b/src/libs/sys/src/sys/mm/address/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 
 pub trait Address
 where
-    Self: core::fmt::Debug + Clone + PartialEq + Eq + PartialOrd + Ord,
+    Self: core::fmt::Debug + Clone + Copy + PartialEq + Eq + PartialOrd + Ord,
 {
     ///
     /// # Description


### PR DESCRIPTION
Add `Copy` as a supertrait bound on the `Address` trait and drop the now-redundant `.clone()` calls in `MemoryRegion`.

The motivation is the Verus verification work: reasoning about `.clone()` in proofs would require extra helper functions, and making these types `Copy` avoids that.