### PR TITLE
[syscall] Scope dlsym(handle) To Load Group

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -31,6 +31,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-needed \
 	test-c-dlfcn-pie \
 	test-c-dlfcn-refcount \
+	test-c-dlfcn-scope \
 	test-c-dlfcn-searchpath \
 	test-c-dlfcn-selflink \
 	test-c-dlfcn-startup \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -181,6 +181,13 @@ POSIX_TEST_PIE_test-c-dlfcn-selflink := yes
 # (including `__nanvix_main`) in `.dynsym` so dlinit() seeds the loader's global
 # symbol table and the dlopen("libc.so") relocation succeeds.
 POSIX_TEST_PIE_test-c-dlfcn-searchpath := yes
+# dlfcn-scope-c links PIE + --export-dynamic so the main executable's
+# `scope_main_export` helper lands in `.dynsym` and is seeded into the loader's
+# global scope by dlinit(). The suite then asserts that dlsym(handle, ...) does
+# NOT resolve that global-only symbol (nor an RTLD_GLOBAL library's symbol)
+# through a specific handle -- only its own load group (self + DT_NEEDED). This
+# is the acceptance test for handle-scoped lookup.
+POSIX_TEST_PIE_test-c-dlfcn-scope := yes
 
 # Per-suite hooks consumed by POSIX_TEST_RULE: extra link-time prerequisites and
 # extra linker arguments appended AFTER the libc/libm `--end-group`. Used by
@@ -329,6 +336,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
@@ -346,6 +354,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HASH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_SCOPE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
@@ -476,6 +485,63 @@ $$(POSIX_TEST_RAMFS_IMG_$(1)): $$(POSIX_TEST_SOLIB_DIR_$(1))/libprovider.so \
 endef
 
 $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(eval $(call POSIX_TEST_SOLIB_RULE,$(suite))))
+
+#---------------------------------------------------------------------------------------------------
+# dlfcn-scope-c: load-group-only dlsym(handle) fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+#   libfoo.so -> libdep.so        (DT_NEEDED: scope_dep_value lives in the group)
+#   libother.so                   (isolated; dlopen'd with RTLD_GLOBAL at run time)
+#
+# libfoo.so is the object the test obtains a handle to. It carries a DT_NEEDED
+# edge on libdep.so (it calls scope_dep_value()), so both scope_foo_value() and
+# scope_dep_value() are in libfoo.so's load group and must resolve through
+# dlsym(libfoo_handle, ...). libother.so has NO relationship with libfoo.so; the
+# suite dlopen()s it with RTLD_GLOBAL to publish scope_other_value() into the
+# loader's global scope. The acceptance criterion is that neither
+# scope_other_value() (RTLD_GLOBAL) nor the main executable's scope_main_export()
+# (--export-dynamic) is reachable through libfoo.so's handle -- only through
+# RTLD_DEFAULT. Built with the same i686 freestanding toolchain as the
+# global/needed/diamond fixtures above; the DT_NEEDED edge is produced by linking
+# libfoo.so against libdep.so with `-L<dir> -ldep` (the linker records the found
+# libdep.so as a bare DT_NEEDED entry, resolved through the loader's default
+# lib/ search path).
+POSIX_TEST_SCOPE_DIR  := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-scope/libs
+POSIX_TEST_SCOPE_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-scope-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-scope.img
+
+# Dependency: libdep.so (no dependencies).
+$(POSIX_TEST_SCOPE_DIR)/libdep.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-scope/libs/dep.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-scope-c/libdep.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Handle library: DT_NEEDED libdep.so (calls scope_dep_value()).
+$(POSIX_TEST_SCOPE_DIR)/libfoo.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-scope/libs/foo.c \
+		$(POSIX_TEST_SCOPE_DIR)/libdep.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-scope-c/libfoo.so (DT_NEEDED libdep.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -L$(POSIX_TEST_SCOPE_DIR) -ldep -o $@
+
+# Isolated library published with RTLD_GLOBAL at run time (no dependencies).
+$(POSIX_TEST_SCOPE_DIR)/libother.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-scope/libs/other.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-scope-c/libother.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Per-suite RAMFS image carrying all three fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope): $(POSIX_TEST_SCOPE_DIR)/libdep.so \
+		$(POSIX_TEST_SCOPE_DIR)/libfoo.so \
+		$(POSIX_TEST_SCOPE_DIR)/libother.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_SCOPE_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_SCOPE_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_SCOPE_DIR)/libdep.so $(POSIX_TEST_SCOPE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_SCOPE_DIR)/libfoo.so $(POSIX_TEST_SCOPE_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_SCOPE_DIR)/libother.so $(POSIX_TEST_SCOPE_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_SCOPE_SEED)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-diamond-c: four-library diamond DT_NEEDED fixture.
@@ -1087,6 +1153,7 @@ POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hash) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-init-concurrent) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-hello) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup) \

--- a/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
@@ -43,7 +43,12 @@ pub fn dlsym(handle: &DlHandle, symbol: &str) -> Result<VirtualAddress, Error> {
         Some(dlfile) => {
             let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
 
-            match dlfile.lookup(symbol)? {
+            // POSIX: `dlsym(handle, name)` searches only the object's load
+            // group (self + DT_NEEDED dependencies), never the global scope.
+            // Global-scope lookups are reserved for the RTLD_DEFAULT /
+            // dlopen(NULL) handle, which is serviced by the DlHandle::GLOBAL
+            // branch above.
+            match dlfile.lookup_load_group(symbol)? {
                 Some((base, offset)) => Ok(VirtualAddress::from_raw_value(base + offset)),
                 None => {
                     let reason: &str = "symbol not found";

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -822,39 +822,61 @@ impl DynamicLibrary {
         None
     }
 
-    /// Looks up a symbol in the dynamic library.
+    /// Looks up a symbol for **relocation resolution**, with global fallback.
     ///
     /// Search order:
     /// 1. The library itself (defined symbols).
-    /// 2. The library's DT_NEEDED dependency tree (recursive, no global fallback).
-    /// 3. The global symbol table (main executable symbols).
+    /// 2. The library's DT_NEEDED dependency tree (recursive).
+    /// 3. The global symbol table (main executable + `RTLD_GLOBAL` symbols).
     ///
-    /// NOTE: Step 3 is needed for relocation resolution (symbols from the main
-    /// executable). Strictly, POSIX `dlsym(handle, ...)` should only search
-    /// the object's load group (steps 1-2), not the global scope. Separating
-    /// the two lookup paths is tracked in #2130.
+    /// Step 3 is required when binding a library's relocations against symbols
+    /// exported by the main executable (`--export-dynamic`) or by libraries
+    /// promoted with `RTLD_GLOBAL`. This global fallback is correct for
+    /// relocation resolution but MUST NOT be used to service
+    /// `dlsym(handle, ...)`: per POSIX, a request against a specific handle
+    /// only searches the object's own load group. `dlsym()` therefore calls
+    /// [`lookup_load_group`](Self::lookup_load_group) instead.
     pub fn lookup(&self, symbol_name: &str) -> Result<Option<(usize, usize)>, Error> {
         ::syslog::trace!("lookup(): symbol={}, dlname={:?}", symbol_name, self.filename);
 
-        // Search self and dependency tree without global fallback.
-        // The visited set tracks which dependencies have been traversed in
-        // this lookup to avoid re-searching in diamond-shaped graphs and to
-        // prevent infinite recursion on cyclic dependencies.
-        let mut visited: BTreeSet<usize> = BTreeSet::new();
-        if let Some(result) = self.lookup_in_load_group(symbol_name, &mut visited)? {
+        // Search self and dependency tree (the load group) without global
+        // fallback first.
+        if let Some(result) = self.lookup_load_group(symbol_name)? {
             return Ok(Some(result));
         }
 
         // Fall back to the global symbol table (symbols from the main
-        // executable, registered via --export-dynamic). This fallback is
-        // performed only once at the top level, not during recursive
-        // dependency traversal.
+        // executable, registered via --export-dynamic, plus any library
+        // promoted with RTLD_GLOBAL). This fallback is performed only once at
+        // the top level, not during recursive dependency traversal.
         if let Some(addr) = super::global_symbol_lookup(symbol_name) {
             // Global symbols are absolute addresses, so base is 0.
             return Ok(Some((0, addr)));
         }
 
         Ok(None)
+    }
+
+    /// Looks up a symbol in this library's **load group only**: the object
+    /// itself plus its `DT_NEEDED` dependency tree — with NO global-scope
+    /// fallback.
+    ///
+    /// This is the lookup path POSIX mandates for `dlsym(handle, name)`: a
+    /// request against a specific handle must resolve only within the object
+    /// and the objects it was loaded with, never the global scope. Using the
+    /// global-fallback [`lookup`](Self::lookup) here would incorrectly resolve
+    /// symbols exported by the main executable (`--export-dynamic`) or by other
+    /// libraries promoted with `RTLD_GLOBAL`. Global-scope searches are reserved
+    /// for the `RTLD_DEFAULT` / `dlopen(NULL)` handle, which `dlsym()` routes to
+    /// `global_symbol_lookup()` separately.
+    pub fn lookup_load_group(&self, symbol_name: &str) -> Result<Option<(usize, usize)>, Error> {
+        ::syslog::trace!("lookup_load_group(): symbol={}, dlname={:?}", symbol_name, self.filename);
+
+        // The visited set tracks which dependencies have been traversed in
+        // this lookup to avoid re-searching in diamond-shaped graphs and to
+        // prevent infinite recursion on cyclic dependencies.
+        let mut visited: BTreeSet<usize> = BTreeSet::new();
+        self.lookup_in_load_group(symbol_name, &mut visited)
     }
 
     /// Searches for a symbol in this library and its dependency tree only.

--- a/src/tests/integration/test-c-dlfcn-scope/libs/dep.c
+++ b/src/tests/integration/test-c-dlfcn-scope/libs/dep.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libdep.so - self-contained DT_NEEDED dependency of libfoo.so.
+ *
+ * Exports scope_dep_value(). Because libfoo.so is linked against this library
+ * (DT_NEEDED) and calls scope_dep_value(), this symbol belongs to libfoo.so's
+ * load group and must therefore be resolvable through
+ * dlsym(libfoo_handle, "scope_dep_value"). The return value (111) is asserted
+ * by the suite's main.c (DEP_VALUE).
+ */
+
+int scope_dep_value(void)
+{
+    return 111;
+}

--- a/src/tests/integration/test-c-dlfcn-scope/libs/foo.c
+++ b/src/tests/integration/test-c-dlfcn-scope/libs/foo.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libfoo.so - the library the test obtains a handle to.
+ *
+ * Exports scope_foo_value() and carries a DT_NEEDED entry on libdep.so (it
+ * calls scope_dep_value()). It deliberately neither defines nor references the
+ * main executable's scope_main_export() nor libother.so's scope_other_value(),
+ * so those names are absent from libfoo.so's load group. A non-NULL
+ * dlsym(libfoo_handle, "scope_main_export" | "scope_other_value") could only
+ * come from an incorrect global-scope fallback.
+ */
+
+extern int scope_dep_value(void);
+
+int scope_foo_value(void)
+{
+    /* Calling into libdep.so forces the DT_NEEDED edge and proves the
+     * dependency is part of this object's load group. Result: 111 + 100 = 211
+     * (FOO_VALUE in the suite's main.c). */
+    return scope_dep_value() + 100;
+}

--- a/src/tests/integration/test-c-dlfcn-scope/libs/other.c
+++ b/src/tests/integration/test-c-dlfcn-scope/libs/other.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libother.so - self-contained library dlopen()'d with RTLD_GLOBAL.
+ *
+ * Exports scope_other_value(). Loading it with RTLD_GLOBAL publishes this
+ * symbol into the loader's global scope, where RTLD_DEFAULT can see it. It has
+ * NO dependency relationship with libfoo.so, so it must remain invisible to
+ * dlsym(libfoo_handle, "scope_other_value"). The return value (333) is asserted
+ * by the suite's main.c (OTHER_VALUE).
+ */
+
+int scope_other_value(void)
+{
+    return 333;
+}

--- a/src/tests/integration/test-c-dlfcn-scope/main.c
+++ b/src/tests/integration/test-c-dlfcn-scope/main.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-scope-c: Validate that dlsym(handle, name) searches ONLY the object's
+ * load group -- the library itself plus its DT_NEEDED dependencies -- and never
+ * falls back to the global symbol scope. Per POSIX, the global scope is
+ * reachable only through the RTLD_DEFAULT / dlopen(NULL) pseudo-handle.
+ *
+ * Regression coverage: dlsym(handle, ...) must not search the global symbol
+ * table when a symbol is absent from the handle's load group. Two distinct
+ * sources populate the global scope, and BOTH must stay
+ * invisible to a specific handle:
+ *
+ *   1. The main executable's own --export-dynamic symbols (seeded into the
+ *      loader's global scope at startup by dlinit()).
+ *   2. Symbols of any library dlopen()'d with RTLD_GLOBAL.
+ *
+ * Fixtures (staged under lib/ by the per-suite RAMFS image):
+ *   - libdep.so   exports scope_dep_value(); self-contained.
+ *   - libfoo.so   exports scope_foo_value(); DT_NEEDED on libdep.so and calls
+ *                 scope_dep_value(), so libdep.so is part of libfoo.so's load
+ *                 group. It neither defines nor references scope_main_export()
+ *                 (main exe) or scope_other_value() (libother.so).
+ *   - libother.so exports scope_other_value(); self-contained and unrelated to
+ *                 libfoo.so (no dependency edge in either direction).
+ *
+ * The main executable is linked PIE + --export-dynamic so scope_main_export()
+ * lands in .dynsym and is registered in the loader's global scope. Because
+ * libfoo.so has no dependency path to either scope_main_export() (main exe) or
+ * scope_other_value() (an RTLD_GLOBAL library), a non-NULL result from
+ * dlsym(libfoo_handle, ...) for those names could ONLY come from an incorrect
+ * global fallback -- exactly the bug this suite guards against. The load-group
+ * probes (scope_foo_value / scope_dep_value) are the complementary regression
+ * check that the fix did not break legitimate self + DT_NEEDED resolution.
+ *
+ * Pass/fail is signalled by the exit code (0 = pass), which nanvixd
+ * propagates; the trailing "ok" write mirrors the other suites' magic marker.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/* Sentinel return values, distinct so a mis-resolved pointer is obvious. Each
+ * must match the literal returned by the corresponding fixture. */
+#define MAIN_EXPORT_VALUE 2130          /* scope_main_export() (this file)  */
+#define DEP_VALUE 111                   /* scope_dep_value()   (libdep.so)  */
+#define FOO_VALUE (DEP_VALUE + 100)     /* scope_foo_value()   (libfoo.so)  */
+#define OTHER_VALUE 333                 /* scope_other_value() (libother.so)*/
+
+/*
+ * Exported by the main executable via --export-dynamic. Registered in the
+ * loader's global scope at startup, so it is reachable through RTLD_DEFAULT but
+ * must NOT be reachable through a specific library handle. Marked `used` so the
+ * compiler emits it even though nothing references it at link time.
+ */
+__attribute__((used)) int scope_main_export(void)
+{
+    return MAIN_EXPORT_VALUE;
+}
+
+/* Function-pointer shape of every probed symbol. */
+typedef int (*int_fn)(void);
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    /* dlerror() may return NULL (no diagnostic available); guard against
+     * passing a NULL pointer to printf("%s"), which is undefined behavior. */
+    printf("  FAIL: %s (%s)\n", name, reason != NULL ? reason : "no diagnostic available");
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Precondition: scope_main_export() really is in the loader's global scope, so
+ * the "hidden from handle" probe below is meaningful. RTLD_DEFAULT searches the
+ * default (global) scope, so it must find and correctly call the symbol.
+ */
+static void test_main_export_visible_via_default(void)
+{
+    const char *name = "main-exe --export-dynamic symbol is visible via RTLD_DEFAULT";
+
+    (void)dlerror();
+    int_fn fn = (int_fn)dlsym(RTLD_DEFAULT, "scope_main_export");
+    if (fn == NULL) {
+        fail(name, "scope_main_export absent from global scope (fixture/link error)");
+        return;
+    }
+    if (fn() != MAIN_EXPORT_VALUE) {
+        fail(name, "scope_main_export resolved to the wrong function");
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Primary probe: the main executable's global-scope symbol must NOT be
+ * reachable through libfoo.so's handle. libfoo.so does not define or depend on
+ * scope_main_export(), so a non-NULL result here is the global-fallback bug.
+ */
+static void test_main_export_hidden_from_handle(void *foo)
+{
+    const char *name = "main-exe global symbol is hidden from dlsym(handle, ...)";
+
+    (void)dlerror();
+    void *p = dlsym(foo, "scope_main_export");
+    if (p != NULL) {
+        fail(name, "global-scope symbol leaked into handle lookup");
+        return;
+    }
+
+    /* A genuine load-group search must record a diagnostic on failure; a stub
+     * that unconditionally returns NULL would leave dlerror() unset. */
+    if (dlerror() == NULL) {
+        fail(name, "missing-symbol handle lookup did not set dlerror()");
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Regression: dlsym(handle, ...) still resolves the object's OWN exported
+ * symbol (step 1 of the load-group search).
+ */
+static void test_handle_resolves_self(void *foo)
+{
+    const char *name = "dlsym(handle, ...) resolves the object's own symbol";
+
+    (void)dlerror();
+    int_fn fn = (int_fn)dlsym(foo, "scope_foo_value");
+    if (fn == NULL) {
+        fail(name, "own symbol not found in the load group");
+        return;
+    }
+    if (fn() != FOO_VALUE) {
+        fail(name, "own symbol resolved incorrectly");
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Regression: dlsym(handle, ...) still resolves a symbol defined in a
+ * DT_NEEDED dependency (step 2 of the load-group search). scope_dep_value()
+ * lives in libdep.so, which is part of libfoo.so's load group.
+ */
+static void test_handle_resolves_dependency(void *foo)
+{
+    const char *name = "dlsym(handle, ...) resolves a DT_NEEDED dependency symbol";
+
+    (void)dlerror();
+    int_fn fn = (int_fn)dlsym(foo, "scope_dep_value");
+    if (fn == NULL) {
+        fail(name, "dependency symbol not found in the load group");
+        return;
+    }
+    if (fn() != DEP_VALUE) {
+        fail(name, "dependency symbol resolved incorrectly");
+        return;
+    }
+
+    pass(name);
+}
+
+/*
+ * Secondary probe: a symbol published into the global scope by a library
+ * loaded with RTLD_GLOBAL must be visible via RTLD_DEFAULT yet remain invisible
+ * to an UNRELATED handle (libfoo.so), which has no dependency edge to it.
+ */
+static void test_rtld_global_hidden_from_handle(void *foo)
+{
+    const char *name = "RTLD_GLOBAL symbol is hidden from an unrelated handle";
+
+    void *other = dlopen("lib/libother.so", RTLD_NOW | RTLD_GLOBAL);
+    if (other == NULL) {
+        fail(name, dlerror());
+        return;
+    }
+
+    /* Now in the global scope: reachable via RTLD_DEFAULT ... */
+    (void)dlerror();
+    int_fn via_default = (int_fn)dlsym(RTLD_DEFAULT, "scope_other_value");
+    if (via_default == NULL || via_default() != OTHER_VALUE) {
+        fail(name, "RTLD_GLOBAL symbol not visible via RTLD_DEFAULT");
+        dlclose(other);
+        return;
+    }
+
+    /* ... but NOT through libfoo.so's handle (no dependency edge to it). */
+    (void)dlerror();
+    void *via_handle = dlsym(foo, "scope_other_value");
+    if (via_handle != NULL) {
+        fail(name, "RTLD_GLOBAL symbol leaked into unrelated handle lookup");
+        dlclose(other);
+        return;
+    }
+
+    /* A genuine load-group search must record a diagnostic on failure; a stub
+     * that unconditionally returns NULL would leave dlerror() unset. */
+    if (dlerror() == NULL) {
+        fail(name, "missing-symbol handle lookup did not set dlerror()");
+        dlclose(other);
+        return;
+    }
+
+    if (dlclose(other) != 0) {
+        fail(name, "dlclose(lib/libother.so) failed");
+        return;
+    }
+
+    pass(name);
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn dlsym(handle) load-group scope tests ===\n");
+    fflush(stdout);
+
+    test_main_export_visible_via_default();
+
+    void *foo = dlopen("lib/libfoo.so", RTLD_NOW);
+    if (foo == NULL) {
+        fail("dlopen(lib/libfoo.so)", dlerror());
+    } else {
+        test_main_export_hidden_from_handle(foo);
+        test_handle_resolves_self(foo);
+        test_handle_resolves_dependency(foo);
+        test_rtld_global_hidden_from_handle(foo);
+
+        if (dlclose(foo) != 0) {
+            fail("dlclose(lib/libfoo.so)", "dlclose failed");
+        }
+    }
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+        return 0;
+    }
+
+    return 1;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -182,6 +182,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-scope"
+program = "./bin/test-c-dlfcn-scope.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-scope.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-searchpath"
 program = "./bin/test-c-dlfcn-searchpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -182,6 +182,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-scope"
+program = "./bin/test-c-dlfcn-scope.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-scope.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-searchpath"
 program = "./bin/test-c-dlfcn-searchpath.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-searchpath.img"


### PR DESCRIPTION
## What

Fix `dlsym(handle, name)` so it resolves symbols only within the target object's **load group** — the object itself plus its `DT_NEEDED` dependency tree — and never falls back to the global symbol scope. Per POSIX, the global scope is reachable only through the `RTLD_DEFAULT` / `dlopen(NULL)` pseudo-handle.

Closes #2130.

## Why

Previously a handle lookup shared the relocation lookup path, which included a global fallback. As a result, symbols exported by the main executable (`--export-dynamic`) or by libraries promoted with `RTLD_GLOBAL` leaked into unrelated `dlsym(handle, ...)` lookups.

## Changes

**Libraries (`syscall::dlfcn`):**
- Split the two lookup paths in `DynamicLibrary`. `lookup()` keeps the global fallback and is retained for **relocation resolution** (a library's relocations legitimately bind against main-exe and `RTLD_GLOBAL` symbols); it now delegates to the new helper first.
- Add `lookup_load_group()`: searches self + `DT_NEEDED` tree only, with **no** global fallback, reusing the existing cycle/diamond-safe recursion.
- Route the `dlsym()` handle branch through `lookup_load_group()`; the `RTLD_DEFAULT` / `dlopen(NULL)` branch still uses `global_symbol_lookup()`.

**Tests:**
- New `test-c-dlfcn-scope` integration suite (PIE + `--export-dynamic`) asserting:
  - `RTLD_DEFAULT` finds the main-exe global symbol (precondition);
  - `dlsym(handle, "scope_main_export")` is `NULL` (primary regression probe);
  - `dlsym(handle, ...)` still resolves the object's own symbol and a `DT_NEEDED` dependency symbol;
  - an `RTLD_GLOBAL` library's symbol is visible via `RTLD_DEFAULT` but hidden from an unrelated handle.
- Fixtures: `libdep.so`, `libfoo.so` (DT_NEEDED `libdep.so`), `libother.so`.

**Build and harness wiring:**
- Register the suite in `guest-posix-tests.mk`; add PIE flag, fixture build rules, and per-suite RAMFS image in `posix-tests.mk`.
- Add `posix/test-c-dlfcn-scope` entries (debug + release) to `test-posix.toml` and `test-posix-windows.toml`.

## Validation

- `test-c-dlfcn-scope` passes (debug + release).
- Full dlfcn family (21 suites) passes (debug + release).
- `run-unit-tests`, `format-check`, and `lint-check` all clean.