### PR TITLE
[libc_pthread] Add pthread_mutexattr_getpshared

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -37,6 +37,8 @@ extern "C" {
 #define PTHREAD_NULL 0 /**< Null thread identifier. */
 #define PTHREAD_CREATE_JOINABLE 0 /**< Thread is created joinable. */
 #define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */
+#define PTHREAD_PROCESS_PRIVATE 0 /**< Synchronization object is private to a process. */
+#define PTHREAD_PROCESS_SHARED 1 /**< Synchronization object is shared between processes. */
 
 /*==================================================================================================
  * Types
@@ -66,6 +68,7 @@ typedef struct {
     int is_initialized; /**< Whether the attributes are initialized. */
     int type;           /**< Type of mutex.                          */
     int recursive;      /**< Whether the mutex is recursive.         */
+    int pshared;        /**< Process-sharing attribute.               */
 } pthread_mutexattr_t;
 
 /** @brief Read-write lock attributes. */
@@ -128,6 +131,7 @@ extern int pthread_mutex_trylock(pthread_mutex_t *mutex);
 extern int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime);
 extern int pthread_mutexattr_init(pthread_mutexattr_t *attr);
 extern int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
+extern int pthread_mutexattr_getpshared(const pthread_mutexattr_t *attr, int *pshared);
 extern int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type_);
 extern int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type_);
 

--- a/src/libs/libc_pthread/src/mutex.rs
+++ b/src/libs/libc_pthread/src/mutex.rs
@@ -107,6 +107,61 @@ pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_
 }
 
 //==================================================================================================
+// pthread_mutexattr_getpshared()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the process-shared attribute from a mutex attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object.
+/// - `pshared`: Pointer where the process-shared attribute is stored on success.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_getpshared()` function returns `0` on success. On error, it returns an
+/// error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_mutexattr_t` object.
+/// - `pshared` points to a valid `int` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_mutexattr_getpshared(
+    attr: *const pthread_mutexattr_t,
+    pshared: *mut c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!("pthread_mutexattr_getpshared(): invalid attr pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `pshared` is not valid.
+    if pshared.is_null() {
+        ::syslog::warn!("pthread_mutexattr_getpshared(): invalid pshared pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the mutex attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_mutexattr_getpshared(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    *pshared = (*attr).pshared();
+    0
+}
+
+//==================================================================================================
 // pthread_mutexattr_settype()
 //==================================================================================================
 

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -49,6 +49,7 @@ typedef struct {
     int is_initialized; /**< Whether the attributes are initialized. */
     int type;           /**< Type of mutex.                          */
     int recursive;      /**< Whether the mutex is recursive.         */
+    int pshared;        /**< Process-sharing attribute.               */
 } pthread_mutexattr_t;
 
 /** @brief Read-write lock attributes. */
@@ -80,7 +81,9 @@ text = '''
 #define PTHREAD_RWLOCK_INITIALIZER 0xffffffff /**< Static read-write lock initializer. */
 #define PTHREAD_NULL 0 /**< Null thread identifier. */
 #define PTHREAD_CREATE_JOINABLE 0 /**< Thread is created joinable. */
-#define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */'''
+#define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */
+#define PTHREAD_PROCESS_PRIVATE 0 /**< Synchronization object is private to a process. */
+#define PTHREAD_PROCESS_SHARED 1 /**< Synchronization object is shared between processes. */'''
 
 [[sections]]
 title = "Threads"
@@ -124,6 +127,7 @@ functions = [
     "pthread_mutex_timedlock",
     "pthread_mutexattr_init",
     "pthread_mutexattr_destroy",
+    "pthread_mutexattr_getpshared",
     "pthread_mutexattr_settype",
     "pthread_mutexattr_gettype",
 ]

--- a/src/libs/sysapi/src/pthread.rs
+++ b/src/libs/sysapi/src/pthread.rs
@@ -35,6 +35,12 @@ pub const PTHREAD_CREATE_JOINABLE: c_int = 0;
 /// Indicates that a thread is created detached.
 pub const PTHREAD_CREATE_DETACHED: c_int = 1;
 
+/// Indicates that a synchronization object is shared only within a process.
+pub const PTHREAD_PROCESS_PRIVATE: c_int = 0;
+
+/// Indicates that a synchronization object is shared between processes.
+pub const PTHREAD_PROCESS_SHARED: c_int = 1;
+
 /// Used to initialize a condition variable statically
 pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0xffffffff;
 

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -22,7 +22,10 @@ use crate::{
         c_ushort,
         c_void,
     },
-    pthread::pthread_mutex_type::PTHREAD_MUTEX_DEFAULT,
+    pthread::{
+        PTHREAD_PROCESS_PRIVATE,
+        pthread_mutex_type::PTHREAD_MUTEX_DEFAULT,
+    },
     sched::{
         sched_param,
         sched_policy::SCHED_OTHER,
@@ -239,6 +242,8 @@ pub struct pthread_mutexattr_t {
     type_: c_int,
     /// Whether the mutex is recursive.
     recursive: c_int,
+    /// Process-sharing attribute.
+    pshared: c_int,
 }
 ::static_assert::assert_eq_size!(pthread_mutexattr_t, pthread_mutexattr_t::SIZE);
 
@@ -249,10 +254,14 @@ impl pthread_mutexattr_t {
     const SIZE_OF_TYPE: usize = size_of::<c_int>();
     /// Size of the `recursive` field.
     const SIZE_OF_RECURSIVE: usize = size_of::<c_int>();
+    /// Size of the `pshared` field.
+    const SIZE_OF_PSHARED: usize = size_of::<c_int>();
 
     /// Size of `pthread_mutexattr_t` structure.
-    pub const SIZE: usize =
-        Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_TYPE + Self::SIZE_OF_RECURSIVE;
+    pub const SIZE: usize = Self::SIZE_OF_IS_INITIALIZED
+        + Self::SIZE_OF_TYPE
+        + Self::SIZE_OF_RECURSIVE
+        + Self::SIZE_OF_PSHARED;
 
     /// Returns whether the mutex attributes object is initialized.
     pub fn is_initialized(&self) -> bool {
@@ -275,6 +284,11 @@ impl pthread_mutexattr_t {
         self.recursive = (type_ == crate::pthread::pthread_mutex_type::PTHREAD_MUTEX_RECURSIVE)
             as crate::ffi::c_int;
     }
+
+    /// Returns the process-sharing attribute.
+    pub fn pshared(&self) -> c_int {
+        self.pshared
+    }
 }
 
 impl Default for pthread_mutexattr_t {
@@ -283,6 +297,7 @@ impl Default for pthread_mutexattr_t {
             is_initialized: 1,
             type_: PTHREAD_MUTEX_DEFAULT,
             recursive: 0,
+            pshared: PTHREAD_PROCESS_PRIVATE,
         }
     }
 }

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -57,6 +57,9 @@ extern void test_pthread_attr_setschedparam(void);
 // Tests if the mutex type attribute can be set and retrieved.
 extern void test_pthread_mutexattr_settype(void);
 
+// Tests if the process-sharing attribute can be retrieved.
+extern void test_pthread_mutexattr_getpshared(void);
+
 // Tests if mutex attributes can be destroyed.
 extern void test_pthread_mutexattr_destroy(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -100,7 +100,8 @@ int main(int argc, const char *argv[])
     STATIC_ASSERT_SIZE(pthread_mutexattr_t,
                        sizeof(int) +     // is_initialized
                            sizeof(int) + // type
-                           sizeof(int)   // recursive
+                           sizeof(int) + // recursive
+                           sizeof(int)   // pshared
     );
 
     // Sanity check size of `pthread_rwlock_t` type.
@@ -127,6 +128,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();
     test_pthread_mutexattr_settype();
+    test_pthread_mutexattr_getpshared();
     test_pthread_mutexattr_destroy();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();

--- a/src/tests/integration/test-c-thread/mutexattr_getpshared.c
+++ b/src/tests/integration/test-c-thread/mutexattr_getpshared.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the process-sharing attribute can be retrieved.
+void test_pthread_mutexattr_getpshared(void)
+{
+    fprintf(stderr, "testing pthread_mutexattr_getpshared() ... ");
+
+    pthread_mutexattr_t attr = {
+        .pshared = PTHREAD_PROCESS_SHARED,
+    };
+    int ret = pthread_mutexattr_init(&attr);
+    assert(ret == 0);
+
+    // Initialization must overwrite caller-provided storage with the default value.
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+
+    int pshared = PTHREAD_PROCESS_SHARED;
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_mutexattr_getpshared(NULL, &pshared);
+    assert(ret != 0);
+    ret = pthread_mutexattr_getpshared(&attr, NULL);
+    assert(ret != 0);
+
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == 0);
+
+    // Uninitialized mutex attributes objects must be rejected.
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret != 0);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Implements `pthread_mutexattr_getpshared()` so callers can query the
process-shared attribute of a mutex attributes object, and adds test
coverage for it.

## What changed

- **libc_pthread:** add `pthread_mutexattr_getpshared()`, which rejects
  null `attr`/`pshared` pointers and otherwise returns the stored
  attribute value.
- **sysapi:** add a `pshared` field (with accessor and size accounting)
  to `pthread_mutexattr_t`, default it to `PTHREAD_PROCESS_PRIVATE`, and
  define the `PTHREAD_PROCESS_PRIVATE` / `PTHREAD_PROCESS_SHARED`
  constants.
- **Headers:** regenerate `include/pthread.h` from `pthread.toml` to
  expose the new prototype, the `pshared` struct field, and the
  `PTHREAD_PROCESS_*` macros.
- **Tests:** add `mutexattr_getpshared.c` to the `test-c-thread` suite
  covering the default value after init, retrieval through the getter,
  and invalid-pointer handling; extend the `pthread_mutexattr_t` size
  assertion for the new field.

## Validation

- `gen-headers-check` reports headers up to date.
- Format and clippy (`-D warnings`) pass for `sysapi` and `libc_pthread`.
- The `test-c-thread` integration suite passes in standalone mode
  (`testing pthread_mutexattr_getpshared() ... passed`, VM exit 0).

closes #510