### PR TITLE
Remove unnecessary build-time constant accessors

### DIFF
--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -214,16 +214,14 @@ impl PhysMemoryManager {
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
     fn check_user_watermark(count: usize) -> Result<(), Error> {
-        // Read the free count before checking the threshold so both success and overflow paths use
-        // the same observed allocator state.
-        let available: usize = frame::free_count();
-        let watermark_threshold: usize =
-            kernel_watermark().checked_add(count).ok_or_else(|| {
+        let watermark_threshold: usize = config::kernel::KERNEL_WATERMARK
+            .checked_add(count)
+            .ok_or_else(|| {
                 let reason: &str = "watermark + count overflow";
                 error!("{reason}");
                 Error::new(ErrorCode::InvalidArgument, reason)
             })?;
-        if available < watermark_threshold {
+        if frame::free_count() < watermark_threshold {
             let reason: &str = "would breach kernel watermark";
             error!("{reason}");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
@@ -388,14 +386,4 @@ impl PhysMemoryManager {
         }
         result
     }
-}
-
-//==================================================================================================
-// Build-time constant accessors
-//==================================================================================================
-
-/// Ties the generated runtime constant to its abstract specification.
-#[inline]
-fn kernel_watermark() -> usize {
-    config::kernel::KERNEL_WATERMARK
 }

--- a/src/libs/sys/src/sys/mm/address/phys.rs
+++ b/src/libs/sys/src/sys/mm/address/phys.rs
@@ -307,7 +307,7 @@ impl From<PhysicalAddress> for usize {
 ///
 #[inline(always)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
-    addr.into_raw_value() < physical_memory_size()
+    addr.into_raw_value() < config::kernel::MEMORY_SIZE
 }
 
 //==================================================================================================
@@ -332,12 +332,3 @@ impl View for PhysicalAddress {
 pub uninterp spec fn spec_physical_memory_size() -> int;
 
 } // end verus!
-
-// Returns the size of the physical address space, in bytes.
-//
-// The concrete value is imported from the build-time `config::kernel::MEMORY_SIZE` constant. It is
-// centralized behind this accessor so that all physical-memory bound checks go through a single
-// point.
-fn physical_memory_size() -> usize {
-    ::config::kernel::MEMORY_SIZE
-}

--- a/src/libs/sys/src/sys/mm/address/phys.rs
+++ b/src/libs/sys/src/sys/mm/address/phys.rs
@@ -307,7 +307,7 @@ impl From<PhysicalAddress> for usize {
 ///
 #[inline(always)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
-    addr.into_raw_value() < config::kernel::MEMORY_SIZE
+    addr.into_raw_value() < ::config::kernel::MEMORY_SIZE
 }
 
 //==================================================================================================


### PR DESCRIPTION
Since `assume_specification` can be attached directly to constants, these accessor wrappers are no longer needed. This reverts the two constant accessors (`physical_memory_size`, `kernel_watermark`) added earlier.

Note: `is_valid_physical_address` keeps the `addr.into_raw_value() < config::kernel::MEMORY_SIZE` form instead of the original `addr < VirtualAddress::from_raw_value(config::kernel::MEMORY_SIZE)`. The latter relies on the derived `<` on `VirtualAddress`, which has no Verus spec and is cumbersome to verify, whereas `into_raw_value()` lowers it to a primitive `usize` comparison.
