### PR TITLE
[libs] F: Add pthread_condattr_getpshared

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -61,6 +61,7 @@ typedef struct {
 typedef struct {
     int is_initialized; /**< Whether the attributes are initialized. */
     clock_t clock;      /**< Clock used for timeouts.                */
+    int pshared;        /**< Process-sharing attribute.               */
 } pthread_condattr_t;
 
 /** @brief Mutex attributes. */
@@ -146,6 +147,7 @@ extern int pthread_cond_broadcast(const pthread_cond_t *cond);
 extern int pthread_cond_wait(const pthread_cond_t *cond, pthread_mutex_t *mutex);
 extern int pthread_cond_timedwait(const pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
 extern int pthread_condattr_init(pthread_condattr_t *attr);
+extern int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 extern int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);
 
 /*==================================================================================================

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -42,6 +42,7 @@ typedef struct {
 typedef struct {
     int is_initialized; /**< Whether the attributes are initialized. */
     clock_t clock;      /**< Clock used for timeouts.                */
+    int pshared;        /**< Process-sharing attribute.               */
 } pthread_condattr_t;
 
 /** @brief Mutex attributes. */
@@ -142,6 +143,7 @@ functions = [
     "pthread_cond_wait",
     "pthread_cond_timedwait",
     "pthread_condattr_init",
+    "pthread_condattr_getpshared",
     "pthread_condattr_setclock",
 ]
 

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -205,6 +205,8 @@ pub struct pthread_condattr_t {
     is_initialized: c_int,
     /// Clock used for timeouts.
     clock: clock_t,
+    /// Process-sharing attribute.
+    pshared: c_int,
 }
 // No `assert_eq_size!`: the serialized size may differ from `sizeof` on 64-bit targets due to
 // alignment padding.
@@ -214,9 +216,22 @@ impl pthread_condattr_t {
     const SIZE_OF_IS_INITIALIZED: usize = size_of::<c_int>();
     // Size of the `clock` field.
     const SIZE_OF_CLOCK: usize = size_of::<clock_t>();
+    // Size of the `pshared` field.
+    const SIZE_OF_PSHARED: usize = size_of::<c_int>();
 
     /// Size of `pthread_condattr_t` structure.
-    pub const SIZE: usize = Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_CLOCK;
+    pub const SIZE: usize =
+        Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_CLOCK + Self::SIZE_OF_PSHARED;
+
+    /// Returns whether the condition variable attributes object is initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.is_initialized != 0
+    }
+
+    /// Returns the process-sharing attribute.
+    pub fn pshared(&self) -> c_int {
+        self.pshared
+    }
 }
 
 impl Default for pthread_condattr_t {
@@ -224,6 +239,7 @@ impl Default for pthread_condattr_t {
         Self {
             is_initialized: 1,
             clock: CLOCK_REALTIME as clock_t,
+            pshared: PTHREAD_PROCESS_PRIVATE,
         }
     }
 }

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -16,6 +16,7 @@ pub mod pthread_cond_init;
 pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
+pub mod pthread_condattr_getpshared;
 pub mod pthread_condattr_init;
 pub mod pthread_condattr_setclock;
 pub mod pthread_create;

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_getpshared.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_getpshared.rs
@@ -1,0 +1,92 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_condattr_t,
+};
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the process-sharing attribute from a condition variable attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object.
+/// - `pshared`: Pointer where the process-sharing attribute is stored on success.
+///
+/// # Returns
+///
+/// The `pthread_condattr_getpshared()` function returns `0` on success. On error, it returns an
+/// error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_condattr_t` object.
+/// - `pshared` points to a valid `int` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_condattr_getpshared(
+    attr: *const pthread_condattr_t,
+    pshared: *mut c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_getpshared(): invalid pointer to condition variable attributes \
+             object (attr={attr:p}, pshared={pshared:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_condattr_t>()) {
+        ::syslog::warn!(
+            "pthread_condattr_getpshared(): misaligned pointer to condition variable attributes \
+             object (attr={attr:p}, pshared={pshared:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `pshared` is not valid.
+    if pshared.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_getpshared(): invalid pointer to process-sharing attribute \
+             (attr={attr:p}, pshared={pshared:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `pshared` is misaligned.
+    if !(pshared as usize).is_multiple_of(::core::mem::align_of::<c_int>()) {
+        ::syslog::warn!(
+            "pthread_condattr_getpshared(): misaligned pointer to process-sharing attribute \
+             (attr={attr:p}, pshared={pshared:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the condition variable attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_condattr_getpshared(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    *pshared = (*attr).pshared();
+    0
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -24,6 +24,9 @@ extern void test_pthread_mutex_dynamic_init(void);
 // Tests if condition variable attributes can be initialized.
 extern void test_pthread_condattr_init(void);
 
+// Tests if the process-sharing attribute can be retrieved.
+extern void test_pthread_condattr_getpshared(void);
+
 // Tests if calling exit() causes the program to exit even if there are other threads running.
 extern void test_pthread_nowait(void);
 

--- a/src/tests/integration/test-c-thread/condattr_getpshared.c
+++ b/src/tests/integration/test-c-thread/condattr_getpshared.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the process-sharing attribute can be retrieved.
+void test_pthread_condattr_getpshared(void)
+{
+    fprintf(stderr, "testing pthread_condattr_getpshared() ... ");
+
+    pthread_condattr_t attr = {
+        .pshared = PTHREAD_PROCESS_SHARED,
+    };
+    int ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+
+    // Initialization must overwrite caller-provided storage with the default value.
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+
+    int pshared = PTHREAD_PROCESS_SHARED;
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_condattr_getpshared(NULL, &pshared);
+    assert(ret != 0);
+    ret = pthread_condattr_getpshared(&attr, NULL);
+    assert(ret != 0);
+
+    // Misaligned pointers must be rejected.
+    _Alignas(pthread_condattr_t) unsigned char attr_storage[sizeof(pthread_condattr_t) + 1];
+    ret = pthread_condattr_getpshared((pthread_condattr_t *)&attr_storage[1], &pshared);
+    assert(ret != 0);
+    _Alignas(int) unsigned char pshared_storage[sizeof(int) + 1];
+    ret = pthread_condattr_getpshared(&attr, (int *)&pshared_storage[1]);
+    assert(ret != 0);
+
+    // Uninitialized condition variable attributes objects must be rejected.
+    attr.is_initialized = 0;
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret != 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -89,8 +89,9 @@ int main(int argc, const char *argv[])
 
     // Sanity check size of `pthread_condattr_t` type.
     STATIC_ASSERT_SIZE(pthread_condattr_t,
-                       sizeof(int) +       // is_initialized
-                           sizeof(clock_t) // clock
+                       sizeof(int) +        // is_initialized
+                           sizeof(clock_t) + // clock
+                           sizeof(int)       // pshared
     );
 
     // Sanity check size of `pthread_mutex_t` type.
@@ -133,6 +134,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
     test_pthread_condattr_init();
+    test_pthread_condattr_getpshared();
     test_pthread_rwlock_static_init();
     test_pthread_rwlock_dynamic_init();
     test_pthread_cond_static_init();
@@ -145,10 +147,7 @@ int main(int argc, const char *argv[])
     test_pthread_nowait();
 
     // Write magic string to signal that the test passed.
-    {
-        const char *magic_string = "ok";
-        write(STDOUT_FILENO, magic_string, 2);
-    }
+    write(STDOUT_FILENO, "ok", 2);
 
     return (0);
 }


### PR DESCRIPTION
## Summary

Adds `pthread_condattr_getpshared()` to retrieve the process-sharing
attribute of a condition variable attributes object, extending the
pthread condition-variable attribute surface toward POSIX conformance.

## Changes

**Libraries:**
- `sysapi`: add the `pshared` field to `pthread_condattr_t`, defaulting
  to `PTHREAD_PROCESS_PRIVATE`, and account for it in the serialized
  `SIZE`. Expose `is_initialized()` and `pshared()` accessors.
- `syscall`: add the `pthread_condattr_getpshared` binding, validating
  the `attr` and `pshared` pointers and the initialized state before
  storing the attribute, and register the module.

**Headers:**
- Declare `pthread_condattr_getpshared()` and add the `pshared` field to
  `pthread_condattr_t` in `include/pthread.h` and the sysapi
  `pthread.toml`.

**Tests:**
- Add `condattr_getpshared.c` to the C threads integration test, covering
  the default value, read-back, NULL-pointer rejection, and
  uninitialized-object rejection.
- Extend the `pthread_condattr_t` `STATIC_ASSERT_SIZE` for the new field.