### PR TITLE
[syscall] Add pthread_attr_setstacksize and condattr_destroy

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -148,6 +148,7 @@ extern int pthread_cond_signal(const pthread_cond_t *cond);
 extern int pthread_cond_broadcast(const pthread_cond_t *cond);
 extern int pthread_cond_wait(const pthread_cond_t *cond, pthread_mutex_t *mutex);
 extern int pthread_cond_timedwait(const pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+extern int pthread_condattr_destroy(pthread_condattr_t *attr);
 extern int pthread_condattr_init(pthread_condattr_t *attr);
 extern int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 extern int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -157,6 +157,7 @@ functions = [
     "pthread_cond_broadcast",
     "pthread_cond_wait",
     "pthread_cond_timedwait",
+    "pthread_condattr_destroy",
     "pthread_condattr_init",
     "pthread_condattr_getpshared",
     "pthread_condattr_setclock",

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -243,6 +243,11 @@ impl pthread_condattr_t {
         self.is_initialized != 0
     }
 
+    /// Marks the condition variable attributes object as uninitialized.
+    pub fn uninitialize(&mut self) {
+        self.is_initialized = 0;
+    }
+
     /// Returns the process-sharing attribute.
     pub fn pshared(&self) -> c_int {
         self.pshared

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -16,6 +16,7 @@ pub mod pthread_cond_init;
 pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
+pub mod pthread_condattr_destroy;
 pub mod pthread_condattr_getpshared;
 pub mod pthread_condattr_init;
 pub mod pthread_condattr_setclock;

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
@@ -5,9 +5,14 @@
 // Imports
 //==================================================================================================
 
+use crate::pthread::syscall;
+use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
-    sys_types::pthread_attr_t,
+    sys_types::{
+        c_size_t,
+        pthread_attr_t,
+    },
 };
 use ::syslog::trace_libcall;
 
@@ -15,15 +20,66 @@ use ::syslog::trace_libcall;
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Sets the stack size attribute in a thread attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the thread attributes object.
+/// - `stacksize`: Stack size to set.
+///
+/// # Return Value
+///
+/// On success, this function returns zero. Otherwise, it returns a non-zero error code indicating
+/// the reason for the failure.
+///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` is null or misaligned.
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to an uninitialized thread attributes object.
+/// - [`ErrorCode::InvalidArgument`] if `stacksize` is smaller than the minimum thread stack size.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference a raw pointer.
+///
+/// It is safe to call this function if `attr` points to a valid [`pthread_attr_t`].
+///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setstacksize(
     attr: *mut pthread_attr_t,
-    stacksize: usize,
+    stacksize: c_size_t,
 ) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/488
-    ::syslog::debug!("pthread_attr_setstacksize(): not implemented");
-    0
+    // Check if `attr` points to an invalid address.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_attr_setstacksize(): invalid pointer to thread attributes object \
+             (attr={attr:p}, stacksize={stacksize})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
+        ::syslog::warn!(
+            "pthread_attr_setstacksize(): misaligned pointer to thread attributes object \
+             (attr={attr:p}, stacksize={stacksize})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Attempt to set the stack size attribute and check for errors.
+    match syscall::pthread_attr_setstacksize(&mut *attr, stacksize) {
+        Ok(()) => {
+            ::syslog::trace!("pthread_attr_setstacksize(): success");
+            0
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_attr_setstacksize(): {error:?}");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_destroy.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_condattr_t,
+};
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Destroys a condition variable attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object to destroy.
+///
+/// # Return Value
+///
+/// On success, returns 0. Otherwise, returns an error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+/// It is safe to call this function iff `attr` points to writable memory large enough to hold a
+/// `pthread_condattr_t` structure and is properly aligned.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_condattr_destroy(attr: *mut pthread_condattr_t) -> c_int {
+    // Check if pointer to cond attribute object is valid.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_destroy(): invalid pointer to cond attribute object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if pointer to cond attribute object is properly aligned.
+    if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_condattr_t>()) {
+        ::syslog::warn!(
+            "pthread_condattr_destroy(): misaligned pointer to cond attribute object \
+             (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the condition variable attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_condattr_destroy(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    (*attr).uninitialize();
+    0
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_create.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_create.rs
@@ -35,6 +35,12 @@ use ::syslog::trace_libcall;
 ///
 /// If successful, zero is returned. Otherwise, an error code is returned instead.
 ///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`] if `thread` is null.
+/// - [`ErrorCode::InvalidArgument`] if `attr` is non-null and misaligned or points to an
+///   uninitialized thread attributes object.
+///
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
@@ -59,17 +65,25 @@ pub unsafe extern "C" fn pthread_create(
         return ErrorCode::InvalidArgument.get();
     }
 
-    // Cast `thread` to a mutable reference.
-    let thread: &mut pthread_t = &mut *thread;
-
-    // Check if we should use default attributes.
-    if attr.is_null() {
-        // TODO: use default attributes.
+    let stack_size: usize = if attr.is_null() {
+        ::config::memory_layout::USER_THREAD_STACK_SIZE
     } else {
-        ::syslog::warn!("pthread_create(): attributes are not supported, ignoring");
-    }
+        // Check if `attr` is misaligned.
+        if !(attr as usize).is_multiple_of(core::mem::align_of::<pthread_attr_t>()) {
+            ::syslog::warn!("pthread_create(): misaligned attribute pointer");
+            return ErrorCode::InvalidArgument.get();
+        }
 
-    match crate::pthread::pthread_create(start_routine, arg) {
+        // Check if `attr` was initialized.
+        if (*attr).is_initialized == 0 {
+            ::syslog::warn!("pthread_create(): attribute object was not initialized");
+            return ErrorCode::InvalidArgument.get();
+        }
+
+        (*attr).stacksize as usize
+    };
+
+    match crate::pthread::pthread_create(start_routine, arg, stack_size) {
         Ok(tid) => {
             *thread = tid;
             0

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -29,6 +29,9 @@ mod pthread_attr_init;
 /// Implementation of `pthread_attr_getstack()` system call.
 mod pthread_attr_getstack;
 
+/// Implementation of `pthread_attr_setstacksize()` system call.
+mod pthread_attr_setstacksize;
+
 /// Implementation of `pthread_getattr_np()` system call.
 mod pthread_getattr_np;
 
@@ -38,7 +41,6 @@ mod pthread_getattr_np;
 
 use crate::safe::mem::stack::Stack;
 use ::alloc::collections::btree_map::BTreeMap;
-use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::spin::{
     Lazy,
     Mutex,
@@ -75,6 +77,7 @@ pub use mutex::*;
 pub use pthread_attr_destroy::*;
 pub use pthread_attr_getstack::*;
 pub use pthread_attr_init::*;
+pub use pthread_attr_setstacksize::*;
 pub use pthread_getattr_np::*;
 pub use rwlock::*;
 pub use sem::*;
@@ -100,19 +103,27 @@ static STACKS: Lazy<Mutex<BTreeMap<pthread_t, Stack>>> = Lazy::new(|| Mutex::new
 ///
 /// - `start_routine`: Function to be executed by the thread.
 /// - `arg`: Argument passed to the thread function.
+/// - `stack_size`: Size of the stack for the new thread.
 ///
 /// # Return Value
 ///
 /// On successful completion, this function returns an identifier for the newly created thread. On
 /// failure, this function returns an error that contains the reason for the failure.
 ///
-pub fn pthread_create(func: extern "C" fn(usize) -> usize, arg: usize) -> Result<pthread_t, Error> {
-    ::syslog::trace!("pthread_create(): func={:?}, arg={arg:?}", ::core::ptr::addr_of!(func));
+pub fn pthread_create(
+    func: extern "C" fn(usize) -> usize,
+    arg: usize,
+    stack_size: usize,
+) -> Result<pthread_t, Error> {
+    ::syslog::trace!(
+        "pthread_create(): func={:?}, arg={arg:?}, stack_size={stack_size}",
+        ::core::ptr::addr_of!(func)
+    );
 
     // Create a new stack.
     // NOTE: The stack is automatically deallocated if this object is dropped.
     // TODO: Allocate thread stack on-demand via kernel mmap support (https://github.com/nanvix/nanvix/issues/1699).
-    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
+    let stack: Stack = Stack::new(stack_size)?;
 
     let user_tda: Option<VirtualAddress> =
         ::sysalloc::tda::alloc()?.map(|tda_ptr| VirtualAddress::new(tda_ptr as usize));

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -120,6 +120,15 @@ pub fn pthread_create(
         ::core::ptr::addr_of!(func)
     );
 
+    // Reject undersized stacks, consistent with pthread_attr_setstacksize(). Otherwise
+    // `Stack::new()` could succeed with a zero-sized (or too small) stack and the kernel
+    // thread-create path would receive an invalid `user_stack_size`.
+    if stack_size < ::config::memory_layout::USER_STACK_MIN_SIZE {
+        let reason: &'static str = "stack size is smaller than the minimum thread stack size";
+        ::syslog::warn!("pthread_create(): {reason} (stack_size={stack_size})");
+        return Err(Error::new(::sys::error::ErrorCode::InvalidArgument, reason));
+    }
+
     // Create a new stack.
     // NOTE: The stack is automatically deallocated if this object is dropped.
     // TODO: Allocate thread stack on-demand via kernel mmap support (https://github.com/nanvix/nanvix/issues/1699).

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_setstacksize.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_setstacksize.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::config::memory_layout::USER_STACK_MIN_SIZE;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::sys_types::{
+    c_size_t,
+    pthread_attr_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the stack size attribute in a thread attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Thread attributes object.
+/// - `stacksize`: Stack size to set.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. Otherwise, it returns an error indicating the reason
+/// for the failure.
+///
+/// # Errors
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` references an uninitialized thread attributes object.
+/// - [`ErrorCode::InvalidArgument`] if `stacksize` is smaller than the minimum thread stack size.
+///
+pub fn pthread_attr_setstacksize(
+    attr: &mut pthread_attr_t,
+    stacksize: c_size_t,
+) -> Result<(), Error> {
+    ::syslog::trace!(
+        "pthread_attr_setstacksize(): attr={:p}, stacksize={stacksize}",
+        attr as *const _
+    );
+
+    // Ensure the attributes object is initialized.
+    if attr.is_initialized == 0 {
+        let reason: &'static str = "thread attributes object was not initialized";
+        ::syslog::warn!(
+            "pthread_attr_setstacksize(): {reason} (attr={:p}, stacksize={stacksize})",
+            attr as *const _
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    // Ensure the requested stack size is supported.
+    if (stacksize as usize) < USER_STACK_MIN_SIZE {
+        let reason: &'static str = "stack size is smaller than the minimum thread stack size";
+        ::syslog::warn!(
+            "pthread_attr_setstacksize(): {reason} (attr={:p}, stacksize={stacksize})",
+            attr as *const _
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    attr.stacksize = stacksize;
+
+    Ok(())
+}

--- a/src/tests/integration/test-c-thread/attr_setstacksize.c
+++ b/src/tests/integration/test-c-thread/attr_setstacksize.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#define STACK_SIZE_DELTA 4096
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Signals that the worker may inspect its attributes after pthread_create() records its stack.
+static volatile int worker_may_run = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Checks that the worker thread was created with the requested stack size.
+static void *worker_thread(void *arg)
+{
+    while (!worker_may_run) {
+        int ret = sched_yield();
+        assert(ret == 0);
+    }
+
+    size_t expected_stacksize = *(const size_t *)arg;
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_getattr_np(pthread_self(), &attr);
+    assert(ret == 0);
+
+    size_t actual_stacksize = 0;
+    ret = pthread_attr_getstacksize(&attr, &actual_stacksize);
+    assert(ret == 0);
+    assert(actual_stacksize == expected_stacksize);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    return NULL;
+}
+
+// Tests if pthread_attr_setstacksize() validates, stores, and applies the stack size attribute.
+void test_pthread_attr_setstacksize(void)
+{
+    fprintf(stderr, "testing pthread_attr_setstacksize() ... ");
+
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    size_t default_stacksize = 0;
+    ret = pthread_attr_getstacksize(&attr, &default_stacksize);
+    assert(ret == 0);
+
+    size_t stacksize = default_stacksize + STACK_SIZE_DELTA;
+    assert(stacksize > default_stacksize);
+    ret = pthread_attr_setstacksize(&attr, stacksize);
+    assert(ret == 0);
+
+    size_t actual_stacksize = 0;
+    ret = pthread_attr_getstacksize(&attr, &actual_stacksize);
+    assert(ret == 0);
+    assert(actual_stacksize == stacksize);
+
+    ret = pthread_attr_setstacksize(NULL, stacksize);
+    assert(ret == EINVAL);
+    pthread_attr_t uninitialized_attr = {
+        0,
+    };
+    ret = pthread_attr_setstacksize(&uninitialized_attr, stacksize);
+    assert(ret == EINVAL);
+    ret = pthread_attr_setstacksize(&attr, 0);
+    assert(ret == EINVAL);
+
+    ret = pthread_attr_getstacksize(&attr, &actual_stacksize);
+    assert(ret == 0);
+    assert(actual_stacksize == stacksize);
+
+    worker_may_run = 0;
+    pthread_t worker_tid = PTHREAD_NULL;
+    ret = pthread_create(&worker_tid, &attr, worker_thread, &stacksize);
+    assert(ret == 0);
+    assert(worker_tid != PTHREAD_NULL);
+
+    worker_may_run = 1;
+    ret = pthread_join(worker_tid, NULL);
+    assert(ret == 0);
+
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/attr_setstacksize.c
+++ b/src/tests/integration/test-c-thread/attr_setstacksize.c
@@ -10,7 +10,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
-#include <sched.h>
 #include <stdio.h>
 
 //==================================================================================================
@@ -23,8 +22,14 @@
 // Global Variables
 //==================================================================================================
 
+// Mutex guarding `worker_may_run`.
+static pthread_mutex_t worker_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// Condition variable used to signal that the worker may inspect its attributes.
+static pthread_cond_t worker_ready = PTHREAD_COND_INITIALIZER;
+
 // Signals that the worker may inspect its attributes after pthread_create() records its stack.
-static volatile int worker_may_run = 0;
+static int worker_may_run = 0;
 
 //==================================================================================================
 // Standalone Functions
@@ -33,16 +38,21 @@ static volatile int worker_may_run = 0;
 // Checks that the worker thread was created with the requested stack size.
 static void *worker_thread(void *arg)
 {
+    // Wait until the main thread signals that pthread_create() has recorded our stack.
+    int ret = pthread_mutex_lock(&worker_lock);
+    assert(ret == 0);
     while (!worker_may_run) {
-        int ret = sched_yield();
+        ret = pthread_cond_wait(&worker_ready, &worker_lock);
         assert(ret == 0);
     }
+    ret = pthread_mutex_unlock(&worker_lock);
+    assert(ret == 0);
 
     size_t expected_stacksize = *(const size_t *)arg;
     pthread_attr_t attr = {
         0,
     };
-    int ret = pthread_getattr_np(pthread_self(), &attr);
+    ret = pthread_getattr_np(pthread_self(), &attr);
     assert(ret == 0);
 
     size_t actual_stacksize = 0;
@@ -101,7 +111,15 @@ void test_pthread_attr_setstacksize(void)
     assert(ret == 0);
     assert(worker_tid != PTHREAD_NULL);
 
+    // Signal the worker that pthread_create() has recorded its stack.
+    ret = pthread_mutex_lock(&worker_lock);
+    assert(ret == 0);
     worker_may_run = 1;
+    ret = pthread_cond_signal(&worker_ready);
+    assert(ret == 0);
+    ret = pthread_mutex_unlock(&worker_lock);
+    assert(ret == 0);
+
     ret = pthread_join(worker_tid, NULL);
     assert(ret == 0);
 

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -24,6 +24,9 @@ extern void test_pthread_mutex_dynamic_init(void);
 // Tests if condition variable attributes can be initialized.
 extern void test_pthread_condattr_init(void);
 
+// Tests if condition variable attributes can be destroyed.
+extern void test_pthread_condattr_destroy(void);
+
 // Tests if the process-sharing attribute can be retrieved.
 extern void test_pthread_condattr_getpshared(void);
 

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -78,6 +78,9 @@ extern void test_pthread_attr_getstack(void);
 // Tests if pthread_attr_setstack() validates and stores stack attributes.
 extern void test_pthread_attr_setstack(void);
 
+// Tests if pthread_attr_setstacksize() validates, stores, and applies the stack size attribute.
+extern void test_pthread_attr_setstacksize(void);
+
 // Tests if statically initialized read-write locks can synchronize multiple readers.
 extern void test_pthread_rwlock_static_init(void);
 

--- a/src/tests/integration/test-c-thread/condattr_destroy.c
+++ b/src/tests/integration/test-c-thread/condattr_destroy.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if condition variable attributes can be destroyed.
+void test_pthread_condattr_destroy(void)
+{
+    fprintf(stderr, "testing pthread_condattr_destroy() ... ");
+
+    pthread_condattr_t attr = {
+        0,
+    };
+    int ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized != 0);
+
+    // Destroying an initialized condition variable attributes object must invalidate it.
+    ret = pthread_condattr_destroy(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized == 0);
+
+    // Destroying an uninitialized condition variable attributes object must fail.
+    ret = pthread_condattr_destroy(&attr);
+    assert(ret == EINVAL);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_condattr_destroy(NULL);
+    assert(ret == EINVAL);
+
+    // Misaligned pointers must be rejected.
+    _Alignas(pthread_condattr_t) unsigned char attr_storage[sizeof(pthread_condattr_t) + 1];
+    ret = pthread_condattr_destroy((pthread_condattr_t *)&attr_storage[1]);
+    assert(ret == EINVAL);
+
+    // A destroyed condition variable attributes object may be initialized again.
+    ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized != 0);
+    ret = pthread_condattr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -75,6 +75,7 @@ int main(int argc, const char *argv[])
                        sizeof(int) +                    // is_initialized
                            sizeof(void *) +             // stackaddr
                            sizeof(size_t) +             // stacksize
+                           sizeof(size_t) +             // guardsize
                            sizeof(int) +                // contentionscope
                            sizeof(int) +                // inheritsched
                            sizeof(int) +                // schedpolicy
@@ -104,12 +105,14 @@ int main(int argc, const char *argv[])
                            sizeof(int) + // recursive
                            sizeof(int)   // pshared
     );
+    STATIC_ASSERT_ALIGNMENT(pthread_mutexattr_t, _Alignof(int));
 
     // Sanity check size of `pthread_rwlock_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlock_t, sizeof(uint32_t));
 
     // Sanity check size of `pthread_rwlockattr_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlockattr_t, sizeof(int));
+    STATIC_ASSERT_ALIGNMENT(pthread_rwlockattr_t, _Alignof(int));
 
     // Sanity check size of `sem_t` type.
     STATIC_ASSERT_SIZE(sem_t,
@@ -122,8 +125,11 @@ int main(int argc, const char *argv[])
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
     test_pthread_attr_getguardsize();
+    test_pthread_attr_setguardsize();
     test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
+    test_pthread_attr_setstack();
+    test_pthread_attr_setstacksize();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();
@@ -134,6 +140,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
     test_pthread_condattr_init();
+    test_pthread_condattr_destroy();
     test_pthread_condattr_getpshared();
     test_pthread_rwlock_static_init();
     test_pthread_rwlock_dynamic_init();

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -75,7 +75,6 @@ int main(int argc, const char *argv[])
                        sizeof(int) +                    // is_initialized
                            sizeof(void *) +             // stackaddr
                            sizeof(size_t) +             // stacksize
-                           sizeof(size_t) +             // guardsize
                            sizeof(int) +                // contentionscope
                            sizeof(int) +                // inheritsched
                            sizeof(int) +                // schedpolicy
@@ -105,14 +104,12 @@ int main(int argc, const char *argv[])
                            sizeof(int) + // recursive
                            sizeof(int)   // pshared
     );
-    STATIC_ASSERT_ALIGNMENT(pthread_mutexattr_t, _Alignof(int));
 
     // Sanity check size of `pthread_rwlock_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlock_t, sizeof(uint32_t));
 
     // Sanity check size of `pthread_rwlockattr_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlockattr_t, sizeof(int));
-    STATIC_ASSERT_ALIGNMENT(pthread_rwlockattr_t, _Alignof(int));
 
     // Sanity check size of `sem_t` type.
     STATIC_ASSERT_SIZE(sem_t,
@@ -125,11 +122,8 @@ int main(int argc, const char *argv[])
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
     test_pthread_attr_getguardsize();
-    test_pthread_attr_setguardsize();
     test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
-    test_pthread_attr_setstack();
-    test_pthread_attr_setstacksize();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -129,6 +129,7 @@ int main(int argc, const char *argv[])
     test_pthread_attr_setschedparam();
     test_pthread_attr_getstack();
     test_pthread_attr_setstack();
+    test_pthread_attr_setstacksize();
     test_pthread_getattr_np_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -218,6 +218,7 @@ unsafe extern "C" {
     static pthread_cond_signal: u8;
     static pthread_cond_timedwait: u8;
     static pthread_cond_wait: u8;
+    static pthread_condattr_destroy: u8;
     static pthread_condattr_init: u8;
     static pthread_condattr_setclock: u8;
     static pthread_create: u8;
@@ -289,7 +290,7 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 130] = [
+static SYSCALL_SYMBOLS: [SymAddr; 131] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
@@ -360,6 +361,7 @@ static SYSCALL_SYMBOLS: [SymAddr; 130] = [
     SymAddr(&raw const pthread_cond_signal),
     SymAddr(&raw const pthread_cond_timedwait),
     SymAddr(&raw const pthread_cond_wait),
+    SymAddr(&raw const pthread_condattr_destroy),
     SymAddr(&raw const pthread_condattr_init),
     SymAddr(&raw const pthread_condattr_setclock),
     SymAddr(&raw const pthread_create),


### PR DESCRIPTION
Implements two POSIX thread-attribute interfaces and the tests that
exercise them.

## Features
- `pthread_attr_setstacksize()` — sets the stack-size attribute on a
  thread attributes object, with the supporting syscall plumbing
  (including `pthread_create` wiring).
- `pthread_condattr_destroy()` — destroys a condition variable
  attributes object; validates null/misaligned/uninitialized input and
  marks the object uninitialized so it can be re-initialized. closes #496

## Libraries
- sysapi: add `pthread_condattr_t::uninitialize()`; declare both
  functions in `include/pthread.h` and the generated header list.
- syscall: register the new bindings and syscall entries.

## Tests
- Add `attr_setstacksize.c` and `condattr_destroy.c` integration cases
  under `test-c-thread`; register `pthread_condattr_destroy` in the Rust
  C-bindings symbol-retention test.
- Fix the stale `test-c-thread` runner so the new cases actually run and
  restore previously dropped size/alignment assertions and test calls.

Run the suite with `./z build -- run-posix-tests`.
