### PR TITLE
[libc_langinfo] Add Message-Catalog Functions

### DIFF
--- a/include/nl_types.h
+++ b/include/nl_types.h
@@ -32,6 +32,14 @@ typedef void *nl_catd;
 #define NL_SETD 1
 #define NL_CAT_LOCALE 1
 
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern nl_catd catopen(const char *name, int oflag);
+extern char *catgets(nl_catd catd, int set_id, int msg_id, const char *s);
+extern int catclose(nl_catd catd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libs/libc_langinfo/src/catgets.rs
+++ b/src/libs/libc_langinfo/src/catgets.rs
@@ -1,0 +1,148 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::set_errno;
+use ::sysapi::{
+    errno::ENOENT,
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+};
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+/// Message catalog descriptor returned by [`catopen()`].
+pub type nl_catd = *mut c_void;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Opens the message catalog identified by `name`.
+///
+/// # Parameters
+///
+/// - `name`: Name of the message catalog to open.
+/// - `oflag`: Flag selecting the locale used to interpret the catalog.
+///
+/// # Returns
+///
+/// Nanvix supports only the C/POSIX locale, which defines no message catalogs, so this function
+/// always reports failure by returning `(nl_catd)-1` with `errno` set to `ENOENT`.
+///
+/// # Safety
+///
+/// This function is safe for all input values. The `name` argument is never dereferenced.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn catopen(name: *const c_char, oflag: c_int) -> nl_catd {
+    let _ = (name, oflag);
+    set_errno(ENOENT);
+    -1isize as nl_catd
+}
+
+///
+/// # Description
+///
+/// Reads a message from the message catalog `catd`.
+///
+/// # Parameters
+///
+/// - `catd`: Message catalog descriptor returned by [`catopen()`].
+/// - `set_id`: Identifier of the message set to search.
+/// - `msg_id`: Identifier of the message to read.
+/// - `s`: Fallback string returned when the message cannot be found.
+///
+/// # Returns
+///
+/// Nanvix defines no message catalogs, so no message is ever found and this function returns the
+/// fallback string `s` unchanged.
+///
+/// # Safety
+///
+/// This function is safe for all input values. The `s` argument is returned unchanged and is never
+/// dereferenced.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn catgets(
+    catd: nl_catd,
+    set_id: c_int,
+    msg_id: c_int,
+    s: *const c_char,
+) -> *mut c_char {
+    let _ = (catd, set_id, msg_id);
+    s.cast_mut()
+}
+
+///
+/// # Description
+///
+/// Closes the message catalog `catd`.
+///
+/// # Parameters
+///
+/// - `catd`: Message catalog descriptor returned by [`catopen()`].
+///
+/// # Returns
+///
+/// Always returns zero, as no message catalog resources are ever allocated.
+///
+/// # Safety
+///
+/// This function is safe for all input values. The `catd` argument is never dereferenced.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub extern "C" fn catclose(catd: nl_catd) -> c_int {
+    let _ = catd;
+    0
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::{
+        catclose,
+        catgets,
+        catopen,
+        nl_catd,
+    };
+
+    #[test]
+    fn test_catopen_reports_failure() {
+        let catd: nl_catd = catopen(c"messages".as_ptr(), 0);
+        assert_eq!(catd, -1isize as nl_catd);
+    }
+
+    #[test]
+    fn test_catgets_returns_fallback() {
+        let fallback = c"fallback".as_ptr();
+        let catd: nl_catd = catopen(c"messages".as_ptr(), 0);
+        assert_eq!(catgets(catd, 1, 1, fallback).cast_const(), fallback);
+    }
+
+    #[test]
+    fn test_catclose_succeeds() {
+        let catd: nl_catd = catopen(c"messages".as_ptr(), 0);
+        assert_eq!(catclose(catd), 0);
+    }
+}

--- a/src/libs/libc_langinfo/src/lib.rs
+++ b/src/libs/libc_langinfo/src/lib.rs
@@ -30,4 +30,64 @@
 // Modules
 //==================================================================================================
 
+pub mod catgets;
 pub mod nl_langinfo;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::{
+    errno::__errno_location,
+    ffi::c_int,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Writes `code` to `errno`.
+///
+/// # Parameters
+///
+/// - `code`: Error code to be written to `errno`.
+///
+#[inline(always)]
+fn set_errno(code: c_int) {
+    // SAFETY: `__errno_location()` returns a valid pointer to `errno`.
+    unsafe {
+        *__errno_location() = code;
+    }
+}
+
+//==================================================================================================
+// Test Support
+//==================================================================================================
+
+// The `catopen()` stub references `__errno_location` to report `ENOENT`. That symbol is provided
+// by the C library in the guest build, but the MSVC C runtime used for host `std` unit tests on
+// Windows does not export this glibc/musl symbol, so supply a thread-local definition here to let
+// the errno-setting path link and run. On Linux hosts the system C library already provides the
+// symbol, so the shim is not compiled there.
+#[cfg(all(test, feature = "std", target_os = "windows"))]
+mod windows_errno_shim {
+    use ::core::cell::Cell;
+    use ::sysapi::ffi::c_int;
+
+    std::thread_local! {
+        static ERRNO: Cell<c_int> = const { Cell::new(0) };
+    }
+
+    /// Host-only definition of `__errno_location` for Windows `std` unit tests.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid for the lifetime of the calling thread.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn __errno_location() -> *mut c_int {
+        ERRNO.with(Cell::as_ptr)
+    }
+}

--- a/src/libs/sysapi/headers/nl_types.toml
+++ b/src/libs/sysapi/headers/nl_types.toml
@@ -8,10 +8,7 @@ brief = "Message catalog and language information types."
 description = '''
 '''
 guard = "_NANVIX_NL_TYPES_H"
-content_order = [
-    "types",
-    "raw:0",
-]
+content_order = ["types", "raw:0", "raw:1"]
 
 [[types]]
 text = '''
@@ -26,3 +23,10 @@ title = "Constants"
 text = '''
 #define NL_SETD 1
 #define NL_CAT_LOCALE 1'''
+
+[[raw_sections]]
+title = "Functions"
+text = '''
+extern nl_catd catopen(const char *name, int oflag);
+extern char *catgets(nl_catd catd, int set_id, int msg_id, const char *s);
+extern int catclose(nl_catd catd);'''

--- a/src/tests/integration/test-c-locale/main.c
+++ b/src/tests/integration/test-c-locale/main.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <locale.h>
+#include <nl_types.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -134,6 +135,23 @@ static void test_stdlib_l(void)
     freelocale(loc);
 }
 
+// Tests the XSI message-catalog functions. Nanvix supports only the C/POSIX locale, which
+// defines no message catalogs, so catopen() reports failure, catgets() echoes the fallback
+// string, and catclose() succeeds.
+static void test_message_catalog(void)
+{
+    // catopen() cannot find any catalog and reports failure with the (nl_catd)-1 sentinel.
+    nl_catd catd = catopen("messages", NL_CAT_LOCALE);
+    assert(catd == (nl_catd)-1);
+
+    // catgets() returns the caller-supplied fallback string unchanged (same pointer).
+    const char *fallback = "fallback message";
+    assert((const char *)catgets(catd, NL_SETD, 1, fallback) == fallback);
+
+    // catclose() always succeeds.
+    assert(catclose(catd) == 0);
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -162,6 +180,7 @@ int main(int argc, const char *argv[])
     test_string_l();
     test_time_l();
     test_stdlib_l();
+    test_message_catalog();
 
     // Write magic string to signal that the test passed.
     {


### PR DESCRIPTION
## Summary

Implements the XSI message-catalog functions `catopen()`, `catgets()`, and
`catclose()` so that libc++ localization (the `messages` facet) compiles for
`i686-unknown-nanvix`. Previously `<nl_types.h>` declared only the
`nl_catd`/`nl_item` typedefs, so building libc++ with localization enabled
failed with `use of undeclared identifier 'catopen'` (and likewise for
`catgets`/`catclose`).

Nanvix supports only the C/POSIX locale, which defines no message catalogs, so a
minimal fail-closed implementation is sufficient: `catopen()` reports failure
with `(nl_catd)-1`, `catgets()` returns the caller's fallback string unchanged,
and `catclose()` always succeeds.

## Changes

**Libraries:**
- Add a `catgets` module to `libc_langinfo` implementing `catopen()`,
  `catgets()`, and `catclose()`, and register it in `lib.rs`.
- Add unit tests covering all three functions.

**Build and headers:**
- Add a Functions raw section to `sysapi`'s `nl_types.toml` and extend
  `content_order` so the generated header emits it.
- Declare the three functions in `include/nl_types.h`.

**Tests:**
- Extend the `test-c-locale` integration test with `test_message_catalog()`,
  which exercises the functions in the guest C environment.

## Validation

- `./z build -- run-unit-tests`
- `./z build -- run-kernel-tests MACHINE=microvm TARGET=x86 LOG_LEVEL=trace`
- `./z build -- run-nanvix-tests`
- `./z build -- run-posix-tests DEPLOYMENT_MODE=standalone` (`posix/test-c-locale`
  passes)

Closes #2829