### PR TITLE
[doc] Fix Stale libposix.a References

### DIFF
--- a/.github/skills/user-app-development/SKILL.md
+++ b/.github/skills/user-app-development/SKILL.md
@@ -147,7 +147,7 @@ For low-level debugging, the standalone UserVM is still available:
 1. Create directory at `src/user/<name>/`.
 2. Create a `Makefile` following the pattern in existing C applications.
 3. Write source files using the Nanvix POSIX layer (`#include <nanvix/...>`).
-4. The application links against `libposix.a`, `libc.a`, and the custom linker script at
+4. The application links against `libc.a` and the custom linker script at
    `build/user/linker/x86/user.ld`.
 
 ## Logging

--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -73,7 +73,7 @@ SECTIONS
 	/*
 	 * Constructor / destructor arrays (the primary ctor/dtor mechanism).
 	 *
-	 * `__nanvix_libc_start_main` (libposix start.rs) walks `.preinit_array`
+	 * `__nanvix_libc_start_main` (nanvix_libc start.rs) walks `.preinit_array`
 	 * then `.init_array` before calling `main`, and `.fini_array` (in reverse)
 	 * after `main` returns.  The bound symbols below are provided HERE — not by
 	 * GCC crtbegin/crtend — because Nanvix ships no crti/crtn/crtbegin/crtend.

--- a/build/user/linker/x86_64/user.ld
+++ b/build/user/linker/x86_64/user.ld
@@ -55,7 +55,7 @@ SECTIONS
 	/*
 	 * Constructor / destructor arrays (the primary ctor/dtor mechanism).
 	 *
-	 * `__nanvix_libc_start_main` (libposix start.rs) walks `.preinit_array`
+	 * `__nanvix_libc_start_main` (nanvix_libc start.rs) walks `.preinit_array`
 	 * then `.init_array` before calling `main`, and `.fini_array` (in reverse)
 	 * after `main` returns.  The bound symbols below are provided HERE — not by
 	 * GCC crtbegin/crtend — because Nanvix ships no crti/crtn/crtbegin/crtend.

--- a/doc/run-linux.md
+++ b/doc/run-linux.md
@@ -62,7 +62,7 @@ boot:
 ```
 
 The three daemon binaries (`procd.elf`, `memd.elf`, `vfsd.elf`) are shipped in the release
-archive under `bin/`. Your application binary must be compiled and linked against `libposix.a`
+archive under `bin/`. Your application binary must be compiled and linked against `libc.a`
 using the `user.ld` linker script (both also in the release archive).
 
 Once the image is created, pass it to `nanvixd` as the program argument:

--- a/doc/run-windows.md
+++ b/doc/run-windows.md
@@ -54,7 +54,7 @@ boot:
 ```
 
 The three daemon binaries (`procd.elf`, `memd.elf`, `vfsd.elf`) are shipped in the release
-archive under `bin/`. Your application binary must be compiled and linked against `libposix.a`
+archive under `bin/`. Your application binary must be compiled and linked against `libc.a`
 using the `user.ld` linker script (both also in the release archive).
 
 Once the image is created, pass it to `nanvixd` as the program argument:


### PR DESCRIPTION
## What

Corrects user-facing docs and linker comments that still referred to a standalone `libposix.a`. The C library is now delivered as a single `libc.a` produced by the `nanvix_libc` aggregator (which bundles the `libc_*` surface, including `libc_stdio`); there is no separate `libposix.a`.

## Changes

- **Run guides** (`doc/run-linux.md`, `doc/run-windows.md`): link apps against `libc.a` instead of `libposix.a`.
- **user-app-development skill**: drop the phantom `libposix.a` from the C application link line.
- **Linker scripts** (`x86`, `x86_64`): attribute `__nanvix_libc_start_main` to `nanvix_libc start.rs` rather than libposix.

## Why

The `libposix.a` archive no longer exists after the `nanvix_libc`/`libc.a` refactor, so following these docs would mislead users into linking against a nonexistent artifact. Documentation-only change; no behavioral impact.

Closes #2648