### PR TITLE
[syscall] Add pthread_testcancel()

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -101,6 +101,7 @@ extern int pthread_kill(pthread_t thread, int sig);
 extern void pthread_exit(void *retval);
 extern pthread_t pthread_self(void);
 extern int pthread_equal(pthread_t thread1, pthread_t thread2);
+extern void pthread_testcancel(void);
 
 /*==================================================================================================
  * Thread Attributes

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -110,6 +110,7 @@ functions = [
     "pthread_exit",
     "pthread_self",
     "pthread_equal",
+    "pthread_testcancel",
 ]
 
 [[sections]]

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -43,6 +43,7 @@ pub mod pthread_self;
 pub mod pthread_setcancelstate;
 pub mod pthread_setspecific;
 pub mod pthread_sigmask;
+pub mod pthread_testcancel;
 pub mod sem_destroy;
 pub mod sem_init;
 pub mod sem_post;

--- a/src/libs/syscall/src/pthread/bindings/pthread_testcancel.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_testcancel.rs
@@ -1,0 +1,23 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Creates a cancellation point in the calling thread.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub extern "C" fn pthread_testcancel() {
+    // Cancellation requests are not supported, so none can be pending.
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -9,6 +9,9 @@
 // Tests if threads can get their own identifiers.
 extern void test_pthread_self(void);
 
+// Tests if a thread can create a cancellation point when no cancellation request is pending.
+extern void test_pthread_testcancel(void);
+
 // Tests if `pthread_mutex_cond_timedwait()` can be used for synchronization.
 extern void test_pthread_cond_timedwait(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -122,6 +122,7 @@ int main(int argc, const char *argv[])
     );
 
     test_pthread_self();
+    test_pthread_testcancel();
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
     test_pthread_attr_getguardsize();

--- a/src/tests/integration/test-c-thread/testcancel.c
+++ b/src/tests/integration/test-c-thread/testcancel.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if a thread can create a cancellation point when no cancellation request is pending.
+void test_pthread_testcancel(void)
+{
+    fprintf(stderr, "testing pthread_testcancel() ... ");
+
+    bool returned = false;
+    pthread_testcancel();
+    returned = true;
+    assert(returned);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -244,6 +244,7 @@ unsafe extern "C" {
     static pthread_setcancelstate: u8;
     static pthread_setspecific: u8;
     static pthread_sigmask: u8;
+    static pthread_testcancel: u8;
     static pwrite: u8;
     static read: u8;
     static readdir: u8;
@@ -293,7 +294,7 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 134] = [
+static SYSCALL_SYMBOLS: [SymAddr; 135] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
@@ -390,6 +391,7 @@ static SYSCALL_SYMBOLS: [SymAddr; 134] = [
     SymAddr(&raw const pthread_setcancelstate),
     SymAddr(&raw const pthread_setspecific),
     SymAddr(&raw const pthread_sigmask),
+    SymAddr(&raw const pthread_testcancel),
     SymAddr(&raw const pwrite),
     SymAddr(&raw const read),
     SymAddr(&raw const readdir),


### PR DESCRIPTION
## What

Adds the `pthread_testcancel()` binding to the `syscall` library and wires it through the public headers:

- New `pthread_testcancel()` C-ABI function in `src/libs/syscall/src/pthread/bindings/`. Since cancellation requests are not supported, no request can ever be pending, so the cancellation point is effectively a no-op.
- Declares the symbol in `include/pthread.h` and the `sysapi` header manifest (`pthread.toml`), and registers it in the bindings `mod.rs`.
- Adds coverage in the `test-c-thread` integration test (`testcancel.c`) and references the new symbol from `test-rust-c-bindings`.

## Why

Provides POSIX-compliant `pthread_testcancel()` so applications relying on the symbol can link and run. The current implementation returns immediately, matching the current threading model where no cancellation state exists.

Closes #516