### PR TITLE
[ci] Fix Echo Breakdown Timestamps

### DIFF
--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -7,6 +7,7 @@ NANVIXD_FEATURES += $(if $(filter single-process,$(DEPLOYMENT_MODE)),single-proc
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 NANVIXD_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
+NANVIXD_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
 NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURES)")
 

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -44,6 +44,8 @@ standalone = []
 gdb = ["uservm/gdb"]
 # Enables fine-grained time profiling.
 profile-time = ["uservm/profile-time"]
+# Enables message timestamping.
+timestamp-messages = ["linuxd?/timestamp-messages", "uservm/timestamp-messages"]
 microvm = ["config/microvm", "uservm/microvm"]
 whp = ["config/whp", "uservm/whp"]
 

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -48,6 +48,8 @@ gdb = [
 ]
 # Enables fine-grained time profiling.
 profile-time = ["nanvix-sandbox/profile-time", "nanvix-terminal/profile-time"]
+# Enables message timestamping.
+timestamp-messages = ["nanvix-sandbox/timestamp-messages"]
 microvm = [
     "config/microvm",
     "nanvix-http/microvm",

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -31,6 +31,8 @@ standalone = ["nanvix/standalone"]
 gdb = ["nanvix/gdb"]
 # Enables fine-grained time profiling.
 profile-time = ["nanvix/profile-time"]
+# Enables message timestamping.
+timestamp-messages = ["nanvix/timestamp-messages"]
 microvm = ["nanvix/microvm"]
 whp = ["nanvix/whp"]
 


### PR DESCRIPTION
## Summary

- propagate `TIMESTAMP_MSG=yes` to the single-process `nanvixd` build
- forward message timestamping through `nanvix` and `nanvix-sandbox` to embedded `linuxd` and `uservm`
- restore all ten timestamps required by the echo-breakdown benchmark

## Root cause

The benchmark build switched from multi-process to single-process deployment, but timestamping remained enabled only for the standalone `linuxd` and `uservm` binaries. The embedded instances in `nanvixd` therefore recorded no timestamps, leaving only the two client-side timestamps.

## Validation

- pre-commit checks for debug microvm standalone and single-process configurations
- release echo-breakdown CI build configuration
- 10-iteration echo-breakdown benchmark