### PR TITLE
[kernel] Add Rendezvous Push/Pull Timeouts

### DIFF
--- a/src/kernel/src/ipc/bulk_pull.rs
+++ b/src/kernel/src/ipc/bulk_pull.rs
@@ -7,6 +7,7 @@
 
 use crate::pm::{
     sync::condvar::Condvar,
+    InterruptReason,
     SleepError,
 };
 use ::alloc::{
@@ -18,11 +19,16 @@ use ::core::sync::atomic::{
     Ordering,
 };
 use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
     ipc::{
         DataChunkHeader,
         Message,
     },
     pm::ThreadIdentifier,
+    time::SystemTime,
 };
 
 //==================================================================================================
@@ -58,6 +64,31 @@ struct PendingBulkPull {
 static mut PENDING_BULK_PULLS: BTreeMap<ThreadIdentifier, PendingBulkPull> = BTreeMap::new();
 
 //==================================================================================================
+// Private Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests whether a sleep error was caused by a timeout rather than by a real abort condition.
+///
+/// # Parameters
+///
+/// - `error`: Sleep error to inspect.
+///
+/// # Returns
+///
+/// This function returns `true` if the wait timed out, and `false` otherwise.
+///
+fn is_timeout(error: &SleepError) -> bool {
+    match error {
+        SleepError::Interrupted(InterruptReason::TimedOut) => true,
+        SleepError::Generic(error) if error.code == ErrorCode::OperationTimedOut => true,
+        _ => false,
+    }
+}
+
+//==================================================================================================
 // Public Functions
 //==================================================================================================
 
@@ -70,13 +101,39 @@ static mut PENDING_BULK_PULLS: BTreeMap<ThreadIdentifier, PendingBulkPull> = BTr
 /// # Parameters
 ///
 /// - `caller_tid`: Thread identifier of the thread requesting the pull.
+/// - `alarm`: Optional absolute deadline that bounds the wait. [`None`] blocks until the host
+///   responds; [`Some`] reports [`ErrorCode::OperationTimedOut`](sys::error::ErrorCode) once the
+///   deadline elapses, so a slow or wedged host cannot block the guest thread forever.
 ///
 /// # Returns
 ///
 /// Upon successful completion (after being woken), the number of bytes transferred is returned.
 /// On failure, a sleep error is returned instead.
 ///
-pub fn register_and_sleep(caller_tid: ThreadIdentifier) -> Result<usize, SleepError> {
+/// # Errors
+///
+/// Fails with [`ErrorCode::ResourceBusy`] if a previous bulk pull from the same thread timed out
+/// while its host completion was still in flight and that completion has not yet drained. The new
+/// request is refused until then, because completions are correlated back to the thread by
+/// identifier alone and overwriting the pending entry would let the stale completion be
+/// mis-delivered to this request.
+///
+/// # Caveats
+///
+/// A finite `alarm` bounds only the *guest* wait; it does **not** cancel the transfer already in
+/// flight on the host. UserVM has been handed the caller's buffer as guest physical segments and
+/// will scatter linuxd's reply into them whenever it eventually arrives, with no liveness check. A
+/// finite deadline is therefore safe only against a host that never responds: if the host is merely
+/// slow and replies *after* the deadline, it can write into buffer pages the caller may have since
+/// freed or reused. Because of this, finite timeouts on the bulk (host) pull path must not be
+/// exposed to callers until the guest-to-host cancel protocol is in place; all current callers use
+/// the infinite variant. Tracked in issue #2908
+/// (<https://github.com/nanvix/nanvix/issues/2908>).
+///
+pub fn register_and_sleep(
+    caller_tid: ThreadIdentifier,
+    alarm: Option<SystemTime>,
+) -> Result<usize, SleepError> {
     let condvar: Condvar = Condvar::new();
     let bytes_transferred: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
 
@@ -88,6 +145,20 @@ pub fn register_and_sleep(caller_tid: ThreadIdentifier) -> Result<usize, SleepEr
     // SAFETY: single-core system with interrupts disabled.
     let pending: &mut BTreeMap<ThreadIdentifier, PendingBulkPull> =
         unsafe { &mut PENDING_BULK_PULLS };
+
+    // Refuse to overwrite an entry left behind by a previous bulk pull from this thread. Such an
+    // entry lingers only when that earlier request timed out while its host completion was still in
+    // flight: the pending map is keyed solely by thread identifier, so the late completion is
+    // correlated back to this thread by TID alone. Because the calling thread is synchronous, an
+    // existing entry can only be such a leftover, and overwriting it would let the stale completion
+    // wake and complete this new request with the earlier request's data. Fail fast until the
+    // in-flight completion drains the entry.
+    if pending.contains_key(&caller_tid) {
+        let reason: &str = "a previous bulk pull from this thread is still in flight";
+        warn!("register_and_sleep(): {reason} (caller_tid={caller_tid:?})");
+        return Err(SleepError::Generic(Error::new(ErrorCode::ResourceBusy, reason)));
+    }
+
     pending.insert(
         caller_tid,
         PendingBulkPull {
@@ -98,19 +169,27 @@ pub fn register_and_sleep(caller_tid: ThreadIdentifier) -> Result<usize, SleepEr
 
     trace!("bulk pull sleeping (caller_tid={caller_tid:?})");
 
-    // Sleep on the condition variable until the completion handler wakes us up.
+    // Sleep on the condition variable until the completion handler wakes us up or the deadline
+    // expires.
     // SAFETY: no global resources are held, the calling thread is not the kernel.
-    match unsafe { condvar.wait(None) } {
+    match unsafe { condvar.wait(alarm) } {
         Ok(()) => {
             let actual: usize = bytes_transferred.load(ORDER);
             Ok(actual)
         },
         Err(error) => {
-            // Remove the pending entry if the thread was interrupted.
-            // SAFETY: single-core system with interrupts disabled.
-            let pending: &mut BTreeMap<ThreadIdentifier, PendingBulkPull> =
-                unsafe { &mut PENDING_BULK_PULLS };
-            pending.remove(&caller_tid);
+            if !is_timeout(&error) {
+                // Remove the pending entry only if the wait was truly aborted. On timeout the
+                // host request is still in flight, so a late completion must be allowed to consume
+                // the entry rather than being dropped as stale. The entry is left keyed by this
+                // thread; a subsequent bulk pull from the same thread is refused (see the guard
+                // above) until that late completion drains it, so the completion can never be
+                // mis-delivered to a different request.
+                // SAFETY: single-core system with interrupts disabled.
+                let pending: &mut BTreeMap<ThreadIdentifier, PendingBulkPull> =
+                    unsafe { &mut PENDING_BULK_PULLS };
+                pending.remove(&caller_tid);
+            }
             Err(error)
         },
     }

--- a/src/kernel/src/ipc/pull.rs
+++ b/src/kernel/src/ipc/pull.rs
@@ -5,11 +5,16 @@
 // Imports
 //==================================================================================================
 
-use crate::pm::SleepError;
 #[cfg(feature = "stdio")]
-use crate::{
-    hal::mem::VirtualAddress,
-    pm::ProcessManager,
+use crate::hal::mem::VirtualAddress;
+use crate::pm::{
+    ProcessManager,
+    SleepError,
+};
+#[cfg(feature = "stdio")]
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 #[cfg(feature = "stdio")]
 use ::sys::ipc::{
@@ -18,10 +23,7 @@ use ::sys::ipc::{
     SG_BULK_MAX_BYTES,
 };
 use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
+    ipc::PullArgs,
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
@@ -44,10 +46,7 @@ use ::sys::{
 ///
 /// - `caller_pid`: Identifier of the calling process.
 /// - `caller_tid`: Identifier of the calling thread.
-/// - `sender_raw`: Raw identifier of the sender process.
-/// - `sender_tid_raw`: Raw identifier of the sender thread.
-/// - `buffer_raw`: Raw pointer to the buffer where data will be stored.
-/// - `transfer_len_raw`: Raw length of data to be transferred.
+/// - `args_ptr`: User-space pointer to the [`PullArgs`] descriptor.
 ///
 /// # Returns
 ///
@@ -57,43 +56,46 @@ use ::sys::{
 pub fn pull(
     caller_pid: ProcessIdentifier,
     caller_tid: ThreadIdentifier,
-    sender_raw: u32,
-    sender_tid_raw: u32,
-    buffer_raw: usize,
-    transfer_len_raw: u32,
+    args_ptr: u32,
 ) -> Result<usize, SleepError> {
-    // Convert sender process identifier.
-    let sender_pid: ProcessIdentifier =
-        ProcessIdentifier::try_from(sender_raw).map_err(|error| {
-            let reason: &str = "invalid sender process identifier";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 sender_raw={sender_raw}, error={error:?})"
-            );
-            SleepError::Generic(error)
-        })?;
+    // Copy the argument descriptor from user space into kernel space.
+    let mut args: PullArgs = PullArgs::zeroed();
+    {
+        // SAFETY: the process manager is initialized and access is synchronized.
+        let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+        crate::pm::copy_from_user(pm, caller_pid, &mut args, args_ptr as *const PullArgs)
+            .map_err(SleepError::Generic)?;
+    }
 
-    // Convert sender thread identifier.
-    let sender_tid: ThreadIdentifier =
-        ThreadIdentifier::try_from(sender_tid_raw).map_err(|error| {
-            let reason: &str = "invalid sender thread identifier";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 sender_tid_raw={sender_tid_raw}, error={error:?})"
-            );
-            SleepError::Generic(error)
-        })?;
+    let sender_pid: ProcessIdentifier = args.src_pid;
+    let sender_tid: ThreadIdentifier = args.src_tid;
+    let buffer_raw: usize = args.buffer as usize;
+    let transfer_len: usize = args.len as usize;
 
-    // Convert transfer length.
-    let transfer_len: usize = usize::try_from(transfer_len_raw).map_err(|_| {
-        let reason: &str = "transfer length is too large";
+    // Validate the sender identifiers copied from user space. The by-pointer ABI lets a caller place
+    // an arbitrary raw value in the descriptor, so reject the negative/sentinel identifiers that the
+    // previous register-based ABI rejected while converting an unsigned register value into an
+    // identifier. Converting the identifier back to a `u32` fails for exactly those negative values,
+    // so invalid identifiers keep failing early and predictably with `InvalidArgument`.
+    u32::try_from(sender_pid).map_err(|error| {
+        let reason: &str = "invalid sender process identifier";
         error!(
             "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-             sender_pid={sender_pid:?}, sender_tid={sender_tid:?}, \
-             transfer_len_raw={transfer_len_raw})"
+             sender_pid={sender_pid:?}, error={error:?})"
         );
-        SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
+        SleepError::Generic(error)
     })?;
+    u32::try_from(sender_tid).map_err(|error| {
+        let reason: &str = "invalid sender thread identifier";
+        error!(
+            "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
+             sender_tid={sender_tid:?}, error={error:?})"
+        );
+        SleepError::Generic(error)
+    })?;
+
+    let timeout: super::rendezvous::RendezvousTimeout =
+        super::rendezvous::RendezvousTimeout::resolve(args.timeout).map_err(SleepError::Generic)?;
 
     trace!(
         "tid={:?}, pid={:?}, src_tid={:?}, src_pid={:?}, buffer={:#x}, len={}",
@@ -143,13 +145,21 @@ pub fn pull(
             sender_tid,
             GuestSgBulkKind::Pull,
             &segments,
-            transfer_len_raw,
+            args.len,
         )
         .map_err(SleepError::Generic)?;
 
         // Register a pending bulk pull and sleep until the completion arrives. UserVM scatters the
-        // response into the guest physical segments before waking this thread.
-        return super::bulk_pull::register_and_sleep(caller_tid);
+        // response into the guest physical segments before waking this thread. The deadline bounds
+        // the wait so a slow or wedged host cannot block the guest thread forever.
+        //
+        // NOTE: a finite deadline does not cancel the in-flight host transfer, so it is safe only
+        // against a non-responding host — a slow host that replies after the deadline still scatters
+        // into the caller's (possibly freed or reused) buffer. See the caveat on
+        // `bulk_pull::register_and_sleep` and issue #2908
+        // (https://github.com/nanvix/nanvix/issues/2908). All current callers use the infinite
+        // variant.
+        return super::bulk_pull::register_and_sleep(caller_tid, timeout.deadline());
     }
 
     super::rendezvous::do_pull(
@@ -159,5 +169,6 @@ pub fn pull(
         sender_tid,
         buffer_raw,
         transfer_len,
+        timeout,
     )
 }

--- a/src/kernel/src/ipc/push.rs
+++ b/src/kernel/src/ipc/push.rs
@@ -5,11 +5,16 @@
 // Imports
 //==================================================================================================
 
-use crate::pm::SleepError;
 #[cfg(feature = "stdio")]
-use crate::{
-    hal::mem::VirtualAddress,
-    pm::ProcessManager,
+use crate::hal::mem::VirtualAddress;
+use crate::pm::{
+    ProcessManager,
+    SleepError,
+};
+#[cfg(feature = "stdio")]
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 #[cfg(feature = "stdio")]
 use ::sys::ipc::{
@@ -18,10 +23,7 @@ use ::sys::ipc::{
     SG_BULK_MAX_BYTES,
 };
 use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
+    ipc::PushArgs,
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
@@ -44,10 +46,7 @@ use ::sys::{
 ///
 /// - `caller_pid`: Identifier of the calling process.
 /// - `caller_tid`: Identifier of the calling thread.
-/// - `destination_raw`: Raw identifier of the destination process.
-/// - `destination_tid_raw`: Raw identifier of the destination thread.
-/// - `buffer_raw`: Raw pointer to the buffer whose contents will be sent.
-/// - `transfer_len_raw`: Raw length of data to be transferred.
+/// - `args_ptr`: User-space pointer to the [`PushArgs`] descriptor.
 ///
 /// # Returns
 ///
@@ -57,40 +56,46 @@ use ::sys::{
 pub fn push(
     caller_pid: ProcessIdentifier,
     caller_tid: ThreadIdentifier,
-    destination_raw: u32,
-    destination_tid_raw: u32,
-    buffer_raw: usize,
-    transfer_len_raw: u32,
+    args_ptr: u32,
 ) -> Result<(), SleepError> {
-    let destination_pid: ProcessIdentifier =
-        ProcessIdentifier::try_from(destination_raw).map_err(|error| {
-            let reason: &str = "invalid destination process identifier";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 destination_raw={destination_raw}, error={error:?})"
-            );
-            SleepError::Generic(error)
-        })?;
+    // Copy the argument descriptor from user space into kernel space.
+    let mut args: PushArgs = PushArgs::zeroed();
+    {
+        // SAFETY: the process manager is initialized and access is synchronized.
+        let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+        crate::pm::copy_from_user(pm, caller_pid, &mut args, args_ptr as *const PushArgs)
+            .map_err(SleepError::Generic)?;
+    }
 
-    let destination_tid: ThreadIdentifier = ThreadIdentifier::try_from(destination_tid_raw)
-        .map_err(|error| {
-            let reason: &str = "invalid destination thread identifier";
-            error!(
-                "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-                 destination_tid_raw={destination_tid_raw}, error={error:?})"
-            );
-            SleepError::Generic(error)
-        })?;
+    let destination_pid: ProcessIdentifier = args.dst_pid;
+    let destination_tid: ThreadIdentifier = args.dst_tid;
+    let buffer_raw: usize = args.buffer as usize;
+    let transfer_len: usize = args.len as usize;
 
-    let transfer_len: usize = usize::try_from(transfer_len_raw).map_err(|_| {
-        let reason: &str = "transfer length is too large";
+    // Validate the destination identifiers copied from user space. The by-pointer ABI lets a caller
+    // place an arbitrary raw value in the descriptor, so reject the negative/sentinel identifiers
+    // that the previous register-based ABI rejected while converting an unsigned register value into
+    // an identifier. Converting the identifier back to a `u32` fails for exactly those negative
+    // values, so invalid identifiers keep failing early and predictably with `InvalidArgument`.
+    u32::try_from(destination_pid).map_err(|error| {
+        let reason: &str = "invalid destination process identifier";
         error!(
             "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
-             destination_pid={destination_pid:?}, destination_tid={destination_tid:?}, \
-             transfer_len_raw={transfer_len_raw})"
+             destination_pid={destination_pid:?}, error={error:?})"
         );
-        SleepError::Generic(Error::new(ErrorCode::InvalidArgument, reason))
+        SleepError::Generic(error)
     })?;
+    u32::try_from(destination_tid).map_err(|error| {
+        let reason: &str = "invalid destination thread identifier";
+        error!(
+            "{reason} (caller_pid={caller_pid:?}, caller_tid={caller_tid:?}, \
+             destination_tid={destination_tid:?}, error={error:?})"
+        );
+        SleepError::Generic(error)
+    })?;
+
+    let timeout: super::rendezvous::RendezvousTimeout =
+        super::rendezvous::RendezvousTimeout::resolve(args.timeout).map_err(SleepError::Generic)?;
 
     trace!(
         "tid={:?}, pid={:?}, dst_tid={:?}, dst_pid={:?}, buffer={:#x}, len={}",
@@ -140,7 +145,7 @@ pub fn push(
             destination_tid,
             GuestSgBulkKind::Push,
             &segments,
-            transfer_len_raw,
+            args.len,
         )
         .map_err(SleepError::Generic);
     }
@@ -152,5 +157,6 @@ pub fn push(
         destination_tid,
         buffer_raw,
         transfer_len,
+        timeout,
     )
 }

--- a/src/kernel/src/ipc/rendezvous.rs
+++ b/src/kernel/src/ipc/rendezvous.rs
@@ -8,6 +8,8 @@
 use crate::{
     hal::mem::VirtualAddress,
     pm::{
+        clock,
+        InterruptReason,
         ProcessManager,
         SleepError,
     },
@@ -22,16 +24,19 @@ use ::core::{
         AtomicUsize,
         Ordering,
     },
+    time::Duration,
 };
 use ::sys::{
     error::{
         Error,
         ErrorCode,
     },
+    ipc::Timeout,
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
     },
+    time::SystemTime,
 };
 
 //==================================================================================================
@@ -41,6 +46,89 @@ use ::sys::{
 /// Ordering used for all atomic operations. Relaxed is safe because Nanvix is a single-core system
 /// and the kernel runs with interrupts disabled.
 const ORDER: Ordering = Ordering::Relaxed;
+
+//==================================================================================================
+// Rendezvous Timeout
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Resolved timeout for a rendezvous operation, derived from the caller-supplied [`Timeout`]
+/// descriptor. It expresses the three-point spectrum — poll, bounded wait, block — that bounds a
+/// blocking rendezvous.
+///
+#[derive(Debug, Clone, Copy)]
+pub enum RendezvousTimeout {
+    /// Block until the counterpart arrives.
+    Infinite,
+    /// Return immediately if no counterpart is ready, without registering a pending entry or
+    /// sleeping.
+    NonBlocking,
+    /// Block until the given absolute deadline, then report a timeout.
+    Deadline(SystemTime),
+}
+
+impl RendezvousTimeout {
+    ///
+    /// # Description
+    ///
+    /// Resolves a wire [`Timeout`] descriptor into a [`RendezvousTimeout`], computing the absolute
+    /// deadline of a finite, non-zero timeout from the monotonic clock.
+    ///
+    /// # Parameters
+    ///
+    /// - `timeout`: The timeout descriptor supplied by the caller.
+    ///
+    /// # Returns
+    ///
+    /// On success, the resolved timeout. On failure (a deadline that overflows the system clock),
+    /// an error is returned instead.
+    ///
+    pub fn resolve(timeout: Timeout) -> Result<Self, Error> {
+        match timeout.as_finite()? {
+            // Infinite: block until the counterpart arrives.
+            None => Ok(Self::Infinite),
+            // Finite, zero duration: non-blocking probe.
+            Some((0, 0)) => Ok(Self::NonBlocking),
+            // Finite, non-zero duration: compute an absolute deadline from the monotonic clock.
+            Some((secs, nanos)) => {
+                let duration: Duration = Duration::new(secs as u64, nanos);
+                let now: SystemTime = clock::now();
+                match now.checked_add_duration(&duration) {
+                    Some(deadline) => Ok(Self::Deadline(deadline)),
+                    None => Err(Error::new(
+                        ErrorCode::InvalidArgument,
+                        "rendezvous timeout overflows the system clock",
+                    )),
+                }
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the absolute deadline to sleep until: [`None`] for an infinite wait, or [`Some`]
+    /// deadline for a bounded or non-blocking wait. A non-blocking timeout yields the current time,
+    /// so the wait expires immediately.
+    ///
+    /// This is used by the guest-to-host bulk pull path, which — unlike the intra-guest rendezvous
+    /// — cannot short-circuit a non-blocking request before emitting it, and so treats it as an
+    /// immediate deadline.
+    ///
+    /// # Returns
+    ///
+    /// The optional sleep deadline.
+    ///
+    pub fn deadline(&self) -> Option<SystemTime> {
+        match self {
+            Self::Infinite => None,
+            Self::NonBlocking => Some(clock::now()),
+            Self::Deadline(deadline) => Some(*deadline),
+        }
+    }
+}
 
 //==================================================================================================
 // Structures
@@ -202,6 +290,7 @@ fn cross_process_copy(
 /// - `dst_tid`: Destination thread identifier.
 /// - `buffer`: Buffer address in the caller's user space.
 /// - `transfer_len`: Number of bytes to transfer.
+/// - `timeout`: Bounds the blocking wait when no matching pull is present.
 ///
 /// # Returns
 ///
@@ -214,6 +303,7 @@ pub fn do_push(
     dst_tid: ThreadIdentifier,
     buffer: usize,
     transfer_len: usize,
+    timeout: RendezvousTimeout,
 ) -> Result<(), SleepError> {
     // Prevent self-deadlock: a thread cannot push to itself.
     if caller_tid == dst_tid {
@@ -297,7 +387,20 @@ pub fn do_push(
 
         Ok(())
     } else {
-        // No matching pull found: register this push and sleep until a matching pull arrives.
+        // No matching pull found.
+        //
+        // A non-blocking probe must not register a pending entry or sleep: report a timeout
+        // immediately so the caller can decide what to do (the syscall layer maps this to EAGAIN
+        // for non-blocking descriptors).
+        if let RendezvousTimeout::NonBlocking = timeout {
+            trace!(
+                "push would block, non-blocking probe reports timeout (caller_tid={caller_tid:?}, \
+                 dst_tid={dst_tid:?})"
+            );
+            return Err(SleepError::Interrupted(InterruptReason::TimedOut));
+        }
+
+        // Register this push and sleep until a matching pull arrives or the deadline expires.
         // SAFETY: single-core system with interrupts disabled.
         let pending_pushes: &mut Vec<PendingPush> = unsafe { PENDING.pushes() };
         pending_pushes.push(PendingPush {
@@ -314,12 +417,19 @@ pub fn do_push(
              dst_pid={dst_pid:?}, dst_tid={dst_tid:?})"
         );
 
-        // Sleep until a matching pull arrives and performs the copy.
+        // A finite timeout sleeps until its deadline; an infinite timeout sleeps indefinitely.
+        let alarm: Option<SystemTime> = match timeout {
+            RendezvousTimeout::Deadline(deadline) => Some(deadline),
+            _ => None,
+        };
+
+        // Sleep until a matching pull arrives and performs the copy, the deadline expires, or the
+        // thread is interrupted.
         // SAFETY: no global resources are held, the calling thread is not the kernel.
-        match unsafe { ProcessManager::sleep(None) } {
+        match unsafe { ProcessManager::sleep(alarm) } {
             Ok(()) => Ok(()),
             Err(error) => {
-                // Remove the pending push if the thread was interrupted.
+                // Remove the pending push if the thread was interrupted or timed out.
                 // NOTE: if a matching pull arrived between `sleep()` returning and this
                 // `retain()` call, the counterpart already consumed the entry via
                 // `swap_remove` and completed the transfer. In that case `retain()` is a
@@ -349,6 +459,7 @@ pub fn do_push(
 /// - `src_tid`: Source thread identifier (expected sender).
 /// - `buffer`: Buffer address in the caller's user space.
 /// - `transfer_len`: Maximum number of bytes to receive.
+/// - `timeout`: Bounds the blocking wait when no matching push is present.
 ///
 /// # Returns
 ///
@@ -362,6 +473,7 @@ pub fn do_pull(
     src_tid: ThreadIdentifier,
     buffer: usize,
     transfer_len: usize,
+    timeout: RendezvousTimeout,
 ) -> Result<usize, SleepError> {
     // Prevent self-deadlock: a thread cannot pull from itself.
     if caller_tid == src_tid {
@@ -442,7 +554,20 @@ pub fn do_pull(
 
         Ok(actual_len)
     } else {
-        // No matching push found: register this pull and sleep until a matching push arrives.
+        // No matching push found.
+        //
+        // A non-blocking probe must not register a pending entry or sleep: report a timeout
+        // immediately so the caller can decide what to do (the syscall layer maps this to EAGAIN
+        // for non-blocking descriptors).
+        if let RendezvousTimeout::NonBlocking = timeout {
+            trace!(
+                "pull would block, non-blocking probe reports timeout (caller_tid={caller_tid:?}, \
+                 src_tid={src_tid:?})"
+            );
+            return Err(SleepError::Interrupted(InterruptReason::TimedOut));
+        }
+
+        // Register this pull and sleep until a matching push arrives or the deadline expires.
         let bytes_transferred: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
         let bytes_transferred_clone: Arc<AtomicUsize> = bytes_transferred.clone();
 
@@ -463,15 +588,22 @@ pub fn do_pull(
              src_pid={src_pid:?}, src_tid={src_tid:?})"
         );
 
-        // Sleep until a matching push arrives and performs the copy.
+        // A finite timeout sleeps until its deadline; an infinite timeout sleeps indefinitely.
+        let alarm: Option<SystemTime> = match timeout {
+            RendezvousTimeout::Deadline(deadline) => Some(deadline),
+            _ => None,
+        };
+
+        // Sleep until a matching push arrives and performs the copy, the deadline expires, or the
+        // thread is interrupted.
         // SAFETY: no global resources are held, the calling thread is not the kernel.
-        match unsafe { ProcessManager::sleep(None) } {
+        match unsafe { ProcessManager::sleep(alarm) } {
             Ok(()) => {
                 let actual: usize = bytes_transferred.load(ORDER);
                 Ok(actual)
             },
             Err(error) => {
-                // Remove the pending pull if the thread was interrupted.
+                // Remove the pending pull if the thread was interrupted or timed out.
                 // NOTE: if a matching push arrived between `sleep()` returning and this
                 // `retain()` call, the counterpart already consumed the entry via
                 // `swap_remove` and completed the transfer. In that case `retain()` is a

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -142,12 +142,12 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
             Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         // SAFETY: The calling thread is not the kernel and no resources are held.
-        KcallNumber::Push => match ipc::push(pid, tid, arg0, arg1, arg2 as usize, arg3) {
+        KcallNumber::Push => match ipc::push(pid, tid, arg0) {
             Ok(()) => KcallResult::ok(),
             Err(sleep_error) => handle_sleep_error(sleep_error, number, arg0, arg1, arg2, arg3),
         },
         // SAFETY: The calling thread is not the kernel and no resources are held.
-        KcallNumber::Pull => match ipc::pull(pid, tid, arg0, arg1, arg2 as usize, arg3) {
+        KcallNumber::Pull => match ipc::pull(pid, tid, arg0) {
             Ok(bytes_transferred) => match u32::try_from(bytes_transferred) {
                 Ok(bytes_u32) => KcallResult::Success(bytes_u32.into()),
                 Err(_) => KcallResult::Error(ErrorCode::InvalidArgument.into()),

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -20,8 +20,12 @@ use crate::{
         ProcessIdentifier,
         ThreadIdentifier,
     },
+    time::NANOSECONDS_PER_SECOND,
 };
-use ::core::mem;
+use ::core::{
+    mem,
+    time::Duration,
+};
 
 //==================================================================================================
 // Constants
@@ -1044,5 +1048,134 @@ impl GuestSgBulkHeader {
         // SAFETY: All bit patterns are valid because the header contains only fixed-width integer
         // fields and a segment whose bit patterns are all valid.
         Ok(unsafe { mem::transmute::<[u8; Self::SIZE], GuestSgBulkHeader>(bytes) })
+    }
+}
+
+///
+/// # Description
+///
+/// Optional timeout for a rendezvous push/pull kernel call.
+///
+/// `push`/`pull` bound their blocking wait with the three-point spectrum common to
+/// synchronous-rendezvous microkernels:
+///
+/// - **Infinite** (`kind == KIND_INFINITE`): block until the counterpart arrives. This is the
+///   historical, unbounded behavior.
+/// - **Finite** (`kind == KIND_FINITE`): block for at most `secs` seconds plus `nanos` nanoseconds.
+///   A finite timeout of zero duration is a non-blocking probe that never sleeps.
+///
+/// This is a plain-old-data encoding carried across the kernel-call boundary inside [`PushArgs`]
+/// and [`PullArgs`]. All fields are fixed-width and naturally aligned, so the layout is identical on
+/// the 32-bit guest and the kernel.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct Timeout {
+    /// Discriminant selecting the timeout mode: [`Self::KIND_INFINITE`] or [`Self::KIND_FINITE`].
+    kind: u32,
+    /// Seconds component of a finite timeout.
+    secs: u32,
+    /// Nanoseconds component of a finite timeout.
+    nanos: u32,
+}
+::static_assert::assert_eq_size!(Timeout, 3 * mem::size_of::<u32>());
+
+impl Timeout {
+    /// Discriminant value for an infinite (unbounded) timeout.
+    const KIND_INFINITE: u32 = 0;
+
+    /// Discriminant value for a finite (bounded) timeout.
+    const KIND_FINITE: u32 = 1;
+
+    /// Size of the descriptor in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates an infinite timeout, i.e. one that blocks until the counterpart arrives.
+    ///
+    /// # Returns
+    ///
+    /// The new infinite timeout.
+    ///
+    pub const fn infinite() -> Self {
+        Self {
+            kind: Self::KIND_INFINITE,
+            secs: 0,
+            nanos: 0,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a finite timeout of the given duration. A zero duration is a non-blocking probe.
+    ///
+    /// # Parameters
+    ///
+    /// - `secs`: Seconds component of the timeout.
+    /// - `nanos`: Nanoseconds component of the timeout.
+    ///
+    /// # Returns
+    ///
+    /// The new finite timeout.
+    ///
+    pub const fn finite(secs: u32, nanos: u32) -> Self {
+        Self {
+            kind: Self::KIND_FINITE,
+            secs,
+            nanos,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a timeout from an optional [`Duration`]: [`None`] yields an infinite timeout, while
+    /// [`Some`] yields a finite one. A duration whose whole-seconds component exceeds [`u32::MAX`]
+    /// is saturated, which still bounds the wait far beyond any practical deadline.
+    ///
+    /// # Parameters
+    ///
+    /// - `timeout`: The optional duration to convert.
+    ///
+    /// # Returns
+    ///
+    /// The corresponding timeout.
+    ///
+    pub fn from_duration(timeout: Option<Duration>) -> Self {
+        match timeout {
+            None => Self::infinite(),
+            Some(duration) => {
+                let secs: u32 = u32::try_from(duration.as_secs()).unwrap_or(u32::MAX);
+                Self::finite(secs, duration.subsec_nanos())
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the finite duration components `(secs, nanos)`, or [`None`] if the timeout is
+    /// infinite.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the descriptor carries an unknown timeout kind or an
+    /// invalid nanosecond component.
+    ///
+    pub fn as_finite(&self) -> Result<Option<(u32, u32)>, Error> {
+        match self.kind {
+            Self::KIND_INFINITE => Ok(None),
+            Self::KIND_FINITE if self.nanos < NANOSECONDS_PER_SECOND => {
+                Ok(Some((self.secs, self.nanos)))
+            },
+            Self::KIND_FINITE => Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "timeout nanoseconds component is out of range",
+            )),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid timeout kind")),
+        }
     }
 }

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -1179,3 +1179,107 @@ impl Timeout {
         }
     }
 }
+
+///
+/// # Description
+///
+/// Arguments for a rendezvous push kernel call, passed by pointer.
+///
+/// `push` and `pull` already consume all four kernel-call argument registers for their mandatory
+/// operands, leaving no register for the optional [`Timeout`]. The operands are therefore gathered
+/// into this descriptor, which the guest builds on its stack and passes by address; the kernel
+/// copies it into kernel space before use, exactly as it does for a [`Message`]. All fields are
+/// fixed-width and naturally aligned, so the layout is identical on the 32-bit guest and the kernel.
+///
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct PushArgs {
+    /// Destination process identifier.
+    pub dst_pid: ProcessIdentifier,
+    /// Destination thread identifier.
+    pub dst_tid: ThreadIdentifier,
+    /// Address of the source buffer in the caller's user space.
+    pub buffer: u32,
+    /// Number of bytes to transfer.
+    pub len: u32,
+    /// Optional timeout that bounds the blocking wait.
+    pub timeout: Timeout,
+}
+::static_assert::assert_eq_size!(PushArgs, 7 * mem::size_of::<u32>());
+
+impl PushArgs {
+    /// Size of the descriptor in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates a zeroed descriptor suitable as a destination for a copy from user space. The
+    /// identifier fields are set to the kernel sentinels (raw value zero); every field is
+    /// overwritten by the copy before use.
+    ///
+    /// # Returns
+    ///
+    /// The zeroed descriptor.
+    ///
+    pub const fn zeroed() -> Self {
+        Self {
+            dst_pid: ProcessIdentifier::KERNEL,
+            dst_tid: ThreadIdentifier::KERNEL,
+            buffer: 0,
+            len: 0,
+            timeout: Timeout::infinite(),
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Arguments for a rendezvous pull kernel call, passed by pointer.
+///
+/// This is the receive-side counterpart of [`PushArgs`]; see that type for the rationale behind the
+/// pointer-passed descriptor. All fields are fixed-width and naturally aligned, so the layout is
+/// identical on the 32-bit guest and the kernel.
+///
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct PullArgs {
+    /// Source (expected sender) process identifier.
+    pub src_pid: ProcessIdentifier,
+    /// Source (expected sender) thread identifier.
+    pub src_tid: ThreadIdentifier,
+    /// Address of the destination buffer in the caller's user space.
+    pub buffer: u32,
+    /// Maximum number of bytes to receive.
+    pub len: u32,
+    /// Optional timeout that bounds the blocking wait.
+    pub timeout: Timeout,
+}
+::static_assert::assert_eq_size!(PullArgs, 7 * mem::size_of::<u32>());
+
+impl PullArgs {
+    /// Size of the descriptor in bytes.
+    pub const SIZE: usize = mem::size_of::<Self>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates a zeroed descriptor suitable as a destination for a copy from user space. The
+    /// identifier fields are set to the kernel sentinels (raw value zero); every field is
+    /// overwritten by the copy before use.
+    ///
+    /// # Returns
+    ///
+    /// The zeroed descriptor.
+    ///
+    pub const fn zeroed() -> Self {
+        Self {
+            src_pid: ProcessIdentifier::KERNEL,
+            src_tid: ThreadIdentifier::KERNEL,
+            buffer: 0,
+            len: 0,
+            timeout: Timeout::infinite(),
+        }
+    }
+}

--- a/src/libs/sys/src/sys/ipc/message/mod.rs
+++ b/src/libs/sys/src/sys/ipc/message/mod.rs
@@ -23,6 +23,8 @@ pub use kernel::{
     Message,
     MessageReceiver,
     MessageSender,
+    PullArgs,
+    PushArgs,
     SegmentCount,
     Timeout,
     VmBusMessage,

--- a/src/libs/sys/src/sys/ipc/message/mod.rs
+++ b/src/libs/sys/src/sys/ipc/message/mod.rs
@@ -24,6 +24,7 @@ pub use kernel::{
     MessageReceiver,
     MessageSender,
     SegmentCount,
+    Timeout,
     VmBusMessage,
     VmBusMessageKind,
     SG_BULK_MAX_BYTES,

--- a/src/libs/sys/src/sys/kcall/ipc.rs
+++ b/src/libs/sys/src/sys/kcall/ipc.rs
@@ -10,15 +10,20 @@ use crate::{
         Error,
         ErrorCode,
     },
-    ipc::Message,
+    ipc::{
+        Message,
+        PullArgs,
+        PushArgs,
+        Timeout,
+    },
     kcall1,
-    kcall4,
     number::KcallNumber,
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
     },
 };
+use ::core::time::Duration;
 
 //==================================================================================================
 // Send Message
@@ -60,7 +65,8 @@ pub fn __kcall_recv() -> Result<Message, Error> {
 ///
 /// # Description
 ///
-/// Pushes data to a destination thread using rendezvous synchronization.
+/// Pushes data to a destination thread using rendezvous synchronization, blocking until the
+/// destination pulls.
 ///
 /// # Parameters
 ///
@@ -83,20 +89,70 @@ pub fn __kcall_push(
     destination_tid: ThreadIdentifier,
     buffer: &[u8],
 ) -> Result<(), Error> {
-    let destination_raw: u32 = u32::try_from(destination_pid)?;
-    let destination_tid_raw: u32 = u32::try_from(destination_tid)?;
+    push_with_timeout(destination_pid, destination_tid, buffer, Timeout::infinite())
+}
+
+///
+/// # Description
+///
+/// Pushes data to a destination thread using rendezvous synchronization, bounding the blocking wait
+/// with a timeout.
+///
+/// # Parameters
+///
+/// - `destination_pid`: Process identifier of the destination.
+/// - `destination_tid`: Thread identifier of the destination.
+/// - `buffer`: Byte slice containing the data to send.
+/// - `timeout`: Optional deadline. [`None`] blocks until the destination pulls; a finite duration
+///   bounds the wait; a zero duration is a non-blocking probe.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`]: Invalid destination identifiers, self-push, or transfer
+///   length exceeds `u32::MAX`.
+/// - [`ErrorCode::OperationTimedOut`]: The destination did not pull before the timeout elapsed
+///   (or, for a zero timeout, was not already waiting).
+///
+#[unsafe(no_mangle)]
+pub fn __kcall_push_timed(
+    destination_pid: ProcessIdentifier,
+    destination_tid: ThreadIdentifier,
+    buffer: &[u8],
+    timeout: Option<Duration>,
+) -> Result<(), Error> {
+    push_with_timeout(destination_pid, destination_tid, buffer, Timeout::from_duration(timeout))
+}
+
+///
+/// # Description
+///
+/// Builds the push descriptor and issues the kernel call. Shared by [`__kcall_push`] and
+/// [`__kcall_push_timed`].
+///
+fn push_with_timeout(
+    destination_pid: ProcessIdentifier,
+    destination_tid: ThreadIdentifier,
+    buffer: &[u8],
+    timeout: Timeout,
+) -> Result<(), Error> {
     let transfer_len: u32 = buffer
         .len()
         .try_into()
         .map_err(|_| Error::new(ErrorCode::InvalidArgument, "transfer length exceeds u32::MAX"))?;
 
-    let result: i64 = kcall4!(
-        KcallNumber::Push.into(),
-        destination_raw,
-        destination_tid_raw,
-        buffer.as_ptr() as usize as u32,
-        transfer_len
-    );
+    let args: PushArgs = PushArgs {
+        dst_pid: destination_pid,
+        dst_tid: destination_tid,
+        buffer: buffer.as_ptr() as usize as u32,
+        len: transfer_len,
+        timeout,
+    };
+
+    let result: i64 = kcall1!(KcallNumber::Push.into(), &args as *const PushArgs as usize as u32);
 
     if result == 0 {
         Ok(())
@@ -112,7 +168,8 @@ pub fn __kcall_push(
 ///
 /// # Description
 ///
-/// Pulls data from a source thread using rendezvous synchronization.
+/// Pulls data from a source thread using rendezvous synchronization, blocking until the source
+/// pushes.
 ///
 /// # Parameters
 ///
@@ -136,20 +193,71 @@ pub fn __kcall_pull(
     sender_tid: ThreadIdentifier,
     buffer: &mut [u8],
 ) -> Result<usize, Error> {
-    let sender_raw: u32 = u32::try_from(sender_pid)?;
-    let sender_tid_raw: u32 = u32::try_from(sender_tid)?;
+    pull_with_timeout(sender_pid, sender_tid, buffer, Timeout::infinite())
+}
+
+///
+/// # Description
+///
+/// Pulls data from a source thread using rendezvous synchronization, bounding the blocking wait
+/// with a timeout.
+///
+/// # Parameters
+///
+/// - `sender_pid`: Process identifier of the expected sender.
+/// - `sender_tid`: Thread identifier of the expected sender.
+/// - `buffer`: Mutable byte slice where received data will be stored.
+/// - `timeout`: Optional deadline. [`None`] blocks until the source pushes; a finite duration
+///   bounds the wait; a zero duration is a non-blocking probe.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes actually transferred is returned. Upon failure,
+/// an error is returned instead.
+///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`]: Invalid sender identifiers, self-pull, or transfer length
+///   exceeds `u32::MAX`.
+/// - [`ErrorCode::OperationTimedOut`]: The source did not push before the timeout elapsed (or, for
+///   a zero timeout, was not already waiting).
+///
+#[unsafe(no_mangle)]
+pub fn __kcall_pull_timed(
+    sender_pid: ProcessIdentifier,
+    sender_tid: ThreadIdentifier,
+    buffer: &mut [u8],
+    timeout: Option<Duration>,
+) -> Result<usize, Error> {
+    pull_with_timeout(sender_pid, sender_tid, buffer, Timeout::from_duration(timeout))
+}
+
+///
+/// # Description
+///
+/// Builds the pull descriptor and issues the kernel call. Shared by [`__kcall_pull`] and
+/// [`__kcall_pull_timed`].
+///
+fn pull_with_timeout(
+    sender_pid: ProcessIdentifier,
+    sender_tid: ThreadIdentifier,
+    buffer: &mut [u8],
+    timeout: Timeout,
+) -> Result<usize, Error> {
     let transfer_len: u32 = buffer
         .len()
         .try_into()
         .map_err(|_| Error::new(ErrorCode::InvalidArgument, "transfer length exceeds u32::MAX"))?;
 
-    let result: i64 = kcall4!(
-        KcallNumber::Pull.into(),
-        sender_raw,
-        sender_tid_raw,
-        buffer.as_mut_ptr() as usize as u32,
-        transfer_len
-    );
+    let args: PullArgs = PullArgs {
+        src_pid: sender_pid,
+        src_tid: sender_tid,
+        buffer: buffer.as_mut_ptr() as usize as u32,
+        len: transfer_len,
+        timeout,
+    };
+
+    let result: i64 = kcall1!(KcallNumber::Pull.into(), &args as *const PullArgs as usize as u32);
 
     if result >= 0 {
         usize::try_from(result).map_err(|_| {

--- a/src/tests/integration/test-rust-kernel/src/rendezvous.rs
+++ b/src/tests/integration/test-rust-kernel/src/rendezvous.rs
@@ -7,10 +7,13 @@
 
 use ::alloc::alloc::Layout;
 use ::config::memory_layout::USER_THREAD_STACK_SIZE;
-use ::core::sync::atomic::{
-    AtomicBool,
-    AtomicU32,
-    Ordering,
+use ::core::{
+    sync::atomic::{
+        AtomicBool,
+        AtomicU32,
+        Ordering,
+    },
+    time::Duration,
 };
 use ::sys::{
     error::{
@@ -2450,6 +2453,534 @@ fn test_interleaved_pending_order() -> Result<(), Error> {
 }
 
 //==================================================================================================
+// Timeout Semantics
+//==================================================================================================
+
+/// Payload used by the timeout tests.
+const TIMEOUT_PAYLOAD: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+
+/// Finite timeout used by the "timeout fires" tests. Long enough to prove the caller actually
+/// blocked and was woken by the timer, yet short enough to keep the test fast.
+const TIMEOUT_FIRES_DELAY: Duration = Duration::from_millis(50);
+
+/// Generous finite timeout used by the "timeout not reached" test. The counterpart always arrives
+/// well within this window, so the call must complete normally instead of timing out.
+const TIMEOUT_GENEROUS_DELAY: Duration = Duration::from_secs(10);
+
+/// Number of times the main thread yields so a child thread can register a pending rendezvous entry
+/// before the main thread probes for it. One yield is sufficient on a single-core system; a small
+/// margin is used for robustness.
+const PENDING_REGISTER_YIELDS: usize = 8;
+
+/// Release flag that lets the idle child thread exit once the main thread finishes probing it.
+static IDLE_RELEASE: AtomicBool = AtomicBool::new(false);
+
+///
+/// # Description
+///
+/// Idle child thread that stays alive without ever pushing or pulling, providing a stable thread
+/// identifier for the main thread to probe against. It exits once [`IDLE_RELEASE`] is set.
+///
+extern "C" fn idle_child(_arg: usize) -> usize {
+    while !IDLE_RELEASE.load(ORDER) {
+        if sched::__kcall_sched_yield().is_err() {
+            return 1;
+        }
+    }
+    0
+}
+
+///
+/// # Description
+///
+/// Child thread that pushes [`TIMEOUT_PAYLOAD`] to the main thread with an infinite timeout,
+/// blocking until the main thread pulls.
+///
+extern "C" fn pusher_child_timeout(_arg: usize) -> usize {
+    let (pid, main_tid): (ProcessIdentifier, ThreadIdentifier) = match load_parent_ids() {
+        Ok(ids) => ids,
+        Err(()) => return 1,
+    };
+
+    match ipc::__kcall_push(pid, main_tid, &TIMEOUT_PAYLOAD) {
+        Ok(()) => 0,
+        Err(_) => 1,
+    }
+}
+
+///
+/// # Description
+///
+/// Child thread that pulls [`TIMEOUT_PAYLOAD`] from the main thread with an infinite timeout,
+/// blocking until the main thread pushes.
+///
+extern "C" fn puller_child_timeout(_arg: usize) -> usize {
+    let (pid, main_tid): (ProcessIdentifier, ThreadIdentifier) = match load_parent_ids() {
+        Ok(ids) => ids,
+        Err(()) => return 1,
+    };
+
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    match ipc::__kcall_pull(pid, main_tid, &mut recv_buf) {
+        Ok(n) if n == TIMEOUT_PAYLOAD.len() && recv_buf == TIMEOUT_PAYLOAD => 0,
+        _ => 1,
+    }
+}
+
+///
+/// # Description
+///
+/// Verifies that `result` failed with [`ErrorCode::OperationTimedOut`], the kernel-level status the
+/// syscall layer maps to `EAGAIN`.  Logs and returns a descriptive error otherwise.
+///
+/// # Parameters
+///
+/// - `test`: Name of the calling test, used for diagnostics.
+/// - `result`: Result to inspect.
+///
+fn expect_timed_out(test: &str, result: Result<(), Error>) -> Result<(), Error> {
+    match result {
+        Err(e) if e.code == ErrorCode::OperationTimedOut => Ok(()),
+        Err(e) => {
+            ::syslog::error!("{test}: expected OperationTimedOut, got error {:?}", e.code);
+            Err(Error::new(e.code, "expected OperationTimedOut"))
+        },
+        Ok(()) => {
+            ::syslog::error!("{test}: expected OperationTimedOut, but the call succeeded");
+            Err(Error::new(ErrorCode::OperationNotPermitted, "expected a timeout"))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Consumes the pending push emitted by [`pusher_child_timeout`] via an infinite pull, so a child
+/// that a misbehaving timed pull failed to unblock cannot leave `join` hanging forever. Used only
+/// on the failure path of the success-oriented timeout tests.
+///
+/// # Parameters
+///
+/// - `pid`: Process identifier shared by the child and the main thread.
+/// - `child_tid`: Thread identifier of the pushing child.
+///
+fn drain_pending_push(pid: ProcessIdentifier, child_tid: ThreadIdentifier) {
+    let mut sink: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let _ = ipc::__kcall_pull(pid, child_tid, &mut sink);
+}
+
+///
+/// # Description
+///
+/// Satisfies the pending pull emitted by [`puller_child_timeout`] with an infinite push, so a child
+/// that a misbehaving timed push failed to unblock cannot leave `join` hanging forever. Used only
+/// on the failure path of the success-oriented timeout tests.
+///
+/// # Parameters
+///
+/// - `pid`: Process identifier shared by the child and the main thread.
+/// - `child_tid`: Thread identifier of the pulling child.
+///
+fn drain_pending_pull(pid: ProcessIdentifier, child_tid: ThreadIdentifier) {
+    let _ = ipc::__kcall_push(pid, child_tid, &TIMEOUT_PAYLOAD);
+}
+
+//==================================================================================================
+// Timeout Test T1: Non-Blocking Pull With No Counterpart
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A non-blocking pull (zero timeout) with no pending push returns immediately with
+/// [`ErrorCode::OperationTimedOut`], without registering a pending entry or sleeping.
+///
+fn test_pull_nonblocking_times_out() -> Result<(), Error> {
+    ::syslog::info!("test_pull_nonblocking_times_out: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    IDLE_RELEASE.store(false, ORDER);
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(idle_child, stack_base)?;
+
+    // The idle child never pushes, so a zero-timeout pull must report a timeout at once.
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let result: Result<usize, Error> =
+        ipc::__kcall_pull_timed(pid, child_tid, &mut recv_buf, Some(Duration::ZERO));
+
+    IDLE_RELEASE.store(true, ORDER);
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    expect_timed_out("test_pull_nonblocking_times_out", result.map(|_| ()))?;
+
+    ::syslog::info!("test_pull_nonblocking_times_out: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T2: Non-Blocking Push With No Counterpart
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A non-blocking push (zero timeout) with no pending pull returns immediately with
+/// [`ErrorCode::OperationTimedOut`], without registering a pending entry or sleeping.
+///
+fn test_push_nonblocking_times_out() -> Result<(), Error> {
+    ::syslog::info!("test_push_nonblocking_times_out: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    IDLE_RELEASE.store(false, ORDER);
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(idle_child, stack_base)?;
+
+    // The idle child never pulls, so a zero-timeout push must report a timeout at once.
+    let result: Result<(), Error> =
+        ipc::__kcall_push_timed(pid, child_tid, &TIMEOUT_PAYLOAD, Some(Duration::ZERO));
+
+    IDLE_RELEASE.store(true, ORDER);
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    expect_timed_out("test_push_nonblocking_times_out", result)?;
+
+    ::syslog::info!("test_push_nonblocking_times_out: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T3: Non-Blocking Pull With a Ready Counterpart
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A non-blocking pull (zero timeout) completes immediately when a matching push is already
+/// pending, transferring the payload rather than reporting a timeout.
+///
+fn test_pull_nonblocking_ready() -> Result<(), Error> {
+    ::syslog::info!("test_pull_nonblocking_ready: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(pusher_child_timeout, stack_base)?;
+
+    // Yield so the child registers its pending push before we probe for it.
+    for _ in 0..PENDING_REGISTER_YIELDS {
+        sched::__kcall_sched_yield()?;
+    }
+
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let result: Result<usize, Error> =
+        ipc::__kcall_pull_timed(pid, child_tid, &mut recv_buf, Some(Duration::ZERO));
+
+    // A successful pull already unblocked the child; otherwise drain it so join cannot hang.
+    if result.is_err() {
+        drain_pending_push(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    let bytes_transferred: usize = result?;
+    if bytes_transferred != TIMEOUT_PAYLOAD.len() {
+        ::syslog::error!(
+            "test_pull_nonblocking_ready: wrong byte count (expected={}, got={})",
+            TIMEOUT_PAYLOAD.len(),
+            bytes_transferred
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, "byte count mismatch"));
+    }
+    if recv_buf != TIMEOUT_PAYLOAD {
+        ::syslog::error!("test_pull_nonblocking_ready: payload mismatch");
+        return Err(Error::new(ErrorCode::InvalidArgument, "payload mismatch"));
+    }
+
+    ::syslog::info!("test_pull_nonblocking_ready: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T4: Non-Blocking Push With a Ready Counterpart
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A non-blocking push (zero timeout) completes immediately when a matching pull is already
+/// pending, transferring the payload rather than reporting a timeout.
+///
+fn test_push_nonblocking_ready() -> Result<(), Error> {
+    ::syslog::info!("test_push_nonblocking_ready: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(puller_child_timeout, stack_base)?;
+
+    // Yield so the child registers its pending pull before we probe for it.
+    for _ in 0..PENDING_REGISTER_YIELDS {
+        sched::__kcall_sched_yield()?;
+    }
+
+    let result: Result<(), Error> =
+        ipc::__kcall_push_timed(pid, child_tid, &TIMEOUT_PAYLOAD, Some(Duration::ZERO));
+
+    // A successful push already unblocked the child; otherwise drain it so join cannot hang.
+    if result.is_err() {
+        drain_pending_pull(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    result?;
+
+    ::syslog::info!("test_push_nonblocking_ready: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T5: Finite Pull Timeout Fires
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A finite pull timeout with no counterpart blocks until the deadline elapses and then reports
+/// [`ErrorCode::OperationTimedOut`], proving the caller actually slept and the timer woke it.
+///
+fn test_pull_timeout_fires() -> Result<(), Error> {
+    ::syslog::info!("test_pull_timeout_fires: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    IDLE_RELEASE.store(false, ORDER);
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(idle_child, stack_base)?;
+
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let result: Result<usize, Error> =
+        ipc::__kcall_pull_timed(pid, child_tid, &mut recv_buf, Some(TIMEOUT_FIRES_DELAY));
+
+    IDLE_RELEASE.store(true, ORDER);
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    expect_timed_out("test_pull_timeout_fires", result.map(|_| ()))?;
+
+    ::syslog::info!("test_pull_timeout_fires: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T6: Finite Push Timeout Fires
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A finite push timeout with no counterpart blocks until the deadline elapses and then reports
+/// [`ErrorCode::OperationTimedOut`].
+///
+fn test_push_timeout_fires() -> Result<(), Error> {
+    ::syslog::info!("test_push_timeout_fires: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    IDLE_RELEASE.store(false, ORDER);
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(idle_child, stack_base)?;
+
+    let result: Result<(), Error> =
+        ipc::__kcall_push_timed(pid, child_tid, &TIMEOUT_PAYLOAD, Some(TIMEOUT_FIRES_DELAY));
+
+    IDLE_RELEASE.store(true, ORDER);
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    expect_timed_out("test_push_timeout_fires", result)?;
+
+    ::syslog::info!("test_push_timeout_fires: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T7: Finite Pull Timeout Not Reached
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A finite pull timeout completes normally when the counterpart pushes before the deadline: the
+/// generous timeout is never reached, so the payload is transferred and no timeout is reported.
+///
+fn test_pull_timeout_not_reached() -> Result<(), Error> {
+    ::syslog::info!("test_pull_timeout_not_reached: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(pusher_child_timeout, stack_base)?;
+
+    // The main thread's pull registers first and sleeps; the child then pushes well within the
+    // generous deadline, so the call completes rather than timing out.
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let result: Result<usize, Error> =
+        ipc::__kcall_pull_timed(pid, child_tid, &mut recv_buf, Some(TIMEOUT_GENEROUS_DELAY));
+
+    if result.is_err() {
+        drain_pending_push(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    let bytes_transferred: usize = result?;
+    if bytes_transferred != TIMEOUT_PAYLOAD.len() {
+        ::syslog::error!(
+            "test_pull_timeout_not_reached: wrong byte count (expected={}, got={})",
+            TIMEOUT_PAYLOAD.len(),
+            bytes_transferred
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, "byte count mismatch"));
+    }
+    if recv_buf != TIMEOUT_PAYLOAD {
+        ::syslog::error!("test_pull_timeout_not_reached: payload mismatch");
+        return Err(Error::new(ErrorCode::InvalidArgument, "payload mismatch"));
+    }
+
+    ::syslog::info!("test_pull_timeout_not_reached: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T8: Finite Push Timeout Not Reached
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A finite push timeout completes normally when the counterpart pulls before the deadline: the
+/// generous timeout is never reached, so the payload is transferred and no timeout is reported.
+///
+fn test_push_timeout_not_reached() -> Result<(), Error> {
+    ::syslog::info!("test_push_timeout_not_reached: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(puller_child_timeout, stack_base)?;
+
+    // The main thread's push registers first and sleeps; the child then pulls well within the
+    // generous deadline, so the call completes rather than timing out.
+    let result: Result<(), Error> =
+        ipc::__kcall_push_timed(pid, child_tid, &TIMEOUT_PAYLOAD, Some(TIMEOUT_GENEROUS_DELAY));
+
+    if result.is_err() {
+        drain_pending_pull(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    result?;
+
+    ::syslog::info!("test_push_timeout_not_reached: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T9: Infinite Pull Timeout via the Timed API
+//==================================================================================================
+
+///
+/// # Description
+///
+/// An infinite timeout (`None`) requested through the timed pull entry point behaves exactly like
+/// the historical blocking pull: it waits until the counterpart pushes and then transfers the
+/// payload.  This guards backward compatibility of the timed ABI.
+///
+fn test_pull_infinite_timeout() -> Result<(), Error> {
+    ::syslog::info!("test_pull_infinite_timeout: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(pusher_child_timeout, stack_base)?;
+
+    let mut recv_buf: [u8; TIMEOUT_PAYLOAD.len()] = [0u8; TIMEOUT_PAYLOAD.len()];
+    let result: Result<usize, Error> = ipc::__kcall_pull_timed(pid, child_tid, &mut recv_buf, None);
+
+    if result.is_err() {
+        drain_pending_push(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    let bytes_transferred: usize = result?;
+    if bytes_transferred != TIMEOUT_PAYLOAD.len() {
+        ::syslog::error!(
+            "test_pull_infinite_timeout: wrong byte count (expected={}, got={})",
+            TIMEOUT_PAYLOAD.len(),
+            bytes_transferred
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, "byte count mismatch"));
+    }
+    if recv_buf != TIMEOUT_PAYLOAD {
+        ::syslog::error!("test_pull_infinite_timeout: payload mismatch");
+        return Err(Error::new(ErrorCode::InvalidArgument, "payload mismatch"));
+    }
+
+    ::syslog::info!("test_pull_infinite_timeout: passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Timeout Test T10: Infinite Push Timeout via the Timed API
+//==================================================================================================
+
+///
+/// # Description
+///
+/// An infinite timeout (`None`) requested through the timed push entry point behaves exactly like
+/// the historical blocking push: it waits until the counterpart pulls and then transfers the
+/// payload. This guards backward compatibility of the timed ABI.
+///
+fn test_push_infinite_timeout() -> Result<(), Error> {
+    ::syslog::info!("test_push_infinite_timeout: starting");
+
+    let (pid, _main_tid): (ProcessIdentifier, ThreadIdentifier) = store_caller_ids()?;
+
+    let (stack_ptr, layout, stack_base): (*mut u8, Layout, VirtualAddress) = alloc_thread_stack()?;
+    let child_tid: ThreadIdentifier = spawn_child_thread(puller_child_timeout, stack_base)?;
+
+    let result: Result<(), Error> = ipc::__kcall_push_timed(pid, child_tid, &TIMEOUT_PAYLOAD, None);
+
+    if result.is_err() {
+        drain_pending_pull(pid, child_tid);
+    }
+    join_child_thread(child_tid)?;
+    // SAFETY: stack is no longer in use after join.
+    unsafe { free_thread_stack(stack_ptr, layout) };
+
+    result?;
+
+    ::syslog::info!("test_push_infinite_timeout: passed");
+    Ok(())
+}
+
+//==================================================================================================
 // Public Entry Point
 //==================================================================================================
 
@@ -2517,6 +3048,19 @@ pub fn run() -> Result<(), Error> {
     // Cleanup and pending list integrity tests.
     test_thread_exit_cleanup()?;
     test_interleaved_pending_order()?;
+
+    // Timeout semantics: non-blocking probes, finite timeouts that fire, finite timeouts that are
+    // not reached, and the infinite timeout requested through the timed ABI.
+    test_pull_nonblocking_times_out()?;
+    test_push_nonblocking_times_out()?;
+    test_pull_nonblocking_ready()?;
+    test_push_nonblocking_ready()?;
+    test_pull_timeout_fires()?;
+    test_push_timeout_fires()?;
+    test_pull_timeout_not_reached()?;
+    test_push_timeout_not_reached()?;
+    test_pull_infinite_timeout()?;
+    test_push_infinite_timeout()?;
 
     ::syslog::info!("rendezvous test suite: all tests passed");
     Ok(())


### PR DESCRIPTION
## Summary

Bounds the two unbounded blocking sites in the Nanvix rendezvous IPC by threading
an optional timeout through `push`/`pull`. Previously `do_push`/`do_pull` and the
guest-to-host bulk pull slept with no deadline, so a missing, slow, or wedged
counterpart could block a thread forever. The wait now honors a caller-supplied
timeout while preserving the single-copy transfer model.

## What changed

- **ABI:** The `Push`/`Pull` kernel calls now take a single pointer to a
  `PushArgs`/`PullArgs` descriptor (mirroring `send`/`recv`) that carries a
  `Timeout { kind, secs, nanos }` POD field, freeing the argument registers that
  were previously fully consumed. The descriptor has a fixed-width, `repr(C)`
  layout identical on the 32-bit guest and the kernel, guarded by size asserts.
- **Kernel:** `push()`/`pull()` copy the descriptor from user space and resolve
  its `Timeout` into a `RendezvousTimeout` (`Infinite`, `NonBlocking`, `Deadline`)
  against the monotonic clock.
  - A zero-timeout probe returns `OperationTimedOut` immediately without
    registering a pending entry or sleeping.
  - A finite timeout sleeps on an alarm; an infinite timeout blocks as before.
  - `bulk_pull::register_and_sleep` takes an alarm and, on timeout, keeps the
    pending entry so a late host completion is not dropped as stale; only a real
    abort removes it.
- **Libraries:** New `__kcall_push_timed`/`__kcall_pull_timed` wrappers accept
  `Option<Duration>`; the existing `__kcall_push`/`__kcall_pull` delegate as
  infinite-timeout shims, so all current callers are unchanged.
- **Tests:** The `test-rust-kernel` rendezvous suite gains timeout coverage —
  non-blocking probe (ready and not ready), finite timeout that fires, finite
  timeout that is not reached, and infinite timeout via the timed API, for both
  push and pull.

## Scope

This delivers the policy-free bounded-blocking **mechanism**. The syscall-layer
POSIX mapping (blocking-fd watchdog, socket `SO_RCVTIMEO`/`SO_SNDTIMEO`,
`EAGAIN` translation) is intentionally out of scope and left as follow-up;
`read`/`write`/socket paths still use the infinite variants.

## Validation

`build -- all`, `format-check`, `lint-check`, `run-unit-tests`, and
`run-nanvix-tests` all pass. The new timeout tests run in-kernel as part of the
`test-rust-kernel` rendezvous suite.

Closes #2904
