### PR TITLE
[syscall] Search Deps In DT_NEEDED Order

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -29,6 +29,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-init-runpath \
 	test-c-dlfcn-initfini \
 	test-c-dlfcn-needed \
+	test-c-dlfcn-order \
 	test-c-dlfcn-pie \
 	test-c-dlfcn-refcount \
 	test-c-dlfcn-scope \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -133,6 +133,10 @@ POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-handle-reuse := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+# dlfcn-order-c dlopen()s libroot.so, whose two providers both export
+# provider_id(); the executable's own symbols land in .dynsym for RTLD_DEFAULT,
+# matching every other dlfcn dlopen suite.
+POSIX_TEST_PIE_test-c-dlfcn-order := yes
 # dlfcn-dlclose-cycle-c's fixtures reference only each other (never the main
 # executable), so PIE is not strictly required; it is set anyway to match every
 # other dlfcn dlopen suite (the executable's own symbols land in .dynsym for
@@ -330,6 +334,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond)
+	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-order)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse)
@@ -349,6 +354,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_CTOR_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DIAMOND_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_ORDER_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DLCLOSE_CYCLE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_DTOR_REENTRY_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HANDLE_REUSE_SEED)
@@ -616,6 +622,65 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond): $(POSIX_TEST_DIAMOND_DIR)/libbase.
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libright.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(CP_CMD) $(POSIX_TEST_DIAMOND_DIR)/libdiamond.so $(POSIX_TEST_DIAMOND_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_DIAMOND_SEED)
+
+#---------------------------------------------------------------------------------------------------
+# dlfcn-order-c: DT_NEEDED dependency search-order fixture (issue #2091).
+#---------------------------------------------------------------------------------------------------
+#
+#   libroot.so -> libbravo.so    (provider_id() == 2)  [first  in DT_NEEDED]
+#              -> libalpha.so     (provider_id() == 1)  [second in DT_NEEDED]
+#
+# Both providers export the SAME symbol provider_id(). libroot.so records its
+# DT_NEEDED entries as (libbravo.so, libalpha.so) -- pinned by the `-lbravo
+# -lalpha` link order -- which is the REVERSE of the alphabetical order of the
+# names. A loader that searches a load group in DT_NEEDED order (BFS, matching
+# glibc's l_searchlist) resolves provider_id() through libroot.so's handle to
+# libbravo.so (2); a loader that searches alphabetically resolves it to
+# libalpha.so (1). The suite asserts the former. Built with the same i686
+# freestanding toolchain as the diamond fixtures above; each DT_NEEDED edge is a
+# bare name recorded by linking with `-L<dir> -l<name>`, resolved through the
+# loader's default lib/ search path where the per-suite RAMFS stages the .so
+# files.
+POSIX_TEST_ORDER_DIR  := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-order/libs
+POSIX_TEST_ORDER_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-order-seed
+POSIX_TEST_RAMFS_IMG_test-c-dlfcn-order := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-order.img
+
+# Provider: libalpha.so (no dependencies). Exports provider_id() == 1.
+$(POSIX_TEST_ORDER_DIR)/libalpha.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-order/libs/alpha.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-order-c/libalpha.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Provider: libbravo.so (no dependencies). Exports provider_id() == 2.
+$(POSIX_TEST_ORDER_DIR)/libbravo.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-order/libs/bravo.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-order-c/libbravo.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o -o $@
+
+# Root: DT_NEEDED libbravo.so then libalpha.so. The `-lbravo -lalpha` order pins
+# the DT_NEEDED order to bravo-before-alpha (the reverse of alphabetical), so the
+# search order is observable. Built after both providers so the linker records
+# the edges.
+$(POSIX_TEST_ORDER_DIR)/libroot.so: $(POSIX_TESTS_SRCDIR)/test-c-dlfcn-order/libs/root.c \
+		$(POSIX_TEST_ORDER_DIR)/libbravo.so $(POSIX_TEST_ORDER_DIR)/libalpha.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-order-c/libroot.so (DT_NEEDED libbravo.so libalpha.so)"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) $@.o \
+		-L$(POSIX_TEST_ORDER_DIR) -lbravo -lalpha -o $@
+
+# Per-suite RAMFS image carrying all three fixtures under lib/.
+$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-order): $(POSIX_TEST_ORDER_DIR)/libalpha.so \
+		$(POSIX_TEST_ORDER_DIR)/libbravo.so \
+		$(POSIX_TEST_ORDER_DIR)/libroot.so all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_ORDER_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_ORDER_SEED)/lib
+	$(CP_CMD) $(POSIX_TEST_ORDER_DIR)/libalpha.so $(POSIX_TEST_ORDER_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_ORDER_DIR)/libbravo.so $(POSIX_TEST_ORDER_SEED)/lib/
+	$(CP_CMD) $(POSIX_TEST_ORDER_DIR)/libroot.so $(POSIX_TEST_ORDER_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_ORDER_SEED)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-dlclose-cycle-c: dlclose() over a multiply-referenced dependency graph.
@@ -1147,6 +1212,7 @@ POSIX_TEST_SOLIB_IMGS := $(foreach suite,$(POSIX_TEST_SOLIB_SUITES),$(POSIX_TEST
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-ctor-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-diamond) \
+	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-order) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dlclose-cycle) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-dtor-reentry) \
 	$(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-handle-reuse) \

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -251,11 +251,11 @@ fn load_all_dependencies(
         // re-locking the (already held) `DynamicLibrary` mutex.
         let self_name: String = new_dlfile.name().to_string();
 
-        // Collect the name of all dependencies.
+        // Collect the name of all dependencies, in DT_NEEDED order.
         let mut dependencies: Vec<String> = new_dlfile
             .dependencies()
-            .keys()
-            .map(|dlname| dlname.to_string())
+            .into_iter()
+            .map(|(dlname, _)| dlname)
             .collect();
 
         // Bind to already loaded dependencies and remove them from the list.
@@ -328,7 +328,10 @@ fn load_all_dependencies(
             true
         });
 
-        // Load remaining dependencies.
+        // Load remaining dependencies in DT_NEEDED order. The loop below uses
+        // `pop()` for ownership, so reverse once to consume the original front
+        // of the list first.
+        dependencies.reverse();
         while let Some(dependency) = dependencies.pop() {
             // Resolve bare library names to full paths using search directories.
             let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -19,6 +19,7 @@ use ::alloc::{
     collections::{
         btree_map::BTreeMap,
         btree_set::BTreeSet,
+        vec_deque::VecDeque,
     },
     ffi::CString,
     fmt,
@@ -245,8 +246,13 @@ pub struct DynamicLibrary {
     load_address: VirtualAddress,
     /// Memory segments.
     _segments: Vec<MemorySegment>, // Keep this here to prevent memory drop.
-    /// Dependencies.
-    dependencies: BTreeMap<String, Option<Arc<Mutex<Self>>>>,
+    /// Dependencies, in `DT_NEEDED` order.
+    ///
+    /// Stored as an ordered list rather than a map so symbol resolution can
+    /// search dependencies in the exact order the linker recorded them — the
+    /// order glibc walks when it builds an object's `l_searchlist` — instead of
+    /// an arbitrary alphabetical order.
+    dependencies: Vec<(String, Option<Arc<Mutex<Self>>>)>,
     /// Dynamic symbols.
     dynsym: SymbolTable,
     /// Dynamic symbols names.
@@ -454,13 +460,19 @@ impl DynamicLibrary {
                     }
                 }
 
-                // Collect dependencies.
-                let mut dependencies: BTreeMap<String, Option<Arc<Mutex<Self>>>> = BTreeMap::new();
-                if !elf.libraries.is_empty() {
-                    for library in elf.libraries.iter() {
-                        ::syslog::debug!("load(): depends on library '{}'", library);
-                        dependencies.insert(library.to_string(), None);
+                // Collect dependencies, preserving the `DT_NEEDED` order the
+                // linker recorded them in. Symbol resolution searches this list
+                // in order, so the order must not be lost. Duplicate entries are
+                // dropped: a repeated `DT_NEEDED` name refers to the same
+                // dependency and must occupy a single slot.
+                let mut dependencies: Vec<(String, Option<Arc<Mutex<Self>>>)> = Vec::new();
+                for library in elf.libraries.iter() {
+                    ::syslog::debug!("load(): depends on library '{}'", library);
+                    let name: String = library.to_string();
+                    if dependencies.iter().any(|(existing, _)| existing == &name) {
+                        continue;
                     }
+                    dependencies.push((name, None));
                 }
 
                 // Collect section headers.
@@ -872,57 +884,72 @@ impl DynamicLibrary {
     pub fn lookup_load_group(&self, symbol_name: &str) -> Result<Option<(usize, usize)>, Error> {
         ::syslog::trace!("lookup_load_group(): symbol={}, dlname={:?}", symbol_name, self.filename);
 
-        // The visited set tracks which dependencies have been traversed in
-        // this lookup to avoid re-searching in diamond-shaped graphs and to
-        // prevent infinite recursion on cyclic dependencies.
-        let mut visited: BTreeSet<usize> = BTreeSet::new();
-        self.lookup_in_load_group(symbol_name, &mut visited)
-    }
+        // POSIX / System V symbol resolution searches a load group in
+        // breadth-first `DT_NEEDED` order: the object itself first, then its
+        // direct dependencies in the order the linker recorded them, then the
+        // dependencies of those, and so on. This mirrors the order glibc walks
+        // when it services a lookup against an object's `l_searchlist`, so a
+        // symbol defined by more than one object in the group resolves to the
+        // first definition in `DT_NEEDED` order rather than to an
+        // alphabetically-first one.
 
-    /// Searches for a symbol in this library and its dependency tree only.
-    ///
-    /// Does NOT fall back to the global symbol table. This ensures that
-    /// recursive dependency searches do not short-circuit to the global scope
-    /// before the entire dependency tree has been checked.
-    ///
-    /// The `visited` set tracks `Arc` allocation addresses of dependencies
-    /// already traversed in this lookup, preventing redundant work on
-    /// diamond-shaped graphs and avoiding false-positive cycle detection.
-    fn lookup_in_load_group(
-        &self,
-        symbol_name: &str,
-        visited: &mut BTreeSet<usize>,
-    ) -> Result<Option<(usize, usize)>, Error> {
+        // The root object itself is the head of the search list.
         if let Some(symbol) = self.find(symbol_name) {
             if !symbol.is_undefined() {
-                // Symbol is defined in this library.
                 return Ok(Some((self.load_address.into_raw_value(), symbol.value() as usize)));
             }
         }
 
-        // Symbol is either undefined in this library or not in its dynsym at
-        // all. Per POSIX, dlsym must search the full dependency tree regardless
-        // of whether the root library references the symbol.
-        for dlfile in self.dependencies.values().flatten() {
-            // Guard against deadlock: if the mutex is held by an ancestor
-            // in our call chain (true cycle back to a locked parent) or by
-            // a concurrent lookup, skip rather than spinning forever.
+        // `visited` records the `Arc` allocation addresses of dependencies
+        // already searched in this lookup, so a diamond-shaped graph searches
+        // each object at most once. `queue` drives the breadth-first walk:
+        // direct dependencies are enqueued in `DT_NEEDED` order and each searched
+        // object appends its own dependencies to the back, so shallower and
+        // earlier `DT_NEEDED` objects are always searched first. A `DT_NEEDED`
+        // cycle is rejected at load time, so the bound graph is acyclic and the
+        // queue is bounded by the number of dependency edges.
+        let mut visited: BTreeSet<usize> = BTreeSet::new();
+        let mut queue: VecDeque<Arc<Mutex<Self>>> = VecDeque::new();
+        for dependency in self.dependencies.iter().filter_map(|(_, dep)| dep.as_ref()) {
+            queue.push_back(dependency.clone());
+        }
+
+        while let Some(dlfile) = queue.pop_front() {
+            // Skip a dependency already searched via a shorter or earlier path
+            // (diamond-shaped graph).
+            let id: usize = Arc::as_ptr(&dlfile) as usize;
+            if visited.contains(&id) {
+                continue;
+            }
+
+            // Guard against deadlock: if the mutex is held by an ancestor in our
+            // call chain (a cycle back to a locked parent) or by a concurrent
+            // lookup, skip rather than spinning forever. Leave it unmarked so
+            // another queued edge may still search it once it is free.
             if dlfile.is_locked() {
                 continue;
             }
-
-            // Use the Arc's heap allocation address as a unique,
-            // lock-free identifier for this dependency. Skip if already
-            // traversed in this lookup (diamond-shaped dependency).
-            let id: usize = Arc::as_ptr(dlfile) as usize;
-            if !visited.insert(id) {
-                continue;
-            }
+            visited.insert(id);
 
             let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
 
-            if let Some(result) = dlfile.lookup_in_load_group(symbol_name, visited)? {
-                return Ok(Some(result));
+            if let Some(symbol) = dlfile.find(symbol_name) {
+                if !symbol.is_undefined() {
+                    return Ok(Some((
+                        dlfile.load_address.into_raw_value(),
+                        symbol.value() as usize,
+                    )));
+                }
+            }
+
+            // Append this object's dependencies to the back of the queue in
+            // `DT_NEEDED` order, preserving the breadth-first search order.
+            for dependency in dlfile
+                .dependencies
+                .iter()
+                .filter_map(|(_, dep)| dep.as_ref())
+            {
+                queue.push_back(dependency.clone());
             }
         }
 
@@ -1249,16 +1276,16 @@ impl DynamicLibrary {
         storage_unit.write_unaligned(final_value as u32);
     }
 
-    /// Returns the file descriptor of the dynamic library.
-    pub fn dependencies(&self) -> BTreeMap<String, Option<Arc<Mutex<Self>>>> {
+    /// Returns a clone of this library's dependency list, in `DT_NEEDED` order.
+    pub fn dependencies(&self) -> Vec<(String, Option<Arc<Mutex<Self>>>)> {
         self.dependencies.clone()
     }
 
     /// Returns the handles of all bound dependencies.
     pub fn dependency_handles(&self) -> Vec<DlHandle> {
         self.dependencies
-            .values()
-            .filter_map(|dep| dep.as_ref().map(|d| d.lock().handle()))
+            .iter()
+            .filter_map(|(_, dep)| dep.as_ref().map(|d| d.lock().handle()))
             .collect()
     }
 
@@ -1294,19 +1321,19 @@ impl DynamicLibrary {
         name: String,
         library: Arc<Mutex<Self>>,
     ) -> Result<(), Error> {
-        match self.dependencies.get(&name) {
-            Some(None) => {
-                self.dependencies.insert(name, Some(library));
+        match self.dependencies.iter_mut().find(|entry| entry.0 == name) {
+            Some(entry) => {
+                if entry.1.is_some() {
+                    let reason: &str = "dependency already loaded";
+                    ::syslog::warn!("bind_dependency(): {}", reason);
+                    return Err(Error::new(ErrorCode::BadFile, reason));
+                }
+                entry.1 = Some(library);
                 Ok(())
-            },
-            Some(Some(_)) => {
-                let reason: &str = "dependency already loaded";
-                ::syslog::warn!("load_dependency(): {}", reason);
-                Err(Error::new(ErrorCode::BadFile, reason))
             },
             None => {
                 let reason: &str = "dependency not listed";
-                ::syslog::warn!("load_dependency(): {}", reason);
+                ::syslog::warn!("bind_dependency(): {}", reason);
                 Err(Error::new(ErrorCode::BadFile, reason))
             },
         }

--- a/src/tests/integration/test-c-dlfcn-order/libs/alpha.c
+++ b/src/tests/integration/test-c-dlfcn-order/libs/alpha.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libalpha.so - one of two providers that export the SAME symbol
+ * `provider_id()`. It is the SECOND entry in libroot.so's DT_NEEDED list but
+ * the FIRST when the dependency names are sorted alphabetically
+ * ("libalpha.so" < "libbravo.so").
+ *
+ * A loader that searches dependencies in DT_NEEDED order (as POSIX/System V
+ * require) must NOT pick this library's `provider_id()` for a lookup made
+ * through libroot.so, because libbravo.so precedes it in DT_NEEDED order. A
+ * loader that instead searches alphabetically WOULD pick this one -- the bug
+ * exercised by the test in ../main.c.
+ */
+
+/* Identity of this provider. Distinct from libbravo.so's so the test can tell
+ * which library a lookup resolved to. */
+int provider_id(void)
+{
+    return 1;
+}
+
+/* Marker unique to this library. Referenced by libroot.so purely to force a
+ * DT_NEEDED entry on libalpha.so regardless of the linker's as-needed default. */
+int alpha_marker(void)
+{
+    return 0xA;
+}

--- a/src/tests/integration/test-c-dlfcn-order/libs/bravo.c
+++ b/src/tests/integration/test-c-dlfcn-order/libs/bravo.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libbravo.so - one of two providers that export the SAME symbol
+ * `provider_id()`. It is the FIRST entry in libroot.so's DT_NEEDED list but the
+ * SECOND when the dependency names are sorted alphabetically
+ * ("libalpha.so" < "libbravo.so").
+ *
+ * A loader that searches dependencies in DT_NEEDED order (as POSIX/System V
+ * require) must resolve a `provider_id()` lookup made through libroot.so to
+ * THIS library, because libbravo.so precedes libalpha.so in DT_NEEDED order.
+ * The test in ../main.c asserts exactly that.
+ */
+
+/* Identity of this provider. Distinct from libalpha.so's so the test can tell
+ * which library a lookup resolved to. */
+int provider_id(void)
+{
+    return 2;
+}
+
+/* Marker unique to this library. Referenced by libroot.so purely to force a
+ * DT_NEEDED entry on libbravo.so regardless of the linker's as-needed default. */
+int bravo_marker(void)
+{
+    return 0xB;
+}

--- a/src/tests/integration/test-c-dlfcn-order/libs/root.c
+++ b/src/tests/integration/test-c-dlfcn-order/libs/root.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libroot.so - the object the test obtains a handle to. It carries TWO
+ * DT_NEEDED edges, recorded in this order by linking against the providers as
+ * `-lbravo -lalpha`:
+ *
+ *   libroot.so
+ *     +-- DT_NEEDED libbravo.so   (provider_id() == 2)  [first  in DT_NEEDED]
+ *     +-- DT_NEEDED libalpha.so   (provider_id() == 1)  [second in DT_NEEDED]
+ *
+ * Both dependencies export the SAME symbol `provider_id()`. The DT_NEEDED order
+ * (bravo, alpha) is deliberately the REVERSE of the alphabetical order of the
+ * library names (libalpha.so < libbravo.so), so a lookup made through
+ * libroot.so resolves to a different provider depending on the search policy:
+ *
+ *   * DT_NEEDED order (correct): libbravo.so  -> provider_id() == 2
+ *   * alphabetical order (bug):  libalpha.so  -> provider_id() == 1
+ *
+ * libroot.so itself does NOT define `provider_id()`; it only references it, so
+ * the loader must resolve it from the dependency list.
+ */
+
+/* Defined by BOTH dependencies. Left undefined here on purpose: the loader must
+ * bind this reference to the FIRST definition in DT_NEEDED order (libbravo.so),
+ * exercising the relocation-time resolution path under RTLD_NOW. */
+extern int provider_id(void);
+
+/* Unique markers, one per dependency. Referencing both forces libbravo.so and
+ * libalpha.so to each be recorded as a DT_NEEDED entry (so neither is dropped by
+ * an as-needed link), pinning the DT_NEEDED order to the link order. */
+extern int alpha_marker(void);
+extern int bravo_marker(void);
+
+/* Touches both dependencies so both DT_NEEDED edges are present and bound. */
+int root_touch(void)
+{
+    return alpha_marker() + bravo_marker();
+}
+
+/* Returns the id of whichever provider the loader bound libroot.so's own
+ * `provider_id()` reference to. Must be libbravo.so's (2) under DT_NEEDED-order
+ * resolution. */
+int root_provider_id(void)
+{
+    return provider_id();
+}

--- a/src/tests/integration/test-c-dlfcn-order/main.c
+++ b/src/tests/integration/test-c-dlfcn-order/main.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * dlfcn-order-c: acceptance test for DT_NEEDED dependency search ORDER
+ * (nanvix/nanvix#2091).
+ *
+ *   libroot.so
+ *     +-- DT_NEEDED libbravo.so   (provider_id() == 2)  [first  in DT_NEEDED]
+ *     +-- DT_NEEDED libalpha.so   (provider_id() == 1)  [second in DT_NEEDED]
+ *
+ * Both dependencies export the SAME symbol `provider_id()`. POSIX/System V (and
+ * glibc, via its `l_searchlist`) resolve a symbol looked up through an object to
+ * the first definition found while searching that object's dependencies in
+ * DT_NEEDED order. libroot.so's DT_NEEDED order is (libbravo.so, libalpha.so),
+ * which is the REVERSE of the alphabetical order of the names -- so:
+ *
+ *   * a DT_NEEDED-order (BFS) loader resolves `provider_id()` to libbravo.so's
+ *     definition, returning 2;
+ *   * a loader that searches dependencies alphabetically (the pre-fix bug,
+ *     where dependencies were stored in a `BTreeMap` keyed by name) resolves it
+ *     to libalpha.so's definition, returning 1.
+ *
+ * The decisive assertions below expect 2. On the buggy loader they observe 1 and
+ * the test fails, so this suite is a genuine regression test for the fix.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/* Identity each provider returns from provider_id(). */
+#define ALPHA_ID 1
+#define BRAVO_ID 2
+
+/* Per-library unique marker values. */
+#define ALPHA_MARK 0xA
+#define BRAVO_MARK 0xB
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    /* dlerror() may return NULL (no diagnostic available); guard against
+     * passing a NULL pointer to printf("%s"), which is undefined behavior. */
+    printf("  FAIL: %s (%s)\n", name, reason != NULL ? reason : "no diagnostic available");
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Sanity: both dependencies are actually loaded and reachable through
+ * libroot.so's handle. Each marker is unique to one library, so this does not
+ * depend on search order -- it just confirms the test setup is sound before the
+ * order-sensitive assertions run.
+ */
+static void test_both_dependencies_loaded(void *h)
+{
+    int (*root_touch)(void) = (int (*)(void))dlsym(h, "root_touch");
+    int (*alpha_marker)(void) = (int (*)(void))dlsym(h, "alpha_marker");
+    int (*bravo_marker)(void) = (int (*)(void))dlsym(h, "bravo_marker");
+
+    if (!root_touch || !alpha_marker || !bravo_marker) {
+        fail("both dependencies loaded", "missing marker symbols");
+        return;
+    }
+    if (alpha_marker() != ALPHA_MARK) {
+        fail("both dependencies loaded", "libalpha.so not reachable via handle");
+        return;
+    }
+    if (bravo_marker() != BRAVO_MARK) {
+        fail("both dependencies loaded", "libbravo.so not reachable via handle");
+        return;
+    }
+    if (root_touch() != ALPHA_MARK + BRAVO_MARK) {
+        fail("both dependencies loaded", "libroot.so relocations not bound to both deps");
+        return;
+    }
+    pass("both dependencies loaded and reachable");
+}
+
+/*
+ * KEY TEST (dlsym path): dlsym(libroot_handle, "provider_id") must resolve to
+ * the FIRST definition in DT_NEEDED order -- libbravo.so's (id 2) -- not the
+ * alphabetically-first one -- libalpha.so's (id 1).
+ */
+static void test_dlsym_resolves_in_dt_needed_order(void *h)
+{
+    int (*provider_id)(void) = (int (*)(void))dlsym(h, "provider_id");
+    if (!provider_id) {
+        fail("dlsym resolves in DT_NEEDED order", dlerror());
+        return;
+    }
+
+    int id = provider_id();
+    if (id != BRAVO_ID) {
+        char reason[128];
+        snprintf(reason, sizeof(reason),
+                 "provider_id()=%d (expected %d from libbravo.so, the first "
+                 "DT_NEEDED entry); got libalpha.so (%d) -- dependencies searched "
+                 "alphabetically instead of in DT_NEEDED order",
+                 id, BRAVO_ID, ALPHA_ID);
+        fail("dlsym resolves in DT_NEEDED order", reason);
+        return;
+    }
+    pass("dlsym resolves provider_id() in DT_NEEDED order");
+}
+
+/*
+ * KEY TEST (relocation path): libroot.so's OWN reference to `provider_id()` is
+ * bound at load time (RTLD_NOW) by the loader's relocation resolver, which uses
+ * the same DT_NEEDED-order search. root_provider_id() calls that bound
+ * reference, so it must likewise return libbravo.so's id (2).
+ */
+static void test_relocation_binds_in_dt_needed_order(void *h)
+{
+    int (*root_provider_id)(void) = (int (*)(void))dlsym(h, "root_provider_id");
+    if (!root_provider_id) {
+        fail("relocation binds in DT_NEEDED order", dlerror());
+        return;
+    }
+
+    int id = root_provider_id();
+    if (id != BRAVO_ID) {
+        char reason[128];
+        snprintf(reason, sizeof(reason),
+                 "root_provider_id()=%d (expected %d from libbravo.so, the first "
+                 "DT_NEEDED entry); loader bound libroot.so's reference to "
+                 "libalpha.so (%d)",
+                 id, BRAVO_ID, ALPHA_ID);
+        fail("relocation binds in DT_NEEDED order", reason);
+        return;
+    }
+    pass("relocation binds provider_id() in DT_NEEDED order");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn DT_NEEDED search-order tests ===\n");
+    fflush(stdout);
+
+    void *h = dlopen("lib/libroot.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("dlopen(libroot.so)", dlerror());
+        printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+        return 1;
+    }
+
+    test_both_dependencies_loaded(h);
+    test_dlsym_resolves_in_dt_needed_order(h);
+    test_relocation_binds_in_dt_needed_order(h);
+
+    dlclose(h);
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 2);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -166,6 +166,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-order"
+program = "./bin/test-c-dlfcn-order.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-order.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-pie"
 program = "./bin/test-c-dlfcn-pie.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -166,6 +166,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-order"
+program = "./bin/test-c-dlfcn-order.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-order.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-pie"
 program = "./bin/test-c-dlfcn-pie.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"


### PR DESCRIPTION
## Summary

Fixes dlfcn dependency search order so a symbol exported by more than one
dependency resolves to the first provider in ELF `DT_NEEDED` order rather than
the alphabetically-first one. Dependencies were stored in a `BTreeMap` keyed by
name, which discarded the linker-recorded order and made lookups diverge from
POSIX/System V (glibc `l_searchlist`) semantics.

## What changed

**Libraries (`syscall`):**
- Store `DynamicLibrary::dependencies` as an ordered `Vec<(String, Option<Arc<Mutex<Self>>>)>`
  instead of a `BTreeMap`, preserving `DT_NEEDED` order; duplicate `DT_NEEDED`
  names are dropped, keeping the first.
- Rewrite `lookup_load_group()` from recursive DFS into an iterative
  breadth-first walk over a `VecDeque`: the object itself first, then its direct
  dependencies in `DT_NEEDED` order, then theirs, marking visited `Arc`
  addresses for diamond graphs and preserving the `is_locked()` deadlock guard.
- Update `dependencies()`, `dependency_handles()`, and `load_dependency()` for
  the new representation; in `load_all_dependencies()`, collect deps in
  `DT_NEEDED` order and reverse before the `pop()`-driven load loop.

**Tests / build wiring:**
- Add `test-c-dlfcn-order`: `libroot.so` lists `DT_NEEDED` (libbravo.so,
  libalpha.so) — the reverse of alphabetical — and both providers export the
  same `provider_id()`. The suite asserts resolution to libbravo.so (2) via both
  the `dlsym` path and the `RTLD_NOW` relocation-binding path; alphabetical
  lookup would pick libalpha.so (1) and fail.
- Register the suite in `guest-posix-tests.mk`, add fixture/RAMFS/clean rules in
  `posix-tests.mk`, and add entries to `test-posix.toml` and
  `test-posix-windows.toml`.

## Validation

- Unit tests, `run-nanvix-tests`, and the POSIX suite (`run-posix-tests`,
  standalone) all pass; the new `posix/test-c-dlfcn-order` exits 0.

closes #2091