### PR TITLE
[syscall] Implement `sendmsg()` and `recvmsg()`

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -16,6 +16,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/uio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,6 +93,17 @@ struct linger {
     int l_linger; /**< Linger time, in seconds.   */
 };
 
+/** @brief Message header for scatter/gather I/O with sendmsg() and recvmsg(). */
+struct msghdr {
+    void *msg_name;           /**< Optional address.             */
+    socklen_t msg_namelen;    /**< Size of the address.          */
+    struct iovec *msg_iov;    /**< Scatter/gather array.         */
+    int msg_iovlen;           /**< Number of elements in msg_iov. */
+    void *msg_control;        /**< Ancillary data.               */
+    socklen_t msg_controllen; /**< Ancillary data buffer length. */
+    int msg_flags;            /**< Flags on the received message. */
+};
+
 /*==================================================================================================
  * Sockets
  *==================================================================================================*/
@@ -108,6 +120,8 @@ extern ssize_t send(int sockfd, const void *buf, size_t len, int flags);
 extern ssize_t recv(int sockfd, void *buf, size_t len, int flags);
 extern ssize_t sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *sockaddr, socklen_t addrlen);
 extern ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags, struct sockaddr *sockaddr, socklen_t *addrlen);
+extern ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags);
+extern ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags);
 extern int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen);
 extern int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen);
 extern int shutdown(int sockfd, int how);

--- a/src/libs/sysapi/headers/sys_socket.toml
+++ b/src/libs/sysapi/headers/sys_socket.toml
@@ -9,14 +9,10 @@ description = '''
 Declares the socket address structures, the address-family and socket-type
 constants, and the core socket interfaces. The constants and layouts mirror the
 Rust definitions in the sysapi crate (sys_socket.rs).'''
-includes = ["sys/types.h"]
+includes = ["sys/types.h", "sys/uio.h"]
 guard = "_NANVIX_SYS_SOCKET_H"
 scan_crates = ["syscall"]
-content_order = [
-    "raw:0",
-    "types",
-    "section:0",
-]
+content_order = ["raw:0", "types", "section:0"]
 
 [[types]]
 text = '''
@@ -44,6 +40,17 @@ struct sockaddr_storage {
 struct linger {
     int l_onoff;  /**< Whether linger is enabled. */
     int l_linger; /**< Linger time, in seconds.   */
+};
+
+/** @brief Message header for scatter/gather I/O with sendmsg() and recvmsg(). */
+struct msghdr {
+    void *msg_name;           /**< Optional address.             */
+    socklen_t msg_namelen;    /**< Size of the address.          */
+    struct iovec *msg_iov;    /**< Scatter/gather array.         */
+    int msg_iovlen;           /**< Number of elements in msg_iov. */
+    void *msg_control;        /**< Ancillary data.               */
+    socklen_t msg_controllen; /**< Ancillary data buffer length. */
+    int msg_flags;            /**< Flags on the received message. */
 };'''
 
 [[raw_sections]]
@@ -88,4 +95,22 @@ text = '''
 
 [[sections]]
 title = "Sockets"
-functions = ["socket", "socketpair", "bind", "listen", "accept", "connect", "getsockname", "getpeername", "send", "recv", "sendto", "recvfrom", "setsockopt", "getsockopt", "shutdown"]
+functions = [
+    "socket",
+    "socketpair",
+    "bind",
+    "listen",
+    "accept",
+    "connect",
+    "getsockname",
+    "getpeername",
+    "send",
+    "recv",
+    "sendto",
+    "recvfrom",
+    "sendmsg",
+    "recvmsg",
+    "setsockopt",
+    "getsockopt",
+    "shutdown",
+]

--- a/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
@@ -6,6 +6,19 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
+#[cfg(feature = "standalone")]
+use crate::sys::socket::{
+    self,
+    SocketAddr,
+};
+#[cfg(feature = "standalone")]
+use ::alloc::vec::Vec;
+#[cfg(feature = "standalone")]
+use ::core::{
+    cmp,
+    mem,
+    slice,
+};
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
@@ -13,6 +26,14 @@ use ::sysapi::{
         c_ssize_t,
         msghdr,
     },
+};
+#[cfg(feature = "standalone")]
+use ::sysapi::{
+    sys_socket::{
+        sockaddr,
+        socklen_t,
+    },
+    sys_uio::iovec,
 };
 use ::syslog::trace_syscall;
 
@@ -63,17 +84,159 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
-#[allow(unreachable_code)]
 pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> c_ssize_t {
     #[cfg(feature = "standalone")]
     {
-        let _ = (sockfd, msg, flags);
-        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
-        return -1;
+        // Check if `msg` is valid.
+        if msg.is_null() {
+            ::syslog::warn!("recvmsg(): invalid message header (sockfd={sockfd:?}, msg={msg:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+        let msg: &mut msghdr = unsafe { &mut *msg };
+
+        // Check if `flags` is valid.
+        if flags != 0 {
+            ::syslog::warn!("recvmsg(): unsupported flags (sockfd={sockfd:?}, flags={flags:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Convert the number of scatter-gather buffers to a count.
+        let msg_iovlen = msg.msg_iovlen;
+        let iovlen: usize = match usize::try_from(msg_iovlen) {
+            Ok(iovlen) => iovlen,
+            Err(_error) => {
+                ::syslog::warn!(
+                    "recvmsg(): invalid iovec count (sockfd={sockfd:?}, msg_iovlen={msg_iovlen:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            },
+        };
+
+        // The number of scatter-gather buffers must not exceed the system limit.
+        if iovlen > ::sysapi::limits::IOV_MAX {
+            ::syslog::warn!(
+                "recvmsg(): iovec count exceeds IOV_MAX (sockfd={sockfd:?}, \
+                 msg_iovlen={msg_iovlen:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // The scatter-gather array must be valid when it is non-empty.
+        if iovlen > 0 && msg.msg_iov.is_null() {
+            ::syslog::warn!("recvmsg(): invalid iovec array (sockfd={sockfd:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // When a source address is requested, the buffer must fit a full `sockaddr`.
+        let want_source: bool = !msg.msg_name.is_null();
+        let msg_namelen = msg.msg_namelen;
+        if want_source && (msg_namelen as usize) < mem::size_of::<sockaddr>() {
+            ::syslog::warn!(
+                "recvmsg(): invalid socket address length (sockfd={sockfd:?}, \
+                 msg_namelen={msg_namelen:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Compute the total capacity of the scatter-gather buffers.
+        let mut total: usize = 0;
+        for index in 0..iovlen {
+            let entry: &iovec = unsafe { &*msg.msg_iov.add(index) };
+            if entry.iov_len == 0 {
+                continue;
+            }
+            if entry.iov_base.is_null() {
+                ::syslog::warn!("recvmsg(): invalid iovec buffer (sockfd={sockfd:?})");
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            }
+            total = total.saturating_add(entry.iov_len);
+        }
+
+        // The receive buffers must have room for at least one byte.
+        if total == 0 {
+            ::syslog::warn!("recvmsg(): invalid buffer length (sockfd={sockfd:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Receive the datagram into a single contiguous staging buffer.
+        let mut buffer: Vec<u8> = ::alloc::vec![0u8; total];
+        let (received, source): (usize, Option<SocketAddr>) = if want_source {
+            match socket::syscall::recvfrom(sockfd, &mut buffer, flags) {
+                Ok((received, source)) => (received, Some(source)),
+                Err(error) => {
+                    ::syslog::warn!("recvmsg(): {error:?} (sockfd={sockfd:?}, flags={flags:?})");
+                    *__errno_location() = error.code.get();
+                    return -1;
+                },
+            }
+        } else {
+            match socket::syscall::recv(sockfd, &mut buffer, flags) {
+                Ok(received) => (received, None),
+                Err(error) => {
+                    ::syslog::warn!("recvmsg(): {error:?} (sockfd={sockfd:?}, flags={flags:?})");
+                    *__errno_location() = error.code.get();
+                    return -1;
+                },
+            }
+        };
+
+        // Scatter the received bytes across the caller's buffers.
+        let mut offset: usize = 0;
+        for index in 0..iovlen {
+            if offset >= received {
+                break;
+            }
+            let entry: &iovec = unsafe { &*msg.msg_iov.add(index) };
+            if entry.iov_len == 0 {
+                continue;
+            }
+            let chunk_len: usize = cmp::min(entry.iov_len, received - offset);
+            let chunk: &mut [u8] = unsafe { slice::from_raw_parts_mut(entry.iov_base, chunk_len) };
+            chunk.copy_from_slice(&buffer[offset..offset + chunk_len]);
+            offset += chunk_len;
+        }
+
+        // Store the source address if the caller requested it.
+        if let Some(source) = source {
+            let (source_addr, source_len): (sockaddr, socklen_t) = source.into();
+            unsafe { *msg.msg_name.cast::<sockaddr>() = source_addr };
+            msg.msg_namelen = source_len;
+        }
+
+        // No ancillary data is delivered by this implementation.
+        msg.msg_controllen = 0;
+        msg.msg_flags = 0;
+
+        // Report the number of bytes received.
+        match received.try_into() {
+            Ok(received) => received,
+            Err(_error) => {
+                ::syslog::warn!(
+                    "recvmsg(): failed to convert bytes received (sockfd={sockfd:?}, \
+                     flags={flags:?})"
+                );
+                *__errno_location() = ErrorCode::ValueOutOfRange.get();
+                -1
+            },
+        }
     }
 
     // TODO: https://github.com/nanvix/nanvix/issues/600
-    ::syslog::debug!("recvmsg(): not implemented");
-    *__errno_location() = ErrorCode::InvalidSysCall.get();
-    -1
+    #[cfg(not(feature = "standalone"))]
+    {
+        let _ = (sockfd, msg, flags);
+        ::syslog::debug!("recvmsg(): not implemented");
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidSysCall.get();
+        }
+        -1
+    }
 }

--- a/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
@@ -6,6 +6,18 @@
 //==================================================================================================
 
 use crate::errno::__errno_location;
+#[cfg(feature = "standalone")]
+use crate::sys::socket::{
+    self,
+    SocketAddr,
+};
+#[cfg(feature = "standalone")]
+use ::alloc::vec::Vec;
+#[cfg(feature = "standalone")]
+use ::core::{
+    mem,
+    slice,
+};
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
@@ -13,6 +25,11 @@ use ::sysapi::{
         c_ssize_t,
         msghdr,
     },
+};
+#[cfg(feature = "standalone")]
+use ::sysapi::{
+    sys_socket::sockaddr,
+    sys_uio::iovec,
 };
 use ::syslog::trace_syscall;
 
@@ -62,19 +79,143 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
-#[allow(unreachable_code)]
 pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> c_ssize_t {
     #[cfg(feature = "standalone")]
     {
-        let _ = (sockfd, msg, flags);
-        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
-        return -1;
+        // Check if `msg` is valid.
+        if msg.is_null() {
+            ::syslog::warn!("sendmsg(): invalid message header (sockfd={sockfd:?}, msg={msg:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+        let msg: &msghdr = unsafe { &*msg };
+
+        // Check if `flags` is valid.
+        if flags != 0 {
+            ::syslog::warn!("sendmsg(): unsupported flags (sockfd={sockfd:?}, flags={flags:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Convert the number of scatter-gather buffers to a count.
+        let msg_iovlen = msg.msg_iovlen;
+        let iovlen: usize = match usize::try_from(msg_iovlen) {
+            Ok(iovlen) => iovlen,
+            Err(_error) => {
+                ::syslog::warn!(
+                    "sendmsg(): invalid iovec count (sockfd={sockfd:?}, msg_iovlen={msg_iovlen:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            },
+        };
+
+        // The number of scatter-gather buffers must not exceed the system limit.
+        if iovlen > ::sysapi::limits::IOV_MAX {
+            ::syslog::warn!(
+                "sendmsg(): iovec count exceeds IOV_MAX (sockfd={sockfd:?}, \
+                 msg_iovlen={msg_iovlen:?})"
+            );
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // The scatter-gather array must be valid when it is non-empty.
+        if iovlen > 0 && msg.msg_iov.is_null() {
+            ::syslog::warn!("sendmsg(): invalid iovec array (sockfd={sockfd:?})");
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+            return -1;
+        }
+
+        // Ancillary data is not supported by this implementation.
+        let msg_control = msg.msg_control;
+        let msg_controllen = msg.msg_controllen;
+        if !msg_control.is_null() || msg_controllen != 0 {
+            ::syslog::warn!(
+                "sendmsg(): ancillary data is not supported (sockfd={sockfd:?}, msg_control={:?}, \
+                 msg_controllen={:?})",
+                msg_control,
+                msg_controllen
+            );
+            *__errno_location() = ErrorCode::OperationNotSupportedOnSocket.get();
+            return -1;
+        }
+
+        // Gather the scatter-gather buffers into a single contiguous datagram.
+        let mut data: Vec<u8> = Vec::new();
+        for index in 0..iovlen {
+            let entry: &iovec = unsafe { &*msg.msg_iov.add(index) };
+            if entry.iov_len == 0 {
+                continue;
+            }
+            if entry.iov_base.is_null() {
+                ::syslog::warn!("sendmsg(): invalid iovec buffer (sockfd={sockfd:?})");
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            }
+            let chunk: &[u8] =
+                unsafe { slice::from_raw_parts(entry.iov_base.cast_const(), entry.iov_len) };
+            data.extend_from_slice(chunk);
+        }
+
+        // When no destination address is supplied, `sendmsg()` behaves like `send()`.
+        let result: Result<usize, ::sys::error::Error> = if msg.msg_name.is_null() {
+            socket::syscall::send(sockfd, &data, flags)
+        } else {
+            // Validate that `msg_namelen` covers a full `sockaddr` before dereferencing the pointer.
+            let msg_namelen = msg.msg_namelen;
+            if (msg_namelen as usize) < mem::size_of::<sockaddr>() {
+                ::syslog::warn!(
+                    "sendmsg(): invalid socket address length (sockfd={sockfd:?}, \
+                     msg_namelen={msg_namelen:?})"
+                );
+                *__errno_location() = ErrorCode::InvalidArgument.get();
+                return -1;
+            }
+
+            // Attempt to convert socket address.
+            let sockaddr: &sockaddr = unsafe { &*msg.msg_name.cast::<sockaddr>() };
+            let sockaddr: SocketAddr = match TryFrom::<&sockaddr>::try_from(sockaddr) {
+                Ok(sockaddr) => sockaddr,
+                Err(error) => {
+                    ::syslog::warn!("sendmsg(): {error:?} (sockfd={sockfd:?})");
+                    *__errno_location() = error.code.get();
+                    return -1;
+                },
+            };
+
+            socket::syscall::sendto(sockfd, &data, flags, &sockaddr)
+        };
+
+        // Check for errors.
+        match result {
+            Ok(bytes_sent) => match bytes_sent.try_into() {
+                Ok(bytes_sent) => bytes_sent,
+                Err(_error) => {
+                    ::syslog::warn!(
+                        "sendmsg(): failed to convert bytes sent (sockfd={sockfd:?}, \
+                         flags={flags:?})"
+                    );
+                    *__errno_location() = ErrorCode::ValueOutOfRange.get();
+                    -1
+                },
+            },
+            Err(error) => {
+                ::syslog::warn!("sendmsg(): {error:?} (sockfd={sockfd:?}, flags={flags:?})");
+                *__errno_location() = error.code.get();
+                -1
+            },
+        }
     }
 
     // TODO: https://github.com/nanvix/nanvix/issues/599.
-    ::syslog::debug!("sendmsg(): not implemented");
-    unsafe {
-        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    #[cfg(not(feature = "standalone"))]
+    {
+        let _ = (sockfd, msg, flags);
+        ::syslog::debug!("sendmsg(): not implemented");
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidSysCall.get();
+        }
+        -1
     }
-    -1
 }

--- a/src/tests/integration/test-c-network/inet.c
+++ b/src/tests/integration/test-c-network/inet.c
@@ -10,10 +10,12 @@
 #include "common.h"
 #include <arpa/inet.h>
 #include <assert.h>
+#include <errno.h>
 #include <netinet/in.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 //==================================================================================================
@@ -180,6 +182,153 @@ static void test_inet_dgram_recv_large(struct in_addr sin_addr)
     assert(ret == 0);
 }
 
+// Tests scatter-gather `sendmsg()`/`recvmsg()` with an explicit destination address. A message
+// split across multiple iovecs is sent to the socket's own address and received back into a
+// different set of iovecs, validating payload reassembly and the reported source address.
+static void test_inet_dgram_sendmsg_recvmsg(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Assemble the outgoing message from three separate buffers.
+    const char part0[] = "hello, ";
+    const char part1[] = "scatter-";
+    const char part2[] = "gather";
+    const size_t total_len = (sizeof(part0) - 1) + (sizeof(part1) - 1) + (sizeof(part2) - 1);
+    struct iovec send_iov[3] = {
+        {.iov_base = (void *)part0, .iov_len = sizeof(part0) - 1},
+        {.iov_base = (void *)part1, .iov_len = sizeof(part1) - 1},
+        {.iov_base = (void *)part2, .iov_len = sizeof(part2) - 1},
+    };
+    struct msghdr send_msg;
+    memset(&send_msg, 0, sizeof(send_msg));
+    send_msg.msg_name = &self;
+    send_msg.msg_namelen = sizeof(self);
+    send_msg.msg_iov = send_iov;
+    send_msg.msg_iovlen = 3;
+
+    ssize_t sent = sendmsg(sockfd, &send_msg, 0);
+    assert(sent == (ssize_t)total_len);
+
+    // Receive the datagram back, scattering it across two buffers and capturing the source address.
+    char head[8];
+    char tail[32];
+    memset(head, 0, sizeof(head));
+    memset(tail, 0, sizeof(tail));
+    struct iovec recv_iov[2] = {
+        {.iov_base = head, .iov_len = sizeof(head)},
+        {.iov_base = tail, .iov_len = sizeof(tail)},
+    };
+    struct sockaddr_in source;
+    memset(&source, 0, sizeof(source));
+    struct msghdr recv_msg;
+    memset(&recv_msg, 0, sizeof(recv_msg));
+    recv_msg.msg_name = &source;
+    recv_msg.msg_namelen = sizeof(source);
+    recv_msg.msg_iov = recv_iov;
+    recv_msg.msg_iovlen = 2;
+
+    ssize_t received = recvmsg(sockfd, &recv_msg, 0);
+    assert(received == (ssize_t)total_len);
+
+    // Reassemble the payload from the scatter buffers and validate it.
+    const char expected[] = "hello, scatter-gather";
+    char assembled[64];
+    memset(assembled, 0, sizeof(assembled));
+    memcpy(assembled, head, sizeof(head));
+    memcpy(assembled + sizeof(head), tail, total_len - sizeof(head));
+    assert(memcmp(assembled, expected, total_len) == 0);
+
+    // The message header must report the source address of the datagram (loopback self-send).
+    assert(recv_msg.msg_namelen == sizeof(source));
+    assert(source.sin_family == AF_INET);
+    assert(source.sin_addr.s_addr == self.sin_addr.s_addr);
+    assert(source.sin_port == self.sin_port);
+
+    // No ancillary data was delivered.
+    assert(recv_msg.msg_controllen == 0);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+}
+
+// Tests scatter-gather `sendmsg()`/`recvmsg()` with a NULL address on a connected socket. When no
+// address is supplied, the calls must behave like `send()`/`recv()` while still honoring the
+// scatter-gather buffers.
+static void test_inet_dgram_sendmsg_recvmsg_connected(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    // Connect the datagram socket to its own address so a NULL destination is valid.
+    int ret = connect(sockfd, (const struct sockaddr *)&self, sizeof(self));
+    assert(ret == 0);
+
+    // With a NULL address, `sendmsg()` behaves like `send()`.
+    const char part0[] = "msg-";
+    const char part1[] = "connected";
+    const size_t total_len = (sizeof(part0) - 1) + (sizeof(part1) - 1);
+    struct iovec send_iov[2] = {
+        {.iov_base = (void *)part0, .iov_len = sizeof(part0) - 1},
+        {.iov_base = (void *)part1, .iov_len = sizeof(part1) - 1},
+    };
+    struct msghdr send_msg;
+    memset(&send_msg, 0, sizeof(send_msg));
+    send_msg.msg_iov = send_iov;
+    send_msg.msg_iovlen = 2;
+
+    ssize_t sent = sendmsg(sockfd, &send_msg, 0);
+    assert(sent == (ssize_t)total_len);
+
+    // With a NULL address, `recvmsg()` behaves like `recv()`.
+    char buffer[32];
+    memset(buffer, 0, sizeof(buffer));
+    struct iovec recv_iov[1] = {
+        {.iov_base = buffer, .iov_len = sizeof(buffer)},
+    };
+    struct msghdr recv_msg;
+    memset(&recv_msg, 0, sizeof(recv_msg));
+    recv_msg.msg_iov = recv_iov;
+    recv_msg.msg_iovlen = 1;
+
+    ssize_t received = recvmsg(sockfd, &recv_msg, 0);
+    assert(received == (ssize_t)total_len);
+    assert(memcmp(buffer, "msg-connected", total_len) == 0);
+
+    ret = close(sockfd);
+    assert(ret == 0);
+}
+
+// Tests that `sendmsg()` does not silently ignore ancillary data. Control messages are not
+// supported yet, so a caller that provides a control buffer must receive an explicit error.
+static void test_inet_dgram_sendmsg_control_unsupported(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    const char message[] = "control";
+    struct iovec send_iov[1] = {
+        {.iov_base = (void *)message, .iov_len = sizeof(message) - 1},
+    };
+    char control[sizeof(int)];
+    struct msghdr send_msg;
+    memset(&send_msg, 0, sizeof(send_msg));
+    send_msg.msg_name = &self;
+    send_msg.msg_namelen = sizeof(self);
+    send_msg.msg_iov = send_iov;
+    send_msg.msg_iovlen = 1;
+    send_msg.msg_control = control;
+    send_msg.msg_controllen = sizeof(control);
+
+    errno = 0;
+    ssize_t sent = sendmsg(sockfd, &send_msg, 0);
+    assert(sent == -1);
+    assert(errno == EOPNOTSUPP);
+
+    int ret = close(sockfd);
+    assert(ret == 0);
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -214,4 +363,9 @@ void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr)
 
     // Exercise a multi-page recv() that returns more than one page in a single call.
     test_inet_dgram_recv_large(sin_addr);
+
+    // Exercise scatter-gather sendmsg()/recvmsg() over loopback.
+    test_inet_dgram_sendmsg_recvmsg(sin_addr);
+    test_inet_dgram_sendmsg_recvmsg_connected(sin_addr);
+    test_inet_dgram_sendmsg_control_unsupported(sin_addr);
 }

--- a/src/utils/gen-headers/src/main.rs
+++ b/src/utils/gen-headers/src/main.rs
@@ -285,6 +285,7 @@ fn map_ident_to_c(ident: &str) -> Option<&'static str> {
         "sockaddr_un" => "struct sockaddr_un",
         "in_addr" => "struct in_addr",
         "iovec" => "struct iovec",
+        "msghdr" => "struct msghdr",
         "timeval" => "struct timeval",
         "tms" => "struct tms",
         "sched_param" => "struct sched_param",


### PR DESCRIPTION
## Summary

Provide working standalone implementations for the `sendmsg()` and `recvmsg()`
socket bindings, which previously returned `OperationNotSupported`. Both now
validate the message header, gather or scatter the caller's iovec buffers, and
delegate to the existing send/recv/sendto/recvfrom syscalls.

## What changed

Libraries:
- `sendmsg()`: validate `msg` and flags, reject ancillary data, gather the
  scatter/gather buffers into a contiguous datagram, and dispatch to `send()`
  or `sendto()` based on `msg_name`.
- `recvmsg()`: validate `msg` and flags, receive into a staging buffer via
  `recv()` or `recvfrom()`, scatter bytes across the iovec buffers, and
  populate `msg_name`/`msg_namelen` when a source address is requested.
- Keep the non-standalone path returning `InvalidSysCall`.

Headers:
- Add `struct msghdr` to `<sys/socket.h>` and the `sys_socket.toml` header
  spec, pulling in `<sys/uio.h>` for `struct iovec`.
- Register `sendmsg`/`recvmsg` in the socket function section and map the
  `msghdr` identifier in gen-headers.

Tests:
- Add scatter-gather `sendmsg()`/`recvmsg()` integration tests over loopback,
  covering payload reassembly, source/destination addressing, connected-socket
  NULL-address behavior, and the `EOPNOTSUPP` rejection of ancillary control
  data.

## Why

Fills in the previously unimplemented message-based socket I/O path and adds
coverage to guard the new behavior.

Closes #599
Closes #600