### PR TITLE
[libc_pthread] Implement pthread_attr_setstack

### DIFF
--- a/src/libs/libc_pthread/src/lib.rs
+++ b/src/libs/libc_pthread/src/lib.rs
@@ -939,6 +939,14 @@ pub unsafe extern "C" fn pthread_attr_setschedparam(
 ///
 /// If successful, zero is returned. Otherwise, an error code is returned instead.
 ///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` is null or misaligned.
+/// - [`ErrorCode::InvalidArgument`] if `attr` is not initialized.
+/// - [`ErrorCode::InvalidArgument`] if `stackaddr` is null or improperly aligned.
+/// - [`ErrorCode::InvalidArgument`] if `stacksize` is too small, the stack region overflows, or the
+///   stack region is improperly aligned.
+///
 /// # Safety
 ///
 /// This function is unsafe because it may dereference raw pointers.
@@ -960,9 +968,55 @@ pub unsafe extern "C" fn pthread_attr_setstack(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // TODO: implement this function.
-    ::syslog::warn!("pthread_attr_setstack(): not supported, failing");
-    ErrorCode::OperationNotSupported.get()
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
+        ::syslog::warn!("pthread_attr_setstack(): misaligned attribute pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` was initialized.
+    if (*attr).is_initialized == 0 {
+        ::syslog::warn!("pthread_attr_setstack(): attribute object was not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `stackaddr` is not valid.
+    if stackaddr.is_null() {
+        ::syslog::warn!("pthread_attr_setstack(): invalid stack address");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    let stack_size: usize = stacksize as usize;
+
+    // Check if `stacksize` is not valid.
+    if stack_size < ::config::memory_layout::USER_STACK_MIN_SIZE {
+        ::syslog::warn!("pthread_attr_setstack(): invalid stack size");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    let stack_alignment: usize = ::sys::mm::Alignment::Align16 as usize;
+    let stack_base: usize = stackaddr as usize;
+
+    // Check if `stackaddr` is misaligned.
+    if !stack_base.is_multiple_of(stack_alignment) {
+        ::syslog::warn!("pthread_attr_setstack(): misaligned stack address");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the stack region overflows or ends at a misaligned address.
+    match stack_base.checked_add(stack_size) {
+        Some(stack_end) if stack_end.is_multiple_of(stack_alignment) => {},
+        _ => {
+            ::syslog::warn!("pthread_attr_setstack(): invalid stack end address");
+            return ErrorCode::InvalidArgument.get();
+        },
+    }
+
+    // Store the stack attributes.
+    (*attr).stackaddr = stackaddr;
+    (*attr).stacksize = stacksize;
+
+    0
 }
 
 //==================================================================================================

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -75,6 +75,9 @@ extern void test_pthread_getattr_np_destroy(void);
 // Tests if pthread_attr_getstack() can retrieve stack attributes and they can be destroyed.
 extern void test_pthread_attr_getstack(void);
 
+// Tests if pthread_attr_setstack() validates and stores stack attributes.
+extern void test_pthread_attr_setstack(void);
+
 // Tests if statically initialized read-write locks can synchronize multiple readers.
 extern void test_pthread_rwlock_static_init(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -128,6 +128,7 @@ int main(int argc, const char *argv[])
     test_pthread_attr_setguardsize();
     test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
+    test_pthread_attr_setstack();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();

--- a/src/tests/integration/test-c-thread/setstack.c
+++ b/src/tests/integration/test-c-thread/setstack.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#define STACK_ALIGNMENT 16
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread_attr_setstack() validates and stores stack attributes.
+void test_pthread_attr_setstack(void)
+{
+    fprintf(stderr, "testing pthread_attr_setstack() ... ");
+
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    void *default_stackaddr = NULL;
+    size_t default_stacksize = 0;
+    ret = pthread_attr_getstack(&attr, &default_stackaddr, &default_stacksize);
+    assert(ret == 0);
+
+    size_t stacksize = default_stacksize + STACK_ALIGNMENT;
+    void *stackaddr = malloc(stacksize);
+    assert(stackaddr != NULL);
+
+    ret = pthread_attr_setstack(&attr, stackaddr, stacksize);
+    assert(ret == 0);
+
+    void *actual_stackaddr = NULL;
+    size_t actual_stacksize = 0;
+    ret = pthread_attr_getstack(&attr, &actual_stackaddr, &actual_stacksize);
+    assert(ret == 0);
+    assert(actual_stackaddr == stackaddr);
+    assert(actual_stacksize == stacksize);
+
+    ret = pthread_attr_setstack(NULL, stackaddr, stacksize);
+    assert(ret == EINVAL);
+    pthread_attr_t uninitialized_attr = {
+        0,
+    };
+    ret = pthread_attr_setstack(&uninitialized_attr, stackaddr, stacksize);
+    assert(ret == EINVAL);
+    ret = pthread_attr_setstack(&attr, NULL, stacksize);
+    assert(ret == EINVAL);
+    ret = pthread_attr_setstack(&attr, stackaddr, 0);
+    assert(ret == EINVAL);
+    ret = pthread_attr_setstack(&attr, (char *)stackaddr + 1, stacksize - 1);
+    assert(ret == EINVAL);
+    ret = pthread_attr_setstack(&attr, stackaddr, stacksize - 1);
+    assert(ret == EINVAL);
+
+    ret = pthread_attr_getstack(&attr, &actual_stackaddr, &actual_stacksize);
+    assert(ret == 0);
+    assert(actual_stackaddr == stackaddr);
+    assert(actual_stacksize == stacksize);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+    free(stackaddr);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Implements `pthread_attr_setstack()` in `libc_pthread`, replacing the previous
stub that returned `OperationNotSupported`. The function now validates and stores
the caller-provided stack attributes so they can be read back via
`pthread_attr_getstack()`, ahead of full `pthread_create()` integration.

## What changed

- **`libc_pthread`:** Implement `pthread_attr_setstack()`:
  - Reject a null or misaligned `attr`, and an uninitialized attribute object.
  - Reject a null or misaligned `stackaddr`, a `stacksize` below
    `USER_STACK_MIN_SIZE`, and a stack region that overflows or ends at a
    misaligned address.
  - Store `stackaddr`/`stacksize` and return zero on success.
  - Document the error conditions in the function's `# Errors` section.
- **Tests:** Add `test_pthread_attr_setstack()` to the `test-c-thread` suite,
  covering the success path (store then read back) and the rejection paths
  (null `attr`, null `stackaddr`, zero `stacksize`, misaligned region), and
  verifying a failed call leaves previously stored attributes intact.

## Validation

- Unit tests, standalone integration tests, and the ported POSIX C suite
  (`run-posix-tests`) pass; `posix/test-c-thread` exits with code 0.

Part of #487