### PR TITLE
[libs] Support pthread_condattr_init()

### DIFF
--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -28,6 +28,7 @@ use crate::{
         sched_policy::SCHED_OTHER,
     },
     sys_socket::socklen_t,
+    time::clock_ids::CLOCK_REALTIME,
 };
 use ::config::memory_layout::{
     USER_STACK_TOP_RAW,
@@ -219,7 +220,7 @@ impl Default for pthread_condattr_t {
     fn default() -> Self {
         Self {
             is_initialized: 1,
-            clock: 0,
+            clock: CLOCK_REALTIME as clock_t,
         }
     }
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
@@ -29,11 +29,6 @@ use ::syslog::trace_libcall;
 ///
 /// On success, returns 0. Otherwise, returns an error code.
 ///
-/// # Notes
-///
-/// This is a dummy implementation. It only validates the input pointer and then returns success.
-/// A full implementation should set default values and mark the object as initialized.
-///
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
@@ -59,9 +54,7 @@ pub unsafe extern "C" fn pthread_condattr_init(attr: *mut pthread_condattr_t) ->
         return ErrorCode::InvalidArgument.get();
     }
 
-    // Dummy initialization: write default structure.
     ::core::ptr::write(attr, pthread_condattr_t::default());
-    ::syslog::warn!("pthread_condattr_init(): dummy implementation (attr={attr:p})");
 
     0
 }

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -21,6 +21,9 @@ extern void test_pthread_mutex_static_init(void);
 // Tests if dynamically initialized mutexes can be used for synchronization.
 extern void test_pthread_mutex_dynamic_init(void);
 
+// Tests if condition variable attributes can be initialized.
+extern void test_pthread_condattr_init(void);
+
 // Tests if calling exit() causes the program to exit even if there are other threads running.
 extern void test_pthread_nowait(void);
 

--- a/src/tests/integration/test-c-thread/condattr_init.c
+++ b/src/tests/integration/test-c-thread/condattr_init.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <time.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if condition variable attributes can be initialized.
+void test_pthread_condattr_init(void)
+{
+    fprintf(stderr, "testing pthread_condattr_init() ... ");
+
+    pthread_condattr_t attr = {
+        .is_initialized = 0,
+        .clock = CLOCK_MONOTONIC,
+    };
+    int ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+
+    // Initialization must overwrite caller-provided storage with default values.
+    assert(attr.is_initialized != 0);
+    assert(attr.clock == CLOCK_REALTIME);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_condattr_init(NULL);
+    assert(ret != 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -129,6 +129,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutexattr_settype();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
+    test_pthread_condattr_init();
     test_pthread_rwlock_static_init();
     test_pthread_rwlock_dynamic_init();
     test_pthread_cond_static_init();


### PR DESCRIPTION
## Summary

Promotes `pthread_condattr_init()` from a dummy stub to a real implementation and adds C integration coverage for its default-initialization contract.

## What changed

- **sysapi**: Default `pthread_condattr_t::clock` to `CLOCK_REALTIME` instead of `0`, matching the POSIX contract.
- **syscall**: Drop the dummy-implementation note and warning from `pthread_condattr_init()`; it now validates the pointer and writes the default attributes.
- **tests**: Add a `test-c-thread` case (`condattr_init.c`) that seeds the attributes object with non-default values, then verifies initialization marks it initialized and selects `CLOCK_REALTIME`, overwriting caller-provided storage. Declared in `common.h` and invoked from `main.c`.

## Validation

- `./z build -- run-posix-tests` (all 53 POSIX C suites pass, including `posix/test-c-thread`)
- `./z build -- test`
- `./z build -- format-check` and `./z build -- lint-check`

Closes #499