### PR TITLE
[build] Migrate host utilities to syn 3 APIs

### DIFF
--- a/src/libs/syslog-macros/src/lib.rs
+++ b/src/libs/syslog-macros/src/lib.rs
@@ -276,8 +276,23 @@ fn build_auto_message(function: &ItemFn) -> Result<(LitStr, Vec<TokenStream2>)> 
     for input in &function.sig.inputs {
         match input {
             FnArg::Receiver(receiver) => {
-                let is_reference: bool = receiver.reference.is_some();
-                let is_mutable: bool = receiver.mutability.is_some();
+                let (is_reference, is_mutable): (bool, bool) = match &receiver.kind {
+                    syn::ReceiverKind::Reference(_, _, mutability) => (true, mutability.is_some()),
+                    // A typed receiver such as `self: &Self` / `self: &mut Self` carries the
+                    // reference in its type, so derive reference/mutability from it. Non-reference
+                    // typed receivers (e.g. `self: Box<Self>`) fall back to value behavior.
+                    syn::ReceiverKind::Typed(_, ty) => match ty.as_ref() {
+                        syn::Type::Reference(reference) => (true, reference.mutability.is_some()),
+                        _ => (false, receiver.mutability.is_some()),
+                    },
+                    syn::ReceiverKind::Value => (false, receiver.mutability.is_some()),
+                    _ => {
+                        return Err(syn::Error::new(
+                            receiver.span(),
+                            "trace_* macros do not support this receiver kind",
+                        ));
+                    },
+                };
 
                 let label: String = match (is_reference, is_mutable) {
                     (false, _) => "self={:?}".to_string(),

--- a/src/utils/gen-headers/src/main.rs
+++ b/src/utils/gen-headers/src/main.rs
@@ -305,7 +305,7 @@ fn map_ident_to_c(ident: &str) -> Option<&'static str> {
 fn map_type(ty: &syn::Type) -> String {
     match ty {
         syn::Type::Ptr(ptr) => {
-            let is_const: bool = ptr.const_token.is_some();
+            let is_const: bool = matches!(&ptr.mutability, syn::PointerMutability::Const(_));
             let inner: String = map_type(&ptr.elem);
             if inner == "void" {
                 return if is_const {
@@ -329,7 +329,7 @@ fn map_type(ty: &syn::Type) -> String {
             }
         },
         syn::Type::Never(_) => "void".to_string(),
-        syn::Type::BareFn(bare) => map_bare_fn(bare),
+        syn::Type::FnPtr(fn_ptr) => map_fn_ptr(fn_ptr),
         syn::Type::Path(path) => map_type_path(path),
         // Strip a redundant outer parenthesis or group, then map the inner type.
         syn::Type::Paren(inner) => map_type(&inner.elem),
@@ -365,13 +365,13 @@ fn map_type_path(path: &syn::TypePath) -> String {
     }
 }
 
-/// Maps a bare function pointer type to a C function pointer placeholder.
-fn map_bare_fn(bare: &syn::TypeBareFn) -> String {
-    let ret: String = match &bare.output {
+/// Maps a function pointer type to a C function pointer placeholder.
+fn map_fn_ptr(fn_ptr: &syn::TypeFnPtr) -> String {
+    let ret: String = match &fn_ptr.output {
         syn::ReturnType::Default => "void".to_string(),
-        syn::ReturnType::Type(_, ty) => map_type(ty),
+        syn::ReturnType::Type(_, ty) => map_type(ty.as_ref()),
     };
-    let params: Vec<String> = bare.inputs.iter().map(|arg| map_type(&arg.ty)).collect();
+    let params: Vec<String> = fn_ptr.inputs.iter().map(|arg| map_type(&arg.ty)).collect();
     let params_str: String = if params.is_empty() {
         "void".to_string()
     } else {


### PR DESCRIPTION
## What

Fixes the release build breakage introduced by the `syn 3.0.1` upgrade, which removed the function-pointer, raw-pointer, and receiver APIs that the host utilities depended on. The stale usages previously compiled only against cached artifacts; the release version bump forced a rebuild and surfaced the errors.

## Changes

**Libraries**
- `syslog-macros`: derive receiver reference/mutability from `ReceiverKind` instead of the removed `Receiver::reference` field, and reject unsupported receiver kinds with a spanned error.

**Build**
- `gen-headers`: replace `Type::BareFn`/`TypeBareFn` with `Type::FnPtr`/`TypeFnPtr`, and detect const raw pointers via `PointerMutability` instead of the removed `TypePtr::const_token`.

## Validation

- `cargo check`/`cargo test` for `gen-headers` and `syslog-macros`
- `./z build -- format-check` and `lint-check`
- Release benchmark build
- Full `./z build -- test` (88/88 Nanvix integration, 53/53 POSIX C tests) — `[OK] Build complete`