### PR TITLE
[networkd] Simplify Inline Dispatch Response Type

### DIFF
--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -105,20 +105,21 @@ pub fn is_networking_header(header: &SystemCallMessageHeader) -> bool {
 /// # Parameters
 ///
 /// - `backend`: Reference to the networking backend.
+/// - `filter`: Host egress filter applied to guest `connect()` destinations.
 /// - `source`: The message source (identifies the calling thread).
 /// - `syscall_msg`: The parsed system call message.
 ///
 /// # Returns
 ///
-/// A vector of response messages on success, or `None` if the message is not a networking
-/// message.
+/// The response message on success. Returns `None` if the message source has no thread
+/// identifier or if the message is not a networking message.
 ///
 pub fn dispatch_message(
     backend: &NetBackend,
     filter: &HostFilter,
     source: MessageSender,
     syscall_msg: SystemCallMessage,
-) -> Option<Vec<Message>> {
+) -> Option<Message> {
     let tid: ThreadIdentifier = source.tid;
     if tid.is_none() {
         error!("networkd::dispatch(): message source has no thread id");
@@ -128,46 +129,46 @@ pub fn dispatch_message(
     match syscall_msg.header {
         SystemCallMessageHeader::AcceptSocketRequest => {
             let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_accept(backend, tid, request)])
+            Some(do_accept(backend, tid, request))
         },
         SystemCallMessageHeader::BindSocketRequest => {
             let request: BindSocketRequest = BindSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_bind(backend, tid, request)])
+            Some(do_bind(backend, tid, request))
         },
         SystemCallMessageHeader::CloseRequest => {
             let request: CloseRequest = CloseRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_close(backend, tid, request)])
+            Some(do_close(backend, tid, request))
         },
         SystemCallMessageHeader::ConnectSocketRequest => {
             let request: ConnectSocketRequest =
                 ConnectSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_connect(backend, filter, tid, request)])
+            Some(do_connect(backend, filter, tid, request))
         },
         SystemCallMessageHeader::CreateSocketPairRequest => {
             let request: CreateSocketPairRequest =
                 CreateSocketPairRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_socketpair(backend, tid, request)])
+            Some(do_socketpair(backend, tid, request))
         },
         SystemCallMessageHeader::CreateSocketRequest => {
             let request: CreateSocketRequest = CreateSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_socket(backend, tid, request)])
+            Some(do_socket(backend, tid, request))
         },
         SystemCallMessageHeader::GetPeerNameRequest => {
             let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_getpeername(backend, tid, request)])
+            Some(do_getpeername(backend, tid, request))
         },
         SystemCallMessageHeader::GetSockNameRequest => {
             let request: GetSockNameRequest = GetSockNameRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_getsockname(backend, tid, request)])
+            Some(do_getsockname(backend, tid, request))
         },
         SystemCallMessageHeader::ListenSocketRequest => {
             let request: ListenSocketRequest = ListenSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_listen(backend, tid, request)])
+            Some(do_listen(backend, tid, request))
         },
         SystemCallMessageHeader::ShutdownSocketRequest => {
             let request: ShutdownSocketRequest =
                 ShutdownSocketRequest::from_bytes(syscall_msg.payload);
-            Some(vec![do_shutdown(backend, tid, request)])
+            Some(do_shutdown(backend, tid, request))
         },
         _ => None,
     }

--- a/src/daemons/networkd/src/lib.rs
+++ b/src/daemons/networkd/src/lib.rs
@@ -70,7 +70,7 @@ impl NetworkDaemon {
     /// # Description
     ///
     /// Processes a single IKC message containing a networking system call request and returns
-    /// the response message(s).
+    /// the response message.
     ///
     /// # Parameters
     ///
@@ -78,10 +78,12 @@ impl NetworkDaemon {
     ///
     /// # Returns
     ///
-    /// On success, returns a vector of response messages to send back to the guest.
-    /// On error (e.g., unrecognized header), returns `None`.
+    /// On success, returns the response message to send back to the guest.
+    /// Returns `None` if the payload cannot be parsed into a system call message, or if
+    /// [`dispatch::dispatch_message`] rejects the request (e.g., unrecognized header or
+    /// missing thread identifier).
     ///
-    pub fn handle_message(&self, msg: Message) -> Option<Vec<Message>> {
+    pub fn handle_message(&self, msg: Message) -> Option<Message> {
         let syscall_msg: SystemCallMessage = match SystemCallMessage::try_from_bytes(msg.payload) {
             Ok(m) => m,
             Err(_) => return None,

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -993,19 +993,16 @@ fn spawn_networking_task(
     trace!("standalone io_handler: spawning networking task");
 
     let handle = tokio::task::spawn_blocking(move || match network_daemon.handle_message(msg) {
-        Some(responses) => {
-            for response in responses {
-                counters.increment_io_thread_messages_received();
-                if vm_stdin_tx
-                    .blocking_send(IkcFrame::Message(response))
-                    .is_err()
-                {
-                    error!(
-                        "standalone io_handler: failed to send networking response (VM input \
-                         channel closed)"
-                    );
-                    return;
-                }
+        Some(response) => {
+            counters.increment_io_thread_messages_received();
+            if vm_stdin_tx
+                .blocking_send(IkcFrame::Message(response))
+                .is_err()
+            {
+                error!(
+                    "standalone io_handler: failed to send networking response (VM input channel \
+                     closed)"
+                );
             }
         },
         None => {


### PR DESCRIPTION
Simplify the networkd inline dispatch path to return `Option<Message>` instead of `Option<Vec<Message>>`.

## What & Why


## Changes

**Libraries (networkd):**
- `NetworkDaemon::handle_message()` now returns `Option<Message>`.
- Doc comments updated accordingly.

**UserVM:**
- The standalone networking task now forwards a single response message instead of iterating a vector.

Part of #2894