### PR TITLE
[syscall] Remove sigaction Feature Flags

### DIFF
--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -49,7 +49,6 @@ dlfcn = ["dep:sysalloc", "dep:elf", "dep:goblin"]
 rustc-dep-of-std = [
     "core",
     "alloc",
-    "sigaction",
     "arch/rustc-dep-of-std",
     "libc_stdlib/rustc-dep-of-std",
     "cfg-if/rustc-dep-of-std",
@@ -65,10 +64,6 @@ rustc-dep-of-std = [
     "spin/rustc-dep-of-std",
 ]
 standalone = ["dep:sysalloc", "dep:proc"]
-
-# TODO (#798): remove these feature flags once the signal module is stable.
-sigaction = []
-signal = ["sigaction"]
 
 # Logging
 error = ["syslog/error"]

--- a/src/libs/syscall/src/signal/bindings/mod.rs
+++ b/src/libs/syscall/src/signal/bindings/mod.rs
@@ -6,7 +6,7 @@
 //==================================================================================================
 
 pub mod kill;
-#[cfg(feature = "sigaction")]
+#[cfg(feature = "rustc-dep-of-std")]
 pub mod sigaction;
-#[cfg(feature = "signal")]
+#[cfg(feature = "rustc-dep-of-std")]
 pub mod sigprocmask;


### PR DESCRIPTION
## Summary

Removes the `sigaction` and `signal` feature flags from the `syscall` crate and ties the signal bindings directly to `rustc-dep-of-std`, their only consumer.

## Why

The flags dated from the NewLib era. NewLib is now retired and the canonical C `sigaction`/`sigprocmask` symbols ship unconditionally from `nanvix_libc`/`libc_signal` (the sole `libc.a`), so the gate no longer serves a purpose. Enabling the modules by default would instead introduce a duplicate `#[no_mangle] sigaction` into `libc.a`; gating on `rustc-dep-of-std` avoids that while keeping the guest/C link behavior byte-for-byte identical (the modules were, and remain, uncompiled outside the Rust `std` build).

## Changes

- `src/libs/syscall/Cargo.toml`: delete the `sigaction`/`signal` feature definitions and remove `sigaction` from the `rustc-dep-of-std` feature list.
- `src/libs/syscall/src/signal/bindings/mod.rs`: gate the `sigaction` and `sigprocmask` modules on `rustc-dep-of-std` instead of the removed flags.

## Validation

- `libc.a` and the `syscall` crate build cleanly.
- Signal integration tests pass: `test-c-sigmask`, `test-rust-sigsegv`, `test-rust-kill` (all exit 0).

Note: `sigprocmask` now compiles under `rustc-dep-of-std` as well (previously the never-enabled `signal` flag left it dead); it shares the same `sys::kcall` requirements as `sigaction`. The Rust `std` build is out-of-tree and not exercised by this repo's CI.

closes #798