### PR TITLE
[gen-headers] E: Add Unit Tests for map_type()

### DIFF
--- a/src/utils/gen-headers/src/main.rs
+++ b/src/utils/gen-headers/src/main.rs
@@ -1102,3 +1102,34 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::syn::parse_quote;
+
+    #[test]
+    fn map_type_maps_raw_pointer_mutability() {
+        let const_void: syn::Type = parse_quote!(*const c_void);
+        let mut_void: syn::Type = parse_quote!(*mut c_void);
+        let const_char: syn::Type = parse_quote!(*const c_char);
+        let mut_char: syn::Type = parse_quote!(*mut c_char);
+
+        assert_eq!(map_type(&const_void), "const void *");
+        assert_eq!(map_type(&mut_void), "void *");
+        assert_eq!(map_type(&const_char), "const char *");
+        assert_eq!(map_type(&mut_char), "char *");
+    }
+
+    #[test]
+    fn map_type_maps_function_pointer() {
+        let fn_ptr: syn::Type =
+            parse_quote!(unsafe extern "C" fn(*const c_void, c_size_t) -> c_int);
+
+        assert_eq!(map_type(&fn_ptr), "int (*)(const void *, size_t)");
+    }
+}


### PR DESCRIPTION
## What

Adds a unit test module for the `gen-headers` utility covering the
`map_type()` function, which translates Rust types into their C header
spellings.

## Why

Locks in `map_type()`'s type mapping behavior and guards against
regressions in generated C headers.

## Tests

- **Raw pointer mutability:** `*const`/`*mut` `c_void` and `c_char` map to
  the expected const/non-const `void *` and `char *` spellings.
- **Function pointer:** an `unsafe extern "C" fn` maps to the correct C
  function-pointer syntax `int (*)(const void *, size_t)`.