### PR TITLE
[vfs] Implement umask() File Creation Mask

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -114,7 +114,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c unlinkat.c mkdirat.c mkdir.c \
-	mkfifo.c mknod.c dirent.c getcwd.c chdir.c fchdir.c
+	mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's
@@ -293,6 +293,9 @@ $(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_RULE,$(suite))))
 
 # Per-suite environment variables (space-separated KEY=VALUE entries). Empty unless set.
 POSIX_TEST_ENV_test-c-misc := NANVIX_TEST=1
+ifneq ($(IS_WINDOWS),yes)
+POSIX_TEST_ENV_test-c-file := NANVIX_TEST_HOSTFS_PERMISSIONS=1
+endif
 
 # $(1) = suite name.
 define POSIX_TEST_IMAGE_RULE

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -29,6 +29,7 @@ use ::sysapi::{
         file_creation_flags::{
             O_CREAT,
             O_DIRECTORY,
+            O_EXCL,
             O_TRUNC,
         },
         file_status_flags::O_APPEND,
@@ -62,6 +63,37 @@ use std::{
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+
+fn open_regular_file(
+    options: &OpenOptions,
+    host_path: &PathBuf,
+    create: bool,
+    exclusive: bool,
+) -> io::Result<(File, bool)> {
+    if !create {
+        return options.open(host_path).map(|file| (file, false));
+    }
+
+    let mut create_options: OpenOptions = options.clone();
+    create_options.create_new(true);
+
+    let mut existing_options: OpenOptions = options.clone();
+    existing_options.create(false);
+
+    loop {
+        match create_options.open(host_path) {
+            Ok(file) => return Ok((file, true)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists && !exclusive => {
+                match existing_options.open(host_path) {
+                    Ok(file) => return Ok((file, false)),
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+                    Err(error) => return Err(error),
+                }
+            },
+            Err(error) => return Err(error),
+        }
+    }
+}
 
 /// The host filesystem request handler.
 ///
@@ -399,6 +431,7 @@ impl HostFsHandler {
         let wronly: bool = (flags & O_ACCMODE) == O_WRONLY;
         let rdwr: bool = (flags & O_ACCMODE) == O_RDWR;
         let o_creat: bool = (flags & O_CREAT) != 0;
+        let o_excl: bool = (flags & O_EXCL) != 0;
         let o_trunc: bool = (flags & O_TRUNC) != 0;
         let o_append: bool = (flags & O_APPEND) != 0;
 
@@ -439,9 +472,9 @@ impl HostFsHandler {
             return;
         }
 
-        let file: File = if is_dir {
+        let (file, created): (File, bool) = if is_dir {
             match open_dir_handle(&host_path) {
-                Ok(f) => f,
+                Ok(file) => (file, false),
                 Err(e) => {
                     set_header(response, SystemCallMessageHeader::HostFsOpenResponse as u16);
                     set_payload_data(response, &io_error_to_code(&e).to_le_bytes());
@@ -449,8 +482,8 @@ impl HostFsHandler {
                 },
             }
         } else {
-            match opts.open(&host_path) {
-                Ok(f) => f,
+            match open_regular_file(&opts, &host_path, o_creat, o_excl) {
+                Ok(result) => result,
                 Err(e) => {
                     set_header(response, SystemCallMessageHeader::HostFsOpenResponse as u16);
                     set_payload_data(response, &io_error_to_code(&e).to_le_bytes());
@@ -458,6 +491,20 @@ impl HostFsHandler {
                 },
             }
         };
+
+        if created {
+            #[cfg(unix)]
+            {
+                let permissions: std::fs::Permissions = std::fs::Permissions::from_mode(req.mode);
+                if let Err(error) = file.set_permissions(permissions) {
+                    drop(file);
+                    let _ = fs::remove_file(&host_path);
+                    set_header(response, SystemCallMessageHeader::HostFsOpenResponse as u16);
+                    set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                    return;
+                }
+            }
+        }
 
         let path_string: String = host_path.to_string_lossy().into_owned();
         match self.fd_table.alloc(file, is_dir, path_string) {
@@ -1080,7 +1127,7 @@ impl HostFsHandler {
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
         let req: OpenRequest = OpenRequest::decode(payload);
-        let path_len: usize = (req.path_len as usize).min(MAX_INLINE_PATH_LEN);
+        let path_len: usize = (req.path_len as usize).min(req.path.len());
         let path_str: &str = match core::str::from_utf8(&req.path[..path_len]) {
             Ok(s) => s,
             Err(_) => {
@@ -1108,6 +1155,7 @@ impl HostFsHandler {
         let wronly: bool = (flags & O_ACCMODE) == O_WRONLY;
         let rdwr: bool = (flags & O_ACCMODE) == O_RDWR;
         let o_creat: bool = (flags & O_CREAT) != 0;
+        let o_excl: bool = (flags & O_EXCL) != 0;
         let o_trunc: bool = (flags & O_TRUNC) != 0;
         let o_append: bool = (flags & O_APPEND) != 0;
 
@@ -1157,10 +1205,10 @@ impl HostFsHandler {
             return;
         }
 
-        let file: File = if is_dir {
+        let (file, created): (File, bool) = if is_dir {
             // For directories, open as read-only. Readdir uses the stored path.
             match open_dir_handle(&host_path) {
-                Ok(f) => f,
+                Ok(file) => (file, false),
                 Err(e) => {
                     log::debug!(
                         "hostfsd: directory open failed (path={:?}, kind={:?}): {}",
@@ -1174,8 +1222,8 @@ impl HostFsHandler {
                 },
             }
         } else {
-            match opts.open(&host_path) {
-                Ok(f) => f,
+            match open_regular_file(&opts, &host_path, o_creat, o_excl) {
+                Ok(result) => result,
                 Err(e) => {
                     log::debug!(
                         "hostfsd: open failed (path={:?}, flags={:#x}, kind={:?}): {}",
@@ -1190,6 +1238,20 @@ impl HostFsHandler {
                 },
             }
         };
+
+        if created {
+            #[cfg(unix)]
+            {
+                let permissions: std::fs::Permissions = std::fs::Permissions::from_mode(req.mode);
+                if let Err(error) = file.set_permissions(permissions) {
+                    drop(file);
+                    let _ = fs::remove_file(&host_path);
+                    set_header(response, SystemCallMessageHeader::HostFsOpenResponse as u16);
+                    set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                    return;
+                }
+            }
+        }
 
         let path_string: String = host_path.to_string_lossy().into_owned();
         match self.fd_table.alloc(file, is_dir, path_string) {

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -13,6 +13,8 @@ use hostfs_api::{
     *,
 };
 use hostfsd::HostFsHandler;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
     path::PathBuf,
@@ -28,6 +30,7 @@ use sysapi::{
         file_creation_flags::{
             O_CREAT,
             O_DIRECTORY,
+            O_EXCL,
             O_TRUNC,
         },
     },
@@ -51,9 +54,9 @@ fn setup() -> (HostFsHandler, TempDir) {
     (handler, tmp)
 }
 
-/// Builds an Open request payload for the given path and flags.
-fn make_open_request(path: &str, flags: i32) -> [u8; Message::PAYLOAD_SIZE] {
-    let req: OpenRequest = OpenRequest::from_path(flags, path.as_bytes())
+/// Builds an Open request payload for the given path, flags, and mode.
+fn make_open_request(path: &str, flags: i32, mode: u32) -> [u8; Message::PAYLOAD_SIZE] {
+    let req: OpenRequest = OpenRequest::from_path(flags, mode, path.as_bytes())
         .expect("test path fits in MAX_INLINE_PATH_LEN");
     req.serialize(
         SystemCallMessageHeader::HostFsOpenRequest as u16,
@@ -194,7 +197,7 @@ fn make_readdir_request_at(fd: i32, offset: u32) -> [u8; Message::PAYLOAD_SIZE] 
 
 /// Opens a file via the handler and returns the remote FD.
 fn open_file(handler: &mut HostFsHandler, path: &str, flags: i32) -> i32 {
-    let payload: [u8; Message::PAYLOAD_SIZE] = make_open_request(path, flags);
+    let payload: [u8; Message::PAYLOAD_SIZE] = make_open_request(path, flags, 0o666);
     let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
     let resp: OpenResponse = OpenResponse::decode(&response);
     resp.fd
@@ -239,6 +242,40 @@ fn test_open_create_flag() {
 
     // Verify file was actually created on disk.
     assert!(tmp.path().join("new-file.txt").exists());
+    #[cfg(unix)]
+    assert_eq!(
+        fs::metadata(tmp.path().join("new-file.txt"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o666,
+        "open should apply the requested creation mode"
+    );
+
+    let exclusive_fd: i32 = open_file(&mut handler, "new-file.txt", O_WRONLY | O_CREAT | O_EXCL);
+    assert!(exclusive_fd < 0, "exclusive creation of an existing file should fail");
+
+    #[cfg(unix)]
+    {
+        let payload: [u8; Message::PAYLOAD_SIZE] =
+            make_open_request("new-file.txt", O_WRONLY | O_CREAT, 0o600);
+        let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
+        let existing_fd: i32 = OpenResponse::decode(&response).fd;
+        assert!(existing_fd > 0, "opening an existing file with O_CREAT should succeed");
+        assert_eq!(
+            fs::metadata(tmp.path().join("new-file.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o666,
+            "open should preserve the mode of an existing file"
+        );
+        handler
+            .handle_request(&make_close_request(existing_fd))
+            .unwrap();
+    }
 
     // Close.
     let payload: [u8; Message::PAYLOAD_SIZE] = make_close_request(fd);
@@ -905,7 +942,7 @@ fn test_op_id_echoed_in_response() {
     fs::write(tmp.path().join("opid.txt"), b"test").unwrap();
 
     // Build a request with a specific op_id.
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = make_open_request("opid.txt", O_RDONLY);
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = make_open_request("opid.txt", O_RDONLY, 0);
     set_op_id(&mut payload, OperationId::from_raw(42));
 
     let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
@@ -935,7 +972,7 @@ fn test_op_id_zero_is_valid() {
     let (mut handler, tmp) = setup();
     fs::write(tmp.path().join("zero.txt"), b"z").unwrap();
 
-    let mut payload: [u8; Message::PAYLOAD_SIZE] = make_open_request("zero.txt", O_RDONLY);
+    let mut payload: [u8; Message::PAYLOAD_SIZE] = make_open_request("zero.txt", O_RDONLY, 0);
     set_op_id(&mut payload, OperationId::from_raw(0));
 
     let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
@@ -979,15 +1016,17 @@ fn make_part_payload(
 fn make_long_open_parts(
     path: &str,
     flags: i32,
+    mode: u32,
     op_id: OperationId,
 ) -> Vec<[u8; Message::PAYLOAD_SIZE]> {
     let path_bytes: &[u8] = path.as_bytes();
     let path_len: u16 = path_bytes.len() as u16;
 
-    // Serialize: [op_id:4][flags:4][path_len:2][path:N]
+    // Serialize: [op_id:4][flags:4][mode:4][path_len:2][path:N]
     let mut data: Vec<u8> = Vec::new();
     data.extend_from_slice(&op_id.to_le_bytes());
     data.extend_from_slice(&flags.to_le_bytes());
+    data.extend_from_slice(&mode.to_le_bytes());
     data.extend_from_slice(&path_len.to_le_bytes());
     data.extend_from_slice(path_bytes);
 
@@ -1007,7 +1046,7 @@ fn test_long_open_single_part() {
     let (mut handler, tmp) = setup();
     fs::write(tmp.path().join("short.txt"), b"data").unwrap();
 
-    let parts = make_long_open_parts("short.txt", O_RDONLY, OperationId::from_raw(7));
+    let parts = make_long_open_parts("short.txt", O_RDONLY, 0, OperationId::from_raw(7));
     assert_eq!(parts.len(), 1, "short path should fit in one part");
 
     let response = handler.handle_request(&parts[0]);
@@ -1016,6 +1055,26 @@ fn test_long_open_single_part() {
     assert_eq!(get_op_id(&response), OperationId::from_raw(7));
     let resp: OpenResponse = OpenResponse::decode(&response);
     assert!(resp.fd > 0, "open should succeed");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_long_open_create_preserves_existing_mode() {
+    let (mut handler, tmp) = setup();
+    let host_path: PathBuf = tmp.path().join("existing.txt");
+    fs::write(&host_path, b"data").unwrap();
+    fs::set_permissions(&host_path, fs::Permissions::from_mode(0o640)).unwrap();
+
+    let parts: Vec<[u8; Message::PAYLOAD_SIZE]> =
+        make_long_open_parts("existing.txt", O_WRONLY | O_CREAT, 0o600, OperationId::from_raw(8));
+    let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&parts[0]).unwrap();
+    let resp: OpenResponse = OpenResponse::decode(&response);
+    assert!(resp.fd > 0, "opening an existing file with O_CREAT should succeed");
+    assert_eq!(
+        fs::metadata(&host_path).unwrap().permissions().mode() & 0o777,
+        0o640,
+        "long open should preserve the mode of an existing file"
+    );
 }
 
 #[test]
@@ -1027,7 +1086,7 @@ fn test_long_open_multi_part() {
     let file_name: String = format!("{}/file.txt", long_name);
     fs::write(tmp.path().join(&file_name), b"hello").unwrap();
 
-    let parts = make_long_open_parts(&file_name, O_RDONLY, OperationId::from_raw(42));
+    let parts = make_long_open_parts(&file_name, O_RDONLY, 0, OperationId::from_raw(42));
     assert!(parts.len() >= 2, "long path should require multiple parts, got {}", parts.len());
 
     // Feed intermediate parts — should return None.
@@ -1049,7 +1108,7 @@ fn test_long_open_multi_part() {
 fn test_long_open_nonexistent_file() {
     let (mut handler, _tmp) = setup();
 
-    let parts = make_long_open_parts("does-not-exist.txt", O_RDONLY, OperationId::from_raw(10));
+    let parts = make_long_open_parts("does-not-exist.txt", O_RDONLY, 0, OperationId::from_raw(10));
     let response = handler.handle_request(&parts[0]).unwrap();
     assert_eq!(get_op_id(&response), OperationId::from_raw(10));
     let ds: usize = HOSTFS_DATA_START;

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -681,9 +681,10 @@ pub(crate) fn handle_getdents_with_hostfs(
 pub(crate) fn handle_openat_with_hostfs(
     source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
-    request: OpenAtRequest,
+    mut request: OpenAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
+    request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
     let resolved: alloc::string::String =
         match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
             Some(p) => p,
@@ -697,7 +698,7 @@ pub(crate) fn handle_openat_with_hostfs(
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
         let open_path: alloc::string::String = alloc::string::String::from(final_path);
-        match hostfs::send_open_request(final_path, request.flags, op_id) {
+        match hostfs::send_open_request(final_path, request.flags, request.mode, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -833,9 +834,10 @@ pub(crate) fn handle_unlinkat_with_hostfs(
 pub(crate) fn handle_mkdirat_with_hostfs(
     source_pid: ProcessIdentifier,
     source: ThreadIdentifier,
-    request: MakeDirectoryAtRequest,
+    mut request: MakeDirectoryAtRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
+    request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
     let resolved: alloc::string::String =
         match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
             Some(p) => p,

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -32,6 +32,8 @@ use ::syscall::{
     sys::stat::message::{
         FileChmodRequest,
         FileChmodResponse,
+        FileCreationMaskRequest,
+        FileCreationMaskResponse,
         UpdateFileAccessTimeRequest,
         UpdateFileAccessTimeResponse,
     },
@@ -248,6 +250,17 @@ pub(crate) fn handle_fchmod(source: ThreadIdentifier, msg: SystemCallMessage) ->
     // fchmod on an fd: our VFS does not support fchmod by fd directly. Return success as a stub.
     ::syslog::trace!("handle_fchmod(): stubbed (fd={}, mode={})", fd, mode);
     FileChmodResponse::build(source, ProcessIdentifier::VFSD, MessageType::Ipc)
+}
+
+pub(crate) fn handle_umask(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
+    let request: FileCreationMaskRequest = FileCreationMaskRequest::from_bytes(msg.payload);
+    let previous_mask = ::vfs::fd::vfs_umask(request.mask);
+    FileCreationMaskResponse::build(
+        source,
+        previous_mask,
+        ProcessIdentifier::VFSD,
+        MessageType::Ipc,
+    )
 }
 
 pub(crate) fn handle_fchdir(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -184,11 +184,12 @@ fn send_long_request(
 pub fn send_open_request(
     path: &str,
     flags: i32,
+    mode: u32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
     let relative: &str = strip_mount_prefix(path);
     let buf: alloc::vec::Vec<u8> =
-        long_msg::serialize_long_open_request(op_id, flags, relative.as_bytes())
+        long_msg::serialize_long_open_request(op_id, flags, mode, relative.as_bytes())
             .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageHeader::HostFsOpenRequestPart)

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -425,6 +425,10 @@ pub(crate) fn handle_ipc_message(
             let response: Message = handler::handle_fchmod(source_tid, syscall_msg);
             send_response(&response);
         },
+        SystemCallMessageHeader::FileCreationMaskRequest => {
+            let response: Message = handler::handle_umask(source_tid, syscall_msg);
+            send_response(&response);
+        },
         SystemCallMessageHeader::FileChownRequest => {
             let response: Message = handler::handle_fchown(source_tid, syscall_msg);
             send_response(&response);

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -55,8 +55,8 @@ use crate::OperationId;
 /// Maximum length of a single path in the long-message wire format (u16::MAX).
 pub const MAX_PATH_LEN: usize = u16::MAX as usize;
 
-/// Header size for long open: op_id(4) + flags(4) + path_len(2) = 10
-pub const OPEN_HEADER_SIZE: usize = 10;
+/// Header size for long open: op_id(4) + flags(4) + mode(4) + path_len(2) = 14.
+pub const OPEN_HEADER_SIZE: usize = 14;
 
 /// Header size for long unlink: op_id(4) + path_len(2) = 6
 pub const UNLINK_HEADER_SIZE: usize = 6;
@@ -330,6 +330,7 @@ pub fn deserialize_long_readdir_response(bytes: &[u8]) -> Option<LongReaddirResp
 pub struct LongOpenRequest {
     pub op_id: OperationId,
     pub flags: i32,
+    pub mode: u32,
     pub path: std::string::String,
 }
 
@@ -341,7 +342,8 @@ pub fn deserialize_long_open(bytes: &[u8]) -> Option<LongOpenRequest> {
     }
     let op_id = OperationId::new(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
     let flags = i32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-    let path_len = u16::from_le_bytes([bytes[8], bytes[9]]) as usize;
+    let mode = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    let path_len = u16::from_le_bytes([bytes[12], bytes[13]]) as usize;
     if bytes.len() < OPEN_HEADER_SIZE + path_len {
         return None;
     }
@@ -349,7 +351,12 @@ pub fn deserialize_long_open(bytes: &[u8]) -> Option<LongOpenRequest> {
         bytes[OPEN_HEADER_SIZE..OPEN_HEADER_SIZE + path_len].to_vec(),
     )
     .ok()?;
-    Some(LongOpenRequest { op_id, flags, path })
+    Some(LongOpenRequest {
+        op_id,
+        flags,
+        mode,
+        path,
+    })
 }
 
 /// Result of deserializing a long UNLINK request.
@@ -558,13 +565,19 @@ pub fn deserialize_long_lstat(bytes: &[u8]) -> Option<LongLstatRequest> {
 
 /// Serializes the body of a long OPEN request.
 ///
-/// Wire format: `[op_id:4][flags:4][path_len:2][path:N]`. Returns `None` if `path`
+/// Wire format: `[op_id:4][flags:4][mode:4][path_len:2][path:N]`. Returns `None` if `path`
 /// is longer than [`MAX_PATH_LEN`].
-pub fn serialize_long_open_request(op_id: OperationId, flags: i32, path: &[u8]) -> Option<Vec<u8>> {
+pub fn serialize_long_open_request(
+    op_id: OperationId,
+    flags: i32,
+    mode: u32,
+    path: &[u8],
+) -> Option<Vec<u8>> {
     let path_len: u16 = u16::try_from(path.len()).ok()?;
     let mut buf: Vec<u8> = Vec::with_capacity(OPEN_HEADER_SIZE + path.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
     buf.extend_from_slice(&flags.to_le_bytes());
+    buf.extend_from_slice(&mode.to_le_bytes());
     buf.extend_from_slice(&path_len.to_le_bytes());
     buf.extend_from_slice(path);
     Some(buf)

--- a/src/libs/hostfs-api/src/open.rs
+++ b/src/libs/hostfs-api/src/open.rs
@@ -12,15 +12,20 @@ use crate::{
 };
 use ::sys::ipc::Message;
 
+/// Maximum path length in an inline open request.
+const MAX_INLINE_OPEN_PATH_LEN: usize = MAX_INLINE_PATH_LEN - 4;
+
 /// Open request: open a file at the given relative path.
 #[derive(Debug, Clone)]
 pub struct OpenRequest {
     /// POSIX open flags (O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, etc.).
     pub flags: i32,
+    /// Mode used when creating a file.
+    pub mode: u32,
     /// Relative path within the mounted directory.
     pub path_len: u16,
-    /// Path bytes (up to `MAX_INLINE_PATH_LEN`).
-    pub path: [u8; MAX_INLINE_PATH_LEN],
+    /// Path bytes.
+    pub path: [u8; MAX_INLINE_OPEN_PATH_LEN],
 }
 
 /// Open response: contains the remote file descriptor and directory flag.
@@ -33,19 +38,20 @@ pub struct OpenResponse {
 }
 
 impl OpenRequest {
-    /// Builds an inline [`OpenRequest`] from a path slice and POSIX `flags`.
+    /// Builds an inline [`OpenRequest`] from a path slice, POSIX `flags`, and creation `mode`.
     ///
-    /// Returns `None` if `path` is longer than [`MAX_INLINE_PATH_LEN`]. Callers must
+    /// Returns `None` if `path` is longer than the inline request capacity. Callers must
     /// fall back to the multi-part request form in [`long_msg`](crate::long_msg) when
     /// this returns `None`.
-    pub fn from_path(flags: i32, path: &[u8]) -> Option<Self> {
-        if path.len() > MAX_INLINE_PATH_LEN {
+    pub fn from_path(flags: i32, mode: u32, path: &[u8]) -> Option<Self> {
+        if path.len() > MAX_INLINE_OPEN_PATH_LEN {
             return None;
         }
-        let mut buf: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
+        let mut buf: [u8; MAX_INLINE_OPEN_PATH_LEN] = [0u8; MAX_INLINE_OPEN_PATH_LEN];
         buf[..path.len()].copy_from_slice(path);
         Some(Self {
             flags,
+            mode,
             path_len: path.len() as u16,
             path: buf,
         })
@@ -58,11 +64,13 @@ impl OpenRequest {
         set_op_id(&mut payload, op_id);
         let data_start: usize = HOSTFS_DATA_START;
         let flags_bytes: [u8; 4] = self.flags.to_le_bytes();
+        let mode_bytes: [u8; 4] = self.mode.to_le_bytes();
         let path_len_bytes: [u8; 2] = self.path_len.to_le_bytes();
         payload[data_start..data_start + 4].copy_from_slice(&flags_bytes);
-        payload[data_start + 4..data_start + 6].copy_from_slice(&path_len_bytes);
-        let path_copy_len: usize = (self.path_len as usize).min(MAX_INLINE_PATH_LEN);
-        payload[data_start + 6..data_start + 6 + path_copy_len]
+        payload[data_start + 4..data_start + 8].copy_from_slice(&mode_bytes);
+        payload[data_start + 8..data_start + 10].copy_from_slice(&path_len_bytes);
+        let path_copy_len: usize = (self.path_len as usize).min(MAX_INLINE_OPEN_PATH_LEN);
+        payload[data_start + 10..data_start + 10 + path_copy_len]
             .copy_from_slice(&self.path[..path_copy_len]);
         payload
     }
@@ -72,13 +80,16 @@ impl OpenRequest {
         let data_start: usize = HOSTFS_DATA_START;
         let flags: i32 =
             i32::from_le_bytes(payload[data_start..data_start + 4].try_into().unwrap());
+        let mode: u32 =
+            u32::from_le_bytes(payload[data_start + 4..data_start + 8].try_into().unwrap());
         let path_len: u16 =
-            u16::from_le_bytes(payload[data_start + 4..data_start + 6].try_into().unwrap());
-        let mut path: [u8; MAX_INLINE_PATH_LEN] = [0u8; MAX_INLINE_PATH_LEN];
-        let copy_len: usize = (path_len as usize).min(MAX_INLINE_PATH_LEN);
-        path[..copy_len].copy_from_slice(&payload[data_start + 6..data_start + 6 + copy_len]);
+            u16::from_le_bytes(payload[data_start + 8..data_start + 10].try_into().unwrap());
+        let mut path: [u8; MAX_INLINE_OPEN_PATH_LEN] = [0u8; MAX_INLINE_OPEN_PATH_LEN];
+        let copy_len: usize = (path_len as usize).min(MAX_INLINE_OPEN_PATH_LEN);
+        path[..copy_len].copy_from_slice(&payload[data_start + 10..data_start + 10 + copy_len]);
         Self {
             flags,
+            mode,
             path_len,
             path,
         }

--- a/src/libs/libc_sys_stat/src/lib.rs
+++ b/src/libs/libc_sys_stat/src/lib.rs
@@ -479,10 +479,14 @@ pub unsafe extern "C" fn mkfifo(path: *const c_char, mode: mode_t) -> c_int {
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
-pub unsafe extern "C" fn umask(mask: u16) -> u16 {
-    // TODO: https://github.com/nanvix/nanvix/issues/597.
-    ::syslog::debug!("umask(): not implemented");
-    0
+pub unsafe extern "C" fn umask(mask: mode_t) -> mode_t {
+    match stat::umask(mask) {
+        Ok(previous_mask) => previous_mask,
+        Err(error) => {
+            ::syslog::error!("umask(): failed (mask={:?}, error={:?})", mask, error);
+            0
+        },
+    }
 }
 
 ///

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -331,6 +331,8 @@ pub enum SystemCallMessageHeader {
     SendToSocketResponse,
     ReceiveFromSocketRequest,
     ReceiveFromSocketResponse,
+    FileCreationMaskRequest,
+    FileCreationMaskResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -506,6 +508,8 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == SendToSocketResponse as u16 => Ok(SendToSocketResponse),
             x if x == ReceiveFromSocketRequest as u16 => Ok(ReceiveFromSocketRequest),
             x if x == ReceiveFromSocketResponse as u16 => Ok(ReceiveFromSocketResponse),
+            x if x == FileCreationMaskRequest as u16 => Ok(FileCreationMaskRequest),
+            x if x == FileCreationMaskResponse as u16 => Ok(FileCreationMaskResponse),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/sys/stat/message/mod.rs
+++ b/src/libs/syscall/src/sys/stat/message/mod.rs
@@ -11,6 +11,7 @@ mod fstat;
 mod fstatat;
 mod futimens;
 mod mkdirat;
+mod umask;
 mod utimensat;
 
 //==================================================================================================
@@ -38,6 +39,10 @@ pub use self::{
     mkdirat::{
         MakeDirectoryAtRequest,
         MakeDirectoryAtResponse,
+    },
+    umask::{
+        FileCreationMaskRequest,
+        FileCreationMaskResponse,
     },
     utimensat::{
         UpdateFileAccessTimeAtRequest,

--- a/src/libs/syscall/src/sys/stat/message/umask.rs
+++ b/src/libs/syscall/src/sys/stat/message/umask.rs
@@ -1,0 +1,135 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::mem;
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::sys_types::mode_t;
+
+//==================================================================================================
+// FileCreationMaskRequest
+//==================================================================================================
+
+/// Request to set the calling process's file mode creation mask.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct FileCreationMaskRequest {
+    /// New file mode creation mask.
+    pub mask: mode_t,
+    /// Padding.
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(FileCreationMaskRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl FileCreationMaskRequest {
+    /// Size of padding.
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<mode_t>();
+
+    fn new(mask: mode_t) -> Self {
+        Self {
+            mask,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        mask: mode_t,
+        destination: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let request: Self = Self::new(mask);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileCreationMaskRequest,
+            request.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(destination, ThreadIdentifier::NONE),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+//==================================================================================================
+// FileCreationMaskResponse
+//==================================================================================================
+
+/// Response carrying the calling process's previous file mode creation mask.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct FileCreationMaskResponse {
+    /// Previous file mode creation mask.
+    pub mask: mode_t,
+    /// Padding.
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(FileCreationMaskResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl FileCreationMaskResponse {
+    /// Size of padding.
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<mode_t>();
+
+    fn new(mask: mode_t) -> Self {
+        Self {
+            mask,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    pub fn build(
+        tid: ThreadIdentifier,
+        mask: mode_t,
+        source: ProcessIdentifier,
+        message_type: MessageType,
+    ) -> Message {
+        let response: Self = Self::new(mask);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::FileCreationMaskResponse,
+            response.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(source, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            message_type,
+            None,
+            message.into_bytes(),
+        )
+    }
+}

--- a/src/libs/syscall/src/sys/stat/mod.rs
+++ b/src/libs/syscall/src/sys/stat/mod.rs
@@ -31,6 +31,7 @@ cfg_if::cfg_if! {
             futimens,
             mkdir,
             mkdirat,
+            umask,
             utimensat,
         };
         pub mod bindings;

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -15,6 +15,7 @@ mod lstat;
 mod mkdir;
 mod mkdirat;
 mod stat;
+mod umask;
 mod utimensat;
 
 //==================================================================================================
@@ -55,6 +56,7 @@ pub use lstat::lstat;
 pub use mkdir::mkdir;
 pub use mkdirat::mkdirat;
 pub use stat::stat;
+pub use umask::umask;
 pub use utimensat::utimensat;
 
 //==================================================================================================

--- a/src/libs/syscall/src/sys/stat/syscall/umask.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/umask.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    sys::stat::message::{
+        FileCreationMaskRequest,
+        FileCreationMaskResponse,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::Message,
+    pm::ThreadIdentifier,
+};
+use ::sysapi::sys_types::mode_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the calling process's file mode creation mask.
+///
+/// # Parameters
+///
+/// - `mask`: New file mode creation mask.
+///
+/// # Returns
+///
+/// Upon success, the previous file mode creation mask is returned. Otherwise, an error is returned.
+///
+pub fn umask(mask: mode_t) -> Result<mode_t, Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let request: Message =
+        FileCreationMaskRequest::build(tid, mask, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    if response.status != 0 {
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        return Err(Error::new(error_code, "umask() failed"));
+    }
+
+    let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+    let header: SystemCallMessageHeader = message.header;
+    if header != SystemCallMessageHeader::FileCreationMaskResponse {
+        return Err(Error::new(ErrorCode::InvalidMessage, "unexpected message header"));
+    }
+
+    let response: FileCreationMaskResponse = FileCreationMaskResponse::from_bytes(message.payload);
+    Ok(response.mask)
+}

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -76,6 +76,7 @@ use ::sysapi::{
     sys_types::{
         c_size_t,
         gid_t,
+        mode_t,
         off_t,
         uid_t,
     },
@@ -98,6 +99,12 @@ const STAT_BLOCK_SIZE: i64 = 4096;
 
 /// Sector size used for `st_blocks` computation (POSIX convention: 512 bytes).
 const STAT_SECTOR_SIZE: u64 = 512;
+
+/// Default file mode creation mask.
+const DEFAULT_FILE_CREATION_MASK: mode_t = 0;
+
+/// File permission bits affected by the file mode creation mask.
+const FILE_PERMISSION_BITS: mode_t = file_mode::S_IRWXU | file_mode::S_IRWXG | file_mode::S_IRWXO;
 
 //==================================================================================================
 // Public Re-Exports
@@ -230,8 +237,10 @@ pub fn vfs_fork_clone(
     //
     // The placeholder can still carry a working directory: the racing child may have issued a
     // `chdir` before this notification arrived. Capture a directory that differs from the default
-    // so the clone below keeps the child's own cwd instead of reverting it to the parent's.
+    // so the clone below keeps the child's own cwd instead of reverting it to the parent's. An
+    // explicit file creation mask is preserved for the same reason, including `umask(0)`.
     let mut child_cwd: Option<String> = None;
+    let mut child_file_creation_mask: Option<mode_t> = None;
     if let Some(existing) = procs.get(&child) {
         if existing.initialized {
             return Err(Fat32Error::AlreadyExists);
@@ -239,6 +248,7 @@ pub fn vfs_fork_clone(
         if existing.cwd != DEFAULT_CWD {
             child_cwd = Some(existing.cwd.clone());
         }
+        child_file_creation_mask = existing.file_creation_mask;
     }
     // The parent must already be registered. `procd` registers every process at creation and is the
     // sole authority for doing so, so forking from an unregistered parent is a contract violation:
@@ -260,8 +270,33 @@ pub fn vfs_fork_clone(
     if let Some(cwd) = child_cwd {
         child_state.cwd = cwd;
     }
+    if child_file_creation_mask.is_some() {
+        child_state.file_creation_mask = child_file_creation_mask;
+    }
     procs.insert(child, child_state);
     Ok(())
+}
+
+/// Sets the current process's file mode creation mask and returns the previous mask.
+pub fn vfs_umask(mask: mode_t) -> mode_t {
+    let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
+        PROCESSES.lock();
+    let state: &mut ProcessState = procs.entry(current_pid()).or_insert_with(ProcessState::new);
+    let previous: mode_t = state
+        .file_creation_mask
+        .unwrap_or(DEFAULT_FILE_CREATION_MASK);
+    state.file_creation_mask = Some(mask & FILE_PERMISSION_BITS);
+    previous
+}
+
+/// Applies the current process's file mode creation mask to `mode`.
+pub fn vfs_apply_umask(mode: mode_t) -> mode_t {
+    let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
+    let mask: mode_t = procs
+        .get(&current_pid())
+        .and_then(|state| state.file_creation_mask)
+        .unwrap_or(DEFAULT_FILE_CREATION_MASK);
+    mode & !mask
 }
 
 /// Seeds the root process's standard console descriptors (`0`/`1`/`2`) and marks its state active.
@@ -2368,6 +2403,31 @@ mod tests {
         CURRENT_PID.store(0, Ordering::Relaxed);
         // Clear the one-shot root-seeding latch so a later test starts from a pristine state.
         ROOT_CONSOLE_SEEDED.store(false, Ordering::Relaxed);
+    }
+
+    /// Tests file creation mask normalization, fork inheritance, and exec preservation.
+    #[test]
+    fn umask_follows_process_lifecycle() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let (parent, child): (ProcessIdentifier, ProcessIdentifier) =
+            (ProcessIdentifier::from(0x7103), ProcessIdentifier::from(0x7104));
+
+        set_current_process(parent);
+        assert_eq!(vfs_umask(0o1277), 0, "a new process starts with an empty mask");
+        assert_eq!(vfs_apply_umask(0o7777), 0o7500, "only the low nine permission bits are masked");
+
+        vfs_fork_clone(parent, child).expect("fork clone should succeed");
+        set_current_process(child);
+        assert_eq!(vfs_apply_umask(0o7777), 0o7500, "a child inherits its parent's mask");
+
+        drop(vfs_exec_cloexec(child));
+        assert_eq!(vfs_apply_umask(0o7777), 0o7500, "exec must preserve the process mask");
+        assert_eq!(vfs_umask(0), 0o277, "umask returns the normalized previous mask");
+
+        set_current_process(parent);
+        assert_eq!(vfs_apply_umask(0o7777), 0o7500, "the child's mask change is isolated");
+
+        forget_processes(&[parent, child]);
     }
 
     /// Tests that the descriptor-table generation advances on every table mutation (open, flag

--- a/src/libs/vfs/src/process.rs
+++ b/src/libs/vfs/src/process.rs
@@ -25,7 +25,10 @@ use ::spin::Mutex;
 use ::sys::pm::ProcessIdentifier;
 use ::sysapi::{
     ffi::c_int,
-    sys_types::off_t,
+    sys_types::{
+        mode_t,
+        off_t,
+    },
 };
 
 //==================================================================================================
@@ -84,6 +87,8 @@ pub(crate) struct ProcessState {
     pub(crate) slots: BTreeMap<c_int, Slot>,
     /// Current working directory.
     pub(crate) cwd: String,
+    /// Explicit file mode creation mask, or `None` for the default mask.
+    pub(crate) file_creation_mask: Option<mode_t>,
     /// Whether this state is active rather than a lazy placeholder.
     pub(crate) initialized: bool,
     /// Descriptor-table coherence generation.
@@ -96,6 +101,7 @@ impl ProcessState {
         Self {
             slots: BTreeMap::new(),
             cwd: String::from(DEFAULT_CWD),
+            file_creation_mask: None,
             initialized: false,
             generation: 0,
         }
@@ -106,6 +112,7 @@ impl ProcessState {
         Self {
             slots: self.slots.clone(),
             cwd: self.cwd.clone(),
+            file_creation_mask: self.file_creation_mask,
             initialized: true,
             generation: self.generation,
         }

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -126,6 +126,12 @@ extern void test_symlinkat(void);
 // Tests whether we can remove a file.
 extern void test_unlinkat(void);
 
+// Tests whether we can set the file mode creation mask.
+extern void test_umask(void);
+
+// Tests whether we can create a RAMFS file while a file mode creation mask is active.
+extern void test_umask_ramfs(void);
+
 // Tests whether we can change file access and modification times.
 extern void test_utimensat(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -129,6 +129,8 @@ int main(int argc, const char *argv[])
     test_mkdir();      // requires stat() and unlinkat().
     test_mkfifo();     // mkfifo() is unsupported; verifies it fails with ENOTSUP.
     test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
+    test_umask_ramfs(); // tests umask(), open(), close(), stat(), and unlink() on RAMFS.
+    test_umask();      // tests umask(), open(), stat(), mkdir(), and unlinkat().
     test_dirent();
     test_getcwd();
     test_chdir(); // requires getcwd().

--- a/src/tests/integration/test-c-file/umask.c
+++ b/src/tests/integration/test-c-file/umask.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Imported Symbols
+//==================================================================================================
+
+extern int mount(
+    const char *source,
+    const char *target,
+    const char *filesystemtype,
+    unsigned long mountflags);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can set the file mode creation mask.
+void test_umask(void)
+{
+    fprintf(stderr, "testing umask() ... ");
+
+    const mode_t permissions = S_IRWXU | S_IRWXG | S_IRWXO;
+    const mode_t mask = S_IWUSR | S_IRWXG | S_IRWXO;
+    const mode_t previous_mask = umask(0);
+
+    // Set the mask and verify that umask() returns its previous normalized value.
+    assert(umask(mask) == 0);
+    assert(umask(mask | ~permissions) == mask);
+    assert(umask(mask) == mask);
+
+    if (getenv("NANVIX_TEST_HOSTFS_PERMISSIONS") != NULL) {
+        const mode_t expected_mode = permissions & ~mask;
+        const char *filename = "/mnt/umask-file";
+        const char *dirname = "/mnt/umask-dir";
+        struct stat st = {0};
+
+        // Hostfs exposes Unix permission bits, unlike the standalone FAT32 filesystem.
+        assert(mount("", "/mnt", "hostfs", 0) == 0);
+
+        // Verify that the mask is applied when creating a regular file.
+        int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, permissions);
+        assert(fd >= 0);
+        assert(close(fd) == 0);
+        assert(stat(filename, &st) == 0);
+        assert(S_ISREG(st.st_mode));
+        assert((st.st_mode & permissions) == expected_mode);
+        assert(unlink(filename) == 0);
+
+        // Verify that the mask is applied when creating a directory.
+        assert(mkdir(dirname, permissions) == 0);
+        assert(stat(dirname, &st) == 0);
+        assert(S_ISDIR(st.st_mode));
+        assert((st.st_mode & permissions) == expected_mode);
+        assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);
+    }
+
+    // Restore the mask for the remaining tests.
+    assert(umask(previous_mask) == mask);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-file/umask_ramfs.c
+++ b/src/tests/integration/test-c-file/umask_ramfs.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can create a RAMFS file while a file mode creation mask is active.
+void test_umask_ramfs(void)
+{
+    fprintf(stderr, "testing umask() on RAMFS ... ");
+
+    const char *filename = "/umask-ramfs-file";
+    const mode_t permissions = S_IRWXU | S_IRWXG | S_IRWXO;
+    const mode_t mask = S_IRWXG | S_IRWXO;
+    const mode_t previous_mask = umask(mask);
+
+    // RAMFS does not preserve POSIX permissions, but file creation must succeed with an active mask.
+    int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, permissions);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+
+    struct stat st = {0};
+    assert(stat(filename, &st) == 0);
+    assert(S_ISREG(st.st_mode));
+    assert(unlink(filename) == 0);
+
+    // Restore the previous mask and verify that the mask remained active during file creation.
+    assert(umask(previous_mask) == mask);
+
+    fprintf(stderr, "passed\n");
+}

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -261,7 +261,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-file"
 program = "./bin/test-c-file.initrd"
-extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img"
+extra_nanvixd_args = "-ramfs ./bin/posix-tests-ramfs.img -mount ./bin/posix-tests-ramfs-seed"
 expected_exit_code = 0
 
 [[tests]]


### PR DESCRIPTION
## Summary

Implements the POSIX file mode creation mask (`umask()`), which was
previously a stub that logged "not implemented" and always returned `0`.
Now `umask()` sets the calling process's mask and returns the previous
one, and mask bits are stripped from the mode of newly created files and
directories. Closes #597.

## What changed

**Libraries**
- `vfs`: add a per-process `file_creation_mask` to `ProcessState`;
  `vfs_umask()` sets/normalizes the mask (low nine permission bits only)
  and `vfs_apply_umask()` clears masked bits from a mode. The mask is
  preserved across `fork` (including explicit `umask(0)`) and `exec`.
- `syscall`: add `FileCreationMask` request/response messages and a
  `umask()` syscall wrapper that talks to vfsd; register the new message
  headers.
- `libc_sys_stat`: route `umask()` through the new syscall, widen its
  signature to `mode_t`, and log on failure.
- `hostfs-api`: thread a creation mode through `OpenRequest` and the long
  open wire format (op_id/flags/mode/path_len header).

**Daemons**
- `vfsd`: dispatch `FileCreationMaskRequest` to a new `handle_umask()`;
  apply the process mask to `openat` and `mkdirat` modes before
  forwarding.
- `hostfsd`: set the requested permissions on files created by `open` on
  Unix hosts, rolling back the file on failure.

**Tests**
- `vfs`: unit test covering mask normalization, fork inheritance, and
  exec preservation.
- `hostfsd`: thread mode through open request helpers and assert the
  creation mode is applied on disk.
- `test-c-file`: `umask_ramfs.c` verifies file creation succeeds with an
  active mask on RAMFS; `umask.c` verifies normalization and, when
  `NANVIX_TEST_HOSTFS_PERMISSIONS` is set, mounts hostfs and asserts the
  mask is applied to created files and directories.

**Build and harness wiring**
- `posix-tests.mk`: register the new sources and set
  `NANVIX_TEST_HOSTFS_PERMISSIONS=1` on non-Windows hosts.
- `test-posix.toml`: seed a host mount directory for the hostfs cases.