### PR TITLE
[syscall] Count Direct dlopen Handles

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -28,6 +28,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \
 	test-c-dlfcn-pie \
+	test-c-dlfcn-refcount \
 	test-c-dlfcn-searchpath \
 	test-c-dlfcn-selflink \
 	test-c-dlfcn-startup \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -392,7 +392,7 @@ POSIX_TEST_INITRDS := $(foreach suite,$(ALL_POSIX_TESTS),$(BINARIES_DIR)/$(suite
 # into lib/) so dlfcn-c can dlopen("lib/libmul.so"). Suites that need the image
 # are listed in POSIX_TEST_RAMFS_SUITES. Suites with their own fixtures (the
 # dlfcn global/needed variants, below) override the image with a per-suite one.
-POSIX_TEST_RAMFS_SUITES := test-c-file test-c-stdio test-c-dlfcn test-c-dlfcn-pie test-c-dlfcn-global test-c-dlfcn-needed test-c-dlfcn-diamond
+POSIX_TEST_RAMFS_SUITES := test-c-file test-c-stdio test-c-dlfcn test-c-dlfcn-refcount test-c-dlfcn-pie test-c-dlfcn-global test-c-dlfcn-needed test-c-dlfcn-diamond
 POSIX_TEST_RAMFS_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-seed
 POSIX_TEST_RAMFS_IMG    := $(BINARIES_DIR)/posix-tests-ramfs.img
 

--- a/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlclose.rs
@@ -59,6 +59,15 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
             },
         };
 
+        // Balance this handle's `dlopen()`. Per POSIX the library only becomes a
+        // candidate for unloading once every direct `dlopen()` has been matched
+        // by a `dlclose()`; while any handle is still live, keep it loaded. This
+        // also covers cache-hit opens that share a handle, which do not each hold
+        // their own `Arc`.
+        if root.lock().decrement_open_count() > 0 {
+            return Ok(());
+        }
+
         // The closing library can only be unloaded if the registry holds the
         // last reference to it. A higher count means another loaded library
         // still depends on it, or it is pinned in the global scope
@@ -108,8 +117,17 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
                 // Once only the registry still references the dependency, it too
                 // becomes part of the unload set. A dependency shared with a
                 // library outside the set (or pinned in the global scope) never
-                // reaches `1` and is correctly left loaded.
-                if *count == 1 && visited.insert(dependency) {
+                // reaches `1` and is correctly left loaded. A dependency that is
+                // ALSO held open by a direct `dlopen()` (its `open_count` is
+                // non-zero) is likewise left loaded even once its edges are gone.
+                if *count == 1
+                    && registry
+                        .get(&dependency)
+                        .map(|dep| dep.lock().open_count())
+                        .unwrap_or(0)
+                        == 0
+                    && visited.insert(dependency)
+                {
                     order.push(dependency);
                     stack.push(dependency);
                 }
@@ -167,6 +185,18 @@ pub fn dlclose(handle: &DlHandle) -> Result<(), Error> {
         for dlfile in fini_order.iter() {
             let handle: DlHandle = dlfile.lock().handle();
             if !registry.contains_key(&handle) {
+                continue;
+            }
+
+            // A destructor (phase 2) may have re-opened this library through a
+            // cache-hit `dlopen()`, which bumps its direct open count without
+            // adding a lasting `Arc`. Honor that open like the entry guard does
+            // and leave the library loaded.
+            if dlfile.lock().open_count() > 0 {
+                ::syslog::debug!(
+                    "dlclose(): keeping re-opened library loaded (handle={:?})",
+                    handle
+                );
                 continue;
             }
 

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -79,6 +79,11 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
             super::register_library_in_global_scope(&dlfile);
         }
 
+        // Record this additional direct open of an already-loaded library so a
+        // later `dlclose()` of one handle does not unload it while another
+        // handle is still live.
+        dlfile.lock().increment_open_count();
+
         // A concurrent `dlopen` may have inserted this library and released the
         // registry lock but not yet finished running its `.init_array`
         // constructors. Wait for them to complete so this caller never observes
@@ -144,6 +149,14 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
                 return Err(e);
             },
         };
+
+    // Record this direct `dlopen()` on the freshly loaded root library. Only
+    // the library named by the caller is counted; dependencies loaded
+    // transitively are tracked by their `Arc` edges, not by this direct open
+    // count.
+    if let Some(dlfile) = registry.get(&handle) {
+        dlfile.lock().increment_open_count();
+    }
 
     // Record the constructing thread on every newly loaded library BEFORE
     // releasing the registry lock. A concurrent `dlopen` that observes any of

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -236,6 +236,15 @@ pub struct DynamicLibrary {
     /// Shared construction state, used to serialize concurrent `dlopen` calls
     /// against this library's `.init_array` constructors.
     init_state: Arc<InitState>,
+    /// Number of outstanding direct `dlopen()` handles that name this library.
+    ///
+    /// Mirrors glibc's `l_direct_opencount`: every `dlopen()` that resolves to
+    /// this file — including a cache hit that returns an already-loaded handle —
+    /// increments it, and every matching `dlclose()` decrements it. The library
+    /// only becomes a candidate for unloading once this count reaches zero.
+    /// Dependencies pulled in transitively are tracked by their `Arc` edges and
+    /// are not reflected here.
+    open_count: usize,
 }
 
 impl DynamicLibrary {
@@ -496,6 +505,7 @@ impl DynamicLibrary {
                     fini_array,
                     runpaths,
                     init_state: Arc::new(InitState::new()),
+                    open_count: 0,
                 })
             },
             Err(error) => {
@@ -1274,6 +1284,29 @@ impl DynamicLibrary {
     /// holding any dlfcn lock.
     pub fn init_state(&self) -> Arc<InitState> {
         self.init_state.clone()
+    }
+
+    /// Returns the number of outstanding direct `dlopen()` handles for this
+    /// library (glibc's `l_direct_opencount`).
+    pub fn open_count(&self) -> usize {
+        self.open_count
+    }
+
+    /// Records an additional direct `dlopen()` of this library and returns the
+    /// updated open count. Invoked on both the initial load and every
+    /// subsequent cache hit so that staggered open/close sequences keep the
+    /// library loaded while any handle is still live.
+    pub fn increment_open_count(&mut self) -> usize {
+        self.open_count = self.open_count.saturating_add(1);
+        self.open_count
+    }
+
+    /// Balances a direct `dlopen()` with a `dlclose()` and returns the updated
+    /// open count. Saturates at zero so an unbalanced `dlclose()` cannot
+    /// underflow the counter.
+    pub fn decrement_open_count(&mut self) -> usize {
+        self.open_count = self.open_count.saturating_sub(1);
+        self.open_count
     }
 
     /// Returns the loaded `.init_array` descriptor as `(base_address,

--- a/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/main.c
+++ b/src/tests/integration/test-c-dlfcn-ctor-dtor-reentry/main.c
@@ -29,9 +29,10 @@
  *
  * Flow: main() dlopen()s libhook.so -- running its constructor, which opens
  * libother.so from inside the still-in-progress outer dlopen(). After the outer
- * dlopen() returns, main() confirms libother.so is visible to it. main() then
- * dlclose()s libhook.so, running its destructor, which uses and closes
- * libother.so from inside the in-progress dlclose().
+ * dlopen() returns, main() confirms libother.so is visible to it, then balances
+ * its own (dedup) open of libother.so with a dlclose(). main() then dlclose()s
+ * libhook.so, running its destructor, which uses and closes libother.so from
+ * inside the in-progress dlclose().
  *
  * Pass/fail is the guest exit code (the harness discards stdout in standalone
  * mode): main() returns 0 only when both callbacks ran and every re-entrant
@@ -164,8 +165,10 @@ int main(int argc, const char *argv[])
 
     /* libother.so is visible to main() (the caller) after the outer dlopen()
      * returned: a dlopen() of it returns the SAME handle the constructor got
-     * (dedup, no second copy), and its symbol resolves. The dedup open adds no
-     * reference, so libother.so is left for the destructor to close. */
+    * (dedup, no second copy), and its symbol resolves. Per POSIX, this dedup
+    * open increments libother.so's open count, so main() must balance it with
+    * its own dlclose() below; the constructor's open is the one left for
+    * libhook.so's destructor to close. */
     void *other = dlopen("lib/libother.so", RTLD_NOW);
     if (other != g_other_handle) {
         return 4;
@@ -174,6 +177,18 @@ int main(int argc, const char *argv[])
     *(void **)(&ov) = dlsym(other, "other_value");
     if (ov == NULL || ov() != OTHER_VALUE) {
         return 5;
+    }
+
+    /* Balance main()'s own dlopen() of libother.so. This decrements its open
+     * count back to the single reference held by the constructor's open, so
+     * the library stays loaded (it must NOT be unloaded here) until the
+     * destructor closes that last handle. Confirm the balancing close did not
+     * prematurely unload it: libother.so's destructor must not have run yet. */
+    if (dlclose(other) != 0) {
+        return 9;
+    }
+    if (g_other_dtor_ran != 0) {
+        return 10;
     }
 
     /* Close libhook.so; its destructor uses and closes libother.so from inside

--- a/src/tests/integration/test-c-dlfcn-refcount/main.c
+++ b/src/tests/integration/test-c-dlfcn-refcount/main.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/**
+ * @brief Shared library exercised by this suite.
+ *
+ * The prebuilt `libmul.so` fixture (staged under `lib/` by the shared POSIX
+ * tests RAMFS image) exports self-contained `add()` and `multiply()` functions
+ * and carries no dependencies, so it is a clean subject for reference-counting
+ * checks.
+ */
+#define LIB_PATH "lib/libmul.so"
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Opens a dynamic load library, requesting immediate binding.
+static void *open_library(const char *path)
+{
+    void *handle = dlopen(path, RTLD_NOW);
+    assert(handle != NULL);
+    return (handle);
+}
+
+// Closes a dynamic load library.
+static void close_library(void *handle)
+{
+    assert(dlclose(handle) == 0);
+}
+
+// Resolves a symbol in a dynamic load library.
+static void *resolve_symbol(void *handle, const char *symbol)
+{
+    void *sym = dlsym(handle, symbol);
+    assert(sym != NULL);
+    return (sym);
+}
+
+// Resolves `add` through `handle` and asserts that the still-mapped code runs.
+static void assert_library_usable(void *handle)
+{
+    int (*add)(int, int) = NULL;
+    *(void **)(&add) = resolve_symbol(handle, "add");
+    assert(add != NULL);
+    assert(add(1, 2) == 3);
+
+    int (*multiply)(int, int) = NULL;
+    *(void **)(&multiply) = resolve_symbol(handle, "multiply");
+    assert(multiply != NULL);
+    assert(multiply(7, 6) == 42);
+}
+
+//==================================================================================================
+// Test Functions
+//==================================================================================================
+
+/**
+ * @brief Regression test: a staggered open/close must not unload a library that
+ * still has a live handle.
+ *
+ * Each dlopen() of an already-loaded library is a cache hit that returns the
+ * same handle, so the loader must track an explicit open count rather than an
+ * internal Arc reference count. Opening twice and closing once must leave the
+ * library mapped; the follow-up dlsym()/call would fault or fail if it had been
+ * wrongly unloaded.
+ */
+static void test_staggered_open_close(void)
+{
+    void *h1 = open_library(LIB_PATH);
+    void *h2 = open_library(LIB_PATH);
+
+    // A second dlopen() of the same file is a cache hit: it returns the same
+    // handle and bumps the open count to two.
+    assert(h1 == h2);
+
+    // First dlclose() drops the open count to one; the library must stay loaded.
+    close_library(h1);
+
+    // The surviving handle must still resolve and run code from the still-mapped
+    // library. On the pre-fix loader the library would already be unloaded here.
+    assert_library_usable(h2);
+
+    // Final dlclose() drops the open count to zero and unloads the library.
+    close_library(h2);
+}
+
+/**
+ * @brief Verifies that the open count balances correctly across more than two
+ * opens.
+ *
+ * Opening three times and closing twice must keep the library loaded; only the
+ * third close (open count reaching zero) may unload it.
+ */
+static void test_balanced_open_close(void)
+{
+    void *h1 = open_library(LIB_PATH);
+    void *h2 = open_library(LIB_PATH);
+    void *h3 = open_library(LIB_PATH);
+
+    // Every cache hit resolves to the same handle.
+    assert(h1 == h2);
+    assert(h2 == h3);
+
+    // Two closes still leave one outstanding open.
+    close_library(h1);
+    assert_library_usable(h2);
+    close_library(h2);
+    assert_library_usable(h3);
+
+    // The third close balances the last open and unloads the library.
+    close_library(h3);
+}
+
+/**
+ * @brief Verifies that a fresh dlopen() after a full close reloads the library.
+ *
+ * Once every handle is closed the library is unloaded; a subsequent dlopen()
+ * must succeed and yield a usable library again.
+ */
+static void test_reopen_after_full_close(void)
+{
+    void *h1 = open_library(LIB_PATH);
+    assert_library_usable(h1);
+    close_library(h1);
+
+    void *h2 = open_library(LIB_PATH);
+    assert_library_usable(h2);
+    close_library(h2);
+}
+
+/**
+ * @brief Tests reference counting of dlopen()/dlclose().
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_staggered_open_close();
+    test_balanced_open_close();
+    test_reopen_after_full_close();
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -158,6 +158,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-refcount"
+program = "./bin/test-c-dlfcn-refcount.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-searchpath"
 program = "./bin/test-c-dlfcn-searchpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -158,6 +158,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-refcount"
+program = "./bin/test-c-dlfcn-refcount.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-searchpath"
 program = "./bin/test-c-dlfcn-searchpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"


### PR DESCRIPTION
## What & Why

Track the number of outstanding direct `dlopen()` handles per loaded
library so a `dlclose()` of one handle no longer unloads a library while
another handle is still live. Previously a direct open shared an `Arc`
(or none, on a cache hit), so staggered open/close sequences could
unload a library that a live handle still referenced. This mirrors
glibc's `l_direct_opencount`: increment on every `dlopen()` (initial
load and cache hit), decrement on `dlclose()`, and unload only once the
count reaches zero.

## Changes

**Library (`syscall`):**
- Add an `open_count` field to `DynamicLibrary` with `open_count()`,
  `increment_open_count()`, and `decrement_open_count()` accessors; the
  decrement saturates at zero to tolerate an unbalanced close.
- `dlopen()` bumps the count on both the initial load and cache-hit
  paths; only the caller-named root is counted, not transitively loaded
  dependencies (those stay tracked by their `Arc` edges).
- `dlclose()` returns early while the count is non-zero, leaves
  dependencies with a non-zero open count out of the unload set, and
  keeps a library loaded when a destructor re-opens it via a cache-hit
  `dlopen()`.

**Tests:**
- New `test-c-dlfcn-refcount` suite covering staggered open/close,
  balanced multi-open close, and reopen after a full close.
- Update `test-c-dlfcn-ctor-dtor-reentry` so `main()` balances its own
  dedup `dlopen()` of `libother.so` and asserts the library is not
  unloaded until the constructor's handle closes it.

**Build and harness wiring:**
- Register the new suite in the guest POSIX test list and
  `POSIX_TEST_RAMFS_SUITES`, and add it to `test-posix.toml` and
  `test-posix-windows.toml` for debug and release modes.

Closes #2089