### PR TITLE
[syscall] Add Push-Based send() Transfer

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -55,6 +55,7 @@ ALL_POSIX_TESTS := \
 	test-c-pathconf \
 	test-c-posix-timers \
 	test-c-regex \
+	test-c-send \
 	test-c-setjmp \
 	test-c-sigmask \
 	test-c-stdio \

--- a/src/daemons/linuxd/src/linux/sys_socket.rs
+++ b/src/daemons/linuxd/src/linux/sys_socket.rs
@@ -288,15 +288,21 @@ pub fn do_send<T>(
     syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: SendSocketRequest,
+    data: &[u8],
 ) -> Result<Message, WorkerThreadError> {
-    trace!("send(): tid={tid:?}, request={request:?}");
+    trace!("send(): tid={tid:?}, request={request:?}, data.len={}", data.len());
 
     let net_backend = match &syscall_table.net_backend {
         Some(backend) => backend,
         None => return Ok(crate::build_error(tid, ErrorCode::OperationNotSupported)),
     };
 
-    match net_backend.send(request.sockfd, &request.buffer, request.count as usize, request.flags) {
+    let count: usize = { request.count } as usize;
+    if data.len() != count {
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
+    }
+
+    match net_backend.send(request.sockfd, data, count, request.flags) {
         Ok(count) => Ok(SendSocketResponse::build(tid, count as i32)),
         Err(NetError::Interrupted) => Err(WorkerThreadError::Interrupted),
         Err(NetError::Errno(code)) => Ok(crate::build_error(tid, code)),

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -552,6 +552,7 @@ impl WorkerThreadHandle {
                                 SystemCallMessageHeader::CloseRequest
                                 | SystemCallMessageHeader::ReadRequest
                                 | SystemCallMessageHeader::ReceiveSocketRequest
+                                | SystemCallMessageHeader::SendSocketRequest
                                 | SystemCallMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
                                         &syscall_table,
@@ -599,7 +600,6 @@ impl WorkerThreadHandle {
                                 | SystemCallMessageHeader::PartialReadRequest
                                 | SystemCallMessageHeader::PartialWriteRequest
                                 | SystemCallMessageHeader::SeekRequest
-                                | SystemCallMessageHeader::SendSocketRequest
                                 | SystemCallMessageHeader::ShutdownSocketRequest
                                 | SystemCallMessageHeader::TimesRequest
                                 | SystemCallMessageHeader::PipeRequest
@@ -786,6 +786,10 @@ impl WorkerThreadHandle {
                     cancel_rx,
                 )
             },
+            SystemCallMessageHeader::SendSocketRequest => {
+                let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
+                Self::handle_send_request(syscall_table, source, request, channel_rx, cancel_rx)
+            },
             header => {
                 // The following statement is unreachable, because the matching logic in this
                 // function should match the one in the `Self::run()` function.
@@ -902,10 +906,6 @@ impl WorkerThreadHandle {
             SystemCallMessageHeader::SeekRequest => {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
                 unistd::do_lseek(&syscall_table, source, request)
-            },
-            SystemCallMessageHeader::SendSocketRequest => {
-                let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
-                sys_socket::do_send(&syscall_table, source, request)
             },
             SystemCallMessageHeader::ShutdownSocketRequest => {
                 let request: ShutdownSocketRequest =
@@ -1408,6 +1408,56 @@ impl WorkerThreadHandle {
                 }
             }
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Handles a socket `send()` request.  Receives the bulk data that carries the payload from
+    /// the channel, then forwards it to the networking backend.  The payload travels out-of-band
+    /// via a page-bounded scatter/gather push, mirroring [`Self::handle_write_request`].
+    ///
+    /// # Parameters
+    ///
+    /// - `syscall_table`: Shared syscall dispatch table.
+    /// - `source`: Thread identifier of the requesting guest thread.
+    /// - `request`: The send request payload.
+    /// - `channel_rx`: Worker command channel receiver (for bulk data).
+    /// - `cancel_rx`: Watch receiver used to detect cancellation.
+    ///
+    /// # Returns
+    ///
+    /// The response [`Message`] on success, or a [`WorkerThreadError`] on failure.
+    ///
+    fn handle_send_request<T>(
+        syscall_table: &SyscallTable<T>,
+        source: ThreadIdentifier,
+        request: SendSocketRequest,
+        channel_rx: &mut Receiver<VenvCommand>,
+        cancel_rx: &mut watch::Receiver<bool>,
+    ) -> Result<Message, WorkerThreadError> {
+        trace!("handle_send_request(): source={source:?}, request={request:?}");
+
+        // Receive bulk data that carries the actual send payload. A timeout prevents the worker
+        // thread from blocking forever if the guest VM crashes mid-protocol.
+        let bulk_data: Vec<u8> =
+            match Self::recv_with_timeout(channel_rx, BULK_DATA_TIMEOUT, cancel_rx) {
+                Ok(VenvCommand::BulkData(bulk)) => bulk.into_data(),
+                Ok(VenvCommand::Shutdown) => {
+                    debug!("handle_send_request(): received shutdown while waiting for bulk data");
+                    return Err(WorkerThreadError::Interrupted);
+                },
+                Ok(VenvCommand::Work(_)) => {
+                    error!("handle_send_request(): expected bulk data, got IKC message");
+                    return Ok(build_error(source, ErrorCode::InvalidMessage));
+                },
+                Err(e) => {
+                    error!("handle_send_request(): failed to receive bulk data");
+                    return Err(e);
+                },
+            };
+
+        sys_socket::do_send(syscall_table, source, request, &bulk_data)
     }
 
     ///

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -164,10 +164,6 @@ pub fn dispatch_message(
             let request: ListenSocketRequest = ListenSocketRequest::from_bytes(syscall_msg.payload);
             Some(vec![do_listen(backend, tid, request)])
         },
-        SystemCallMessageHeader::SendSocketRequest => {
-            let request: SendSocketRequest = SendSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_send(backend, tid, request)])
-        },
         SystemCallMessageHeader::ShutdownSocketRequest => {
             let request: ShutdownSocketRequest =
                 ShutdownSocketRequest::from_bytes(syscall_msg.payload);
@@ -175,6 +171,34 @@ pub fn dispatch_message(
         },
         _ => None,
     }
+}
+
+///
+/// # Description
+///
+/// Dispatches a `send()` request whose payload was delivered out-of-band via a scatter/gather
+/// push.
+///
+/// # Parameters
+///
+/// - `backend`: Reference to the networking backend.
+/// - `source`: The message source (identifies the calling thread).
+/// - `syscall_msg`: The parsed `SendSocketRequest` system call message.
+/// - `data`: The payload pulled from the caller.
+///
+/// # Returns
+///
+/// The response message to send back to the guest.
+///
+pub fn dispatch_send(
+    backend: &NetBackend,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    data: &[u8],
+) -> Message {
+    let tid: ThreadIdentifier = source.tid;
+    let request: SendSocketRequest = SendSocketRequest::from_bytes(syscall_msg.payload);
+    do_send(backend, tid, request, data)
 }
 
 ///
@@ -447,14 +471,19 @@ fn do_shutdown(
     }
 }
 
-fn do_send(backend: &NetBackend, tid: ThreadIdentifier, request: SendSocketRequest) -> Message {
-    trace!("networkd::send(): tid={tid:?}, request={request:?}");
-    match backend.send(
-        to_host_fd(request.sockfd),
-        &request.buffer,
-        request.count as usize,
-        request.flags,
-    ) {
+fn do_send(
+    backend: &NetBackend,
+    tid: ThreadIdentifier,
+    request: SendSocketRequest,
+    data: &[u8],
+) -> Message {
+    trace!("networkd::send(): tid={tid:?}, request={request:?}, data.len={}", data.len());
+    let count: usize = { request.count } as usize;
+    if data.len() != count {
+        return build_error(tid, ErrorCode::InvalidArgument);
+    }
+
+    match backend.send(to_host_fd(request.sockfd), data, count, request.flags) {
         Ok(count) => SendSocketResponse::build(tid, count as i32),
         Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
         Err(NetError::Errno(code)) => build_error(tid, code),

--- a/src/daemons/networkd/src/lib.rs
+++ b/src/daemons/networkd/src/lib.rs
@@ -93,6 +93,31 @@ impl NetworkDaemon {
     ///
     /// # Description
     ///
+    /// Processes a `send()` request whose payload was delivered out-of-band via a scatter/gather
+    /// push.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Identifies the calling thread.
+    /// - `syscall_msg`: The parsed `SendSocketRequest` system call message.
+    /// - `data`: The payload pulled from the caller.
+    ///
+    /// # Returns
+    ///
+    /// The response message to send back to the guest.
+    ///
+    pub fn handle_send(
+        &self,
+        source: MessageSender,
+        syscall_msg: SystemCallMessage,
+        data: &[u8],
+    ) -> Message {
+        dispatch::dispatch_send(&self.backend, source, syscall_msg, data)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Processes a `sendto()` request whose datagram payload was delivered out-of-band via a
     /// scatter/gather push.
     ///

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -37,22 +37,28 @@ pub struct SendSocketRequest {
     pub sockfd: i32,
     pub count: u32,
     pub flags: i32,
-    pub buffer: [u8; Self::BUFFER_SIZE],
+    _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(SendSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
 
 impl SendSocketRequest {
-    pub const BUFFER_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+    /// Maximum number of payload bytes a single `send()` transfer may carry. The data travels
+    /// out-of-band via a scatter/gather push, so it is bounded by a single page rather than by the
+    /// IPC message payload. A stream `send()` may transfer fewer bytes than requested, so a caller
+    /// with a larger buffer resubmits the remainder on the resulting short send.
+    pub const MAX_DATA_SIZE: usize = ::arch::mem::PAGE_SIZE;
+
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
         - mem::size_of::<u32>()
         - mem::size_of::<i32>();
 
-    pub fn new(sockfd: i32, count: c_size_t, flags: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    pub fn new(sockfd: i32, count: c_size_t, flags: i32) -> Self {
         Self {
             sockfd,
             count,
             flags,
-            buffer,
+            _padding: [0; Self::PADDING_SIZE],
         }
     }
 
@@ -64,14 +70,8 @@ impl SendSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(
-        tid: ThreadIdentifier,
-        sockfd: i32,
-        count: c_size_t,
-        flags: i32,
-        buffer: [u8; Self::BUFFER_SIZE],
-    ) -> Message {
-        let message: SendSocketRequest = SendSocketRequest::new(sockfd, count, flags, buffer);
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, count: c_size_t, flags: i32) -> Message {
+        let message: SendSocketRequest = SendSocketRequest::new(sockfd, count, flags);
         let message: SystemCallMessage = SystemCallMessage::new(
             SystemCallMessageHeader::SendSocketRequest,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -20,7 +20,10 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::{
     ffi::c_int,
@@ -31,65 +34,68 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Sends data on a connected socket.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `buffer`: Buffer that holds the message to send.
+/// - `flags`: Type of message transmission.
+///
+/// # Returns
+///
+/// On success, the number of bytes sent is returned. On error, an error is returned.
+///
 pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
     // Address networkd by the descriptor it assigned: the caller passes a flat descriptor.
-    let sockfd = crate::fdtable::resolve_socket(sockfd, "send")?;
+    let sockfd: c_int = crate::fdtable::resolve_socket(sockfd, "send")?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
         return Err(Error::new(ErrorCode::InvalidArgument, "buffer length is zero"));
     }
 
-    let mut total_written: usize = 0;
-    let mut offset: usize = 0;
+    // The payload travels out-of-band via a scatter/gather push, so cap the request at one page.
+    // A stream socket may transfer fewer bytes than requested, so the caller is expected to
+    // resubmit the remainder on a short send.
+    let send_len: usize = cmp::min(SendSocketRequest::MAX_DATA_SIZE, buffer.len());
 
-    while offset < buffer.len() {
-        let chunk_size: usize = cmp::min(SendSocketRequest::BUFFER_SIZE, buffer.len() - offset);
-        let mut chunk: [u8; SendSocketRequest::BUFFER_SIZE] = [0; SendSocketRequest::BUFFER_SIZE];
-        chunk[..chunk_size].copy_from_slice(&buffer[offset..offset + chunk_size]);
+    // Build metadata-only request and send it via IPC message.
+    let request: Message = SendSocketRequest::build(tid, sockfd, send_len as c_size_t, flags);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
 
-        // Build request and send it.
-        let request: Message =
-            SendSocketRequest::build(tid, sockfd, chunk_size as c_size_t, flags, chunk);
-        ::sys::kcall::ipc::__kcall_send(&request)?;
+    // Push the payload via data chunk transfer.
+    ::sys::kcall::ipc::__kcall_push(
+        ProcessIdentifier::KERNEL,
+        ThreadIdentifier::KERNEL,
+        &buffer[..send_len],
+    )?;
 
-        // Receive response.
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    // Receive response.
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
 
-        // Check whether system call succeeded or not.
-        if response.status != 0 {
-            // System call failed, parse error code and return it.
-            let error_code = ErrorCode::try_from(response.status)?;
-            return Err(Error::new(error_code, "failed to send data through socket"));
-        } else {
-            // System call succeeded, parse response.
-            match SystemCallMessage::try_from_bytes(response.payload) {
-                // Response was successfully parsed.
-                Ok(message) => match message.header {
-                    // Response was successfully parsed.
-                    SystemCallMessageHeader::SendSocketResponse => {
-                        // Parse response.
-                        let response: SendSocketResponse =
-                            SendSocketResponse::from_bytes(message.payload);
-
-                        // Update total written count.
-                        total_written += response.count as usize;
-                        offset += chunk_size;
-                    },
-                    _ => {
-                        return Err(Error::new(
-                            ErrorCode::InvalidMessage,
-                            "unexpected message header",
-                        ))
-                    },
+    // Check whether system call succeeded or not.
+    if response.status != 0 {
+        // System call failed, parse error code and return it.
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        Err(Error::new(error_code, "failed to send data through socket"))
+    } else {
+        // System call succeeded, parse response.
+        match SystemCallMessage::try_from_bytes(response.payload) {
+            Ok(message) => match message.header {
+                SystemCallMessageHeader::SendSocketResponse => {
+                    let response: SendSocketResponse =
+                        SendSocketResponse::from_bytes(message.payload);
+                    Ok(response.count as usize)
                 },
-                // Response was not successfully parsed.
-                Err(_) => return Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
-            }
+                _ => Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header")),
+            },
+            Err(_) => Err(Error::new(ErrorCode::InvalidMessage, "invalid response")),
         }
     }
-
-    Ok(total_written)
 }

--- a/src/tests/integration/test-c-send/main.c
+++ b/src/tests/integration/test-c-send/main.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// IPv4 loopback address (127.0.0.1) in host byte order.
+#define LOOPBACK_ADDR 0x7f000001u
+
+// Payload length exercised by the push-based transfer. It is deliberately far larger than the
+// number of bytes that once fit inline in a single IPC message (the previous chunked `send()` path
+// carried only a couple dozen bytes per round trip) and stays below both a memory page and the
+// socket buffer, so a single-threaded send/recv round trip cannot deadlock.
+#define PAYLOAD_LEN 1000
+
+// Number of bytes that fit in one page-bounded push.
+#define PAGE_BYTES 4096u
+
+// Payload length that spans several page-bounded send() calls while staying comfortably below a
+// loopback socket's buffer pipeline, so a single-threaded send-then-receive of the whole payload
+// never blocks and therefore cannot deadlock.
+#define LARGE_PAYLOAD_LEN (16u * 1024u)
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Fills a buffer with a deterministic, position-dependent pattern.
+static void fill_pattern(char *buffer, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        buffer[i] = (char)((i * 31u + 7u) & 0xffu);
+    }
+}
+
+// Sends the whole buffer, resubmitting the remainder on a short send. A stream `send()` may
+// transfer fewer bytes than requested, so the caller loops until everything is written.
+static void send_all(int sockfd, const char *buffer, size_t len)
+{
+    size_t offset = 0;
+    while (offset < len) {
+        ssize_t sent = send(sockfd, buffer + offset, len - offset, 0);
+        assert(sent > 0);
+        offset += (size_t)sent;
+    }
+    assert(offset == len);
+}
+
+// Receives exactly `len` bytes, looping until the whole payload has been drained.
+static void recv_all(int sockfd, char *buffer, size_t len)
+{
+    size_t offset = 0;
+    while (offset < len) {
+        ssize_t received = recv(sockfd, buffer + offset, len - offset, 0);
+        assert(received > 0);
+        offset += (size_t)received;
+    }
+    assert(offset == len);
+}
+
+// Establishes a pair of connected stream sockets over the IPv4 loopback interface. A listening
+// socket is bound to an ephemeral port, a client connects to it, and the accepted endpoint is
+// returned alongside the client endpoint.
+static void connect_loopback_pair(int *client_out, int *accepted_out)
+{
+    int server = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(server >= 0);
+
+    struct sockaddr_in bind_addr = {
+        .sin_len = sizeof(bind_addr),
+        .sin_family = AF_INET,
+        .sin_port = htons(0),
+        .sin_addr = {.s_addr = htonl(LOOPBACK_ADDR)},
+    };
+    assert(bind(server, (const struct sockaddr *)&bind_addr, sizeof(bind_addr)) == 0);
+    assert(listen(server, 1) == 0);
+
+    // Learn the ephemeral port the system assigned to the listening socket.
+    struct sockaddr_in listen_addr;
+    memset(&listen_addr, 0, sizeof(listen_addr));
+    socklen_t listen_len = sizeof(listen_addr);
+    assert(getsockname(server, (struct sockaddr *)&listen_addr, &listen_len) == 0);
+    assert(listen_addr.sin_family == AF_INET);
+
+    int client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(client >= 0);
+    assert(connect(client, (const struct sockaddr *)&listen_addr, sizeof(listen_addr)) == 0);
+
+    int accepted = accept(server, NULL, NULL);
+    assert(accepted >= 0);
+
+    assert(close(server) == 0);
+
+    *client_out = client;
+    *accepted_out = accepted;
+}
+
+// Sends a payload from `from_fd`, receives it on `to_fd`, and verifies that the bytes round trip
+// unchanged. This exercises the push-based `send()` payload transfer end to end.
+static void test_send_payload(int from_fd, int to_fd)
+{
+    char sent[PAYLOAD_LEN];
+    fill_pattern(sent, sizeof(sent));
+
+    send_all(from_fd, sent, sizeof(sent));
+
+    char received[PAYLOAD_LEN];
+    memset(received, 0, sizeof(received));
+    recv_all(to_fd, received, sizeof(received));
+
+    assert(memcmp(sent, received, sizeof(sent)) == 0);
+}
+
+// Sends the whole buffer, returning the largest number of bytes transferred by a single send()
+// call. A stream send() may accept fewer bytes than offered, so the caller loops until everything
+// is written, tracking the largest single transfer to verify the page-bounded push.
+static size_t send_all_max_chunk(int sockfd, const char *buffer, size_t len)
+{
+    size_t offset = 0;
+    size_t max_chunk = 0;
+    while (offset < len) {
+        ssize_t sent = send(sockfd, buffer + offset, len - offset, 0);
+        assert(sent > 0);
+        if ((size_t)sent > max_chunk) {
+            max_chunk = (size_t)sent;
+        }
+        offset += (size_t)sent;
+    }
+    assert(offset == len);
+    return max_chunk;
+}
+
+// Static buffers keep the multi-page payload off the stack.
+static char large_sent[LARGE_PAYLOAD_LEN];
+static char large_received[LARGE_PAYLOAD_LEN];
+
+// Transfers a multi-page payload over a connected stream socket and verifies both that no single
+// send() exceeds the page-bounded push limit and that every byte round trips unchanged. The payload
+// fits within the socket buffer pipeline, so the whole buffer is sent before it is drained without a
+// concurrent reader and without deadlocking.
+static void test_send_large_payload(int from_fd, int to_fd)
+{
+    fill_pattern(large_sent, sizeof(large_sent));
+    memset(large_received, 0, sizeof(large_received));
+
+    size_t max_chunk = send_all_max_chunk(from_fd, large_sent, sizeof(large_sent));
+
+    recv_all(to_fd, large_received, sizeof(large_received));
+
+    // The wrapper caps each transfer at one page, so a larger stream write must complete through
+    // repeated short sends.
+    assert(max_chunk <= PAGE_BYTES);
+    assert(memcmp(large_sent, large_received, sizeof(large_sent)) == 0);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Validates the push-based `send()` payload transfer over a connected stream socket.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    int client = -1;
+    int accepted = -1;
+    connect_loopback_pair(&client, &accepted);
+
+    // Exercise `send()` in both directions of the connection.
+    test_send_payload(client, accepted);
+    test_send_payload(accepted, client);
+
+    assert(close(client) == 0);
+    assert(close(accepted) == 0);
+
+    // Exercise a payload that spans multiple page-bounded send() calls over a fresh connection in
+    // both directions.
+    connect_loopback_pair(&client, &accepted);
+    test_send_large_payload(client, accepted);
+    test_send_large_payload(accepted, client);
+    assert(close(client) == 0);
+    assert(close(accepted) == 0);
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 2);
+    }
+
+    return (0);
+}

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -622,6 +622,17 @@ async fn standalone_io_handler(
                         )
                         .await;
                     },
+                    SystemCallMessageHeader::SendSocketRequest => {
+                        handle_send_request(
+                            &mut vm_stdout_rx,
+                            &vm_stdin_tx,
+                            &network_daemon,
+                            msg.source,
+                            syscall_msg,
+                            &counters,
+                        )
+                        .await;
+                    },
                     SystemCallMessageHeader::SendToSocketRequest => {
                         handle_sendto_request(
                             &mut vm_stdout_rx,
@@ -1245,6 +1256,70 @@ async fn handle_read_request(
     if vm_stdin_tx.send(IkcFrame::Message(response)).await.is_err() {
         error!("standalone io_handler: failed to send ReadResponse (VM input channel closed)");
     }
+}
+
+///
+/// # Description
+///
+/// Handles a guest `SendSocketRequest` by consuming the subsequent push data frame and forwarding
+/// the payload to networkd on a blocking task, which sends the response back to the guest.
+///
+/// The push data frame must always be drained, even when networking is disabled, otherwise the
+/// IKC frame stream desynchronizes and subsequent requests are misinterpreted.
+///
+async fn handle_send_request(
+    vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    network_daemon: &Option<Arc<NetworkDaemon>>,
+    source: MessageSender,
+    syscall_msg: SystemCallMessage,
+    counters: &MessageCounters,
+) {
+    let tid: ThreadIdentifier = extract_tid(source);
+    trace!("standalone io_handler: handling SendSocketRequest (tid={tid:?})");
+
+    // Wait for the push data frame that the guest's `ipc::push()` emits after the request.
+    let data: Vec<u8> = match vm_stdout_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => bulk.into_data(),
+        other => {
+            error!(
+                "standalone io_handler: expected bulk frame after SendSocketRequest, got {:?}",
+                other.as_ref().map(|f| f.frame_type_byte())
+            );
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    let network_daemon: Arc<NetworkDaemon> = match network_daemon {
+        Some(nd) => nd.clone(),
+        None => {
+            warn!("standalone io_handler: networking not allowed, rejecting send (tid={tid:?})");
+            send_networking_error(vm_stdin_tx, tid, counters).await;
+            return;
+        },
+    };
+
+    // Run the (potentially blocking) backend call on its own thread so it does not stall the I/O
+    // handler loop, mirroring `spawn_networking_task`.
+    let vm_stdin_tx: mpsc::Sender<IkcFrame> = vm_stdin_tx.clone();
+    let counters: MessageCounters = counters.clone();
+    let handle = tokio::task::spawn_blocking(move || {
+        let response: Message = network_daemon.handle_send(source, syscall_msg, &data);
+        counters.increment_io_thread_messages_received();
+        if vm_stdin_tx
+            .blocking_send(IkcFrame::Message(response))
+            .is_err()
+        {
+            error!("standalone io_handler: failed to send send response (VM input channel closed)");
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            error!("standalone io_handler: send task panicked: {e}");
+        }
+    });
 }
 
 ///

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -330,6 +330,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-send"
+program = "./bin/test-c-send.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-setjmp"
 program = "./bin/test-c-setjmp.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -330,6 +330,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-send"
+program = "./bin/test-c-send.initrd"
+extra_nanvixd_args = "-allow-host-networking"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-setjmp"
 program = "./bin/test-c-setjmp.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

Rework `send()` to transfer its payload out-of-band via a scatter/gather push
instead of copying it inline through the IPC message body, matching the
`sendto()`/`recv()` data path. The previous implementation looped over the user
buffer in tiny `BUFFER_SIZE` chunks, issuing a full request/response IPC round
trip per chunk; the payload now travels in a single page-bounded push. A stream
`send()` may transfer fewer bytes than requested, so callers resubmit the
remainder on a short send.

## Changes

**Libraries (`syscall`)**
- `SendSocketRequest` is now metadata-only (`sockfd`, `count`, `flags` + padding);
  the inline `buffer` field is dropped and `MAX_DATA_SIZE = PAGE_SIZE` is added.
- `send()` builds the metadata request, `__kcall_send`s it, `__kcall_push`es the
  payload, then `__kcall_recv`s the single response.

**Daemons**
- `networkd`: `SendSocketRequest` leaves `dispatch_message` and is handled
  out-of-band via `dispatch_send()` / `handle_send()`.
- `linuxd`: `SendSocketRequest` routes through the bulk-data worker path,
  receiving the pushed payload (timeout-guarded) before forwarding.
- Both `do_send()` implementations take the pushed payload and reject a
  length/count mismatch with `InvalidArgument`.

**UserVM**
- The standalone I/O handler drains the push data frame following a
  `SendSocketRequest` and forwards it to `networkd` on a blocking task.

**Tests**
- New `test-c-send` POSIX suite validates the transfer end to end over connected
  loopback stream sockets: single-page and multi-page (16 KiB, via repeated short
  sends) payloads round trip unchanged, and no single `send()` exceeds one page.
  Registered in the POSIX harness configs with host networking enabled.

## Validation

Validated on Windows: `build all`, `run-unit-tests`, `run-kernel-tests`, and the
standalone POSIX suite (`test-c-send` passes).

closes #2890
