### PR TITLE
[ci] B: Fix Manual Release Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,8 @@ on:
     # Publish release artifacts for the latest version nightly at midnight UTC.
     - cron: "0 0 * * *"
 
+  # Dispatched by manual-release.yml after it pushes the version bump to dev.
   workflow_dispatch:
-    inputs:
-      release-type:
-        description: "Release bump type (only used for manual releases)"
-        required: false
-        default: "patch"
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
   pull_request:
     types:
@@ -1839,30 +1830,3 @@ jobs:
         uses: ./.github/actions/create-release
         with:
           bump-type: "patch"
-
-  # Manual release via workflow_dispatch.
-  # Allows selecting patch/minor/major bump type from the GitHub Actions UI.
-  # No `needs:` gate — the caller is responsible for ensuring dev is green.
-  # Mark the resulting commit with [skip ci] so this dispatch remains the only
-  # pipeline that writes benchmark baseline data for the manual release.
-  create-release-manual:
-    name: "Create Release (Manual)"
-    # Only run on manual dispatch; exclude bot to prevent loops.
-    if: >-
-      github.event_name == 'workflow_dispatch' && github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v7
-        with:
-          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
-          fetch-depth: 0
-
-      - name: "Create Release"
-        uses: ./.github/actions/create-release
-        with:
-          bump-type: ${{ github.event.inputs.release-type }}
-          skip-merge-check: "true"
-          skip-ci: "true"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,50 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Manual Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Release bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: manual-release
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  create-release:
+    name: "Create Release"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
+          fetch-depth: 0
+
+      - name: "Create Release"
+        uses: ./.github/actions/create-release
+        with:
+          bump-type: ${{ github.event.inputs.release-type }}
+          skip-merge-check: "true"
+          skip-ci: "true"
+
+      - name: "Dispatch Release Pipeline"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" --ref dev

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v7
         with:
+          ref: dev
           ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- move manual version bumping into a dedicated workflow
- keep the bump commit marked with `[skip ci]`
- dispatch the CI/CD workflow only after `dev` points to the bumped commit

## Problem

PR #2927 prevented the bump commit from triggering a competing CI run, but the original dispatch remained pinned to the pre-bump SHA. As a result, the bump was committed while the release pipeline still published the previous version.

## Validation

- pre-commit checks (`debug`, `microvm`)
- workflow YAML and handoff assertions
- VS Code workflow diagnostics
- `git diff --check`