### PR TITLE
[libc_pthread] Support pthread_attr_setguardsize()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -49,6 +49,7 @@ typedef struct {
     int is_initialized;            /**< Whether the attributes are initialized. */
     void *stackaddr;               /**< Stack base address.                     */
     size_t stacksize;              /**< Stack size.                             */
+    size_t guardsize;              /**< Guard size.                             */
     int contentionscope;           /**< Contention scope.                       */
     int inheritsched;              /**< Inherit-scheduler attribute.            */
     int schedpolicy;               /**< Scheduling policy.                      */
@@ -109,6 +110,7 @@ extern int pthread_attr_init(pthread_attr_t *attr);
 extern int pthread_attr_destroy(pthread_attr_t *attr);
 extern int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate);
 extern int pthread_attr_getguardsize(const pthread_attr_t *attr, size_t *guardsize);
+extern int pthread_attr_setguardsize(pthread_attr_t *attr, size_t guardsize);
 extern int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
 extern int pthread_attr_getschedparam(const pthread_attr_t *attr, struct sched_param *param);
 extern int pthread_attr_setschedparam(pthread_attr_t *attr, const struct sched_param *param);

--- a/src/libs/libc_pthread/src/lib.rs
+++ b/src/libs/libc_pthread/src/lib.rs
@@ -161,8 +161,8 @@ pub unsafe extern "C" fn pthread_attr_getguardsize(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // Nanvix does not currently provide guard areas for user thread stacks.
-    *guardsize = 0;
+    // Store the guard size.
+    *guardsize = (*attr).guardsize;
 
     0
 }
@@ -863,9 +863,10 @@ pub unsafe extern "C" fn pthread_attr_setguardsize(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // TODO: implement this function.
-    ::syslog::warn!("pthread_attr_setguardsize(): not supported, failing");
-    ErrorCode::OperationNotSupported.get()
+    // Store the guard size.
+    (*attr).guardsize = guardsize;
+
+    0
 }
 
 //==================================================================================================

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -119,6 +119,7 @@ functions = [
     "pthread_attr_destroy",
     "pthread_attr_getdetachstate",
     "pthread_attr_getguardsize",
+    "pthread_attr_setguardsize",
     "pthread_attr_setdetachstate",
     "pthread_attr_getschedparam",
     "pthread_attr_setschedparam",

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -137,6 +137,8 @@ pub struct pthread_attr_t {
     pub stackaddr: *mut c_void,
     /// Stack size.
     pub stacksize: c_size_t,
+    /// Guard size.
+    pub guardsize: c_size_t,
     /// Contention scope.
     pub contentionscope: c_int,
     /// Inherit-scheduler attribute.
@@ -160,6 +162,8 @@ impl pthread_attr_t {
     const SIZE_OF_STACKADDR: usize = size_of::<*mut c_void>();
     /// Size of the `stacksize` field.
     const SIZE_OF_STACKSIZE: usize = size_of::<c_size_t>();
+    /// Size of the `guardsize` field.
+    const SIZE_OF_GUARDSIZE: usize = size_of::<c_size_t>();
     /// Size of the `contentionscope` field.
     const SIZE_OF_CONTENTIONSCOPE: usize = size_of::<c_int>();
     /// Size of the `inheritsched` field.
@@ -177,6 +181,7 @@ impl pthread_attr_t {
     pub const _SIZE: usize = Self::SIZE_OF_IS_INITIALIZED
         + Self::SIZE_OF_STACKADDR
         + Self::SIZE_OF_STACKSIZE
+        + Self::SIZE_OF_GUARDSIZE
         + Self::SIZE_OF_CONTENTIONSCOPE
         + Self::SIZE_OF_INHERITSCHED
         + Self::SIZE_OF_SCHEDPOLICY
@@ -192,6 +197,7 @@ impl Default for pthread_attr_t {
             is_initialized: 1,
             stackaddr: USER_STACK_TOP_RAW as *mut _,
             stacksize: USER_THREAD_STACK_SIZE as c_size_t,
+            guardsize: 0,
             contentionscope: 0,
             inheritsched: 0,
             schedpolicy: SCHED_OTHER,

--- a/src/tests/integration/test-c-thread/attr_setguardsize.c
+++ b/src/tests/integration/test-c-thread/attr_setguardsize.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the guard size attribute can be set and retrieved.
+void test_pthread_attr_setguardsize(void)
+{
+    fprintf(stderr, "testing pthread_attr_setguardsize() ... ");
+
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    size_t guardsize = 0;
+    ret = pthread_attr_setguardsize(&attr, 4096);
+    assert(ret == 0);
+    ret = pthread_attr_getguardsize(&attr, &guardsize);
+    assert(ret == 0);
+    assert(guardsize == 4096);
+
+    ret = pthread_attr_setguardsize(&attr, 0);
+    assert(ret == 0);
+    ret = pthread_attr_getguardsize(&attr, &guardsize);
+    assert(ret == 0);
+    assert(guardsize == 0);
+
+    ret = pthread_attr_setguardsize(NULL, 4096);
+    assert(ret == EINVAL);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -54,6 +54,9 @@ extern void test_pthread_attr_setdetachstate(void);
 // Tests if the guard size attribute can be retrieved.
 extern void test_pthread_attr_getguardsize(void);
 
+// Tests if the guard size attribute can be set and retrieved.
+extern void test_pthread_attr_setguardsize(void);
+
 // Tests if scheduling parameters can be set and retrieved.
 extern void test_pthread_attr_setschedparam(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -75,6 +75,7 @@ int main(int argc, const char *argv[])
                        sizeof(int) +                    // is_initialized
                            sizeof(void *) +             // stackaddr
                            sizeof(size_t) +             // stacksize
+                           sizeof(size_t) +             // guardsize
                            sizeof(int) +                // contentionscope
                            sizeof(int) +                // inheritsched
                            sizeof(int) +                // schedpolicy
@@ -124,6 +125,7 @@ int main(int argc, const char *argv[])
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
     test_pthread_attr_getguardsize();
+    test_pthread_attr_setguardsize();
     test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
     test_pthread_getattr_np_destroy();


### PR DESCRIPTION
## Summary

Implements `pthread_attr_setguardsize()` and completes guard-size attribute handling in `pthread_attr_t`.

- Store the requested guard size in `pthread_attr_setguardsize()` (replacing the previous `ENOTSUP` stub) and return it from `pthread_attr_getguardsize()` instead of a hardcoded zero.
- Add a `guardsize` field to `pthread_attr_t` (after `stacksize`), defaulting to zero, and include it in the computed struct size.
- Keep the generated `pthread.h` and its header manifest in sync with the Rust definition (new field + setter declaration), preserving the C ABI.

## Notes

Guard pages are not yet enforced; only the attribute round-trips through `pthread_attr_t`.

## Tests

Adds a `test-c-thread` case covering the set/get round-trip (non-zero and zero) and `EINVAL` for a NULL attributes pointer, and extends the `pthread_attr_t` size assertion for the new field.

Part of #478