### PR TITLE
[syscall] Add Pull-Based recv() Transfer

### DIFF
--- a/src/daemons/linuxd/src/linux/sys_socket.rs
+++ b/src/daemons/linuxd/src/linux/sys_socket.rs
@@ -233,23 +233,27 @@ pub fn do_recv<T>(
     syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ReceiveSocketRequest,
-) -> Result<Message, WorkerThreadError> {
+) -> Result<(Message, Vec<u8>), WorkerThreadError> {
     trace!("recv(): tid={tid:?}, request={request:?}");
 
     let net_backend = match &syscall_table.net_backend {
         Some(backend) => backend,
-        None => return Ok(crate::build_error(tid, ErrorCode::OperationNotSupported)),
+        None => return Ok((crate::build_error(tid, ErrorCode::OperationNotSupported), Vec::new())),
     };
 
     let recv_len: usize =
-        core::cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
-    let mut buffer: [u8; ReceiveSocketResponse::BUFFER_SIZE] =
-        [0; ReceiveSocketResponse::BUFFER_SIZE];
+        core::cmp::min(ReceiveSocketResponse::MAX_DATA_SIZE, request.count as usize);
+    let mut buffer: Vec<u8> = vec![0u8; recv_len];
 
     match net_backend.recv(request.sockfd, &mut buffer, recv_len, request.flags) {
-        Ok(count) => Ok(ReceiveSocketResponse::build(tid, count as u32, buffer)),
+        Ok(count) => {
+            // Trim the buffer to the bytes actually received so the bulk transfer carries only
+            // the received payload.
+            buffer.truncate(count as usize);
+            Ok((ReceiveSocketResponse::build(tid, count as u32), buffer))
+        },
         Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
-        Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),
+        Err(NetError::Errno(code)) => Ok((crate::build_error(tid, code), Vec::new())),
     }
 }
 

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -551,6 +551,7 @@ impl WorkerThreadHandle {
                                 // backend provider.
                                 SystemCallMessageHeader::CloseRequest
                                 | SystemCallMessageHeader::ReadRequest
+                                | SystemCallMessageHeader::ReceiveSocketRequest
                                 | SystemCallMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
                                         &syscall_table,
@@ -597,7 +598,6 @@ impl WorkerThreadHandle {
                                 | SystemCallMessageHeader::ListenSocketRequest
                                 | SystemCallMessageHeader::PartialReadRequest
                                 | SystemCallMessageHeader::PartialWriteRequest
-                                | SystemCallMessageHeader::ReceiveSocketRequest
                                 | SystemCallMessageHeader::SeekRequest
                                 | SystemCallMessageHeader::SendSocketRequest
                                 | SystemCallMessageHeader::ShutdownSocketRequest
@@ -774,6 +774,18 @@ impl WorkerThreadHandle {
                     cancel_rx,
                 )
             },
+            SystemCallMessageHeader::ReceiveSocketRequest => {
+                let request: ReceiveSocketRequest =
+                    ReceiveSocketRequest::from_bytes(message.payload);
+                Self::handle_recv_request(
+                    syscall_table,
+                    source,
+                    request,
+                    channel_rx,
+                    uvm_stream,
+                    cancel_rx,
+                )
+            },
             header => {
                 // The following statement is unreachable, because the matching logic in this
                 // function should match the one in the `Self::run()` function.
@@ -886,11 +898,6 @@ impl WorkerThreadHandle {
             SystemCallMessageHeader::PartialWriteRequest => {
                 let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
                 unistd::do_pwrite(&syscall_table, source, request)
-            },
-            SystemCallMessageHeader::ReceiveSocketRequest => {
-                let request: ReceiveSocketRequest =
-                    ReceiveSocketRequest::from_bytes(message.payload);
-                sys_socket::do_recv(&syscall_table, source, request)
             },
             SystemCallMessageHeader::SeekRequest => {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
@@ -1591,6 +1598,106 @@ impl WorkerThreadHandle {
                     ))
                 }
             }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Handles a `recv()` request.  Waits for the pull-header bulk frame the guest's `ipc::pull()`
+    /// emits after the request, performs the receive on the networking backend, pushes the
+    /// received payload directly into the guest buffer, and returns the response message.
+    ///
+    /// # Parameters
+    ///
+    /// - `syscall_table`: Shared syscall dispatch table.
+    /// - `source`: Thread identifier of the requesting guest thread.
+    /// - `request`: The receive request payload.
+    /// - `channel_rx`: Worker command channel receiver (for bulk data).
+    /// - `uvm_stream`: Writer stream to the user VM.
+    /// - `cancel_rx`: Watch receiver used to detect cancellation.
+    ///
+    /// # Returns
+    ///
+    /// The response [`Message`] on success, or a [`WorkerThreadError`] on failure.
+    ///
+    fn handle_recv_request<T>(
+        syscall_table: &SyscallTable<T>,
+        source: ThreadIdentifier,
+        request: ReceiveSocketRequest,
+        channel_rx: &mut Receiver<VenvCommand>,
+        uvm_stream: Arc<Mutex<SocketStreamWriter>>,
+        cancel_rx: &mut watch::Receiver<bool>,
+    ) -> Result<Message, WorkerThreadError> {
+        trace!("handle_recv_request(): source={source:?}, request={request:?}");
+
+        // Wait for the BulkData pull request that the guest's `ipc::pull()` emits after the
+        // request. It carries the kernel buffer address where the payload must be written. A
+        // timeout prevents the worker thread from blocking forever if the guest VM crashes
+        // mid-protocol.
+        let pull_header: ::sys::ipc::DataChunkHeader =
+            match Self::recv_with_timeout(channel_rx, BULK_DATA_TIMEOUT, cancel_rx) {
+                Ok(VenvCommand::BulkData(bulk)) => *bulk.header(),
+                Ok(VenvCommand::Shutdown) => {
+                    debug!("handle_recv_request(): received shutdown while waiting for bulk data");
+                    return Err(WorkerThreadError::Interrupted);
+                },
+                Ok(VenvCommand::Work(_)) => {
+                    error!("handle_recv_request(): expected BulkData, got IKC message");
+                    return Ok(build_error(source, ErrorCode::InvalidMessage));
+                },
+                Err(e) => {
+                    error!("handle_recv_request(): failed to receive bulk data");
+                    return Err(e);
+                },
+            };
+
+        // Helper closure: push a bulk payload back into the guest buffer.
+        let send_bulk_response = |data: Vec<u8>, len: u32| -> Result<(), WorkerThreadError> {
+            let bulk: ::sys::ipc::DataChunk = ::sys::ipc::DataChunk::new(
+                ::sys::ipc::DataChunkHeader::new(
+                    pull_header.source_pid(),
+                    pull_header.source_tid(),
+                    pull_header.destination_pid(),
+                    pull_header.destination_tid(),
+                    pull_header.data_addr(),
+                    len,
+                ),
+                data,
+            );
+            Handle::current()
+                .block_on(Self::send_bulk(uvm_stream.clone(), &bulk))
+                .map_err(|e| {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        debug!("handle_recv_request(): UVM stream closed (broken pipe)");
+                    } else {
+                        error!("handle_recv_request(): failed to send bulk response (error={e:?})");
+                    }
+                    WorkerThreadError::Interrupted
+                })
+        };
+
+        // Perform the receive on the networking backend.
+        match sys_socket::do_recv(syscall_table, source, request) {
+            Ok((response, data)) => {
+                // The payload is bounded by the scatter/gather bulk limit, so its length fits in
+                // the bulk header field.
+                let len: u32 = data.len() as u32;
+                send_bulk_response(data, len)?;
+                Ok(response)
+            },
+            Err(WorkerThreadError::Interrupted) => {
+                // Release the guest blocked in `ipc::pull()` with an empty transfer before
+                // returning so the kernel pull thread does not block.
+                if let Err(bulk_err) = send_bulk_response(Vec::new(), 0) {
+                    warn!(
+                        "handle_recv_request(): failed to send empty bulk response on interrupt, \
+                         kernel pull thread may block (error={bulk_err:?})"
+                    );
+                }
+                Err(WorkerThreadError::Interrupted)
+            },
+            Err(e) => Err(e),
         }
     }
 

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -164,11 +164,6 @@ pub fn dispatch_message(
             let request: ListenSocketRequest = ListenSocketRequest::from_bytes(syscall_msg.payload);
             Some(vec![do_listen(backend, tid, request)])
         },
-        SystemCallMessageHeader::ReceiveSocketRequest => {
-            let request: ReceiveSocketRequest =
-                ReceiveSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_recv(backend, tid, request)])
-        },
         SystemCallMessageHeader::SendSocketRequest => {
             let request: SendSocketRequest = SendSocketRequest::from_bytes(syscall_msg.payload);
             Some(vec![do_send(backend, tid, request)])
@@ -237,6 +232,32 @@ pub fn dispatch_recvfrom(
     let request: ReceiveFromSocketRequest =
         ReceiveFromSocketRequest::from_bytes(syscall_msg.payload);
     do_recvfrom(backend, tid, request)
+}
+
+///
+/// # Description
+///
+/// Dispatches a `recv()` request whose payload is delivered out-of-band via a scatter/gather
+/// pull.
+///
+/// # Parameters
+///
+/// - `backend`: Reference to the networking backend.
+/// - `source`: The message source (identifies the calling thread).
+/// - `syscall_msg`: The parsed `ReceiveSocketRequest` system call message.
+///
+/// # Returns
+///
+/// A tuple with the response message and the payload to push back to the guest.
+///
+pub fn dispatch_recv(
+    backend: &NetBackend,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+) -> (Message, Vec<u8>) {
+    let tid: ThreadIdentifier = source.tid;
+    let request: ReceiveSocketRequest = ReceiveSocketRequest::from_bytes(syscall_msg.payload);
+    do_recv(backend, tid, request)
 }
 
 //==================================================================================================
@@ -392,16 +413,24 @@ fn do_accept(backend: &NetBackend, tid: ThreadIdentifier, request: AcceptSocketR
     }
 }
 
-fn do_recv(backend: &NetBackend, tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Message {
+fn do_recv(
+    backend: &NetBackend,
+    tid: ThreadIdentifier,
+    request: ReceiveSocketRequest,
+) -> (Message, Vec<u8>) {
     trace!("networkd::recv(): tid={tid:?}, request={request:?}");
     let recv_len: usize =
-        core::cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
-    let mut buffer: [u8; ReceiveSocketResponse::BUFFER_SIZE] =
-        [0; ReceiveSocketResponse::BUFFER_SIZE];
+        core::cmp::min(ReceiveSocketResponse::MAX_DATA_SIZE, request.count as usize);
+    let mut buffer: Vec<u8> = vec![0u8; recv_len];
     match backend.recv(to_host_fd(request.sockfd), &mut buffer, recv_len, request.flags) {
-        Ok(count) => ReceiveSocketResponse::build(tid, count as u32, buffer),
-        Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
-        Err(NetError::Errno(code)) => build_error(tid, code),
+        Ok(count) => {
+            // Trim the buffer to the bytes actually received so the bulk transfer carries only
+            // the received payload.
+            buffer.truncate(count as usize);
+            (ReceiveSocketResponse::build(tid, count as u32), buffer)
+        },
+        Err(NetError::Interrupted) => (build_error(tid, ErrorCode::Interrupted), Vec::new()),
+        Err(NetError::Errno(code)) => (build_error(tid, code), Vec::new()),
     }
 }
 

--- a/src/daemons/networkd/src/lib.rs
+++ b/src/daemons/networkd/src/lib.rs
@@ -141,6 +141,29 @@ impl NetworkDaemon {
     ///
     /// # Description
     ///
+    /// Processes a `recv()` request whose payload is delivered out-of-band via a scatter/gather
+    /// pull.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Identifies the calling thread.
+    /// - `syscall_msg`: The parsed `ReceiveSocketRequest` system call message.
+    ///
+    /// # Returns
+    ///
+    /// A tuple with the response message and the payload to push back to the guest.
+    ///
+    pub fn handle_recv(
+        &self,
+        source: MessageSender,
+        syscall_msg: SystemCallMessage,
+    ) -> (Message, Vec<u8>) {
+        dispatch::dispatch_recv(&self.backend, source, syscall_msg)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns `true` if the given message header corresponds to a networking system call that
     /// this daemon handles.
     ///

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -16,6 +16,7 @@ use ::sys::{
         MessageReceiver,
         MessageSender,
         MessageType,
+        SG_BULK_MAX_BYTES,
     },
     pm::{
         ProcessIdentifier,
@@ -86,15 +87,23 @@ impl ReceiveSocketRequest {
 #[repr(C, packed)]
 pub struct ReceiveSocketResponse {
     pub count: c_size_t,
-    pub buffer: [u8; Self::BUFFER_SIZE],
+    _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(ReceiveSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl ReceiveSocketResponse {
-    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_size_t>();
+    /// Maximum number of payload bytes a single `recv()` transfer may carry. The data travels
+    /// out-of-band via a scatter/gather pull, so it is bounded by the maximum scatter/gather
+    /// transfer size rather than by a single page or by the IPC message payload.
+    pub const MAX_DATA_SIZE: usize = SG_BULK_MAX_BYTES;
 
-    pub fn new(count: c_size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
-        Self { count, buffer }
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_size_t>();
+
+    pub fn new(count: c_size_t) -> Self {
+        Self {
+            count,
+            _padding: [0; Self::PADDING_SIZE],
+        }
     }
 
     pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
@@ -105,12 +114,8 @@ impl ReceiveSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(
-        tid: ThreadIdentifier,
-        count: c_size_t,
-        buffer: [u8; Self::BUFFER_SIZE],
-    ) -> Message {
-        let message: ReceiveSocketResponse = ReceiveSocketResponse::new(count, buffer);
+    pub fn build(tid: ThreadIdentifier, count: c_size_t) -> Message {
+        let message: ReceiveSocketResponse = ReceiveSocketResponse::new(count);
         let message: SystemCallMessage = SystemCallMessage::new(
             SystemCallMessageHeader::ReceiveSocketResponse,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/message/recvfrom.rs
@@ -20,6 +20,7 @@ use ::sys::{
         MessageReceiver,
         MessageSender,
         MessageType,
+        SG_BULK_MAX_BYTES,
     },
     pm::{
         ProcessIdentifier,
@@ -100,9 +101,9 @@ pub struct ReceiveFromSocketResponse {
 
 impl ReceiveFromSocketResponse {
     /// Maximum number of payload bytes a single `recvfrom()` datagram may carry. The data travels
-    /// out-of-band via a scatter/gather pull, so it is bounded by a single page rather than by the
-    /// IPC message payload.
-    pub const MAX_DATA_SIZE: usize = ::arch::mem::PAGE_SIZE;
+    /// out-of-band via a scatter/gather pull, so it is bounded by the maximum scatter/gather
+    /// transfer size rather than by a single page or by the IPC message payload.
+    pub const MAX_DATA_SIZE: usize = SG_BULK_MAX_BYTES;
 
     pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<c_size_t>()

--- a/src/libs/syscall/src/sys/socket/message/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/message/sendto.rs
@@ -20,6 +20,7 @@ use ::sys::{
         MessageReceiver,
         MessageSender,
         MessageType,
+        SG_BULK_MAX_BYTES,
     },
     pm::{
         ProcessIdentifier,
@@ -47,9 +48,9 @@ pub struct SendToSocketRequest {
 
 impl SendToSocketRequest {
     /// Maximum number of payload bytes a single `sendto()` datagram may carry. The data travels
-    /// out-of-band via a scatter/gather push, so it is bounded by a single page rather than by the
-    /// IPC message payload.
-    pub const MAX_DATA_SIZE: usize = ::arch::mem::PAGE_SIZE;
+    /// out-of-band via a scatter/gather push, so it is bounded by the maximum scatter/gather
+    /// transfer size rather than by a single page or by the IPC message payload.
+    pub const MAX_DATA_SIZE: usize = SG_BULK_MAX_BYTES;
 
     pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -20,7 +20,10 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::ffi::c_int;
 
@@ -32,71 +35,69 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
-    let sockfd = crate::fdtable::resolve_socket(sockfd, "recv")?;
+    let sockfd: c_int = crate::fdtable::resolve_socket(sockfd, "recv")?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
         return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));
     }
 
-    let mut total_read: usize = 0;
-    let mut buffer_offset: usize = 0;
+    // The payload is delivered out-of-band via a single scatter/gather pull, so cap the request at
+    // a single round trip.
+    let recv_len: usize = cmp::min(ReceiveSocketResponse::MAX_DATA_SIZE, buffer.len());
 
-    while buffer_offset < buffer.len() {
-        let recv_len: usize =
-            cmp::min(ReceiveSocketResponse::BUFFER_SIZE, buffer.len() - buffer_offset);
+    // Build metadata-only request and send it via IPC message.
+    let request: Message = ReceiveSocketRequest::build(tid, sockfd, recv_len as u32, flags);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
-        // Build request and send it.
-        let request: Message = ReceiveSocketRequest::build(tid, sockfd, recv_len as u32, flags);
-        ::sys::kcall::ipc::__kcall_send(&request)?;
+    // Pull the payload via data chunk transfer directly into the user buffer.
+    let bytes_pulled: usize = ::sys::kcall::ipc::__kcall_pull(
+        ProcessIdentifier::KERNEL,
+        ThreadIdentifier::KERNEL,
+        &mut buffer[..recv_len],
+    )?;
 
-        // Receive response.
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
-        // Check whether system call succeeded or not.
-        if response.status != 0 {
-            // System call failed, parse error code and return it.
-            let error_code = ErrorCode::try_from(response.status)?;
-            return Err(Error::new(error_code, "failed to receive data on socket"));
-        } else {
-            // System call succeeded, parse response.
-            match SystemCallMessage::try_from_bytes(response.payload) {
-                // Response was successfully parsed.
-                Ok(message) => match message.header {
-                    // Response was successfully parsed.
-                    SystemCallMessageHeader::ReceiveSocketResponse => {
-                        // Parse response.
-                        let response: ReceiveSocketResponse =
-                            ReceiveSocketResponse::from_bytes(message.payload);
+    // Check whether system call succeeded or not.
+    if response.status != 0 {
+        // System call failed, parse error code and return it.
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        Err(Error::new(error_code, "failed to receive data on socket"))
+    } else {
+        // System call succeeded, parse response.
+        match SystemCallMessage::try_from_bytes(response.payload) {
+            Ok(message) => match message.header {
+                SystemCallMessageHeader::ReceiveSocketResponse => {
+                    let response: ReceiveSocketResponse =
+                        ReceiveSocketResponse::from_bytes(message.payload);
 
-                        // Check if any data was received.
-                        if response.count == 0 {
-                            break;
-                        }
+                    let count: usize = response.count as usize;
 
-                        // Copy response buffer to user buffer.
-                        buffer[buffer_offset..buffer_offset + response.count as usize]
-                            .copy_from_slice(&response.buffer[..response.count as usize]);
-                        total_read += response.count as usize;
-                        buffer_offset += response.count as usize;
-
-                        // Check for partial receive.
-                        if (response.count as usize) < recv_len {
-                            break;
-                        }
-                    },
-                    _ => {
+                    // Validate the reported count against the requested length to avoid
+                    // out-of-bounds behavior on a malformed or buggy response.
+                    if count > recv_len {
                         return Err(Error::new(
                             ErrorCode::InvalidMessage,
-                            "unexpected message header",
-                        ))
-                    },
+                            "response count exceeds requested length",
+                        ));
+                    }
+
+                    // The payload was already delivered into the user buffer by the pull above, so
+                    // the metadata count must match the bytes actually pulled.
+                    if count != bytes_pulled {
+                        return Err(Error::new(
+                            ErrorCode::InvalidMessage,
+                            "response count does not match bytes pulled",
+                        ));
+                    }
+
+                    Ok(count)
                 },
-                // Response was not successfully parsed.
-                Err(_) => return Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
-            }
+                _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
+            },
+            Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
         }
     }
-
-    Ok(total_read)
 }

--- a/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
@@ -66,7 +66,7 @@ pub fn recvfrom(
     }
 
     // A datagram cannot be reassembled across transfers, so cap the request at a single
-    // page-bounded pull.
+    // scatter/gather pull.
     let recv_len: usize = cmp::min(ReceiveFromSocketResponse::MAX_DATA_SIZE, buffer.len());
 
     // Build metadata-only request and send it via IPC message.

--- a/src/libs/syscall/src/sys/socket/syscall/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/sendto.rs
@@ -72,7 +72,7 @@ pub fn sendto(
         return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));
     }
 
-    // A datagram cannot be split across transfers, so it must fit in a single page-bounded push.
+    // A datagram cannot be split across transfers, so it must fit in a single scatter/gather push.
     if buffer.len() > SendToSocketRequest::MAX_DATA_SIZE {
         return Err(Error::new(
             ErrorCode::MessageTooLong,

--- a/src/tests/integration/test-c-network/inet.c
+++ b/src/tests/integration/test-c-network/inet.c
@@ -109,6 +109,77 @@ static void test_inet_dgram_null_address(struct in_addr sin_addr)
     assert(ret == 0);
 }
 
+// Tests `send()`/`recv()` on a connected datagram socket over loopback. A message is sent to the
+// socket's own address and received back through the connected endpoint. This exercises the
+// pull-based payload transfer used by `recv()`, which delivers the payload out-of-band directly
+// into the user buffer rather than inline in the response message.
+static void test_inet_dgram_send_recv(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Connect the datagram socket to its own address so `send()`/`recv()` operate on it.
+    int ret = connect(sockfd, (const struct sockaddr *)&self, sizeof(self));
+    assert(ret == 0);
+
+    // Send a message through the connected socket.
+    const char message[] = "recv-pull";
+    const size_t message_len = sizeof(message) - 1;
+    ssize_t sent = send(sockfd, message, message_len, 0);
+    assert(sent == (ssize_t)message_len);
+
+    // Receive the message back through the connected socket. The receive buffer is larger than the
+    // payload, so `recv()` must report exactly the number of bytes delivered by the pull.
+    char buffer[16];
+    memset(buffer, 0, sizeof(buffer));
+    ssize_t received = recv(sockfd, buffer, sizeof(buffer), 0);
+    assert(received == (ssize_t)message_len);
+    assert(memcmp(buffer, message, message_len) == 0);
+
+    ret = close(sockfd);
+    assert(ret == 0);
+}
+
+// Tests that `recv()` can deliver a payload larger than a single page in one call. A multi-page
+// datagram is sent with `sendto()` -- which transfers the whole datagram atomically through a
+// single scatter/gather push -- to the socket's own address, then received back with one `recv()`.
+// This exercises the multi-page scatter/gather pull that the raised `MAX_DATA_SIZE` enables: before
+// the limit was lifted every transfer was capped at one page, so `recv()` could not return this
+// many bytes in a single call.
+static void test_inet_dgram_recv_large(struct in_addr sin_addr)
+{
+    // A three-page payload: comfortably above the old single-page limit, and well within both the
+    // scatter/gather ceiling and the socket receive buffer.
+    enum { ONE_PAGE = 4096, PAYLOAD_SIZE = 3 * ONE_PAGE };
+    static unsigned char sndbuf[PAYLOAD_SIZE];
+    static unsigned char rcvbuf[PAYLOAD_SIZE + ONE_PAGE];
+
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Fill the payload with a position-dependent pattern so truncation or reordering is detectable.
+    for (size_t i = 0; i < PAYLOAD_SIZE; i++) {
+        sndbuf[i] = (unsigned char)((i * 31u + 7u) & 0xFFu);
+    }
+
+    // `sendto()` delivers the whole datagram in a single push, so the peer receives one
+    // PAYLOAD_SIZE-byte datagram rather than page-sized fragments.
+    ssize_t sent =
+        sendto(sockfd, sndbuf, PAYLOAD_SIZE, 0, (const struct sockaddr *)&self, sizeof(self));
+    assert(sent == (ssize_t)PAYLOAD_SIZE);
+
+    // A single `recv()` must return the entire multi-page datagram. The receive buffer is larger
+    // than the datagram, so the reported count reflects the bytes actually delivered by the pull.
+    memset(rcvbuf, 0, sizeof(rcvbuf));
+    ssize_t received = recv(sockfd, rcvbuf, sizeof(rcvbuf), 0);
+    assert(received == (ssize_t)PAYLOAD_SIZE);
+    assert(received > (ssize_t)ONE_PAGE);
+    assert(memcmp(rcvbuf, sndbuf, PAYLOAD_SIZE) == 0);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -137,4 +208,10 @@ void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr)
     // Exercise datagram sendto()/recvfrom() over loopback.
     test_inet_dgram_sendto_recvfrom(sin_addr);
     test_inet_dgram_null_address(sin_addr);
+
+    // Exercise connected-datagram send()/recv() over loopback.
+    test_inet_dgram_send_recv(sin_addr);
+
+    // Exercise a multi-page recv() that returns more than one page in a single call.
+    test_inet_dgram_recv_large(sin_addr);
 }

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -644,6 +644,17 @@ async fn standalone_io_handler(
                         )
                         .await;
                     },
+                    SystemCallMessageHeader::ReceiveSocketRequest => {
+                        handle_recv_request(
+                            &mut vm_stdout_rx,
+                            &vm_stdin_tx,
+                            &network_daemon,
+                            msg.source,
+                            syscall_msg,
+                            &counters,
+                        )
+                        .await;
+                    },
                     header if header.is_hostfs() => {
                         // For multi-part long requests, vfsd allocates a single pending
                         // entry keyed on the logical op_id but emits N SystemCallMessagePart
@@ -1358,9 +1369,9 @@ async fn handle_recvfrom_request(
         let (response, data): (Message, Vec<u8>) =
             network_daemon.handle_recvfrom(source, syscall_msg);
 
-        // The datagram payload is bounded by a single page, so its length normally fits in u32.
-        // Guard the conversion anyway, releasing the guest's pull with an empty transfer and an
-        // error on the unexpected overflow so it does not deadlock.
+        // The datagram payload is bounded by the scatter/gather bulk limit. Guard the conversion
+        // anyway, releasing the guest's pull with an empty transfer and an error on the unexpected
+        // overflow so it does not deadlock.
         let actual_len: u32 = match u32::try_from(data.len()) {
             Ok(n) => n,
             Err(_) => {
@@ -1431,8 +1442,138 @@ async fn handle_recvfrom_request(
 ///
 /// # Description
 ///
+/// Handles a guest `ReceiveSocketRequest` by consuming the pull-header bulk frame and forwarding
+/// the request to networkd on a blocking task, which pushes the received payload back to the guest
+/// followed by the response message.
+///
+async fn handle_recv_request(
+    vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    network_daemon: &Option<Arc<NetworkDaemon>>,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    counters: &MessageCounters,
+) {
+    let tid: ThreadIdentifier = extract_tid(source);
+    trace!("standalone io_handler: handling ReceiveSocketRequest (tid={tid:?})");
+
+    // Wait for the pull-header bulk frame that the guest's `ipc::pull()` emits after the request.
+    // It carries the bulk location the received payload must be written to.
+    let pull_header: DataChunkHeader = match vm_stdout_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
+        other => {
+            error!(
+                "standalone io_handler: expected bulk frame after ReceiveSocketRequest, got {:?}",
+                other.as_ref().map(|f| f.frame_type_byte())
+            );
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    let network_daemon: Arc<NetworkDaemon> = match network_daemon {
+        Some(nd) => nd.clone(),
+        None => {
+            warn!("standalone io_handler: networking not allowed, rejecting recv (tid={tid:?})");
+            // Release the guest blocked in `ipc::pull()` with an empty transfer before reporting
+            // the error so it does not deadlock.
+            send_empty_pull_response(vm_stdin_tx, &pull_header, counters).await;
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    // Run the blocking `recv()` on its own thread so a waiting socket does not stall the I/O
+    // handler loop.
+    let vm_stdin_tx: mpsc::Sender<IkcFrame> = vm_stdin_tx.clone();
+    let counters: MessageCounters = counters.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        let (response, data): (Message, Vec<u8>) = network_daemon.handle_recv(source, syscall_msg);
+
+        // The payload is bounded by the scatter/gather bulk limit. Guard the conversion anyway,
+        // releasing the guest's pull with an empty transfer and an error on the unexpected overflow
+        // so it does not deadlock.
+        let actual_len: u32 = match u32::try_from(data.len()) {
+            Ok(n) => n,
+            Err(_) => {
+                error!("standalone io_handler: recv size overflows u32 (len={})", data.len());
+                let empty_header: DataChunkHeader = DataChunkHeader::new(
+                    pull_header.source_pid(),
+                    pull_header.source_tid(),
+                    pull_header.destination_pid(),
+                    pull_header.destination_tid(),
+                    pull_header.data_addr(),
+                    0,
+                );
+                counters.increment_io_thread_messages_received();
+                counters.increment_io_thread_messages_received();
+                if let Err(error) = vm_stdin_tx
+                    .blocking_send(IkcFrame::Bulk(DataChunk::new(empty_header, Vec::new())))
+                {
+                    error!(
+                        "standalone io_handler: failed to send empty bulk response (VM input \
+                         channel closed): {error}"
+                    );
+                }
+                let err: Message = Message::new(
+                    MessageSender::NETWORKD,
+                    MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+                    MessageType::Ikc,
+                    Some(ErrorCode::InvalidMessage),
+                    [0u8; Message::PAYLOAD_SIZE],
+                );
+                if let Err(error) = vm_stdin_tx.blocking_send(IkcFrame::Message(err)) {
+                    error!(
+                        "standalone io_handler: failed to send recv error response (VM input \
+                         channel closed): {error}"
+                    );
+                }
+                return;
+            },
+        };
+        let response_header: DataChunkHeader = DataChunkHeader::new(
+            pull_header.source_pid(),
+            pull_header.source_tid(),
+            pull_header.destination_pid(),
+            pull_header.destination_tid(),
+            pull_header.data_addr(),
+            actual_len,
+        );
+        let response_bulk: DataChunk = DataChunk::new(response_header, data);
+
+        // Increment once for the bulk frame and once for the message response that follow.
+        counters.increment_io_thread_messages_received();
+        counters.increment_io_thread_messages_received();
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Bulk(response_bulk))
+            .is_err()
+        {
+            error!(
+                "standalone io_handler: failed to send recv bulk response (VM input channel \
+                 closed)"
+            );
+            return;
+        }
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Message(response))
+            .is_err()
+        {
+            error!("standalone io_handler: failed to send recv response (VM input channel closed)");
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            error!("standalone io_handler: recv task panicked: {e}");
+        }
+    });
+}
+
+///
+/// # Description
+///
 /// Sends a networking error response addressed to `tid`, releasing a guest blocked in
-/// `ipc::recv()` after a sendto/recvfrom request when the operation cannot proceed.
+/// `ipc::recv()` after a sendto/recvfrom/recv request when the operation cannot proceed.
 ///
 async fn send_networking_error(
     vm_stdin_tx: &mpsc::Sender<IkcFrame>,
@@ -1463,7 +1604,7 @@ async fn send_networking_error(
 /// # Description
 ///
 /// Pushes an empty bulk transfer back to the guest to release a thread blocked in `ipc::pull()`
-/// when a `recvfrom()` cannot be served.
+/// when a pull-based networking request cannot be served.
 ///
 async fn send_empty_pull_response(
     vm_stdin_tx: &mpsc::Sender<IkcFrame>,


### PR DESCRIPTION
## Summary

Moves `recv()` payload delivery out-of-band and raises the socket transfer
ceiling for all three datagram/stream data-path calls, bringing `recv()` in
line with `recvfrom()`/`sendto()`.

Previously `recv()` carried its payload inline in the IPC response body and
looped over the user buffer in `BUFFER_SIZE` chunks — one request/response
round trip per chunk. It now issues a **single** round trip: send the
metadata request, `__kcall_pull` the payload straight into the user buffer,
then `recv` a metadata-only response. This removes the per-chunk IPC overhead
and lets a single `recv()` return a whole multi-page transfer.

The out-of-band cap for `recv()`/`recvfrom()`/`sendto()` is raised from a
single page to `SG_BULK_MAX_BYTES`, matching the socket cap to the transport
limit already enforced by the kernel pull/push paths and the uservm bulk path.

`closes #2891`

## Changes

**Libraries (`syscall`)**
- `ReceiveSocketResponse` is now metadata-only (`count` + padding); the inline
  buffer field is dropped and `MAX_DATA_SIZE = SG_BULK_MAX_BYTES` is exposed.
- `recv()` validates `count <= recv_len` and `count == bytes_pulled`.
- `recvfrom()`/`sendto()` `MAX_DATA_SIZE` lifted from `PAGE_SIZE` to
  `SG_BULK_MAX_BYTES`.

**Daemons**
- `networkd`: add `dispatch_recv()`/`handle_recv()`; `do_recv()` returns the
  response plus the payload `Vec` (truncated to the received count) and is
  removed from the inline `dispatch_message()` path.
- `linuxd`: `do_recv()` returns a `(message, payload)` tuple; route
  `ReceiveSocketRequest` through the bulk special-message path via the new
  `handle_recv_request()`, which pushes the payload then the response and
  releases the guest's pull with an empty transfer on error.

**UserVM**
- `standalone`: add `handle_recv_request()` to consume the pull-header bulk
  frame and forward to `networkd` on a blocking task, mirroring the
  `sendto()`/`recvfrom()` handlers.

**Tests**
- Extend the inet socket integration test with connected-datagram
  `send()`/`recv()` coverage and a three-page `recv()` case that validates the
  raised `MAX_DATA_SIZE`.

## Validation

- Unit and in-kernel tests pass.
- Standalone (`posix/test-c-network`) and single-process (`http/test-rust-network.elf`)
  network integration tests pass.
- `format-check` and `lint-check` pass.