### PR TITLE
[syscall] Add pthread_condattr_setpshared()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -153,6 +153,7 @@ extern int pthread_condattr_init(pthread_condattr_t *attr);
 extern int pthread_condattr_getclock(const pthread_condattr_t *attr, clockid_t *clock_id);
 extern int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 extern int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);
+extern int pthread_condattr_setpshared(pthread_condattr_t *attr, int pshared);
 
 /*==================================================================================================
  * Read-Write Locks

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -162,6 +162,7 @@ functions = [
     "pthread_condattr_getclock",
     "pthread_condattr_getpshared",
     "pthread_condattr_setclock",
+    "pthread_condattr_setpshared",
 ]
 
 [[sections]]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -257,6 +257,11 @@ impl pthread_condattr_t {
     pub fn pshared(&self) -> c_int {
         self.pshared
     }
+
+    /// Sets the process-sharing attribute.
+    pub fn set_pshared(&mut self, pshared: c_int) {
+        self.pshared = pshared;
+    }
 }
 
 impl Default for pthread_condattr_t {

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -21,6 +21,7 @@ pub mod pthread_condattr_getclock;
 pub mod pthread_condattr_getpshared;
 pub mod pthread_condattr_init;
 pub mod pthread_condattr_setclock;
+pub mod pthread_condattr_setpshared;
 pub mod pthread_create;
 pub mod pthread_getattr_np;
 pub mod pthread_getschedparam;

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_setpshared.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_setpshared.rs
@@ -1,0 +1,91 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    pthread::{
+        PTHREAD_PROCESS_PRIVATE,
+        PTHREAD_PROCESS_SHARED,
+    },
+    sys_types::pthread_condattr_t,
+};
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the process-sharing attribute in a condition variable attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object.
+/// - `pshared`: Process-sharing attribute to set.
+///
+/// # Returns
+///
+/// The `pthread_condattr_setpshared()` function returns `0` on success. On error, it returns an
+/// error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference a raw pointer.
+///
+/// It is safe to call this function if `attr` points to a valid `pthread_condattr_t` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_condattr_setpshared(
+    attr: *mut pthread_condattr_t,
+    pshared: c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_condattr_setpshared(): invalid pointer to condition variable attributes \
+             object (attr={attr:p}, pshared={pshared})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_condattr_t>()) {
+        ::syslog::warn!(
+            "pthread_condattr_setpshared(): misaligned pointer to condition variable attributes \
+             object (attr={attr:p}, pshared={pshared})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the condition variable attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_condattr_setpshared(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    match pshared {
+        PTHREAD_PROCESS_PRIVATE => {
+            (*attr).set_pshared(pshared);
+            0
+        },
+        PTHREAD_PROCESS_SHARED => {
+            ::syslog::warn!("pthread_condattr_setpshared(): process-shared mode is not supported");
+            ErrorCode::OperationNotSupported.get()
+        },
+        _ => {
+            ::syslog::warn!(
+                "pthread_condattr_setpshared(): invalid process-sharing attribute (attr={attr:p}, \
+                 pshared={pshared})"
+            );
+            ErrorCode::InvalidArgument.get()
+        },
+    }
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -33,6 +33,9 @@ extern void test_pthread_condattr_getclock(void);
 // Tests if the process-sharing attribute can be retrieved.
 extern void test_pthread_condattr_getpshared(void);
 
+// Tests if the process-sharing attribute can be set and retrieved.
+extern void test_pthread_condattr_setpshared(void);
+
 // Tests if calling exit() causes the program to exit even if there are other threads running.
 extern void test_pthread_nowait(void);
 

--- a/src/tests/integration/test-c-thread/condattr_setpshared.c
+++ b/src/tests/integration/test-c-thread/condattr_setpshared.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the process-sharing attribute can be set and retrieved.
+void test_pthread_condattr_setpshared(void)
+{
+    fprintf(stderr, "testing pthread_condattr_setpshared() ... ");
+
+    pthread_condattr_t attr = {
+        0,
+    };
+    int ret = pthread_condattr_init(&attr);
+    assert(ret == 0);
+
+    ret = pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == 0);
+
+    int pshared = PTHREAD_PROCESS_SHARED;
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Process-shared condition variables are not supported.
+    ret = pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+    assert(ret == ENOTSUP);
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid values must not change the attribute.
+    ret = pthread_condattr_setpshared(&attr, -1);
+    assert(ret == EINVAL);
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_condattr_setpshared(NULL, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    ret = pthread_condattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Misaligned pointers must be rejected.
+    _Alignas(pthread_condattr_t) unsigned char attr_storage[sizeof(pthread_condattr_t) + 1];
+    const unsigned char sentinel = 0xa5;
+    memset(attr_storage, sentinel, sizeof(attr_storage));
+    unsigned char attr_storage_before[sizeof(attr_storage)];
+    memcpy(attr_storage_before, attr_storage, sizeof(attr_storage));
+    ret = pthread_condattr_setpshared((pthread_condattr_t *)&attr_storage[1],
+                                     PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    assert(memcmp(attr_storage, attr_storage_before, sizeof(attr_storage)) == 0);
+
+    // Uninitialized condition variable attributes objects must be rejected.
+    ret = pthread_condattr_destroy(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized == 0);
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+    ret = pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    assert(attr.is_initialized == 0);
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -143,6 +143,7 @@ int main(int argc, const char *argv[])
     test_pthread_condattr_destroy();
     test_pthread_condattr_getclock();
     test_pthread_condattr_getpshared();
+    test_pthread_condattr_setpshared();
     test_pthread_rwlock_static_init();
     test_pthread_rwlock_dynamic_init();
     test_pthread_cond_static_init();

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -222,6 +222,7 @@ unsafe extern "C" {
     static pthread_condattr_getclock: u8;
     static pthread_condattr_init: u8;
     static pthread_condattr_setclock: u8;
+    static pthread_condattr_setpshared: u8;
     static pthread_create: u8;
     static pthread_getattr_np: u8;
     static pthread_getschedparam: u8;
@@ -291,7 +292,7 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 132] = [
+static SYSCALL_SYMBOLS: [SymAddr; 133] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
@@ -366,6 +367,7 @@ static SYSCALL_SYMBOLS: [SymAddr; 132] = [
     SymAddr(&raw const pthread_condattr_getclock),
     SymAddr(&raw const pthread_condattr_init),
     SymAddr(&raw const pthread_condattr_setclock),
+    SymAddr(&raw const pthread_condattr_setpshared),
     SymAddr(&raw const pthread_create),
     SymAddr(&raw const pthread_getattr_np),
     SymAddr(&raw const pthread_getschedparam),


### PR DESCRIPTION
## Summary

Implements `pthread_condattr_setpshared()` so callers can set the process-sharing
attribute on a condition variable attributes object.

Because Nanvix only supports process-private synchronization, the setter accepts
`PTHREAD_PROCESS_PRIVATE` and rejects `PTHREAD_PROCESS_SHARED` with `ENOTSUP`.
Invalid values, and null, misaligned, or uninitialized attribute objects return
`EINVAL`. The binding validates the `attr` pointer (null → alignment →
initialization) before applying the value, matching the existing `getpshared`
sibling.

## Changes

**Libraries:**
- Add the `pthread_condattr_setpshared` binding and register its module.
- Add `pthread_condattr_t::set_pshared()` accessor in `sysapi`.
- Declare the function in `include/pthread.h` and the pthread header manifest.

**Tests:**
- Add `test_pthread_condattr_setpshared()` to the `test-c-thread` suite covering
  success for PRIVATE, `ENOTSUP` for SHARED, and `EINVAL` for invalid value, null,
  misaligned, and uninitialized inputs (asserting the attribute is unchanged on
  every failure path).
- Retain the symbol in the `test-rust-c-bindings` link test (count bumped to 133).

## Validation

- `./z build -- run-unit-tests` — pass
- `./z build -- run-posix-tests` — pass (`test-c-thread`)
- `./z build -- run-nanvix-tests` — pass

closes #501