### PR TITLE
[syscall] Stage dlopen() Loads Until Resolved

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -36,6 +36,7 @@ ALL_POSIX_TESTS := \
 	test-c-dlfcn-scope \
 	test-c-dlfcn-searchpath \
 	test-c-dlfcn-selflink \
+	test-c-dlfcn-staging \
 	test-c-dlfcn-startup \
 	test-c-dlfcn-weak \
 	test-c-echo \

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -133,6 +133,7 @@ POSIX_TEST_PIE_test-c-dlfcn-global := yes
 POSIX_TEST_PIE_test-c-dlfcn-handle-reuse := yes
 POSIX_TEST_PIE_test-c-dlfcn-needed := yes
 POSIX_TEST_PIE_test-c-dlfcn-diamond := yes
+POSIX_TEST_PIE_test-c-dlfcn-staging := yes
 # dlfcn-order-c dlopen()s libroot.so, whose two providers both export
 # provider_id(); the executable's own symbols land in .dynsym for RTLD_DEFAULT,
 # matching every other dlfcn dlopen suite.
@@ -344,6 +345,7 @@ clean-posix-tests:
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-searchpath)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-selflink)
+	$(RM_CMD) $(POSIX_TEST_STAGING_IMG)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-startup)
 	$(RM_CMD) $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-initfini)
 	$(RM_CMD) $(POSIX_TEST_WEAK_IMG)
@@ -362,6 +364,7 @@ clean-posix-tests:
 	$(FORCE_RM_CMD) $(POSIX_TEST_INIT_CONCURRENT_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SCOPE_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SELFLINK_SEED)
+	$(FORCE_RM_CMD) $(POSIX_TEST_STAGING_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_HELLO_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_SEARCHPATH_SEED)
 	$(FORCE_RM_CMD) $(POSIX_TEST_STARTUP_SEED)
@@ -548,6 +551,71 @@ $(POSIX_TEST_RAMFS_IMG_test-c-dlfcn-scope): $(POSIX_TEST_SCOPE_DIR)/libdep.so \
 	$(CP_CMD) $(POSIX_TEST_SCOPE_DIR)/libfoo.so $(POSIX_TEST_SCOPE_SEED)/lib/
 	$(CP_CMD) $(POSIX_TEST_SCOPE_DIR)/libother.so $(POSIX_TEST_SCOPE_SEED)/lib/
 	$(MKRAMFS) -o $@ $(POSIX_TEST_SCOPE_SEED)
+
+#---------------------------------------------------------------------------------------------------
+# dlfcn-staging-c: failed-load staging fixtures.
+#---------------------------------------------------------------------------------------------------
+#
+#   libfailed-root.so -> libstaged.so
+#                     -> libbad.so -> missing_value (strong undefined symbol)
+#
+# The failed root reaches relocation only after all three libraries have been
+# opened. The loader must discard that staged graph when libbad.so cannot be
+# resolved. A later direct load of libstaged.so must therefore open a fresh copy
+# and run its constructor. libgood-root.so then verifies that a newly staged root
+# can bind against the now-resident libstaged.so from the stable registry.
+POSIX_TEST_STAGING_DIR := $(POSIX_TESTS_OBJDIR)/test-c-dlfcn-staging/libs
+POSIX_TEST_STAGING_SEED := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-staging-seed
+POSIX_TEST_STAGING_IMG := $(BINARIES_DIR)/posix-tests-ramfs-test-c-dlfcn-staging.img
+
+$(POSIX_TEST_STAGING_DIR)/libstaged.so: \
+		$(POSIX_TESTS_SRCDIR)/test-c-dlfcn-staging/libs/staged.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-staging-c/libstaged.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libstaged.so $@.o -o $@
+
+$(POSIX_TEST_STAGING_DIR)/libbad.so: \
+		$(POSIX_TESTS_SRCDIR)/test-c-dlfcn-staging/libs/bad.c
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-staging-c/libbad.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libbad.so $@.o -o $@
+
+$(POSIX_TEST_STAGING_DIR)/libfailed-root.so: \
+		$(POSIX_TESTS_SRCDIR)/test-c-dlfcn-staging/libs/failed_root.c \
+		$(POSIX_TEST_STAGING_DIR)/libstaged.so \
+		$(POSIX_TEST_STAGING_DIR)/libbad.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-staging-c/libfailed-root.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libfailed-root.so $@.o \
+		--no-as-needed $(POSIX_TEST_STAGING_DIR)/libstaged.so \
+		$(POSIX_TEST_STAGING_DIR)/libbad.so -o $@
+
+$(POSIX_TEST_STAGING_DIR)/libgood-root.so: \
+		$(POSIX_TESTS_SRCDIR)/test-c-dlfcn-staging/libs/good_root.c \
+		$(POSIX_TEST_STAGING_DIR)/libstaged.so
+	@$(MKDIR_CMD) $(dir $@)
+	@echo "[posix-test] building dlfcn-staging-c/libgood-root.so"
+	$(GUEST_C_APP_CC) $(POSIX_TEST_SOLIB_CFLAGS) -c $< -o $@.o
+	$(GUEST_C_APP_LD) $(POSIX_TEST_SOLIB_LDFLAGS) -soname libgood-root.so $@.o \
+		--no-as-needed $(POSIX_TEST_STAGING_DIR)/libstaged.so -o $@
+
+POSIX_TEST_STAGING_LIBS := \
+	libstaged.so \
+	libbad.so \
+	libfailed-root.so \
+	libgood-root.so
+
+$(POSIX_TEST_STAGING_IMG): \
+		$(foreach lib,$(POSIX_TEST_STAGING_LIBS),$(POSIX_TEST_STAGING_DIR)/$(lib)) \
+		all-host-binaries-mkramfs
+	$(FORCE_RM_CMD) $(POSIX_TEST_STAGING_SEED)
+	@$(MKDIR_CMD) $(POSIX_TEST_STAGING_SEED)/lib
+	$(CP_CMD) $(foreach lib,$(POSIX_TEST_STAGING_LIBS),$(POSIX_TEST_STAGING_DIR)/$(lib)) \
+		$(POSIX_TEST_STAGING_SEED)/lib/
+	$(MKRAMFS) -o $@ $(POSIX_TEST_STAGING_SEED)
 
 #---------------------------------------------------------------------------------------------------
 # dlfcn-diamond-c: four-library diamond DT_NEEDED fixture.
@@ -1397,6 +1465,7 @@ all-posix-test-images: $(POSIX_TEST_INITRDS) \
 		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
 		$(POSIX_TEST_SOLIB_IMGS) \
 		$(POSIX_TEST_RUNPATH_IMG) \
+		$(POSIX_TEST_STAGING_IMG) \
 		$(POSIX_TEST_WEAK_IMG) \
 		$(POSIX_TEST_EXECVP_IMG)
 	@echo "All POSIX C test-suite images built."
@@ -1430,7 +1499,10 @@ ifneq ($(TARGET),x86)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (guest C toolchain is i686-only; TARGET=$(TARGET) unsupported)."
 else ifeq ($(DEPLOYMENT_MODE),standalone)
-run-posix-tests: $(POSIX_HEADERS_CXX_STAMP) $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG) $(POSIX_TEST_WEAK_IMG) $(POSIX_TEST_EXECVP_IMG)
+run-posix-tests: $(POSIX_HEADERS_CXX_STAMP) $(POSIX_TEST_INITRDS) \
+		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
+		$(POSIX_TEST_SOLIB_IMGS) $(POSIX_TEST_RUNPATH_IMG) $(POSIX_TEST_STAGING_IMG) \
+		$(POSIX_TEST_WEAK_IMG) $(POSIX_TEST_EXECVP_IMG)
 	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -101,54 +101,55 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
         return Ok(dlhandle);
     }
 
-    // Snapshot the registry keys before we start inserting, so we can roll back
-    // all new entries on failure. This ensures a failed dlopen never leaves
-    // stale handles with unpatched relocations in the registry.
-    let handles_before: BTreeSet<DlHandle> = registry.keys().copied().collect();
+    // Keep newly opened libraries out of the global registry until the complete
+    // dependency graph has been loaded and resolved successfully.
+    let mut staging: BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>> = BTreeMap::new();
 
     // Open and pre-load the dynamic library file.
     let new_dlfile: DynamicLibrary = DynamicLibrary::open(filename)?;
     let handle: DlHandle = new_dlfile.handle();
     let new_dlfile: Arc<Mutex<DynamicLibrary>> = Arc::new(Mutex::new(new_dlfile));
 
-    // Insert the opened file into the map.
-    registry.insert(handle, new_dlfile.clone());
+    // Stage the opened file while its dependency graph is assembled.
+    staging.insert(handle, new_dlfile.clone());
 
-    // Load dependencies and resolve symbols. If either step fails, remove all
-    // entries that were added during this call (the library itself and any
-    // transitive dependencies) so subsequent dlopen calls start fresh.
+    // Load dependencies and resolve symbols. If either step fails, dropping the
+    // staging map cleans up every library opened during this call without
+    // scanning or mutating the global registry.
     let init_order: Vec<Arc<Mutex<DynamicLibrary>>> =
-        match load_all_dependencies(&mut registry, new_dlfile)
-            .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
+        match load_all_dependencies(&registry, &mut staging, new_dlfile)
+            .and_then(|_| resolve_all_symbols(&staging))
         {
-            Ok(order) => {
-                // If RTLD_GLOBAL was requested, publish the library's exported
-                // symbols into the global symbol table so subsequently loaded
-                // libraries can resolve them.
-                if global {
-                    if let Some(dlfile) = registry.get(&handle) {
-                        super::register_library_in_global_scope(dlfile);
-                    }
-                }
-                order
-            },
-            Err(e) => {
-                let new_handles: Vec<DlHandle> = registry
-                    .keys()
-                    .filter(|h| !handles_before.contains(h))
-                    .copied()
-                    .collect();
+            Ok(order) => order,
+            Err(error) => {
                 ::syslog::warn!(
-                    "dlopen(): rolling back {} entries after failure (error={:?})",
-                    new_handles.len(),
-                    e
+                    "dlopen(): discarding {} staged entries after failure (error={:?})",
+                    staging.len(),
+                    error
                 );
-                for h in new_handles {
-                    registry.remove(&h);
-                }
-                return Err(e);
+                return Err(error);
             },
         };
+
+    // Resolve the constructor owner before publishing the staged graph. A
+    // lookup failure must leave the global registry unchanged.
+    let constructor_tid: i32 = current_tid()?;
+
+    // Promote the fully resolved graph to the global registry in one step while
+    // the registry lock is still held.
+    for (staged_handle, staged_dlfile) in staging {
+        if let Some(dlfile) = registry.insert(staged_handle, staged_dlfile) {
+            unreachable!("dlopen(): library file already loaded (dlfile={:?})", dlfile);
+        }
+    }
+
+    // If RTLD_GLOBAL was requested, publish the root library's exported symbols
+    // so subsequently loaded libraries can resolve them.
+    if global {
+        if let Some(dlfile) = registry.get(&handle) {
+            super::register_library_in_global_scope(dlfile);
+        }
+    }
 
     // Record this direct `dlopen()` on the freshly loaded root library. Only
     // the library named by the caller is counted; dependencies loaded
@@ -165,7 +166,6 @@ pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
     // one of the constructors). Publishing the thread id under the registry
     // lock guarantees no concurrent observer can see the pre-set sentinel as a
     // constructor owner.
-    let constructor_tid: i32 = current_tid()?;
     for dlfile in init_order.iter() {
         dlfile
             .lock()
@@ -224,17 +224,49 @@ fn current_tid() -> Result<i32, Error> {
 
 /// Recursively loads all transitive dependencies of a newly opened library.
 ///
-/// For each `DT_NEEDED` entry, checks if it is already loaded in the registry,
-/// and if not, opens and inserts it. Recurses into each dependency's own
-/// `DT_NEEDED` entries.
+/// For each `DT_NEEDED` entry, checks if it is already loaded in the registry or
+/// staging map and, if not, opens and stages it. Recurses into each dependency's
+/// own `DT_NEEDED` entries.
 fn load_all_dependencies(
-    dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
+    registry: &BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
+    staging: &mut BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
     new_dlfile: Arc<Mutex<DynamicLibrary>>,
 ) -> Result<(), Error> {
     ::syslog::trace!("load_all_dependencies(): new_dlfile={:?}", new_dlfile.lock().name());
 
+    fn find_loaded_dependency(
+        registry: &BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
+        staging: &BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
+        new_dlhandle: &DlHandle,
+        ancestors: &BTreeMap<DlHandle, String>,
+        dependency: &str,
+        resolved_dependency: &str,
+    ) -> Option<(DlHandle, Arc<Mutex<DynamicLibrary>>)> {
+        for dlfiles in [registry, staging] {
+            for (dlhandle, dlfile) in dlfiles.iter() {
+                // Skip the dynamic library itself and any ancestor held by an
+                // outer frame's lock.
+                if dlhandle == new_dlhandle || ancestors.contains_key(dlhandle) {
+                    continue;
+                }
+
+                let is_match: bool = {
+                    let loaded_file: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+                    let loaded_name: &str = loaded_file.name();
+                    loaded_name == dependency || loaded_name == resolved_dependency
+                };
+                if is_match {
+                    return Some((*dlhandle, dlfile.clone()));
+                }
+            }
+        }
+
+        None
+    }
+
     fn load_all_dependencies_recursive(
-        dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
+        registry: &BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
+        staging: &mut BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
         new_dlhandle: &DlHandle,
         new_dlfile: &mut MutexGuard<'_, DynamicLibrary>,
         ancestors: &mut BTreeMap<DlHandle, String>,
@@ -295,35 +327,27 @@ fn load_all_dependencies(
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
             let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
-            for (dlhandle, dlfile) in dlfiles.iter() {
-                // Skip the dynamic library itself and any ancestor held by
-                // an outer frame's lock — locking them would deadlock.
-                if dlhandle == new_dlhandle || ancestors.contains_key(dlhandle) {
-                    continue;
+            if let Some((dlhandle, dlfile)) = find_loaded_dependency(
+                registry,
+                staging,
+                new_dlhandle,
+                ancestors,
+                dependency,
+                &resolved_dep,
+            ) {
+                ::syslog::debug!(
+                    "load_all_dependencies_recursive(): already loaded dependency '{}' \
+                     (handle={:?})",
+                    dependency,
+                    dlhandle
+                );
+                // Update the dependency to the already loaded file.
+                if let Err(_error) = new_dlfile.bind_dependency(dependency.clone(), dlfile) {
+                    // TODO: comment
+                    unreachable!("cannot fail to bind dependency");
                 }
 
-                let is_match: bool = {
-                    let loaded_file: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
-                    let loaded_name: &str = loaded_file.name();
-                    loaded_name == dependency.as_str() || loaded_name == resolved_dep
-                };
-                if is_match {
-                    ::syslog::debug!(
-                        "load_all_dependencies_recursive(): already loaded dependency '{}' \
-                         (handle={:?})",
-                        dependency,
-                        dlhandle
-                    );
-                    // Update the dependency to the already loaded file.
-                    if let Err(_error) =
-                        new_dlfile.bind_dependency(dependency.clone(), dlfile.clone())
-                    {
-                        // TODO: comment
-                        unreachable!("cannot fail to bind dependency");
-                    }
-
-                    return false;
-                }
+                return false;
             }
             true
         });
@@ -344,7 +368,7 @@ fn load_all_dependencies(
             // handle (as `retain` and the re-check do) would just open a fresh
             // copy on a new handle and recurse forever. Cycles in `DT_NEEDED`
             // are pathological — no sane toolchain emits them — so reject the
-            // load cleanly; `dlopen` then rolls back every entry added during
+            // load cleanly; `dlopen` then discards every entry staged during
             // this call.
             if self_name == dependency
                 || self_name == resolved_dep
@@ -361,12 +385,12 @@ fn load_all_dependencies(
                 return Err(Error::new(ErrorCode::BadFile, reason));
             }
 
-            // Re-check the registry before opening: an EARLIER iteration of
-            // THIS frame's own load loop may have already loaded this exact
-            // dependency transitively. `retain` above runs only once, at frame
-            // entry, before any sibling is processed, so it cannot see a
-            // sibling that a later-processed sibling pulls in. Concretely, when
-            // a parent directly `DT_NEEDED`s both `libX` and `libbase` and
+            // Re-check the registry and staging map before opening: an EARLIER
+            // iteration of THIS frame's own load loop may have already loaded
+            // this exact dependency transitively. `retain` above runs only once,
+            // at frame entry, before any sibling is processed, so it cannot see
+            // a sibling that a later-processed sibling pulls in. Concretely,
+            // when a parent directly `DT_NEEDED`s both `libX` and `libbase` and
             // `libX -> libbase`:
             //
             //   libdiamond.so -> libright.so -> libbase.so   (processed first)
@@ -380,19 +404,15 @@ fn load_all_dependencies(
             // second time — two distinct in-memory copies with two private
             // `unique_counter`s — or trip the `unreachable!()` below if the VFS
             // recycles the underlying file descriptor.
-            let already_loaded: Option<Arc<Mutex<DynamicLibrary>>> =
-                dlfiles.iter().find_map(|(dlhandle, dlfile)| {
-                    if dlhandle == new_dlhandle || ancestors.contains_key(dlhandle) {
-                        return None;
-                    }
-                    let loaded_file: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
-                    let loaded_name: &str = loaded_file.name();
-                    if loaded_name == dependency.as_str() || loaded_name == resolved_dep {
-                        Some(dlfile.clone())
-                    } else {
-                        None
-                    }
-                });
+            let already_loaded: Option<Arc<Mutex<DynamicLibrary>>> = find_loaded_dependency(
+                registry,
+                staging,
+                new_dlhandle,
+                ancestors,
+                &dependency,
+                &resolved_dep,
+            )
+            .map(|(_, dlfile)| dlfile);
             if let Some(existing) = already_loaded {
                 ::syslog::debug!(
                     "load_all_dependencies_recursive(): dependency '{}' loaded transitively \
@@ -408,8 +428,8 @@ fn load_all_dependencies(
             let handle: DlHandle = dep_dlfile.handle();
             let dep_dlfile: Arc<Mutex<DynamicLibrary>> = Arc::new(Mutex::new(dep_dlfile));
 
-            // Insert the opened file into the map.
-            if let Some(dlfile) = dlfiles.insert(handle, dep_dlfile.clone()) {
+            // Insert the opened file into the staging map.
+            if let Some(dlfile) = staging.insert(handle, dep_dlfile.clone()) {
                 unreachable!("dlopen(): library file already loaded (dlfile={:?})", dlfile);
             }
 
@@ -422,7 +442,8 @@ fn load_all_dependencies(
             // cycle back to us for a brand-new library.
             ancestors.insert(*new_dlhandle, self_name.clone());
             let mut dlfile: MutexGuard<'_, DynamicLibrary> = dep_dlfile.lock();
-            let result = load_all_dependencies_recursive(dlfiles, &handle, &mut dlfile, ancestors);
+            let result =
+                load_all_dependencies_recursive(registry, staging, &handle, &mut dlfile, ancestors);
             ancestors.remove(new_dlhandle);
             result?;
         }
@@ -433,30 +454,31 @@ fn load_all_dependencies(
     let mut new_dlfile = new_dlfile.lock();
     let new_dlhandle = new_dlfile.handle();
     let mut ancestors: BTreeMap<DlHandle, String> = BTreeMap::new();
-    load_all_dependencies_recursive(dlfiles, &new_dlhandle, &mut new_dlfile, &mut ancestors)?;
+    load_all_dependencies_recursive(
+        registry,
+        staging,
+        &new_dlhandle,
+        &mut new_dlfile,
+        &mut ancestors,
+    )?;
 
     Ok(())
 }
 
-/// Resolves all relocations for libraries added during this `dlopen` call and
-/// returns them in dependency order (leaves first, root last) so the caller
-/// can invoke `.init_array` constructors in the correct sequence.
+/// Resolves all relocations for staged libraries and returns them in dependency
+/// order (leaves first, root last) so the caller can invoke `.init_array`
+/// constructors in the correct sequence.
 ///
 /// Libraries are resolved in dependency order. This ensures that when a
 /// library's relocations reference symbols from its dependencies, those
 /// dependencies are already fully resolved.
 fn resolve_all_symbols(
-    dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
-    handles_before: &BTreeSet<DlHandle>,
+    staging: &BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>,
 ) -> Result<Vec<Arc<Mutex<DynamicLibrary>>>, Error> {
     ::syslog::trace!("resolve_all_symbols()");
 
-    // Collect all newly added libraries.
-    let new_handles: Vec<DlHandle> = dlfiles
-        .keys()
-        .filter(|h| !handles_before.contains(h))
-        .copied()
-        .collect();
+    // Collect all newly staged libraries.
+    let new_handles: Vec<DlHandle> = staging.keys().copied().collect();
 
     // Build a resolution order: resolve dependencies before their dependents.
     // A library can be resolved once all its bound dependencies (that are also
@@ -478,12 +500,12 @@ fn resolve_all_symbols(
 
             // Check if all of this library's dependencies that are new in
             // this dlopen call have been resolved.
-            let dlfile: &Arc<Mutex<DynamicLibrary>> = match dlfiles.get(&handle) {
+            let dlfile: &Arc<Mutex<DynamicLibrary>> = match staging.get(&handle) {
                 Some(f) => f,
                 None => {
-                    // Handle came from dlfiles.keys(), so this should not happen.
+                    // Handle came from staging.keys(), so this should not happen.
                     ::syslog::warn!(
-                        "resolve_all_symbols(): handle {:?} missing from registry",
+                        "resolve_all_symbols(): handle {:?} missing from staging map",
                         handle
                     );
                     continue;
@@ -493,8 +515,9 @@ fn resolve_all_symbols(
             let all_deps_resolved: bool = {
                 let lib: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
                 lib.dependency_handles().iter().all(|dep_handle| {
-                    // Dependencies that existed before this dlopen are already resolved.
-                    handles_before.contains(dep_handle) || resolved.contains(dep_handle)
+                    // Dependencies outside staging existed before this dlopen and
+                    // are already resolved.
+                    !staging.contains_key(dep_handle) || resolved.contains(dep_handle)
                 })
             };
 
@@ -528,7 +551,7 @@ fn resolve_all_symbols(
     // Resolve in dependency order (leaves first).
     let mut init_order: Vec<Arc<Mutex<DynamicLibrary>>> = Vec::with_capacity(ordered.len());
     for handle in ordered {
-        if let Some(dlfile) = dlfiles.get(&handle) {
+        if let Some(dlfile) = staging.get(&handle) {
             dlfile.lock().resolve_all()?;
             init_order.push(dlfile.clone());
         }

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -284,7 +284,7 @@ fn load_all_dependencies(
         let self_name: String = new_dlfile.name().to_string();
 
         // Collect the name of all dependencies, in DT_NEEDED order.
-        let mut dependencies: Vec<String> = new_dlfile
+        let dependencies: Vec<String> = new_dlfile
             .dependencies()
             .into_iter()
             .map(|(dlname, _)| dlname)
@@ -292,7 +292,7 @@ fn load_all_dependencies(
 
         // Bind to already loaded dependencies and remove them from the list.
         //
-        // The closure below calls `dlfile.lock()` on every other entry in the
+        // The scan below calls `dlfile.lock()` on every other entry in the
         // registry while looking for a matching name. Those locks must skip
         // BOTH the current library (`new_dlhandle`) AND every ancestor still
         // held by an outer recursive frame — otherwise any non-trivial
@@ -301,11 +301,11 @@ fn load_all_dependencies(
         //
         //   dlopen(libdiamond.so)                  // holds libdiamond lock
         //     -> recurse into libright.so          // also holds libright lock
-        //          -> retain() iterates dlfiles    // tries to lock libdiamond
-        //             ^ blocks forever, libdiamond is still held by the
-        //               outer frame.
+        //          -> pre-load scan probes registry // tries to lock libdiamond
+        //             ^ blocks forever, libdiamond is still held by the outer
+        //               frame.
         //
-        // What this `retain` legitimately consolidates is a dependency that a
+        // What this scan legitimately consolidates is a dependency that a
         // PRIOR, already-finished iteration of an OUTER frame loaded. In the
         // classic diamond
         //
@@ -313,7 +313,7 @@ fn load_all_dependencies(
         //                 -> libright.so -> libbase.so
         //
         // libdiamond finishes libleft first (recursing in and loading
-        // libbase), then starts libright's frame; libright's `retain` then
+        // libbase), then starts libright's frame; libright's pre-load scan then
         // sees libbase already resident and binds libright's `libbase` edge to
         // that single shared instance here. (The other shape — a sibling
         // pulled in LATER within the *same* frame's own dependency list — is
@@ -323,16 +323,17 @@ fn load_all_dependencies(
         // legitimately resolve to an ancestor is a `DT_NEEDED` cycle, which is
         // detected and rejected explicitly in the load loop below (see the
         // `self_name`/`ancestors` cycle check), so it never reaches this scan.
-        dependencies.retain(|dependency| {
+        let mut unloaded_dependencies: Vec<String> = Vec::new();
+        for dependency in dependencies {
             // Resolve bare name so we can match against loaded libraries
             // that were opened with a full path.
-            let resolved_dep: String = super::resolve_library_path(dependency, Some(&runpaths));
+            let resolved_dep: String = super::resolve_library_path(&dependency, Some(&runpaths));
             if let Some((dlhandle, dlfile)) = find_loaded_dependency(
                 registry,
                 staging,
                 new_dlhandle,
                 ancestors,
-                dependency,
+                &dependency,
                 &resolved_dep,
             ) {
                 ::syslog::debug!(
@@ -342,19 +343,16 @@ fn load_all_dependencies(
                     dlhandle
                 );
                 // Update the dependency to the already loaded file.
-                if let Err(_error) = new_dlfile.bind_dependency(dependency.clone(), dlfile) {
-                    // TODO: comment
-                    unreachable!("cannot fail to bind dependency");
-                }
-
-                return false;
+                new_dlfile.bind_dependency(dependency, dlfile)?;
+            } else {
+                unloaded_dependencies.push(dependency);
             }
-            true
-        });
+        }
 
         // Load remaining dependencies in DT_NEEDED order. The loop below uses
         // `pop()` for ownership, so reverse once to consume the original front
         // of the list first.
+        let mut dependencies: Vec<String> = unloaded_dependencies;
         dependencies.reverse();
         while let Some(dependency) = dependencies.pop() {
             // Resolve bare library names to full paths using search directories.
@@ -365,8 +363,8 @@ fn load_all_dependencies(
             // ancestor still being loaded by an outer recursive frame cannot be
             // followed: the ancestor's mutex is held, so we can neither recurse
             // into it nor lock it to consolidate onto it, and skipping it by
-            // handle (as `retain` and the re-check do) would just open a fresh
-            // copy on a new handle and recurse forever. Cycles in `DT_NEEDED`
+            // handle (as the pre-load scan and the re-check do) would just open
+            // a fresh copy on a new handle and recurse forever. Cycles in `DT_NEEDED`
             // are pathological — no sane toolchain emits them — so reject the
             // load cleanly; `dlopen` then discards every entry staged during
             // this call.
@@ -387,9 +385,10 @@ fn load_all_dependencies(
 
             // Re-check the registry and staging map before opening: an EARLIER
             // iteration of THIS frame's own load loop may have already loaded
-            // this exact dependency transitively. `retain` above runs only once,
-            // at frame entry, before any sibling is processed, so it cannot see
-            // a sibling that a later-processed sibling pulls in. Concretely,
+            // this exact dependency transitively. The pre-load scan above runs
+            // only once, at frame entry, before any sibling is processed, so it
+            // cannot see a sibling that a later-processed sibling pulls in.
+            // Concretely,
             // when a parent directly `DT_NEEDED`s both `libX` and `libbase` and
             // `libX -> libbase`:
             //

--- a/src/tests/integration/test-c-dlfcn-cycle/main.c
+++ b/src/tests/integration/test-c-dlfcn-cycle/main.c
@@ -18,7 +18,7 @@
  * guest stack overflows. That failure mode is silent (an OOM / fault, not a
  * clean error), so this suite pins the fixed behavior: dlopen() of a cyclic
  * graph returns NULL cleanly, with dlerror() set, and every entry the failed
- * call added is rolled back so the loader stays usable afterwards.
+ * call staged is discarded so the loader stays usable afterwards.
  *
  * A correct loader:
  *   * loads the dependency-free control library libok.so (proves the RAMFS
@@ -26,8 +26,8 @@
  *   * refuses dlopen("lib/libcyclea.so") and dlopen("lib/libcycleb.so") with
  *     a NULL handle + non-NULL dlerror() (the two-node cycle), then
  *   * still refuses a repeat dlopen of the cyclic library deterministically
- *     and still loads libok.so afterwards (rollback left the registry
- *     clean), then
+ *     and still loads libok.so afterwards (discarding staging left the
+ *     registry clean), then
  *   * refuses dlopen("lib/libselfcycle.so") the same way (the self-loop).
  *
  * A broken (pre-fix) loader instead recurses without bound on the cyclic
@@ -63,7 +63,7 @@ static void fail(const char *name, const char *reason)
  * Loads the dependency-free control library and confirms one of its symbols
  * returns the expected sentinel. Returns 1 on success, 0 on failure. Used
  * both as the opening sanity check and to prove the loader still works after
- * the cyclic loads have been rejected and rolled back.
+ * the cyclic loads have been rejected and their staged entries discarded.
  */
 static int load_control(const char *name)
 {
@@ -139,19 +139,19 @@ static void test_two_node_cycle(void)
 }
 
 /*
- * Test 2: rejecting a cycle must roll back every entry the failed dlopen()
- * added, so a repeat attempt fails identically (not, say, by finding a
+ * Test 2: rejecting a cycle must discard every entry the failed dlopen()
+ * staged, so a repeat attempt fails identically (not, say, by finding a
  * half-loaded stale copy) and an unrelated well-formed library still loads.
  */
-static void test_cycle_rollback(void)
+static void test_cycle_cleanup(void)
 {
-    if (!expect_cycle_rejected("lib/libcyclea.so", "re-dlopen(libcyclea.so) [rollback]")) {
+    if (!expect_cycle_rejected("lib/libcyclea.so", "re-dlopen(libcyclea.so) [cleanup]")) {
         return;
     }
-    if (!load_control("dlopen(libok.so) after rejected cycle [rollback]")) {
+    if (!load_control("dlopen(libok.so) after rejected cycle [cleanup]")) {
         return;
     }
-    pass("cycle rejection rolled back cleanly (loader still usable)");
+    pass("cycle rejection cleaned up cleanly (loader still usable)");
 }
 
 /*
@@ -176,7 +176,7 @@ int main(int argc, const char *argv[])
 
     test_positive_control();
     test_two_node_cycle();
-    test_cycle_rollback();
+    test_cycle_cleanup();
     test_self_cycle();
 
     printf("\n%d passed, %d failed\n", tests_passed, tests_failed);

--- a/src/tests/integration/test-c-dlfcn-staging/libs/bad.c
+++ b/src/tests/integration/test-c-dlfcn-staging/libs/bad.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+extern int missing_value(void);
+
+int bad_value(void)
+{
+    return (missing_value());
+}

--- a/src/tests/integration/test-c-dlfcn-staging/libs/failed_root.c
+++ b/src/tests/integration/test-c-dlfcn-staging/libs/failed_root.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+extern int bad_value(void);
+extern int staged_value(void);
+
+int failed_root_value(void)
+{
+    return (staged_value() + bad_value());
+}

--- a/src/tests/integration/test-c-dlfcn-staging/libs/good_root.c
+++ b/src/tests/integration/test-c-dlfcn-staging/libs/good_root.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+extern int staged_value(void);
+
+int good_root_value(void)
+{
+    return (staged_value() + 1);
+}

--- a/src/tests/integration/test-c-dlfcn-staging/libs/staged.c
+++ b/src/tests/integration/test-c-dlfcn-staging/libs/staged.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+enum {
+    STAGED_CONSTRUCTOR_VALUE = 0x5a61,
+};
+
+static int constructor_value = 0;
+
+static void __attribute__((constructor)) staged_constructor(void)
+{
+    constructor_value = STAGED_CONSTRUCTOR_VALUE;
+}
+
+int staged_value(void)
+{
+    return (constructor_value);
+}

--- a/src/tests/integration/test-c-dlfcn-staging/main.c
+++ b/src/tests/integration/test-c-dlfcn-staging/main.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+enum {
+    STAGED_CONSTRUCTOR_VALUE = 0x5a61,
+    GOOD_ROOT_VALUE = STAGED_CONSTRUCTOR_VALUE + 1,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+static void clear_dlerror(void)
+{
+    (void)dlerror();
+}
+
+static void *open_library(const char *path)
+{
+    clear_dlerror();
+
+    void *handle = dlopen(path, RTLD_NOW);
+    assert(handle != NULL);
+    assert(dlerror() == NULL);
+
+    return (handle);
+}
+
+static int (*resolve_value(void *handle, const char *name))(void)
+{
+    clear_dlerror();
+
+    int (*value)(void) = NULL;
+    *(void **)(&value) = dlsym(handle, name);
+    assert(value != NULL);
+    assert(dlerror() == NULL);
+
+    return (value);
+}
+
+static void test_failed_load_discards_staging(void)
+{
+    clear_dlerror();
+
+    void *handle = dlopen("lib/libfailed-root.so", RTLD_NOW);
+    assert(handle == NULL);
+    assert(dlerror() != NULL);
+
+    handle = open_library("lib/libstaged.so");
+    int (*staged_value)(void) = resolve_value(handle, "staged_value");
+    assert(staged_value() == STAGED_CONSTRUCTOR_VALUE);
+
+    void *root = open_library("lib/libgood-root.so");
+    int (*good_root_value)(void) = resolve_value(root, "good_root_value");
+    assert(good_root_value() == GOOD_ROOT_VALUE);
+
+    assert(dlclose(root) == 0);
+    assert(dlclose(handle) == 0);
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_failed_load_discards_staging();
+
+    const char *magic = "ok";
+    write(STDOUT_FILENO, magic, 2);
+
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -221,6 +221,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-staging"
+program = "./bin/test-c-dlfcn-staging.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-staging.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-startup"
 program = "./bin/test-c-dlfcn-startup.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-startup.img"

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -221,6 +221,14 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-dlfcn-staging"
+program = "./bin/test-c-dlfcn-staging.initrd"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-staging.img"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-dlfcn-startup"
 program = "./bin/test-c-dlfcn-startup.initrd"
 extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs-test-c-dlfcn-startup.img"


### PR DESCRIPTION
## Summary

Optimize `dlopen()` failure handling by assembling a newly opened library's
dependency graph in a local staging map and promoting it to the global registry
only after every dependency has loaded and every relocation has resolved.

Previously the loader inserted each library into the registry immediately and,
on failure, snapshotted the pre-call handles and removed every entry added
during the call. The staging approach drops the per-call snapshot on the common
success path and relies on RAII to clean up a failed load — dropping the staging
map unmaps segments and closes descriptors without scanning or mutating the
registry.

## Loader (`src/libs/syscall/.../dlopen.rs`)

- Introduce a staging `BTreeMap` for in-progress libraries; the registry only
  ever holds fully resolved graphs.
- Thread the read-only registry and mutable staging map through
  `load_all_dependencies()`; factor the loaded-library lookup into
  `find_loaded_dependency()`, which searches both maps.
- Resolve relocations over the staging map in `resolve_all_symbols()`.
- Resolve the constructor thread id before promotion so a `gettid()` failure
  leaves the registry unchanged.

## Tests, build, and harness wiring

- New `test-c-dlfcn-staging` suite: a failed `dlopen()` must discard its staged
  graph, a fresh reopen runs the library's constructor, and a later root binds
  to the now-resident copy.
- Realign the cycle suite's wording from "rollback" to "staging discard".
- Build the staging fixtures/ramfs image and register the suite in
  `test-posix.toml` and `test-posix-windows.toml`.

## Validation

- `run-posix-tests`: `test-c-dlfcn-staging` and `test-c-dlfcn-cycle` pass.
- `run-unit-tests`, `run-nanvix-tests`, `format-check`, `lint-check`: pass.

closes #2141