### PR TITLE
[ci] Skip CI on Manual Release Commits

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Skip the merge commit verification (for manual dispatch releases)"
     required: false
     default: "false"
+  skip-ci:
+    description: "Add [skip ci] to the release commit message"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -57,5 +61,8 @@ runs:
         EXTRA_ARGS=""
         if [ "${{ inputs.skip-merge-check }}" = "true" ]; then
           EXTRA_ARGS="--skip-merge-check"
+        fi
+        if [ "${{ inputs.skip-ci }}" = "true" ]; then
+          EXTRA_ARGS="${EXTRA_ARGS} --skip-ci"
         fi
         python3 scripts/create-release.py --${{ inputs.bump-type }} --push ${EXTRA_ARGS}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1843,6 +1843,8 @@ jobs:
   # Manual release via workflow_dispatch.
   # Allows selecting patch/minor/major bump type from the GitHub Actions UI.
   # No `needs:` gate — the caller is responsible for ensuring dev is green.
+  # Mark the resulting commit with [skip ci] so this dispatch remains the only
+  # pipeline that writes benchmark baseline data for the manual release.
   create-release-manual:
     name: "Create Release (Manual)"
     # Only run on manual dispatch; exclude bot to prevent loops.
@@ -1863,3 +1865,4 @@ jobs:
         with:
           bump-type: ${{ github.event.inputs.release-type }}
           skip-merge-check: "true"
+          skip-ci: "true"

--- a/scripts/create-release.py
+++ b/scripts/create-release.py
@@ -221,7 +221,9 @@ def is_default_branch() -> bool:
     return current == default
 
 
-def git_commit(cargo_toml: str, cargo_lock: str, new_version: str) -> None:
+def git_commit(
+    cargo_toml: str, cargo_lock: str, new_version: str, skip_ci: bool
+) -> None:
     """Commit the version bump if there are changes."""
     toml_changed = _git("diff", "--quiet", cargo_toml).returncode != 0
     lock_changed = _git("diff", "--quiet", cargo_lock).returncode != 0
@@ -232,7 +234,10 @@ def git_commit(cargo_toml: str, cargo_lock: str, new_version: str) -> None:
         if result.returncode != 0:
             print_error("Failed to stage files for commit.")
             sys.exit(1)
-        result = _git("commit", "--no-verify", "-m", f"Nanvix {new_version}")
+        commit_message = f"Nanvix {new_version}"
+        if skip_ci:
+            commit_message += " [skip ci]"
+        result = _git("commit", "--no-verify", "-m", commit_message)
         if result.returncode != 0:
             print_error("Failed to commit version bump.")
             sys.exit(1)
@@ -300,6 +305,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip the merge commit requirement (for manual releases).",
     )
+    parser.add_argument(
+        "--skip-ci",
+        action="store_true",
+        help="Add [skip ci] to the release commit message.",
+    )
     return parser.parse_args()
 
 
@@ -332,7 +342,7 @@ def main() -> None:
 
     update_cargo_toml(cargo_toml, new_version)
     update_cargo_lock(repo_root)
-    git_commit(cargo_toml, cargo_lock, new_version)
+    git_commit(cargo_toml, cargo_lock, new_version, args.skip_ci)
 
     if args.push:
         git_push()


### PR DESCRIPTION
## Summary

Prevent manual `workflow_dispatch` releases from triggering a second,
concurrent CI pipeline that races benchmark-baseline persistence and
corrupts the `data/` CSVs with merge-conflict markers.

The `create-release-manual` job pushes a version-bump commit to `dev`,
which previously started its own push-triggered CI run. That run raced
the original dispatch run when both persisted benchmark baselines,
producing the recurring `[data] B: Fix Merge Conflicts` cleanups.
Tagging the manual release commit with `[skip ci]` keeps the dispatch
run as the sole pipeline. Automatic merge-driven releases are unaffected
and still trigger CI normally.

## Changes

- `scripts/create-release.py`: add a `--skip-ci` flag that appends
  `[skip ci]` to the `Nanvix X.Y.Z` commit message.
- `.github/actions/create-release`: add a `skip-ci` input that forwards
  `--skip-ci` to the release script.
- `.github/workflows/ci.yml`: enable `skip-ci` only for the
  `create-release-manual` job.