### PR TITLE
[uservm] Scope vCPU Shutdown to Its Thread

### DIFF
--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -22,13 +22,23 @@ use ::user_vm_api::UserVmIdentifier;
 ///
 /// # Description
 ///
-/// Timeout for waiting for graceful shutdown of UserVM instances.
+/// Timeout for waiting for graceful shutdown of standalone UserVM instances.
 ///
-/// We use control-plane messages to synchronize the graceful shutdown of different components.
-/// However, if components are faulty or hang, the sandbox cannot block. Instead, we wait for this
-/// timeout and revert to non-graceful shutdowns if the timeout is met.
+/// Standalone workloads normally terminate themselves, so this is a short final cleanup bound.
 ///
-pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(feature = "standalone")]
+pub const STANDALONE_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+
+///
+/// # Description
+///
+/// Timeout for waiting for graceful shutdown of single-process UserVM instances.
+///
+/// This exceeds the UserVM's five-second vCPU shutdown watchdog and its two bounded worker joins,
+/// preventing the sandbox from detaching a teardown task while those safeguards are still active.
+///
+#[cfg(feature = "single-process")]
+pub const SINGLE_PROCESS_CLEANUP_TIMEOUT: Duration = Duration::from_secs(16);
 
 ///
 /// # Description

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -12,7 +12,7 @@
 //==================================================================================================
 
 use crate::{
-    config::CLEANUP_TIMEOUT,
+    config::SINGLE_PROCESS_CLEANUP_TIMEOUT,
     UserVmArgs,
 };
 use ::anyhow::Result;
@@ -111,9 +111,7 @@ impl UserVm {
     /// On success, this function returns a handle to the spawned User VM instance. On failure,
     /// this function returns an error object instead.
     ///
-    pub async fn spawn(
-        args: &UserVmArgs,
-    ) -> Result<PendingUserVm> {
+    pub async fn spawn(args: &UserVmArgs) -> Result<PendingUserVm> {
         trace!("spawn(): args={args:?}");
 
         // Check if CPU affinity settings were provided.
@@ -363,7 +361,7 @@ impl UserVm {
 
         // Wait for User VM to finish.
         if let Some(task) = self.task.take() {
-            match timeout(CLEANUP_TIMEOUT, task).await {
+            match timeout(SINGLE_PROCESS_CLEANUP_TIMEOUT, task).await {
                 Ok(join_result) => match join_result {
                     Ok(Ok(raw_code)) => {
                         let exit_code: ExitCode = ExitCode::from(raw_code);

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -14,7 +14,7 @@
 //==================================================================================================
 
 use crate::{
-    config::CLEANUP_TIMEOUT,
+    config::STANDALONE_CLEANUP_TIMEOUT,
     UserVmArgs,
 };
 use ::anyhow::Result;
@@ -214,7 +214,7 @@ impl UserVm {
         trace!("shutdown()");
 
         if let Some(task) = self.task.take() {
-            match timeout(CLEANUP_TIMEOUT, task).await {
+            match timeout(STANDALONE_CLEANUP_TIMEOUT, task).await {
                 Ok(join_result) => match join_result {
                     Ok(Ok(raw_code)) => {
                         return Some(exit_status_from_exit_code(raw_code));

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -633,8 +633,8 @@ fn resume_microvm(guest: Arc<Mutex<Guest>>, vmem: Arc<Mutex<VirtualMemory>>) -> 
 }
 
 fn shutdown_vcpu_fn(vmm: Vmm) -> Box<ShutdownVcpuFn> {
-    Box::new(move || {
-        vmm.request_shutdown();
+    Box::new(move |vcpu_tid| {
+        vmm.request_shutdown(vcpu_tid);
     })
 }
 

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -5,8 +5,6 @@
 // Imports
 //==================================================================================================
 
-#[cfg(target_os = "linux")]
-use crate::vmm::KILL_SIGNAL;
 use ::anyhow::Result;
 use ::log::{
     debug,
@@ -45,7 +43,7 @@ use ::tokio::{
 pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 
 /// Timeout for shutdown operations.
-/// After this timeout, the orchestrator will forcefully terminate the vCPU thread.
+/// After this timeout, the orchestrator retries the backend shutdown request.
 pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(5000);
 
 //==================================================================================================
@@ -58,7 +56,7 @@ pub type CreateSnapshotFn =
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + 'static;
 pub type LoadSnapshotFn =
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + 'static;
-pub type ShutdownVcpuFn = dyn Fn() + Send + 'static;
+pub type ShutdownVcpuFn = dyn Fn(u64) + Send + 'static;
 
 //==================================================================================================
 // Structure
@@ -98,6 +96,8 @@ pub struct Orchestrator {
     /// Callback function to request vCPU shutdown (sets shared flag and cancels the vCPU run).
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     shutdown_vcpu: Box<ShutdownVcpuFn>,
+    /// Maximum time to wait for the vCPU to confirm shutdown.
+    shutdown_timeout: Duration,
 }
 
 //==================================================================================================
@@ -228,6 +228,7 @@ impl Orchestrator {
             _create_snapshot: create_snapshot,
             load_snapshot,
             shutdown_vcpu,
+            shutdown_timeout: SHUTDOWN_TIMEOUT,
         }
     }
 
@@ -244,7 +245,7 @@ impl Orchestrator {
         loop {
             // If we're in shutting down state, add timeout to prevent indefinite hang.
             if self.state == State::ShuttingDown {
-                match timeout(SHUTDOWN_TIMEOUT, self.wait_for_shutdown()).await {
+                match timeout(self.shutdown_timeout, self.wait_for_shutdown()).await {
                     Ok(Ok(())) => break,
                     Ok(Err(error)) => {
                         error!("run(): error during shutdown: {error:?}");
@@ -252,20 +253,12 @@ impl Orchestrator {
                     },
                     Err(_) => {
                         error!(
-                            "run(): shutdown timeout after {}ms, forcefully terminating vCPU \
-                             thread",
-                            SHUTDOWN_TIMEOUT.as_millis()
+                            "run(): shutdown timeout after {}ms, retrying vCPU shutdown request",
+                            self.shutdown_timeout.as_millis()
                         );
-                        // Forcefully terminate the vCPU thread.
-                        #[cfg(target_os = "linux")]
-                        {
-                            let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                            unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
-                        }
-                        #[cfg(target_os = "windows")]
-                        {
-                            (self.shutdown_vcpu)();
-                        }
+                        // Retry the backend-specific shutdown request. A process-directed fatal
+                        // signal cannot safely terminate only the vCPU thread.
+                        (self.shutdown_vcpu)(self.vcpu_tid);
                         break;
                     },
                 }
@@ -332,14 +325,16 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     async fn wait_for_shutdown(&mut self) -> Result<()> {
+        let mut io_control_open: bool = true;
         loop {
             select! {
-                result = self.io_control_rx.recv() => {
+                result = self.io_control_rx.recv(), if io_control_open => {
                     // Ignore I/O commands during shutdown.
                     if result.is_none() {
                         let reason: String =
                             "I/O control channel closed during shutdown".to_string();
                         warn!("wait_for_shutdown(): {reason}");
+                        io_control_open = false;
                     }
                 },
 
@@ -503,27 +498,13 @@ impl Orchestrator {
             IoControlCommand::Shutdown => {
                 debug!("try_receive_from_io_thread(): received shutdown command");
 
-                // After sending an interrupt to the vCPU thread, we continue processing
-                // messages until we receive a shutdown message from the vCPU thread itself.
-                // SAFETY: we call pthread_kill on a non-zero TID that we have received from
-                // the VCPU thread after boot, so this is safe.
+                // After requesting vCPU shutdown, continue processing messages until the vCPU
+                // thread confirms that it stopped.
                 debug!(
                     "try_receive_from_io_thread(): signaling to vcpu thread (tid={})",
                     self.vcpu_tid
                 );
-                #[cfg(target_os = "linux")]
-                {
-                    let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                    unsafe { ::libc::pthread_kill(pthread_id, crate::vmm::INTERRUPT_SIGNAL) };
-                }
-                #[cfg(target_os = "windows")]
-                {
-                    debug!(
-                        "try_receive_from_io_thread(): requesting vCPU shutdown (tid={})",
-                        self.vcpu_tid
-                    );
-                    (self.shutdown_vcpu)();
-                }
+                (self.shutdown_vcpu)(self.vcpu_tid);
 
                 // Transition to shutting down state.
                 self.state = State::ShuttingDown;
@@ -730,6 +711,7 @@ mod tests {
         vcpu_cmd_rx: mpsc::Receiver<VcpuControlCommand>,
         pause_called: Arc<AtomicBool>,
         resume_called: Arc<AtomicBool>,
+        shutdown_called: Arc<AtomicBool>,
     }
 
     fn build_harness() -> Harness {
@@ -744,10 +726,12 @@ mod tests {
         let pause_called: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let resume_called: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let snapshot_called: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let shutdown_called: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         let pause_flag: Arc<AtomicBool> = pause_called.clone();
         let resume_flag: Arc<AtomicBool> = resume_called.clone();
         let snapshot_flag: Arc<AtomicBool> = snapshot_called.clone();
+        let shutdown_flag: Arc<AtomicBool> = shutdown_called.clone();
 
         let orchestrator: Orchestrator = Orchestrator::new(
             0, // vcpu_tid (unused for these tests)
@@ -788,7 +772,7 @@ mod tests {
                     })
                 })
             },
-            Box::new(|| {}),
+            Box::new(move |_vcpu_tid| shutdown_flag.store(true, Ordering::SeqCst)),
         );
 
         Harness {
@@ -800,6 +784,7 @@ mod tests {
             vcpu_cmd_rx,
             pause_called,
             resume_called,
+            shutdown_called,
         }
     }
 
@@ -833,6 +818,51 @@ mod tests {
         // Join orchestrator task (should be Ok(()))
         let res: Result<()> = handle.await.expect("orchestrator join failed");
         assert!(res.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_uses_backend_callback() -> AnyResult<()> {
+        let mut h: Harness = build_harness();
+        h.orchestrator.state = State::ShuttingDown;
+        h.orchestrator.shutdown_timeout = Duration::from_millis(1);
+        let handle: JoinHandle<Result<()>> = h.orchestrator.spawn();
+
+        let mem_cmd: MemoryControlCommand =
+            timeout(Duration::from_millis(500), h.mem_cmd_rx.recv())
+                .await?
+                .expect("memory control channel closed unexpectedly");
+        assert!(matches!(mem_cmd, MemoryControlCommand::Shutdown));
+        assert!(h.shutdown_called.load(Ordering::SeqCst));
+
+        let io_resp: IoControlResponse = recv_io_resp(&mut h.io_resp_rx).await;
+        assert!(matches!(io_resp, IoControlResponse::Shutdown));
+
+        let result: Result<()> = handle.await.expect("orchestrator join failed");
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_ignores_closed_io_control_channel() -> AnyResult<()> {
+        let mut h: Harness = build_harness();
+        h.orchestrator.state = State::ShuttingDown;
+        drop(h.io_cmd_tx);
+
+        let handle: JoinHandle<Result<()>> = h.orchestrator.spawn();
+        h.vcpu_resp_tx.send(VcpuControlResponse::Shutdown).await?;
+
+        let mem_cmd: MemoryControlCommand =
+            timeout(Duration::from_millis(500), h.mem_cmd_rx.recv())
+                .await?
+                .expect("memory control channel closed unexpectedly");
+        assert!(matches!(mem_cmd, MemoryControlCommand::Shutdown));
+
+        let io_resp: IoControlResponse = recv_io_resp(&mut h.io_resp_rx).await;
+        assert!(matches!(io_resp, IoControlResponse::Shutdown));
+
+        let result: Result<()> = handle.await.expect("orchestrator join failed");
+        assert!(result.is_ok());
         Ok(())
     }
 

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -310,6 +310,11 @@ impl VirtualProcessor {
         Ok(())
     }
 
+    /// Returns a pointer to KVM's immediate-exit byte for this vCPU.
+    pub fn immediate_exit_ptr(&mut self) -> *mut u8 {
+        &mut self.fd.get_kvm_run().immediate_exit
+    }
+
     ///
     /// # Description
     ///

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -57,6 +57,7 @@ use crate::{
 use ::anyhow::Result;
 #[cfg(target_os = "linux")]
 use ::kvm_ioctls::{
+    Cap,
     Kvm,
     VmFd,
 };
@@ -75,6 +76,7 @@ use ::log::{
 };
 #[cfg(target_os = "linux")]
 use ::std::{
+    cell::Cell,
     ffi::OsStr,
     fs::File,
     io::Write,
@@ -264,10 +266,6 @@ pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 #[cfg(target_os = "linux")]
 pub const PROFILER_SIGNAL: c_int = libc::SIGUSR2;
 
-/// Signal used to kill the vCPU thread.
-#[cfg(target_os = "linux")]
-pub const KILL_SIGNAL: c_int = libc::SIGKILL;
-
 //==================================================================================================
 // Thread-Local Variables (Linux/KVM only)
 //==================================================================================================
@@ -284,11 +282,40 @@ thread_local! {
     /// process.
     ///
     static SHUTDOWN: AtomicBool = const { AtomicBool::new(false) };
+
+    /// Address of KVM's immediate-exit byte for the vCPU running on this thread.
+    static KVM_IMMEDIATE_EXIT: Cell<*mut u8> = const { Cell::new(::core::ptr::null_mut()) };
 }
 
 //==================================================================================================
 // Structures (Linux/KVM only)
 //==================================================================================================
+
+/// Clears the thread-local KVM immediate-exit pointer when the vCPU run loop exits.
+#[cfg(target_os = "linux")]
+struct KvmImmediateExitGuard;
+
+#[cfg(target_os = "linux")]
+impl KvmImmediateExitGuard {
+    /// Registers KVM's immediate-exit byte for the current vCPU thread.
+    ///
+    /// # Safety
+    ///
+    /// `immediate_exit` must remain valid and writable until the returned guard is dropped.
+    unsafe fn register(immediate_exit: *mut u8) -> Self {
+        // SAFETY: The caller guarantees that `immediate_exit` points into the live vCPU mapping.
+        unsafe { immediate_exit.write_volatile(0) };
+        KVM_IMMEDIATE_EXIT.with(|slot| slot.set(immediate_exit));
+        Self
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for KvmImmediateExitGuard {
+    fn drop(&mut self) {
+        KVM_IMMEDIATE_EXIT.with(|slot| slot.set(::core::ptr::null_mut()));
+    }
+}
 
 ///
 /// # Description
@@ -374,6 +401,15 @@ pub type StderrFn = dyn Write + Send;
 #[cfg(target_os = "linux")]
 extern "C" fn vcpu_thread_signal_handler(_: i32) {
     SHUTDOWN.with(|shutdown| shutdown.store(true, Ordering::SeqCst));
+    KVM_IMMEDIATE_EXIT.with(|slot| {
+        let immediate_exit: *mut u8 = slot.get();
+        if !immediate_exit.is_null() {
+            // SAFETY: The pointer is registered while the vCPU mapping is live and is cleared
+            // before that mapping can be dropped. The KVM API permits this write from a signal
+            // handler to make a subsequent KVM_RUN return with EINTR.
+            unsafe { immediate_exit.write_volatile(1) };
+        }
+    });
 }
 
 /// No-op signal handler for profiler timer. Only purpose is to interrupt
@@ -420,6 +456,11 @@ impl Vmm {
         let partition_create_start: Instant = Instant::now();
 
         let mut kvm: Kvm = Kvm::new()?;
+        if !kvm.check_extension(Cap::ImmediateExit) {
+            let reason: String = "KVM_CAP_IMMEDIATE_EXIT is required".to_string();
+            error!("new(): {reason}");
+            anyhow::bail!(reason);
+        }
         let mut vm: VmFd = kvm.create_vm()?;
 
         let irqchip: IrqChip = IrqChip::new(&mut kvm, &mut vm)?;
@@ -631,11 +672,7 @@ impl Vmm {
     }
 
     pub fn spawn(mut self) -> tokio::task::JoinHandle<Result<u16>> {
-        task::spawn_blocking(move || {
-            let pthread_id: libc::pthread_t = unsafe { libc::pthread_self() };
-            Handle::current().block_on(self.send_tid(pthread_id))?;
-            self.run()
-        })
+        task::spawn_blocking(move || self.run())
     }
 
     ///
@@ -785,6 +822,12 @@ impl Vmm {
         // Reset shutdown flag from any previous runs.
         SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
 
+        let immediate_exit: *mut u8 = self.vcpu.blocking_lock().immediate_exit_ptr();
+        // SAFETY: `immediate_exit` points into the vCPU mapping owned by `self`. The guard is
+        // dropped before `self` and clears the thread-local pointer on every return path.
+        let _immediate_exit_guard: KvmImmediateExitGuard =
+            unsafe { KvmImmediateExitGuard::register(immediate_exit) };
+
         let profiling: bool = self.guest_profiler.is_some();
 
         // Install signal handlers in the virtual processor's thread.
@@ -792,6 +835,11 @@ impl Vmm {
         if profiling {
             Self::install_profiler_signal_handler();
         }
+
+        // Publish the vCPU thread ID only after its shutdown handler and immediate-exit pointer
+        // are ready, so the orchestrator cannot race an early shutdown request with setup.
+        let pthread_id: libc::pthread_t = unsafe { libc::pthread_self() };
+        Handle::current().block_on(self.send_tid(pthread_id))?;
 
         // When GDB server is enabled, delegate to the GDB event loop instead of the normal loop.
         #[cfg(feature = "gdb")]
@@ -1161,8 +1209,8 @@ impl Vmm {
             },
             Err(error) => {
                 warn!("handle_shutdown(): failed to notify orchestrator thread (error={error:?})");
-                // Don't bail as we are shutting down anyway. The orchestrator will detect
-                // this via timeout and forcefully terminate the vCPU thread if needed.
+                // Don't bail as we are shutting down anyway. The orchestrator will retry the
+                // backend shutdown request if its wait times out.
             },
         }
     }
@@ -1389,8 +1437,14 @@ impl Vmm {
         Ok(())
     }
 
-    /// No-op on the KVM/microvm backend. Shutdown is handled via `pthread_kill`.
-    pub fn request_shutdown(&self) {}
+    /// Requests shutdown of the KVM vCPU thread.
+    pub fn request_shutdown(&self, vcpu_tid: u64) {
+        let pthread_id: libc::pthread_t = vcpu_tid as libc::pthread_t;
+        let result: c_int = unsafe { libc::pthread_kill(pthread_id, INTERRUPT_SIGNAL) };
+        if result != 0 {
+            warn!("request_shutdown(): failed to signal vCPU thread (error={result})");
+        }
+    }
 
     //==============================================================================================
     // Diagnostic Dump Helpers
@@ -1638,5 +1692,35 @@ impl Vmm {
 
             current_rbp = saved_rbp;
         }
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shutdown_signal_sets_kvm_immediate_exit() {
+        let mut immediate_exit: u8 = 7;
+        let immediate_exit_ptr: *mut u8 = ::core::ptr::addr_of_mut!(immediate_exit);
+        // SAFETY: `immediate_exit` remains live until after the guard is dropped.
+        let guard: KvmImmediateExitGuard =
+            unsafe { KvmImmediateExitGuard::register(immediate_exit_ptr) };
+
+        assert_eq!(immediate_exit, 0);
+        SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
+
+        vcpu_thread_signal_handler(INTERRUPT_SIGNAL);
+
+        assert!(SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)));
+        assert_eq!(immediate_exit, 1);
+
+        drop(guard);
+        assert!(KVM_IMMEDIATE_EXIT.with(|slot| slot.get().is_null()));
+        SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
     }
 }

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -109,12 +109,6 @@ pub use vmem::VirtualMemory;
 // Constants
 //==================================================================================================
 
-/// Signal used to interrupt the vCPU thread (unused on Windows, but required by orchestrator).
-pub const INTERRUPT_SIGNAL: i32 = 0;
-
-/// Signal used to kill the vCPU thread (unused on Windows, but required by orchestrator).
-pub const KILL_SIGNAL: i32 = 0;
-
 /// IDT vector for IRQ 9 (IKC): PIC2 base (0x28) + (IRQ 9 - 8) = 0x29.
 const IKC_VECTOR: u32 = 0x29;
 
@@ -359,6 +353,8 @@ pub struct Vmm {
     /// Shared shutdown flag. When set to `true` from any thread, the VMM
     /// run loop will break on the next iteration.
     shutdown_flag: Arc<AtomicBool>,
+    /// Indicates that the vCPU is about to enter or is blocked in `WHvRunVirtualProcessor`.
+    run_pending: Arc<AtomicBool>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorWhpHandle>>,
     /// Pvclock time base in nanoseconds. When restoring from a snapshot, this is set to
@@ -397,6 +393,35 @@ struct InteriorWhpHandle {
     /// When true, the guest is entitled to take exactly one snapshot.
     /// Set from the `snapshot` kernel option; consumed on the first successful request.
     snapshot_allowed: bool,
+}
+
+/// Clears the WHP run-pending flag whenever a vCPU entry attempt finishes or unwinds.
+struct RunPendingGuard<'a> {
+    run_pending: &'a AtomicBool,
+}
+
+impl<'a> RunPendingGuard<'a> {
+    fn new(run_pending: &'a AtomicBool) -> Self {
+        run_pending.store(true, Ordering::SeqCst);
+        Self { run_pending }
+    }
+}
+
+impl Drop for RunPendingGuard<'_> {
+    fn drop(&mut self) {
+        self.run_pending.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Repeatedly requests cancellation until the pending or active WHP run finishes.
+fn cancel_while_run_pending<F>(run_pending: &AtomicBool, mut cancel: F)
+where
+    F: FnMut(),
+{
+    while run_pending.load(Ordering::SeqCst) {
+        cancel();
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
 }
 
 //==================================================================================================
@@ -682,6 +707,7 @@ impl Vmm {
             partition_handle,
             timer,
             shutdown_flag,
+            run_pending: Arc::new(AtomicBool::new(false)),
             inner: Arc::new(Mutex::new(InteriorWhpHandle {
                 _partition: partition,
                 emulator,
@@ -701,9 +727,6 @@ impl Vmm {
 
     pub fn spawn(mut self) -> tokio::task::JoinHandle<Result<u16>> {
         task::spawn_blocking(move || {
-            let thread_id: u64 =
-                unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as u64 };
-            Handle::current().block_on(self.send_tid(thread_id))?;
             warn!("VMM spawn_blocking: calling run()");
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.run()));
             warn!("VMM spawn_blocking: run() returned (is_ok={})", result.is_ok());
@@ -733,6 +756,12 @@ impl Vmm {
 
         // Reset shutdown flag from any previous runs.
         self.shutdown_flag.store(false, Ordering::SeqCst);
+
+        // Publish the vCPU thread ID only after the shutdown flag is initialized. Otherwise an
+        // early request from the orchestrator could be overwritten by the reset above.
+        let thread_id: u64 =
+            unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as u64 };
+        Handle::current().block_on(self.send_tid(thread_id))?;
 
         let loop_start: Instant = Instant::now();
 
@@ -877,10 +906,25 @@ impl Vmm {
                     );
                     break Ok(locked_vcpu.exit_status());
                 }
+
+                // Publish intent before the final shutdown check. If shutdown races with this
+                // boundary, either this check observes it or the shutdown callback observes
+                // `run_pending` and keeps canceling until the WHP call returns.
+                let run_pending_guard: RunPendingGuard<'_> =
+                    RunPendingGuard::new(self.run_pending.as_ref());
+                if self.shutdown_flag.load(Ordering::SeqCst) {
+                    drop(run_pending_guard);
+                    drop(locked_vcpu);
+                    let exit_status: u16 = 0;
+                    warn!("VMM exit: SHUTDOWN flag before vCPU entry");
+                    Handle::current().block_on(self.handle_shutdown(exit_status));
+                    break Ok(exit_status);
+                }
                 #[cfg(feature = "profile-time")]
                 let run_start: Instant = Instant::now();
 
                 let ctx: VirtualProcessorExitContext = locked_vcpu.run();
+                drop(run_pending_guard);
 
                 #[cfg(feature = "profile-time")]
                 {
@@ -1419,18 +1463,36 @@ impl Vmm {
     /// `WHvRunVirtualProcessor` call so the VMM loop can observe the flag
     /// on its next iteration.
     ///
-    pub fn request_shutdown(&self) {
+    pub fn request_shutdown(&self, _vcpu_tid: u64) {
         self.shutdown_flag.store(true, Ordering::SeqCst);
-        // SAFETY: `partition_handle` is a valid WHP partition handle that outlives this call.
-        unsafe {
-            let hr = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
-                self.partition_handle,
-                0,
-                0,
-            );
-            if hr.is_err() {
-                warn!("WHvCancelRunVirtualProcessor(0) failed during request_shutdown(): {hr:?}");
-            }
+
+        if self.run_pending.load(Ordering::SeqCst) {
+            let inner: Arc<Mutex<InteriorWhpHandle>> = self.inner.clone();
+            let partition_handle = self.partition_handle;
+            let run_pending: Arc<AtomicBool> = self.run_pending.clone();
+            let vcpu: Arc<Mutex<VirtualProcessor>> = self.vcpu.clone();
+            let _cancel_worker: std::thread::JoinHandle<()> = std::thread::spawn(move || {
+                let mut error_logged: bool = false;
+                cancel_while_run_pending(run_pending.as_ref(), || {
+                    // SAFETY: `inner` and `vcpu` keep the WHP partition and virtual processor
+                    // alive until this worker exits.
+                    unsafe {
+                        if let Err(error) =
+                            windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                                partition_handle,
+                                0,
+                                0,
+                            )
+                            && !error_logged
+                        {
+                            warn!("request_shutdown(): failed to cancel vCPU (error={error:?})");
+                            error_logged = true;
+                        }
+                    }
+                });
+                drop(vcpu);
+                drop(inner);
+            });
         }
     }
 
@@ -1635,5 +1697,39 @@ impl Vmm {
         // Even version signals "stable snapshot".
         *pvclock_version += 1;
         let _ = vmem.write_bytes(gpa, &pvclock_version.to_le_bytes());
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_pending_guard_tracks_vcpu_entry() {
+        let run_pending: AtomicBool = AtomicBool::new(false);
+        {
+            let _guard: RunPendingGuard<'_> = RunPendingGuard::new(&run_pending);
+            assert!(run_pending.load(Ordering::SeqCst));
+        }
+        assert!(!run_pending.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn cancellation_retries_until_run_finishes() {
+        let run_pending: AtomicBool = AtomicBool::new(true);
+        let mut attempts: usize = 0;
+
+        cancel_while_run_pending(&run_pending, || {
+            attempts += 1;
+            if attempts == 2 {
+                run_pending.store(false, Ordering::SeqCst);
+            }
+        });
+
+        assert_eq!(attempts, 2);
     }
 }

--- a/src/utils/nanvix-bench/src/benchmarks/system/mod.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/system/mod.rs
@@ -300,7 +300,12 @@ impl Benchmark {
             .await?;
 
         if response.exit_code != 0 {
-            error!("error killing user VM (id={user_vm_id}, exit-code={})", response.exit_code);
+            let reason: String = format!(
+                "error killing user VM (id={user_vm_id}, exit-code={})",
+                response.exit_code
+            );
+            error!("{reason}");
+            anyhow::bail!(reason);
         }
 
         Ok(())


### PR DESCRIPTION
## What & why

The vCPU shutdown fallback used `pthread_kill(tid, SIGKILL)`. `SIGKILL`
is process-directed and cannot target a single thread, so it tore down
the entire UserVM process — and, in single-process mode, the hosting
sandbox/`nanvixd` with it. This reworks shutdown to be thread-scoped and
cooperative so it can never take down the host process.

## Changes

**UserVM (KVM)**
- `request_shutdown()` signals the vCPU thread with `SIGUSR1`; the handler
  now also writes KVM's `immediate_exit` byte so a `KVM_RUN` racing the
  signal returns immediately instead of blocking.
- Require `KVM_CAP_IMMEDIATE_EXIT` at partition creation.
- Publish the vCPU tid only after the signal handler and immediate-exit
  pointer are installed, closing a race where an early shutdown request
  could hit `SIGUSR1`'s default (process-terminating) disposition.
- Remove `KILL_SIGNAL`/`SIGKILL`.

**UserVM (WHP)**
- Track run-pending state and retry `WHvCancelRunVirtualProcessor` from a
  worker until the run returns; re-check the shutdown flag right before
  entering the vCPU.

**Orchestrator**
- `ShutdownVcpuFn` now takes the vCPU tid; on shutdown timeout it retries
  the backend request instead of forcibly killing the thread.
- Ignore a closed I/O control channel during shutdown to avoid a busy
  loop. Adds tests for the timeout and closed-channel paths.

**Sandbox**
- Split `CLEANUP_TIMEOUT` into `STANDALONE_CLEANUP_TIMEOUT` (1s) and
  `SINGLE_PROCESS_CLEANUP_TIMEOUT` (16s) so teardown does not detach while
  the vCPU shutdown watchdog and bounded worker joins are still active.

**Benchmark**
- Fail instead of only logging when killing a user VM returns a non-zero
  exit code.

## Validation
- `./z build -- run-unit-tests` and `./z build -- test-uservm` pass
  (80 uservm tests, including new shutdown tests).
- `./z build -- run-nanvix-tests DEPLOYMENT_MODE=single-process` passes
  (47 tests); logs confirm uservm instances are killed while `nanvixd`
  keeps running and exits gracefully.

## Issues 

Closes #2911