### PR TITLE
[tests] Add dlfcn DT_NEEDED cycle test

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -17,6 +17,7 @@ ALL_POSIX_TESTS := \
 	test-c-ctor \
 	test-c-dlfcn \
 	test-c-dlfcn-ctor-dtor-reentry \
+	test-c-dlfcn-cycle \
 	test-c-dlfcn-diamond \
 	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -132,6 +132,11 @@ POSIX_TEST_PIE_test-c-dlfcn-pie := yes
 POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+# dlfcn-cycle-c dlopen()s freestanding fixtures. Its cyclic libraries are refused
+# before relocation and its positive-control library exports no undefined symbols,
+# so PIE is not strictly required; it is set anyway to match every other dlfcn
+# dlopen suite (the executable's own symbols land in .dynsym for RTLD_DEFAULT).
+POSIX_TEST_PIE_test-c-dlfcn-cycle := yes
 # dlfcn-ctor-dtor-reentry-c links PIE + --export-dynamic so the main executable's
 # `hook_open_other`/`hook_close_other`/`other_report_dtor` helpers land in
 # `.dynsym`; libhook.so's constructor and destructor -- and libother.so's
@@ -310,6 +315,7 @@ clean-posix-tests:
 	$(RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite).img)
 	$(RM_CMD) $(POSIX_TEST_RUNPATH_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent)
@@ -324,6 +330,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(BINARIES_DIR)/posix-tests-ramfs-$(suite)-seed)
 	$(FORCE_RM_CMD) $(POSIX_TEST_RUNPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
@@ -531,6 +538,103 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond): $(POSIX_TEST_DIAMOND_DIR)/libbase.
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libright.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libdiamond.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_DIAMOND_SEED)
+
+#---------------------------------------------------------------------------------------------------
+# dlfcn-cycle-c: DT_NEEDED cycle-rejection fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+#   libcyclea.so    DT_NEEDED libcycleb.so    --+
+#   libcycleb.so    DT_NEEDED libcyclea.so    --+  (two-node cycle)
+#   libselfcycle.so DT_NEEDED libselfcycle.so       (single-node self-loop)
+#   libok.so        (no dependencies)               (positive control)
+#
+# The loader must refuse a dlopen() of any cyclic graph with a clean NULL +
+# dlerror() result instead of recursing without bound (see
+# load_all_dependencies_recursive in
+# src/libs/syscall/src/dlfcn/syscall/dlopen.rs); dlfcn-cycle-c/main.c asserts that
+# rejection and that the dependency-free control library still loads before and
+# after it.
+#
+# A circular DT_NEEDED pair cannot be produced by a single link -- each library
+# must already exist before the other can record a DT_NEEDED entry on it -- so the
+# cycle is bootstrapped in stages. A "stage-1" image of one node is linked first
+# with NO dependency (its cross-reference to the other node is left undefined,
+# which shared objects permit) purely so the other node has something to link
+# against; the two final images are then linked against each other. Each final
+# link lists its dependency's image directly on the command line under
+# --no-as-needed, so the linker records that image's SONAME as a bare DT_NEEDED
+# entry that the loader resolves through its default lib/ search path (exactly like
+# the diamond fixture above). -soname pins each recorded name regardless of linker
+# (GNU ld vs ld.lld). Built with the same i686 freestanding toolchain as the
+# fixtures above.
+POSIX_TEST_CYCLE_DIR  := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-cycle/libs
+POSIX_TEST_CYCLE_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-cycle-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-cycle.img
+
+# Positive control: dependency-free, zero undefined symbols.
+$(POSIX_TEST_CYCLE_DIR)/libok.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/ok.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libok.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libok.so $@.o -o $@
+
+# Stage-1 libcycleb.so: no DT_NEEDED yet (its cyclea_value reference is left
+# undefined) so libcyclea.so has something to link against. SONAME=libcycleb.so.
+$(POSIX_TEST_CYCLE_DIR)/libcycleb-stage1.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/cycleb.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libcycleb.so (stage 1, no DT_NEEDED)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libcycleb.so $@.o -o $@
+
+# Final libcyclea.so: DT_NEEDED libcycleb.so (linked against the stage-1 image).
+$(POSIX_TEST_CYCLE_DIR)/libcyclea.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/cyclea.c \
+		$(POSIX_TEST_CYCLE_DIR)/libcycleb-stage1.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libcyclea.so (DT_NEEDED libcycleb.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libcyclea.so \
+		$@.o --no-as-needed $(POSIX_TEST_CYCLE_DIR)/libcycleb-stage1.so -o $@
+
+# Final libcycleb.so: DT_NEEDED libcyclea.so (linked against the final
+# libcyclea.so), closing the libcyclea.so <-> libcycleb.so cycle.
+$(POSIX_TEST_CYCLE_DIR)/libcycleb.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/cycleb.c \
+		$(POSIX_TEST_CYCLE_DIR)/libcyclea.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libcycleb.so (DT_NEEDED libcyclea.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libcycleb.so \
+		$@.o --no-as-needed $(POSIX_TEST_CYCLE_DIR)/libcyclea.so -o $@
+
+# Stage-1 libselfcycle.so: no DT_NEEDED yet. SONAME=libselfcycle.so.
+$(POSIX_TEST_CYCLE_DIR)/libselfcycle-stage1.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/selfcycle.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libselfcycle.so (stage 1, no DT_NEEDED)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libselfcycle.so $@.o -o $@
+
+# Final libselfcycle.so: DT_NEEDED libselfcycle.so (linked against its own stage-1
+# image under --no-as-needed, since it references no symbol from it), forming a
+# single-node self-loop.
+$(POSIX_TEST_CYCLE_DIR)/libselfcycle.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-cycle/libs/selfcycle.c \
+		$(POSIX_TEST_CYCLE_DIR)/libselfcycle-stage1.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-cycle-c/libselfcycle.so (DT_NEEDED libselfcycle.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libselfcycle.so \
+		$@.o --no-as-needed $(POSIX_TEST_CYCLE_DIR)/libselfcycle-stage1.so -o $@
+
+# Per-suite RAMFS image carrying the control + cyclic fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle): $(POSIX_TEST_CYCLE_DIR)/libok.so \
+		$(POSIX_TEST_CYCLE_DIR)/libcyclea.so \
+		$(POSIX_TEST_CYCLE_DIR)/libcycleb.so \
+		$(POSIX_TEST_CYCLE_DIR)/libselfcycle.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_CYCLE_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_CYCLE_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_CYCLE_DIR)/libok.so $(POSIX_TEST_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_CYCLE_DIR)/libcyclea.so $(POSIX_TEST_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_CYCLE_DIR)/libcycleb.so $(POSIX_TEST_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_CYCLE_DIR)/libselfcycle.so $(POSIX_TEST_CYCLE_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_CYCLE_SEED)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-selflink-c: main-executable GOT/PLT self-linking fixture.
@@ -804,6 +908,7 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry): $(POSIX_TEST_CTOR_DTOR_R
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent) \

--- a/src/tests/integration/test-c-dlfcn-cycle/libs/cyclea.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/libs/cyclea.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libcyclea.so - one node of the two-node DT_NEEDED cycle exercised by
+ * dlfcn-cycle-c:
+ *
+ *   libcyclea.so DT_NEEDED libcycleb.so
+ *   libcycleb.so DT_NEEDED libcyclea.so
+ *
+ * cyclea_value() references libcycleb.so's cycleb_value(), which forces the
+ * DT_NEEDED edge on libcycleb.so at link time. The call is never actually
+ * executed: the loader must reject dlopen("libcyclea.so") while walking the
+ * dependency graph -- before any relocation or code in this library runs --
+ * so the otherwise-mutual recursion below is unreachable.
+ */
+
+extern int cycleb_value(void);
+
+int cyclea_value(void)
+{
+    return cycleb_value() + 1;
+}

--- a/src/tests/integration/test-c-dlfcn-cycle/libs/cycleb.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/libs/cycleb.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libcycleb.so - the other node of the two-node DT_NEEDED cycle exercised by
+ * dlfcn-cycle-c:
+ *
+ *   libcyclea.so DT_NEEDED libcycleb.so
+ *   libcycleb.so DT_NEEDED libcyclea.so
+ *
+ * cycleb_value() references libcyclea.so's cyclea_value(), which forces the
+ * DT_NEEDED edge on libcyclea.so at link time. The call is never actually
+ * executed: the loader rejects the cycle while walking the dependency graph,
+ * so the otherwise-mutual recursion below is unreachable.
+ */
+
+extern int cyclea_value(void);
+
+int cycleb_value(void)
+{
+    return cyclea_value() + 1;
+}

--- a/src/tests/integration/test-c-dlfcn-cycle/libs/ok.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/libs/ok.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libok.so - dependency-free positive-control library for dlfcn-cycle-c.
+ *
+ * Carries zero DT_NEEDED edges and zero undefined symbols, so a correct
+ * loader dlopen()s it without walking any dependencies. The suite loads it
+ * FIRST (and again after the cyclic loads fail) to prove the per-suite
+ * RAMFS is mounted and the loader resolves a well-formed library. Without
+ * this control a later "dlopen(cyclic) == NULL" assertion could pass for
+ * the wrong reason -- e.g. the library file was never found -- instead of
+ * because the loader rejected a DT_NEEDED cycle.
+ */
+
+int ok_value(void)
+{
+    return 0x2479;
+}

--- a/src/tests/integration/test-c-dlfcn-cycle/libs/selfcycle.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/libs/selfcycle.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libselfcycle.so - single-node DT_NEEDED self-loop (libselfcycle.so
+ * DT_NEEDED libselfcycle.so). Exercises the loader's direct self-cycle
+ * branch, where a library's own dependency resolves back to itself.
+ *
+ * The self-edge is forced at link time by listing this library's own
+ * stage-1 image on its final link line, not by any symbol reference, so a
+ * single dependency-free leaf function is all this source needs to provide.
+ */
+
+int selfcycle_value(void)
+{
+    return 0x5E1F;
+}

--- a/src/tests/integration/test-c-dlfcn-cycle/main.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/main.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * dlfcn-cycle-c: DT_NEEDED cycle rejection.
+ *
+ *   libcyclea.so DT_NEEDED libcycleb.so
+ *   libcycleb.so DT_NEEDED libcyclea.so   (two-node cycle)
+ *
+ *   libselfcycle.so DT_NEEDED libselfcycle.so   (single-node self-loop)
+ *
+ * The dynamic loader walks DT_NEEDED edges recursively when a library is
+ * dlopen()ed. A cyclic edge must be detected: the frame that would re-open
+ * an ancestor (or the library itself) has to bail out instead of recursing.
+ * A loader that misses the cycle hands out a fresh file descriptor -- hence
+ * a distinct handle -- for every recursive re-open of the ancestor, slips
+ * past the already-loaded lookup, and recurses without bound until the
+ * guest stack overflows. That failure mode is silent (an OOM / fault, not a
+ * clean error), so this suite pins the fixed behavior: dlopen() of a cyclic
+ * graph returns NULL cleanly, with dlerror() set, and every entry the failed
+ * call added is rolled back so the loader stays usable afterwards.
+ *
+ * A correct loader:
+ *   * loads the dependency-free control library libok.so (proves the RAMFS
+ *     is mounted and a well-formed library resolves), then
+ *   * refuses dlopen("lib/libcyclea.so") and dlopen("lib/libcycleb.so") with
+ *     a NULL handle + non-NULL dlerror() (the two-node cycle), then
+ *   * still refuses a repeat dlopen of the cyclic library deterministically
+ *     and still loads libok.so afterwards (rollback left the registry
+ *     clean), then
+ *   * refuses dlopen("lib/libselfcycle.so") the same way (the self-loop).
+ *
+ * A broken (pre-fix) loader instead recurses without bound on the cyclic
+ * libraries; the guest never returns from dlopen() and the test harness
+ * catches the runaway via its external watchdog timeout. Every assertion
+ * that a cyclic dlopen() returns NULL therefore also guards against the
+ * unbounded-recursion regression, because reaching the assertion at all
+ * requires dlopen() to have returned.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Loads the dependency-free control library and confirms one of its symbols
+ * returns the expected sentinel. Returns 1 on success, 0 on failure. Used
+ * both as the opening sanity check and to prove the loader still works after
+ * the cyclic loads have been rejected and rolled back.
+ */
+static int load_control(const char *name)
+{
+    void *h = dlopen("lib/libok.so", RTLD_NOW);
+    if (h == NULL) {
+        fail(name, dlerror());
+        return 0;
+    }
+
+    int (*ov)(void) = (int (*)(void))dlsym(h, "ok_value");
+    if (!ov || ov() != 0x2479) {
+        fail(name, "ok_value() missing or returned the wrong value");
+        dlclose(h);
+        return 0;
+    }
+
+    dlclose(h);
+    return 1;
+}
+
+/*
+ * Asserts that dlopen(path, RTLD_NOW) is refused cleanly: a NULL handle plus
+ * a non-NULL dlerror() message. Calling dlerror() also clears the error state
+ * for the next probe. Returns 1 on the expected rejection, 0 otherwise.
+ *
+ * Reaching this function's return at all means dlopen() came back rather than
+ * recursing forever, so a `1` result is the positive witness for cycle
+ * detection; the pre-fix loader would hang here instead and trip the
+ * harness watchdog.
+ */
+static int expect_cycle_rejected(const char *path, const char *name)
+{
+    void *h = dlopen(path, RTLD_NOW);
+    if (h != NULL) {
+        fail(name, "expected NULL handle for a cyclic library, but it loaded");
+        dlclose(h);
+        return 0;
+    }
+
+    const char *error = dlerror();
+    if (error == NULL) {
+        fail(name, "dlopen() returned NULL without setting dlerror()");
+        return 0;
+    }
+
+    return 1;
+}
+
+/*
+ * Test 0 (positive control): a well-formed, dependency-free library loads.
+ */
+static void test_positive_control(void)
+{
+    if (load_control("dlopen(libok.so) [positive control]")) {
+        pass("dlopen(libok.so) [positive control]");
+    }
+}
+
+/*
+ * Test 1: the two-node cycle libcyclea.so <-> libcycleb.so is rejected from
+ * either entry point. Whichever library is opened first becomes the in-progress
+ * ancestor; the recursion back onto it through the other node must be caught.
+ */
+static void test_two_node_cycle(void)
+{
+    if (!expect_cycle_rejected("lib/libcyclea.so", "dlopen(libcyclea.so) [cycle]")) {
+        return;
+    }
+    if (!expect_cycle_rejected("lib/libcycleb.so", "dlopen(libcycleb.so) [cycle]")) {
+        return;
+    }
+    pass("two-node DT_NEEDED cycle rejected from both entry points");
+}
+
+/*
+ * Test 2: rejecting a cycle must roll back every entry the failed dlopen()
+ * added, so a repeat attempt fails identically (not, say, by finding a
+ * half-loaded stale copy) and an unrelated well-formed library still loads.
+ */
+static void test_cycle_rollback(void)
+{
+    if (!expect_cycle_rejected("lib/libcyclea.so", "re-dlopen(libcyclea.so) [rollback]")) {
+        return;
+    }
+    if (!load_control("dlopen(libok.so) after rejected cycle [rollback]")) {
+        return;
+    }
+    pass("cycle rejection rolled back cleanly (loader still usable)");
+}
+
+/*
+ * Test 3: a single-node self-loop (libselfcycle.so DT_NEEDED libselfcycle.so)
+ * is rejected the same way. This exercises the loader's direct self-cycle
+ * branch rather than the multi-node ancestor branch above.
+ */
+static void test_self_cycle(void)
+{
+    if (expect_cycle_rejected("lib/libselfcycle.so", "dlopen(libselfcycle.so) [self-loop]")) {
+        pass("single-node DT_NEEDED self-loop rejected");
+    }
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn DT_NEEDED cycle tests ===\n");
+    fflush(stdout);
+
+    test_positive_control();
+    test_two_node_cycle();
+    test_cycle_rollback();
+    test_self_cycle();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-cycle"
+program = "./bin/test-c-dlfcn-cycle.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-cycle.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-diamond"
 program = "./bin/test-c-dlfcn-diamond.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-diamond.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -74,6 +74,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-cycle"
+program = "./bin/test-c-dlfcn-cycle.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-cycle.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-diamond"
 program = "./bin/test-c-dlfcn-diamond.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-diamond.img"


### PR DESCRIPTION
## Summary

Adds the `test-c-dlfcn-cycle` POSIX integration suite that pins the dynamic
loader''s `DT_NEEDED` cycle-rejection behavior. A `dlopen()` of a cyclic
dependency graph must fail cleanly (NULL handle + set `dlerror()`) and roll
back every entry the failed call added, instead of recursing without bound
until the guest stack overflows.

Closes #2479.

## What changed

**Test suite** (`src/tests/integration/test-c-dlfcn-cycle/`):
- `main.c` exercises four cases: a dependency-free positive control
  (`libok.so`); the two-node cycle `libcyclea.so <-> libcycleb.so` rejected
  from both entry points; a rollback re-check (repeat cyclic `dlopen()` fails
  identically and the control still loads afterward); and a single-node
  self-loop (`libselfcycle.so`).
- `libs/cyclea.c`, `libs/cycleb.c`, `libs/ok.c`, `libs/selfcycle.c` fixtures.

**Build and harness wiring:**
- `guest-posix-tests.mk`: register the `test-c-dlfcn-cycle` suite.
- `posix-tests.mk`: stage-bootstrapped link rules that construct the cyclic
  `.so` graph (stage-1 image with an undefined back-reference, then final
  links closing each cycle via `--no-as-needed` + `-soname`), per-suite RAMFS
  image, PIE flag, and clean-up targets.
- `test-posix.toml` / `test-posix-windows.toml`: add the suite entry for both
  `debug` and `release`, expecting guest exit code 0.

## Validation

- Focused `posix/test-c-dlfcn-cycle` run passes in debug and release.
- `run-unit-tests`, `run-kernel-tests`, and `run-nanvix-tests` pass on Windows
  (standalone).
- Verified the built fixtures carry the intended `DT_NEEDED` graph.