### PR TITLE
[build] Update Rust Toolchain

### DIFF
--- a/build/targets/x86-kernel.json
+++ b/build/targets/x86-kernel.json
@@ -7,7 +7,7 @@
 	"target-c-int-width": 32,
 	"max-atomic-width": 32,
 	"features": "-mmx,-avx,-avx2,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,+soft-float",
-	"rustc-abi": "x86-softfloat",
+	"rustc-abi": "softfloat",
 	"os": "nanvix",
 	"target-family": [
 		"unix"

--- a/build/targets/x86_64-kernel.json
+++ b/build/targets/x86_64-kernel.json
@@ -7,7 +7,7 @@
 	"target-c-int-width": 32,
 	"max-atomic-width": 64,
 	"features": "-mmx,-avx,-avx2,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,+soft-float",
-	"rustc-abi": "x86-softfloat",
+	"rustc-abi": "softfloat",
 	"os": "nanvix",
 	"target-family": [
 		"unix"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-05-21"
+channel = "nightly-2026-07-09"
 components = [
     "rust-src",
     "llvm-tools",

--- a/src/libs/libc_string/src/lib.rs
+++ b/src/libs/libc_string/src/lib.rs
@@ -22,6 +22,8 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
+// Nanvix uses a fixed-width C ABI where c_size_t and usize are both 32-bit.
+#![allow(suspicious_runtime_symbol_definitions)]
 // The following lints are allowed in tests to facilitate testing of error conditions.
 #![cfg_attr(not(test), forbid(clippy::expect_used))]
 

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -109,7 +109,7 @@ impl DlHandle {
 
     /// Allocates a fresh handle that is unique for the lifetime of the process.
     fn allocate() -> Result<Self, Error> {
-        match NEXT_HANDLE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+        match NEXT_HANDLE.try_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
             if next <= LAST_GENERATED_HANDLE {
                 Some(next + 1)
             } else {

--- a/src/tests/stress/test-rust-memory/src/main.rs
+++ b/src/tests/stress/test-rust-memory/src/main.rs
@@ -11,6 +11,8 @@
 #![deny(clippy::as_conversions)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
+// Nanvix uses a fixed-width C ABI where c_size_t and usize are both 32-bit.
+#![allow(suspicious_runtime_symbol_definitions)]
 
 //==================================================================================================
 // Modules


### PR DESCRIPTION
## What & why

Bump Rust from `nightly-2026-05-21` to `nightly-2026-07-09` and adapt Nanvix to compiler changes introduced by the newer nightly.

The bump exposed three build blockers:

- rustc renamed the custom-target ABI value `x86-softfloat` to `softfloat`;
- `AtomicU32::fetch_update()` was deprecated in favor of `try_update()`;
- the new `suspicious_runtime_symbol_definitions` lint expects Rust's nominal `usize` for known libc symbols, while Nanvix intentionally uses its fixed-width `c_size_t` C ABI.

## Changes

- Pin `nightly-2026-07-09`.
- Update the x86 and x86_64 kernel target specifications to use `rustc-abi = "softfloat"`.
- Replace `fetch_update()` with the behaviorally equivalent `try_update()` in dynamic-library handle allocation.
- Allow `suspicious_runtime_symbol_definitions` in `libc_string` and the memory stress test. Their runtime-symbol signatures remain ABI-compatible because the Nanvix guest target is 32-bit and both `c_size_t` and `usize` are 32-bit.

## Validation

- `./z build -- all`
- `./z build -- all DEPLOYMENT_MODE=single-process`
- `./z build -- format-check`
- `./z build -- lint-check`
- `./z build -- lint-check DEPLOYMENT_MODE=single-process`
- pre-commit checks for standalone and single-process configurations

The single-process lint emits existing future-incompatibility warnings from `tokio::select!` expanding `allow(clippy::modulo_one)` under `#![forbid(clippy::all)]` in `nanvix-test`; the lint gate still passes and this PR does not change that code.
