### PR TITLE
[net-backend] Add non-blocking socket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,9 +731,11 @@ name = "error"
 version = "0.19.17"
 dependencies = [
  "compiler_builtins",
+ "libc",
  "rustc-std-workspace-core",
  "sysapi",
  "vstd",
+ "windows",
 ]
 
 [[package]]

--- a/src/libs/error/Cargo.toml
+++ b/src/libs/error/Cargo.toml
@@ -22,6 +22,12 @@ compiler_builtins = { workspace = true, optional = true }
 sysapi = { workspace = true }
 vstd = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { workspace = true, features = ["Win32_Networking_WinSock"] }
+
 [features]
 default = []
 std = []

--- a/src/libs/error/src/lib.rs
+++ b/src/libs/error/src/lib.rs
@@ -13,6 +13,9 @@
 
 use ::sysapi::errno::*;
 
+#[cfg(target_os = "windows")]
+use ::windows::Win32::Networking::WinSock as winsock_errno;
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -24,7 +27,8 @@ use ::sysapi::errno::*;
 ///
 /// # Notes
 ///
-/// The values in this enumeration intentionally match the error codes defined in the Linux kernel.
+/// The numeric discriminants in this enumeration are the Nanvix errno values exported by
+/// `sysapi::errno`, not host OS errno values.
 ///
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
@@ -284,6 +288,241 @@ impl ErrorCode {
     pub fn get(&self) -> i32 {
         *self as i32
     }
+
+    /// Converts a Linux host `errno` value into an [`ErrorCode`].
+    ///
+    /// Linux and Nanvix do not use the same numeric layout for all `errno`s, so callers that are
+    /// translating host syscall failures should use this instead of [`ErrorCode::try_from`].
+    #[cfg(target_os = "linux")]
+    fn try_from_linux_errno(errno: i32) -> Result<Self, Error> {
+        let errno: i32 = normalize_host_errno_value(errno);
+        match errno {
+            libc::EPERM => Ok(Self::OperationNotPermitted),
+            libc::ENOENT => Ok(Self::NoSuchEntry),
+            libc::ESRCH => Ok(Self::NoSuchProcess),
+            libc::EINTR => Ok(Self::Interrupted),
+            libc::EIO => Ok(Self::IoErr),
+            libc::ENXIO => Ok(Self::NoSuchDeviceOrAddress),
+            libc::E2BIG => Ok(Self::TooBig),
+            libc::ENOEXEC => Ok(Self::InvalidExecutableFormat),
+            libc::EBADF => Ok(Self::BadFile),
+            libc::ECHILD => Ok(Self::NoChildProcess),
+            libc::EAGAIN => Ok(Self::TryAgain),
+            libc::ENOMEM => Ok(Self::OutOfMemory),
+            libc::EACCES => Ok(Self::PermissionDenied),
+            libc::EFAULT => Ok(Self::BadAddress),
+            libc::ENOTBLK => Ok(Self::NotBlockDevice),
+            libc::EBUSY => Ok(Self::ResourceBusy),
+            libc::EEXIST => Ok(Self::EntryExists),
+            libc::EXDEV => Ok(Self::CrossDeviceLink),
+            libc::ENODEV => Ok(Self::NoSuchDevice),
+            libc::ENOTDIR => Ok(Self::InvalidDirectory),
+            libc::EISDIR => Ok(Self::IsDirectory),
+            libc::EINVAL => Ok(Self::InvalidArgument),
+            libc::ENFILE => Ok(Self::FileTableOVerflow),
+            libc::EMFILE => Ok(Self::TooManyOpenFiles),
+            libc::ENOTTY => Ok(Self::NotTerminal),
+            libc::ETXTBSY => Ok(Self::TextFileBusy),
+            libc::EFBIG => Ok(Self::FileTooLarge),
+            libc::ENOSPC => Ok(Self::NoSpaceOnDevice),
+            libc::ESPIPE => Ok(Self::IllegalSeek),
+            libc::EROFS => Ok(Self::ReadOnlyFileSystem),
+            libc::EMLINK => Ok(Self::TooManyLinks),
+            libc::EPIPE => Ok(Self::BrokenPipe),
+            libc::EDOM => Ok(Self::MathArgDomainErr),
+            libc::ERANGE => Ok(Self::ValueOutOfRange),
+            libc::EDEADLK => Ok(Self::Deadlock),
+            libc::ENAMETOOLONG => Ok(Self::NameTooLong),
+            libc::ENOLCK => Ok(Self::LockNotAvailable),
+            libc::ENOSYS => Ok(Self::InvalidSysCall),
+            libc::ENOTEMPTY => Ok(Self::DirectoryNotEmpty),
+            libc::ELOOP => Ok(Self::SymbolicLinkLoop),
+            libc::ENOMSG => Ok(Self::NoMessageAvailable),
+            libc::EIDRM => Ok(Self::IdentifierRemoved),
+            libc::ECHRNG => Ok(Self::OutOfRangeChannel),
+            libc::EL2NSYNC => Ok(Self::Level2NotSynchronized),
+            libc::EL3HLT => Ok(Self::Level3Halted),
+            libc::EL3RST => Ok(Self::Level3Reset),
+            libc::ELNRNG => Ok(Self::InvalidLinkNumber),
+            libc::EUNATCH => Ok(Self::InvalidProtocolDriver),
+            libc::ENOCSI => Ok(Self::NoStructAvailable),
+            libc::EL2HLT => Ok(Self::Level2Halted),
+            libc::EBADE => Ok(Self::InvalidExchange),
+            libc::EBADR => Ok(Self::InvalidRequestDescriptor),
+            libc::EXFULL => Ok(Self::ExchangeFull),
+            libc::ENOANO => Ok(Self::InvalidAnode),
+            libc::EBADRQC => Ok(Self::InvalidRequestCode),
+            libc::EBADSLT => Ok(Self::InvalidSlot),
+            libc::EBFONT => Ok(Self::BadFontFormat),
+            libc::ENOSTR => Ok(Self::NoStreamDeviceAvailable),
+            libc::ENODATA => Ok(Self::NoDataAvailable),
+            libc::ETIME => Ok(Self::TimerExpired),
+            libc::ENOSR => Ok(Self::NoStreamResources),
+            libc::ENONET => Ok(Self::NoNetwork),
+            libc::ENOPKG => Ok(Self::MissingPackage),
+            libc::EREMOTE => Ok(Self::RemoteObject),
+            libc::ENOLINK => Ok(Self::NoLink),
+            libc::EADV => Ok(Self::AdvertiseErr),
+            libc::ESRMNT => Ok(Self::MountErr),
+            libc::ECOMM => Ok(Self::CommunicationErr),
+            libc::EPROTO => Ok(Self::ProtocolErr),
+            libc::EMULTIHOP => Ok(Self::MultipleHopAttemped),
+            libc::EDOTDOT => Ok(Self::RfsErr),
+            libc::EBADMSG => Ok(Self::InvalidMessage),
+            libc::EOVERFLOW => Ok(Self::ValueOverflow),
+            libc::ENOTUNIQ => Ok(Self::NonUniqueName),
+            libc::EBADFD => Ok(Self::InvalidFileDescriptor),
+            libc::EREMCHG => Ok(Self::RemoteAddressChanged),
+            libc::ELIBACC => Ok(Self::LibraryAccessErr),
+            libc::ELIBBAD => Ok(Self::InvalidLibraryAccess),
+            libc::ELIBSCN => Ok(Self::CorruptedLibSection),
+            libc::ELIBMAX => Ok(Self::ExcessiveLibraryLinkCount),
+            libc::ELIBEXEC => Ok(Self::InvalidExecSharedLibrary),
+            libc::EILSEQ => Ok(Self::IllegalByteSequence),
+            libc::ESTRPIPE => Ok(Self::StreamPipeErr),
+            libc::EUSERS => Ok(Self::TooManyUsers),
+            libc::ENOTSOCK => Ok(Self::NotSocketFile),
+            libc::EDESTADDRREQ => Ok(Self::DestinationAddressRequired),
+            libc::EMSGSIZE => Ok(Self::MessageTooLong),
+            libc::EPROTOTYPE => Ok(Self::BadProtocolType),
+            libc::ENOPROTOOPT => Ok(Self::ProtocolOptionNotAvailable),
+            libc::EPROTONOSUPPORT => Ok(Self::ProtocolNotSupported),
+            libc::ESOCKTNOSUPPORT => Ok(Self::SocketTypeNotSupported),
+            libc::EOPNOTSUPP => Ok(Self::OperationNotSupportedOnSocket),
+            libc::EPFNOSUPPORT => Ok(Self::ProtocolFamilyNotSupported),
+            libc::EAFNOSUPPORT => Ok(Self::AddressFamilyNotSupported),
+            libc::EADDRINUSE => Ok(Self::AddressInUse),
+            libc::EADDRNOTAVAIL => Ok(Self::AddressNotAvailable),
+            libc::ENETDOWN => Ok(Self::NetworkDown),
+            libc::ENETUNREACH => Ok(Self::NetworkUnreachable),
+            libc::ENETRESET => Ok(Self::NetworkReset),
+            libc::ECONNABORTED => Ok(Self::ConnectionAborted),
+            libc::ECONNRESET => Ok(Self::ConnectionReset),
+            libc::ENOBUFS => Ok(Self::NoBufferSpace),
+            libc::EISCONN => Ok(Self::TransportEndpointConnected),
+            libc::ENOTCONN => Ok(Self::TransportEndpointNotConnected),
+            libc::ESHUTDOWN => Ok(Self::TransportEndpointShutdown),
+            libc::ETOOMANYREFS => Ok(Self::TooManyReferences),
+            libc::ETIMEDOUT => Ok(Self::OperationTimedOut),
+            libc::ECONNREFUSED => Ok(Self::ConnectionRefused),
+            libc::EHOSTDOWN => Ok(Self::HostDown),
+            libc::EHOSTUNREACH => Ok(Self::HostUnreachable),
+            libc::EALREADY => Ok(Self::OperationAlreadyInProgress),
+            libc::EINPROGRESS => Ok(Self::OperationInProgress),
+            libc::ESTALE => Ok(Self::StaleHandle),
+            libc::EDQUOT => Ok(Self::QuotaExceeded),
+            libc::ENOMEDIUM => Ok(Self::MediumNotFound),
+            libc::ECANCELED => Ok(Self::OperationCanceled),
+            libc::EOWNERDEAD => Ok(Self::DeadOwner),
+            libc::ENOTRECOVERABLE => Ok(Self::UnrecoverableState),
+            _ => Err(invalid_error_code(errno)),
+        }
+    }
+
+    /// Converts a Winsock error value into an [`ErrorCode`].
+    #[cfg(target_os = "windows")]
+    fn try_from_winsock_errno(errno: i32) -> Result<Self, Error> {
+        let errno: i32 = normalize_host_errno_value(errno);
+        match winsock_errno::WSA_ERROR(errno) {
+            winsock_errno::WSAEINTR => Ok(Self::Interrupted),
+            winsock_errno::WSAEBADF => Ok(Self::BadFile),
+            winsock_errno::WSAEACCES => Ok(Self::PermissionDenied),
+            winsock_errno::WSAEFAULT => Ok(Self::BadAddress),
+            winsock_errno::WSAEINVAL => Ok(Self::InvalidArgument),
+            winsock_errno::WSAEMFILE => Ok(Self::TooManyOpenFiles),
+            winsock_errno::WSAEWOULDBLOCK => Ok(Self::TryAgain),
+            winsock_errno::WSAEINPROGRESS => Ok(Self::OperationInProgress),
+            winsock_errno::WSAEALREADY => Ok(Self::OperationAlreadyInProgress),
+            winsock_errno::WSAENOTSOCK => Ok(Self::NotSocketFile),
+            winsock_errno::WSAEDESTADDRREQ => Ok(Self::DestinationAddressRequired),
+            winsock_errno::WSAEMSGSIZE => Ok(Self::MessageTooLong),
+            winsock_errno::WSAEPROTOTYPE => Ok(Self::BadProtocolType),
+            winsock_errno::WSAENOPROTOOPT => Ok(Self::ProtocolOptionNotAvailable),
+            winsock_errno::WSAEPROTONOSUPPORT => Ok(Self::ProtocolNotSupported),
+            winsock_errno::WSAESOCKTNOSUPPORT => Ok(Self::SocketTypeNotSupported),
+            winsock_errno::WSAEOPNOTSUPP => Ok(Self::OperationNotSupportedOnSocket),
+            winsock_errno::WSAEPFNOSUPPORT => Ok(Self::ProtocolFamilyNotSupported),
+            winsock_errno::WSAEAFNOSUPPORT => Ok(Self::AddressFamilyNotSupported),
+            winsock_errno::WSAEADDRINUSE => Ok(Self::AddressInUse),
+            winsock_errno::WSAEADDRNOTAVAIL => Ok(Self::AddressNotAvailable),
+            winsock_errno::WSAENETDOWN => Ok(Self::NetworkDown),
+            winsock_errno::WSAENETUNREACH => Ok(Self::NetworkUnreachable),
+            winsock_errno::WSAENETRESET => Ok(Self::NetworkReset),
+            winsock_errno::WSAECONNABORTED => Ok(Self::ConnectionAborted),
+            winsock_errno::WSAECONNRESET => Ok(Self::ConnectionReset),
+            winsock_errno::WSAENOBUFS => Ok(Self::NoBufferSpace),
+            winsock_errno::WSAEISCONN => Ok(Self::TransportEndpointConnected),
+            winsock_errno::WSAENOTCONN => Ok(Self::TransportEndpointNotConnected),
+            winsock_errno::WSAESHUTDOWN => Ok(Self::TransportEndpointShutdown),
+            winsock_errno::WSAETOOMANYREFS => Ok(Self::TooManyReferences),
+            winsock_errno::WSAETIMEDOUT => Ok(Self::OperationTimedOut),
+            winsock_errno::WSAECONNREFUSED => Ok(Self::ConnectionRefused),
+            winsock_errno::WSAELOOP => Ok(Self::SymbolicLinkLoop),
+            winsock_errno::WSAENAMETOOLONG => Ok(Self::NameTooLong),
+            winsock_errno::WSAEHOSTDOWN => Ok(Self::HostDown),
+            winsock_errno::WSAEHOSTUNREACH => Ok(Self::HostUnreachable),
+            winsock_errno::WSAENOTEMPTY => Ok(Self::DirectoryNotEmpty),
+            winsock_errno::WSAEUSERS => Ok(Self::TooManyUsers),
+            winsock_errno::WSAEDQUOT => Ok(Self::QuotaExceeded),
+            winsock_errno::WSAESTALE => Ok(Self::StaleHandle),
+            winsock_errno::WSAEREMOTE => Ok(Self::RemoteObject),
+            winsock_errno::WSANOTINITIALISED => Ok(Self::InvalidFileDescriptor),
+            _ => Err(invalid_error_code(errno)),
+        }
+    }
+
+    /// Converts a Winsock `connect()` error value into an [`ErrorCode`].
+    ///
+    /// Winsock reports a newly pending non-blocking `connect()` as `WSAEWOULDBLOCK`, while regular
+    /// non-blocking I/O uses the same code for would-block.
+    #[cfg(target_os = "windows")]
+    fn try_from_winsock_connect_errno(errno: i32) -> Result<Self, Error> {
+        let errno: i32 = normalize_host_errno_value(errno);
+        match winsock_errno::WSA_ERROR(errno) {
+            winsock_errno::WSAEWOULDBLOCK => Ok(Self::OperationInProgress),
+            _ => Self::try_from_winsock_errno(errno),
+        }
+    }
+}
+
+/// Converts a host errno value into an [`ErrorCode`] for the current target OS.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub fn errno_to_error_code(errno: i32) -> ErrorCode {
+    #[cfg(target_os = "linux")]
+    {
+        ErrorCode::try_from_linux_errno(errno).unwrap_or(ErrorCode::ValueOutOfRange)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        ErrorCode::try_from_winsock_errno(errno).unwrap_or(ErrorCode::ValueOutOfRange)
+    }
+}
+
+/// Converts a host `connect()` errno value into an [`ErrorCode`] for the current target OS.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub fn connect_errno_to_error_code(errno: i32) -> ErrorCode {
+    #[cfg(target_os = "linux")]
+    {
+        errno_to_error_code(errno)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        ErrorCode::try_from_winsock_connect_errno(errno).unwrap_or(ErrorCode::ValueOutOfRange)
+    }
+}
+
+#[allow(dead_code)]
+fn normalize_host_errno_value(value: i32) -> i32 {
+    if value < 0 {
+        match value.checked_abs() {
+            Some(abs) => abs,
+            None => value,
+        }
+    } else {
+        value
+    }
 }
 
 // Manual conversion from i32 to ErrorCode using constants.
@@ -433,7 +672,7 @@ impl TryFrom<i32> for ErrorCode {
 ///
 /// # Description
 ///
-/// Constructs a default error.
+/// Constructs the error returned when a value is not a valid Nanvix error code.
 ///
 /// # Parameters
 ///
@@ -443,7 +682,7 @@ impl TryFrom<i32> for ErrorCode {
 ///
 /// Default error.
 ///
-fn invalid_error_code(_value: i32) -> Error {
+pub fn invalid_error_code(_value: i32) -> Error {
     Error {
         code: ErrorCode::InvalidArgument,
         reason: "invalid error code",
@@ -516,6 +755,95 @@ impl TryFrom<i64> for ErrorCode {
         // Attempt to convert i32 to ErrorCode.
         ErrorCode::try_from(value)
             .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid error code"))
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that Linux errno values that collide with unrelated Nanvix errno values are translated
+    /// by semantic name instead of by raw number.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn try_from_linux_errno_translates_socket_family() {
+        assert_eq!(
+            ErrorCode::try_from_linux_errno(libc::EINPROGRESS).unwrap(),
+            ErrorCode::OperationInProgress
+        );
+        assert_eq!(
+            ErrorCode::try_from_linux_errno(libc::EALREADY).unwrap(),
+            ErrorCode::OperationAlreadyInProgress
+        );
+        assert_eq!(
+            ErrorCode::try_from_linux_errno(libc::EISCONN).unwrap(),
+            ErrorCode::TransportEndpointConnected
+        );
+    }
+
+    /// Tests that unknown Linux errno values do not fall through into Nanvix errno numbering.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn try_from_linux_errno_rejects_unknown_values() {
+        assert!(ErrorCode::try_from_linux_errno(41).is_err());
+    }
+
+    /// Tests that Winsock errno values are translated by semantic name.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn try_from_winsock_errno_translates_socket_family() {
+        let cases: [(i32, ErrorCode); 12] = [
+            (winsock_errno::WSAEAFNOSUPPORT.0, ErrorCode::AddressFamilyNotSupported),
+            (winsock_errno::WSAEADDRINUSE.0, ErrorCode::AddressInUse),
+            (winsock_errno::WSAEDESTADDRREQ.0, ErrorCode::DestinationAddressRequired),
+            (winsock_errno::WSAEHOSTUNREACH.0, ErrorCode::HostUnreachable),
+            (winsock_errno::WSAEISCONN.0, ErrorCode::TransportEndpointConnected),
+            (winsock_errno::WSAENETDOWN.0, ErrorCode::NetworkDown),
+            (winsock_errno::WSAENETRESET.0, ErrorCode::NetworkReset),
+            (winsock_errno::WSAEPROTONOSUPPORT.0, ErrorCode::ProtocolNotSupported),
+            (winsock_errno::WSAEPROTOTYPE.0, ErrorCode::BadProtocolType),
+            (winsock_errno::WSAESHUTDOWN.0, ErrorCode::TransportEndpointShutdown),
+            (winsock_errno::WSAESOCKTNOSUPPORT.0, ErrorCode::SocketTypeNotSupported),
+            (winsock_errno::WSAETIMEDOUT.0, ErrorCode::OperationTimedOut),
+        ];
+
+        for (winsock_error, expected) in cases {
+            assert_eq!(ErrorCode::try_from_winsock_errno(winsock_error).unwrap(), expected);
+        }
+    }
+
+    /// Tests that `WSAEWOULDBLOCK` is connect-specific: generic I/O sees `TryAgain`, while
+    /// `connect()` sees `OperationInProgress`.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn try_from_winsock_connect_errno_handles_wouldblock() {
+        assert_eq!(
+            ErrorCode::try_from_winsock_errno(winsock_errno::WSAEWOULDBLOCK.0).unwrap(),
+            ErrorCode::TryAgain
+        );
+        assert_eq!(
+            ErrorCode::try_from_winsock_connect_errno(winsock_errno::WSAEWOULDBLOCK.0).unwrap(),
+            ErrorCode::OperationInProgress
+        );
+        assert_eq!(
+            ErrorCode::try_from_winsock_connect_errno(winsock_errno::WSAEINVAL.0).unwrap(),
+            ErrorCode::InvalidArgument
+        );
+        assert_eq!(
+            ErrorCode::try_from_winsock_connect_errno(winsock_errno::WSAEALREADY.0).unwrap(),
+            ErrorCode::OperationAlreadyInProgress
+        );
+    }
+
+    /// Tests that unknown Winsock errno values do not fall through into Nanvix errno numbering.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn try_from_winsock_errno_rejects_unknown_values() {
+        assert!(ErrorCode::try_from_winsock_errno(99999).is_err());
     }
 }
 

--- a/src/libs/net-backend/src/error.rs
+++ b/src/libs/net-backend/src/error.rs
@@ -20,6 +20,25 @@ pub enum NetError {
     Errno(ErrorCode),
 }
 
+impl NetError {
+    /// Returns `true` if this error indicates that a non-blocking operation could not be completed
+    /// immediately and would block (`EAGAIN` / `EWOULDBLOCK`).
+    pub fn is_would_block(&self) -> bool {
+        matches!(self, NetError::Errno(ErrorCode::TryAgain))
+    }
+
+    /// Returns `true` if this error indicates that a non-blocking `connect()` has been initiated
+    /// or is still in progress (`EINPROGRESS` / `EALREADY`).
+    ///
+    /// Completion is signalled later by the socket becoming writable.
+    pub fn is_in_progress(&self) -> bool {
+        matches!(
+            self,
+            NetError::Errno(ErrorCode::OperationInProgress | ErrorCode::OperationAlreadyInProgress)
+        )
+    }
+}
+
 impl core::fmt::Display for NetError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -30,3 +49,30 @@ impl core::fmt::Display for NetError {
 }
 
 impl std::error::Error for NetError {}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Tests that `is_would_block` is true only for the `TryAgain` errno.
+    #[test]
+    fn is_would_block_matches_tryagain() {
+        assert!(NetError::Errno(ErrorCode::TryAgain).is_would_block());
+        assert!(!NetError::Errno(ErrorCode::OperationInProgress).is_would_block());
+        assert!(!NetError::Errno(ErrorCode::ConnectionRefused).is_would_block());
+        assert!(!NetError::Interrupted.is_would_block());
+    }
+
+    /// Tests that `is_in_progress` is true for pending non-blocking connect errnos.
+    #[test]
+    fn is_in_progress_matches_pending_connect_errors() {
+        assert!(NetError::Errno(ErrorCode::OperationInProgress).is_in_progress());
+        assert!(NetError::Errno(ErrorCode::OperationAlreadyInProgress).is_in_progress());
+        assert!(!NetError::Errno(ErrorCode::TryAgain).is_in_progress());
+        assert!(!NetError::Interrupted.is_in_progress());
+    }
+}

--- a/src/libs/net-backend/src/io.rs
+++ b/src/libs/net-backend/src/io.rs
@@ -11,7 +11,6 @@ use crate::{
         i32_to_raw,
         is_interrupted,
         last_socket_error,
-        normalize_errno,
         raw_recv,
         raw_recvfrom,
         raw_send,
@@ -31,7 +30,10 @@ use ::log::{
     debug,
     error,
 };
-use ::sys::error::ErrorCode;
+use ::sys::error::{
+    errno_to_error_code,
+    ErrorCode,
+};
 use ::sysapi::sys_socket::sockaddr;
 
 //==================================================================================================
@@ -81,8 +83,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::send(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         }
     }
@@ -129,8 +130,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::recv(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         }
     }
@@ -197,8 +197,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::sendto(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         }
     }
@@ -262,8 +261,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::recvfrom(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         }
     }

--- a/src/libs/net-backend/src/platform/unix.rs
+++ b/src/libs/net-backend/src/platform/unix.rs
@@ -85,13 +85,6 @@ pub(crate) fn socket_failed(result: RawSocket) -> bool {
     result == INVALID_SOCKET
 }
 
-/// Maps a platform errno to the POSIX-like errno values used by `ErrorCode::try_from`.
-/// On Unix, errno is already POSIX.
-#[inline]
-pub(crate) fn normalize_errno(errno: i32) -> i32 {
-    errno
-}
-
 //==================================================================================================
 // Socket Close
 //==================================================================================================
@@ -206,6 +199,29 @@ pub(crate) unsafe fn raw_socketpair(
     libc::socketpair(domain, typ, protocol, sv.as_mut_ptr())
 }
 
+/// Raw operation to enable or disable non-blocking mode on a socket.
+///
+/// Uses `fcntl(F_GETFL)` followed by `fcntl(F_SETFL)` to toggle `O_NONBLOCK`. Returns 0 on success
+/// and -1 on failure, with the platform errno set.
+///
+/// # Safety
+///
+/// `fd` must be a file descriptor that is valid for `fcntl()` on this process. The caller is
+/// responsible for ensuring that concurrent users of the descriptor tolerate status-flag changes.
+#[inline]
+pub(crate) unsafe fn raw_set_nonblocking(fd: RawSocket, nonblocking: bool) -> libc::c_int {
+    let flags: libc::c_int = libc::fcntl(fd, libc::F_GETFL, 0);
+    if flags < 0 {
+        return -1;
+    }
+    let new_flags: libc::c_int = if nonblocking {
+        flags | libc::O_NONBLOCK
+    } else {
+        flags & !libc::O_NONBLOCK
+    };
+    libc::fcntl(fd, libc::F_SETFL, new_flags)
+}
+
 //==================================================================================================
 // Message Flags
 //==================================================================================================
@@ -272,16 +288,6 @@ mod test {
         let input: [u8; 14] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
         let result: [u8; 14] = sa_data_to_u8(sa_data_from_u8(input));
         assert_eq!(result, input, "non-zero roundtrip should be identity");
-    }
-
-    // ---- normalize_errno ------------------------------------------------------------------------
-
-    /// Tests that `normalize_errno` is identity on Unix.
-    #[test]
-    fn normalize_errno_identity() {
-        assert_eq!(normalize_errno(libc::EINTR), libc::EINTR, "EINTR should pass through");
-        assert_eq!(normalize_errno(libc::EINVAL), libc::EINVAL, "EINVAL should pass through");
-        assert_eq!(normalize_errno(42), 42, "arbitrary value should pass through");
     }
 
     // ---- Boolean helpers ------------------------------------------------------------------------

--- a/src/libs/net-backend/src/platform/windows.rs
+++ b/src/libs/net-backend/src/platform/windows.rs
@@ -92,53 +92,6 @@ pub(crate) fn socket_failed(result: RawSocket) -> bool {
     result == INVALID_SOCKET
 }
 
-/// Maps a Winsock error code to a POSIX-like errno value for `ErrorCode::try_from`.
-///
-/// The numeric values correspond to Linux `errno.h` constants for errors that
-/// the MSVC `libc` crate does not expose.
-#[inline]
-pub(crate) fn normalize_errno(errno: i32) -> i32 {
-    // Linux errno.h constants not available via `libc` on Windows.
-    const LINUX_EMSGSIZE: i32 = 90;
-    const LINUX_EOPNOTSUPP: i32 = 95;
-    const LINUX_EADDRINUSE: i32 = 98;
-    const LINUX_EADDRNOTAVAIL: i32 = 99;
-    const LINUX_ENETUNREACH: i32 = 101;
-    const LINUX_ECONNABORTED: i32 = 103;
-    const LINUX_ECONNRESET: i32 = 104;
-    const LINUX_ENOBUFS: i32 = 105;
-    const LINUX_EISCONN: i32 = 106;
-    const LINUX_ENOTCONN: i32 = 107;
-    const LINUX_ETIMEDOUT: i32 = 110;
-    const LINUX_ECONNREFUSED: i32 = 111;
-    const LINUX_EINPROGRESS: i32 = 115;
-    const LINUX_EAGAIN: i32 = 11;
-    const LINUX_EBADFD: i32 = 77;
-
-    match errno {
-        winsock::WSAEACCES => libc::EACCES,
-        winsock::WSAEADDRINUSE => LINUX_EADDRINUSE,
-        winsock::WSAEADDRNOTAVAIL => LINUX_EADDRNOTAVAIL,
-        winsock::WSAECONNABORTED => LINUX_ECONNABORTED,
-        winsock::WSAECONNREFUSED => LINUX_ECONNREFUSED,
-        winsock::WSAECONNRESET => LINUX_ECONNRESET,
-        winsock::WSAEINPROGRESS => LINUX_EINPROGRESS,
-        winsock::WSAEINTR => libc::EINTR,
-        winsock::WSAEINVAL => libc::EINVAL,
-        winsock::WSAEISCONN => LINUX_EISCONN,
-        winsock::WSAEMSGSIZE => LINUX_EMSGSIZE,
-        winsock::WSAENETUNREACH => LINUX_ENETUNREACH,
-        winsock::WSAENOBUFS => LINUX_ENOBUFS,
-        winsock::WSAENOTCONN => LINUX_ENOTCONN,
-        winsock::WSAENOTSOCK => libc::ENOTSOCK,
-        winsock::WSAEOPNOTSUPP => LINUX_EOPNOTSUPP,
-        winsock::WSAETIMEDOUT => LINUX_ETIMEDOUT,
-        winsock::WSAEWOULDBLOCK => LINUX_EAGAIN,
-        winsock::WSANOTINITIALISED => LINUX_EBADFD, // closest match
-        _ => errno,
-    }
-}
-
 //==================================================================================================
 // Socket Close
 //==================================================================================================
@@ -292,6 +245,21 @@ pub(crate) unsafe fn raw_socketpair(
     -1
 }
 
+/// Raw operation to enable or disable non-blocking mode on a socket.
+///
+/// Uses `ioctlsocket(FIONBIO)`. Returns 0 on success and `SOCKET_ERROR` (-1) on failure, with the
+/// Winsock error retrievable via `WSAGetLastError`.
+///
+/// # Safety
+///
+/// `fd` must be a socket handle that is valid for `ioctlsocket()` on this process. The caller is
+/// responsible for ensuring that concurrent users of the socket tolerate mode changes.
+#[inline]
+pub(crate) unsafe fn raw_set_nonblocking(fd: RawSocket, nonblocking: bool) -> libc::c_int {
+    let mut mode: libc::c_ulong = if nonblocking { 1 } else { 0 };
+    winsock::ioctlsocket(fd, winsock::FIONBIO, &mut mode as *mut libc::c_ulong)
+}
+
 //==================================================================================================
 // Message Flags
 //==================================================================================================
@@ -342,35 +310,22 @@ pub(crate) mod winsock {
     use libc::{
         c_char,
         c_int,
+        c_long,
+        c_ulong,
         sockaddr,
         SOCKET,
     };
 
     // Winsock error codes
-    pub const WSANOTINITIALISED: i32 = 10093;
     pub const WSAEINTR: i32 = 10004;
-    pub const WSAEACCES: i32 = 10013;
-    pub const WSAEINVAL: i32 = 10022;
-    pub const WSAEWOULDBLOCK: i32 = 10035;
-    pub const WSAEINPROGRESS: i32 = 10036;
-    pub const WSAEMSGSIZE: i32 = 10040;
-    pub const WSAEOPNOTSUPP: i32 = 10045;
-    pub const WSAEADDRINUSE: i32 = 10048;
-    pub const WSAEADDRNOTAVAIL: i32 = 10049;
-    pub const WSAENETUNREACH: i32 = 10051;
-    pub const WSAECONNABORTED: i32 = 10053;
-    pub const WSAECONNRESET: i32 = 10054;
-    pub const WSAENOBUFS: i32 = 10055;
-    pub const WSAEISCONN: i32 = 10056;
-    pub const WSAENOTCONN: i32 = 10057;
-    pub const WSAETIMEDOUT: i32 = 10060;
-    pub const WSAECONNREFUSED: i32 = 10061;
-    pub const WSAENOTSOCK: i32 = 10038;
 
     // Message flags
     pub const MSG_PEEK: c_int = 0x2;
     pub const MSG_OOB: c_int = 0x1;
     pub const MSG_WAITALL: c_int = 0x8;
+
+    // ioctlsocket command to enable/disable non-blocking mode (FIONBIO).
+    pub const FIONBIO: c_long = 0x8004667Eu32 as c_long;
 
     /// WSADATA structure for WSAStartup.
     #[repr(C)]
@@ -407,6 +362,7 @@ pub(crate) mod winsock {
         pub fn WSACleanup() -> c_int;
         pub fn WSAGetLastError() -> c_int;
         pub fn closesocket(s: SOCKET) -> c_int;
+        pub fn ioctlsocket(s: SOCKET, cmd: c_long, argp: *mut c_ulong) -> c_int;
         pub fn shutdown(s: SOCKET, how: c_int) -> c_int;
         pub fn send(s: SOCKET, buf: *const c_char, len: c_int, flags: c_int) -> c_int;
         pub fn recv(s: SOCKET, buf: *mut c_char, len: c_int, flags: c_int) -> c_int;
@@ -453,38 +409,6 @@ mod test {
         let input: [u8; 14] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
         let result: [u8; 14] = sa_data_to_u8(sa_data_from_u8(input));
         assert_eq!(result, input, "non-zero roundtrip should be identity");
-    }
-
-    // ---- normalize_errno ------------------------------------------------------------------------
-
-    /// Tests that `normalize_errno` maps `WSAECONNREFUSED` to Linux `ECONNREFUSED` (111).
-    #[test]
-    fn normalize_wsaeconnrefused() {
-        assert_eq!(normalize_errno(winsock::WSAECONNREFUSED), 111, "WSAECONNREFUSED -> 111");
-    }
-
-    /// Tests that `normalize_errno` maps `WSAETIMEDOUT` to Linux `ETIMEDOUT` (110).
-    #[test]
-    fn normalize_wsaetimedout() {
-        assert_eq!(normalize_errno(winsock::WSAETIMEDOUT), 110, "WSAETIMEDOUT -> 110");
-    }
-
-    /// Tests that `normalize_errno` maps `WSAEADDRINUSE` to Linux `EADDRINUSE` (98).
-    #[test]
-    fn normalize_wsaeaddrinuse() {
-        assert_eq!(normalize_errno(winsock::WSAEADDRINUSE), 98, "WSAEADDRINUSE -> 98");
-    }
-
-    /// Tests that `normalize_errno` maps `WSAEINVAL` to `libc::EINVAL`.
-    #[test]
-    fn normalize_wsaeinval() {
-        assert_eq!(normalize_errno(winsock::WSAEINVAL), libc::EINVAL, "WSAEINVAL -> EINVAL");
-    }
-
-    /// Tests that `normalize_errno` passes through unknown error codes.
-    #[test]
-    fn normalize_unknown_passthrough() {
-        assert_eq!(normalize_errno(99999), 99999, "unknown code should pass through");
     }
 
     // ---- Boolean helpers ------------------------------------------------------------------------

--- a/src/libs/net-backend/src/query.rs
+++ b/src/libs/net-backend/src/query.rs
@@ -11,7 +11,6 @@ use crate::{
         i32_to_raw,
         is_interrupted,
         last_socket_error,
-        normalize_errno,
         sa_data_to_u8,
         SocklenT,
     },
@@ -21,7 +20,10 @@ use ::log::{
     debug,
     error,
 };
-use ::sys::error::ErrorCode;
+use ::sys::error::{
+    errno_to_error_code,
+    ErrorCode,
+};
 use ::sysapi::sys_socket::sockaddr;
 
 //==================================================================================================
@@ -44,8 +46,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::getpeername(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => {
@@ -74,8 +75,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::getsockname(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => {

--- a/src/libs/net-backend/src/socket.rs
+++ b/src/libs/net-backend/src/socket.rs
@@ -12,7 +12,7 @@ use crate::{
         i32_to_raw,
         is_interrupted,
         last_socket_error,
-        normalize_errno,
+        raw_set_nonblocking,
         raw_shutdown,
         raw_socketpair,
         raw_to_i32,
@@ -35,7 +35,11 @@ use ::log::{
     debug,
     error,
 };
-use ::sys::error::ErrorCode;
+use ::sys::error::{
+    connect_errno_to_error_code,
+    errno_to_error_code,
+    ErrorCode,
+};
 use ::sysapi::sys_socket::{
     sockaddr,
     socklen_t,
@@ -80,8 +84,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::socket(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         } else {
             let sockfd = raw_to_i32(result);
@@ -126,8 +129,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::socketpair(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => {
@@ -160,8 +162,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::bind(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => Ok(()),
@@ -204,8 +205,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::connect(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = connect_errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => Ok(()),
@@ -224,8 +224,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::listen(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             _ => Ok(()),
@@ -250,8 +249,7 @@ impl NetBackend {
                 return Err(NetError::Interrupted);
             }
             error!("libc::accept(): failed with errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(normalize_errno(errno)).unwrap_or(ErrorCode::ValueOutOfRange);
+            let error: ErrorCode = errno_to_error_code(errno);
             Err(NetError::Errno(error))
         } else {
             let new_sockfd = raw_to_i32(result);
@@ -281,8 +279,7 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::shutdown(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             ret => unreachable!("libc::shutdown() returned invalid value {ret:?}"),
@@ -302,11 +299,35 @@ impl NetBackend {
                     return Err(NetError::Interrupted);
                 }
                 error!("libc::close(): failed with errno={errno:?}");
-                let error: ErrorCode = ErrorCode::try_from(normalize_errno(errno))
-                    .unwrap_or(ErrorCode::ValueOutOfRange);
+                let error: ErrorCode = errno_to_error_code(errno);
                 Err(NetError::Errno(error))
             },
             ret => unreachable!("libc::close() returned invalid value {ret:?}"),
+        }
+    }
+
+    /// Enables or disables non-blocking mode on a socket.
+    ///
+    /// When non-blocking mode is enabled, I/O operations that cannot complete immediately fail with
+    /// an error for which [`NetError::is_would_block`] returns `true`, and a `connect()` that cannot
+    /// complete immediately reports [`NetError::is_in_progress`].
+    pub fn set_nonblocking(&self, sockfd: i32, nonblocking: bool) -> Result<(), NetError> {
+        debug!("set_nonblocking(): sockfd={sockfd:?}, nonblocking={nonblocking:?}");
+
+        let raw = i32_to_raw(sockfd);
+        // SAFETY: `raw` is the platform socket handle supplied by the caller. Invalid handles are
+        // reported by the OS and converted to `NetError` below.
+        match unsafe { raw_set_nonblocking(raw, nonblocking) } {
+            0 => Ok(()),
+            _ => {
+                let errno: i32 = last_socket_error();
+                if is_interrupted(errno) {
+                    return Err(NetError::Interrupted);
+                }
+                error!("set_nonblocking(): failed with errno={errno:?}");
+                let error: ErrorCode = errno_to_error_code(errno);
+                Err(NetError::Errno(error))
+            },
         }
     }
 }
@@ -395,6 +416,40 @@ mod test {
             NetBackend::new().expect("platform initialization should succeed");
         let result: Result<(), NetError> = backend.close(-1);
         assert!(result.is_err(), "closing an invalid fd should fail");
+    }
+
+    /// Tests that a `recvfrom` on an empty non-blocking socket reports would-block.
+    #[test]
+    fn nonblocking_recvfrom_would_block() {
+        let backend: NetBackend =
+            NetBackend::new().expect("platform initialization should succeed");
+        let sockfd: i32 = backend
+            .socket(AddressFamily::Inet, SocketType::Datagram, Protocol::Udp)
+            .expect("creating a UDP socket should succeed");
+        let addr: sockaddr = sockaddr {
+            sa_len: core::mem::size_of::<sockaddr>() as u8,
+            sa_family: 2, // AF_INET
+            sa_data: [0, 0, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        };
+        backend
+            .bind(sockfd, &addr)
+            .expect("binding UDP socket should succeed");
+        backend
+            .set_nonblocking(sockfd, true)
+            .expect("enabling non-blocking mode should succeed");
+
+        let mut buf: [u8; 16] = [0; 16];
+        let buf_len: usize = buf.len();
+        let result: Result<(isize, sockaddr), NetError> =
+            backend.recvfrom(sockfd, &mut buf, buf_len, 0);
+        match result {
+            Err(ref e) => assert!(e.is_would_block(), "expected would-block, got {e:?}"),
+            Ok(_) => panic!("recvfrom on an empty non-blocking socket should not succeed"),
+        }
+
+        backend
+            .close(sockfd)
+            .expect("closing the socket should succeed");
     }
 
     /// Tests that `socket()` rejects `AddressFamily::Unspec`.


### PR DESCRIPTION
Add NetBackend::set_nonblocking() plus NetError::is_would_block() and is_in_progress() so callers can drive host sockets without blocking. The mode is opt-in: sockets are still created blocking, so existing callers are unaffected.

Move host errno normalization into the shared error crate and update net-backend to use it. Linux and Winsock errno values are now translated to Nanvix errno numbering before conversion to ErrorCode, avoiding raw host errno values being reinterpreted as unrelated Nanvix errors. This is needed because Linux/Winsock and Nanvix use different numeric layouts for many socket errors, such as EINPROGRESS, EALREADY, and EISCONN.

Handle the Windows non-blocking connect() special case separately: generic WSAEWOULDBLOCK still maps to TryAgain, while connect() maps it to OperationInProgress. EALREADY is also treated as an in-progress connect state.

This is groundwork for the decoupled networkd epoll reactor, which multiplexes non-blocking host sockets and parks operations that report would-block or in-progress.