### PR TITLE
[libc_netdb] Implement getaddrinfo() and add tests

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -46,6 +46,7 @@ ALL_POSIX_TESTS := \
 	test-c-math \
 	test-c-memory \
 	test-c-misc \
+	test-c-netdb \
 	test-c-network \
 	test-c-noop \
 	test-c-pathconf \

--- a/src/libs/libc_netdb/src/lib.rs
+++ b/src/libs/libc_netdb/src/lib.rs
@@ -11,6 +11,11 @@
 // Imports
 //==================================================================================================
 
+use ::core::{
+    mem,
+    ptr,
+    slice,
+};
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::{
@@ -19,13 +24,90 @@ use ::sysapi::{
         c_void,
     },
     netdb::addrinfo,
-    sys_socket::socklen_t,
+    netinet_in::{
+        in_addr,
+        sockaddr_in,
+        sockopt_levels::{
+            IPPROTO_TCP,
+            IPPROTO_UDP,
+        },
+    },
+    sys_socket::{
+        sa_family_t,
+        sockaddr,
+        socket_address_family::{
+            AF_INET,
+            AF_UNSPEC,
+        },
+        socket_types::{
+            SOCK_DGRAM,
+            SOCK_RAW,
+            SOCK_STREAM,
+        },
+        socklen_t,
+    },
     sys_types::c_size_t,
 };
 use ::syslog::{
     trace_libcall,
     trace_syscall,
 };
+
+//==================================================================================================
+// External Functions
+//==================================================================================================
+
+extern "C" {
+    fn malloc(size: c_size_t) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+    fn inet_aton(cp: *const c_char, inp: *mut in_addr) -> c_int;
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Address-information flags for `getaddrinfo()`. These mirror the values in `include/netdb.h`.
+
+/// Returns socket addresses suitable for binding a passive (listening) socket.
+const AI_PASSIVE: c_int = 0x0001;
+/// Requests the canonical name of the host.
+const AI_CANONNAME: c_int = 0x0002;
+/// Interprets `node` only as a numeric address string (never a host name).
+const AI_NUMERICHOST: c_int = 0x0004;
+/// Interprets `service` only as a numeric port string (never a service name).
+const AI_NUMERICSERV: c_int = 0x0008;
+/// Returns IPv4-mapped IPv6 addresses when no IPv6 addresses are found.
+const AI_V4MAPPED: c_int = 0x0800;
+/// Returns both IPv4 and IPv6 addresses (used together with `AI_V4MAPPED`).
+const AI_ALL: c_int = 0x0100;
+/// Returns addresses only for configured address families.
+const AI_ADDRCONFIG: c_int = 0x0400;
+/// Set of all recognized `getaddrinfo()` flags.
+const AI_MASK: c_int = AI_PASSIVE
+    | AI_CANONNAME
+    | AI_NUMERICHOST
+    | AI_NUMERICSERV
+    | AI_V4MAPPED
+    | AI_ALL
+    | AI_ADDRCONFIG;
+
+// Error codes returned by `getaddrinfo()`. These mirror the values in `include/netdb.h`.
+
+/// The `flags` field of the `hints` structure had an invalid value.
+const EAI_BADFLAGS: c_int = -1;
+/// The name does not resolve for the supplied parameters.
+const EAI_NONAME: c_int = -2;
+/// A non-recoverable error occurred.
+const EAI_FAIL: c_int = -4;
+/// The requested address family is not supported.
+const EAI_FAMILY: c_int = -6;
+/// The requested socket type is not supported.
+const EAI_SOCKTYPE: c_int = -7;
+/// The requested service is not available for the requested socket type.
+const EAI_SERVICE: c_int = -8;
+/// A memory-allocation failure occurred.
+const EAI_MEMORY: c_int = -10;
 
 //==================================================================================================
 // Global State
@@ -62,7 +144,15 @@ pub static mut h_errno: c_int = 0;
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn freeaddrinfo(res: *mut addrinfo) {
-    ::syslog::debug!("freeaddrinfo(): not implemented");
+    // Each node returned by `getaddrinfo()` is a single allocation whose `ai_addr` and
+    // `ai_canonname` buffers live inside the same block, so freeing the node pointer releases the
+    // whole entry. Walk the list, capturing `ai_next` before releasing each node.
+    let mut cursor: *mut addrinfo = res;
+    while !cursor.is_null() {
+        let next: *mut addrinfo = (*cursor).ai_next;
+        free(cursor as *mut c_void);
+        cursor = next;
+    }
 }
 
 ///
@@ -99,8 +189,97 @@ pub unsafe extern "C" fn getaddrinfo(
     hints: *const addrinfo,
     res: *mut *mut addrinfo,
 ) -> c_int {
-    ::syslog::debug!("getaddrinfo(): not implemented");
-    ErrorCode::InvalidSysCall.get()
+    // The caller must provide somewhere to store the resulting list.
+    if res.is_null() {
+        return EAI_FAIL;
+    }
+    // Start from an empty list so the caller never observes a stale pointer on error.
+    *res = ptr::null_mut();
+
+    // At least one of `node` and `service` must be supplied.
+    if node.is_null() && service.is_null() {
+        return EAI_NONAME;
+    }
+
+    // Read the criteria from `hints`, defaulting to an unconstrained lookup when it is null.
+    let (flags, family, hint_socktype, hint_protocol): (c_int, c_int, c_int, c_int) =
+        if hints.is_null() {
+            (0, AF_UNSPEC, 0, 0)
+        } else {
+            ((*hints).ai_flags, (*hints).ai_family, (*hints).ai_socktype, (*hints).ai_protocol)
+        };
+
+    // Reject flags outside the recognized set.
+    if flags & !AI_MASK != 0 {
+        return EAI_BADFLAGS;
+    }
+
+    // Only IPv4 is supported, so anything other than an unspecified or IPv4 family is rejected.
+    if family != AF_UNSPEC && family != AF_INET {
+        return EAI_FAMILY;
+    }
+
+    // Only stream, datagram, and raw socket types are recognized.
+    if hint_socktype != 0
+        && hint_socktype != SOCK_STREAM
+        && hint_socktype != SOCK_DGRAM
+        && hint_socktype != SOCK_RAW
+    {
+        return EAI_SOCKTYPE;
+    }
+
+    // Resolve the host and service. No name resolver is available, so only numeric forms succeed.
+    let addr: in_addr = match resolve_node(node, flags) {
+        Ok(addr) => addr,
+        Err(code) => return code,
+    };
+    let port: u16 = match resolve_service(service, flags) {
+        Ok(port) => port,
+        Err(code) => return code,
+    };
+
+    // Determine the (socket type, protocol) pairs to emit, one addrinfo node per pair.
+    let mut pairs: [(c_int, c_int); 2] = [(0, 0); 2];
+    let count: usize = match fill_socktype_pairs(hint_socktype, hint_protocol, &mut pairs) {
+        Ok(count) => count,
+        Err(code) => return code,
+    };
+
+    // The canonical name, when requested, is attached to the first node only.
+    let canon: Option<&[u8]> = if flags & AI_CANONNAME != 0 {
+        Some(if node.is_null() {
+            if flags & AI_PASSIVE != 0 {
+                b"0.0.0.0".as_slice()
+            } else {
+                b"127.0.0.1".as_slice()
+            }
+        } else {
+            slice::from_raw_parts(node as *const u8, c_str_len(node))
+        })
+    } else {
+        None
+    };
+
+    // Build the linked list, freeing any partial result on allocation failure.
+    let mut head: *mut addrinfo = ptr::null_mut();
+    let mut tail: *mut addrinfo = ptr::null_mut();
+    for (index, &(socktype, protocol)) in pairs.iter().take(count).enumerate() {
+        let node_canon: Option<&[u8]> = if index == 0 { canon } else { None };
+        let entry: *mut addrinfo = alloc_node(socktype, protocol, port, addr, node_canon);
+        if entry.is_null() {
+            freeaddrinfo(head);
+            return EAI_MEMORY;
+        }
+        if head.is_null() {
+            head = entry;
+        } else {
+            (*tail).ai_next = entry;
+        }
+        tail = entry;
+    }
+
+    *res = head;
+    0
 }
 
 ///
@@ -367,4 +546,311 @@ pub unsafe extern "C" fn hstrerror(err: c_int) -> *const c_char {
 pub unsafe extern "C" fn __h_errno() -> *mut c_int {
     ::syslog::debug!("__h_errno(): not implemented");
     ::core::ptr::null_mut()
+}
+
+//==================================================================================================
+// Private Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Resolves the `node` argument of `getaddrinfo()` into an IPv4 address. Because no name resolver
+/// is available, only numeric address strings are accepted; a null `node` yields the loopback
+/// address, or `INADDR_ANY` when `AI_PASSIVE` is set.
+///
+/// # Parameters
+///
+/// - `node`: Pointer to a null-terminated host string, or null.
+/// - `flags`: The `ai_flags` value supplied through the `hints` structure.
+///
+/// # Returns
+///
+/// The resolved [`in_addr`] on success, or an `EAI_*` error code on failure.
+///
+/// # Safety
+///
+/// The caller must ensure `node` is either null or a valid null-terminated string.
+///
+unsafe fn resolve_node(node: *const c_char, flags: c_int) -> Result<in_addr, c_int> {
+    if node.is_null() {
+        // With `AI_PASSIVE` the result is meant for binding, so use the wildcard address;
+        // otherwise use the loopback address.
+        let s_addr: u32 = if flags & AI_PASSIVE != 0 {
+            // INADDR_ANY (0.0.0.0).
+            0
+        } else {
+            // INADDR_LOOPBACK (127.0.0.1), stored in network byte order.
+            0x7f00_0001u32.to_be()
+        };
+        return Ok(in_addr { s_addr });
+    }
+
+    let mut addr: in_addr = in_addr { s_addr: 0 };
+    if inet_aton(node, &raw mut addr) != 0 {
+        Ok(addr)
+    } else {
+        // Not a numeric address, and there is no resolver to consult.
+        Err(EAI_NONAME)
+    }
+}
+
+///
+/// # Description
+///
+/// Resolves the `service` argument of `getaddrinfo()` into a port number. Because no service
+/// database is available, only numeric port strings are accepted; a null `service` yields port 0.
+///
+/// # Parameters
+///
+/// - `service`: Pointer to a null-terminated service string, or null.
+/// - `flags`: The `ai_flags` value supplied through the `hints` structure.
+///
+/// # Returns
+///
+/// The resolved port in host byte order on success, or an `EAI_*` error code on failure.
+///
+/// # Safety
+///
+/// The caller must ensure `service` is either null or a valid null-terminated string.
+///
+unsafe fn resolve_service(service: *const c_char, flags: c_int) -> Result<u16, c_int> {
+    if service.is_null() {
+        return Ok(0);
+    }
+
+    match parse_port(service) {
+        Some(port) => Ok(port),
+        None => {
+            if flags & AI_NUMERICSERV != 0 {
+                // A numeric service was required but the string was not numeric.
+                Err(EAI_NONAME)
+            } else {
+                // Named services cannot be resolved without a services database.
+                Err(EAI_SERVICE)
+            }
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Parses a decimal port number from a null-terminated string.
+///
+/// # Parameters
+///
+/// - `service`: Pointer to a null-terminated string.
+///
+/// # Returns
+///
+/// The parsed port on success, or [`None`] if the string is empty, contains a non-digit, or the
+/// value exceeds 65535.
+///
+/// # Safety
+///
+/// The caller must ensure `service` points to a valid null-terminated string.
+///
+unsafe fn parse_port(service: *const c_char) -> Option<u16> {
+    let mut index: usize = 0;
+    let mut value: u32 = 0;
+    let mut digits: usize = 0;
+    loop {
+        let byte: u8 = *service.add(index) as u8;
+        if byte == 0 {
+            break;
+        }
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value * 10 + u32::from(byte - b'0');
+        if value > u32::from(u16::MAX) {
+            return None;
+        }
+        digits += 1;
+        index += 1;
+    }
+
+    if digits == 0 {
+        return None;
+    }
+
+    Some(value as u16)
+}
+
+///
+/// # Description
+///
+/// Determines the `(socket type, protocol)` pairs that `getaddrinfo()` should emit for the given
+/// hints. When the socket type is unspecified, both stream (TCP) and datagram (UDP) entries are
+/// produced unless a protocol pins a single one.
+///
+/// # Parameters
+///
+/// - `socktype`: The requested socket type, or 0 if unspecified.
+/// - `protocol`: The requested protocol, or 0 if unspecified.
+/// - `out`: Destination array that receives the pairs.
+///
+/// # Returns
+///
+/// The number of pairs written to `out`, or an `EAI_*` error code when the requested protocol
+/// cannot be represented by the requested socket type.
+///
+fn fill_socktype_pairs(
+    socktype: c_int,
+    protocol: c_int,
+    out: &mut [(c_int, c_int); 2],
+) -> Result<usize, c_int> {
+    if socktype == SOCK_STREAM && protocol != 0 && protocol != IPPROTO_TCP {
+        return Err(EAI_SOCKTYPE);
+    }
+    if socktype == SOCK_DGRAM && protocol != 0 && protocol != IPPROTO_UDP {
+        return Err(EAI_SOCKTYPE);
+    }
+
+    if socktype != 0 {
+        out[0] = (socktype, resolve_protocol(socktype, protocol));
+        Ok(1)
+    } else if protocol == IPPROTO_TCP {
+        out[0] = (SOCK_STREAM, IPPROTO_TCP);
+        Ok(1)
+    } else if protocol == IPPROTO_UDP {
+        out[0] = (SOCK_DGRAM, IPPROTO_UDP);
+        Ok(1)
+    } else if protocol != 0 {
+        Err(EAI_SERVICE)
+    } else {
+        out[0] = (SOCK_STREAM, resolve_protocol(SOCK_STREAM, protocol));
+        out[1] = (SOCK_DGRAM, resolve_protocol(SOCK_DGRAM, protocol));
+        Ok(2)
+    }
+}
+
+///
+/// # Description
+///
+/// Selects the protocol for an addrinfo entry, honoring an explicit protocol and otherwise
+/// inferring it from the socket type.
+///
+/// # Parameters
+///
+/// - `socktype`: The socket type of the entry.
+/// - `protocol`: The requested protocol, or 0 if unspecified.
+///
+/// # Returns
+///
+/// The protocol to record in the entry.
+///
+fn resolve_protocol(socktype: c_int, protocol: c_int) -> c_int {
+    if protocol != 0 {
+        protocol
+    } else if socktype == SOCK_STREAM {
+        IPPROTO_TCP
+    } else if socktype == SOCK_DGRAM {
+        IPPROTO_UDP
+    } else {
+        0
+    }
+}
+
+///
+/// # Description
+///
+/// Allocates and initializes a single addrinfo node. The node, its [`sockaddr_in`], and its
+/// optional canonical name are packed into one allocation so that `freeaddrinfo()` can release the
+/// whole entry with a single call to `free()`.
+///
+/// # Parameters
+///
+/// - `socktype`: Socket type to record in the node.
+/// - `protocol`: Protocol to record in the node.
+/// - `port`: Port number in host byte order.
+/// - `addr`: IPv4 address in network byte order.
+/// - `canon`: Optional canonical name bytes (without the terminating NUL).
+///
+/// # Returns
+///
+/// A pointer to the initialized node, or null if allocation fails.
+///
+/// # Safety
+///
+/// This function allocates memory with `malloc` and writes through raw pointers.
+///
+unsafe fn alloc_node(
+    socktype: c_int,
+    protocol: c_int,
+    port: u16,
+    addr: in_addr,
+    canon: Option<&[u8]>,
+) -> *mut addrinfo {
+    let ai_size: usize = mem::size_of::<addrinfo>();
+    let sa_size: usize = mem::size_of::<sockaddr_in>();
+    let canon_size: usize = canon.map_or(0, |bytes| bytes.len() + 1);
+    let total: usize = ai_size + sa_size + canon_size;
+
+    let block: *mut u8 = malloc(total as c_size_t) as *mut u8;
+    if block.is_null() {
+        return ptr::null_mut();
+    }
+
+    // Carve the block into the addrinfo header, the socket address, and the canonical name.
+    let sa_ptr: *mut sockaddr_in = block.add(ai_size) as *mut sockaddr_in;
+    let canon_ptr: *const c_char = match canon {
+        Some(bytes) => {
+            let dst: *mut u8 = block.add(ai_size + sa_size);
+            ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
+            *dst.add(bytes.len()) = 0;
+            dst as *const c_char
+        },
+        None => ptr::null(),
+    };
+
+    // `sockaddr_in` is packed, so build the value and write it as a whole.
+    let sin: sockaddr_in = sockaddr_in {
+        sin_len: sa_size as u8,
+        sin_family: AF_INET as sa_family_t,
+        sin_port: port.to_be(),
+        sin_addr: addr,
+        sin_zero: [0; 8],
+    };
+    ptr::write(sa_ptr, sin);
+
+    let info: addrinfo = addrinfo {
+        ai_flags: 0,
+        ai_family: AF_INET,
+        ai_socktype: socktype,
+        ai_protocol: protocol,
+        ai_addrlen: sa_size as socklen_t,
+        ai_canonname: canon_ptr,
+        ai_addr: sa_ptr as *const sockaddr,
+        ai_next: ptr::null_mut(),
+    };
+    ptr::write(block as *mut addrinfo, info);
+
+    block as *mut addrinfo
+}
+
+///
+/// # Description
+///
+/// Computes the length of a null-terminated string, excluding the terminating NUL.
+///
+/// # Parameters
+///
+/// - `s`: Pointer to a null-terminated string.
+///
+/// # Returns
+///
+/// The number of bytes preceding the terminating NUL.
+///
+/// # Safety
+///
+/// The caller must ensure `s` points to a valid null-terminated string.
+///
+unsafe fn c_str_len(s: *const c_char) -> usize {
+    let mut len: usize = 0;
+    while *s.add(len) != 0 {
+        len += 1;
+    }
+    len
 }

--- a/src/tests/integration/test-c-netdb/main.c
+++ b/src/tests/integration/test-c-netdb/main.c
@@ -1,0 +1,568 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Returns the number of entries in an addrinfo linked list.
+static size_t ai_count(const struct addrinfo *list)
+{
+    size_t count = 0;
+    for (const struct addrinfo *node = list; node != NULL; node = node->ai_next) {
+        count++;
+    }
+    return count;
+}
+
+// Asserts that an addrinfo node carries an IPv4 socket address with the expected network-order
+// address and (host-order) port.
+static void check_ipv4(const struct addrinfo *ai, in_addr_t expect_net_addr, uint16_t expect_port)
+{
+    assert(ai->ai_family == AF_INET);
+    assert(ai->ai_addr != NULL);
+    assert(ai->ai_addrlen == sizeof(struct sockaddr_in));
+
+    const struct sockaddr_in *sin = (const struct sockaddr_in *)(const void *)ai->ai_addr;
+    assert(sin->sin_family == AF_INET);
+    assert(sin->sin_addr.s_addr == expect_net_addr);
+    assert(sin->sin_port == htons(expect_port));
+}
+
+//==================================================================================================
+// getaddrinfo(): numeric host resolution (#458)
+//==================================================================================================
+
+// Tests that a numeric host with a pinned stream socket type yields a single TCP entry.
+static void test_numeric_host_stream(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "8080", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+
+    // A pinned socket type produces exactly one entry.
+    assert(ai_count(res) == 1);
+    assert(res->ai_next == NULL);
+    assert(res->ai_socktype == SOCK_STREAM);
+    assert(res->ai_protocol == IPPROTO_TCP);
+    check_ipv4(res, htonl(0x7f000001), 8080);
+
+    freeaddrinfo(res);
+}
+
+// Tests that a numeric host with a pinned datagram socket type yields a single UDP entry.
+static void test_numeric_host_dgram(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("192.168.1.1", "53", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+
+    assert(ai_count(res) == 1);
+    assert(res->ai_socktype == SOCK_DGRAM);
+    assert(res->ai_protocol == IPPROTO_UDP);
+    check_ipv4(res, inet_addr("192.168.1.1"), 53);
+
+    freeaddrinfo(res);
+}
+
+// Tests that an unspecified socket type produces one stream and one datagram entry, in that order.
+static void test_unspecified_socktype(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("10.0.0.1", "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    assert(ai_count(res) == 2);
+
+    const struct addrinfo *first = res;
+    const struct addrinfo *second = res->ai_next;
+    assert(first->ai_socktype == SOCK_STREAM);
+    assert(first->ai_protocol == IPPROTO_TCP);
+    assert(second->ai_socktype == SOCK_DGRAM);
+    assert(second->ai_protocol == IPPROTO_UDP);
+    assert(second->ai_next == NULL);
+
+    check_ipv4(first, inet_addr("10.0.0.1"), 80);
+    check_ipv4(second, inet_addr("10.0.0.1"), 80);
+
+    freeaddrinfo(res);
+}
+
+// Tests that null hints behave like an unconstrained IPv4 lookup.
+static void test_null_hints(void)
+{
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("8.8.8.8", "443", NULL, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+
+    // Every entry must describe the same IPv4 endpoint.
+    for (const struct addrinfo *node = res; node != NULL; node = node->ai_next) {
+        check_ipv4(node, inet_addr("8.8.8.8"), 443);
+    }
+
+    freeaddrinfo(res);
+}
+
+// Tests that AI_NUMERICHOST accepts a numeric host.
+static void test_numeric_host_flag(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    check_ipv4(res, htonl(0x7f000001), 80);
+
+    freeaddrinfo(res);
+}
+
+// Tests that a protocol hint alone selects the matching socket type.
+static void test_protocol_selects_socktype(void)
+{
+    struct addrinfo hints;
+    struct addrinfo *res;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_protocol = IPPROTO_TCP;
+    res = NULL;
+    assert(getaddrinfo("127.0.0.1", "80", &hints, &res) == 0);
+    assert(ai_count(res) == 1);
+    assert(res->ai_socktype == SOCK_STREAM);
+    assert(res->ai_protocol == IPPROTO_TCP);
+    freeaddrinfo(res);
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_protocol = IPPROTO_UDP;
+    res = NULL;
+    assert(getaddrinfo("127.0.0.1", "80", &hints, &res) == 0);
+    assert(ai_count(res) == 1);
+    assert(res->ai_socktype == SOCK_DGRAM);
+    assert(res->ai_protocol == IPPROTO_UDP);
+    freeaddrinfo(res);
+}
+
+// Tests that contradictory protocol and socket-type hints are rejected.
+static void test_protocol_rejects_incompatible_socktype(void)
+{
+    struct addrinfo hints;
+    struct addrinfo *res;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    res = NULL;
+    assert(getaddrinfo("127.0.0.1", "80", &hints, &res) == EAI_SOCKTYPE);
+    assert(res == NULL);
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    res = NULL;
+    assert(getaddrinfo("127.0.0.1", "80", &hints, &res) == EAI_SOCKTYPE);
+    assert(res == NULL);
+}
+
+// Tests that an unspecified socket type cannot be inferred from an unsupported protocol.
+static void test_protocol_rejects_unknown_socktype(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_protocol = IPPROTO_RAW;
+
+    struct addrinfo *res = NULL;
+    assert(getaddrinfo("127.0.0.1", "80", &hints, &res) == EAI_SERVICE);
+    assert(res == NULL);
+}
+
+// Tests that a raw socket type is accepted and passed through with the requested protocol.
+static void test_raw_socktype(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_RAW;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "0", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    assert(ai_count(res) == 1);
+    assert(res->ai_socktype == SOCK_RAW);
+
+    freeaddrinfo(res);
+}
+
+//==================================================================================================
+// getaddrinfo(): passive and loopback defaults
+//==================================================================================================
+
+// Tests that a null host with AI_PASSIVE resolves to the wildcard address.
+static void test_passive_wildcard(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo(NULL, "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    check_ipv4(res, htonl(INADDR_ANY), 80);
+
+    freeaddrinfo(res);
+}
+
+// Tests that a null host without AI_PASSIVE resolves to the loopback address.
+static void test_null_host_loopback(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo(NULL, "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    check_ipv4(res, htonl(INADDR_LOOPBACK), 80);
+
+    freeaddrinfo(res);
+}
+
+//==================================================================================================
+// getaddrinfo(): service handling
+//==================================================================================================
+
+// Tests that a null service resolves to port zero.
+static void test_service_null(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", NULL, &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    check_ipv4(res, htonl(INADDR_LOOPBACK), 0);
+
+    freeaddrinfo(res);
+}
+
+// Tests that the boundary numeric ports are accepted.
+static void test_service_port_bounds(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    assert(getaddrinfo("127.0.0.1", "0", &hints, &res) == 0);
+    check_ipv4(res, htonl(INADDR_LOOPBACK), 0);
+    freeaddrinfo(res);
+
+    res = NULL;
+    assert(getaddrinfo("127.0.0.1", "65535", &hints, &res) == 0);
+    check_ipv4(res, htonl(INADDR_LOOPBACK), 65535);
+    freeaddrinfo(res);
+}
+
+//==================================================================================================
+// getaddrinfo(): canonical name
+//==================================================================================================
+
+// Tests that AI_CANONNAME reports the numeric host string.
+static void test_canonname_numeric(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_CANONNAME;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    assert(res->ai_canonname != NULL);
+    assert(strcmp(res->ai_canonname, "127.0.0.1") == 0);
+
+    freeaddrinfo(res);
+}
+
+// Tests that AI_CANONNAME attaches the canonical name to the first entry only.
+static void test_canonname_first_only(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_flags = AI_CANONNAME;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+    assert(ret == 0);
+    assert(res != NULL);
+    assert(ai_count(res) == 2);
+    assert(res->ai_canonname != NULL);
+    assert(strcmp(res->ai_canonname, "127.0.0.1") == 0);
+    assert(res->ai_next->ai_canonname == NULL);
+
+    freeaddrinfo(res);
+}
+
+// Tests that AI_CANONNAME reports the synthesized address string for a null host.
+static void test_canonname_null_host(void)
+{
+    struct addrinfo hints;
+    struct addrinfo *res;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_CANONNAME | AI_PASSIVE;
+    res = NULL;
+    assert(getaddrinfo(NULL, "80", &hints, &res) == 0);
+    assert(res->ai_canonname != NULL);
+    assert(strcmp(res->ai_canonname, "0.0.0.0") == 0);
+    freeaddrinfo(res);
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_CANONNAME;
+    res = NULL;
+    assert(getaddrinfo(NULL, "80", &hints, &res) == 0);
+    assert(res->ai_canonname != NULL);
+    assert(strcmp(res->ai_canonname, "127.0.0.1") == 0);
+    freeaddrinfo(res);
+}
+
+//==================================================================================================
+// getaddrinfo(): error handling
+//==================================================================================================
+
+// Tests that supplying neither a host nor a service fails with EAI_NONAME.
+static void test_both_null(void)
+{
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo(NULL, NULL, NULL, &res);
+    assert(ret == EAI_NONAME);
+}
+
+// Tests that a non-numeric host fails with EAI_NONAME, as no resolver is available.
+static void test_nonnumeric_host(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("example.com", "80", &hints, &res);
+    assert(ret == EAI_NONAME);
+    // On error the result list must be left empty.
+    assert(res == NULL);
+
+    // AI_NUMERICHOST rejects a non-numeric host the same way.
+    hints.ai_flags = AI_NUMERICHOST;
+    ret = getaddrinfo("example.com", "80", &hints, &res);
+    assert(ret == EAI_NONAME);
+}
+
+// Tests that a named service is not resolvable without a services database.
+static void test_named_service(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+
+    // Without AI_NUMERICSERV a named service is reported as unavailable.
+    assert(getaddrinfo("127.0.0.1", "http", &hints, &res) == EAI_SERVICE);
+
+    // With AI_NUMERICSERV a non-numeric service is reported as an unresolvable name.
+    hints.ai_flags = AI_NUMERICSERV;
+    assert(getaddrinfo("127.0.0.1", "http", &hints, &res) == EAI_NONAME);
+}
+
+// Tests that out-of-range and malformed numeric services are rejected.
+static void test_service_out_of_range(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    assert(getaddrinfo("127.0.0.1", "65536", &hints, &res) == EAI_SERVICE);
+    assert(getaddrinfo("127.0.0.1", "99999", &hints, &res) == EAI_SERVICE);
+    assert(getaddrinfo("127.0.0.1", "80x", &hints, &res) == EAI_SERVICE);
+    assert(getaddrinfo("127.0.0.1", "-1", &hints, &res) == EAI_SERVICE);
+}
+
+// Tests that unknown flags fail with EAI_BADFLAGS.
+static void test_bad_flags(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = 0x8000; // Not a recognized AI_* flag.
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+    assert(ret == EAI_BADFLAGS);
+}
+
+// Tests that an unsupported address family fails with EAI_FAMILY.
+static void test_unsupported_family(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET6; // Only IPv4 is supported.
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("::1", "80", &hints, &res);
+    assert(ret == EAI_FAMILY);
+}
+
+// Tests that an unsupported socket type fails with EAI_SOCKTYPE.
+static void test_unsupported_socktype(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = 999; // Not a recognized SOCK_* type.
+
+    struct addrinfo *res = NULL;
+    int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+    assert(ret == EAI_SOCKTYPE);
+}
+
+//==================================================================================================
+// freeaddrinfo()  (#457)
+//==================================================================================================
+
+// Tests that freeaddrinfo() releases a multi-entry list without error and tolerates a null list.
+static void test_freeaddrinfo(void)
+{
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_flags = AI_CANONNAME; // Force a canonical-name allocation on the first entry.
+
+    // Repeatedly allocate and free a multi-entry list; a leak or double-free would surface as an
+    // allocation failure or a crash across iterations.
+    for (int i = 0; i < 64; i++) {
+        struct addrinfo *res = NULL;
+        int ret = getaddrinfo("127.0.0.1", "80", &hints, &res);
+        assert(ret == 0);
+        assert(res != NULL);
+        assert(ai_count(res) == 2);
+        freeaddrinfo(res);
+    }
+
+    // Freeing a null list is a well-defined no-op.
+    freeaddrinfo(NULL);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests the POSIX network database calls exposed by <netdb.h>.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_numeric_host_stream();
+    test_numeric_host_dgram();
+    test_unspecified_socktype();
+    test_null_hints();
+    test_numeric_host_flag();
+    test_protocol_selects_socktype();
+    test_protocol_rejects_incompatible_socktype();
+    test_protocol_rejects_unknown_socktype();
+    test_raw_socktype();
+    test_passive_wildcard();
+    test_null_host_loopback();
+    test_service_null();
+    test_service_port_bounds();
+    test_canonname_numeric();
+    test_canonname_first_only();
+    test_canonname_null_host();
+    test_both_null();
+    test_nonnumeric_host();
+    test_named_service();
+    test_service_out_of_range();
+    test_bad_flags();
+    test_unsupported_family();
+    test_unsupported_socktype();
+    test_freeaddrinfo();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -281,6 +281,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-netdb"
+program = "./bin/test-c-netdb.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-network"
 program = "./bin/test-c-network.initrd"
 extra_nanvixd_args = "-allow-host-networking"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -281,6 +281,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-netdb"
+program = "./bin/test-c-netdb.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-network"
 program = "./bin/test-c-network.initrd"
 extra_nanvixd_args = "-allow-host-networking"


### PR DESCRIPTION
## Summary

Implement `getaddrinfo()` and `freeaddrinfo()` in `libc_netdb` for numeric IPv4
lookups, replacing the previous stubs, and add a POSIX C integration suite that
exercises the new behavior.

## What changed

**Library (`libc_netdb`):**
- Implement `getaddrinfo()` for numeric IPv4 hosts (via `inet_aton`) and numeric
  ports. No name/service resolver is available, so only numeric forms succeed.
- Validate hints: reject unknown `ai_flags` (`EAI_BADFLAGS`), non-IPv4 families
  (`EAI_FAMILY`), unsupported/contradictory socket types (`EAI_SOCKTYPE`), and
  require at least one of node/service (`EAI_NONAME`).
- Resolve a null node to loopback, or `INADDR_ANY` under `AI_PASSIVE`; resolve a
  null service to port 0.
- Emit one `addrinfo` node per (socktype, protocol) pair, defaulting to TCP+UDP
  when the socket type is unspecified; attach the canonical name to the first
  node only under `AI_CANONNAME`.
- Pack each node, its `sockaddr_in`, and its canonical name into a single
  allocation so `freeaddrinfo()` releases one entry per `free()`. Free partial
  results on allocation failure (`EAI_MEMORY`).

**Tests:**
- Add the `test-c-netdb` POSIX suite covering numeric host resolution across
  socket types, protocol-driven selection, passive/loopback defaults, service
  handling and boundaries, `AI_CANONNAME`, error paths, and `freeaddrinfo()`
  over multi-entry and null lists.
- Register the suite in the POSIX build list and the Linux/Windows POSIX test
  manifests.

## Validation

- `./z build -- run-posix-tests DEPLOYMENT_MODE=standalone` (includes
  `posix/test-c-netdb`)
- `./z build -- test`

Closes #457, closes #458.