### PR TITLE
[kernel] Add watermark accessor function

### DIFF
--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -214,14 +214,16 @@ impl PhysMemoryManager {
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
     fn check_user_watermark(count: usize) -> Result<(), Error> {
-        let watermark_threshold: usize = config::kernel::KERNEL_WATERMARK
-            .checked_add(count)
-            .ok_or_else(|| {
+        // Read the free count before checking the threshold so both success and overflow paths use
+        // the same observed allocator state.
+        let available: usize = frame::free_count();
+        let watermark_threshold: usize =
+            kernel_watermark().checked_add(count).ok_or_else(|| {
                 let reason: &str = "watermark + count overflow";
                 error!("{reason}");
                 Error::new(ErrorCode::InvalidArgument, reason)
             })?;
-        if frame::free_count() < watermark_threshold {
+        if available < watermark_threshold {
             let reason: &str = "would breach kernel watermark";
             error!("{reason}");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
@@ -386,4 +388,14 @@ impl PhysMemoryManager {
         }
         result
     }
+}
+
+//==================================================================================================
+// Build-time constant accessors
+//==================================================================================================
+
+/// Ties the generated runtime constant to its abstract specification.
+#[inline]
+fn kernel_watermark() -> usize {
+    config::kernel::KERNEL_WATERMARK
 }


### PR DESCRIPTION
Add a `kernel_watermark()` helper that returns the `config::kernel::KERNEL_WATERMARK` constant, and use it in the watermark check.

The constant is generated by `build.rs`, which Verus can't reason about directly, so wrapping it in a helper lets us attach an `external_body` spec later to bring it into verification.