### PR TITLE
[syscall] Serialize dlopen Constructors

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -20,6 +20,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \
 	test-c-dlfcn-hello \
+	test-c-dlfcn-init-concurrent \
 	test-c-dlfcn-init-runpath \
 	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -137,6 +137,11 @@ POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
 # destructor then resolves its `extern void dtor_probe(void)` reference from the
 # loader's global symbol table while it is being torn down.
 POSIX_TEST_PIE_test-c-dlfcn-dtor-reentry := yes
+# dlfcn-init-concurrent-c links PIE + --export-dynamic so the main executable's
+# `ctor_mark_started`/`ctor_racer_arrived`/`ctor_mark_done` helpers land in
+# `.dynsym`; libslowctor.so's constructor then resolves those references from
+# the loader's global symbol table while it runs.
+POSIX_TEST_PIE_test-c-dlfcn-init-concurrent := yes
 # dlfcn-init-runpath-c links PIE with --export-dynamic so the main executable's
 # `g_dtor_ran` global lands in `.dynsym`; the loader's global symbol table then
 # satisfies libctor.so's `extern volatile int g_dtor_ran` reference at load time.
@@ -300,6 +305,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
@@ -312,6 +318,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
@@ -699,10 +706,45 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry): $(POSIX_TEST_DTOR_REENTRY_LIB
 	$(CP_CMD) $(POSIX_TEST_DTOR_REENTRY_LIBDIR)/libreentry.so $(POSIX_TEST_DTOR_REENTRY_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_DTOR_REENTRY_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-init-concurrent-c: constructor-vs-concurrent-dlopen fixture.
+#---------------------------------------------------------------------------------------------------
+#
+# Ships ONE shared library, libslowctor.so, built with the same i686 freestanding
+# toolchain as the fixtures above. It carries a `.init_array` constructor whose
+# run is deliberately slow and observable, and leaves three symbols UNDEFINED --
+# ctor_mark_started / ctor_racer_arrived / ctor_mark_done (functions) -- which the
+# loader resolves from the main executable's exported global scope at load time
+# (the suite ELF is PIE + --export-dynamic, see POSIX_TEST_PIE_* above). An
+# explicit -soname pins the SONAME to the bare name `libslowctor.so`. Staged at
+# lib/libslowctor.so, where main.c dlopen()s it from two threads at once: a
+# correct loader makes the racing dlopen() wait for the constructor, so the
+# racing thread never observes the library before its constructor finished.
+POSIX_TEST_INIT_CONCURRENT_SUITE  := test-c-dlfcn-init-concurrent
+POSIX_TEST_INIT_CONCURRENT_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_INIT_CONCURRENT_SUITE)/libs
+POSIX_TEST_INIT_CONCURRENT_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_INIT_CONCURRENT_SUITE)-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_INIT_CONCURRENT_SUITE).img
+
+# libslowctor.so: slow `.init_array` constructor; SONAME=libslowctor.so.
+$(POSIX_TEST_INIT_CONCURRENT_LIBDIR)/libslowctor.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_INIT_CONCURRENT_SUITE)/libs/slowctor.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_INIT_CONCURRENT_SUITE)/libslowctor.so (.init_array)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libslowctor.so $@.o -o $@
+
+# Per-suite RAMFS image carrying libslowctor.so under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent): $(POSIX_TEST_INIT_CONCURRENT_LIBDIR)/libslowctor.so \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_INIT_CONCURRENT_LIBDIR)/libslowctor.so $(POSIX_TEST_INIT_CONCURRENT_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_INIT_CONCURRENT_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -8,6 +8,7 @@
 use super::dynlib::{
     DlHandle,
     DynamicLibrary,
+    InitState,
 };
 use crate::dlfcn::syscall::DYNAMIC_LIBRARY_REGISTRY;
 use ::alloc::{
@@ -64,15 +65,35 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
         DYNAMIC_LIBRARY_REGISTRY.lock();
 
     // Check if dynamic library is already opened.
+    let mut already_loaded: Option<(DlHandle, Arc<Mutex<DynamicLibrary>>)> = None;
     for (dlhandle, dlfile) in registry.iter() {
         if dlfile.lock().name() == filename {
-            // If the caller requests RTLD_GLOBAL on a library that was
-            // previously loaded without it, promote it to global scope now.
-            if global {
-                super::register_library_in_global_scope(dlfile);
-            }
-            return Ok(*dlhandle);
+            already_loaded = Some((*dlhandle, dlfile.clone()));
+            break;
         }
+    }
+    if let Some((dlhandle, dlfile)) = already_loaded {
+        // If the caller requests RTLD_GLOBAL on a library that was
+        // previously loaded without it, promote it to global scope now.
+        if global {
+            super::register_library_in_global_scope(&dlfile);
+        }
+
+        // A concurrent `dlopen` may have inserted this library and released the
+        // registry lock but not yet finished running its `.init_array`
+        // constructors. Wait for them to complete so this caller never observes
+        // a handle to an uninitialized library.
+        //
+        // The registry lock is dropped BEFORE waiting: the constructing thread
+        // needs it to service the constructor's own `dlsym`/`dlopen` calls, so
+        // holding it here would deadlock them. A re-entrant open from the
+        // constructing thread itself does not wait — see
+        // `InitState::wait_until_constructed`.
+        let tid: i32 = current_tid()?;
+        let init_state: Arc<InitState> = dlfile.lock().init_state();
+        drop(registry);
+        init_state.wait_until_constructed(tid);
+        return Ok(dlhandle);
     }
 
     // Snapshot the registry keys before we start inserting, so we can roll back
@@ -124,6 +145,21 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
             },
         };
 
+    // Record the constructing thread on every newly loaded library BEFORE
+    // releasing the registry lock. A concurrent `dlopen` that observes any of
+    // them on the dedup path above then either waits for their constructors
+    // (a different thread) or skips the wait (this same thread re-entering from
+    // one of the constructors). Publishing the thread id under the registry
+    // lock guarantees no concurrent observer can see the pre-set sentinel as a
+    // constructor owner.
+    let constructor_tid: i32 = current_tid()?;
+    for dlfile in init_order.iter() {
+        dlfile
+            .lock()
+            .init_state()
+            .set_constructor_thread(constructor_tid);
+    }
+
     // Drop the registry lock before invoking `.init_array` constructors so a
     // constructor may legally call `dlsym` (and, in a future relaxation,
     // `dlopen`) without deadlocking on `DYNAMIC_LIBRARY_REGISTRY`.
@@ -139,9 +175,9 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // deadlock any constructor that calls `dlsym(self_handle, ...)`, because
     // `dlsym` re-locks the same library to look up symbols.
     for dlfile in init_order.iter() {
-        let (descriptor, name): (Option<(usize, usize)>, String) = {
+        let (descriptor, name, init_state): (Option<(usize, usize)>, String, Arc<InitState>) = {
             let lib: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
-            (lib.init_array_descriptor(), String::from(lib.name()))
+            (lib.init_array_descriptor(), String::from(lib.name()), lib.init_state())
         };
         // SAFETY: `descriptor` was produced under the per-library lock for
         // a library still held alive by `init_order`'s `Arc`; relocations
@@ -150,9 +186,27 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
         unsafe {
             DynamicLibrary::invoke_init_array(descriptor, &name);
         }
+        // Publish completion (leaves first) so a concurrent `dlopen` blocked in
+        // the dedup path above may now return this library's handle. Marking
+        // per-library — rather than once after the whole batch — lets a waiter
+        // for a dependency proceed as soon as that dependency is constructed,
+        // without waiting for its dependents.
+        init_state.mark_constructed();
     }
 
     Ok(handle)
+}
+
+/// Returns the raw identifier of the calling thread.
+///
+/// The identifier is mandatory: it is the only way to tell a re-entrant
+/// `dlopen` issued by a constructor running on the loading thread apart from a
+/// genuine concurrent open on another thread. Without it, such a re-entrant
+/// call would block forever in [`InitState::wait_until_constructed`] waiting for
+/// constructors that cannot finish until this very call returns. A lookup
+/// failure is therefore propagated to the caller rather than silently ignored.
+fn current_tid() -> Result<i32, Error> {
+    Ok(i32::from(::sys::kcall::pm::__kcall_gettid()?))
 }
 
 /// Recursively loads all transitive dependencies of a newly opened library.

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -31,7 +31,14 @@ use ::alloc::{
     vec::Vec,
 };
 use ::arch::mem::PAGE_ALIGNMENT;
-use ::core::mem;
+use ::core::{
+    mem,
+    sync::atomic::{
+        AtomicBool,
+        AtomicI32,
+        Ordering,
+    },
+};
 use ::elf::{
     RelocationEntry,
     RelocationTable,
@@ -96,6 +103,95 @@ impl DlHandle {
 }
 
 //==================================================================================================
+// InitState
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Shared, lock-free construction state for a dynamically loaded library.
+///
+/// `dlopen` releases [`DYNAMIC_LIBRARY_REGISTRY`](super::DYNAMIC_LIBRARY_REGISTRY)
+/// before running a newly loaded library's `.init_array` constructors, so that a
+/// constructor may legally call back into the loader (`dlsym`, and — for a
+/// re-entrant open of the same library from its own constructor — `dlopen`)
+/// without deadlocking. That released window let a *concurrent* `dlopen` of the
+/// same filename observe the library as "loaded" on the dedup fast path and
+/// return its handle before the constructors had run.
+///
+/// This state closes the window. The dedup fast path waits on
+/// [`constructors_done`](Self::constructors_done) before handing back a handle,
+/// while a re-entrant open from the *constructing* thread itself is detected via
+/// [`constructor_tid`](Self::constructor_tid) and returns immediately — matching
+/// the System V gABI rule that constructors run exactly once, on the loading
+/// thread (and avoiding a self-deadlock).
+///
+/// The state lives behind an [`Arc`] so a waiting `dlopen` can hold on to it and
+/// poll it after dropping every dlfcn lock.
+///
+pub struct InitState {
+    /// Set to `true` once this library's `.init_array` constructors have
+    /// finished running. Observed with `Acquire` ordering by a concurrent
+    /// `dlopen` so the constructors' writes are visible once it returns.
+    constructors_done: AtomicBool,
+    /// Raw identifier of the thread that is running (or is about to run) this
+    /// library's constructors. Valid only while `constructors_done` is `false`;
+    /// initialized to [`Self::NO_THREAD`] when no owner is known.
+    constructor_tid: AtomicI32,
+}
+
+impl InitState {
+    /// Sentinel meaning "no constructing thread recorded yet". Distinct from
+    /// every real (non-negative) thread identifier.
+    const NO_THREAD: i32 = -1;
+
+    /// Creates a fresh state for a library whose constructors have not run.
+    fn new() -> Self {
+        Self {
+            constructors_done: AtomicBool::new(false),
+            constructor_tid: AtomicI32::new(Self::NO_THREAD),
+        }
+    }
+
+    /// Records the thread that will run this library's constructors.
+    ///
+    /// `dlopen` calls this while `DYNAMIC_LIBRARY_REGISTRY` is held — before the
+    /// lock is released and constructors begin — so no concurrent observer can
+    /// see the pre-set [`Self::NO_THREAD`] sentinel.
+    pub fn set_constructor_thread(&self, tid: i32) {
+        self.constructor_tid.store(tid, Ordering::Relaxed);
+    }
+
+    /// Marks this library's constructors as finished, releasing any concurrent
+    /// `dlopen` blocked in [`wait_until_constructed`](Self::wait_until_constructed).
+    pub fn mark_constructed(&self) {
+        self.constructors_done.store(true, Ordering::Release);
+    }
+
+    /// Blocks until this library's constructors have finished.
+    ///
+    /// Returns immediately if the constructors are already done, or if the
+    /// calling thread (`current_tid`) is the very thread running them — a
+    /// re-entrant `dlopen` from a constructor must not wait on itself.
+    /// Otherwise it spins, yielding the CPU so the constructing thread is
+    /// scheduled, until the constructors complete.
+    pub fn wait_until_constructed(&self, current_tid: i32) {
+        if self.constructors_done.load(Ordering::Acquire) {
+            return;
+        }
+        if self.constructor_tid.load(Ordering::Relaxed) == current_tid {
+            return;
+        }
+        while !self.constructors_done.load(Ordering::Acquire) {
+            // Yield so the constructing thread makes progress; fall back to a
+            // spin hint if the scheduler kernel call is unavailable.
+            let _ = ::sys::kcall::sched::__kcall_sched_yield();
+            ::core::hint::spin_loop();
+        }
+    }
+}
+
+//==================================================================================================
 // DlFile
 //==================================================================================================
 
@@ -129,6 +225,9 @@ pub struct DynamicLibrary {
     fini_array: Option<(usize, usize)>,
     /// `DT_RUNPATH` directories of this library, already split on `:`.
     runpaths: Vec<String>,
+    /// Shared construction state, used to serialize concurrent `dlopen` calls
+    /// against this library's `.init_array` constructors.
+    init_state: Arc<InitState>,
 }
 
 impl DynamicLibrary {
@@ -381,6 +480,7 @@ impl DynamicLibrary {
                     init_array,
                     fini_array,
                     runpaths,
+                    init_state: Arc::new(InitState::new()),
                 })
             },
             Err(error) => {
@@ -1065,6 +1165,13 @@ impl DynamicLibrary {
     /// Returns the `DT_RUNPATH` directories of the library, split on `:`.
     pub fn runpaths(&self) -> &[String] {
         &self.runpaths
+    }
+
+    /// Returns a cloneable handle to this library's construction state so a
+    /// concurrent `dlopen` can wait for its constructors to finish without
+    /// holding any dlfcn lock.
+    pub fn init_state(&self) -> Arc<InitState> {
+        self.init_state.clone()
     }
 
     /// Returns the loaded `.init_array` descriptor as `(base_address,

--- a/src/tests/integration/test-c-dlfcn-init-concurrent/libs/slowctor.c
+++ b/src/tests/integration/test-c-dlfcn-init-concurrent/libs/slowctor.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libslowctor.so - fixture for dlfcn-init-concurrent-c.
+ *
+ * Carries a `.init_array` constructor whose execution is deliberately slow and
+ * observable, so a second thread that dlopen()s this library while the
+ * constructor is running can prove its dlopen() did NOT return until the
+ * constructor finished.
+ *
+ * The constructor:
+ *   1. calls ctor_mark_started() so the racing thread knows the constructor is
+ *      running (and this library is therefore already resident in the loader
+ *      registry, discoverable on the dedup fast path);
+ *   2. busy-waits until ctor_racer_arrived() reports the racing thread is about
+ *      to re-enter dlopen();
+ *   3. busy-waits a further fixed window so that if the loader is buggy and lets
+ *      the racing dlopen() return early, that early return is observable BEFORE
+ *      the completion witnesses below are set;
+ *   4. records SLOW_STATE_READY into g_slow_state (exported via slow_state())
+ *      and calls ctor_mark_done().
+ *
+ * ctor_mark_started / ctor_racer_arrived / ctor_mark_done are defined in the
+ * main executable and left UNDEFINED here; the loader resolves them from the
+ * global scope at load time (the suite ELF is PIE + --export-dynamic).
+ */
+
+#include <stdatomic.h>
+
+/* Value stored once the constructor has finished. Must match main.c. */
+#define SLOW_STATE_READY 0x2476
+
+/*
+ * Iterations of the post-arrival window spin. Large enough that a buggy loader's
+ * early return from the racing dlopen() (a few instructions) lands inside the
+ * window, so the racing thread snapshots an unfinished constructor. `volatile`
+ * on the loop counter keeps the -O2 build from eliminating the delay.
+ */
+#define SLOW_CTOR_WINDOW_SPINS 50000000L
+
+/* Defined in the main executable, exported via --export-dynamic; resolved from
+ * the loader's global symbol table at load time. */
+extern void ctor_mark_started(void);
+extern int ctor_racer_arrived(void);
+extern void ctor_mark_done(void);
+
+/* Side effect the constructor produces; observed via slow_state() by both the
+ * loader thread and the racing thread. */
+static atomic_int g_slow_state = ATOMIC_VAR_INIT(0);
+
+/* Runs from `.init_array` before dlopen() returns to the loading thread. */
+static void __attribute__((constructor)) slow_ctor(void)
+{
+    /* Announce that the constructor is running (and this library is resident). */
+    ctor_mark_started();
+
+    /* Busy-wait until the racing thread announces it is about to re-enter
+     * dlopen() of this same library. */
+    while (ctor_racer_arrived() == 0) {
+        /* spin */
+    }
+
+    /* Widen the post-arrival window so a buggy loader's early return in the
+     * racing thread is observable before the witnesses below are set. */
+    for (volatile long i = 0; i < SLOW_CTOR_WINDOW_SPINS; i++) {
+        /* spin */
+    }
+
+    atomic_store_explicit(&g_slow_state, SLOW_STATE_READY, memory_order_release);
+    ctor_mark_done();
+}
+
+/* Exported so both threads can observe the constructor's side effect via
+ * dlsym(). */
+int slow_state(void)
+{
+    return atomic_load_explicit(&g_slow_state, memory_order_acquire);
+}

--- a/src/tests/integration/test-c-dlfcn-init-concurrent/main.c
+++ b/src/tests/integration/test-c-dlfcn-init-concurrent/main.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-init-concurrent-c: Validate that a concurrent dlopen() of a library
+ * does not observe it before its `.init_array` constructors have finished
+ * running.
+ *
+ * dlopen() drops the loader registry lock before invoking a newly loaded
+ * library's constructors, so that a constructor may legally call back into the
+ * loader (dlsym, and a re-entrant dlopen of the same library). Before the fix,
+ * that released window let a SECOND thread calling dlopen() on the same
+ * filename hit the dedup fast path and get the handle back the instant the
+ * registry lock was released -- well before the constructors had run. A dlsym()
+ * through that handle could then reference state a constructor had not yet
+ * initialized.
+ *
+ * Fixture (staged under lib/ by the per-suite RAMFS image):
+ *   - libslowctor.so: a `.init_array` constructor that (1) announces it is
+ *     running, (2) busy-waits until the racing thread says it is about to
+ *     re-enter dlopen, (3) busy-waits a further fixed window so a buggy loader's
+ *     early return is observable, then (4) records SLOW_STATE_READY into its own
+ *     `slow_state()` and marks the run finished. The entry points it calls
+ *     (ctor_mark_started / ctor_racer_arrived / ctor_mark_done) live in this
+ *     executable and are resolved from the loader's global scope at load time
+ *     (the suite ELF is PIE + --export-dynamic).
+ *
+ * Flow: main() spawns a racing thread and then dlopen()s libslowctor.so.
+ * Because the racing thread is parked until the constructor announces itself,
+ * main() deterministically wins the registry insert and is the thread that runs
+ * the constructor. The racing thread then dlopen()s the SAME library while that
+ * constructor is still on main()'s stack.
+ *
+ * Pass/fail is the guest exit code (the harness discards stdout in standalone
+ * mode): main() returns 0 only when the racing dlopen() returned AFTER the
+ * constructor finished AND a dlsym() through the racing thread's handle observes
+ * the constructor's side effect. A buggy loader lets the racing dlopen() return
+ * early, so the racing thread snapshots an unfinished constructor (exit 8) or a
+ * pre-constructor slow_state() (exit 9).
+ */
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdatomic.h>
+#include <unistd.h>
+
+/* Value the constructor stores into libslowctor.so's slow_state() once it has
+ * finished. Must match the definition in libs/slowctor.c. */
+#define SLOW_STATE_READY 0x2476
+
+/*
+ * Witnesses owned by the executable. These are atomics because the constructor
+ * and the racing thread intentionally communicate without taking a pthread lock.
+ */
+static atomic_int g_ctor_started = ATOMIC_VAR_INIT(0); /* set by the constructor */
+static atomic_int g_racer_arrived = ATOMIC_VAR_INIT(0); /* set by the racer       */
+static atomic_int g_ctor_done = ATOMIC_VAR_INIT(0);     /* set by the constructor */
+
+/* Outcome recorded by the racing thread for main() to check after join. */
+static void *g_racer_handle = NULL;
+static int g_racer_saw_ctor_done = -1;
+static int g_racer_slow_state = -1;
+
+/* Entry points called from libslowctor.so's constructor (resolved from this
+ * executable's exported global scope at load time). */
+void ctor_mark_started(void)
+{
+    atomic_store_explicit(&g_ctor_started, 1, memory_order_release);
+}
+
+int ctor_racer_arrived(void)
+{
+    return atomic_load_explicit(&g_racer_arrived, memory_order_acquire);
+}
+
+void ctor_mark_done(void)
+{
+    atomic_store_explicit(&g_ctor_done, 1, memory_order_release);
+}
+
+/*
+ * Racing thread: dlopen()s libslowctor.so WHILE main()'s thread is running its
+ * constructor, then records whether that dlopen() returned only after the
+ * constructor finished.
+ */
+static void *racer_thread(void *arg)
+{
+    (void)arg;
+
+    /* Wait until main()'s thread is inside the constructor. */
+    while (atomic_load_explicit(&g_ctor_started, memory_order_acquire) == 0) {
+        /* Busy-wait; the preemptive scheduler runs the loader thread. */
+    }
+
+    /* Announce arrival (releasing the constructor's wait), then immediately
+     * race into dlopen() of the SAME library. */
+    atomic_store_explicit(&g_racer_arrived, 1, memory_order_release);
+    void *h = dlopen("lib/libslowctor.so", RTLD_NOW);
+    g_racer_handle = h;
+
+    /* Snapshot the constructor-completion witness the instant dlopen() returns:
+     * with the fix this is 1 (dlopen waited for the constructor); a buggy loader
+     * returns early while the constructor is still in its window, so it is 0. */
+    g_racer_saw_ctor_done = atomic_load_explicit(&g_ctor_done, memory_order_acquire);
+
+    if (h != NULL) {
+        int (*fn)(void) = NULL;
+        *(void **)(&fn) = dlsym(h, "slow_state");
+        g_racer_slow_state = (fn != NULL) ? fn() : -2;
+    }
+
+    return NULL;
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, racer_thread, NULL) != 0) {
+        return 1;
+    }
+
+    /* This thread wins the registry insert (the racer is parked until the
+     * constructor sets g_ctor_started), so it is deterministically the loader
+     * that runs libslowctor.so's constructor. */
+    void *h1 = dlopen("lib/libslowctor.so", RTLD_NOW);
+    if (h1 == NULL) {
+        return 2;
+    }
+
+    if (pthread_join(tid, NULL) != 0) {
+        return 3;
+    }
+
+    /* The constructor ran to completion on this (loader) thread. */
+    if (atomic_load_explicit(&g_ctor_done, memory_order_acquire) != 1) {
+        return 4;
+    }
+
+    /* The loader thread's own handle observes the constructor's side effect. */
+    int (*fn1)(void) = NULL;
+    *(void **)(&fn1) = dlsym(h1, "slow_state");
+    if (fn1 == NULL || fn1() != SLOW_STATE_READY) {
+        return 5;
+    }
+
+    /* The racer obtained a handle... */
+    if (g_racer_handle == NULL) {
+        return 6;
+    }
+    /* ...to the very same library (dedup, no second copy)... */
+    if (g_racer_handle != (void *)h1) {
+        return 7;
+    }
+    /* ...whose dlopen() returned only AFTER the constructor finished (the
+     * racing dlopen() must not observe the library early)... */
+    if (g_racer_saw_ctor_done != 1) {
+        return 8;
+    }
+    /* ...and a dlsym() through the racer's handle observes the constructor's
+     * side effect. */
+    if (g_racer_slow_state != SLOW_STATE_READY) {
+        return 9;
+    }
+
+    /* Success: emit the magic string some harnesses expect, then return 0. */
+    const char *magic = "ok";
+    write(STDOUT_FILENO, magic, 2);
+
+    return 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -98,6 +98,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-init-concurrent"
+program = "./bin/test-c-dlfcn-init-concurrent.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-concurrent.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-init-runpath"
 program = "./bin/test-c-dlfcn-init-runpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-runpath.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -98,6 +98,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-init-concurrent"
+program = "./bin/test-c-dlfcn-init-concurrent.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-concurrent.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-init-runpath"
 program = "./bin/test-c-dlfcn-init-runpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-init-runpath.img"


### PR DESCRIPTION
## Summary

`dlopen()` drops the loader registry lock before running a newly loaded
library''s `.init_array` constructors (so a constructor may legally re-enter
the loader via `dlsym`/`dlopen`). That released window let a concurrent
`dlopen()` of the same filename hit the dedup fast path and return a handle
to a still-uninitialized library -- a `dlsym()` through that handle could
then reference state a constructor had not yet initialized.

This change closes the race and adds a regression test.

## What changed

**Loader (`syscall`):**
- Add a per-library `InitState` tracking constructor completion and the
  constructing thread id.
- Publish the constructor owner while the registry lock is still held, then
  drop the lock before invoking constructors.
- Make a duplicate `dlopen()` wait until constructors finish before returning
  the existing handle. A re-entrant `dlopen()` from the constructing thread
  itself returns without waiting (avoids self-deadlock, cf. #2474).
- Mark each library constructed as soon as its own constructors finish, so a
  waiter on a dependency proceeds without waiting for its dependents.

**Tests + wiring:**
- Add `test-c-dlfcn-init-concurrent`: a slow `.init_array` constructor in
  `libslowctor.so` plus a racing thread that `dlopen()`s the same library
  mid-construction. It fails distinctly if the racing `dlopen()` returns
  before construction completes or if `dlsym()` observes pre-constructor
  state. Cross-thread witnesses use C17 atomics.
- Link the suite PIE with exported helper symbols, build/stage `libslowctor.so`
  in a per-suite RAMFS image, and register the suite in the POSIX test list and
  both the Linux and Windows POSIX harness configs.

## Validation

- `run-unit-tests`, `run-nanvix-tests`, and the targeted
  `posix/test-c-dlfcn-init-concurrent` suite pass; `syscall` crate lint and
  format checks pass.

Closes #2476.