### PR TITLE
[syscall] Implement pthread_setcancelstate

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -37,6 +37,8 @@ extern "C" {
 #define PTHREAD_NULL 0 /**< Null thread identifier. */
 #define PTHREAD_CREATE_JOINABLE 0 /**< Thread is created joinable. */
 #define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */
+#define PTHREAD_CANCEL_ENABLE 0 /**< Thread cancellation is enabled. */
+#define PTHREAD_CANCEL_DISABLE 1 /**< Thread cancellation is disabled. */
 #define PTHREAD_PROCESS_PRIVATE 0 /**< Synchronization object is private to a process. */
 #define PTHREAD_PROCESS_SHARED 1 /**< Synchronization object is shared between processes. */
 
@@ -101,6 +103,7 @@ extern int pthread_kill(pthread_t thread, int sig);
 extern void pthread_exit(void *retval);
 extern pthread_t pthread_self(void);
 extern int pthread_equal(pthread_t thread1, pthread_t thread2);
+extern int pthread_setcancelstate(int state, int *oldstate);
 extern void pthread_testcancel(void);
 
 /*==================================================================================================

--- a/src/libs/sys/src/sys/kcall/arch/x86.rs
+++ b/src/libs/sys/src/sys/kcall/arch/x86.rs
@@ -266,6 +266,39 @@ pub unsafe fn write_tda_u32(offset: u32, val: u32) {
     }
 }
 
+///
+/// # Description
+///
+/// Atomically replaces a `u32` value in the Thread Data Area (TDA) via the `%gs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+/// - `val`: The new `u32` value to store at `gs:[offset]`.
+///
+/// # Returns
+///
+/// The previous `u32` value stored at `gs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%gs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn swap_tda_u32(offset: u32, mut val: u32) -> u32 {
+    unsafe {
+        arch::asm!(
+            "xchg gs:[{0:e}], {1:e}",
+            in(reg) offset,
+            inout(reg) val,
+            options(nostack, preserves_flags),
+        );
+    }
+    val
+}
+
 //==================================================================================================
 // Fork Support
 //==================================================================================================

--- a/src/libs/sys/src/sys/kcall/arch/x86_64.rs
+++ b/src/libs/sys/src/sys/kcall/arch/x86_64.rs
@@ -71,3 +71,36 @@ pub unsafe fn write_tda_u32(offset: u32, val: u32) {
         );
     }
 }
+
+///
+/// # Description
+///
+/// Atomically replaces a `u32` value in the Thread Data Area (TDA) via the `%fs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+/// - `val`: The new `u32` value to store at `fs:[offset]`.
+///
+/// # Returns
+///
+/// The previous `u32` value stored at `fs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%fs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn swap_tda_u32(offset: u32, mut val: u32) -> u32 {
+    unsafe {
+        arch::asm!(
+            "xchg fs:[{0:e}], {1:e}",
+            in(reg) offset,
+            inout(reg) val,
+            options(nostack, preserves_flags),
+        );
+    }
+    val
+}

--- a/src/libs/sysalloc/src/tda.rs
+++ b/src/libs/sysalloc/src/tda.rs
@@ -32,8 +32,19 @@ pub const TDA_TID_OFFSET: usize = core::mem::size_of::<*mut u8>();
 /// Size of the cached thread ID field in the TDA header, in bytes.
 pub const TDA_TID_SIZE: usize = core::mem::size_of::<u32>();
 
-/// Total size of the TDA header (self-pointer + cached thread ID), in bytes.
-const TDA_HEADER_SIZE: usize = TDA_TID_OFFSET + TDA_TID_SIZE;
+/// Offset of the cancellation state within the TDA header, in bytes.
+pub const TDA_CANCEL_STATE_OFFSET: usize = TDA_TID_OFFSET + TDA_TID_SIZE;
+
+/// Size of the cancellation state field in the TDA header, in bytes.
+pub const TDA_CANCEL_STATE_SIZE: usize = core::mem::size_of::<u32>();
+
+/// Default cancellation state for a newly allocated thread data area.
+///
+/// This value must match `sysapi::pthread::PTHREAD_CANCEL_ENABLE`.
+const TDA_CANCEL_STATE_DEFAULT: u32 = 0;
+
+/// Total size of the TDA header, in bytes.
+const TDA_HEADER_SIZE: usize = TDA_CANCEL_STATE_OFFSET + TDA_CANCEL_STATE_SIZE;
 
 /// Sentinel value indicating the cached thread ID has not been populated yet.
 pub const TDA_TID_UNSET: u32 = 0;
@@ -47,16 +58,11 @@ pub const TDA_TID_UNSET: u32 = 0;
 /// # Safety Invariant
 ///
 /// This flag is set to `true` by [`mark_initialized`] after `set_thread_data_area()` succeeds
-/// during runtime init, and reset to `false` by [`mark_uninitialized`] in [`cleanup`] before the
-/// segment base is cleared. Code that reads the TDA via a segment register (e.g., the
-/// `pthread_self()` fast path) must check this flag first.
+/// during runtime init. Code that reads the TDA via a segment register must check this flag and
+/// verify that the calling thread has a non-null TDA first.
 ///
-/// The flag is process-wide, which is sound because:
-/// - The main thread sets it once during `init()`, before any child thread is created.
-/// - Child threads inherit a valid TDA from the kernel (configured via `FS_BASE`/GDT on context
-///   switch) and never run user code without one.
-/// - `cleanup()` resets the flag and then diverges via `exit_thread()`, so no subsequent
-///   `pthread_self()` call can observe a stale `true`.
+/// This flag is process-wide and only indicates that TDA support was initialized. Raw kernel
+/// threads may still have no TDA.
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 /// Marks the TDA subsystem as initialized.
@@ -66,14 +72,7 @@ pub fn mark_initialized() {
     INITIALIZED.store(true, Ordering::Release);
 }
 
-/// Marks the TDA subsystem as uninitialized.
-///
-/// Must be called before clearing the segment base in [`cleanup`].
-pub fn mark_uninitialized() {
-    INITIALIZED.store(false, Ordering::Release);
-}
-
-/// Returns `true` if [`mark_initialized`] has been called and [`mark_uninitialized`] has not.
+/// Returns `true` if [`mark_initialized`] has been called.
 pub fn is_initialized() -> bool {
     INITIALIZED.load(Ordering::Acquire)
 }
@@ -99,7 +98,6 @@ extern "C" {
 ///
 /// On successful completion, this function returns a pointer to the newly allocated thread data
 /// area. It is the caller's responsibility to deallocate this memory using the [`dealloc`] function.
-/// If the main executable has no thread-local storage segment, this function returns `Ok(None)`.
 /// On failure, this function returns an error that contains the reason for the failure.
 ///
 /// # Notes
@@ -113,6 +111,10 @@ extern "C" {
 /// High Address
 ///     ↑
 /// +---------------------+ <- tda_ptr + tda_header_size (end of allocation)
+/// |                     |
+/// | Cancellation State  | c_int slot for pthread cancellation state
+/// |                     | Initialized to PTHREAD_CANCEL_ENABLE
+/// +---------------------+ <- tda_ptr + TDA_CANCEL_STATE_OFFSET
 /// |                     |
 /// | Cached Thread ID    | u32 slot for fast pthread_self()
 /// |                     | Zero-initialized; lazily populated by pthread_self()
@@ -140,7 +142,7 @@ extern "C" {
 /// Low Address
 ///
 /// Where:
-/// - TDA_HEADER_SIZE = TDA_TID_OFFSET + TDA_TID_SIZE
+/// - TDA_HEADER_SIZE = TDA_CANCEL_STATE_OFFSET + TDA_CANCEL_STATE_SIZE
 /// - allocation_size = allocation_padding_size + TDA_HEADER_SIZE
 /// - allocation_padding_size = align_up(tls_size, max(PAGE_ALIGNMENT, align_of::<*mut u8>()))
 /// - tda_ptr = allocation + allocation_padding_size
@@ -169,13 +171,8 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
          allocation_padding_size={allocation_padding_size}, allocation_size={allocation_size}",
     );
 
-    // Check if thread-local storage is empty.
-    if tls_size == 0 {
-        return Ok(None);
-    }
-
     // Check if thread-local storage has an invalid alignment.
-    if !tls_start_addr.is_multiple_of(tls_alignment) {
+    if tls_size != 0 && !tls_start_addr.is_multiple_of(tls_alignment) {
         let reason: &'static str = "tls start address is not page-aligned";
         ::syslog::warn!(
             "alloc(): {reason} (tls_start_addr={tls_start_addr:x?}, tls_alignment={tls_alignment})",
@@ -222,6 +219,13 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
         *tid_ptr = TDA_TID_UNSET;
     }
 
+    // Initialize the calling thread's cancellation state.
+    let cancellation_state_ptr: *mut u32 =
+        unsafe { tda_ptr.add(TDA_CANCEL_STATE_OFFSET).cast::<u32>() };
+    unsafe {
+        *cancellation_state_ptr = TDA_CANCEL_STATE_DEFAULT;
+    }
+
     // Compute pointer to thread-local storage.
     // SAFETY: `tda_ptr` is non-null and pointer arithmetic is within bounds.
     let tls_aligned_size: usize = align_up(tls_size, PAGE_ALIGNMENT).ok_or_else(|| {
@@ -264,16 +268,10 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
         return Ok(());
     }
 
-    // Deallocate thread-local storage.
-    dealloc(tcb_ptr)?;
-
-    // Mark TDA as uninitialized before clearing the segment base so that no subsequent
-    // segment-relative access (e.g., pthread_self() fast path) can observe a stale flag.
-    mark_uninitialized();
-
-    // Clear the thread-local storage pointer first to avoid dangling pointers.
+    // Clear the thread-local storage pointer before deallocating it to avoid a dangling segment
+    // base.
     match sys::kcall::pm::__kcall_set_thread_data_area(core::ptr::null_mut()) {
-        Ok(()) => Ok(()),
+        Ok(()) => unsafe { dealloc(tcb_ptr) },
         Err(error) => {
             ::syslog::warn!("cleanup_tda(): failed to clear tda pointer (error={error:?})");
             Err(error)
@@ -295,7 +293,11 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
 /// On success, this function returns empty. Otherwise, it returns an error object that contains the
 /// reason for the failure.
 ///
-fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
+/// # Safety
+///
+/// `tda_ptr` must have been returned by [`alloc`] and must not have been deallocated previously.
+///
+pub unsafe fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
     extern "C" {
         static __TLS_START: u8;
         static __TLS_END: u8;

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -65,6 +65,14 @@ path = "pthread::PTHREAD_CREATE_DETACHED"
 comment = "Thread is created detached."
 
 [[rust_constants]]
+path = "pthread::PTHREAD_CANCEL_ENABLE"
+comment = "Thread cancellation is enabled."
+
+[[rust_constants]]
+path = "pthread::PTHREAD_CANCEL_DISABLE"
+comment = "Thread cancellation is disabled."
+
+[[rust_constants]]
 path = "pthread::PTHREAD_PROCESS_PRIVATE"
 comment = "Synchronization object is private to a process."
 
@@ -110,6 +118,7 @@ functions = [
     "pthread_exit",
     "pthread_self",
     "pthread_equal",
+    "pthread_setcancelstate",
     "pthread_testcancel",
 ]
 

--- a/src/libs/sysapi/src/pthread.rs
+++ b/src/libs/sysapi/src/pthread.rs
@@ -35,6 +35,12 @@ pub const PTHREAD_CREATE_JOINABLE: c_int = 0;
 /// Indicates that a thread is created detached.
 pub const PTHREAD_CREATE_DETACHED: c_int = 1;
 
+/// Indicates that thread cancellation is enabled.
+pub const PTHREAD_CANCEL_ENABLE: c_int = 0;
+
+/// Indicates that thread cancellation is disabled.
+pub const PTHREAD_CANCEL_DISABLE: c_int = 1;
+
 /// Indicates that a synchronization object is shared only within a process.
 pub const PTHREAD_PROCESS_PRIVATE: c_int = 0;
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
@@ -5,8 +5,21 @@
 // Imports
 //==================================================================================================
 
-use ::sys::error::ErrorCode;
-use ::sysapi::ffi::c_int;
+use ::sys::{
+    error::ErrorCode,
+    kcall::{
+        arch,
+        pm::__kcall_get_thread_data_area,
+    },
+};
+use ::sysalloc::tda::TDA_CANCEL_STATE_OFFSET;
+use ::sysapi::{
+    ffi::c_int,
+    pthread::{
+        PTHREAD_CANCEL_DISABLE,
+        PTHREAD_CANCEL_ENABLE,
+    },
+};
 use ::syslog::trace_libcall;
 
 //==================================================================================================
@@ -21,7 +34,7 @@ use ::syslog::trace_libcall;
 /// # Parameters
 ///
 /// - `state`: New cancellability state.
-/// - `oldstate`: Old cancellability state.
+/// - `oldstate`: Storage location for the old cancellability state. This may be null.
 ///
 /// # Returns
 ///
@@ -33,18 +46,40 @@ use ::syslog::trace_libcall;
 ///
 /// It is safe to call this function if the following conditions are met:
 ///
-/// - `oldstate` points to a valid `c_int` variable.
+/// - If `oldstate` is non-null, it points to a valid `c_int` variable.
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_setcancelstate(state: c_int, oldstate: *mut c_int) -> c_int {
-    // Check if `oldstate` is not valid.
-    if oldstate.is_null() {
-        ::syslog::warn!("pthread_setcancelstate(): invalid old state pointer");
+    // Check if `state` is not valid.
+    if state != PTHREAD_CANCEL_ENABLE && state != PTHREAD_CANCEL_DISABLE {
+        ::syslog::warn!("pthread_setcancelstate(): invalid state (state={state})");
         return ErrorCode::InvalidArgument.get();
     }
 
-    // TODO: implement this function.
-    ::syslog::debug!("pthread_setcancelstate(): not supported, ignoring");
+    // Check if the calling thread has a valid thread data area.
+    match __kcall_get_thread_data_area() {
+        Ok(tda_ptr) if !tda_ptr.is_null() => {},
+        Ok(_) => {
+            ::syslog::warn!("pthread_setcancelstate(): thread data area is not configured");
+            return ErrorCode::InvalidSysCall.get();
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_setcancelstate(): failed to get thread data area ({error:?})");
+            return error.code.get();
+        },
+    }
+
+    // Atomically update the cancellation state of the calling thread.
+    let previous_state: c_int =
+        unsafe { arch::swap_tda_u32(TDA_CANCEL_STATE_OFFSET as u32, state as u32) as c_int };
+
+    // Store the previous cancellation state if requested.
+    if !oldstate.is_null() {
+        unsafe {
+            *oldstate = previous_state;
+        }
+    }
+
     0
 }

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -40,7 +40,10 @@ mod pthread_getattr_np;
 //==================================================================================================
 
 use crate::safe::mem::stack::Stack;
-use ::alloc::collections::btree_map::BTreeMap;
+use ::alloc::{
+    boxed::Box,
+    collections::btree_map::BTreeMap,
+};
 use ::spin::{
     Lazy,
     Mutex,
@@ -52,6 +55,7 @@ use ::sys::{
         pm::{
             __kcall_create_thread,
             __kcall_exit_thread,
+            __kcall_get_thread_data_area,
             __kcall_gettid,
             __kcall_join_thread,
         },
@@ -90,9 +94,25 @@ pub use tda::*;
 /// Map of stacks for threads.
 static STACKS: Lazy<Mutex<BTreeMap<pthread_t, Stack>>> = Lazy::new(|| Mutex::new(BTreeMap::new()));
 
+struct ThreadStartArgs {
+    func: extern "C" fn(usize) -> usize,
+    arg: usize,
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
+
+extern "C" fn pthread_start(arg: usize) -> usize {
+    let start_args: Box<ThreadStartArgs> = unsafe { Box::from_raw(arg as *mut ThreadStartArgs) };
+    let retval: usize = (start_args.func)(start_args.arg);
+
+    if let Err(error) = ::sysalloc::tda::cleanup() {
+        ::syslog::warn!("pthread_start(): failed to cleanup thread data area ({error:?})");
+    }
+
+    retval
+}
 
 ///
 /// # Description
@@ -134,20 +154,46 @@ pub fn pthread_create(
     // TODO: Allocate thread stack on-demand via kernel mmap support (https://github.com/nanvix/nanvix/issues/1699).
     let stack: Stack = Stack::new(stack_size)?;
 
+    let user_tda_ptr: Option<*mut u8> = ::sysalloc::tda::alloc()?;
     let user_tda: Option<VirtualAddress> =
-        ::sysalloc::tda::alloc()?.map(|tda_ptr| VirtualAddress::new(tda_ptr as usize));
+        user_tda_ptr.map(|tda_ptr| VirtualAddress::new(tda_ptr as usize));
 
+    let start_args: *mut ThreadStartArgs = Box::into_raw(Box::new(ThreadStartArgs { func, arg }));
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         // Placeholder for user wrapper function, it will be overridden by the kernel call interface.
         user_fn: ThreadCreateArgs::NULL_USER_FN,
-        user_fn_arg0: func as usize,
-        user_fn_arg1: arg,
+        user_fn_arg0: pthread_start as *const () as usize,
+        user_fn_arg1: start_args as usize,
         user_stack_base: stack.base(),
         user_stack_size: stack.size(),
         user_tda,
     };
 
-    let thread: pthread_t = __kcall_create_thread(&mut args)?.try_into()?;
+    let tid: ThreadIdentifier = match __kcall_create_thread(&mut args) {
+        Ok(tid) => tid,
+        Err(error) => {
+            unsafe {
+                drop(Box::from_raw(start_args));
+            }
+            if let Some(tda_ptr) = user_tda_ptr {
+                if let Err(cleanup_error) = unsafe { ::sysalloc::tda::dealloc(tda_ptr) } {
+                    ::syslog::warn!(
+                        "pthread_create(): failed to cleanup thread data area ({cleanup_error:?})"
+                    );
+                }
+            }
+            return Err(error);
+        },
+    };
+    let thread: pthread_t = match tid.try_into() {
+        Ok(thread) => thread,
+        Err(error) => {
+            // The kernel call only returns non-negative thread identifiers, so conversion to
+            // `pthread_t` cannot fail. Retain the live thread's stack if this invariant is broken.
+            ::core::mem::forget(stack);
+            unreachable!("pthread_create(): invalid thread identifier ({error:?})");
+        },
+    };
 
     // Store the stack in the global map.
     // NOTE: The stack will be dropped either when the thread is joined or the process exits.
@@ -238,11 +284,11 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
 pub fn pthread_self() -> pthread_t {
     // Fast path: read the cached thread ID from the TDA via segment register.
     //
-    // Safety: `is_initialized()` is process-wide but sound here because:
-    // - It is set only after `set_thread_data_area()` succeeds (main thread init).
-    // - Child threads always have a valid TDA configured by the kernel before first execution.
-    // - `cleanup()` resets the flag before clearing the segment base and then diverges.
-    if ::sysalloc::tda::is_initialized() {
+    // Safety: `is_initialized()` indicates that TDA support was initialized for the process, and
+    // `__kcall_get_thread_data_area()` verifies that the calling thread has a valid segment base.
+    let has_tda: bool = ::sysalloc::tda::is_initialized()
+        && __kcall_get_thread_data_area().is_ok_and(|tda_ptr| !tda_ptr.is_null());
+    if has_tda {
         let tid: u32 = unsafe { arch::read_tda_u32(TDA_TID_OFFSET as u32) };
 
         // Check if the TDA slot contains a valid thread ID.

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -12,6 +12,9 @@ extern void test_pthread_self(void);
 // Tests if a thread can create a cancellation point when no cancellation request is pending.
 extern void test_pthread_testcancel(void);
 
+// Tests if the cancellation state of the calling thread can be changed.
+extern void test_pthread_setcancelstate(void);
+
 // Tests if `pthread_mutex_cond_timedwait()` can be used for synchronization.
 extern void test_pthread_cond_timedwait(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -122,6 +122,7 @@ int main(int argc, const char *argv[])
     );
 
     test_pthread_self();
+    test_pthread_setcancelstate();
     test_pthread_testcancel();
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();

--- a/src/tests/integration/test-c-thread/setcancelstate.c
+++ b/src/tests/integration/test-c-thread/setcancelstate.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Worker thread.
+static void *worker_thread(void *arg)
+{
+    assert(arg == NULL);
+
+    int oldstate = -1;
+    int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
+    assert(ret == 0);
+    assert(oldstate == PTHREAD_CANCEL_ENABLE);
+
+    ret = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    assert(ret == 0);
+
+    return NULL;
+}
+
+// Tests if the cancellation state of the calling thread can be changed.
+void test_pthread_setcancelstate(void)
+{
+    fprintf(stderr, "testing pthread_setcancelstate() ... ");
+
+    int oldstate = -1;
+    int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
+    assert(ret == 0);
+    assert(oldstate == PTHREAD_CANCEL_ENABLE);
+
+    pthread_t worker_tid = PTHREAD_NULL;
+    ret = pthread_create(&worker_tid, NULL, worker_thread, NULL);
+    assert(ret == 0);
+    ret = pthread_join(worker_tid, NULL);
+    assert(ret == 0);
+
+    oldstate = -1;
+    ret = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &oldstate);
+    assert(ret == 0);
+    assert(oldstate == PTHREAD_CANCEL_DISABLE);
+
+    ret = pthread_setcancelstate(-1, &oldstate);
+    assert(ret == EINVAL);
+    assert(oldstate == PTHREAD_CANCEL_DISABLE);
+
+    oldstate = -1;
+    ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
+    assert(ret == 0);
+    assert(oldstate == PTHREAD_CANCEL_ENABLE);
+
+    ret = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Implement `pthread_setcancelstate()` so a thread's cancellability state is
tracked per thread instead of being ignored, and add integration coverage for
the new behavior.

## What changed and why

Previously `pthread_setcancelstate()` was a no-op stub that discarded the
requested state. This series stores the cancellation state in a dedicated slot
of the Thread Data Area (TDA) and updates it atomically, so the state can be
queried and toggled per thread.

### Libraries
- **sys:** add `swap_tda_u32()` for x86 and x86_64, an atomic `xchg` through the
  `gs`/`fs` segment register.
- **sysalloc:** add a cancellation-state field to the TDA header, initialize it
  to `PTHREAD_CANCEL_ENABLE` in `alloc()`, always allocate a TDA even with empty
  TLS, and make `dealloc()` a public `unsafe` function. Drop the process-wide
  `mark_uninitialized()` path and clear the segment base before deallocating in
  `cleanup()`.
- **sysapi:** add `PTHREAD_CANCEL_ENABLE` / `PTHREAD_CANCEL_DISABLE` constants
  and export them and `pthread_setcancelstate` through the header bindings.
- **syscall:** validate the requested state, atomically swap it into the TDA,
  and store the previous state only when `oldstate` is non-null. Wrap thread
  entry in `pthread_start()` to clean up the TDA on exit, roll back start args
  and the TDA on create failure, and gate the `pthread_self()` fast path on
  `__kcall_get_thread_data_area()`.

### Headers
- Declare `pthread_setcancelstate()` and the `PTHREAD_CANCEL_*` macros in
  `include/pthread.h`.

### Tests
- Add `test-c-thread/setcancelstate.c` covering enable/disable transitions,
  `oldstate` read-back, a null `oldstate` argument, and the `EINVAL` error path,
  exercised on both the main thread and a worker thread.

## Issues

Closes #339 