### PR TITLE
[syscall] B: Stabilize dlopen Library Handles

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -21,6 +21,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-diamond \
 	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \
+	test-c-dlfcn-handle-reuse \
 	test-c-dlfcn-hash \
 	test-c-dlfcn-hello \
 	test-c-dlfcn-init-concurrent \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -130,6 +130,7 @@ POSIX_TEST_PIE_LDFLAGS := -pie --export-dynamic --no-dynamic-linker -z notext -z
 # Suites linked as position-independent executables (PIE).
 POSIX_TEST_PIE_test-c-dlfcn-pie := yes
 POSIX_TEST_PIE_test-c-dlfcn-global := yes
+POSIX_TEST_PIE_test-c-dlfcn-handle-reuse := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
 # dlfcn-cycle-c dlopen()s freestanding fixtures. Its cyclic libraries are refused
@@ -318,6 +319,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello)
@@ -334,6 +336,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HASH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
@@ -950,12 +953,55 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash): $(POSIX_TEST_HASH_LIBDIR)/libsyms-sys
 	$(CP_CMD) $(POSIX_TEST_HASH_LIBDIR)/libsyms-gnu.so $(POSIX_TEST_HASH_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_HASH_SEED)
 
+#---------------------------------------------------------------------------------------------------
+# dlfcn-handle-reuse-c: stable-handle / stale-alias regression fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+# Ships TWO self-contained shared libraries (zero undefined symbols), built with
+# the same i686 freestanding toolchain as the fixtures above. Both export the
+# SAME symbol name library_id() but with a DISTINCT return value:
+#   * libalpha.so - library_id() returns 0x0A0A0A0A.
+#   * libbeta.so  - library_id() returns 0x0B0B0B0B.
+# main.c dlopen()s libalpha.so, dlclose()s it (freeing its file descriptor), then
+# dlopen()s libbeta.so -- which the loader typically maps onto the just-freed
+# descriptor. The distinct return values make any stale-handle aliasing directly
+# observable. The fixtures are opened by explicit path, so no SONAME/DT_NEEDED
+# wiring is needed; both are staged under lib/, where main.c opens them.
+POSIX_TEST_HANDLE_REUSE_SUITE  := test-c-dlfcn-handle-reuse
+POSIX_TEST_HANDLE_REUSE_LIBDIR := $(POSIX_TESTS_OBJDIR)/$(POSIX_TEST_HANDLE_REUSE_SUITE)/libs
+POSIX_TEST_HANDLE_REUSE_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_HANDLE_REUSE_SUITE)-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse := $(BINARIES_DIR)/posix-tests-ramfs-$(POSIX_TEST_HANDLE_REUSE_SUITE).img
+
+# libalpha.so: self-contained; library_id() returns 0x0A0A0A0A.
+$(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libalpha.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_HANDLE_REUSE_SUITE)/libs/alpha.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_HANDLE_REUSE_SUITE)/libalpha.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# libbeta.so: self-contained; library_id() returns 0x0B0B0B0B.
+$(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libbeta.so: $(POSIX_TESTS_SRCDIR)/$(POSIX_TEST_HANDLE_REUSE_SUITE)/libs/beta.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building $(POSIX_TEST_HANDLE_REUSE_SUITE)/libbeta.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Per-suite RAMFS image carrying both fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse): $(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libalpha.so \
+		$(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libbeta.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libalpha.so $(POSIX_TEST_HANDLE_REUSE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_HANDLE_REUSE_LIBDIR)/libbeta.so $(POSIX_TEST_HANDLE_REUSE_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_HANDLE_REUSE_SEED)
+
 # All per-suite RAMFS images (built on demand by the runner).
 POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST_RAMFS_IMG_$(suite))) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello) \

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -36,6 +36,7 @@ use ::core::{
     sync::atomic::{
         AtomicBool,
         AtomicI32,
+        AtomicU32,
         Ordering,
     },
 };
@@ -89,11 +90,39 @@ use ::type_safe::UnalignedPointer;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DlHandle(c_int);
 
+/// First loader-generated library handle.
+const FIRST_GENERATED_HANDLE: u32 = 1;
+
+/// Last loader-generated library handle, keeping [`DlHandle::GLOBAL`] reserved.
+const LAST_GENERATED_HANDLE: u32 = c_int::MAX as u32 - 1;
+
+/// Monotonically increasing source of loader-generated library handles.
+static NEXT_HANDLE: AtomicU32 = AtomicU32::new(FIRST_GENERATED_HANDLE);
+
 impl DlHandle {
     /// Sentinel handle returned by `dlopen(NULL)` representing the global
-    /// symbol scope (main executable + pre-loaded libraries). This value
-    /// never collides with real file-descriptor-based handles.
+    /// symbol scope (main executable + pre-loaded libraries). It is drawn from
+    /// the very top of the handle space, so it never collides with a
+    /// loader-generated handle.
     pub const GLOBAL: Self = DlHandle(c_int::MAX);
+
+    /// Allocates a fresh handle that is unique for the lifetime of the process.
+    fn allocate() -> Result<Self, Error> {
+        match NEXT_HANDLE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+            if next <= LAST_GENERATED_HANDLE {
+                Some(next + 1)
+            } else {
+                None
+            }
+        }) {
+            Ok(handle) => Ok(DlHandle(handle as c_int)),
+            Err(_) => {
+                let reason: &str = "dynamic library handle space exhausted";
+                ::syslog::warn!("allocate(): {}", reason);
+                Err(Error::new(ErrorCode::ValueOverflow, reason))
+            },
+        }
+    }
 
     /// Casts the target handle to a pointer.
     pub fn as_mut_ptr(&self) -> *mut c_void {
@@ -207,6 +236,9 @@ impl InitState {
 pub struct DynamicLibrary {
     /// Library name.
     filename: CString,
+    /// Stable, loader-generated handle that uniquely identifies this library
+    /// for its whole lifetime.
+    handle: DlHandle,
     /// Underlying file descriptor.
     fd: RegularFile,
     /// Load address.
@@ -492,6 +524,7 @@ impl DynamicLibrary {
 
                 Ok(DynamicLibrary {
                     filename,
+                    handle: DlHandle::allocate()?,
                     fd,
                     load_address,
                     dependencies,
@@ -574,9 +607,9 @@ impl DynamicLibrary {
         self.filename.to_str().unwrap_or("")
     }
 
-    /// Returns a handle that uniquely identifies the dynamic library file.
+    /// Returns the stable handle that uniquely identifies this dynamic library.
     pub fn handle(&self) -> DlHandle {
-        DlHandle(self.fd.as_raw_fd())
+        self.handle
     }
 
     /// Gets the relocation table for global variables (`.rel.dyn).

--- a/src/tests/integration/test-c-dlfcn-handle-reuse/libs/alpha.c
+++ b/src/tests/integration/test-c-dlfcn-handle-reuse/libs/alpha.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libalpha.so - Self-contained shared library (zero undefined symbols).
+ *
+ * Exports library_id() returning a sentinel that is DISTINCT from the one
+ * libbeta.so returns for the same symbol name. The handle-reuse suite loads
+ * this library first, then unloads it (freeing its file descriptor) before
+ * loading libbeta.so, so a mismatched return value would reveal a stale handle
+ * silently aliasing the other library.
+ */
+
+int library_id(void)
+{
+    return 0x0A0A0A0A;
+}

--- a/src/tests/integration/test-c-dlfcn-handle-reuse/libs/beta.c
+++ b/src/tests/integration/test-c-dlfcn-handle-reuse/libs/beta.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libbeta.so - Self-contained shared library (zero undefined symbols).
+ *
+ * Exports library_id() returning a sentinel that is DISTINCT from the one
+ * libalpha.so returns for the same symbol name. The handle-reuse suite loads
+ * this library onto the file descriptor just freed by unloading libalpha.so, so
+ * resolving library_id() through libalpha.so's stale handle must never return
+ * this value.
+ */
+
+int library_id(void)
+{
+    return 0x0B0B0B0B;
+}

--- a/src/tests/integration/test-c-dlfcn-handle-reuse/main.c
+++ b/src/tests/integration/test-c-dlfcn-handle-reuse/main.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-handle-reuse-c: Validate that a dlopen() handle is a stable, opaque
+ * identifier that never aliases a different library, even after the underlying
+ * file descriptor is recycled.
+ *
+ * Before the fix, a library's handle WAS its underlying file descriptor number.
+ * File descriptor numbers are recycled by the kernel after close(), so a handle
+ * to a closed library could silently alias a completely different library
+ * loaded afterwards:
+ *
+ *   h1 = dlopen("libalpha.so");   // handle == fd (e.g. 5)
+ *   dlclose(h1);                  // fd 5 freed
+ *   h2 = dlopen("libbeta.so");    // fd 5 reused -> handle == 5 == h1
+ *   dlsym(h1, "library_id");      // h1 == h2 -> silently resolves in libbeta!
+ *
+ * Fixtures (staged under lib/ by the per-suite RAMFS image), each exporting the
+ * SAME symbol name library_id() with a DISTINCT return value so any aliasing is
+ * directly observable:
+ *   - libalpha.so: library_id() == 0x0A0A0A0A. Self-contained.
+ *   - libbeta.so:  library_id() == 0x0B0B0B0B. Self-contained.
+ *
+ * Flow: load libalpha.so, confirm its symbol, then unload it (freeing its file
+ * descriptor). Load libbeta.so, which the loader typically maps onto the
+ * just-freed descriptor. The fresh handle must differ from the stale one, the
+ * fresh handle must resolve libbeta.so's symbol, and the stale handle must fail
+ * cleanly (dlsym returns NULL) instead of resolving into libbeta.so.
+ *
+ * The harness discards stdout in standalone terminal mode, so every check
+ * returns a distinct non-zero code that pinpoints the failing step; the process
+ * exits 0 only when the whole sequence succeeds.
+ */
+
+#include <dlfcn.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#define ALPHA_PATH "lib/libalpha.so"
+#define BETA_PATH "lib/libbeta.so"
+
+#define ALPHA_ID 0x0A0A0A0A
+#define BETA_ID 0x0B0B0B0B
+
+typedef int (*id_fn)(void);
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* Load libalpha.so; its handle is h1. */
+    void *h1 = dlopen(ALPHA_PATH, RTLD_NOW);
+    if (h1 == NULL) {
+        return (1);
+    }
+
+    /* Sanity: h1 resolves libalpha.so's library_id(). */
+    id_fn alpha_id = NULL;
+    *(void **)(&alpha_id) = dlsym(h1, "library_id");
+    if (alpha_id == NULL) {
+        return (2);
+    }
+    if (alpha_id() != ALPHA_ID) {
+        return (3);
+    }
+
+    /* Unload libalpha.so; its underlying file descriptor is now free to reuse. */
+    if (dlclose(h1) != 0) {
+        return (4);
+    }
+
+    /* Load libbeta.so; the loader typically reuses the descriptor just freed. */
+    void *h2 = dlopen(BETA_PATH, RTLD_NOW);
+    if (h2 == NULL) {
+        return (5);
+    }
+
+    /* The fresh handle must not alias the stale one, even on descriptor reuse. */
+    if (h1 == h2) {
+        return (6);
+    }
+
+    /* Sanity: h2 resolves libbeta.so's library_id(). */
+    id_fn beta_id = NULL;
+    *(void **)(&beta_id) = dlsym(h2, "library_id");
+    if (beta_id == NULL) {
+        return (7);
+    }
+    if (beta_id() != BETA_ID) {
+        return (8);
+    }
+
+    /* The stale handle must fail cleanly, not resolve into libbeta.so. */
+    if (dlsym(h1, "library_id") != NULL) {
+        return (9);
+    }
+
+    /* Clean up. */
+    if (dlclose(h2) != 0) {
+        return (10);
+    }
+
+    /* Success. */
+    (void)write(STDOUT_FILENO, "ok", 2);
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -102,6 +102,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-handle-reuse"
+program = "./bin/test-c-dlfcn-handle-reuse.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-handle-reuse.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-hash"
 program = "./bin/test-c-dlfcn-hash.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-hash.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -102,6 +102,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-handle-reuse"
+program = "./bin/test-c-dlfcn-handle-reuse.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-handle-reuse.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-hash"
 program = "./bin/test-c-dlfcn-hash.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-hash.img"


### PR DESCRIPTION
## What

Fixes a dlopen loader bug where a library handle was derived from the underlying file descriptor. Because the kernel recycles descriptor numbers after `close()`, an fd-based handle to a closed library could silently alias a different library opened afterwards, letting a stale `dlsym()` resolve into the wrong object.

## Changes

**Loader (`syscall`):**
- `DynamicLibrary` now carries a stable, loader-generated `DlHandle`, assigned once from `DlHandle::allocate()` when the library is opened; `handle()` returns that stored value instead of `DlHandle(fd)`.
- `allocate()` hands out monotonically increasing ids via an `AtomicU32`, keeps `DlHandle::GLOBAL` reserved at the top of the space, and returns `ErrorCode::ValueOverflow` when the range is exhausted rather than reusing or colliding with an id.

**Tests:**
- Add the `test-c-dlfcn-handle-reuse` acceptance suite. `main.c` opens `libalpha.so`, closes it (freeing its fd), then opens `libbeta.so` onto the just-freed descriptor and asserts the two handles differ, the fresh handle resolves libbeta's symbol, and the stale handle's `dlsym()` returns `NULL`.
- Two self-contained fixtures export the same `library_id()` symbol with distinct sentinels (`0x0A0A0A0A` vs `0x0B0B0B0B`) so any stale-handle aliasing is directly observable.

**Build and harness wiring:**
- Register the suite in `ALL_POSIX_TESTS`, mark it PIE, add fixture build rules, a per-suite RAMFS image, and clean-up targets in `posix-tests.mk`.
- Add the suite to `test-posix.toml` and `test-posix-windows.toml` for debug and release, expecting exit code 0.

## Validation

- `run-unit-tests`, `run-nanvix-tests` (standalone), and the full `test` target pass on Windows.

closes #2090