### PR TITLE
[tests] Add dlfcn ctor/dtor re-entrancy suite

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -16,6 +16,7 @@ ALL_POSIX_TESTS := \
 	test-c-bindings \
 	test-c-ctor \
 	test-c-dlfcn \
+	test-c-dlfcn-ctor-dtor-reentry \
 	test-c-dlfcn-diamond \
 	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -132,6 +132,12 @@ POSIX_TEST_PIE_test-c-dlfcn-pie := yes
 POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+# dlfcn-ctor-dtor-reentry-c links PIE + --export-dynamic so the main executable's
+# `hook_open_other`/`hook_close_other`/`other_report_dtor` helpers land in
+# `.dynsym`; libhook.so's constructor and destructor -- and libother.so's
+# destructor -- then resolve those references from the loader's global symbol
+# table while they run inside the in-progress dlopen()/dlclose().
+POSIX_TEST_PIE_test-c-dlfcn-ctor-dtor-reentry := yes
 # dlfcn-dtor-reentry-c links PIE + --export-dynamic so the main executable's
 # `dtor_probe` helper (and its witness globals) land in `.dynsym`; libreentry.so's
 # destructor then resolves its `extern void dtor_probe(void)` reference from the
@@ -303,6 +309,7 @@ clean-posix-tests:
 	$(RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs.img
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent)
@@ -316,6 +323,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(BINARIES_DIR)/posix-tests-ramfs-seed
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
@@ -740,8 +748,62 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent): $(POSIX_TEST_INIT_CONCURRE
 	$(CP_CMD) $(POSIX_TEST_INIT_CONCURRENT_LIBDIR)/libslowctor.so $(POSIX_TEST_INIT_CONCURRENT_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_INIT_CONCURRENT_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-ctor-dtor-reentry-c: constructor/destructor cross-library re-entrancy.
+#---------------------------------------------------------------------------------------------------
+#
+# Ships TWO shared libraries (built with the same i686 freestanding toolchain as
+# the fixtures above):
+#   * libother.so - the library opened by libhook.so's constructor and closed by
+#                   its destructor. Exports other_value() for the re-entrant
+#                   dlsym() checks, and carries a `.fini_array` destructor that
+#                   calls the main executable's other_report_dtor() (left
+#                   UNDEFINED, resolved from the global scope at load time) so the
+#                   suite can confirm the destructor-time dlclose() unloaded it.
+#                   An explicit -soname pins the SONAME to the bare name
+#                   `libother.so`.
+#   * libhook.so  - carries a `.init_array` constructor that calls hook_open_other()
+#                   and a `.fini_array` destructor that calls hook_close_other()
+#                   (both UNDEFINED, resolved from the main executable's exported
+#                   global scope; the suite ELF is PIE + --export-dynamic, see
+#                   POSIX_TEST_PIE_* above). Those helpers dlopen()/dlsym()/
+#                   dlclose() libother.so from inside the in-progress outer
+#                   dlopen()/dlclose(). libhook.so does NOT DT_NEEDED libother.so
+#                   -- it reaches it purely through a runtime dlopen() -- so no
+#                   -lother link edge is recorded here.
+# Both are staged under lib/, where main.c dlopen()s libhook.so; libother.so is
+# reached through the loader's default lib/ search path.
+POSIX_TEST_CTOR_DTOR_REENTRY_SUITE  := test-c-dlfcn-ctor-dtor-reentry
+POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)/libs
+POSIX_TEST_CTOR_DTOR_REENTRY_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE).img
+
+# libother.so: opened/closed by libhook.so's ctor/dtor; SONAME=libother.so.
+$(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libother.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)/libs/other.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)/libother.so (.fini_array)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libother.so $@.o -o $@
+
+# libhook.so: `.init_array` opens libother.so, `.fini_array` closes it.
+$(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libhook.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)/libs/hook.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_CTOR_DTOR_REENTRY_SUITE)/libhook.so (.init_array/.fini_array)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libhook.so $@.o -o $@
+
+# Per-suite RAMFS image carrying both fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry): $(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libother.so \
+		$(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libhook.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libother.so $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_LIBDIR)/libhook.so $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent) \

--- a/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/libs/hook.c
+++ b/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/libs/hook.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libhook.so - driver fixture for dlfcn-ctor-dtor-reentry-c.
+ *
+ * Models a library that manages another library's lifecycle across its own
+ * constructor and destructor:
+ *   - its `.init_array` constructor calls hook_open_other(), which dlopen()s
+ *     libother.so from inside the still-in-progress outer dlopen() (a
+ *     constructor calling dlopen);
+ *   - its `.fini_array` destructor calls hook_close_other(), which dlsym()s and
+ *     then dlclose()s that same libother.so handle from inside the
+ *     in-progress dlclose() (a destructor calling dlsym / dlclose on another
+ *     library).
+ *
+ * hook_open_other / hook_close_other are defined in the main executable and left
+ * UNDEFINED here; the loader resolves them from the global scope at load time
+ * (the suite ELF is PIE + --export-dynamic). Keeping the loader re-entry logic in
+ * the executable mirrors the sibling dlfcn re-entrancy suites and lets main()
+ * own the witnesses and the libother.so handle shared between the two callbacks.
+ */
+
+/* Defined in the main executable, exported via --export-dynamic; resolved from
+ * the loader's global symbol table at load time. */
+extern void hook_open_other(void);
+extern void hook_close_other(void);
+
+/* Runs from `.init_array` before dlopen("lib/libhook.so") returns. */
+static void __attribute__((constructor)) hook_ctor(void)
+{
+    hook_open_other();
+}
+
+/* Runs from `.fini_array` while dlclose(hook_handle) tears libhook.so down. */
+static void __attribute__((destructor)) hook_dtor(void)
+{
+    hook_close_other();
+}

--- a/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/libs/other.c
+++ b/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/libs/other.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libother.so - the library that libhook.so's constructor dlopen()s and whose
+ * handle libhook.so's destructor dlclose()s, for dlfcn-ctor-dtor-reentry-c.
+ *
+ * Exports other_value() so the re-entrant dlsym() checks have a symbol to
+ * resolve, and carries a `.fini_array` destructor that reports back to the main
+ * executable through other_report_dtor() -- left UNDEFINED here and resolved
+ * from the loader's global scope at load time (the suite ELF is PIE +
+ * --export-dynamic). That report lets the suite confirm the destructor-time
+ * dlclose() actually unloaded this library rather than leaving it resident.
+ */
+
+/* Value the re-entrant dlsym() checks expect; must match main.c. */
+#define OTHER_VALUE 0x2474
+
+/* Defined in the main executable, exported via --export-dynamic; resolved from
+ * the loader's global symbol table at load time. Called from this library's
+ * destructor while dlclose() (itself invoked from libhook.so's destructor) tears
+ * it down. */
+extern void other_report_dtor(void);
+
+/* Exported so the re-entrant dlsym() checks can resolve it. */
+int other_value(void)
+{
+    return OTHER_VALUE;
+}
+
+/* Runs from `.fini_array` when libother.so is unloaded. */
+static void __attribute__((destructor)) other_dtor(void)
+{
+    other_report_dtor();
+}

--- a/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/main.c
+++ b/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/main.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-ctor-dtor-reentry-c: Validate that a library's `.init_array` constructor
+ * may dlopen() ANOTHER library, and its `.fini_array` destructor may dlsym() and
+ * dlclose() that other library, without deadlocking on the loader's registry
+ * lock.
+ *
+ * dlopen() drops the loader registry lock before running a newly loaded
+ * library's constructors, and dlclose() runs destructors with no loader lock
+ * held. That makes the loader re-entrant from constructor/destructor context: a
+ * constructor may recursively dlopen() a further library, and a destructor may
+ * recursively dlsym()/dlclose() one. Without that drop-and-resume structure
+ * these paths would recursively acquire DYNAMIC_LIBRARY_REGISTRY and deadlock.
+ *
+ * Fixtures (staged under lib/ by the per-suite RAMFS image):
+ *   - libother.so: exports other_value() == 0x2474; its `.fini_array` destructor
+ *     calls other_report_dtor() (below) so the suite can confirm it was actually
+ *     unloaded. This is the library opened by the constructor and closed by the
+ *     destructor.
+ *   - libhook.so:  its `.init_array` constructor calls hook_open_other() (which
+ *     dlopen()s libother.so); its `.fini_array` destructor calls
+ *     hook_close_other() (which dlsym()s then dlclose()s that handle). Both
+ *     callbacks live in this executable and are resolved from the loader's global
+ *     scope at load time (the suite ELF is PIE + --export-dynamic).
+ *
+ * Flow: main() dlopen()s libhook.so -- running its constructor, which opens
+ * libother.so from inside the still-in-progress outer dlopen(). After the outer
+ * dlopen() returns, main() confirms libother.so is visible to it. main() then
+ * dlclose()s libhook.so, running its destructor, which uses and closes
+ * libother.so from inside the in-progress dlclose().
+ *
+ * Pass/fail is the guest exit code (the harness discards stdout in standalone
+ * mode): main() returns 0 only when both callbacks ran and every re-entrant
+ * dlopen()/dlsym()/dlclose() succeeded. Non-zero codes encode where it failed
+ * (see the returns below), with the 0x10/0x20 bands carrying the failing
+ * per-check bits for post-mortem.
+ */
+
+#include <dlfcn.h>
+#include <stddef.h>
+#include <unistd.h>
+
+/* Value libother.so's other_value() returns; must match libs/other.c. */
+#define OTHER_VALUE 0x2474
+
+/* Sentinels proving each callback actually ran (distinct, non-zero). */
+#define CTOR_SENTINEL       0xC0C0
+#define DTOR_SENTINEL       0xD0D0
+#define OTHER_DTOR_SENTINEL 0xE0E0
+
+/* Per-check result bits recorded by the constructor-side callback. */
+#define BIT_CTOR_DLOPEN_OK 0x1 /* ctor's dlopen("libother.so") returned non-NULL */
+#define BIT_CTOR_SYM_OK    0x2 /* ctor's dlsym(other, "other_value") resolved    */
+#define CTOR_EXPECTED      (BIT_CTOR_DLOPEN_OK | BIT_CTOR_SYM_OK)
+
+/* Per-check result bits recorded by the destructor-side callback. */
+#define BIT_DTOR_SYM_OK     0x1 /* dtor's dlsym(other, "other_value") resolved */
+#define BIT_DTOR_DLCLOSE_OK 0x2 /* dtor's dlclose(other) returned 0            */
+#define DTOR_EXPECTED       (BIT_DTOR_SYM_OK | BIT_DTOR_DLCLOSE_OK)
+
+/*
+ * Witnesses owned by the executable. The constructor and destructor callbacks
+ * (also in this executable) run on main()'s own thread -- the loader invokes
+ * `.init_array`/`.fini_array` synchronously from dlopen()/dlclose() -- so plain
+ * `volatile` (no atomics) is sufficient; there is no second thread. `volatile`
+ * keeps the optimizer from caching these across the callbacks.
+ */
+static volatile int g_ctor_ran = 0;
+static volatile int g_ctor_result = 0;
+static volatile int g_dtor_ran = 0;
+static volatile int g_dtor_result = 0;
+static volatile int g_other_dtor_ran = 0;
+static void *volatile g_other_handle = NULL;
+
+/*
+ * Called from libhook.so's constructor, i.e. from WITHIN main()'s dlopen() of
+ * libhook.so. Recursively dlopen()s libother.so (the constructor-calls-dlopen
+ * path) and resolves a symbol from it, recording the handle for the destructor.
+ */
+void hook_open_other(void)
+{
+    int result = 0;
+
+    g_ctor_ran = CTOR_SENTINEL;
+
+    void *other = dlopen("lib/libother.so", RTLD_NOW);
+    g_other_handle = other;
+    if (other != NULL) {
+        result |= BIT_CTOR_DLOPEN_OK;
+
+        int (*ov)(void) = NULL;
+        *(void **)(&ov) = dlsym(other, "other_value");
+        if (ov != NULL && ov() == OTHER_VALUE) {
+            result |= BIT_CTOR_SYM_OK;
+        }
+    }
+
+    g_ctor_result = result;
+}
+
+/*
+ * Called from libhook.so's destructor, i.e. from WITHIN main()'s dlclose() of
+ * libhook.so. Recursively dlsym()s (the destructor-calls-dlsym path) and then
+ * dlclose()s libother.so (the destructor-calls-dlclose path). libother.so's own
+ * destructor then sets g_other_dtor_ran, proving the recursive dlclose() ran to
+ * completion.
+ */
+void hook_close_other(void)
+{
+    int result = 0;
+
+    g_dtor_ran = DTOR_SENTINEL;
+
+    if (g_other_handle != NULL) {
+        int (*ov)(void) = NULL;
+        *(void **)(&ov) = dlsym(g_other_handle, "other_value");
+        if (ov != NULL && ov() == OTHER_VALUE) {
+            result |= BIT_DTOR_SYM_OK;
+        }
+
+        if (dlclose(g_other_handle) == 0) {
+            result |= BIT_DTOR_DLCLOSE_OK;
+        }
+    }
+
+    g_dtor_result = result;
+}
+
+/*
+ * Called from libother.so's destructor when the destructor-time dlclose() above
+ * tears it down. Proves the recursive dlclose() actually unloaded libother.so.
+ */
+void other_report_dtor(void)
+{
+    g_other_dtor_ran = OTHER_DTOR_SENTINEL;
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* Load libhook.so; its constructor opens libother.so from inside this
+     * dlopen() call. */
+    void *hook = dlopen("lib/libhook.so", RTLD_NOW);
+    if (hook == NULL) {
+        return 1;
+    }
+
+    /* The constructor ran, and its recursive dlopen()/dlsym() both succeeded. */
+    if (g_ctor_ran != CTOR_SENTINEL) {
+        return 2;
+    }
+    if (g_ctor_result != CTOR_EXPECTED) {
+        return 0x10 | (CTOR_EXPECTED & ~g_ctor_result);
+    }
+    if (g_other_handle == NULL) {
+        return 3;
+    }
+
+    /* libother.so is visible to main() (the caller) after the outer dlopen()
+     * returned: a dlopen() of it returns the SAME handle the constructor got
+     * (dedup, no second copy), and its symbol resolves. The dedup open adds no
+     * reference, so libother.so is left for the destructor to close. */
+    void *other = dlopen("lib/libother.so", RTLD_NOW);
+    if (other != g_other_handle) {
+        return 4;
+    }
+    int (*ov)(void) = NULL;
+    *(void **)(&ov) = dlsym(other, "other_value");
+    if (ov == NULL || ov() != OTHER_VALUE) {
+        return 5;
+    }
+
+    /* Close libhook.so; its destructor uses and closes libother.so from inside
+     * this dlclose() call. */
+    if (dlclose(hook) != 0) {
+        return 6;
+    }
+
+    /* The destructor ran, and its recursive dlsym()/dlclose() both succeeded. */
+    if (g_dtor_ran != DTOR_SENTINEL) {
+        return 7;
+    }
+    if (g_dtor_result != DTOR_EXPECTED) {
+        return 0x20 | (DTOR_EXPECTED & ~g_dtor_result);
+    }
+
+    /* The recursive dlclose() actually unloaded libother.so (its destructor
+     * ran). */
+    if (g_other_dtor_ran != OTHER_DTOR_SENTINEL) {
+        return 8;
+    }
+
+    /* Success: emit the magic string some harnesses expect, then return 0. */
+    const char *magic = "ok";
+    write(STDOUT_FILENO, magic, 2);
+
+    return 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -66,6 +66,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-ctor-dtor-reentry"
+program = "./bin/test-c-dlfcn-ctor-dtor-reentry.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-ctor-dtor-reentry.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-diamond"
 program = "./bin/test-c-dlfcn-diamond.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-diamond.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -66,6 +66,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-ctor-dtor-reentry"
+program = "./bin/test-c-dlfcn-ctor-dtor-reentry.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-ctor-dtor-reentry.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-diamond"
 program = "./bin/test-c-dlfcn-diamond.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-diamond.img"


### PR DESCRIPTION
## Summary

Adds a POSIX C integration suite that validates dynamic-loader re-entrancy
from constructor and destructor context, guarding the drop-and-resume
structure of `dlopen()`/`dlclose()` against regressions.

A library's `.init_array` constructor may `dlopen()` another library, and its
`.fini_array` destructor may `dlsym()`/`dlclose()` that library, without
deadlocking on the loader registry lock (`DYNAMIC_LIBRARY_REGISTRY`).

Closes #2474.

## What changed

**Tests**
- `test-c-dlfcn-ctor-dtor-reentry/main.c` drives the flow: `dlopen(libhook)`
  runs a constructor that opens `libother` from inside the in-progress outer
  `dlopen()`; `dlclose(libhook)` runs a destructor that `dlsym()`s and
  `dlclose()`s `libother` from inside the in-progress `dlclose()`. The exit
  code encodes which per-check bit failed for post-mortem.
- `libs/hook.c`: constructor calls `hook_open_other()`, destructor calls
  `hook_close_other()` (both resolved from the executable''s global scope).
- `libs/other.c`: exports `other_value()` and a destructor that reports back
  via `other_report_dtor()` to confirm the recursive `dlclose()` unloaded it.

**Build and harness wiring**
- Register the suite in `ALL_POSIX_TESTS`.
- Build `libhook.so`/`libother.so` fixtures, stage them under `lib/` in a
  per-suite RAMFS image, and link the suite PIE + `--export-dynamic` so the
  fixtures resolve the executable''s callbacks at load time.
- Add `[[tests]]` entries to `test-posix.toml` and `test-posix-windows.toml`
  with the per-suite `-ramfs` image, for both debug and release modes.

## Validation

- `run-unit-tests`, `run-nanvix-tests`, and `run-kernel-tests` pass.
- The new suite and the existing `posix/test-c-dlfcn*` family pass in debug.