### PR TITLE
[libc_stdlib] Implement __cxa_atexit

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -14,6 +14,7 @@
 # single line, minimizing merge conflicts between branches that each add a suite.
 ALL_POSIX_TESTS := \
 	test-c-bindings \
+	test-c-cxa-atexit \
 	test-c-ctor \
 	test-c-dlfcn \
 	test-c-dlfcn-ctor-dtor-reentry \

--- a/src/libs/libc_stdlib/src/atexit.rs
+++ b/src/libs/libc_stdlib/src/atexit.rs
@@ -5,25 +5,135 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::c_int;
+use ::spin::Mutex;
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
 
 //==================================================================================================
 // Constants
 //==================================================================================================
 
-/// Maximum number of atexit handlers that can be registered.
+/// Maximum number of process-exit handlers that can be registered.
 const MAX_ATEXIT_HANDLERS: usize = 32;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Registered process-exit handler.
+#[derive(Clone, Copy)]
+enum AtExitHandler {
+    /// Handler registered through `atexit()`.
+    Plain(unsafe extern "C" fn()),
+    /// Handler registered through `__cxa_atexit()`.
+    Cxa {
+        func: unsafe extern "C" fn(*mut c_void),
+        arg: *mut c_void,
+        dso_handle: *mut c_void,
+    },
+}
+
+// SAFETY: C++ ABI arguments and DSO handles are opaque pointer values. The registry only stores
+// them and passes each argument back to its handler; it never dereferences either pointer.
+unsafe impl Send for AtExitHandler {}
+
+impl AtExitHandler {
+    /// Invokes this handler.
+    unsafe fn call(self) {
+        match self {
+            Self::Plain(func) => unsafe { func() },
+            Self::Cxa {
+                func,
+                arg,
+                dso_handle: _,
+            } => unsafe { func(arg) },
+        }
+    }
+}
+
+/// Registry of process-exit handlers in registration order.
+struct AtExitRegistry {
+    handlers: [Option<AtExitHandler>; MAX_ATEXIT_HANDLERS],
+    count: usize,
+}
+
+impl AtExitRegistry {
+    /// Creates an empty process-exit handler registry.
+    const fn new() -> Self {
+        Self {
+            handlers: [None; MAX_ATEXIT_HANDLERS],
+            count: 0,
+        }
+    }
+
+    /// Appends `handler` to the registry.
+    fn push(&mut self, handler: AtExitHandler) -> bool {
+        if self.count >= MAX_ATEXIT_HANDLERS {
+            return false;
+        }
+
+        self.handlers[self.count] = Some(handler);
+        self.count += 1;
+        true
+    }
+
+    /// Removes and returns the most recently registered handler.
+    fn pop(&mut self) -> Option<AtExitHandler> {
+        if self.count == 0 {
+            return None;
+        }
+
+        self.count -= 1;
+        self.handlers[self.count].take()
+    }
+
+    /// Removes and returns the most recently registered C++ ABI handler for `dso_handle`.
+    fn pop_cxa(&mut self, dso_handle: *mut c_void) -> Option<AtExitHandler> {
+        let mut index: usize = self.count;
+
+        while index > 0 {
+            index -= 1;
+
+            let matches: bool = match self.handlers[index] {
+                Some(AtExitHandler::Cxa {
+                    dso_handle: registered_dso,
+                    ..
+                }) => dso_handle.is_null() || registered_dso == dso_handle,
+                _ => false,
+            };
+
+            if matches {
+                return self.remove(index);
+            }
+        }
+
+        None
+    }
+
+    /// Removes and returns the handler at `index`, preserving registration order.
+    fn remove(&mut self, index: usize) -> Option<AtExitHandler> {
+        let handler: Option<AtExitHandler> = self.handlers[index];
+        let mut current: usize = index;
+
+        while current + 1 < self.count {
+            self.handlers[current] = self.handlers[current + 1];
+            current += 1;
+        }
+
+        self.count -= 1;
+        self.handlers[self.count] = None;
+        handler
+    }
+}
 
 //==================================================================================================
 // Global State
 //==================================================================================================
 
-/// Table of registered atexit handler functions.
-static mut ATEXIT_HANDLERS: [Option<unsafe extern "C" fn()>; MAX_ATEXIT_HANDLERS] =
-    [None; MAX_ATEXIT_HANDLERS];
-
-/// Number of currently registered atexit handlers.
-static mut ATEXIT_COUNT: usize = 0;
+/// Registry of process-exit handlers.
+static ATEXIT_REGISTRY: Mutex<AtExitRegistry> = Mutex::new(AtExitRegistry::new());
 
 //==================================================================================================
 // Standalone Functions
@@ -44,7 +154,7 @@ static mut ATEXIT_COUNT: usize = 0;
 ///
 /// # Safety
 ///
-/// This function is unsafe because it accesses global mutable state.
+/// The caller must ensure that `func` remains valid until it is called at process exit.
 ///
 /// # References
 ///
@@ -52,68 +162,264 @@ static mut ATEXIT_COUNT: usize = 0;
 ///
 #[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
 pub unsafe extern "C" fn atexit(func: Option<unsafe extern "C" fn()>) -> c_int {
-    let func = match func {
-        Some(f) => f,
+    let func: unsafe extern "C" fn() = match func {
+        Some(func) => func,
         None => return -1,
     };
 
-    if ATEXIT_COUNT >= MAX_ATEXIT_HANDLERS {
-        return -1;
+    if ATEXIT_REGISTRY.lock().push(AtExitHandler::Plain(func)) {
+        0
+    } else {
+        -1
     }
-
-    ATEXIT_HANDLERS[ATEXIT_COUNT] = Some(func);
-    ATEXIT_COUNT += 1;
-    0
 }
 
-/// Invokes all registered atexit handlers in reverse order of registration.
-pub(crate) unsafe fn call_atexit_handlers() {
-    while ATEXIT_COUNT > 0 {
-        ATEXIT_COUNT -= 1;
-        if let Some(f) = ATEXIT_HANDLERS[ATEXIT_COUNT] {
-            f();
-            ATEXIT_HANDLERS[ATEXIT_COUNT] = None;
+///
+/// # Description
+///
+/// Registers a C++ ABI destructor to run at process exit or when its shared object is finalized.
+///
+/// # Parameters
+///
+/// - `func`: Destructor function to register.
+/// - `arg`: Opaque argument passed to `func` when it is invoked.
+/// - `dso_handle`: Shared-object handle associated with this registration.
+///
+/// # Returns
+///
+/// `0` on success, or `-1` if the handler table is full or `func` is `None`.
+///
+/// # Safety
+///
+/// The caller must ensure that `func`, `arg`, and `dso_handle` remain valid until the handler is
+/// finalized.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __cxa_atexit(
+    func: Option<unsafe extern "C" fn(*mut c_void)>,
+    arg: *mut c_void,
+    dso_handle: *mut c_void,
+) -> c_int {
+    let func: unsafe extern "C" fn(*mut c_void) = match func {
+        Some(func) => func,
+        None => return -1,
+    };
+
+    let handler: AtExitHandler = AtExitHandler::Cxa {
+        func,
+        arg,
+        dso_handle,
+    };
+
+    if ATEXIT_REGISTRY.lock().push(handler) {
+        0
+    } else {
+        -1
+    }
+}
+
+///
+/// # Description
+///
+/// Invokes registered C++ ABI destructors in reverse registration order. A null `dso_handle`
+/// selects every C++ ABI destructor; otherwise, only destructors registered with the matching
+/// handle are selected. Each registration is removed before its destructor is called.
+///
+/// # Parameters
+///
+/// - `dso_handle`: Shared-object handle to finalize, or null to finalize all shared objects.
+///
+/// # Safety
+///
+/// The registered destructors must still be valid and uphold their individual safety contracts.
+///
+#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
+pub unsafe extern "C" fn __cxa_finalize(dso_handle: *mut c_void) {
+    loop {
+        let handler: Option<AtExitHandler> = ATEXIT_REGISTRY.lock().pop_cxa(dso_handle);
+
+        match handler {
+            Some(handler) => unsafe { handler.call() },
+            None => break,
         }
     }
 }
 
-/// Resets the atexit handler table. Used for test isolation.
-#[cfg(test)]
-pub(crate) unsafe fn reset_atexit_handlers() {
-    ATEXIT_COUNT = 0;
-    // Use indexed assignment (a place expression) rather than `&mut ATEXIT_HANDLERS` to avoid
-    // creating a reference to a mutable static. A `while` loop sidesteps `needless_range_loop`,
-    // which would otherwise suggest the disallowed iterator form.
-    let mut i = 0;
-    while i < MAX_ATEXIT_HANDLERS {
-        ATEXIT_HANDLERS[i] = None;
-        i += 1;
+///
+/// # Description
+///
+/// Invokes all registered process-exit handlers in reverse registration order. Each registration
+/// is removed before its handler is called.
+///
+/// # Safety
+///
+/// The registered handlers must still be valid and uphold their individual safety contracts.
+///
+pub unsafe fn call_atexit_handlers() {
+    loop {
+        let handler: Option<AtExitHandler> = ATEXIT_REGISTRY.lock().pop();
+
+        match handler {
+            Some(handler) => unsafe { handler.call() },
+            None => break,
+        }
     }
+}
+
+/// Resets the process-exit handler registry. Used for test isolation.
+#[cfg(test)]
+fn reset_atexit_handlers() {
+    *ATEXIT_REGISTRY.lock() = AtExitRegistry::new();
 }
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::{
+        __cxa_atexit,
+        __cxa_finalize,
         atexit,
+        call_atexit_handlers,
         reset_atexit_handlers,
+        MAX_ATEXIT_HANDLERS,
     };
+    use ::core::sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    };
+    use ::std::sync::{
+        Mutex,
+        MutexGuard,
+    };
+    use ::sysapi::ffi::c_void;
 
-    unsafe extern "C" fn dummy_handler() {}
+    static CALL_ORDER: AtomicUsize = AtomicUsize::new(0);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    unsafe extern "C" fn plain_handler() {
+        record_call(9);
+    }
+
+    unsafe extern "C" fn cxa_handler(arg: *mut c_void) {
+        let value: usize = unsafe { *arg.cast::<usize>() };
+        record_call(value);
+    }
+
+    fn record_call(value: usize) {
+        let previous: usize = CALL_ORDER.load(Ordering::SeqCst);
+        CALL_ORDER.store(previous * 10 + value, Ordering::SeqCst);
+    }
+
+    fn lock_tests() -> MutexGuard<'static, ()> {
+        match TEST_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(error) => error.into_inner(),
+        }
+    }
 
     #[test]
     fn register_handler() {
-        unsafe { reset_atexit_handlers() };
-        assert_eq!(unsafe { atexit(Some(dummy_handler)) }, 0);
-        unsafe { reset_atexit_handlers() };
+        let _guard: MutexGuard<'static, ()> = lock_tests();
+        reset_atexit_handlers();
+        assert_eq!(unsafe { atexit(Some(plain_handler)) }, 0);
+        reset_atexit_handlers();
     }
 
     #[test]
     fn register_too_many() {
-        unsafe { reset_atexit_handlers() };
-        for _ in 0..32 {
-            assert_eq!(unsafe { atexit(Some(dummy_handler)) }, 0);
+        let _guard: MutexGuard<'static, ()> = lock_tests();
+        reset_atexit_handlers();
+        for _ in 0..MAX_ATEXIT_HANDLERS {
+            assert_eq!(unsafe { atexit(Some(plain_handler)) }, 0);
         }
-        assert_eq!(unsafe { atexit(Some(dummy_handler)) }, -1);
-        unsafe { reset_atexit_handlers() };
+        assert_eq!(unsafe { atexit(Some(plain_handler)) }, -1);
+        reset_atexit_handlers();
+    }
+
+    #[test]
+    fn finalize_cxa_handlers_by_dso() {
+        static DSO_A: u8 = 0;
+        static DSO_B: u8 = 0;
+        static FIRST: usize = 1;
+        static SECOND: usize = 2;
+        static THIRD: usize = 3;
+
+        let _guard: MutexGuard<'static, ()> = lock_tests();
+        let first_dso: *mut c_void = (&raw const DSO_A).cast_mut().cast();
+        let second_dso: *mut c_void = (&raw const DSO_B).cast_mut().cast();
+
+        reset_atexit_handlers();
+        CALL_ORDER.store(0, Ordering::SeqCst);
+
+        assert_eq!(unsafe { atexit(Some(plain_handler)) }, 0);
+        assert_eq!(
+            unsafe {
+                __cxa_atexit(Some(cxa_handler), (&raw const FIRST).cast_mut().cast(), first_dso)
+            },
+            0
+        );
+        assert_eq!(
+            unsafe {
+                __cxa_atexit(Some(cxa_handler), (&raw const SECOND).cast_mut().cast(), second_dso)
+            },
+            0
+        );
+        assert_eq!(
+            unsafe {
+                __cxa_atexit(Some(cxa_handler), (&raw const THIRD).cast_mut().cast(), first_dso)
+            },
+            0
+        );
+
+        unsafe { __cxa_finalize(first_dso) };
+        assert_eq!(CALL_ORDER.load(Ordering::SeqCst), 31);
+
+        unsafe { __cxa_finalize(first_dso) };
+        assert_eq!(CALL_ORDER.load(Ordering::SeqCst), 31);
+
+        unsafe { call_atexit_handlers() };
+        assert_eq!(CALL_ORDER.load(Ordering::SeqCst), 3129);
+        reset_atexit_handlers();
+    }
+
+    #[test]
+    fn finalize_all_cxa_handlers() {
+        static DSO_A: u8 = 0;
+        static DSO_B: u8 = 0;
+        static FIRST: usize = 1;
+        static SECOND: usize = 2;
+
+        let _guard: MutexGuard<'static, ()> = lock_tests();
+
+        reset_atexit_handlers();
+        CALL_ORDER.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            unsafe {
+                __cxa_atexit(
+                    Some(cxa_handler),
+                    (&raw const FIRST).cast_mut().cast(),
+                    (&raw const DSO_A).cast_mut().cast(),
+                )
+            },
+            0
+        );
+        assert_eq!(unsafe { atexit(Some(plain_handler)) }, 0);
+        assert_eq!(
+            unsafe {
+                __cxa_atexit(
+                    Some(cxa_handler),
+                    (&raw const SECOND).cast_mut().cast(),
+                    (&raw const DSO_B).cast_mut().cast(),
+                )
+            },
+            0
+        );
+
+        unsafe { __cxa_finalize(::core::ptr::null_mut()) };
+        assert_eq!(CALL_ORDER.load(Ordering::SeqCst), 21);
+
+        unsafe { call_atexit_handlers() };
+        assert_eq!(CALL_ORDER.load(Ordering::SeqCst), 219);
+        reset_atexit_handlers();
     }
 }

--- a/src/libs/libc_stdlib/src/lib.rs
+++ b/src/libs/libc_stdlib/src/lib.rs
@@ -138,7 +138,12 @@ use ::sysapi::{
 pub use abort::abort;
 pub use abs_fn::abs;
 pub use aligned_alloc::aligned_alloc;
-pub use atexit::atexit;
+pub use atexit::{
+    __cxa_atexit,
+    __cxa_finalize,
+    atexit,
+    call_atexit_handlers,
+};
 pub use atof::atof;
 pub use atoi::atoi;
 pub use atol::atol;

--- a/src/libs/nanvix_libc/src/lib.rs
+++ b/src/libs/nanvix_libc/src/lib.rs
@@ -360,25 +360,6 @@ pub unsafe extern "C" fn __nanvix_sigsuspend(_mask: *const libc_signal::signal::
     -1
 }
 
-//==================================================================================================
-// Stub symbols required by libstdc++ but not yet implemented
-//==================================================================================================
-
-/// C++ ABI: register a function to be called at exit or when a shared library is unloaded.
-///
-/// # Safety
-///
-/// This is a C++ runtime ABI function.
-#[cfg_attr(not(feature = "std"), unsafe(no_mangle))]
-pub unsafe extern "C" fn __cxa_atexit(
-    _func: Option<unsafe extern "C" fn(*mut c_void)>,
-    _arg: *mut c_void,
-    _dso_handle: *mut c_void,
-) -> c_int {
-    // Stub — atexit handlers are not supported in this environment.
-    0
-}
-
 /// Wrapper to make a raw pointer `Sync` for use as a static.
 #[allow(dead_code)]
 #[repr(transparent)]

--- a/src/libs/nanvix_libc/src/start.rs
+++ b/src/libs/nanvix_libc/src/start.rs
@@ -243,6 +243,14 @@ pub unsafe extern "C" fn __nanvix_libc_start_main(argp: *mut c_char, envp: *mut 
     // based on which crt0 feature is active.
     let status: i32 = unsafe { __nanvix_main(argc, argv_ptr) };
 
+    // Returning from main() is equivalent to calling exit(), so run every registered process-exit
+    // handler before global destructors and runtime teardown. C applications use the `staticlib`
+    // feature, which pulls in the libc_stdlib registry; lean Rust no_std binaries do not.
+    #[cfg(feature = "staticlib")]
+    unsafe {
+        ::libc_stdlib::call_atexit_handlers();
+    }
+
     // Run global destructors after `main` returns, in REVERSE registration
     // order, before the heap is torn down (a destructor may still allocate or
     // free).  Mirrors the constructor walk above and is gated on the same

--- a/src/tests/integration/test-c-cxa-atexit/main.c
+++ b/src/tests/integration/test-c-cxa-atexit/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef void (*cxa_destructor_t)(void *);
+
+extern int __cxa_atexit(cxa_destructor_t func, void *arg, void *dso_handle);
+extern void __cxa_finalize(void *dso_handle);
+
+static char dso_a;
+static char dso_b;
+static char dso_c;
+static int first = 1;
+static int second = 2;
+static int third = 3;
+static int fifth = 5;
+static int call_order;
+
+static void record_cxa(void *arg)
+{
+    call_order = call_order * 10 + *(int *)arg;
+}
+
+static void record_plain(void)
+{
+    call_order = call_order * 10 + 4;
+}
+
+static void verify_exit(void)
+{
+    _exit(call_order == 31542 ? 0 : 1);
+}
+
+int main(void)
+{
+    if (atexit(verify_exit) != 0)
+        return 2;
+    if (__cxa_atexit(record_cxa, &first, &dso_a) != 0)
+        return 3;
+    if (__cxa_atexit(record_cxa, &second, &dso_b) != 0)
+        return 4;
+    if (__cxa_atexit(record_cxa, &third, &dso_a) != 0)
+        return 5;
+
+    __cxa_finalize(&dso_a);
+    if (call_order != 31)
+        return 6;
+
+    /* Finalizing the same DSO twice must not invoke its handlers again. */
+    __cxa_finalize(&dso_a);
+    if (call_order != 31)
+        return 7;
+
+    if (atexit(record_plain) != 0)
+        return 8;
+    if (__cxa_atexit(record_cxa, &fifth, &dso_c) != 0)
+        return 9;
+
+    /*
+     * Returning exercises normal process-exit dispatch. The remaining handlers
+     * must run in reverse registration order: cxa(5), plain(4), cxa(2), then
+     * verify_exit(), which turns this sentinel into a successful exit status.
+     */
+    return 42;
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -47,6 +47,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-cxa-atexit"
+program = "./bin/test-c-cxa-atexit.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-ctor"
 program = "./bin/test-c-ctor.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -47,6 +47,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-cxa-atexit"
+program = "./bin/test-c-cxa-atexit.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-ctor"
 program = "./bin/test-c-ctor.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## What & why

`__cxa_atexit` was a no-op stub, so C++ static destructors and
compiler-rt runtimes that schedule work at process exit (e.g. the
profile/coverage `.profraw` flush) never ran. This implements a real
exit-handler registry so those handlers execute at process exit with
their `arg`.

## Changes

**Libraries**
- Add a bounded registry backing both `atexit()` and `__cxa_atexit()`,
  recording `(func, arg, dso_handle)` for C++ ABI registrations.
- Add `__cxa_finalize(dso_handle)`: a null handle finalizes every C++ ABI
  destructor; a non-null handle only those matching that DSO.
- Add `call_atexit_handlers()` to drain all handlers in reverse
  registration order at process exit; each handler is removed before it
  is called, so dispatch is idempotent and safe against handlers that
  re-register or call `exit()`.
- Remove the old `__cxa_atexit` no-op stub from `nanvix_libc` and
  re-export the new symbols from `libc_stdlib`.

**Startup**
- Dispatch registered handlers when `main()` returns, gated on the
  `staticlib` feature that pulls in the `libc_stdlib` registry.

**Tests**
- In-crate unit tests: registration, table exhaustion, per-DSO and full
  finalize, and reverse-order dispatch.
- New `test-c-cxa-atexit` C integration suite wired into the Linux and
  Windows POSIX manifests; it uses a sentinel exit status that only
  succeeds if every handler runs in the correct order.

## Validation
- \`./z build -- test-guest-rlib-libc_stdlib\` (166 passed).
- Clippy \`-D warnings\` + rustfmt check on \`libc_stdlib\` and \`nanvix_libc\`.
- \`test-c-cxa-atexit\` integration suite: guest \`VM exited (exit_status=0)\`.


## Issues

Closes #2873