### PR TITLE
[libs] Implement pthread_condattr_getclock

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -150,6 +150,7 @@ extern int pthread_cond_wait(const pthread_cond_t *cond, pthread_mutex_t *mutex)
 extern int pthread_cond_timedwait(const pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
 extern int pthread_condattr_destroy(pthread_condattr_t *attr);
 extern int pthread_condattr_init(pthread_condattr_t *attr);
+extern int pthread_condattr_getclock(const pthread_condattr_t *attr, clockid_t *clock_id);
 extern int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 extern int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);
 

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -159,6 +159,7 @@ functions = [
     "pthread_cond_timedwait",
     "pthread_condattr_destroy",
     "pthread_condattr_init",
+    "pthread_condattr_getclock",
     "pthread_condattr_getpshared",
     "pthread_condattr_setclock",
 ]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -248,6 +248,11 @@ impl pthread_condattr_t {
         self.is_initialized = 0;
     }
 
+    /// Returns the clock attribute.
+    pub fn clock(&self) -> clockid_t {
+        self.clock as clockid_t
+    }
+
     /// Returns the process-sharing attribute.
     pub fn pshared(&self) -> c_int {
         self.pshared

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -17,6 +17,7 @@ pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
 pub mod pthread_condattr_destroy;
+pub mod pthread_condattr_getclock;
 pub mod pthread_condattr_getpshared;
 pub mod pthread_condattr_init;
 pub mod pthread_condattr_setclock;

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_getclock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_getclock.rs
@@ -1,0 +1,95 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::{
+        clockid_t,
+        pthread_condattr_t,
+    },
+};
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Gets the clock attribute from a condition variable attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object.
+/// - `clock_id`: Pointer where the clock attribute is stored on success.
+///
+/// # Returns
+///
+/// The `pthread_condattr_getclock()` function returns `0` on success. On error, it returns an error
+/// number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_condattr_t` object.
+/// - `clock_id` points to a valid `clockid_t` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_condattr_getclock(
+    attr: *const pthread_condattr_t,
+    clock_id: *mut clockid_t,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_getclock(): invalid pointer to condition variable attributes object \
+             (attr={attr:p}, clock_id={clock_id:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_condattr_t>()) {
+        ::syslog::warn!(
+            "pthread_condattr_getclock(): misaligned pointer to condition variable attributes \
+             object (attr={attr:p}, clock_id={clock_id:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `clock_id` is not valid.
+    if clock_id.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_getclock(): invalid pointer to clock attribute (attr={attr:p}, \
+             clock_id={clock_id:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `clock_id` is misaligned.
+    if !(clock_id as usize).is_multiple_of(::core::mem::align_of::<clockid_t>()) {
+        ::syslog::warn!(
+            "pthread_condattr_getclock(): misaligned pointer to clock attribute (attr={attr:p}, \
+             clock_id={clock_id:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the condition variable attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_condattr_getclock(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    *clock_id = (*attr).clock();
+    0
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -27,6 +27,9 @@ extern void test_pthread_condattr_init(void);
 // Tests if condition variable attributes can be destroyed.
 extern void test_pthread_condattr_destroy(void);
 
+// Tests if the clock attribute can be retrieved.
+extern void test_pthread_condattr_getclock(void);
+
 // Tests if the process-sharing attribute can be retrieved.
 extern void test_pthread_condattr_getpshared(void);
 

--- a/src/tests/integration/test-c-thread/condattr_getclock.c
+++ b/src/tests/integration/test-c-thread/condattr_getclock.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <time.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the clock attribute can be retrieved.
+void test_pthread_condattr_getclock(void)
+{
+    fprintf(stderr, "testing pthread_condattr_getclock() ... ");
+
+    pthread_condattr_t attr = {
+        .clock = CLOCK_MONOTONIC,
+    };
+    int ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+
+    clockid_t clock_id = CLOCK_MONOTONIC;
+    ret = pthread_condattr_getclock(&attr, &clock_id);
+    assert(ret == 0);
+    assert(clock_id == CLOCK_REALTIME);
+
+    // The stored clock attribute must be returned instead of a hard-coded default.
+    attr.clock = CLOCK_MONOTONIC;
+    ret = pthread_condattr_getclock(&attr, &clock_id);
+    assert(ret == 0);
+    assert(clock_id == CLOCK_MONOTONIC);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_condattr_getclock(NULL, &clock_id);
+    assert(ret != 0);
+    ret = pthread_condattr_getclock(&attr, NULL);
+    assert(ret != 0);
+
+    // Misaligned pointers must be rejected.
+    _Alignas(pthread_condattr_t) unsigned char attr_storage[sizeof(pthread_condattr_t) + 1];
+    ret = pthread_condattr_getclock((pthread_condattr_t *)&attr_storage[1], &clock_id);
+    assert(ret != 0);
+    _Alignas(clockid_t) unsigned char clock_id_storage[sizeof(clockid_t) + 1];
+    ret = pthread_condattr_getclock(&attr, (clockid_t *)&clock_id_storage[1]);
+    assert(ret != 0);
+
+    // Uninitialized condition variable attributes objects must be rejected.
+    attr.is_initialized = 0;
+    ret = pthread_condattr_getclock(&attr, &clock_id);
+    assert(ret != 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -141,6 +141,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_timedlock();
     test_pthread_condattr_init();
     test_pthread_condattr_destroy();
+    test_pthread_condattr_getclock();
     test_pthread_condattr_getpshared();
     test_pthread_rwlock_static_init();
     test_pthread_rwlock_dynamic_init();

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -219,6 +219,7 @@ unsafe extern "C" {
     static pthread_cond_timedwait: u8;
     static pthread_cond_wait: u8;
     static pthread_condattr_destroy: u8;
+    static pthread_condattr_getclock: u8;
     static pthread_condattr_init: u8;
     static pthread_condattr_setclock: u8;
     static pthread_create: u8;
@@ -290,7 +291,7 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 131] = [
+static SYSCALL_SYMBOLS: [SymAddr; 132] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
@@ -362,6 +363,7 @@ static SYSCALL_SYMBOLS: [SymAddr; 131] = [
     SymAddr(&raw const pthread_cond_timedwait),
     SymAddr(&raw const pthread_cond_wait),
     SymAddr(&raw const pthread_condattr_destroy),
+    SymAddr(&raw const pthread_condattr_getclock),
     SymAddr(&raw const pthread_condattr_init),
     SymAddr(&raw const pthread_condattr_setclock),
     SymAddr(&raw const pthread_create),


### PR DESCRIPTION
Implement the POSIX `pthread_condattr_getclock()` binding so callers can
read back the clock attribute stored in a condition variable attributes
object, and add coverage for it.

The binding validates its arguments (rejecting null, misaligned, and
uninitialized inputs with `EINVAL`) before returning the stored clock,
mirroring the existing `pthread_condattr_getpshared()` binding.

## Libraries
- Add the `pthread_condattr_getclock()` binding under `syscall`'s pthread
  bindings and register it in the bindings module.
- Expose a `clock()` accessor on `pthread_condattr_t` in `sysapi`.
- Declare the function in `include/pthread.h` and the `sysapi` pthread
  header manifest.

## Tests
- Add a `test-c-thread` case covering the default clock after
  `pthread_condattr_init()`, confirming the stored clock is returned
  instead of a hard-coded default, and rejecting null, misaligned, and
  uninitialized inputs.
- Reference the symbol in `test-rust-c-bindings` and bump the retained
  symbol count to keep the binding exported.

closes #497