### PR TITLE
[ci] Reuse ubuntu-core.sh in CI Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -22,43 +22,17 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ---------------------------------------------------------------------------
-# System packages — mirrors scripts/setup/ubuntu-core.sh
+# System packages — reuses scripts/setup/ubuntu-core.sh to avoid duplication.
+#
+# The extra packages installed here (python3-pip, sudo) are CI-container
+# specific and therefore not part of the shared setup script.
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        bc                    \
-        bridge-utils          \
-        build-essential       \
-        bzip2                 \
-        clang                 \
-        cmake                 \
-        codespell             \
-        cpio                  \
-        curl                  \
-        dosfstools            \
-        doxygen               \
-        gawk                  \
-        gdb-multiarch         \
-        git                   \
-        graphviz              \
-        grub2                 \
-        iproute2              \
-        jq                    \
-        kpartx                \
-        libvirt-clients       \
-        libvirt-daemon-system \
-        mmdebstrap            \
-        mtools                \
-        netcat-openbsd        \
-        ninja-build           \
-        pkg-config            \
-        python3-pip           \
-        python3-venv          \
-        shellcheck            \
-        sudo                  \
-        unzip                 \
-        wget                  \
-        xorriso               \
-    && rm -rf /var/lib/apt/lists/*
+COPY scripts/setup/ubuntu-core.sh /tmp/ubuntu-core.sh
+RUN bash /tmp/ubuntu-core.sh \
+    && apt-get install -y --no-install-recommends \
+        python3-pip \
+        sudo \
+    && rm -rf /var/lib/apt/lists/* /tmp/ubuntu-core.sh
 
 # ---------------------------------------------------------------------------
 # Rust toolchain — derived from rust-toolchain at build time.


### PR DESCRIPTION
## What

Replace the duplicated `apt-get` package list in the CI container image with a call to the shared `scripts/setup/ubuntu-core.sh`, so system dependencies are defined in a single place.

## Why

The Dockerfile previously mirrored the full package list from `ubuntu-core.sh` by hand, meaning any dependency change had to be made in two places. The CI workflow already rebuilds the image whenever `ubuntu-core.sh` changes, so the image can consume the script directly.

## Changes

- `COPY` and run `bash /tmp/ubuntu-core.sh` instead of inlining the full package list, keeping the dev-machine and CI dependency sets in sync.
- Install the container-specific extras (`python3-pip`, `sudo`) separately, since they are intentionally not part of the shared script (`sudo` must pre-exist to run the script; `python3-pip` is not needed by the dev flow).
- Remove the copied script and apt lists in the same layer to keep the image small.
