### PR TITLE
[ci] Revert Windows Benchmark Gate to 40%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1566,11 +1566,6 @@ jobs:
           git fetch origin dev --quiet
           git checkout origin/dev -- data/windows-baremetal
           benchmarks="boot-time,cold-start"
-          # TEMPORARY: the Windows regression threshold is raised from 40 to 60.
-          # Defaulting guest memory to 256MB (#2845) increased WHP boot-time ~40-45%
-          # because WHP commits guest RAM eagerly at VM creation (see #2851). The dev
-          # baseline still reflects 128MB and self-heals once #2845 lands on dev.
-          # Revert to 40 once the dev baseline stabilizes on 256MB: #2852.
           python3 ./scripts/benchmark.py \
             ci-gate \
             --dev-dir "data/windows-baremetal" \
@@ -1578,7 +1573,7 @@ jobs:
             --benchmarks "${benchmarks}" \
             --machine-types "microvm" \
             --archs "X64" \
-            --regression-threshold 60 \
+            --regression-threshold 40 \
             --baseline-window 20
 
       - name: "Persist results on dev"


### PR DESCRIPTION
## Summary

Restore the Windows performance regression gate in .github/workflows/ci.yml to a 40% threshold, matching the Linux gate.

The Windows gate was temporarily raised to 60% to absorb the one-time WHP boot-time step change caused by defaulting guest memory to 256MB (#2845). WHP commits guest RAM eagerly at VM creation, so boot-time rose ~40-45%. The dev Windows baseline has since stabilized on 256MB, so the elevated threshold is no longer needed.

## Changes

- Set \--regression-threshold\ back to \40\ on the Windows \ci-gate\ step.
- Remove the obsolete \TEMPORARY\ comment block.

closes #2852