### PR TITLE
[libc_locale] Add C99 intl monetary lconv fields

### DIFF
--- a/include/locale.h
+++ b/include/locale.h
@@ -49,6 +49,12 @@ struct lconv {
     char n_sep_by_space;     /**< Space separates symbol and negative.*/
     char p_sign_posn;        /**< Positive sign position.             */
     char n_sign_posn;        /**< Negative sign position.             */
+    char int_p_cs_precedes;  /**< Int. symbol precedes positive.      */
+    char int_p_sep_by_space; /**< Int. space separates positive.      */
+    char int_n_cs_precedes;  /**< Int. symbol precedes negative.      */
+    char int_n_sep_by_space; /**< Int. space separates negative.      */
+    char int_p_sign_posn;    /**< Int. positive sign position.        */
+    char int_n_sign_posn;    /**< Int. negative sign position.        */
 };
 
 /*==================================================================================================

--- a/src/libs/libc_locale/header.toml
+++ b/src/libs/libc_locale/header.toml
@@ -103,6 +103,12 @@ struct lconv {
     char n_sep_by_space;     /**< Space separates symbol and negative.*/
     char p_sign_posn;        /**< Positive sign position.             */
     char n_sign_posn;        /**< Negative sign position.             */
+    char int_p_cs_precedes;  /**< Int. symbol precedes positive.      */
+    char int_p_sep_by_space; /**< Int. space separates positive.      */
+    char int_n_cs_precedes;  /**< Int. symbol precedes negative.      */
+    char int_n_sep_by_space; /**< Int. space separates negative.      */
+    char int_p_sign_posn;    /**< Int. positive sign position.        */
+    char int_n_sign_posn;    /**< Int. negative sign position.        */
 };
 """
 

--- a/src/libs/libc_locale/src/localeconv.rs
+++ b/src/libs/libc_locale/src/localeconv.rs
@@ -56,6 +56,18 @@ pub struct lconv {
     pub p_sign_posn: c_char,
     /// Positioning of negative sign for monetary values.
     pub n_sign_posn: c_char,
+    /// 1 if `int_curr_symbol` precedes a positive international monetary value.
+    pub int_p_cs_precedes: c_char,
+    /// 1 if a space separates `int_curr_symbol` from a positive international monetary value.
+    pub int_p_sep_by_space: c_char,
+    /// 1 if `int_curr_symbol` precedes a negative international monetary value.
+    pub int_n_cs_precedes: c_char,
+    /// 1 if a space separates `int_curr_symbol` from a negative international monetary value.
+    pub int_n_sep_by_space: c_char,
+    /// Positioning of positive sign for international monetary values.
+    pub int_p_sign_posn: c_char,
+    /// Positioning of negative sign for international monetary values.
+    pub int_n_sign_posn: c_char,
 }
 
 //==================================================================================================
@@ -101,6 +113,12 @@ static C_LCONV: SyncLconv = SyncLconv(lconv {
     n_sep_by_space: CHAR_MAX,
     p_sign_posn: CHAR_MAX,
     n_sign_posn: CHAR_MAX,
+    int_p_cs_precedes: CHAR_MAX,
+    int_p_sep_by_space: CHAR_MAX,
+    int_n_cs_precedes: CHAR_MAX,
+    int_n_sep_by_space: CHAR_MAX,
+    int_p_sign_posn: CHAR_MAX,
+    int_n_sign_posn: CHAR_MAX,
 });
 
 //==================================================================================================

--- a/src/tests/integration/test-c-locale/main.c
+++ b/src/tests/integration/test-c-locale/main.c
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <locale.h>
 #include <nl_types.h>
 #include <stddef.h>
@@ -152,6 +153,45 @@ static void test_message_catalog(void)
     assert(catclose(catd) == 0);
 }
 
+// Tests localeconv(): in the C/POSIX locale the decimal point is ".", every other string field is
+// empty, and every numeric field is CHAR_MAX ("not available"). This includes the six C99
+// international monetary members (int_p_cs_precedes and friends).
+static void test_localeconv(void)
+{
+    struct lconv *lc = localeconv();
+    assert(lc != NULL);
+
+    // Only the decimal point is non-empty in the C locale; all other string fields are empty.
+    assert(strcmp(lc->decimal_point, ".") == 0);
+    assert(strcmp(lc->thousands_sep, "") == 0);
+    assert(strcmp(lc->grouping, "") == 0);
+    assert(strcmp(lc->int_curr_symbol, "") == 0);
+    assert(strcmp(lc->currency_symbol, "") == 0);
+    assert(strcmp(lc->mon_decimal_point, "") == 0);
+    assert(strcmp(lc->mon_thousands_sep, "") == 0);
+    assert(strcmp(lc->mon_grouping, "") == 0);
+    assert(strcmp(lc->positive_sign, "") == 0);
+    assert(strcmp(lc->negative_sign, "") == 0);
+
+    // Local numeric and monetary members are all CHAR_MAX in the C locale.
+    assert(lc->int_frac_digits == CHAR_MAX);
+    assert(lc->frac_digits == CHAR_MAX);
+    assert(lc->p_cs_precedes == CHAR_MAX);
+    assert(lc->p_sep_by_space == CHAR_MAX);
+    assert(lc->n_cs_precedes == CHAR_MAX);
+    assert(lc->n_sep_by_space == CHAR_MAX);
+    assert(lc->p_sign_posn == CHAR_MAX);
+    assert(lc->n_sign_posn == CHAR_MAX);
+
+    // C99 international monetary members.
+    assert(lc->int_p_cs_precedes == CHAR_MAX);
+    assert(lc->int_p_sep_by_space == CHAR_MAX);
+    assert(lc->int_n_cs_precedes == CHAR_MAX);
+    assert(lc->int_n_sep_by_space == CHAR_MAX);
+    assert(lc->int_p_sign_posn == CHAR_MAX);
+    assert(lc->int_n_sign_posn == CHAR_MAX);
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -181,6 +221,7 @@ int main(int argc, const char *argv[])
     test_time_l();
     test_stdlib_l();
     test_message_catalog();
+    test_localeconv();
 
     // Write magic string to signal that the test passed.
     {


### PR DESCRIPTION
## Summary

Extends `struct lconv` with the six C99 (§7.11) international monetary
members so that `<locale.h>` matches the standard layout. libc++
localization (`LIBCXX_ENABLE_LOCALIZATION=ON`) fails to compile
`libcxx/src/locale.cpp` for `i686-unknown-nanvix` because these members
are absent; adding them unblocks that build.

## Changes

**Libraries:**
- Add `int_p_cs_precedes`, `int_p_sep_by_space`, `int_n_cs_precedes`,
  `int_n_sep_by_space`, `int_p_sign_posn`, and `int_n_sign_posn` to the
  `lconv` Rust mirror in `libc_locale` and initialize them to `CHAR_MAX`
  ("not available") for the C/POSIX locale.
- Mirror the new members in the `header.toml` spec and regenerate the
  matching `include/locale.h` declarations.

**Tests:**
- Add a `test_localeconv()` case to the `test-c-locale` suite verifying
  the full `lconv` contract in the C locale (decimal point `"."`, empty
  string fields, all numeric fields `CHAR_MAX`), including the six new
  international monetary members.

Closes #2828