### PR TITLE
[scripts] Set MEMORY_SIZE_BYTES for Rust Analyzer

### DIFF
--- a/scripts/setup/vscode/settings-linux.json
+++ b/scripts/setup/vscode/settings-linux.json
@@ -30,6 +30,12 @@
     // Rust Analyzer Settings
     //==============================================================================================
     "rust-analyzer.cargo.allTargets": false,
+    "rust-analyzer.cargo.extraEnv": {
+        "MEMORY_SIZE_BYTES": "268435456"
+    },
+    "rust-analyzer.check.extraEnv": {
+        "MEMORY_SIZE_BYTES": "268435456"
+    },
     "rust-analyzer.checkOnSave": true,
     "rust-analyzer.check.overrideCommand": [
         "./z",

--- a/scripts/setup/vscode/settings-windows.json
+++ b/scripts/setup/vscode/settings-windows.json
@@ -45,6 +45,12 @@
     // Rust Analyzer Settings
     //==============================================================================================
     "rust-analyzer.cargo.allTargets": false,
+    "rust-analyzer.cargo.extraEnv": {
+        "MEMORY_SIZE_BYTES": "268435456"
+    },
+    "rust-analyzer.check.extraEnv": {
+        "MEMORY_SIZE_BYTES": "268435456"
+    },
     "rust-analyzer.checkOnSave": true,
     "rust-analyzer.files.exclude": [
         "target",


### PR DESCRIPTION
## Summary

Provides `MEMORY_SIZE_BYTES` to Rust Analyzer's cargo and check environments in the VS Code setup settings for both Linux and Windows.

## Why

Rust Analyzer drives cargo/check invocations that expect the same `MEMORY_SIZE_BYTES` configuration as the regular toolchain. Without it, analysis and check-on-save can fail on the missing environment variable. Setting it in `extraEnv` keeps in-editor builds consistent with the command-line workflow.

## Changes

- `scripts/setup/vscode/settings-linux.json`, `scripts/setup/vscode/settings-windows.json`: add `rust-analyzer.cargo.extraEnv` and `rust-analyzer.check.extraEnv` with `MEMORY_SIZE_BYTES` set to `268435456`.