### PR TITLE
[tests] Add dlfcn dlclose-cycle test

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -19,6 +19,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-ctor-dtor-reentry \
 	test-c-dlfcn-cycle \
 	test-c-dlfcn-diamond \
+	test-c-dlfcn-dlclose-cycle \
 	test-c-dlfcn-dtor-reentry \
 	test-c-dlfcn-global \
 	test-c-dlfcn-handle-reuse \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -133,6 +133,11 @@ POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-handle-reuse := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+# dlfcn-dlclose-cycle-c's fixtures reference only each other (never the main
+# executable), so PIE is not strictly required; it is set anyway to match every
+# other dlfcn dlopen suite (the executable's own symbols land in .dynsym for
+# RTLD_DEFAULT).
+POSIX_TEST_PIE_test-c-dlfcn-dlclose-cycle := yes
 # dlfcn-cycle-c dlopen()s freestanding fixtures. Its cyclic libraries are refused
 # before relocation and its positive-control library exports no undefined symbols,
 # so PIE is not strictly required; it is set anyway to match every other dlfcn
@@ -318,6 +323,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash)
@@ -335,6 +341,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HASH_SEED)
@@ -543,6 +550,80 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond): $(POSIX_TEST_DIAMOND_DIR)/libbase.
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libright.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libdiamond.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_DIAMOND_SEED)
+
+#---------------------------------------------------------------------------------------------------
+# dlfcn-dlclose-cycle-c: dlclose() over a multiply-referenced dependency graph.
+#---------------------------------------------------------------------------------------------------
+#
+#   libroot.so -> libmidx.so -> libleaf.so
+#              -> libmidy.so -> libleaf.so
+#              -> libleaf.so                (direct edge)
+#
+# libleaf.so is reachable from libroot.so through THREE DT_NEEDED edges, so a
+# single dlclose(libroot.so) visits it more than once while walking the
+# dependency graph. That repeated visit is what made the pre-fix dlclose() panic
+# (it removed each dependency with `extract_if` and asserted exactly one entry
+# was removed per step); the post-fix reference-count peel records visited nodes
+# and must instead unload libleaf.so exactly once, and only after every edge that
+# references it is gone. A true DT_NEEDED cycle is refused at load time, so this
+# loadable diamond-with-a-direct-edge graph is the equivalent that still drives
+# the repeated-visit teardown path.
+# Built with the same i686 freestanding toolchain as the diamond fixtures above;
+# each DT_NEEDED edge is produced by linking the dependent against its
+# dependencies with `-L<dir> -l<name>` (the linker records each found
+# `lib<name>.so` as a bare DT_NEEDED entry, resolved through the loader's default
+# lib/ search path).
+POSIX_TEST_DLCLOSE_CYCLE_DIR  := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-dlclose-cycle/libs
+POSIX_TEST_DLCLOSE_CYCLE_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-dlclose-cycle-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-dlclose-cycle.img
+
+# Leaf: libleaf.so (no dependencies).
+$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-dlclose-cycle/libs/leaf.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-dlclose-cycle-c/libleaf.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Intermediate libmidx.so: DT_NEEDED libleaf.so.
+$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidx.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-dlclose-cycle/libs/midx.c \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-dlclose-cycle-c/libmidx.so (DT_NEEDED libleaf.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -L$(POSIX_TEST_DLCLOSE_CYCLE_DIR) -lleaf -o $@
+
+# Intermediate libmidy.so: DT_NEEDED libleaf.so.
+$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidy.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-dlclose-cycle/libs/midy.c \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-dlclose-cycle-c/libmidy.so (DT_NEEDED libleaf.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -L$(POSIX_TEST_DLCLOSE_CYCLE_DIR) -lleaf -o $@
+
+# Root: DT_NEEDED libmidx.so + libmidy.so + libleaf.so. The direct libleaf.so
+# edge (alongside the two intermediates that also pull it in) is what makes
+# libleaf.so reachable more than once during dlclose(libroot.so).
+$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libroot.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-dlclose-cycle/libs/root.c \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidx.so $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidy.so \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-dlclose-cycle-c/libroot.so (DT_NEEDED libmidx.so libmidy.so libleaf.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o \
+		-L$(POSIX_TEST_DLCLOSE_CYCLE_DIR) -lmidx -lmidy -lleaf -o $@
+
+# Per-suite RAMFS image carrying all four fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle): $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidx.so \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidy.so \
+		$(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libroot.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libleaf.so $(POSIX_TEST_DLCLOSE_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidx.so $(POSIX_TEST_DLCLOSE_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libmidy.so $(POSIX_TEST_DLCLOSE_CYCLE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_DIR)/libroot.so $(POSIX_TEST_DLCLOSE_CYCLE_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_DLCLOSE_CYCLE_SEED)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-cycle-c: DT_NEEDED cycle-rejection fixtures.
@@ -1000,6 +1081,7 @@ POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash) \

--- a/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/leaf.c
+++ b/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/leaf.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libleaf.so - shared leaf of the dlfcn-dlclose-cycle graph.
+ *
+ *   libroot.so  DT_NEEDED libmidx.so, libmidy.so, libleaf.so  (direct edge)
+ *   libmidx.so  DT_NEEDED libleaf.so
+ *   libmidy.so  DT_NEEDED libleaf.so
+ *   libleaf.so  (no dependencies)
+ *
+ * libleaf.so is reachable from libroot.so through THREE distinct dependency
+ * edges (root->midx->leaf, root->midy->leaf, and root's own direct edge), so a
+ * single dlclose(libroot.so) visits it more than once while it walks the
+ * dependency graph. That repeated visit is exactly the condition that made the
+ * pre-fix dlclose() panic (it removed each dependency with `extract_if` and
+ * asserted `len == 1`, which tripped the second time a node was reached). The
+ * post-fix reference-count peel tracks visited nodes and must instead unload
+ * libleaf.so exactly once, and only after every edge that references it is gone.
+ *
+ * `unique_counter` is a process-lifetime counter that main.c uses as the witness
+ * for a single shared instance: if the loader ever mapped libleaf.so more than
+ * once, midx/midy/root would each observe their own private counter starting at
+ * zero. A fresh value of zero after a full dlclose() also proves the library was
+ * genuinely unloaded (its zero-initialized BSS is re-created on the next load).
+ */
+
+/* Process-lifetime counter. Bumped by every call to `leaf_bump()`. */
+static int unique_counter = 0;
+
+int leaf_bump(void)
+{
+    unique_counter += 1;
+    return unique_counter;
+}
+
+int leaf_get(void)
+{
+    return unique_counter;
+}

--- a/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/midx.c
+++ b/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/midx.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libmidx.so - one intermediate node of the dlfcn-dlclose-cycle graph:
+ *
+ *   libmidx.so DT_NEEDED libleaf.so
+ *
+ * `midx_touch()` references libleaf.so's `leaf_bump()`, which forces the
+ * DT_NEEDED edge on libleaf.so at link time. libmidx.so and libmidy.so both
+ * depend on the SAME libleaf.so, so a correct loader binds both to a single
+ * shared instance; dlclose() must keep that instance loaded while EITHER
+ * intermediate is still referenced.
+ */
+
+extern int leaf_bump(void);
+
+int midx_touch(void)
+{
+    return leaf_bump();
+}

--- a/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/midy.c
+++ b/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/midy.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libmidy.so - the other intermediate node of the dlfcn-dlclose-cycle graph:
+ *
+ *   libmidy.so DT_NEEDED libleaf.so
+ *
+ * `midy_touch()` references libleaf.so's `leaf_bump()`, which forces the
+ * DT_NEEDED edge on libleaf.so at link time. It shares libleaf.so with
+ * libmidx.so; the staggered-dlclose test uses this shared edge to prove that
+ * closing one intermediate leaves libleaf.so loaded for the other.
+ */
+
+extern int leaf_bump(void);
+
+int midy_touch(void)
+{
+    return leaf_bump();
+}

--- a/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/root.c
+++ b/src/tests/integration/test-c-dlfcn-dlclose-cycle/libs/root.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libroot.so - root of the dlfcn-dlclose-cycle graph:
+ *
+ *   libroot.so DT_NEEDED libmidx.so, libmidy.so, libleaf.so
+ *
+ * `root_touch()` references a symbol from each of libmidx.so (`midx_touch`),
+ * libmidy.so (`midy_touch`) and libleaf.so (`leaf_bump`/`leaf_get`), which
+ * forces all three DT_NEEDED edges at link time. The direct libleaf.so edge --
+ * alongside the two that arrive transitively through the intermediates -- is
+ * what makes libleaf.so reachable more than once during a single
+ * dlclose(libroot.so) traversal, reproducing the repeated-visit condition.
+ */
+
+extern int leaf_bump(void);
+extern int leaf_get(void);
+extern int midx_touch(void);
+extern int midy_touch(void);
+
+int root_touch(void)
+{
+    (void)midx_touch();
+    (void)midy_touch();
+    (void)leaf_bump();
+    return leaf_get();
+}

--- a/src/tests/integration/test-c-dlfcn-dlclose-cycle/main.c
+++ b/src/tests/integration/test-c-dlfcn-dlclose-cycle/main.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * dlfcn-dlclose-cycle-c: dlclose() over a multiply-referenced dependency graph.
+ *
+ *   libroot.so  DT_NEEDED libmidx.so, libmidy.so, libleaf.so  (direct edge)
+ *   libmidx.so  DT_NEEDED libleaf.so
+ *   libmidy.so  DT_NEEDED libleaf.so
+ *   libleaf.so  (no dependencies)
+ *
+ * dlclose() tears a library's dependency graph down by walking its DT_NEEDED
+ * edges. When a single library is reachable through more than one edge, that
+ * walk reaches it more than once. The pre-fix loader removed each dependency
+ * with `extract_if` and asserted that exactly one entry was removed per step;
+ * the second time a node was reached the removal found nothing and the
+ * `assert_eq!(len, 1)` panicked, crashing the whole process. The fix replaces
+ * that with a reference-count peel that records visited nodes, so a repeated
+ * visit is handled gracefully and each library is unloaded exactly once -- and
+ * only after every edge that references it has been released.
+ *
+ * A true DT_NEEDED cycle (libA <-> libB) is refused at load time by dlopen(),
+ * so it can never reach dlclose(). The graph above is the loadable equivalent
+ * that still drives the repeated-visit path: libleaf.so is reachable from
+ * libroot.so through three edges (via libmidx.so, via libmidy.so, and directly),
+ * so a single dlclose(libroot.so) visits it three times.
+ *
+ * This suite asserts the fixed behavior:
+ *   * a well-formed, dependency-free control library loads (proves the RAMFS is
+ *     mounted and the loader resolves a library);
+ *   * dlopen(libroot.so) binds all three libleaf.so edges to ONE shared
+ *     instance, and dlclose(libroot.so) returns cleanly (no panic) and unloads
+ *     the entire graph -- reproducing and pinning the regression fix;
+ *   * with libmidx.so and libmidy.so opened independently, closing one leaves
+ *     the shared libleaf.so loaded for the other, and only closing the last
+ *     reference unloads it ("unloaded only when all references are released");
+ *   * the loader stays usable afterwards.
+ *
+ * Reaching any assertion after a dlclose() at all is itself the witness that
+ * dlclose() returned rather than panicking; a pre-fix loader would have aborted
+ * the process inside the multiply-referenced teardown.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Opens libleaf.so by itself and confirms its counter reads as a freshly
+ * initialized zero. Used both as the opening sanity check and, after a graph is
+ * torn down, to prove libleaf.so was genuinely unloaded: a re-load re-creates
+ * its zero-initialized counter, so a non-zero value would mean a stale instance
+ * survived the dlclose(). Returns 1 on success, 0 on failure.
+ */
+static int leaf_reloads_fresh(const char *name)
+{
+    void *h = dlopen("lib/libleaf.so", RTLD_NOW);
+    if (h == NULL) {
+        fail(name, dlerror());
+        return 0;
+    }
+
+    int (*get)(void) = (int (*)(void))dlsym(h, "leaf_get");
+    if (get == NULL) {
+        fail(name, "leaf_get() not found");
+        dlclose(h);
+        return 0;
+    }
+    if (get() != 0) {
+        fail(name, "libleaf.so counter was not fresh -- a stale instance survived");
+        dlclose(h);
+        return 0;
+    }
+
+    if (dlclose(h) != 0) {
+        fail(name, "dlclose(libleaf.so) failed");
+        return 0;
+    }
+    return 1;
+}
+
+/*
+ * Test 0 (positive control): the dependency-free libleaf.so loads on its own.
+ */
+static void test_positive_control(void)
+{
+    if (leaf_reloads_fresh("dlopen(libleaf.so) [positive control]")) {
+        pass("dlopen(libleaf.so) [positive control]");
+    }
+}
+
+/*
+ * Test 1: dlopen(libroot.so) binds every libleaf.so edge to a single shared
+ * instance, then dlclose(libroot.so) tears the whole graph down without
+ * panicking on the multiply-referenced libleaf.so and unloads it exactly once.
+ * This is the direct reproduction of the repeated-visit regression.
+ */
+static void test_multipath_dlclose(void)
+{
+    const char *name = "dlclose(libroot.so) [multiply-referenced leaf]";
+
+    void *h = dlopen("lib/libroot.so", RTLD_NOW);
+    if (h == NULL) {
+        fail(name, dlerror());
+        return;
+    }
+
+    int (*midx_touch)(void) = (int (*)(void))dlsym(h, "midx_touch");
+    int (*midy_touch)(void) = (int (*)(void))dlsym(h, "midy_touch");
+    int (*root_touch)(void) = (int (*)(void))dlsym(h, "root_touch");
+    int (*leaf_get)(void) = (int (*)(void))dlsym(h, "leaf_get");
+    if (!midx_touch || !midy_touch || !root_touch || !leaf_get) {
+        fail(name, "missing symbol across the dependency graph");
+        dlclose(h);
+        return;
+    }
+
+    /*
+     * midx and midy bump the SAME leaf counter: if libleaf.so had been loaded
+     * twice, midy_touch() would restart from 1 instead of continuing to 2.
+     */
+    if (midx_touch() != 1 || midy_touch() != 2) {
+        fail(name, "libmidx.so and libmidy.so do not share one libleaf.so");
+        dlclose(h);
+        return;
+    }
+
+    /*
+     * root_touch() bumps the counter through all three of libroot.so's edges
+     * (via midx, via midy, and directly): 2 -> 3 -> 4 -> 5. A value other than 5
+     * would mean libroot.so's direct libleaf.so edge resolved to a different
+     * instance than the intermediates use.
+     */
+    if (root_touch() != 5 || leaf_get() != 5) {
+        fail(name, "libroot.so's direct libleaf.so edge is not the shared instance");
+        dlclose(h);
+        return;
+    }
+
+    /*
+     * The teardown that tripped the regression: libleaf.so is reached three
+     * times. A clean return (dlclose() == 0) is the witness that the peel did
+     * not panic.
+     */
+    if (dlclose(h) != 0) {
+        fail(name, "dlclose(libroot.so) failed");
+        return;
+    }
+
+    /* The graph had no other references, so it must have fully unloaded. */
+    if (!leaf_reloads_fresh(name)) {
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Test 2: libmidx.so and libmidy.so are opened independently and share one
+ * libleaf.so. Closing libmidx.so must leave libleaf.so loaded (libmidy.so still
+ * references it); only closing libmidy.so releases the final reference and
+ * unloads libleaf.so. This pins the "unloaded only when all references are
+ * released" half of the regression.
+ */
+static void test_shared_dependency_refcount(void)
+{
+    const char *name = "dlclose() unloads shared libleaf.so only on last reference";
+
+    void *hx = dlopen("lib/libmidx.so", RTLD_NOW);
+    if (hx == NULL) {
+        fail(name, dlerror());
+        return;
+    }
+    void *hy = dlopen("lib/libmidy.so", RTLD_NOW);
+    if (hy == NULL) {
+        fail(name, dlerror());
+        dlclose(hx);
+        return;
+    }
+
+    int (*midx_touch)(void) = (int (*)(void))dlsym(hx, "midx_touch");
+    /*
+     * Resolve libmidy.so's entry point (and the shared leaf accessor) up front,
+     * so they can be called after libmidx.so is closed. The function pointers
+     * stay valid because libmidy.so and libleaf.so remain mapped until hy is
+     * closed.
+     */
+    int (*midy_touch)(void) = (int (*)(void))dlsym(hy, "midy_touch");
+    int (*leaf_get)(void) = (int (*)(void))dlsym(hy, "leaf_get");
+    if (!midx_touch || !midy_touch || !leaf_get) {
+        fail(name, "missing symbol across the shared dependency");
+        dlclose(hy);
+        dlclose(hx);
+        return;
+    }
+
+    /* Shared instance: 1 (via midx) then 2 (via midy). */
+    if (midx_touch() != 1 || midy_touch() != 2) {
+        fail(name, "libmidx.so and libmidy.so do not share one libleaf.so");
+        dlclose(hy);
+        dlclose(hx);
+        return;
+    }
+
+    /* Close one referrer. libleaf.so must stay loaded for libmidy.so. */
+    if (dlclose(hx) != 0) {
+        fail(name, "dlclose(libmidx.so) failed");
+        dlclose(hy);
+        return;
+    }
+
+    /*
+     * If closing libmidx.so had wrongly unloaded the shared libleaf.so, this
+     * call would either fault or observe a counter reset to 1; a correct loader
+     * continues the shared counter to 3.
+     */
+    if (midy_touch() != 3 || leaf_get() != 3) {
+        fail(name, "shared libleaf.so was unloaded while libmidy.so still referenced it");
+        dlclose(hy);
+        return;
+    }
+
+    /* Release the last referrer: libleaf.so must now unload. */
+    if (dlclose(hy) != 0) {
+        fail(name, "dlclose(libmidy.so) failed");
+        return;
+    }
+    if (!leaf_reloads_fresh(name)) {
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Test 3: after all of the above teardown, the loader is still usable -- the
+ * whole graph loads and unloads cleanly one more time.
+ */
+static void test_loader_still_usable(void)
+{
+    const char *name = "loader still usable after multi-reference dlclose";
+
+    void *h = dlopen("lib/libroot.so", RTLD_NOW);
+    if (h == NULL) {
+        fail(name, dlerror());
+        return;
+    }
+    int (*root_touch)(void) = (int (*)(void))dlsym(h, "root_touch");
+    if (!root_touch || root_touch() != 3) {
+        fail(name, "libroot.so did not reload cleanly");
+        dlclose(h);
+        return;
+    }
+    if (dlclose(h) != 0) {
+        fail(name, "dlclose(libroot.so) failed");
+        return;
+    }
+    pass(name);
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn dlclose multiply-referenced graph tests ===\n");
+    fflush(stdout);
+
+    test_positive_control();
+    test_multipath_dlclose();
+    test_shared_dependency_refcount();
+    test_loader_still_usable();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -86,6 +86,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-dlclose-cycle"
+program = "./bin/test-c-dlfcn-dlclose-cycle.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dlclose-cycle.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-dtor-reentry"
 program = "./bin/test-c-dlfcn-dtor-reentry.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dtor-reentry.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -86,6 +86,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-dlclose-cycle"
+program = "./bin/test-c-dlfcn-dlclose-cycle.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dlclose-cycle.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-dtor-reentry"
 program = "./bin/test-c-dlfcn-dtor-reentry.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-dtor-reentry.img"


### PR DESCRIPTION
Adds a POSIX integration suite that exercises `dlclose()` over a multiply-referenced dependency graph, pinning the loader fix that replaced the panicking `extract_if`/`assert_eq!(len, 1)` teardown with a reference-count peel.

## Why

`libleaf.so` is reachable from `libroot.so` through three `DT_NEEDED` edges (via `libmidx.so`, via `libmidy.so`, and directly), so a single `dlclose(libroot.so)` visits it repeatedly — the exact condition that aborted the pre-fix loader. This suite reproduces and pins that regression.

## What

**Tests**
- New fixtures `libleaf`/`libmidx`/`libmidy`/`libroot` with a shared process-lifetime counter that witnesses a single shared `libleaf.so` instance and a genuine unload on reload.
- `main.c` covering a positive control load, the multiply-referenced `dlclose` reproduction, staggered `dlclose` proving the shared library unloads only on its last reference, and loader reusability afterward.

**Build and harness wiring**
- Registered the suite in `guest-posix-tests.mk` and added per-suite RAMFS image rules building the four solibs in `posix-tests.mk`.
- Added the test entry to `test-posix.toml` and `test-posix-windows.toml`.

Closes #2092