### PR TITLE
[syscall] Add pthread_mutexattr_setpshared()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -135,6 +135,7 @@ extern int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec
 extern int pthread_mutexattr_init(pthread_mutexattr_t *attr);
 extern int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
 extern int pthread_mutexattr_getpshared(const pthread_mutexattr_t *attr, int *pshared);
+extern int pthread_mutexattr_setpshared(pthread_mutexattr_t *attr, int pshared);
 extern int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type_);
 extern int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type_);
 

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -144,6 +144,7 @@ functions = [
     "pthread_mutexattr_init",
     "pthread_mutexattr_destroy",
     "pthread_mutexattr_getpshared",
+    "pthread_mutexattr_setpshared",
     "pthread_mutexattr_settype",
     "pthread_mutexattr_gettype",
 ]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -336,6 +336,11 @@ impl pthread_mutexattr_t {
     pub fn pshared(&self) -> c_int {
         self.pshared
     }
+
+    /// Sets the process-sharing attribute.
+    pub fn set_pshared(&mut self, pshared: c_int) {
+        self.pshared = pshared;
+    }
 }
 
 impl Default for pthread_mutexattr_t {

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -33,6 +33,7 @@ pub mod pthread_mutex_destroy;
 pub mod pthread_mutex_init;
 pub mod pthread_mutex_lock;
 pub mod pthread_mutex_unlock;
+pub mod pthread_mutexattr_setpshared;
 pub mod pthread_rwlock_destroy;
 pub mod pthread_rwlock_init;
 pub mod pthread_rwlock_rdlock;

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutexattr_setpshared.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutexattr_setpshared.rs
@@ -1,0 +1,91 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    pthread::{
+        PTHREAD_PROCESS_PRIVATE,
+        PTHREAD_PROCESS_SHARED,
+    },
+    sys_types::pthread_mutexattr_t,
+};
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the process-sharing attribute in a mutex attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object.
+/// - `pshared`: Process-sharing attribute to set.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_setpshared()` function returns `0` on success. On error, it returns an
+/// error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference a raw pointer.
+///
+/// It is safe to call this function if `attr` points to a valid `pthread_mutexattr_t` object.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_mutexattr_setpshared(
+    attr: *mut pthread_mutexattr_t,
+    pshared: c_int,
+) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::warn!(
+            "pthread_mutexattr_setpshared(): invalid pointer to mutex attributes object \
+             (attr={attr:p}, pshared={pshared})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` is misaligned.
+    if !(attr as usize).is_multiple_of(::core::mem::align_of::<pthread_mutexattr_t>()) {
+        ::syslog::warn!(
+            "pthread_mutexattr_setpshared(): misaligned pointer to mutex attributes object \
+             (attr={attr:p}, pshared={pshared})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if the mutex attributes object is initialized.
+    if !(*attr).is_initialized() {
+        ::syslog::warn!("pthread_mutexattr_setpshared(): attr is not initialized");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    match pshared {
+        PTHREAD_PROCESS_PRIVATE => {
+            (*attr).set_pshared(pshared);
+            0
+        },
+        PTHREAD_PROCESS_SHARED => {
+            ::syslog::warn!("pthread_mutexattr_setpshared(): process-shared mode is not supported");
+            ErrorCode::OperationNotSupported.get()
+        },
+        _ => {
+            ::syslog::warn!(
+                "pthread_mutexattr_setpshared(): invalid process-sharing attribute \
+                 (attr={attr:p}, pshared={pshared})"
+            );
+            ErrorCode::InvalidArgument.get()
+        },
+    }
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -75,6 +75,9 @@ extern void test_pthread_mutexattr_settype(void);
 // Tests if the process-sharing attribute can be retrieved.
 extern void test_pthread_mutexattr_getpshared(void);
 
+// Tests if the process-sharing attribute can be set and retrieved.
+extern void test_pthread_mutexattr_setpshared(void);
+
 // Tests if mutex attributes can be destroyed.
 extern void test_pthread_mutexattr_destroy(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -136,6 +136,7 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_dynamic_init();
     test_pthread_mutexattr_settype();
     test_pthread_mutexattr_getpshared();
+    test_pthread_mutexattr_setpshared();
     test_pthread_mutexattr_destroy();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();

--- a/src/tests/integration/test-c-thread/mutexattr_setpshared.c
+++ b/src/tests/integration/test-c-thread/mutexattr_setpshared.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if the process-sharing attribute can be set and retrieved.
+void test_pthread_mutexattr_setpshared(void)
+{
+    fprintf(stderr, "testing pthread_mutexattr_setpshared() ... ");
+
+    pthread_mutexattr_t attr = {
+        0,
+    };
+    int ret = pthread_mutexattr_init(&attr);
+    assert(ret == 0);
+
+    ret = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == 0);
+
+    int pshared = PTHREAD_PROCESS_SHARED;
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Process-shared mutexes are not supported.
+    ret = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+    assert(ret == ENOTSUP);
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid values must not change the attribute.
+    ret = pthread_mutexattr_setpshared(&attr, -1);
+    assert(ret == EINVAL);
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Invalid pointers must be rejected.
+    ret = pthread_mutexattr_setpshared(NULL, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    ret = pthread_mutexattr_getpshared(&attr, &pshared);
+    assert(ret == 0);
+    assert(pshared == PTHREAD_PROCESS_PRIVATE);
+
+    // Misaligned pointers must be rejected.
+    _Alignas(pthread_mutexattr_t) unsigned char attr_storage[sizeof(pthread_mutexattr_t) + 1];
+    const unsigned char sentinel = 0xa5;
+    memset(attr_storage, sentinel, sizeof(attr_storage));
+    unsigned char attr_storage_before[sizeof(attr_storage)];
+    memcpy(attr_storage_before, attr_storage, sizeof(attr_storage));
+    ret = pthread_mutexattr_setpshared((pthread_mutexattr_t *)&attr_storage[1],
+                                      PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    assert(memcmp(attr_storage, attr_storage_before, sizeof(attr_storage)) == 0);
+
+    // Uninitialized mutex attributes objects must be rejected.
+    ret = pthread_mutexattr_destroy(&attr);
+    assert(ret == 0);
+    assert(attr.is_initialized == 0);
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+    ret = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+    assert(ret == EINVAL);
+    assert(attr.is_initialized == 0);
+    assert(attr.pshared == PTHREAD_PROCESS_PRIVATE);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -234,6 +234,7 @@ unsafe extern "C" {
     static pthread_mutex_init: u8;
     static pthread_mutex_lock: u8;
     static pthread_mutex_unlock: u8;
+    static pthread_mutexattr_setpshared: u8;
     static pthread_rwlock_destroy: u8;
     static pthread_rwlock_init: u8;
     static pthread_rwlock_rdlock: u8;
@@ -292,7 +293,7 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 133] = [
+static SYSCALL_SYMBOLS: [SymAddr; 134] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
@@ -379,6 +380,7 @@ static SYSCALL_SYMBOLS: [SymAddr; 133] = [
     SymAddr(&raw const pthread_mutex_init),
     SymAddr(&raw const pthread_mutex_lock),
     SymAddr(&raw const pthread_mutex_unlock),
+    SymAddr(&raw const pthread_mutexattr_setpshared),
     SymAddr(&raw const pthread_rwlock_destroy),
     SymAddr(&raw const pthread_rwlock_init),
     SymAddr(&raw const pthread_rwlock_rdlock),


### PR DESCRIPTION
## What

Adds the `pthread_mutexattr_setpshared()` C binding to set the process-sharing attribute of a mutex attributes object.

- Declares the function in `include/pthread.h` and registers it in the sysapi header manifest.
- Adds a `set_pshared()` setter on `pthread_mutexattr_t`.
- Implements the binding with validation of the `attr` pointer (null/alignment/initialized checks):
  - `PTHREAD_PROCESS_PRIVATE`: sets the attribute and returns `0`.
  - `PTHREAD_PROCESS_SHARED`: returns `OperationNotSupported` (process-shared mode is not supported).
  - Any other value: returns `InvalidArgument`.
- Adds integration test coverage (`test-c-thread/mutexattr_setpshared.c`) and updates the Rust C-bindings test.

## Why

Completes the mutex attribute API surface alongside the existing `pthread_mutexattr_getpshared()`, providing a POSIX-conformant entry point for setting the process-sharing attribute.

Part of #512