### PR TITLE
[syscall] Implement Unnamed Semaphores

### DIFF
--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SEMAPHORE_H
+#define _NANVIX_SEMAPHORE_H
+
+/**
+ * @file semaphore.h
+ * @brief Semaphores.
+ *
+ * Declares the POSIX unnamed semaphore type and operations. The semaphore is
+ * built on top of the kernel mutex and condition variable primitives; its layout
+ * mirrors the Rust definition in the sysapi crate (sys_types.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Unnamed semaphore. */
+typedef struct {
+    int __count;            /**< Current value of the semaphore.          */
+    pthread_mutex_t __lock; /**< Mutex that guards the semaphore state.    */
+    pthread_cond_t __cond;  /**< Condition variable used to block waiters. */
+} sem_t;
+
+/*==================================================================================================
+ * Semaphores
+ *==================================================================================================*/
+
+extern int sem_init(sem_t *sem, int pshared, unsigned int value);
+extern int sem_destroy(sem_t *sem);
+extern int sem_post(sem_t *sem);
+extern int sem_wait(sem_t *sem);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SEMAPHORE_H */

--- a/src/libs/sysapi/headers/semaphore.toml
+++ b/src/libs/sysapi/headers/semaphore.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for semaphore.h.
+
+file = "semaphore.h"
+brief = "Semaphores."
+description = '''
+Declares the POSIX unnamed semaphore type and operations. The semaphore is
+built on top of the kernel mutex and condition variable primitives; its layout
+mirrors the Rust definition in the sysapi crate (sys_types.rs).'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SEMAPHORE_H"
+scan_crates = ["syscall"]
+
+[[types]]
+text = '''
+/** @brief Unnamed semaphore. */
+typedef struct {
+    int __count;            /**< Current value of the semaphore.          */
+    pthread_mutex_t __lock; /**< Mutex that guards the semaphore state.    */
+    pthread_cond_t __cond;  /**< Condition variable used to block waiters. */
+} sem_t;'''
+
+[[sections]]
+title = "Semaphores"
+functions = ["sem_init", "sem_destroy", "sem_post", "sem_wait"]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -406,6 +406,41 @@ impl pthread_once_t {
     }
 }
 
+///
+/// # Description
+///
+/// Unnamed semaphore.
+///
+/// This is the backing storage for a POSIX unnamed semaphore. It is built on top of the kernel
+/// mutex and condition variable primitives: `lock` serializes access to `count`, while `cond`
+/// blocks waiters until the semaphore value becomes positive. The `lock` and `cond` fields are
+/// identified by their addresses, exactly like a `pthread_mutex_t` / `pthread_cond_t`, so each
+/// distinct `sem_t` owns a distinct pair of kernel synchronization objects.
+///
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct sem_t {
+    /// Current value of the semaphore.
+    pub count: c_int,
+    /// Mutex that guards the semaphore value.
+    pub lock: pthread_mutex_t,
+    /// Condition variable used to block waiters.
+    pub cond: pthread_cond_t,
+}
+::static_assert::assert_eq_size!(sem_t, sem_t::SIZE);
+
+impl sem_t {
+    /// Size of the `count` field.
+    const SIZE_OF_COUNT: usize = size_of::<c_int>();
+    /// Size of the `lock` field.
+    const SIZE_OF_LOCK: usize = size_of::<pthread_mutex_t>();
+    /// Size of the `cond` field.
+    const SIZE_OF_COND: usize = size_of::<pthread_cond_t>();
+
+    /// Size of `sem_t` structure.
+    pub const SIZE: usize = Self::SIZE_OF_COUNT + Self::SIZE_OF_LOCK + Self::SIZE_OF_COND;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 #[cfg(target_pointer_width = "32")]

--- a/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
@@ -5,9 +5,11 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use crate::errno::__errno_location;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::sem_t,
 };
 use ::syslog::trace_libcall;
 
@@ -15,12 +17,44 @@ use ::syslog::trace_libcall;
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Destroys the unnamed semaphore referred to by `sem`.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to destroy.
+///
+/// # Returns
+///
+/// Upon successful completion, `0` is returned. Otherwise, `-1` is returned and `errno` is set to
+/// indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `sem` points to a valid `sem_t` structure that was previously initialized by `sem_init()`.
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn sem_destroy(sem: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/722
-    ::syslog::debug!("sem_destroy(): not implemented");
-    0
+pub unsafe extern "C" fn sem_destroy(sem: *mut sem_t) -> c_int {
+    // Check if `sem` is not valid.
+    if sem.is_null() {
+        ::syslog::warn!("sem_destroy(): invalid semaphore pointer");
+        *__errno_location() = ErrorCode::InvalidArgument.get();
+        return -1;
+    }
+
+    match crate::pthread::sem_destroy(&mut *sem) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::warn!("sem_destroy(): {error:?}");
+            *__errno_location() = error.code.get();
+            -1
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_init.rs
@@ -5,9 +5,14 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use crate::errno::__errno_location;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uint,
+    },
+    sys_types::sem_t,
 };
 use ::syslog::trace_libcall;
 
@@ -15,12 +20,53 @@ use ::syslog::trace_libcall;
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Initializes the unnamed semaphore referred to by `sem` and sets its initial value to `value`.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to initialize.
+/// - `pshared`: Whether the semaphore is shared between processes.
+/// - `value`: Initial value of the semaphore.
+///
+/// # Returns
+///
+/// Upon successful completion, `0` is returned. Otherwise, `-1` is returned and `errno` is set to
+/// indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `sem` points to a valid `sem_t` structure.
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn sem_init(sem: *mut c_void, pshared: c_int, value: u32) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/721
-    ::syslog::debug!("sem_init(): not implemented");
-    0
+pub unsafe extern "C" fn sem_init(sem: *mut sem_t, pshared: c_int, value: c_uint) -> c_int {
+    // Check if `sem` is not valid.
+    if sem.is_null() {
+        ::syslog::warn!("sem_init(): invalid semaphore pointer");
+        *__errno_location() = ErrorCode::InvalidArgument.get();
+        return -1;
+    }
+
+    // Process-shared semaphores are not supported; only process-private semantics are provided.
+    if pshared != 0 {
+        ::syslog::warn!("sem_init(): process-shared semaphores are not supported");
+        *__errno_location() = ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
+    match crate::pthread::sem_init(&mut *sem, value) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::warn!("sem_init(): {error:?}");
+            *__errno_location() = error.code.get();
+            -1
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_post.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_post.rs
@@ -5,9 +5,11 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use crate::errno::__errno_location;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::sem_t,
 };
 use ::syslog::trace_libcall;
 
@@ -15,11 +17,45 @@ use ::syslog::trace_libcall;
 // Standalone Functions
 //==================================================================================================
 
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Unlocks the unnamed semaphore referred to by `sem`, incrementing its value and waking up a
+/// blocked waiter, if any.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to unlock.
+///
+/// # Returns
+///
+/// Upon successful completion, `0` is returned. Otherwise, `-1` is returned and `errno` is set to
+/// indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `sem` points to a valid `sem_t` structure that was previously initialized by `sem_init()`.
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn sem_post(sem: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/723
-    ::syslog::debug!("sem_post(): not implemented");
-    0
+pub unsafe extern "C" fn sem_post(sem: *mut sem_t) -> c_int {
+    // Check if `sem` is not valid.
+    if sem.is_null() {
+        ::syslog::warn!("sem_post(): invalid semaphore pointer");
+        *__errno_location() = ErrorCode::InvalidArgument.get();
+        return -1;
+    }
+
+    match crate::pthread::sem_post(&mut *sem) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::warn!("sem_post(): {error:?}");
+            *__errno_location() = error.code.get();
+            -1
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_wait.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_wait.rs
@@ -5,19 +5,57 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::c_int;
+use crate::errno::__errno_location;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::sem_t,
+};
 use ::syslog::trace_libcall;
-use sysapi::ffi::c_void;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Locks the unnamed semaphore referred to by `sem`, blocking the calling thread until its value
+/// becomes positive and then decrementing it.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to lock.
+///
+/// # Returns
+///
+/// Upon successful completion, `0` is returned. Otherwise, `-1` is returned and `errno` is set to
+/// indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `sem` points to a valid `sem_t` structure that was previously initialized by `sem_init()`.
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
-pub unsafe extern "C" fn sem_wait(sem: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/724
-    unimplemented!()
+pub unsafe extern "C" fn sem_wait(sem: *mut sem_t) -> c_int {
+    // Check if `sem` is not valid.
+    if sem.is_null() {
+        ::syslog::warn!("sem_wait(): invalid semaphore pointer");
+        *__errno_location() = ErrorCode::InvalidArgument.get();
+        return -1;
+    }
+
+    match crate::pthread::sem_wait(&mut *sem) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::warn!("sem_wait(): {error:?}");
+            *__errno_location() = error.code.get();
+            -1
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -27,6 +27,10 @@ cfg_if::cfg_if! {
         pub use syscall::pthread_rwlock_rdlock;
         pub use syscall::pthread_rwlock_wrlock;
         pub use syscall::pthread_rwlock_unlock;
+        pub use syscall::sem_init;
+        pub use syscall::sem_destroy;
+        pub use syscall::sem_post;
+        pub use syscall::sem_wait;
         pub use syscall::pthread_cond_broadcast;
         pub use syscall::pthread_cond_destroy;
         pub use syscall::pthread_cond_init;

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -14,6 +14,9 @@ mod mutex;
 /// Read-write locks.
 mod rwlock;
 
+/// Semaphores.
+mod sem;
+
 /// Thread-specific data area.
 mod tda;
 
@@ -74,6 +77,7 @@ pub use pthread_attr_getstack::*;
 pub use pthread_attr_init::*;
 pub use pthread_getattr_np::*;
 pub use rwlock::*;
+pub use sem::*;
 pub use tda::*;
 
 //==================================================================================================

--- a/src/libs/syscall/src/pthread/syscall/sem.rs
+++ b/src/libs/syscall/src/pthread/syscall/sem.rs
@@ -1,0 +1,150 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_uint,
+    },
+    pthread::{
+        PTHREAD_COND_INITIALIZER,
+        PTHREAD_MUTEX_INITIALIZER,
+    },
+    sys_types::{
+        pthread_condattr_t,
+        pthread_mutexattr_t,
+        sem_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes an unnamed semaphore built on top of the kernel mutex and condition variable
+/// primitives.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to initialize.
+/// - `value`: Initial value of the semaphore.
+///
+/// # Returns
+///
+/// Upon success, an empty result is returned. Upon failure, an error is returned instead.
+///
+pub fn sem_init(sem: &mut sem_t, value: c_uint) -> Result<(), Error> {
+    // Reject values that cannot be represented by the semaphore counter.
+    if value > c_int::MAX as c_uint {
+        let reason: &str = "semaphore value exceeds maximum";
+        ::syslog::warn!("sem_init(): {} (value={})", reason, value);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    // Initialize the semaphore state. The `lock` and `cond` words are set to their static
+    // initializer sentinels so that they are recognized as initialized even along the lazy
+    // registration path (e.g. after `fork()`).
+    sem.count = value as c_int;
+    sem.lock = PTHREAD_MUTEX_INITIALIZER;
+    sem.cond = PTHREAD_COND_INITIALIZER;
+
+    // Register the internal mutex and condition variable, keyed by their addresses.
+    super::pthread_mutex_init(&mut sem.lock, &pthread_mutexattr_t::default())?;
+    super::pthread_cond_init(&mut sem.cond, &pthread_condattr_t::default())?;
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Destroys an unnamed semaphore, releasing its internal mutex and condition variable.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to destroy.
+///
+/// # Returns
+///
+/// Upon success, an empty result is returned. Upon failure, an error is returned instead.
+///
+pub fn sem_destroy(sem: &mut sem_t) -> Result<(), Error> {
+    super::pthread_cond_destroy(&mut sem.cond)?;
+    super::pthread_mutex_destroy(&mut sem.lock)?;
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Unlocks a semaphore, incrementing its value and waking up a blocked waiter, if any.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to unlock.
+///
+/// # Returns
+///
+/// Upon success, an empty result is returned. Upon failure, an error is returned instead.
+///
+pub fn sem_post(sem: &mut sem_t) -> Result<(), Error> {
+    super::pthread_mutex_lock(&mut sem.lock)?;
+
+    // Refuse to overflow the semaphore value.
+    if sem.count == c_int::MAX {
+        let _ = super::pthread_mutex_unlock(&mut sem.lock);
+        let reason: &str = "semaphore value would overflow";
+        ::syslog::warn!("sem_post(): {}", reason);
+        return Err(Error::new(ErrorCode::ValueOverflow, reason));
+    }
+
+    // Increment the value and wake up a single waiter.
+    sem.count += 1;
+    let signal_result: Result<(), Error> = super::pthread_cond_signal(&sem.cond);
+
+    let unlock_result: Result<(), Error> = super::pthread_mutex_unlock(&mut sem.lock);
+
+    signal_result.and(unlock_result)
+}
+
+///
+/// # Description
+///
+/// Locks a semaphore, blocking the calling thread until its value becomes positive and then
+/// decrementing it.
+///
+/// # Parameters
+///
+/// - `sem`: Semaphore to lock.
+///
+/// # Returns
+///
+/// Upon success, an empty result is returned. Upon failure, an error is returned instead.
+///
+pub fn sem_wait(sem: &mut sem_t) -> Result<(), Error> {
+    super::pthread_mutex_lock(&mut sem.lock)?;
+
+    // Wait until the semaphore value is positive.
+    while sem.count == 0 {
+        if let Err(error) = super::pthread_cond_wait(&sem.cond, &sem.lock) {
+            let _ = super::pthread_mutex_unlock(&mut sem.lock);
+            return Err(error);
+        }
+    }
+
+    // Acquire the semaphore.
+    sem.count -= 1;
+
+    super::pthread_mutex_unlock(&mut sem.lock)
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -57,4 +57,7 @@ extern void test_pthread_rwlock_static_init(void);
 // Tests if dynamically initialized read-write locks work (init/destroy + exclusion semantics).
 extern void test_pthread_rwlock_dynamic_init(void);
 
+// Tests if unnamed POSIX semaphores can be used for synchronization.
+extern void test_semaphore(void);
+
 #endif

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -9,6 +9,7 @@
 
 #include "common.h"
 #include <pthread.h>
+#include <semaphore.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -108,6 +109,13 @@ int main(int argc, const char *argv[])
     // Sanity check size of `pthread_rwlockattr_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlockattr_t, sizeof(int));
 
+    // Sanity check size of `sem_t` type.
+    STATIC_ASSERT_SIZE(sem_t,
+                       sizeof(int) +                    // count
+                           sizeof(pthread_mutex_t) +    // lock
+                           sizeof(pthread_cond_t)       // cond
+    );
+
     test_pthread_self();
     test_pthread_attr_init_destroy();
     test_pthread_attr_getstack();
@@ -124,6 +132,7 @@ int main(int argc, const char *argv[])
     test_pthread_cond_timedwait();
     test_pthread_tda();
     test_thread_local();
+    test_semaphore();
 
     // Must be last test.
     test_pthread_nowait();

--- a/src/tests/integration/test-c-thread/semaphore.c
+++ b/src/tests/integration/test-c-thread/semaphore.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <stddef.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Number of items exchanged in the producer/consumer test.
+#define NITERATIONS 32
+
+// Number of scheduler yields granted to a blocked worker to prove it stays blocked.
+#define NYIELDS 1000
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Semaphore that counts filled slots (items ready to be consumed).
+static sem_t sem_filled;
+
+// Semaphore that counts empty slots (space available to produce).
+static sem_t sem_empty;
+
+// Single-slot buffer shared between the producer and the consumer.
+static volatile int shared_slot;
+
+// Semaphore used to check that sem_wait() blocks until a matching sem_post().
+static sem_t sem_handoff;
+
+// Flag set by the worker thread just before it blocks on the semaphore.
+static volatile int handoff_waiting;
+
+// Flag set by the worker thread once it has been released by the main thread.
+static volatile int handoff_done;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests basic counting semantics of a semaphore without blocking.
+static void test_sem_basic(void)
+{
+    fprintf(stderr, "testing sem_init/sem_wait/sem_post/sem_destroy (basic) ... ");
+
+    sem_t sem;
+
+    // Initialize the semaphore with a value of two.
+    assert(sem_init(&sem, 0, 2) == 0);
+
+    // Two waits should succeed immediately without blocking.
+    assert(sem_wait(&sem) == 0);
+    assert(sem_wait(&sem) == 0);
+
+    // Replenish the semaphore and drain it again.
+    assert(sem_post(&sem) == 0);
+    assert(sem_post(&sem) == 0);
+    assert(sem_wait(&sem) == 0);
+    assert(sem_wait(&sem) == 0);
+
+    // Destroy the semaphore.
+    assert(sem_destroy(&sem) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Worker thread that blocks on `sem_handoff` and records when it is released.
+static void *handoff_thread(void *arg)
+{
+    (void)arg;
+
+    // Announce that we are about to block on the semaphore.
+    handoff_waiting = 1;
+
+    // Block until the main thread posts the semaphore.
+    assert(sem_wait(&sem_handoff) == 0);
+    handoff_done = 1;
+
+    return (NULL);
+}
+
+// Tests that sem_wait() blocks until a matching sem_post().
+static void test_sem_blocking(void)
+{
+    fprintf(stderr, "testing sem_wait() blocking ... ");
+
+    handoff_waiting = 0;
+    handoff_done = 0;
+
+    // Initialize the semaphore with a value of zero so that a waiter blocks.
+    assert(sem_init(&sem_handoff, 0, 0) == 0);
+
+    // Spawn a worker that blocks on the semaphore.
+    pthread_t tid = PTHREAD_NULL;
+    assert(pthread_create(&tid, NULL, handoff_thread, NULL) == 0);
+
+    // Wait until the worker has reached the point where it blocks on the semaphore.
+    while (!handoff_waiting) {
+        sched_yield();
+    }
+
+    // Give the worker ample opportunity to run: while the semaphore has not been
+    // posted, sem_wait() must keep the worker blocked and it must not complete.
+    for (int i = 0; i < NYIELDS; i++) {
+        assert(handoff_done == 0);
+        sched_yield();
+    }
+
+    // Release the worker and wait for it to finish.
+    assert(sem_post(&sem_handoff) == 0);
+    assert(pthread_join(tid, NULL) == 0);
+
+    // The worker must have observed the release.
+    assert(handoff_done == 1);
+
+    assert(sem_destroy(&sem_handoff) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Consumer thread of the producer/consumer test.
+static void *consumer_thread(void *arg)
+{
+    (void)arg;
+
+    for (int i = 0; i < NITERATIONS; i++) {
+        // Wait for the producer to fill the slot.
+        assert(sem_wait(&sem_filled) == 0);
+
+        // Consume the item and check that it matches the expected value.
+        assert(shared_slot == i);
+
+        // Signal that the slot is empty again.
+        assert(sem_post(&sem_empty) == 0);
+    }
+
+    return (NULL);
+}
+
+// Tests producer/consumer synchronization using a pair of semaphores.
+static void test_sem_producer_consumer(void)
+{
+    fprintf(stderr, "testing sem producer/consumer ... ");
+
+    // Initially the buffer is empty: no filled slots, one empty slot.
+    assert(sem_init(&sem_filled, 0, 0) == 0);
+    assert(sem_init(&sem_empty, 0, 1) == 0);
+    shared_slot = -1;
+
+    // Spawn the consumer thread.
+    pthread_t tid = PTHREAD_NULL;
+    assert(pthread_create(&tid, NULL, consumer_thread, NULL) == 0);
+
+    // Produce items one at a time.
+    for (int i = 0; i < NITERATIONS; i++) {
+        // Wait for an empty slot.
+        assert(sem_wait(&sem_empty) == 0);
+
+        // Produce the item.
+        shared_slot = i;
+
+        // Signal that the slot is filled.
+        assert(sem_post(&sem_filled) == 0);
+    }
+
+    // Wait for the consumer to finish.
+    assert(pthread_join(tid, NULL) == 0);
+
+    assert(sem_destroy(&sem_filled) == 0);
+    assert(sem_destroy(&sem_empty) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests that semaphore functions reject invalid arguments.
+static void test_sem_einval(void)
+{
+    fprintf(stderr, "testing sem invalid arguments ... ");
+
+    sem_t sem;
+
+    // A NULL semaphore pointer must be rejected by every operation.
+    errno = 0;
+    assert(sem_init(NULL, 0, 0) == -1);
+    assert(errno == EINVAL);
+
+    // Process-shared semaphores are not supported.
+    errno = 0;
+    assert(sem_init(&sem, 1, 0) == -1);
+    assert(errno == ENOTSUP);
+
+    errno = 0;
+    assert(sem_wait(NULL) == -1);
+    assert(errno == EINVAL);
+
+    errno = 0;
+    assert(sem_post(NULL) == -1);
+    assert(errno == EINVAL);
+
+    errno = 0;
+    assert(sem_destroy(NULL) == -1);
+    assert(errno == EINVAL);
+
+    // An initial value larger than the maximum must be rejected.
+    errno = 0;
+    assert(sem_init(&sem, 0, UINT_MAX) == -1);
+    assert(errno == EINVAL);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests unnamed POSIX semaphores.
+void test_semaphore(void)
+{
+    test_sem_basic();
+    test_sem_blocking();
+    test_sem_producer_consumer();
+    test_sem_einval();
+}

--- a/src/utils/gen-headers/src/main.rs
+++ b/src/utils/gen-headers/src/main.rs
@@ -272,6 +272,8 @@ fn map_ident_to_c(ident: &str) -> Option<&'static str> {
         "pthread_spinlock_t" => "pthread_spinlock_t",
         "pthread_key_t" => "pthread_key_t",
         "pthread_once_t" => "pthread_once_t",
+        // POSIX unnamed semaphore (sysapi/sys_types.rs).
+        "sem_t" => "sem_t",
         // POSIX struct types (the C side spells these `struct X`; the Rust side
         // refers to them by the bare struct name, possibly module-qualified —
         // `map_type_path` already reduces a path to its last segment).


### PR DESCRIPTION
## Summary

Implements the POSIX unnamed semaphore operations (`sem_init`,
`sem_destroy`, `sem_post`, `sem_wait`), which were previously stubbed out.
Each semaphore is layered on the kernel mutex and condition variable
primitives: an internal mutex guards the counter while a condition variable
blocks waiters until the value becomes positive.

## Changes

- **Libraries:** Add the four semaphore calls to the `syscall` crate, backed
  by a shared `sem` module and re-exported from `pthread`. Arguments are
  validated at the FFI boundary — NULL semaphores and out-of-range initial
  values yield `EINVAL`, process-shared semaphores yield `ENOTSUP`, and
  counter overflow in `sem_post()` yields `EOVERFLOW`.
- **Types & headers:** Add the `sem_t` type to `sysapi`, the `semaphore.h`
  spec and its generated header, and a Rust→C mapping for `sem_t` in
  `gen-headers`.
- **Tests:** Add a semaphore suite to the `test-c-thread` integration test
  covering counting semantics, blocking, single-slot producer/consumer
  synchronization, invalid-argument handling, and the `sem_t` layout.

## Validation

- `gen-headers --check` (headers up to date), standalone build, the
  `test-c-thread` integration test (all semaphore subtests pass, guest
  exit 0), and the unit-test suite.

Closes #721
Closes #722 
Closes #723 
Closes #724
