### PR TITLE
Verify physical memory modules (proofs)

### DIFF
--- a/src/kernel/src/hal/mem/types/address/aligned/page.rs
+++ b/src/kernel/src/hal/mem/types/address/aligned/page.rs
@@ -219,7 +219,7 @@ impl PageAligned<PhysicalAddress> {
     }
 
     /// Converts a page-aligned physical address into its frame number.
-    #[verus_verify(external_body)]
+    #[verus_verify]
     #[verus_spec(result =>
         ensures
             result@ == self@ / (::arch::mem::PAGE_SIZE as int),

--- a/src/kernel/src/hal/mem/types/address/frame.proof.rs
+++ b/src/kernel/src/hal/mem/types/address/frame.proof.rs
@@ -1,0 +1,38 @@
+use vstd::arithmetic::div_mod::{
+    lemma_fundamental_div_mod,
+    lemma_mod_multiples_basic,
+};
+
+verus! {
+
+// =================================================================================================
+// Proof obligations for `FrameAddress`'s frame-number conversions.
+//
+// The facts below are elementary divisibility properties of `spec_page_size()`, which is the
+// `#[verus_verify]` constant `arch::mem::PAGE_SIZE == 4096` and therefore strictly positive.
+// =================================================================================================
+
+// `frame_index * PAGE_SIZE` is a multiple of `PAGE_SIZE`, hence page-aligned. Used by
+// `from_frame_number` to discharge `PageAligned::from_address`'s alignment success condition.
+pub proof fn lemma_frame_base_aligned(frame: FrameNumber)
+    ensures
+        frame@ * spec_page_size() % spec_page_size() == 0,
+{
+    // `frame@ * spec_page_size()` is a multiple of `spec_page_size()`, so its remainder mod
+    // `spec_page_size()` is zero.
+    lemma_mod_multiples_basic(frame@, spec_page_size());
+}
+
+// For a page-aligned address, dividing by `PAGE_SIZE` then multiplying recovers the address
+// exactly. Used by `into_frame_number` to relate the recovered frame number back to `self@`.
+pub proof fn lemma_aligned_div_mul(addr: int)
+    requires
+        addr % spec_page_size() == 0,
+    ensures
+        (addr / spec_page_size()) * spec_page_size() == addr,
+{
+    // `addr == s * (addr / s) + (addr % s)` with `addr % s == 0`, so `(addr / s) * s == addr`.
+    lemma_fundamental_div_mod(addr, spec_page_size());
+}
+
+} // verus!

--- a/src/kernel/src/hal/mem/types/address/frame.rs
+++ b/src/kernel/src/hal/mem/types/address/frame.rs
@@ -8,6 +8,8 @@
 use vstd::prelude::*;
 #[cfg(verus_keep_ghost)]
 include!("frame.spec.rs");
+#[cfg(verus_keep_ghost)]
+include!("frame.proof.rs");
 
 use crate::hal::mem::types::address::{
     Address,
@@ -57,7 +59,6 @@ impl FrameAddress {
     // Constructs a frame address from a frame number. The frame's base address is
     // `frame_number * PAGE_SIZE`, page-aligned by construction, so the call always succeeds and the
     // result satisfies `inv()`.
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         ensures
             result is Ok,
@@ -65,6 +66,7 @@ impl FrameAddress {
             (result->Ok_0)@ == frame_number@ * spec_page_size(),
     )]
     pub fn from_frame_number(frame_number: FrameNumber) -> Result<Self, Error> {
+        proof! { lemma_frame_base_aligned(frame_number); }
         Ok(Self(PageAligned::from_address(PhysicalAddress::from(frame_number))?))
     }
 
@@ -73,7 +75,6 @@ impl FrameAddress {
     // holds); representability is automatic because the underlying
     // `PhysicalAddress::into_frame_number` is total. The result is the exact inverse of
     // `from_frame_number`.
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             self.inv(),
@@ -82,12 +83,12 @@ impl FrameAddress {
             result@ * spec_page_size() == self@,
     )]
     pub fn into_frame_number(self) -> FrameNumber {
+        proof! { lemma_aligned_div_mul(self@); }
         self.0.into_frame_number()
     }
 
     // Succeeds only for page-aligned inputs. The contract exposes the validated raw address to
     // verified callers.
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         ensures
             match result {

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -11,7 +11,8 @@
 #![allow(static_mut_refs)] // https://github.com/nanvix/kernel/issues/454
 #![allow(internal_features)]
 #![feature(allocator_api)] // kheap uses this.
-#![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
+#![feature(proc_macro_hygiene)] // statement-level verus_spec loop invariants need this.
+#![cfg_attr(not(verus_keep_ghost), feature(stmt_expr_attributes))]
 #![feature(linked_list_cursors)] // vmem uses this.
 #![feature(linked_list_remove)] // vmem uses this.
 #![feature(linked_list_retain)] // vmem uses this.

--- a/src/kernel/src/mm/phys/frame.proof.rs
+++ b/src/kernel/src/mm/phys/frame.proof.rs
@@ -73,4 +73,1283 @@ impl Inner {
     }
 }
 
+//==================================================================================================
+// Arithmetic helper lemmas relating frame addresses and bitmap indices
+//==================================================================================================
+
+/// For a page-aligned address `a`, dividing by the page size then multiplying recovers `a`.
+proof fn lemma_aligned_addr_index(a: int)
+    requires
+        a % spec_page_size() == 0,
+        spec_page_size() > 0,
+    ensures
+        frame_addr_of(a / spec_page_size()) == a,
+{
+    vstd::arithmetic::div_mod::lemma_fundamental_div_mod(a, spec_page_size());
+    vstd::arithmetic::mul::lemma_mul_is_commutative(a / spec_page_size(), spec_page_size());
+}
+
+/// `frame_addr_of` is injective: distinct indices map to distinct frame addresses.
+proof fn lemma_frame_addr_injective(i: int, j: int)
+    requires
+        frame_addr_of(i) == frame_addr_of(j),
+        spec_page_size() > 0,
+    ensures
+        i == j,
+{
+    vstd::arithmetic::mul::lemma_mul_is_commutative(i, spec_page_size());
+    vstd::arithmetic::mul::lemma_mul_is_commutative(j, spec_page_size());
+    vstd::arithmetic::mul::lemma_mul_equality_converse(spec_page_size(), i, j);
+}
+
+/// Every frame address is page-aligned: `frame_addr_of(i) % spec_page_size() == 0`.
+proof fn lemma_frame_addr_mod_zero(i: int)
+    requires
+        spec_page_size() > 0,
+    ensures
+        frame_addr_of(i) % spec_page_size() == 0,
+{
+    vstd::arithmetic::div_mod::lemma_mod_multiples_basic(i, spec_page_size());
+}
+
+/// Dividing a frame address by the page size recovers its index.
+proof fn lemma_frame_addr_div(i: int)
+    requires
+        spec_page_size() > 0,
+    ensures
+        frame_addr_of(i) / spec_page_size() == i,
+{
+    vstd::arithmetic::div_mod::lemma_div_multiples_vanish(i, spec_page_size());
+}
+
+/// Frame addresses split additively over the index: `frame_addr_of(base + j)` is
+/// `frame_addr_of(base) + j * spec_page_size()`.
+proof fn lemma_frame_addr_split(base: int, j: int)
+    ensures
+        frame_addr_of(base + j) == frame_addr_of(base) + j * spec_page_size(),
+{
+    vstd::arithmetic::mul::lemma_mul_is_distributive_add_other_way(spec_page_size(), base, j);
+}
+
+/// Division by the page size distributes over a sum of two page-aligned values.
+proof fn lemma_aligned_div_sum(a: int, b: int)
+    requires
+        spec_page_size() > 0,
+        a % spec_page_size() == 0,
+        b % spec_page_size() == 0,
+    ensures
+        (a + b) / spec_page_size() == a / spec_page_size() + b / spec_page_size(),
+{
+    let ps = spec_page_size();
+    vstd::arithmetic::div_mod::lemma_fundamental_div_mod(a, ps);
+    vstd::arithmetic::div_mod::lemma_fundamental_div_mod(b, ps);
+    // a == (a/ps)*ps and b == (b/ps)*ps, so a + b == (a/ps + b/ps)*ps.
+    assert(a == ps * (a / ps));
+    assert(b == ps * (b / ps));
+    assert(a + b == ps * (a / ps + b / ps)) by {
+        vstd::arithmetic::mul::lemma_mul_is_distributive_add(ps, a / ps, b / ps);
+    }
+    vstd::arithmetic::div_mod::lemma_div_multiples_vanish(a / ps + b / ps, ps);
+}
+
+/// A positive, page-aligned size spans at least one frame.
+proof fn lemma_size_div_pos(size: int)
+    requires
+        spec_page_size() > 0,
+        size > 0,
+        size % spec_page_size() == 0,
+    ensures
+        size / spec_page_size() >= 1,
+{
+    let ps = spec_page_size();
+    vstd::arithmetic::div_mod::lemma_fundamental_div_mod(size, ps);
+    vstd::arithmetic::div_mod::lemma_div_pos_is_pos(size, ps);
+    assert(size == ps * (size / ps));
+    if size / ps == 0 {
+        assert(size == ps * 0);
+    }
+}
+
+// A non-page-aligned address can never be a tracked (allocated) frame.
+//==================================================================================================
+// Refcount-slot accessors
+//==================================================================================================
+
+/// The integer value of the refcount slot for index `i`. A spec-fn wrapper so the value can be
+/// named in `proof fn` postconditions without dereferencing the `&'static mut [u8]` field directly
+/// (which Verus rejects in an `ensures`); reading the field in a spec-fn body is the same context
+/// `view()`/`internal_inv()` already use.
+closed spec fn spec_refcount_slot(inner: &Inner, i: int) -> int {
+    inner.refcount@[i] as int
+}
+
+/// The full refcount sequence of `inner`. A spec-fn wrapper so the `&'static mut [u8]` field can
+/// be named in `proof fn` postconditions (Verus rejects dereferencing a `&mut` field directly in
+/// an `ensures`); reading the field in a spec-fn body is the same context `view()` already uses.
+closed spec fn spec_refcount_seq(inner: &Inner) -> Seq<u8> {
+    inner.refcount@
+}
+
+//==================================================================================================
+// Covered-frame membership lemmas (collapsed single-refcount-map view)
+//==================================================================================================
+
+/// A non-page-aligned address is never covered by the allocator.
+proof fn lemma_uncovered_unaligned(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() != 0,
+    ensures
+        !inner@.is_covered(addr),
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    if inner@.is_covered(addr) {
+        let i = addr_to_frame(addr);
+        lemma_frame_addr_mod_zero(i);
+        assert(addr == frame_addr_of(i));
+        assert(false);
+    }
+}
+
+/// A page-aligned address is covered iff its bitmap index is in range.
+proof fn lemma_covered_iff(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+    ensures
+        inner@.is_covered(addr) <==> 0 <= addr / spec_page_size() < inner.bitmap@.num_bits,
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    let i = addr / spec_page_size();
+    lemma_aligned_addr_index(addr);
+    assert(frame_addr_of(i) == addr);
+}
+
+/// The refcount-map value at a covered address equals the underlying refcount slot.
+proof fn lemma_refcount_value(inner: &Inner, addr: int)
+    requires
+        inner@.refcounts.contains_key(addr),
+    ensures
+        inner@.refcounts[addr] == spec_refcount_slot(inner, addr / spec_page_size()),
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+}
+
+/// A page-aligned address is allocated iff its bitmap index is in range and its bit is set.
+proof fn lemma_alloc_contains(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+    ensures
+        inner@.is_allocated(addr) <==> {
+            let i = addr / spec_page_size();
+            &&& 0 <= i < inner.bitmap@.num_bits
+            &&& inner.bitmap@.set_bits.contains(i)
+        },
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    let i = addr / spec_page_size();
+    lemma_covered_iff(inner, addr);
+    if inner@.is_covered(addr) {
+        lemma_refcount_value(inner, addr);
+    } else {
+        if 0 <= i < inner.bitmap@.num_bits && inner.bitmap@.set_bits.contains(i) {
+            assert(false);
+        }
+    }
+}
+
+/// A page-aligned address is free iff its bitmap index is in range and its bit is unset.
+proof fn lemma_free_contains(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+    ensures
+        inner@.is_free(addr) <==> {
+            let i = addr / spec_page_size();
+            &&& 0 <= i < inner.bitmap@.num_bits
+            &&& !inner.bitmap@.set_bits.contains(i)
+        },
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    let i = addr / spec_page_size();
+    lemma_covered_iff(inner, addr);
+    if inner@.is_covered(addr) {
+        lemma_refcount_value(inner, addr);
+    }
+}
+
+//==================================================================================================
+// Refcount-query error-path lemma
+//==================================================================================================
+
+/// A frame index that is past the refcount slice, or that names a zero refcount slot, cannot be a
+/// set bit. Extracted from the two error paths of `Inner::refcount` so their reasoning lives here
+/// instead of inline in the exec body.
+proof fn lemma_refcount_err_bit_clear(inner: &Inner, i: int)
+    requires
+        inner.internal_inv(),
+        i >= 0,
+        i >= spec_refcount_seq(inner).len() || spec_refcount_slot(inner, i) == 0,
+    ensures
+        !inner.bitmap@.set_bits.contains(i),
+{
+    // In-range indices (`i < num_bits <= refcount.len()`) have `i < len`, so the slice slot is the
+    // relevant zero and `internal_inv` ties a zero slot to a clear bit. Out-of-range indices are
+    // excluded by bitmap well-formedness (`wf`: `set_bits` only holds indices `< num_bits`).
+    if i < inner.bitmap@.num_bits {
+        assert(spec_refcount_slot(inner, i) == 0);
+    }
+}
+
+//==================================================================================================
+// Pure view reconstruction and state-transition lemmas
+//==================================================================================================
+
+/// Pure, field-level reconstruction of `Inner::view()` from its bitmap width and refcount
+/// sequence. In the collapsed model the abstract view depends only on `num_bits` (which fixes the
+/// covered domain) and `refcount` (the per-frame counts); `set_bits` is retained in the signature
+/// for symmetry with the bitmap mutations but does not affect the result.
+closed spec fn view_of(set_bits: Set<int>, num_bits: int, refcount: Seq<u8>) -> FrameAllocView {
+    FrameAllocView {
+        refcounts: Map::new(
+            covered_addrs(num_bits),
+            |addr: int| refcount[addr_to_frame(addr)] as int,
+        ),
+    }
+}
+
+/// `Inner::view()` equals `view_of` applied to its own bitmap/refcount component values.
+proof fn lemma_view_of(inner: &Inner)
+    ensures
+        inner@ == view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner)),
+{
+    broadcast use vstd::map::group_map_lemmas;
+    let v = view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner));
+    assert(inner@.refcounts =~= v.refcounts);
+    assert(inner@ =~= v);
+}
+
+//==================================================================================================
+// `Inner::book` support lemmas
+//==================================================================================================
+
+/// Setup facts for `Inner::book`: the abstract view is the field-level reconstruction, and freeness
+/// of `addr` is decided by its bit. Extracted from the entry `proof!` block of `book`.
+proof fn lemma_book_pre(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+    ensures
+        inner@ == view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner)),
+        inner@.is_free(addr) <==> {
+            let i = addr / spec_page_size();
+            0 <= i < inner.bitmap@.num_bits && !inner.bitmap@.set_bits.contains(i)
+        },
+{
+    lemma_view_of(inner);
+    lemma_free_contains(inner, addr);
+}
+
+/// Err-path facts for `Inner::book`: when `bitmap.set` fails the state is unchanged (so the view
+/// still equals `g_old`) and `addr` was not free to begin with. Extracted from the `Err` branch's
+/// `proof!` block of `book`; the failed-`set` condition is threaded in as a precondition.
+proof fn lemma_book_set_failed(inner: &Inner, addr: int, g_old: FrameAllocView)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+        g_old == view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner)),
+        ({
+            let i = addr / spec_page_size();
+            i >= inner.bitmap@.num_bits || inner.bitmap@.set_bits.contains(i)
+        }),
+    ensures
+        inner@ == g_old,
+        !g_old.is_free(addr),
+{
+    lemma_view_of(inner);
+    lemma_free_contains(inner, addr);
+}
+
+/// Setup facts for `Inner::free`: the abstract view is the field-level reconstruction, and
+/// allocation of `addr` is decided by its bit. Extracted from the entry `proof!` block of `free`.
+proof fn lemma_free_pre(inner: &Inner, addr: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+    ensures
+        inner@ == view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner)),
+        inner@.is_allocated(addr) <==> {
+            let i = addr / spec_page_size();
+            0 <= i < inner.bitmap@.num_bits && inner.bitmap@.set_bits.contains(i)
+        },
+{
+    lemma_view_of(inner);
+    lemma_alloc_contains(inner, addr);
+}
+
+/// Overflow-path facts for `Inner::share`: when `checked_add` rejects the increment the refcount
+/// slot was already at the `u8` ceiling, so the state is unchanged and the abstract count is 255.
+/// Extracted from the `None` branch's `proof!` block of `share`.
+proof fn lemma_share_overflow(inner: &Inner, addr: int, fnx: int, g_old: FrameAllocView)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < spec_refcount_seq(inner).len(),
+        spec_refcount_slot(inner, fnx) == 255,
+        g_old == view_of(inner.bitmap@.set_bits, inner.bitmap@.num_bits, spec_refcount_seq(inner)),
+    ensures
+        inner@ == g_old,
+        g_old.refcounts[addr] == 255,
+{
+    lemma_view_of(inner);
+    lemma_frame_allocated(inner, addr, fnx);
+}
+
+/// The set of frame addresses of a contiguous index range `[start, start + count)`.
+closed spec fn spec_range_frames(start: int, count: int) -> Set<int> {
+    BitmapView::range_set(start, start + count).map_by(|i: int| frame_addr_of(i), |addr: int| addr_to_frame(addr))
+}
+
+/// Core single-slot transition: writing refcount slot `fnx` (page index of `addr`) to value `v`
+/// updates exactly the abstract refcount at `addr`, leaving the covered domain and every other
+/// count unchanged. The `set_bits` arguments are irrelevant to the collapsed view and may differ.
+proof fn lemma_view_of_set_slot(
+    sb2: Set<int>,
+    sb: Set<int>,
+    nb: int,
+    rc: Seq<u8>,
+    fnx: int,
+    addr: int,
+    v: u8,
+)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+    ensures
+        view_of(sb2, nb, rc.update(fnx, v)) == (FrameAllocView {
+            refcounts: view_of(sb, nb, rc).refcounts.insert(addr, v as int),
+        }),
+{
+    broadcast use
+        vstd::set_lib::group_set_lib_default,
+        vstd::map::group_map_lemmas,
+        vstd::map_lib::group_map_properties;
+    lemma_aligned_addr_index(addr);
+    lemma_frame_addr_div(fnx);
+    assert(frame_addr_of(fnx) == addr);
+    let lhs = view_of(sb2, nb, rc.update(fnx, v)).refcounts;
+    let rhs = view_of(sb, nb, rc).refcounts.insert(addr, v as int);
+    assert(covered_addrs(nb).contains(addr));
+    assert(lhs.dom() =~= rhs.dom());
+    assert forall|a: int| lhs.dom().contains(a) implies #[trigger] lhs[a] == rhs[a] by {
+        let j = addr_to_frame(a);
+        assert(covered_addrs(nb).contains(a));
+        assert(a == frame_addr_of(j));
+        lemma_frame_addr_div(j);
+        if a == addr {
+            assert(j == fnx);
+        } else {
+            assert(j != fnx) by {
+                lemma_frame_addr_injective_ne(j, fnx);
+            }
+        }
+    }
+    assert(lhs =~= rhs);
+    assert(view_of(sb2, nb, rc.update(fnx, v)) =~= (FrameAllocView { refcounts: rhs }));
+}
+
+/// Reserve one frame: writing its refcount slot to 1 sets the abstract refcount at `addr` to 1.
+proof fn lemma_reserve_one_v(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+    ensures
+        view_of(sb.insert(fnx), nb, rc.update(fnx, 1u8)) == (FrameAllocView {
+            refcounts: view_of(sb, nb, rc).refcounts.insert(addr, 1int),
+        }),
+{
+    lemma_view_of_set_slot(sb.insert(fnx), sb, nb, rc, fnx, addr, 1u8);
+}
+
+/// Release one frame's last reference: writing its refcount slot to 0 sets the abstract refcount
+/// at `addr` to 0 (the frame stays covered but becomes free).
+proof fn lemma_release_one_v(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+    ensures
+        view_of(sb.remove(fnx), nb, rc.update(fnx, 0u8)) == (FrameAllocView {
+            refcounts: view_of(sb, nb, rc).refcounts.insert(addr, 0int),
+        }),
+{
+    lemma_view_of_set_slot(sb.remove(fnx), sb, nb, rc, fnx, addr, 0u8);
+}
+
+/// Update one frame's refcount in place: rewriting its refcount slot to `nv` sets the abstract
+/// refcount at `addr` to `nv`, leaving the covered domain unchanged.
+proof fn lemma_update_refcount_v(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int, nv: u8)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+    ensures
+        view_of(sb, nb, rc.update(fnx, nv)) == (FrameAllocView {
+            refcounts: view_of(sb, nb, rc).refcounts.insert(addr, nv as int),
+        }),
+{
+    lemma_view_of_set_slot(sb, sb, nb, rc, fnx, addr, nv);
+}
+
+/// Reserve a contiguous range of frames: writing refcount slots `[start, start + count)` to 1
+/// merges the range into the abstract refcount map with count 1, leaving the covered domain fixed.
+proof fn lemma_reserve_range_v(
+    sb: Set<int>,
+    nb: int,
+    rc: Seq<u8>,
+    rc2: Seq<u8>,
+    start: int,
+    count: int,
+)
+    requires
+        spec_page_size() > 0,
+        0 <= start,
+        count > 0,
+        start + count <= nb,
+        nb <= rc.len(),
+        rc2.len() == rc.len(),
+        forall|k: int|
+            0 <= k < rc.len() ==> #[trigger] rc2[k] == (if start <= k < start + count {
+                1u8
+            } else {
+                rc[k]
+            }),
+    ensures
+        view_of(sb.union(BitmapView::range_set(start, start + count)), nb, rc2) == (FrameAllocView {
+            refcounts: view_of(sb, nb, rc).refcounts.union_prefer_right(
+                Map::new(spec_range_frames(start, count), |addr: int| 1int),
+            ),
+        }),
+{
+    broadcast use
+        vstd::set_lib::group_set_lib_default,
+        vstd::map::group_map_lemmas,
+        vstd::map_lib::group_map_properties;
+    let frames = spec_range_frames(start, count);
+    let range_map = Map::new(frames, |addr: int| 1int);
+    let lhs = view_of(sb.union(BitmapView::range_set(start, start + count)), nb, rc2).refcounts;
+    let rhs = view_of(sb, nb, rc).refcounts.union_prefer_right(range_map);
+    assert(lhs.dom() =~= rhs.dom()) by {
+        assert forall|a: int| #[trigger] frames.contains(a) implies covered_addrs(nb).contains(a) by {
+            let k = addr_to_frame(a);
+            assert(a == frame_addr_of(k));
+            assert(start <= k < start + count);
+        }
+    }
+    assert forall|a: int| lhs.dom().contains(a) implies #[trigger] lhs[a] == rhs[a] by {
+        let j = addr_to_frame(a);
+        assert(covered_addrs(nb).contains(a));
+        assert(a == frame_addr_of(j));
+        lemma_frame_addr_div(j);
+        if frames.contains(a) {
+            let k = addr_to_frame(a);
+            assert(a == frame_addr_of(k));
+            assert(start <= k < start + count);
+            assert(k == j);
+            assert(rc2[j] == 1u8);
+        } else {
+            assert(!(start <= j < start + count)) by {
+                if start <= j < start + count {
+                    assert(frames.contains(frame_addr_of(j)));
+                }
+            }
+            assert(rc2[j] == rc[j]);
+        }
+    }
+    assert(lhs =~= rhs);
+    assert(view_of(sb.union(BitmapView::range_set(start, start + count)), nb, rc2)
+        =~= (FrameAllocView { refcounts: rhs }));
+}
+
+/// Contrapositive helper of `lemma_frame_addr_injective`: distinct indices have distinct frame
+/// addresses (used to discharge `frame_addr_of(i) != addr` side conditions).
+proof fn lemma_frame_addr_injective_ne(i: int, j: int)
+    requires
+        spec_page_size() > 0,
+        i != j,
+    ensures
+        frame_addr_of(i) != frame_addr_of(j),
+{
+    if frame_addr_of(i) == frame_addr_of(j) {
+        lemma_frame_addr_injective(i, j);
+    }
+}
+
+
+//==================================================================================================
+// Bridging lemmas: derive abstract view predicates from concrete bitmap/refcount values
+//==================================================================================================
+
+/// Expose the `internal_inv` link between bitmap bits and refcount slots so callers (which see
+/// `internal_inv()` only as an opaque predicate) can use it on captured component values.
+proof fn lemma_internal_inv_facts(inner: &Inner)
+    requires
+        inner.internal_inv(),
+    ensures
+        spec_page_size() > 0,
+        spec_refcount_seq(inner).len() >= inner.bitmap@.num_bits,
+        forall|i: int| 0 <= i < inner.bitmap@.num_bits ==>
+            (#[trigger] inner.bitmap@.set_bits.contains(i) <==> spec_refcount_slot(inner, i) > 0),
+        forall|i: int| 0 <= i < inner.bitmap@.num_bits ==>
+            (!(#[trigger] inner.bitmap@.set_bits.contains(i)) <==> spec_refcount_slot(inner, i) == 0),
+{
+}
+
+/// `view_of(.., rc)` reports `addr` covered with refcount slot value at index `fnx`.
+proof fn lemma_view_of_refcount_val(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+    ensures
+        view_of(sb, nb, rc).is_covered(addr),
+        view_of(sb, nb, rc).refcounts[addr] == rc[fnx] as int,
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    lemma_aligned_addr_index(addr);
+    lemma_frame_addr_div(fnx);
+    assert(frame_addr_of(fnx) == addr);
+    assert(covered_addrs(nb).contains(addr));
+}
+
+/// `view_of(.., rc)` reports `addr` free when its refcount slot is 0 and the index is in range.
+proof fn lemma_view_of_is_free(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+        rc[fnx] == 0,
+    ensures
+        view_of(sb, nb, rc).is_free(addr),
+{
+    lemma_view_of_refcount_val(sb, nb, rc, fnx, addr);
+}
+
+/// `view_of(.., rc)` reports `addr` allocated when its refcount slot is positive and in range.
+proof fn lemma_view_of_is_allocated(sb: Set<int>, nb: int, rc: Seq<u8>, fnx: int, addr: int)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < nb,
+        nb <= rc.len(),
+        rc[fnx] > 0,
+    ensures
+        view_of(sb, nb, rc).is_allocated(addr),
+{
+    lemma_view_of_refcount_val(sb, nb, rc, fnx, addr);
+}
+
+/// If every in-range refcount slot is positive, no covered frame is free.
+proof fn lemma_view_of_no_free(sb: Set<int>, nb: int, rc: Seq<u8>)
+    requires
+        spec_page_size() > 0,
+        nb <= rc.len(),
+        forall|i: int| 0 <= i < nb ==> #[trigger] rc[i] > 0,
+    ensures
+        view_of(sb, nb, rc).no_free_frames(),
+{
+    broadcast use vstd::set_lib::group_set_lib_default, vstd::map::group_map_lemmas;
+    let v = view_of(sb, nb, rc);
+    assert forall|addr: int| #[trigger] v.refcounts.contains_key(addr) implies v.refcounts[addr] > 0 by {
+        let i = addr_to_frame(addr);
+        assert(covered_addrs(nb).contains(addr));
+        assert(addr == frame_addr_of(i));
+        lemma_frame_addr_div(i);
+    }
+}
+
+/// `view_of(.., rc)` reports every address of `frames` free when each maps to an in-range,
+/// zero-refcount, page-aligned index.
+proof fn lemma_view_of_all_free(sb: Set<int>, nb: int, rc: Seq<u8>, frames: Set<int>)
+    requires
+        spec_page_size() > 0,
+        nb <= rc.len(),
+        forall|addr: int| #[trigger] frames.contains(addr) ==> {
+            &&& addr % spec_page_size() == 0
+            &&& 0 <= addr / spec_page_size() < nb
+            &&& rc[addr / spec_page_size()] == 0
+        },
+    ensures
+        view_of(sb, nb, rc).all_free(frames),
+{
+    let v = view_of(sb, nb, rc);
+    assert forall|addr: int| #[trigger] frames.contains(addr) implies v.is_free(addr) by {
+        lemma_view_of_is_free(sb, nb, rc, addr / spec_page_size(), addr);
+    }
+}
+
+//==================================================================================================
+// Operation-level bridge lemmas
+//
+// These capture the recurring reasoning of the frame-allocator method bodies so the bodies stay
+// readable. Each lemma is phrased over the captured component snapshots (`pre_sb`/`pre_nb`/`pre_rc`)
+// and the post-mutation `&Inner`, mirroring the facts the original inline proof blocks produced.
+//==================================================================================================
+
+/// Snapshot the pre-state view and unpack the bitmap/refcount invariant link into facts over the
+/// captured component values, so later proof obligations can read them off `pre_sb`/`pre_rc`.
+proof fn lemma_capture_inv_facts(
+    inner: &Inner,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        inner.internal_inv(),
+        g_old == inner@,
+        pre_sb == inner.bitmap@.set_bits,
+        pre_nb == inner.bitmap@.num_bits,
+        pre_rc == spec_refcount_seq(inner),
+    ensures
+        spec_page_size() > 0,
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+        pre_rc.len() >= pre_nb,
+        forall|i: int| 0 <= i < pre_nb ==> (#[trigger] pre_sb.contains(i) <==> pre_rc[i] > 0),
+        forall|i: int| 0 <= i < pre_nb ==> (!(#[trigger] pre_sb.contains(i)) <==> pre_rc[i] == 0),
+        forall|i: int| pre_nb <= i < pre_rc.len() ==> #[trigger] pre_rc[i] == 0,
+        forall|i: int| 0 <= i < pre_nb ==> {
+            &&& #[trigger] frame_addr_of(i) >= 0
+            &&& frame_addr_of(i) <= usize::MAX as int
+            &&& i <= FrameNumber::spec_max() as int
+        },
+{
+    lemma_view_of(inner);
+    lemma_internal_inv_facts(inner);
+    assert forall|i: int| pre_nb <= i < pre_rc.len() implies #[trigger] pre_rc[i] == 0 by {}
+    assert forall|i: int| 0 <= i < pre_nb implies {
+        &&& #[trigger] frame_addr_of(i) >= 0
+        &&& frame_addr_of(i) <= usize::MAX as int
+        &&& i <= FrameNumber::spec_max() as int
+    } by {}
+}
+
+/// Representability of a single in-range frame index, instantiated from the captured pre-state
+/// representability quantifier (ensured by `lemma_capture_inv_facts`). Extracted from `alloc`, where
+/// `internal_inv` is transiently broken between the bitmap update and the refcount write, so the
+/// fact must be read off the captured snapshot rather than the live state.
+proof fn lemma_alloc_index_repr(idx: int, pre_nb: int)
+    requires
+        0 <= idx < pre_nb,
+        forall|i: int| 0 <= i < pre_nb ==> {
+            &&& #[trigger] frame_addr_of(i) >= 0
+            &&& frame_addr_of(i) <= usize::MAX as int
+            &&& i <= FrameNumber::spec_max() as int
+        },
+    ensures
+        frame_addr_of(idx) <= usize::MAX as int,
+        idx <= FrameNumber::spec_max() as int,
+{
+    assert(frame_addr_of(idx) >= 0);
+}
+
+/// A frame whose refcount slot is non-zero and in range is allocated: its bit is set, its index is
+/// below `num_bits`, and the abstract refcount equals the concrete slot value.
+proof fn lemma_frame_allocated(inner: &Inner, addr: int, fnx: int)
+    requires
+        inner.internal_inv(),
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < spec_refcount_seq(inner).len(),
+        spec_refcount_seq(inner)[fnx] != 0,
+    ensures
+        fnx < inner.bitmap@.num_bits,
+        inner.bitmap@.set_bits.contains(fnx),
+        inner@.is_allocated(addr),
+        inner@.is_covered(addr),
+        inner@.refcounts[addr] == spec_refcount_slot(inner, fnx),
+{
+    assert(fnx < inner.bitmap@.num_bits);
+    assert(inner.bitmap@.set_bits.contains(fnx));
+    lemma_alloc_contains(inner, addr);
+    assert(inner@.is_allocated(addr));
+    assert(inner@.is_covered(addr));
+    lemma_refcount_value(inner, addr);
+}
+
+/// Post-state of an in-place refcount write (no bitmap change): the abstract refcount at `addr`
+/// becomes the new slot value `nv`, every other count and the covered domain unchanged.
+proof fn lemma_post_update_slot(
+    inner: &Inner,
+    addr: int,
+    fnx: int,
+    nv: u8,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < pre_nb,
+        pre_nb <= pre_rc.len(),
+        inner.bitmap@.set_bits == pre_sb,
+        inner.bitmap@.num_bits == pre_nb,
+        spec_refcount_seq(inner) == pre_rc.update(fnx, nv),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        inner@ == (FrameAllocView { refcounts: g_old.refcounts.insert(addr, nv as int) }),
+{
+    lemma_view_of(inner);
+    lemma_update_refcount_v(pre_sb, pre_nb, pre_rc, fnx, addr, nv);
+}
+
+/// Post-state of releasing a frame's last reference (bit cleared, slot written to 0): the abstract
+/// refcount at `addr` becomes 0 (the frame stays covered but free).
+proof fn lemma_post_release_one(
+    inner: &Inner,
+    addr: int,
+    fnx: int,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < pre_nb,
+        pre_nb <= pre_rc.len(),
+        inner.bitmap@.set_bits == pre_sb.remove(fnx),
+        inner.bitmap@.num_bits == pre_nb,
+        spec_refcount_seq(inner) == pre_rc.update(fnx, 0u8),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        inner@ == (FrameAllocView { refcounts: g_old.refcounts.insert(addr, 0int) }),
+{
+    lemma_view_of(inner);
+    lemma_release_one_v(pre_sb, pre_nb, pre_rc, fnx, addr);
+}
+
+/// Post-state of reserving a single free frame (bit set, slot written to 1): `addr` was free in the
+/// pre-state and its abstract refcount becomes 1.
+proof fn lemma_post_reserve_one(
+    inner: &Inner,
+    addr: int,
+    fnx: int,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        spec_page_size() > 0,
+        addr % spec_page_size() == 0,
+        fnx == addr / spec_page_size(),
+        0 <= fnx < pre_nb,
+        pre_nb <= pre_rc.len(),
+        pre_rc[fnx] == 0,
+        inner.bitmap@.set_bits == pre_sb.insert(fnx),
+        inner.bitmap@.num_bits == pre_nb,
+        spec_refcount_seq(inner) == pre_rc.update(fnx, 1u8),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        g_old.is_free(addr),
+        inner@ == (FrameAllocView { refcounts: g_old.refcounts.insert(addr, 1int) }),
+{
+    lemma_view_of_is_free(pre_sb, pre_nb, pre_rc, fnx, addr);
+    lemma_view_of(inner);
+    lemma_reserve_one_v(pre_sb, pre_nb, pre_rc, fnx, addr);
+}
+
+/// `lemma_post_reserve_one` keyed by the frame *index* rather than its address: the reserved frame
+/// is `frame_addr_of(idx)`. Lets `alloc`'s success arm reserve a freshly-allocated frame number
+/// without restating the address-alignment side conditions.
+proof fn lemma_post_reserve_one_by_index(
+    inner: &Inner,
+    idx: int,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        spec_page_size() > 0,
+        0 <= idx < pre_nb,
+        pre_nb <= pre_rc.len(),
+        pre_rc[idx] == 0,
+        inner.bitmap@.set_bits == pre_sb.insert(idx),
+        inner.bitmap@.num_bits == pre_nb,
+        spec_refcount_seq(inner) == pre_rc.update(idx, 1u8),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        g_old.is_free(frame_addr_of(idx)),
+        inner@ == (FrameAllocView { refcounts: g_old.refcounts.insert(frame_addr_of(idx), 1int) }),
+{
+    lemma_frame_addr_mod_zero(idx);
+    lemma_frame_addr_div(idx);
+    lemma_post_reserve_one(inner, frame_addr_of(idx), idx, g_old, pre_sb, pre_nb, pre_rc);
+}
+
+/// A full bitmap (allocation failed) has no free covered frame: every in-range refcount slot is
+/// positive, so `no_free_frames()` holds on the unchanged pre-state view.
+proof fn lemma_alloc_full_no_free(
+    inner: &Inner,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        inner.internal_inv(),
+        inner.bitmap@.is_full(),
+        pre_sb == inner.bitmap@.set_bits,
+        pre_nb == inner.bitmap@.num_bits,
+        pre_rc == spec_refcount_seq(inner),
+        g_old == inner@,
+    ensures
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+        g_old.no_free_frames(),
+{
+    lemma_view_of(inner);
+    assert forall|i: int| 0 <= i < pre_nb implies #[trigger] pre_rc[i] > 0 by {
+        assert(inner.bitmap@.set_bits.contains(i));
+    }
+    lemma_view_of_no_free(pre_sb, pre_nb, pre_rc);
+}
+
+/// Re-establish `internal_inv` after booking the contiguous index range `[lo, hi)`: the bitmap has
+/// the whole range set and the refcount loop wrote exactly the range's slots to 1.
+proof fn lemma_reestablish_inv_range(
+    inner: &Inner,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+    lo: int,
+    hi: int,
+)
+    requires
+        spec_page_size() > 0,
+        0 <= lo <= hi <= pre_nb,
+        pre_nb <= pre_rc.len(),
+        forall|i: int| 0 <= i < pre_nb ==> (#[trigger] pre_sb.contains(i) <==> pre_rc[i] > 0),
+        forall|i: int| 0 <= i < pre_nb ==> (!(#[trigger] pre_sb.contains(i)) <==> pre_rc[i] == 0),
+        forall|i: int| pre_nb <= i < pre_rc.len() ==> #[trigger] pre_rc[i] == 0,
+        forall|i: int| 0 <= i < pre_nb ==> {
+            &&& #[trigger] frame_addr_of(i) >= 0
+            &&& frame_addr_of(i) <= usize::MAX as int
+            &&& i <= FrameNumber::spec_max() as int
+        },
+        inner.bitmap.inv(),
+        inner.bitmap@.num_bits == pre_nb,
+        inner.bitmap@.set_bits == pre_sb.union(BitmapView::range_set(lo, hi)),
+        spec_refcount_seq(inner).len() == pre_rc.len(),
+        forall|k: int| 0 <= k < pre_rc.len() ==>
+            #[trigger] spec_refcount_seq(inner)[k] == (if lo <= k < hi { 1u8 } else { pre_rc[k] }),
+    ensures
+        inner.internal_inv(),
+{
+    broadcast use vstd::set_lib::group_set_lib_default;
+    assert forall|k: int| 0 <= k < pre_nb implies {
+        &&& (inner.bitmap@.set_bits.contains(k) <==> #[trigger] inner.refcount@[k] > 0)
+        &&& (!inner.bitmap@.set_bits.contains(k) <==> inner.refcount@[k] == 0)
+        &&& (inner.bitmap@.set_bits.contains(k) ==> 0 < inner.refcount@[k] <= 255)
+    } by {
+        if lo <= k < hi {
+            assert(BitmapView::range_set(lo, hi).contains(k));
+            assert(inner.refcount@[k] == 1u8);
+        } else {
+            assert(!BitmapView::range_set(lo, hi).contains(k));
+            assert(inner.refcount@[k] == pre_rc[k]);
+            assert(pre_sb.contains(k) <==> pre_rc[k] > 0);
+        }
+    }
+    assert forall|k: int| pre_nb <= k < inner.refcount@.len() implies inner.refcount@[k] == 0 by {
+        assert(inner.refcount@[k] == pre_rc[k]);
+    }
+}
+
+/// Post-state of `alloc_contiguous`: the booked run `[start, start + count)` was entirely free and
+/// the resulting view merges the run (count 1) into the pre-state refcount map. `frames` is the
+/// contract's address set `{ base + i * PS | 0 <= i < count }`.
+proof fn lemma_alloc_contiguous_post(
+    inner: &Inner,
+    base: int,
+    start: int,
+    count: int,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        spec_page_size() > 0,
+        base == frame_addr_of(start),
+        0 <= start,
+        count > 0,
+        start + count <= pre_nb,
+        pre_nb <= pre_rc.len(),
+        forall|i: int| 0 <= i < pre_nb ==> (!(#[trigger] pre_sb.contains(i)) <==> pre_rc[i] == 0),
+        forall|j: int| start <= j < start + count ==> !pre_sb.contains(j),
+        inner.bitmap@.set_bits == pre_sb.union(BitmapView::range_set(start, start + count)),
+        inner.bitmap@.num_bits == pre_nb,
+        spec_refcount_seq(inner).len() == pre_rc.len(),
+        forall|k: int| 0 <= k < pre_rc.len() ==>
+            #[trigger] spec_refcount_seq(inner)[k] == (if start <= k < start + count { 1u8 } else { pre_rc[k] }),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        ({
+            let frames = Set::range(0, count).map_by(
+                |i: int| base + i * spec_page_size(),
+                |addr: int| (addr - base) / spec_page_size(),
+            );
+            &&& g_old.all_free(frames)
+            &&& inner@ == (FrameAllocView {
+                refcounts: g_old.refcounts.union_prefer_right(Map::new(frames, |addr: int| 1int)),
+            })
+        }),
+{
+    broadcast use
+        vstd::set_lib::group_set_lib_default,
+        vstd::map::group_map_lemmas,
+        vstd::map_lib::group_map_properties;
+    let frames = Set::range(0, count).map_by(
+        |i: int| base + i * spec_page_size(),
+        |addr: int| (addr - base) / spec_page_size(),
+    );
+    assert(frames =~= spec_range_frames(start, count)) by {
+        assert forall|addr: int| #[trigger] frames.contains(addr) implies
+            spec_range_frames(start, count).contains(addr) by {
+            let i = (addr - base) / spec_page_size();
+            lemma_frame_addr_split(start, i);
+            lemma_frame_addr_div(start + i);
+        }
+        assert forall|addr: int| spec_range_frames(start, count).contains(addr) implies
+            #[trigger] frames.contains(addr) by {
+            let k = addr / spec_page_size();
+            lemma_frame_addr_split(start, k - start);
+            lemma_frame_addr_div(k);
+        }
+    }
+    assert forall|addr: int| #[trigger] frames.contains(addr) implies {
+        &&& addr % spec_page_size() == 0
+        &&& 0 <= addr / spec_page_size() < pre_nb
+        &&& pre_rc[addr / spec_page_size()] == 0
+    } by {
+        let i = (addr - base) / spec_page_size();
+        lemma_frame_addr_split(start, i);
+        lemma_frame_addr_div(start + i);
+        lemma_frame_addr_mod_zero(start + i);
+        assert(!pre_sb.contains(start + i));
+    }
+    lemma_view_of_all_free(pre_sb, pre_nb, pre_rc, frames);
+    lemma_view_of(inner);
+    lemma_reserve_range_v(pre_sb, pre_nb, pre_rc, inner.refcount@, start, count);
+    assert(Map::new(frames, |addr: int| 1int)
+        =~= Map::new(spec_range_frames(start, count), |addr: int| 1int));
+    assert(inner@.refcounts =~= g_old.refcounts.union_prefer_right(
+        Map::new(frames, |addr: int| 1int)));
+    assert(inner@ == (FrameAllocView {
+        refcounts: g_old.refcounts.union_prefer_right(Map::new(frames, |addr: int| 1int)),
+    }));
+}
+
+/// If the abstract view has a contiguous run of `count` free frames based at address `base`, then
+/// the underlying bitmap has a contiguous run of `count` clear bits at index `base / PAGE_SIZE`.
+/// This is the bridge that lets `alloc_contiguous`'s `Err` arm state that no such free run exists.
+proof fn lemma_free_run_implies_bitmap_range(inner: &Inner, base: int, count: int)
+    requires
+        inner.internal_inv(),
+        count > 0,
+        inner@.contiguous_free_run_at(base, count),
+    ensures
+        inner.bitmap@.exists_contiguous_free_range(count),
+{
+    broadcast use
+        vstd::set_lib::group_set_lib_default,
+        vstd::map::group_map_lemmas;
+    lemma_internal_inv_facts(inner);
+    let ps = spec_page_size();
+    let frames = Set::range(0, count).map_by(
+        |i: int| base + i * ps,
+        |addr: int| (addr - base) / ps,
+    );
+    // Each run element `base + i * ps` (0 <= i < count) is a member of `frames`.
+    assert forall|i: int| 0 <= i < count implies #[trigger] frames.contains(base + i * ps) by {
+        lemma_frame_addr_div(i);
+    }
+    // The base frame (i = 0) is free, hence covered, hence page-aligned.
+    assert(frames.contains(base + 0 * ps));
+    assert(inner@.is_free(base));
+    if base % ps != 0 {
+        lemma_uncovered_unaligned(inner, base);
+    }
+    let b = base / ps;
+    lemma_aligned_addr_index(base);
+    // Lower bound: the base frame (index `b`) is in range.
+    lemma_free_contains(inner, base);
+    // Upper bound: the last frame (index `b + count - 1`) is in range.
+    assert(frames.contains(base + (count - 1) * ps));
+    lemma_frame_addr_split(b, count - 1);
+    lemma_frame_addr_div(b + count - 1);
+    lemma_frame_addr_mod_zero(b + count - 1);
+    lemma_free_contains(inner, base + (count - 1) * ps);
+    // Every bit in `[b, b + count)` is clear.
+    assert forall|k: int| b <= k < b + count implies !inner.bitmap@.is_bit_set(k) by {
+        let i = k - b;
+        lemma_frame_addr_split(b, i);
+        lemma_frame_addr_div(b + i);
+        lemma_frame_addr_mod_zero(b + i);
+        assert(frames.contains(base + i * ps));
+        lemma_free_contains(inner, base + i * ps);
+    }
+    assert(inner.bitmap@.has_free_range_at(b, count));
+}
+
+/// Contrapositive helper: if the bitmap has no contiguous run of `count` clear bits, then the
+/// abstract view has no contiguous run of `count` free frames.
+proof fn lemma_no_bitmap_range_implies_no_free_run(inner: &Inner, count: int)
+    requires
+        inner.internal_inv(),
+        count > 0,
+        !inner.bitmap@.exists_contiguous_free_range(count),
+    ensures
+        !inner@.exists_contiguous_free_run(count),
+{
+    if inner@.exists_contiguous_free_run(count) {
+        let base = choose|base: int| inner@.contiguous_free_run_at(base, count);
+        lemma_free_run_implies_bitmap_range(inner, base, count);
+    }
+}
+
+/// No-overflow / divisibility geometry for `alloc_range`: a non-empty page-aligned region spans at
+/// least one frame, the exclusive upper bound divides cleanly, and `start + nframes` does not
+/// overflow `usize`.
+proof fn lemma_alloc_range_geometry(rstart: int, rsize: int, ps: int, start_fn: int, nfr: int)
+    requires
+        ps == spec_page_size(),
+        ps == 4096,
+        rsize > 0,
+        rstart % ps == 0,
+        rsize % ps == 0,
+        rstart <= usize::MAX as int,
+        rsize <= usize::MAX as int,
+        start_fn == rstart / ps,
+        nfr == rsize / ps,
+    ensures
+        nfr >= 1,
+        (rstart + rsize) / ps == start_fn + nfr,
+        start_fn <= usize::MAX as int / ps,
+        nfr <= usize::MAX as int / ps,
+        start_fn + nfr <= usize::MAX as int,
+{
+    lemma_size_div_pos(rsize);
+    lemma_aligned_div_sum(rstart, rsize);
+    vstd::arithmetic::div_mod::lemma_div_is_ordered(rstart, usize::MAX as int, ps);
+    vstd::arithmetic::div_mod::lemma_div_is_ordered(rsize, usize::MAX as int, ps);
+}
+
+/// A requested range index that is not covered by the bitmap cannot be free, so the whole requested
+/// `frames` set is not all-free.
+proof fn lemma_range_uncovered_not_all_free(
+    inner: &Inner,
+    index: int,
+    rstart: int,
+    rsize: int,
+    ps: int,
+    start_fn: int,
+    nfr: int,
+    g_old: FrameAllocView,
+)
+    requires
+        inner.internal_inv(),
+        ps == spec_page_size(),
+        g_old == inner@,
+        0 <= start_fn,
+        rstart / ps == start_fn,
+        (rstart + rsize) / ps == start_fn + nfr,
+        start_fn <= index < start_fn + nfr,
+        index >= inner.bitmap@.num_bits,
+    ensures
+        !g_old.all_free(Set::range(rstart / ps, (rstart + rsize) / ps).map(|i: int| i * spec_page_size())),
+{
+    broadcast use vstd::set_lib::group_set_lib_default;
+    let a = frame_addr_of(index);
+    let frame_numbers = Set::range(rstart / ps, (rstart + rsize) / ps);
+    let frames = frame_numbers.map(|i: int| i * spec_page_size());
+    assert(frame_numbers.contains(index));
+    assert(frames.contains(a));
+    lemma_frame_addr_mod_zero(index);
+    lemma_frame_addr_div(index);
+    lemma_covered_iff(inner, a);
+    assert(!g_old.is_covered(a));
+    assert(!g_old.is_free(a));
+    if g_old.all_free(frames) {
+        assert(g_old.is_free(a));
+    }
+}
+
+/// A requested range index that is covered but already allocated is not free, so the whole
+/// requested `frames` set is not all-free.
+proof fn lemma_range_allocated_not_all_free(
+    inner: &Inner,
+    index: int,
+    rstart: int,
+    rsize: int,
+    ps: int,
+    start_fn: int,
+    nfr: int,
+    g_old: FrameAllocView,
+)
+    requires
+        inner.internal_inv(),
+        ps == spec_page_size(),
+        g_old == inner@,
+        0 <= start_fn,
+        rstart / ps == start_fn,
+        (rstart + rsize) / ps == start_fn + nfr,
+        start_fn <= index < start_fn + nfr,
+        index < inner.bitmap@.num_bits,
+        inner.bitmap@.set_bits.contains(index),
+    ensures
+        !g_old.all_free(Set::range(rstart / ps, (rstart + rsize) / ps).map(|i: int| i * spec_page_size())),
+{
+    broadcast use vstd::set_lib::group_set_lib_default;
+    let a = frame_addr_of(index);
+    let frame_numbers = Set::range(rstart / ps, (rstart + rsize) / ps);
+    let frames = frame_numbers.map(|i: int| i * spec_page_size());
+    assert(frame_numbers.contains(index));
+    assert(frames.contains(a));
+    lemma_frame_addr_mod_zero(index);
+    lemma_frame_addr_div(index);
+    lemma_alloc_contains(inner, a);
+    assert(g_old.is_allocated(a));
+    assert(!g_old.is_free(a));
+    if g_old.all_free(frames) {
+        assert(g_old.is_free(a));
+    }
+}
+
+/// Post-state of `alloc_range`: re-establish `internal_inv` after booking, prove the requested
+/// `frames` set was all-free in the pre-state, and reconstruct the post-state view as the pre-state
+/// map merged with the booked run (count 1). `frames` is the contract's
+/// `{ i * PS | start_fn <= i < start_fn + nfr }`.
+proof fn lemma_alloc_range_post(
+    inner: &Inner,
+    rstart: int,
+    rsize: int,
+    ps: int,
+    lo: int,
+    nfr: int,
+    g_old: FrameAllocView,
+    pre_sb: Set<int>,
+    pre_nb: int,
+    pre_rc: Seq<u8>,
+)
+    requires
+        ps == spec_page_size(),
+        ps > 0,
+        rstart / ps == lo,
+        (rstart + rsize) / ps == lo + nfr,
+        0 <= lo,
+        nfr >= 1,
+        lo + nfr <= pre_nb,
+        pre_nb <= pre_rc.len(),
+        forall|i: int| 0 <= i < pre_nb ==> (#[trigger] pre_sb.contains(i) <==> pre_rc[i] > 0),
+        forall|i: int| 0 <= i < pre_nb ==> (!(#[trigger] pre_sb.contains(i)) <==> pre_rc[i] == 0),
+        forall|i: int| pre_nb <= i < pre_rc.len() ==> #[trigger] pre_rc[i] == 0,
+        forall|i: int| 0 <= i < pre_nb ==> {
+            &&& #[trigger] frame_addr_of(i) >= 0
+            &&& frame_addr_of(i) <= usize::MAX as int
+            &&& i <= FrameNumber::spec_max() as int
+        },
+        forall|j: int| lo <= j < lo + nfr ==> !pre_sb.contains(j),
+        inner.bitmap.inv(),
+        inner.bitmap@.num_bits == pre_nb,
+        inner.bitmap@.set_bits == pre_sb.union(BitmapView::range_set(lo, lo + nfr)),
+        spec_refcount_seq(inner).len() == pre_rc.len(),
+        forall|k: int| 0 <= k < pre_rc.len() ==>
+            #[trigger] spec_refcount_seq(inner)[k] == (if lo <= k < lo + nfr { 1u8 } else { pre_rc[k] }),
+        g_old == view_of(pre_sb, pre_nb, pre_rc),
+    ensures
+        inner.internal_inv(),
+        ({
+            let frames = Set::range(rstart / ps, (rstart + rsize) / ps).map(|i: int| i * spec_page_size());
+            &&& g_old.all_free(frames)
+            &&& inner@ == (FrameAllocView {
+                refcounts: g_old.refcounts.union_prefer_right(Map::new(frames, |addr: int| 1int)),
+            })
+        }),
+{
+    lemma_reestablish_inv_range(inner, pre_sb, pre_nb, pre_rc, lo, lo + nfr);
+    broadcast use
+        vstd::set_lib::group_set_lib_default,
+        vstd::map::group_map_lemmas,
+        vstd::map_lib::group_map_properties;
+    lemma_view_of(inner);
+    assert forall|x: int| pre_sb.contains(x) implies 0 <= x < pre_nb by {
+        assert(inner.bitmap@.set_bits.contains(x));
+    }
+    lemma_reserve_range_v(pre_sb, pre_nb, pre_rc, inner.refcount@, lo, nfr);
+    let frame_numbers = Set::range(rstart / ps, (rstart + rsize) / ps);
+    let frames = frame_numbers.map(|i: int| i * spec_page_size());
+    assert(frame_numbers == Set::range(lo, lo + nfr));
+    assert(frames =~= spec_range_frames(lo, nfr)) by {
+        assert forall|addr: int| #[trigger] frames.contains(addr) implies
+            spec_range_frames(lo, nfr).contains(addr) by {
+            let i = choose|i: int|
+                frame_numbers.contains(i) && addr == #[trigger] (i * spec_page_size());
+            lemma_frame_addr_div(i);
+            assert(lo <= i < lo + nfr && addr == frame_addr_of(i));
+        }
+        assert forall|addr: int| spec_range_frames(lo, nfr).contains(addr) implies
+            #[trigger] frames.contains(addr) by {
+            let i = addr / spec_page_size();
+            lemma_frame_addr_div(i);
+            assert(frame_numbers.contains(i));
+            assert(addr == i * spec_page_size());
+        }
+    }
+    assert forall|addr: int| #[trigger] frames.contains(addr) implies {
+        &&& addr % spec_page_size() == 0
+        &&& 0 <= addr / spec_page_size() < pre_nb
+        &&& pre_rc[addr / spec_page_size()] == 0
+    } by {
+        let i = choose|i: int|
+            frame_numbers.contains(i) && addr == #[trigger] (i * spec_page_size());
+        assert(lo <= i < lo + nfr);
+        lemma_frame_addr_div(i);
+        lemma_frame_addr_mod_zero(i);
+        assert(!pre_sb.contains(i));
+    }
+    lemma_view_of_all_free(pre_sb, pre_nb, pre_rc, frames);
+    assert(Map::new(frames, |addr: int| 1int)
+        =~= Map::new(spec_range_frames(lo, nfr), |addr: int| 1int));
+    assert(inner@.refcounts =~= g_old.refcounts.union_prefer_right(
+        Map::new(frames, |addr: int| 1int)));
+    assert(inner@ == (FrameAllocView {
+        refcounts: g_old.refcounts.union_prefer_right(Map::new(frames, |addr: int| 1int)),
+    }));
+}
+
 }

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -112,7 +112,6 @@ impl Inner {
     /// Upon success, the address of the allocated frame is returned. Upon failure, an error is
     /// returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -133,19 +132,45 @@ impl Inner {
             },
     )]
     fn alloc(&mut self) -> Result<FrameAddress, Error> {
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+        }
+        proof! {
+            // Snapshot the pre-state view and expose the bitmap/refcount invariant link so later
+            // proof obligations can read it off the captured component snapshots.
+            lemma_capture_inv_facts(self, g_old, pre_sb, pre_nb, pre_rc);
+        }
         let frame_number: usize = match self.bitmap.alloc() {
             Ok(index) => index,
             Err(error) => {
+                proof! {
+                    // The bitmap is full (every bit set), so every covered frame has refcount > 0
+                    // and no covered frame is free.
+                    lemma_alloc_full_no_free(self, g_old, pre_sb, pre_nb, pre_rc);
+                }
                 error!("{error:?}");
                 return Err(error);
             },
         };
+        proof_decl! { let ghost idx = frame_number as int; }
+        proof! {
+            // Representability of the new in-range index (from the captured invariant).
+            lemma_alloc_index_repr(idx, pre_nb);
+        }
         // Newly allocated frames have a single owner.
+        #[cfg(not(verus_keep_ghost))]
         debug_assert_eq!(self.refcount[frame_number], 0);
         self.refcount[frame_number] = 1;
         let frame_number: FrameNumber = match FrameNumber::from_raw_value(frame_number) {
             Some(frame_number) => frame_number,
             None => {
+                proof! {
+                    // `None` requires `idx > spec_max`, contradicting representability. Unreachable.
+                    assert(false);
+                }
                 let reason: &str = "frame number is out of bounds";
                 error!("{reason:?}");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
@@ -154,8 +179,17 @@ impl Inner {
 
         // Attempt to convert the frame number to a frame address.
         match FrameAddress::from_frame_number(frame_number) {
-            Ok(frame_address) => Ok(frame_address),
+            Ok(frame_address) => {
+                proof! {
+                    lemma_post_reserve_one_by_index(self, idx, g_old, pre_sb, pre_nb, pre_rc);
+                }
+                Ok(frame_address)
+            },
             Err(error) => {
+                proof! {
+                    // `from_frame_number` is total (always `Ok`); this arm is unreachable.
+                    assert(false);
+                }
                 error!("{error:?}");
                 Err(error)
             },
@@ -176,7 +210,6 @@ impl Inner {
     /// Upon success, the base `FrameAddress` of the contiguous range is returned. Upon failure,
     /// an error is returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -207,8 +240,26 @@ impl Inner {
             },
     )]
     fn alloc_contiguous(&mut self, count: usize) -> Result<FrameAddress, Error> {
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+        }
+        proof! {
+            // Snapshot the pre-state view and expose the bitmap/refcount invariant link so later
+            // proof obligations can read it off the captured component snapshots.
+            lemma_capture_inv_facts(self, g_old, pre_sb, pre_nb, pre_rc);
+        }
         // Reject impossible requests before delegating to the bitmap range allocator.
         if count > self.bitmap.number_of_bits() {
+            proof! {
+                // With fewer than `count` bits, no run of `count` clear bits can exist.
+                assert forall|start: int|
+                    #![trigger self.bitmap@.has_free_range_at(start, count as int)]
+                    !self.bitmap@.has_free_range_at(start, count as int) by {}
+                lemma_no_bitmap_range_implies_no_free_run(self, count as int);
+            }
             let reason: &str = "requested range exceeds bitmap size";
             error!("{reason} (count={count}, bitmap_bits={})", self.bitmap.number_of_bits());
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -216,18 +267,61 @@ impl Inner {
         let frame_number: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,
             Err(error) => {
+                proof! {
+                    // `alloc_range` failed: no run of `count` clear bits exists in the bitmap.
+                    lemma_no_bitmap_range_implies_no_free_run(self, count as int);
+                }
                 error!("{error:?} (count={count})");
                 return Err(error);
             },
         };
+        proof_decl! { let ghost start = frame_number as int; }
+        // `alloc_range` Ok guarantees the booked range was entirely clear beforehand.
+        proof! {
+            assert forall|j: int| start <= j < start + count as int implies !pre_sb.contains(j) by {
+                assert(!old(self).bitmap@.is_bit_set(j));
+            }
+        }
         // Newly allocated frames have a single owner.
+        #[verus_spec(
+            invariant
+                start == frame_number as int,
+                0 <= start,
+                start + count as int <= pre_nb,
+                pre_nb <= pre_rc.len(),
+                self.bitmap@.num_bits == pre_nb,
+                self.bitmap.inv(),
+                self.bitmap@.set_bits
+                    == pre_sb.union(BitmapView::range_set(start, start + count as int)),
+                self.refcount@.len() == pre_rc.len(),
+                forall|j: int| start <= j < start + count as int ==> !pre_sb.contains(j),
+                forall|k: int| 0 <= k < pre_rc.len() ==>
+                    #[trigger] self.refcount@[k] == (if start <= k < i as int {
+                        1u8
+                    } else {
+                        pre_rc[k]
+                    }),
+            decreases frame_number + count - i,
+        )]
         for i in frame_number..frame_number + count {
+            #[cfg(not(verus_keep_ghost))]
             debug_assert_eq!(self.refcount[i], 0);
             self.refcount[i] = 1;
+        }
+        proof! {
+            // Re-establish `internal_inv` after range booking: the bitmap has the whole range set,
+            // and the refcount loop set exactly the range's slots to 1.
+            lemma_reestablish_inv_range(self, pre_sb, pre_nb, pre_rc, start, start + count as int);
+            // Representability: `start < pre_nb`, so `old(self)`'s internal_inv bounds `start`.
+            lemma_alloc_index_repr(start, pre_nb);
         }
         let frame_number: FrameNumber = match FrameNumber::from_raw_value(frame_number) {
             Some(frame_number) => frame_number,
             None => {
+                proof! {
+                    // `None` requires `start > spec_max`, contradicting representability. Unreachable.
+                    assert(false);
+                }
                 let reason: &str = "frame number is out of bounds";
                 error!("{reason:?}");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
@@ -235,8 +329,18 @@ impl Inner {
         };
 
         match FrameAddress::from_frame_number(frame_number) {
-            Ok(frame_address) => Ok(frame_address),
+            Ok(frame_address) => {
+                proof! {
+                    let base = frame_address@;
+                    lemma_alloc_contiguous_post(self, base, start, count as int, g_old, pre_sb, pre_nb, pre_rc);
+                }
+                Ok(frame_address)
+            },
             Err(error) => {
+                proof! {
+                    // `from_frame_number` is total (always `Ok`); this arm is unreachable.
+                    assert(false);
+                }
                 error!("{error:?}");
                 Err(error)
             },
@@ -256,7 +360,6 @@ impl Inner {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -283,8 +386,21 @@ impl Inner {
     )]
     fn free(&mut self, frame: FrameAddress) -> Result<(), Error> {
         let frame_number: usize = frame.into_frame_number().into_raw_value();
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+        }
+        proof! {
+            lemma_free_pre(self, frame@);
+        }
 
         if frame_number >= self.refcount.len() {
+            proof! {
+                // frame_number >= refcount.len() >= num_bits, so the bit is clear: not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "frame number out of bounds";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
@@ -292,9 +408,18 @@ impl Inner {
 
         // Reject double-frees: the frame must currently have at least one owner.
         if self.refcount[frame_number] == 0 {
+            proof! {
+                // refcount[fnx] == 0, so the bit is clear (internal_inv), hence not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "frame is already free";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // The frame is currently allocated: refcount[fnx] > 0 and fnx < num_bits, so the bit is set.
+        proof! {
+            lemma_frame_allocated(self, frame@, frame_number as int);
         }
 
         self.refcount[frame_number] -= 1;
@@ -302,13 +427,28 @@ impl Inner {
         // Only release the bit in the bitmap when the last owner releases the frame.
         if self.refcount[frame_number] == 0 {
             match self.bitmap.clear(frame_number) {
-                Ok(()) => Ok(()),
+                Ok(()) => {
+                    proof! {
+                        lemma_post_release_one(self, frame@, frame_number as int, g_old, pre_sb, pre_nb, pre_rc);
+                    }
+                    Ok(())
+                },
                 Err(error) => {
+                    proof! {
+                        // Unreachable: the bit is set and in range, so `clear` returns `Ok`.
+                        assert(false);
+                    }
                     error!("{error:?} (frame={frame:?})");
                     Err(error)
                 },
             }
         } else {
+            // Still shared: only the refcount slot changed (decremented by one); the
+            // allocated/free partition is unchanged.
+            proof! {
+                let nv = self.refcount@[frame_number as int];
+                lemma_post_update_slot(self, frame@, frame_number as int, nv, g_old, pre_sb, pre_nb, pre_rc);
+            }
             Ok(())
         }
     }
@@ -330,7 +470,6 @@ impl Inner {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -359,8 +498,21 @@ impl Inner {
     )]
     fn share(&mut self, frame: FrameAddress) -> Result<(), Error> {
         let frame_number: usize = frame.into_frame_number().into_raw_value();
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+        }
+        proof! {
+            lemma_free_pre(self, frame@);
+        }
 
         if frame_number >= self.refcount.len() {
+            proof! {
+                // frame_number >= refcount.len() >= num_bits, so the bit is clear: not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "frame number out of bounds";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
@@ -369,19 +521,40 @@ impl Inner {
         // The frame must currently have at least one owner. Sharing an unallocated
         // frame is a logic error.
         if self.refcount[frame_number] == 0 {
+            proof! {
+                // refcount[fnx] == 0, so the bit is clear (internal_inv), hence not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "cannot share an unallocated frame";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
+        proof! {
+            // The frame is allocated: refcount[fnx] > 0 and fnx < num_bits, so the bit is set.
+            lemma_frame_allocated(self, frame@, frame_number as int);
+        }
+
         self.refcount[frame_number] = match self.refcount[frame_number].checked_add(1) {
             Some(n) => n,
             None => {
+                // Overflow: the old refcount was at its u8 maximum (255). The state is
+                // unchanged, satisfying the Err arm's refcount-saturated disjunct.
+                proof! {
+                    lemma_share_overflow(self, frame@, frame_number as int, g_old);
+                }
                 let reason: &str = "frame reference count overflow";
                 error!("{reason} (frame={frame:?})");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             },
         };
+
+        // Only the refcount slot changed (incremented by one); the allocated/free partition
+        // is unchanged.
+        proof! {
+            let nv = self.refcount@[frame_number as int];
+            lemma_post_update_slot(self, frame@, frame_number as int, nv, g_old, pre_sb, pre_nb, pre_rc);
+        }
 
         Ok(())
     }
@@ -400,7 +573,6 @@ impl Inner {
     /// Upon success, the current reference count is returned. Upon failure, an error is
     /// returned instead (out-of-bounds address, or the frame is not currently allocated).
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             self.inv(),
@@ -419,19 +591,36 @@ impl Inner {
     )]
     fn refcount(&self, frame: FrameAddress) -> Result<u8, Error> {
         let frame_number: usize = frame.into_frame_number().into_raw_value();
+        proof! {
+            vstd::arithmetic::div_mod::lemma_div_pos_is_pos(frame@, spec_page_size());
+            lemma_alloc_contains(self, frame@);
+        }
 
         if frame_number >= self.refcount.len() {
+            proof! {
+                // frame_number >= refcount.len() >= num_bits, so the bit is clear: not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "frame number out of bounds";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
         if self.refcount[frame_number] == 0 {
+            proof! {
+                // refcount[i] == 0, so the bit is clear (internal_inv), hence not allocated.
+                lemma_refcount_err_bit_clear(self, frame_number as int);
+            }
             let reason: &str = "frame is not allocated";
             error!("{reason} (frame={frame:?})");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
+        proof! {
+            // refcount[i] != 0 and i < refcount.len(); tail-zero forces i < num_bits, so the
+            // bit is set, the frame is allocated, and its refcount-map value is the slot value.
+            lemma_frame_allocated(self, frame@, frame_number as int);
+        }
         Ok(self.refcount[frame_number])
     }
 
@@ -448,7 +637,6 @@ impl Inner {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -470,13 +658,31 @@ impl Inner {
     )]
     fn book(&mut self, phys_addr: PageAligned<PhysicalAddress>) -> Result<(), Error> {
         let frame_number: usize = phys_addr.into_frame_number().into_raw_value();
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+        }
+        proof! {
+            lemma_book_pre(self, phys_addr@);
+        }
         match self.bitmap.set(frame_number) {
             Ok(()) => {
+                #[cfg(not(verus_keep_ghost))]
                 debug_assert_eq!(self.refcount[frame_number], 0);
                 self.refcount[frame_number] = 1;
+                proof! {
+                    lemma_post_reserve_one(self, phys_addr@, frame_number as int, g_old, pre_sb, pre_nb, pre_rc);
+                }
                 Ok(())
             },
             Err(error) => {
+                // `set()` failed: the bit was already set or out of range, so the frame is not
+                // free in `old(self)`.
+                proof! {
+                    lemma_book_set_failed(self, phys_addr@, g_old);
+                }
                 error!("{error:?} (phys_addr={phys_addr:?})");
                 Err(error)
             },
@@ -492,7 +698,6 @@ impl Inner {
     ///
     /// `true` if the frame allocator tracks the frame at `phys_addr`, `false` otherwise.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(ret =>
         requires
             self.inv(),
@@ -503,6 +708,10 @@ impl Inner {
     )]
     fn is_covered(&self, phys_addr: PageAligned<PhysicalAddress>) -> bool {
         let frame_number: usize = phys_addr.into_frame_number().into_raw_value();
+        proof! {
+            vstd::arithmetic::div_mod::lemma_div_pos_is_pos(phys_addr@, spec_page_size());
+            lemma_covered_iff(self, phys_addr@);
+        }
         frame_number < self.bitmap.number_of_bits()
     }
 
@@ -519,7 +728,6 @@ impl Inner {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         requires
             old(self).inv(),
@@ -549,7 +757,27 @@ impl Inner {
         region: &TruncatedMemoryRegion<PhysicalAddress>,
     ) -> Result<(), Error> {
         let start_frame_number: usize = region.start().into_frame_number().into_raw_value();
-        let end_exclusive: usize = start_frame_number + region.size() / mem::FRAME_SIZE;
+        let nframes: usize = region.size() / mem::FRAME_SIZE;
+        proof_decl! {
+            let ghost g_old = self@;
+            let ghost pre_sb = self.bitmap@.set_bits;
+            let ghost pre_nb = self.bitmap@.num_bits;
+            let ghost pre_rc = self.refcount@;
+            let ghost ps = spec_page_size();
+            let ghost rstart = region@.start;
+            let ghost rsize = region@.size;
+            let ghost start_fn = start_frame_number as int;
+            let ghost nfr = nframes as int;
+        }
+        proof! {
+            lemma_capture_inv_facts(self, g_old, pre_sb, pre_nb, pre_rc);
+            assert(ps == 4096);
+            lemma_alloc_range_geometry(rstart, rsize, ps, start_fn, nfr);
+        }
+        let end_exclusive: usize = start_frame_number + nframes;
+        proof! {
+            assert(end_exclusive as int == start_fn + nfr);
+        }
 
         // Check that all frames in the range are covered by the bitmap and free,
         // then book them. Uncovered frames indicate a memory layout bug.
@@ -557,41 +785,127 @@ impl Inner {
         // The coverage check runs unconditionally — including optimized builds —
         // because out-of-bounds indices must be rejected before attempting to set them.
         // This loop runs only at boot when booking memory regions, so the overhead is negligible.
+        #[verus_spec(
+            invariant
+                start_fn == start_frame_number as int,
+                end_exclusive as int == start_fn + nfr,
+                nfr >= 1,
+                ps == spec_page_size(),
+                rstart == region@.start,
+                rsize == region@.size,
+                rstart / ps == start_fn,
+                (rstart + rsize) / ps == start_fn + nfr,
+                self@ == g_old,
+                self@ == old(self)@,
+                self.bitmap@.set_bits == pre_sb,
+                self.bitmap@.num_bits == pre_nb,
+                self.refcount@ == pre_rc,
+                self.bitmap.inv(),
+                self.internal_inv(),
+                forall|k: int| start_fn <= k < index as int ==>
+                    #[trigger] pre_sb.contains(k) == false && k < pre_nb,
+            decreases end_exclusive - index,
+        )]
         for index in start_frame_number..end_exclusive {
             if index >= self.bitmap.number_of_bits() {
                 // `index` is out of range here, so `index * FRAME_SIZE` can overflow `usize`
                 // (e.g. on 32-bit targets), panicking in debug builds on the very error path
                 // meant to report the problem. Saturate: the value only feeds a diagnostic.
-                let uncovered_addr: usize = index.saturating_mul(mem::FRAME_SIZE);
+                proof! {
+                    // This frame is in the requested range but not covered, so it cannot be free.
+                    lemma_range_uncovered_not_all_free(self, index as int, rstart, rsize, ps, start_fn, nfr, g_old);
+                }
                 let reason: &str = "frame index not covered by the bitmap";
-                error!("{} (frame={:#010x}, region={:?})", reason, uncovered_addr, region);
+                error!(
+                    "{} (frame={:#010x}, region={:?})",
+                    reason,
+                    index.saturating_mul(mem::FRAME_SIZE),
+                    region
+                );
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             }
             match self.bitmap.test(index) {
-                Ok(false) => {},
+                Ok(false) => {
+                    proof! {
+                        // Record coverage of `index` so the loop invariant extends to `index + 1`.
+                        assert(!pre_sb.contains(index as int));
+                        assert((index as int) < pre_nb);
+                    }
+                },
                 Ok(true) => {
-                    let conflicting_addr: usize = index.saturating_mul(mem::FRAME_SIZE);
+                    proof! {
+                        // This frame is in the requested range but already allocated, not free.
+                        lemma_range_allocated_not_all_free(self, index as int, rstart, rsize, ps, start_fn, nfr, g_old);
+                    }
                     let region_start: usize = region.start().into_raw_value();
                     let region_end: usize = region_start.saturating_add(region.size());
                     let reason: &str = "frame is already allocated";
                     error!(
                         "{} (frame={:#010x}, region_start={:#010x}, region_end={:#010x})",
-                        reason, conflicting_addr, region_start, region_end
+                        reason,
+                        index.saturating_mul(mem::FRAME_SIZE),
+                        region_start,
+                        region_end
                     );
                     return Err(Error::new(ErrorCode::OutOfMemory, reason));
                 },
-                Err(err) => return Err(err),
+                Err(err) => {
+                    proof! {
+                        // `index < num_bits` was checked above, so `test` cannot fail. Unreachable.
+                        assert(index < self.bitmap@.num_bits);
+                        assert(false);
+                    }
+                    return Err(err);
+                },
             }
+        }
+        // The for-loop's exit invariant covers every index in `[start_fn, start_fn + nfr)`:
+        // each frame is free in the pre-state bitmap and lies within bounds.
+        proof! {
+            assert(pre_sb.contains(start_fn + nfr - 1) == false);
+            assert(start_fn + nfr <= pre_nb);
+            assert forall|j: int| start_fn <= j < start_fn + nfr implies !pre_sb.contains(j) by {}
         }
 
         // Book all frames in the range.
+        #[verus_spec(
+            invariant
+                start_fn == start_frame_number as int,
+                end_exclusive as int == start_fn + nfr,
+                start_fn + nfr <= pre_nb,
+                pre_nb <= pre_rc.len(),
+                self.bitmap.inv(),
+                self.bitmap@.num_bits == pre_nb,
+                self.bitmap@.set_bits == pre_sb.union(BitmapView::range_set(start_fn, index as int)),
+                self.refcount@.len() == pre_rc.len(),
+                forall|j: int| start_fn <= j < start_fn + nfr ==> !pre_sb.contains(j),
+                forall|k: int| 0 <= k < pre_rc.len() ==>
+                    #[trigger] self.refcount@[k] == (if start_fn <= k < index as int {
+                        1u8
+                    } else {
+                        pre_rc[k]
+                    }),
+            decreases end_exclusive - index,
+        )]
         for index in start_frame_number..end_exclusive {
             if let Err(error) = self.bitmap.set(index) {
+                // The bit at `index` is still clear and in range, so `set` cannot fail.
+                proof! {
+                    assert(!BitmapView::range_set(start_fn, index as int).contains(index as int));
+                    assert(!pre_sb.contains(index as int));
+                    assert(false);
+                }
                 error!("{error:?} (region={region:?})");
                 return Err(error);
             }
+            #[cfg(not(verus_keep_ghost))]
             debug_assert_eq!(self.refcount[index], 0);
             self.refcount[index] = 1;
+        }
+        proof! {
+            // Re-establish `internal_inv` after booking, prove the requested range was free, and
+            // reconstruct the post-state view as the pre-state map merged with the booked run.
+            lemma_alloc_range_post(self, rstart, rsize, ps, start_fn, nfr, g_old, pre_sb, pre_nb, pre_rc);
         }
 
         Ok(())

--- a/src/libs/arch/src/lib.rs
+++ b/src/libs/arch/src/lib.rs
@@ -3,6 +3,9 @@
 
 #![no_std]
 #![allow(clippy::all)]
+// To support attributes on statements (e.g., inline `proof!{}` blocks) under Verus,
+// we need `proc_macro_hygiene`.
+#![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;

--- a/src/libs/arch/src/x86/mem/paging/frame/number.proof.rs
+++ b/src/libs/arch/src/x86/mem/paging/frame/number.proof.rs
@@ -1,0 +1,72 @@
+verus! {
+
+use vstd::arithmetic::div_mod::lemma_div_is_ordered;
+use vstd::arithmetic::div_mod::lemma_fundamental_div_mod_converse_mod;
+use vstd::arithmetic::power2::lemma2_to64;
+use vstd::arithmetic::power2::lemma_pow2_adds;
+use vstd::arithmetic::power2::lemma_pow2_pos;
+use vstd::arithmetic::power2::pow2;
+use vstd::bits::lemma_usize_shr_is_div;
+use vstd::layout::unsigned_int_max_values;
+
+impl FrameNumber {
+    // Divisibility facts backing the `From<PhysicalAddress>` conversion: shifting a raw address
+    // right by `FRAME_SHIFT` is exactly integer division by `FRAME_SIZE`, and the quotient of any
+    // representable `usize` address is a valid frame index (`<= spec_max()`), so the conversion's
+    // `from_raw_value(..).unwrap()` never panics.
+    pub proof fn lemma_raw_shr_frame_shift(raw: usize)
+        ensures
+            (raw >> (mem::FRAME_SHIFT as usize)) as int == (raw as int) / (mem::FRAME_SIZE as int),
+            (raw >> (mem::FRAME_SHIFT as usize)) as int <= Self::spec_max(),
+    {
+        // `raw >> FRAME_SHIFT == raw / 2^FRAME_SHIFT` and `2^FRAME_SHIFT == FRAME_SIZE`, which
+        // discharges the first ensures.
+        lemma_usize_shr_is_div(raw, mem::FRAME_SHIFT as usize);
+        lemma2_to64();
+        assert(pow2(mem::FRAME_SHIFT as nat) == mem::FRAME_SIZE as nat);
+        // `usize::MAX` is the last byte of its frame, so `spec_max() == MAX_ADDRESS / FRAME_SIZE`.
+        Self::lemma_usize_max_frame_boundary();
+        // Division preserves order, so `raw / FRAME_SIZE <= MAX_ADDRESS / FRAME_SIZE == spec_max()`.
+        lemma_div_is_ordered(raw as int, mem::MAX_ADDRESS as int, mem::FRAME_SIZE as int);
+    }
+
+    // `usize::MAX` is always the last addressable byte of its frame, independent of the (32- or
+    // 64-bit) word size: `usize::MAX == 2^BITS - 1` and `2^BITS == FRAME_SIZE * 2^(BITS - FRAME_SHIFT)`,
+    // hence `usize::MAX % FRAME_SIZE == FRAME_SIZE - 1`. This resolves the `spec_max()` branch to
+    // `MAX_ADDRESS / FRAME_SIZE` without depending on `bit_vector` (which rejects the symbolic word
+    // width).
+    proof fn lemma_usize_max_frame_boundary()
+        ensures
+            (mem::MAX_ADDRESS as int) % (mem::FRAME_SIZE as int) == (mem::FRAME_SIZE as int) - 1,
+    {
+        let bits: nat = usize::BITS as nat;
+        let shift: nat = mem::FRAME_SHIFT as nat;
+        assert(bits == 32 || bits == 64);
+        assert(shift == 12);
+        assert(mem::FRAME_SIZE as int == 4096);
+        // `usize::MAX == 2^BITS - 1` and `2^BITS == 2^FRAME_SHIFT * 2^(BITS - FRAME_SHIFT)`.
+        unsigned_int_max_values();
+        assert(mem::MAX_ADDRESS as int == pow2(bits) - 1);
+        lemma2_to64();
+        assert(pow2(shift) == 4096);
+        lemma_pow2_pos((bits - shift) as nat);
+        lemma_pow2_adds(shift, (bits - shift) as nat);
+        assert(shift + (bits - shift) as nat == bits);
+        let k: int = pow2((bits - shift) as nat) as int;
+        assert(k >= 1);
+        assert(pow2(bits) == pow2(shift) * pow2((bits - shift) as nat));
+        assert(pow2(bits) == 4096 * k);
+        // `usize::MAX == 4096 * k - 1 == (k - 1) * FRAME_SIZE + (FRAME_SIZE - 1)`.
+        assert(mem::MAX_ADDRESS as int == 4096 * k - 1);
+        assert((mem::MAX_ADDRESS as int)
+            == (k - 1) * (mem::FRAME_SIZE as int) + ((mem::FRAME_SIZE as int) - 1));
+        lemma_fundamental_div_mod_converse_mod(
+            mem::MAX_ADDRESS as int,
+            mem::FRAME_SIZE as int,
+            k - 1,
+            (mem::FRAME_SIZE as int) - 1,
+        );
+    }
+}
+
+} // verus!

--- a/src/libs/arch/src/x86/mem/paging/frame/number.rs
+++ b/src/libs/arch/src/x86/mem/paging/frame/number.rs
@@ -9,6 +9,9 @@ use vstd::prelude::*;
 #[cfg(verus_keep_ghost)]
 include!("number.spec.rs");
 
+#[cfg(verus_keep_ghost)]
+include!("number.proof.rs");
+
 use crate::mem;
 use ::sys::mm::{
     Address,
@@ -94,13 +97,13 @@ impl FrameNumber {
     ///
     /// The raw value of the target [`FrameNumber`].
     ///
-    #[verus_verify(external_body)]
     #[verus_spec(result =>
         ensures
             result as int == self@,
             0 <= self@ <= Self::spec_max(),
     )]
     pub fn into_raw_value(self) -> usize {
+        proof! { use_type_invariant(self); }
         self.0
     }
 }
@@ -121,10 +124,18 @@ impl From<FrameNumber> for PhysicalAddress {
     }
 }
 
+#[verus_verify]
 impl From<PhysicalAddress> for FrameNumber {
+    #[verus_spec(result =>
+        ensures
+            result@ == phys_addr@ / (mem::FRAME_SIZE as int),
+    )]
     fn from(phys_addr: PhysicalAddress) -> Self {
         let raw_addr: usize = phys_addr.into_raw_value();
         let frame_number: usize = raw_addr >> mem::FRAME_SHIFT;
+        proof! {
+            FrameNumber::lemma_raw_shr_frame_shift(raw_addr);
+        }
         // The unwrap below never panics: `FrameNumber::MAX` is the number of the frame that
         // contains `MAX_ADDRESS`, so `raw_addr >> FRAME_SHIFT <= FrameNumber::MAX` holds for
         // every address in the space.

--- a/src/libs/arch/src/x86/mem/paging/frame/number.spec.rs
+++ b/src/libs/arch/src/x86/mem/paging/frame/number.spec.rs
@@ -1,3 +1,5 @@
+use vstd::std_specs::convert::FromSpecImpl;
+
 verus! {
 
 //==================================================================================================
@@ -43,6 +45,20 @@ impl FrameNumber {
     #[verifier::type_invariant]
     pub open spec fn inv(&self) -> bool {
         0 <= self@ <= Self::spec_max()
+    }
+}
+
+// The forward `From<PhysicalAddress>` conversion is proven directly against the `#[verus_spec]`
+// contract on `from`, so it does not obey the generic `from_spec` model. Declaring `obeys_from_spec`
+// as `false` makes the inherited `From`-trait postcondition vacuous without introducing any trusted
+// leaf (this is a spec-only fact, not an `external_body`/`assume_specification`).
+impl FromSpecImpl<PhysicalAddress> for FrameNumber {
+    open spec fn obeys_from_spec() -> bool {
+        false
+    }
+
+    open spec fn from_spec(v: PhysicalAddress) -> FrameNumber {
+        vstd::prelude::arbitrary()
     }
 }
 

--- a/src/libs/sys/src/sys/mm/address/phys.rs
+++ b/src/libs/sys/src/sys/mm/address/phys.rs
@@ -6,6 +6,8 @@
 //==================================================================================================
 
 use vstd::prelude::*;
+#[cfg(verus_keep_ghost)]
+include!("phys.spec.rs");
 
 use crate::{
     error::{
@@ -36,6 +38,7 @@ pub struct PhysicalAddress(VirtualAddress);
 // Implementations
 //==================================================================================================
 
+#[verus_verify]
 impl PhysicalAddress {
     ///
     /// # Description
@@ -54,6 +57,14 @@ impl PhysicalAddress {
     ///
     /// This function returns an error if the address is outside the physical address space.
     ///
+    #[verus_spec(result =>
+        ensures
+            match result {
+                Ok(a) => addr@ < spec_physical_memory_size() && a@ == addr@,
+                Err(e) => !(addr@ < spec_physical_memory_size())
+                    && e.code == ErrorCode::BadAddress,
+            },
+    )]
     pub fn from_virtual_address(addr: VirtualAddress) -> Result<Self, Error> {
         if !is_valid_physical_address(addr) {
             return Err(Error::new(
@@ -113,6 +124,7 @@ impl PhysicalAddress {
     /// Upon success, the new [`PhysicalAddress`] is returned. Upon failure (overflow), `None` is
     /// returned instead.
     ///
+    #[verus_verify(external)]
     pub fn checked_add(&self, rhs: usize) -> Option<Self> {
         self.0
             .checked_add(rhs)
@@ -147,7 +159,6 @@ impl Address for PhysicalAddress {
     /// - `Ok(Self)`: The new address.
     /// - `Err(Error::BadAddress)`: If the provided address is invalid.
     ///
-    #[verifier::external_body]
     fn from_raw_value(value: usize) -> Result<Self, Error> {
         Self::from_virtual_address(VirtualAddress::from_raw_value(value))
     }
@@ -227,17 +238,14 @@ impl Address for PhysicalAddress {
         ::config::kernel::MEMORY_SIZE - 1
     }
 
-    #[verifier::external_body]
     fn into_raw_value(self) -> usize {
         self.0.into_raw_value()
     }
 
-    #[verifier::external_body]
     fn as_ptr(&self) -> *const u8 {
         self.0.as_ptr()
     }
 
-    #[verifier::external_body]
     fn as_mut_ptr(&self) -> *mut u8 {
         self.0.as_mut_ptr()
     }
@@ -306,6 +314,11 @@ impl From<PhysicalAddress> for usize {
 /// `true` if `addr` falls within the physical address space, `false` otherwise.
 ///
 #[inline(always)]
+#[verus_verify]
+#[verus_spec(result =>
+    ensures
+        result == (addr@ < spec_physical_memory_size()),
+)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
     addr.into_raw_value() < ::config::kernel::MEMORY_SIZE
 }
@@ -324,11 +337,5 @@ impl View for PhysicalAddress {
         self.0@
     }
 }
-
-// Abstract size of the physical address space. Its concrete value is the build-time constant
-// `config::kernel::MEMORY_SIZE`, which Verus cannot read because `config` is intentionally outside
-// the verified crate set. `spec_physical_memory_size` names that value abstractly so that the
-// physical-address validity predicate can refer to it.
-pub uninterp spec fn spec_physical_memory_size() -> int;
 
 } // end verus!

--- a/src/libs/sys/src/sys/mm/address/phys.spec.rs
+++ b/src/libs/sys/src/sys/mm/address/phys.spec.rs
@@ -1,0 +1,17 @@
+verus! {
+
+// Abstract size of the physical address space. Its concrete value is the build-time constant
+// `config::kernel::MEMORY_SIZE`, which Verus cannot read because `config` is intentionally outside
+// the verified crate set. `spec_physical_memory_size` names that value abstractly so that the
+// physical-address validity predicate can refer to it.
+pub uninterp spec fn spec_physical_memory_size() -> int;
+
+// Trusted specification that ties the concrete build-time `config::kernel::MEMORY_SIZE` constant to
+// the abstract `spec_physical_memory_size`. This is the single point where the constant enters the
+// verified world.
+pub assume_specification[ ::config::kernel::MEMORY_SIZE ] -> (res: usize)
+    ensures
+        res as int == spec_physical_memory_size(),
+;
+
+} // verus!

--- a/src/libs/sys/src/sys/mm/address/virt.rs
+++ b/src/libs/sys/src/sys/mm/address/virt.rs
@@ -189,6 +189,7 @@ impl VirtualAddress {
     }
 }
 
+#[verus_verify]
 impl Address for VirtualAddress {
     ///
     /// # Description
@@ -221,6 +222,7 @@ impl Address for VirtualAddress {
     ///
     /// Upon success, the aligned address is returned. Upon failure, an error is returned instead.
     ///
+    #[verus_verify(external_body)]
     fn align_up(&self, align: Alignment) -> Result<Self, Error> {
         self.align_up(align)
             .ok_or_else(|| Error::new(ErrorCode::BadAddress, "align_up overflow"))
@@ -240,6 +242,7 @@ impl Address for VirtualAddress {
     ///
     /// Upon success, the aligned address is returned. Upon failure, an error is returned instead.
     ///
+    #[verus_verify(external_body)]
     fn align_down(&self, align: Alignment) -> Result<Self, Error> {
         Ok(self.align_down(align))
     }
@@ -258,6 +261,7 @@ impl Address for VirtualAddress {
     /// Upon success, `true` is returned if the address is aligned, otherwise `false`. Upon failure,
     /// an error is returned instead.
     ///
+    #[verus_verify(external_body)]
     fn is_aligned(&self, align: Alignment) -> Result<bool, Error> {
         Ok(self.is_aligned(align))
     }
@@ -279,10 +283,12 @@ impl Address for VirtualAddress {
         self.0
     }
 
+    #[verus_verify(external_body)]
     fn as_ptr(&self) -> *const u8 {
         self.0 as *const u8
     }
 
+    #[verus_verify(external_body)]
     fn as_mut_ptr(&self) -> *mut u8 {
         self.0 as *mut u8
     }


### PR DESCRIPTION
Add the physical-memory proofs on top of the specifications merged in #2815.
Note that the `external_body` in `phys.rs` and `virt.rs` are required because the `Address` trait must be implemented and verified as a whole (a trait impl cannot be split, nor can individual methods be excluded), while some of its method bodies use constructs Verus cannot model (such as  `usize -to-raw-pointer` casts and alignment arithmetic). 