### PR TITLE
[syscall] Implement pthread_sigmask

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -53,6 +53,7 @@ ALL_POSIX_TESTS := \
 	test-c-posix-timers \
 	test-c-regex \
 	test-c-setjmp \
+	test-c-sigmask \
 	test-c-stdio \
 	test-c-termios \
 	test-c-thread \

--- a/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
@@ -5,26 +5,69 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
-};
+use crate::signal::sigset_t;
+use ::sysapi::ffi::c_int;
 use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Compile-Time ABI Assertions
+//==================================================================================================
+
+// The user-space `sigset_t` and the kernel-call `sys::pm::SigSet` are both 64-bit blocked-signal
+// bitmasks, so the pointer casts below are only sound while the two stay ABI-compatible. Guard
+// their size and alignment at compile time; any future divergence fails the build instead of
+// silently corrupting the ABI.
+::static_assert::assert_eq_size!(sigset_t, ::core::mem::size_of::<::sys::pm::SigSet>());
+::static_assert::assert_eq_align!(sigset_t, ::core::mem::align_of::<::sys::pm::SigSet>());
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Examines and/or changes the calling thread's blocked-signal mask.
+///
+/// `pthread_sigmask()` has the same semantics as `sigprocmask()`, differing only in how it reports
+/// errors: it returns the error number directly instead of setting `errno`. Nanvix keeps the
+/// blocked-signal mask per thread in the kernel, so both calls funnel through the same
+/// `sigprocmask()` kernel call.
+///
+/// # Parameters
+///
+/// - `how`: One of `SIG_BLOCK`, `SIG_UNBLOCK`, or `SIG_SETMASK`; ignored when `set` is null.
+/// - `set`: New signals to apply per `how`, or null to leave the mask unchanged.
+/// - `oldset`: Receives the previous mask, or null if not wanted.
+///
+/// # Returns
+///
+/// Zero on success, or a positive error number on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences the raw pointers `set` and `oldset`, which must
+/// each be either null or a valid, properly aligned pointer to a `sigset_t`.
+///
+/// # References
+///
+/// - <https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_sigmask.html>
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_sigmask(
     how: c_int,
-    set: *const c_void,
-    oldset: *mut c_void,
+    set: *const sigset_t,
+    oldset: *mut sigset_t,
 ) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/717
-    ::syslog::debug!("pthread_sigmask(): not implemented");
-    0
+    match unsafe {
+        ::sys::kcall::pm::__kcall_sigprocmask(
+            how,
+            set as *const ::sys::pm::SigSet,
+            oldset as *mut ::sys::pm::SigSet,
+        )
+    } {
+        Ok(()) => 0,
+        Err(error) => error.code.get(),
+    }
 }

--- a/src/tests/integration/test-c-sigmask/main.c
+++ b/src/tests/integration/test-c-sigmask/main.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Integration test for the POSIX signal-mask API:
+ *
+ *   - sigemptyset / sigfillset / sigaddset / sigdelset / sigismember
+ *   - sigprocmask     (SIG_BLOCK / SIG_UNBLOCK / SIG_SETMASK, oldset round-trip,
+ *                      SIGKILL/SIGSTOP cannot be blocked, EINVAL on bad `how`)
+ *   - pthread_sigmask (same semantics as sigprocmask but returns the error
+ *                      number directly, and shares the per-thread mask with
+ *                      sigprocmask)
+ *
+ * The harness is exit-code only (stdout is discarded in standalone terminal
+ * mode), so every check returns a distinct non-zero code that pinpoints the
+ * failing step; the process exits 0 only when the whole sequence succeeds.
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <unistd.h>
+
+/* Returns a distinct non-zero code identifying the failing check. */
+#define CHECK(step, cond)     \
+    do {                      \
+        if (!(cond)) {        \
+            return (step);    \
+        }                     \
+    } while (0)
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    sigset_t set;
+    sigset_t old;
+    sigset_t cur;
+
+    /*==============================================================================================
+     * Signal-set operations.
+     *============================================================================================*/
+
+    /* An empty set contains no signals. */
+    CHECK(1, sigemptyset(&set) == 0);
+    CHECK(2, sigismember(&set, SIGUSR1) == 0);
+    CHECK(3, sigismember(&set, SIGUSR2) == 0);
+
+    /* sigaddset marks membership; unrelated signals stay out. */
+    CHECK(4, sigaddset(&set, SIGUSR1) == 0);
+    CHECK(5, sigismember(&set, SIGUSR1) == 1);
+    CHECK(6, sigismember(&set, SIGUSR2) == 0);
+
+    /* sigdelset removes only the requested signal. */
+    CHECK(7, sigaddset(&set, SIGUSR2) == 0);
+    CHECK(8, sigdelset(&set, SIGUSR1) == 0);
+    CHECK(9, sigismember(&set, SIGUSR1) == 0);
+    CHECK(10, sigismember(&set, SIGUSR2) == 1);
+
+    /* A full set contains every standard signal. */
+    CHECK(11, sigfillset(&set) == 0);
+    CHECK(12, sigismember(&set, SIGINT) == 1);
+    CHECK(13, sigismember(&set, SIGUSR1) == 1);
+    CHECK(14, sigismember(&set, SIGKILL) == 1);
+
+    /* An out-of-range signal number is rejected. */
+    CHECK(15, sigismember(&set, 0) == -1);
+    CHECK(16, sigaddset(&set, 0) == -1);
+
+    /*==============================================================================================
+     * sigprocmask.
+     *============================================================================================*/
+
+    /* Start from a known, empty mask. */
+    CHECK(17, sigemptyset(&set) == 0);
+    CHECK(18, sigprocmask(SIG_SETMASK, &set, NULL) == 0);
+
+    /* Blocking SIGUSR1 reports the previous (empty) mask through oldset. */
+    CHECK(19, sigemptyset(&set) == 0);
+    CHECK(20, sigaddset(&set, SIGUSR1) == 0);
+    CHECK(21, sigprocmask(SIG_BLOCK, &set, &old) == 0);
+    CHECK(22, sigismember(&old, SIGUSR1) == 0);
+
+    /* A null `set` leaves the mask unchanged and returns it through oldset. */
+    CHECK(23, sigprocmask(SIG_BLOCK, NULL, &cur) == 0);
+    CHECK(24, sigismember(&cur, SIGUSR1) == 1);
+
+    /* Unblocking clears only the requested signal. */
+    CHECK(25, sigprocmask(SIG_UNBLOCK, &set, NULL) == 0);
+    CHECK(26, sigprocmask(SIG_SETMASK, NULL, &cur) == 0);
+    CHECK(27, sigismember(&cur, SIGUSR1) == 0);
+
+    /* SIGKILL and SIGSTOP can never be blocked; requests are silently ignored. */
+    CHECK(28, sigfillset(&set) == 0);
+    CHECK(29, sigprocmask(SIG_SETMASK, &set, NULL) == 0);
+    CHECK(30, sigprocmask(SIG_BLOCK, NULL, &cur) == 0);
+    CHECK(31, sigismember(&cur, SIGKILL) == 0);
+    CHECK(32, sigismember(&cur, SIGSTOP) == 0);
+
+    /* Restore an empty mask. */
+    CHECK(33, sigemptyset(&set) == 0);
+    CHECK(34, sigprocmask(SIG_SETMASK, &set, NULL) == 0);
+
+    /* An invalid `how` combined with a non-null `set` fails with EINVAL. */
+    CHECK(35, sigaddset(&set, SIGUSR1) == 0);
+    errno = 0;
+    CHECK(36, sigprocmask(-1, &set, NULL) == -1);
+    CHECK(37, errno == EINVAL);
+
+    /*==============================================================================================
+     * pthread_sigmask.
+     *============================================================================================*/
+
+    /* Start from a known, empty mask. */
+    CHECK(38, sigemptyset(&set) == 0);
+    CHECK(39, pthread_sigmask(SIG_SETMASK, &set, NULL) == 0);
+
+    /* Blocking SIGUSR2 reports the previous (empty) mask through oldset. */
+    CHECK(40, sigaddset(&set, SIGUSR2) == 0);
+    CHECK(41, pthread_sigmask(SIG_BLOCK, &set, &old) == 0);
+    CHECK(42, sigismember(&old, SIGUSR2) == 0);
+
+    /* pthread_sigmask and sigprocmask share the same per-thread mask. */
+    CHECK(43, sigprocmask(SIG_BLOCK, NULL, &cur) == 0);
+    CHECK(44, sigismember(&cur, SIGUSR2) == 1);
+
+    /* A null `set` returns the current mask through oldset. */
+    CHECK(45, pthread_sigmask(SIG_SETMASK, NULL, &cur) == 0);
+    CHECK(46, sigismember(&cur, SIGUSR2) == 1);
+
+    /* Unblocking through pthread_sigmask is visible to sigprocmask. */
+    CHECK(47, pthread_sigmask(SIG_UNBLOCK, &set, NULL) == 0);
+    CHECK(48, sigprocmask(SIG_BLOCK, NULL, &cur) == 0);
+    CHECK(49, sigismember(&cur, SIGUSR2) == 0);
+
+    /* SIGKILL and SIGSTOP can never be blocked. */
+    CHECK(50, sigfillset(&set) == 0);
+    CHECK(51, pthread_sigmask(SIG_SETMASK, &set, NULL) == 0);
+    CHECK(52, sigprocmask(SIG_BLOCK, NULL, &cur) == 0);
+    CHECK(53, sigismember(&cur, SIGKILL) == 0);
+    CHECK(54, sigismember(&cur, SIGSTOP) == 0);
+
+    /* An invalid `how` returns the error number directly instead of -1. */
+    CHECK(55, pthread_sigmask(-1, &set, NULL) == EINVAL);
+
+    /* Restore an empty mask. */
+    CHECK(56, sigemptyset(&set) == 0);
+    CHECK(57, pthread_sigmask(SIG_SETMASK, &set, NULL) == 0);
+
+    /* Success. */
+    (void)write(STDOUT_FILENO, "ok", 2);
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -313,6 +313,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-sigmask"
+program = "./bin/test-c-sigmask.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-stdio"
 program = "./bin/test-c-stdio.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -313,6 +313,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-sigmask"
+program = "./bin/test-c-sigmask.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-stdio"
 program = "./bin/test-c-stdio.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"


### PR DESCRIPTION
## Summary

Implements `pthread_sigmask()` and adds an integration test covering the POSIX signal-mask API.

Previously `pthread_sigmask()` was a no-op stub that logged "not implemented" and returned success. It now forwards to the `sigprocmask()` kernel call, sharing the per-thread blocked-signal mask with `sigprocmask()`, and reports failure by returning the error number directly instead of setting `errno`, per POSIX.

## Changes

- **syscall:** Implement `pthread_sigmask()` over `__kcall_sigprocmask`; type the `set`/`oldset` parameters as `sigset_t`, guard `sigset_t` vs `sys::pm::SigSet` size/alignment at compile time with `static_assert`, and add full documentation with a Safety section.
- **tests:** Add the `test-c-sigmask` exit-code integration suite exercising the sigsetops family (`sigemptyset`/`sigfillset`/`sigaddset`/`sigdelset`/`sigismember`), `sigprocmask`, and `pthread_sigmask` (including that `pthread_sigmask` shares the per-thread mask with `sigprocmask`). Wired into `ALL_POSIX_TESTS` and both `test-posix.toml` and `test-posix-windows.toml` (debug + release).

## Validation

- `.\z.ps1 build -- all`, `run-unit-tests`, `format-check`, `lint-check`, `spellcheck` — all pass.
- `test-c-sigmask` passes in debug; standalone `run-nanvix-tests` is green.

Part of #2475
