### PR TITLE
[libc_pthread] pthread_attr_setschedparam()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -105,6 +105,8 @@ extern int pthread_attr_init(pthread_attr_t *attr);
 extern int pthread_attr_destroy(pthread_attr_t *attr);
 extern int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate);
 extern int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
+extern int pthread_attr_getschedparam(const pthread_attr_t *attr, struct sched_param *param);
+extern int pthread_attr_setschedparam(pthread_attr_t *attr, const struct sched_param *param);
 extern int pthread_attr_getstack(const pthread_attr_t *attr, void **stackaddr, size_t *stacksize);
 extern int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr, size_t stacksize);
 extern int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);

--- a/src/libs/libc_pthread/src/lib.rs
+++ b/src/libs/libc_pthread/src/lib.rs
@@ -913,9 +913,10 @@ pub unsafe extern "C" fn pthread_attr_setschedparam(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // TODO: implement this function.
-    ::syslog::warn!("pthread_attr_setschedparam(): not supported, failing");
-    ErrorCode::OperationNotSupported.get()
+    // Store the scheduling parameters.
+    (*attr).schedparam = *param;
+
+    0
 }
 
 //==================================================================================================

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -101,6 +101,8 @@ functions = [
     "pthread_attr_destroy",
     "pthread_attr_getdetachstate",
     "pthread_attr_setdetachstate",
+    "pthread_attr_getschedparam",
+    "pthread_attr_setschedparam",
     "pthread_attr_getstack",
     "pthread_attr_setstack",
     "pthread_attr_getstacksize",

--- a/src/tests/integration/test-c-thread/attr_setschedparam.c
+++ b/src/tests/integration/test-c-thread/attr_setschedparam.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if scheduling parameters can be set and retrieved.
+void test_pthread_attr_setschedparam(void)
+{
+    fprintf(stderr, "testing pthread_attr_setschedparam() ... ");
+
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    struct sched_param param = {
+        .sched_priority = -1,
+    };
+    ret = pthread_attr_getschedparam(&attr, &param);
+    assert(ret == 0);
+    assert(param.sched_priority == 0);
+
+    param.sched_priority = 42;
+    ret = pthread_attr_setschedparam(&attr, &param);
+    assert(ret == 0);
+
+    param.sched_priority = -1;
+    ret = pthread_attr_getschedparam(&attr, &param);
+    assert(ret == 0);
+    assert(param.sched_priority == 42);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -45,6 +45,9 @@ extern void test_pthread_attr_init_destroy(void);
 // Tests if the detach state attribute can be set and retrieved.
 extern void test_pthread_attr_setdetachstate(void);
 
+// Tests if scheduling parameters can be set and retrieved.
+extern void test_pthread_attr_setschedparam(void);
+
 // Tests if the mutex type attribute can be set and retrieved.
 extern void test_pthread_mutexattr_settype(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -119,6 +119,7 @@ int main(int argc, const char *argv[])
     test_pthread_self();
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
+    test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();


### PR DESCRIPTION
## Summary

Implements `pthread_attr_setschedparam()` and adds integration coverage.

Previously the function was an `ENOTSUP` stub. It now stores the
caller-provided scheduling parameters in the thread attributes object
after validating the `attr` and `param` pointers (null pointers still
return `EINVAL`), so callers can configure a thread's scheduling
priority through `pthread_attr_t`.

## Changes

- **Libraries:** assign the validated `sched_param` to
  `pthread_attr_t.schedparam` in `libc_pthread`; expose
  `pthread_attr_getschedparam()` and `pthread_attr_setschedparam()` in
  the generated `pthread.h` via the sysapi header specification.
- **Tests:** add a `test-c-thread` integration case
  (`attr_setschedparam.c`) that confirms the default zero priority and
  round-trips a nonzero scheduling priority through
  `pthread_attr_getschedparam()`.

## Validation

- `./z build -- test` (unit, kernel, smoke, standalone, and all POSIX
  suites, including `test-c-thread`)
- `./z build -- format-check gen-headers-check`
- Guest `libc_pthread` compile and Clippy checks

Closes #479.