### PR TITLE
[libc_pthread] pthread_attr_setdetachstate()

### DIFF
--- a/src/libs/libc_pthread/src/lib.rs
+++ b/src/libs/libc_pthread/src/lib.rs
@@ -36,7 +36,11 @@ use ::sysapi::{
         c_int,
         c_void,
     },
-    pthread::PTHREAD_MUTEX_INITIALIZER,
+    pthread::{
+        PTHREAD_CREATE_DETACHED,
+        PTHREAD_CREATE_JOINABLE,
+        PTHREAD_MUTEX_INITIALIZER,
+    },
     sched::sched_param,
     sys_types::{
         c_size_t,
@@ -809,9 +813,16 @@ pub unsafe extern "C" fn pthread_attr_setdetachstate(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // TODO: implement this function.
-    ::syslog::warn!("pthread_attr_setdetachstate(): not supported, failing");
-    ErrorCode::OperationNotSupported.get()
+    // Check if `detachstate` is not valid.
+    if detachstate != PTHREAD_CREATE_JOINABLE && detachstate != PTHREAD_CREATE_DETACHED {
+        ::syslog::warn!("pthread_attr_setdetachstate(): invalid detach state");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Store the detach state.
+    (*attr).detachstate = detachstate;
+
+    0
 }
 
 //==================================================================================================

--- a/src/libs/sysapi/src/pthread.rs
+++ b/src/libs/sysapi/src/pthread.rs
@@ -11,12 +11,15 @@
 // Imports
 //==================================================================================================
 
-use crate::sys_types::{
-    pthread_cond_t,
-    pthread_mutex_t,
-    pthread_once_t,
-    pthread_rwlock_t,
-    pthread_t,
+use crate::{
+    ffi::c_int,
+    sys_types::{
+        pthread_cond_t,
+        pthread_mutex_t,
+        pthread_once_t,
+        pthread_rwlock_t,
+        pthread_t,
+    },
 };
 
 //==================================================================================================
@@ -25,6 +28,12 @@ use crate::sys_types::{
 
 /// Used to identify the null thread.
 pub const PTHREAD_NULL: pthread_t = 0;
+
+/// Indicates that a thread is created joinable.
+pub const PTHREAD_CREATE_JOINABLE: c_int = 0;
+
+/// Indicates that a thread is created detached.
+pub const PTHREAD_CREATE_DETACHED: c_int = 1;
 
 /// Used to initialize a condition variable statically
 pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0xffffffff;

--- a/src/tests/integration/test-c-thread/attr_setdetachstate.c
+++ b/src/tests/integration/test-c-thread/attr_setdetachstate.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the detach state attribute can be set and retrieved.
+void test_pthread_attr_setdetachstate(void)
+{
+    fprintf(stderr, "testing pthread_attr_setdetachstate() ... ");
+
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    int detachstate = -1;
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_JOINABLE);
+
+    ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    assert(ret == 0);
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_DETACHED);
+
+    ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+    assert(ret == 0);
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_JOINABLE);
+
+    ret = pthread_attr_setdetachstate(&attr, -1);
+    assert(ret == EINVAL);
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_JOINABLE);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -42,6 +42,9 @@ extern void test_thread_local(void);
 // Tests if pthread attributes can be initialized and destroyed.
 extern void test_pthread_attr_init_destroy(void);
 
+// Tests if the detach state attribute can be set and retrieved.
+extern void test_pthread_attr_setdetachstate(void);
+
 // Tests if the mutex type attribute can be set and retrieved.
 extern void test_pthread_mutexattr_settype(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -118,6 +118,7 @@ int main(int argc, const char *argv[])
 
     test_pthread_self();
     test_pthread_attr_init_destroy();
+    test_pthread_attr_setdetachstate();
     test_pthread_attr_getstack();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();


### PR DESCRIPTION
## Summary

Implement `pthread_attr_setdetachstate()` in `libc_pthread`, replacing the
previous `ENOTSUP` stub with a working setter, and add focused POSIX
integration coverage.

The setter validates the requested detach state and stores it in the
attributes object, so callers can select joinable or detached threads.
Invalid states are rejected with `EINVAL` and leave the attribute
unchanged. The companion `pthread_attr_getdetachstate()` already reads
this field, so the two now round-trip.

## Changes

- **Libraries:**
  - Add `PTHREAD_CREATE_JOINABLE` and `PTHREAD_CREATE_DETACHED` constants
    to `sysapi::pthread` and import them in `libc_pthread`.
  - Validate `detachstate` and assign it to `pthread_attr_t.detachstate`,
    returning `0` on success and `EINVAL` for unsupported values.
- **Tests:**
  - Add `test-c-thread/attr_setdetachstate.c` exercising the default
    joinable state, detached/joinable round-trips through
    `pthread_attr_getdetachstate()`, and rejection of an invalid state
    without mutating the attribute.
  - Declare and invoke the new case from `common.h` and `main.c`.

## Validation

- `./z build -- format-check lint-check`
- Focused suite: `BUILD_MODE=debug RUST_LOG=info ./bin/nanvix-test.elf
  -test '*test-c-thread*' test/test-posix.toml` (passes).

Closes #477
