### PR TITLE
[libc_pthread] Support pthread_mutexattr_destroy()

### DIFF
--- a/src/libs/libc_pthread/src/mutex.rs
+++ b/src/libs/libc_pthread/src/mutex.rs
@@ -90,7 +90,19 @@ pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) 
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/509
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!("pthread_mutexattr_destroy(): invalid attr pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the mutex attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_mutexattr_destroy(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    (*attr).uninitialize();
     0
 }
 

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -254,6 +254,16 @@ impl pthread_mutexattr_t {
     pub const SIZE: usize =
         Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_TYPE + Self::SIZE_OF_RECURSIVE;
 
+    /// Returns whether the mutex attributes object is initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.is_initialized != 0
+    }
+
+    /// Marks the mutex attributes object as uninitialized.
+    pub fn uninitialize(&mut self) {
+        self.is_initialized = 0;
+    }
+
     /// Returns the mutex type stored in the attributes object.
     pub fn type_(&self) -> c_int {
         self.type_

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -57,6 +57,9 @@ extern void test_pthread_attr_setschedparam(void);
 // Tests if the mutex type attribute can be set and retrieved.
 extern void test_pthread_mutexattr_settype(void);
 
+// Tests if mutex attributes can be destroyed.
+extern void test_pthread_mutexattr_destroy(void);
+
 // Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
 extern void test_pthread_getattr_np_destroy(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -127,6 +127,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();
     test_pthread_mutexattr_settype();
+    test_pthread_mutexattr_destroy();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
     test_pthread_condattr_init();

--- a/src/tests/integration/test-c-thread/mutexattr_destroy.c
+++ b/src/tests/integration/test-c-thread/mutexattr_destroy.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if mutex attributes can be destroyed.
+void test_pthread_mutexattr_destroy(void)
+{
+    fprintf(stderr, "testing pthread_mutexattr_destroy() ... ");
+
+    pthread_mutexattr_t attr = {
+        0,
+    };
+    int ret = pthread_mutexattr_init(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized != 0);
+
+    // Destroying an initialized mutex attributes object must invalidate it.
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized == 0);
+
+    // Destroying an uninitialized mutex attributes object must fail.
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == EINVAL);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_mutexattr_destroy(NULL);
+    assert(ret == EINVAL);
+
+    // A destroyed mutex attributes object may be initialized again.
+    ret = pthread_mutexattr_init(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized != 0);
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
Implement `pthread_mutexattr_destroy()`, replacing the stub that always
returned success. The function now validates its argument and manages the
attribute object lifecycle, and a C integration test covers the new
behavior. Closes #509.

## What changed

Libraries:
- `libc_pthread`: `pthread_mutexattr_destroy()` rejects a null or
  uninitialized attributes object with `EINVAL`, and clears the
  initialized marker on success so a double destroy is detected.
- `sysapi`: add `is_initialized()` and `uninitialize()` accessors on
  `pthread_mutexattr_t` to expose the lifecycle marker.

Tests:
- Add `test-c-thread/mutexattr_destroy.c` asserting that destroying an
  initialized object succeeds and clears the marker, that destroying an
  uninitialized object or a null pointer returns `EINVAL`, and that a
  destroyed object can be reinitialized.
- Wire the test into `common.h` and the `test-c-thread` driver.