### PR TITLE
[syscall] Implement poll() System Call

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -105,13 +105,13 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 # A suite may restrict the compiled set via POSIX_TEST_FILES_<suite> (a list of
 # file names under the suite directory) — used by file-c, whose link-only and
 # guarded sub-tests need features absent from the standalone VFS (FAT32 has no
-# links/permissions; poll/select have no standalone backend).
+# links/permissions; select has no standalone backend).
 
 # file-c: only the sub-tests that main.c runs under __NANVIX_STANDALONE__. The
 # remaining files exercise links, permissions/ownership, timestamps, and
-# poll/select, which the standalone FAT32 VFS does not support.
+# select(), which the standalone FAT32 VFS does not support.
 POSIX_TEST_FILES_test-c-file := \
-	main.c open_close.c create_unlink.c write_read.c posix_fadvise.c lseek.c \
+	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c unlinkat.c mkdirat.c mkdir.c \
 	mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
@@ -294,7 +294,8 @@ $(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_RULE,$(suite))))
 # Per-suite environment variables (space-separated KEY=VALUE entries). Empty unless set.
 POSIX_TEST_ENV_test-c-misc := NANVIX_TEST=1
 ifneq ($(IS_WINDOWS),yes)
-POSIX_TEST_ENV_test-c-file := NANVIX_TEST_HOSTFS_PERMISSIONS=1
+POSIX_TEST_ENV_test-c-file := NANVIX_TEST_HOSTFS=1
+POSIX_TEST_ENV_test-c-network := NANVIX_TEST_HOSTFS=1
 endif
 
 # $(1) = suite name.

--- a/include/poll.h
+++ b/include/poll.h
@@ -42,7 +42,9 @@ struct pollfd {
 #define POLLHUP 0x0010
 #define POLLNVAL 0x0020
 #define POLLRDNORM POLLIN
+#define POLLRDBAND 0x0080
 #define POLLWRNORM POLLOUT
+#define POLLWRBAND 0x0100
 
 /*==================================================================================================
  * Functions

--- a/src/daemons/networkd/src/dispatch.rs
+++ b/src/daemons/networkd/src/dispatch.rs
@@ -28,6 +28,10 @@ use ::sys::{
     },
 };
 use ::syscall::{
+    poll::socket_message::{
+        PollSocketRequest,
+        PollSocketResponse,
+    },
     sys::socket::{
         message::{
             AcceptSocketRequest,
@@ -94,6 +98,7 @@ pub fn is_networking_header(header: &SystemCallMessageHeader) -> bool {
             | SystemCallMessageHeader::SendSocketRequest
             | SystemCallMessageHeader::SendToSocketRequest
             | SystemCallMessageHeader::ShutdownSocketRequest
+            | SystemCallMessageHeader::PollSocketRequest
     )
 }
 
@@ -169,6 +174,10 @@ pub fn dispatch_message(
             let request: ShutdownSocketRequest =
                 ShutdownSocketRequest::from_bytes(syscall_msg.payload);
             Some(do_shutdown(backend, tid, request))
+        },
+        SystemCallMessageHeader::PollSocketRequest => {
+            let request: PollSocketRequest = PollSocketRequest::from_bytes(syscall_msg.payload);
+            Some(do_poll(backend, tid, request))
         },
         _ => None,
     }
@@ -313,6 +322,14 @@ fn do_socket(backend: &NetBackend, tid: ThreadIdentifier, request: CreateSocketR
     trace!("networkd::socket(): tid={tid:?}, request={request:?}");
     match backend.socket(request.domain, request.typ, request.protocol) {
         Ok(sockfd) => CreateSocketResponse::build(tid, to_guest_fd(sockfd)),
+        Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
+        Err(NetError::Errno(code)) => build_error(tid, code),
+    }
+}
+
+fn do_poll(backend: &NetBackend, tid: ThreadIdentifier, request: PollSocketRequest) -> Message {
+    match backend.poll_socket(to_host_fd(request.sockfd()), request.events()) {
+        Ok(revents) => PollSocketResponse::build(tid, revents),
         Err(NetError::Interrupted) => build_error(tid, ErrorCode::Interrupted),
         Err(NetError::Errno(code)) => build_error(tid, code),
     }

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::{
+    console_wait::ConsoleWaitTable,
     error::build_error,
     handler,
     pending::PendingQueue,
@@ -29,6 +30,7 @@ use ::syscall::{
         SystemCallLongMessage,
         SystemCallMessagePart,
     },
+    poll::message::PollRequest,
     sys::{
         mount::message::{
             MountRequest,
@@ -78,6 +80,7 @@ pub(crate) fn assemble_and_dispatch(
     part: SystemCallMessagePart,
     assemblers: &mut BTreeMap<(i32, u16), AssemblerEntry>,
     pending: &mut PendingQueue,
+    console_wait: &mut ConsoleWaitTable,
 ) -> Option<Vec<Message>> {
     let key: (i32, u16) = (i32::from(source), header as u16);
 
@@ -108,7 +111,14 @@ pub(crate) fn assemble_and_dispatch(
     let parts: Vec<SystemCallMessagePart> = completed.assembler.take_parts();
 
     // Dispatch based on the header type.
-    Some(dispatch_assembled_request(source_pid, source, completed.header, &parts, pending))
+    Some(dispatch_assembled_request(
+        source_pid,
+        source,
+        completed.header,
+        &parts,
+        pending,
+        console_wait,
+    ))
 }
 
 fn max_capacity_for_header(header: SystemCallMessageHeader) -> usize {
@@ -158,6 +168,9 @@ fn max_capacity_for_header(header: SystemCallMessageHeader) -> usize {
         SystemCallMessageHeader::HostUmountRequestPart => {
             UmountRequest::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE)
         },
+        SystemCallMessageHeader::PollRequestPart => {
+            PollRequest::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE)
+        },
         // Fallback: generous capacity.
         _ => 64,
     }
@@ -169,6 +182,7 @@ fn dispatch_assembled_request(
     header: SystemCallMessageHeader,
     parts: &[SystemCallMessagePart],
     pending: &mut PendingQueue,
+    console_wait: &mut ConsoleWaitTable,
 ) -> Vec<Message> {
     match header {
         SystemCallMessageHeader::OpenAtRequestPart => match OpenAtRequest::from_parts(parts) {
@@ -313,6 +327,13 @@ fn dispatch_assembled_request(
             Ok(req) => handler::handle_umount(source, req),
             Err(e) => {
                 ::syslog::error!("dispatch: umount from_parts failed (error={:?})", e);
+                vec![build_error(source, ErrorCode::InvalidMessage)]
+            },
+        },
+        SystemCallMessageHeader::PollRequestPart => match PollRequest::from_parts(parts) {
+            Ok(request) => handler::handle_poll(source_pid, source, request, console_wait),
+            Err(error) => {
+                ::syslog::error!("dispatch: poll from_parts failed (error={:?})", error);
                 vec![build_error(source, ErrorCode::InvalidMessage)]
             },
         },

--- a/src/daemons/vfsd/src/console_wait.rs
+++ b/src/daemons/vfsd/src/console_wait.rs
@@ -1,0 +1,106 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Suspended console readers awaiting cooked terminal input.
+
+extern crate alloc;
+
+use ::alloc::collections::VecDeque;
+use ::sys::{
+    error::ErrorCode,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+/// A blocking console read parked by VFSD.
+pub(crate) struct BlockedConsoleReader {
+    /// Process that issued the read.
+    pub source_pid: ProcessIdentifier,
+    /// Thread that issued the read.
+    pub source_tid: ThreadIdentifier,
+    /// Console descriptor in the caller's table.
+    pub fd: i32,
+    /// Maximum number of cooked bytes requested.
+    pub count: usize,
+    /// Error to report without consulting the terminal state.
+    pub error: Option<ErrorCode>,
+}
+
+/// FIFO of blocking reads on the shared console input device.
+pub(crate) struct ConsoleWaitTable {
+    readers: VecDeque<BlockedConsoleReader>,
+    input_available: bool,
+    read_retry_pending: bool,
+}
+
+impl ConsoleWaitTable {
+    /// Creates an empty wait table.
+    pub fn new() -> Self {
+        Self {
+            readers: VecDeque::new(),
+            input_available: false,
+            read_retry_pending: false,
+        }
+    }
+
+    /// Parks a reader at the back of the console queue.
+    pub fn park(&mut self, reader: BlockedConsoleReader) {
+        self.readers.push_back(reader);
+    }
+
+    /// Returns the routing data for the front reader.
+    pub fn front(
+        &self,
+    ) -> Option<(ProcessIdentifier, ThreadIdentifier, i32, usize, Option<ErrorCode>)> {
+        let reader: &BlockedConsoleReader = self.readers.front()?;
+        Some((reader.source_pid, reader.source_tid, reader.fd, reader.count, reader.error))
+    }
+
+    /// Removes the front reader.
+    pub fn pop(&mut self) -> Option<BlockedConsoleReader> {
+        self.readers.pop_front()
+    }
+
+    /// Cancels every parked read issued by one thread.
+    pub fn cancel(&mut self, pid: ProcessIdentifier, tid: ThreadIdentifier) {
+        self.readers
+            .retain(|reader| reader.source_pid != pid || reader.source_tid != tid);
+    }
+
+    /// Removes all requests belonging to a terminated process.
+    pub fn purge_pid(&mut self, pid: ProcessIdentifier) {
+        self.readers.retain(|reader| reader.source_pid != pid);
+    }
+
+    /// Records that UserVM has console input or EOF available for one snapshot.
+    pub fn mark_input_available(&mut self) {
+        self.input_available = true;
+    }
+
+    /// Consumes a pending input-availability token.
+    pub fn take_input_available(&mut self) -> bool {
+        core::mem::replace(&mut self.input_available, false)
+    }
+
+    /// Returns whether the front reader needs terminal input rather than a queued error.
+    pub fn front_needs_input(&self) -> bool {
+        matches!(self.readers.front(), Some(reader) if reader.error.is_none())
+    }
+
+    /// Marks a read-delivery retry pending and reports whether one should be enqueued.
+    pub fn schedule_read_retry(&mut self) -> bool {
+        if self.read_retry_pending {
+            false
+        } else {
+            self.read_retry_pending = true;
+            true
+        }
+    }
+
+    /// Clears the pending read-delivery retry marker.
+    pub fn consume_read_retry(&mut self) {
+        self.read_retry_pending = false;
+    }
+}

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -23,6 +23,7 @@
 extern crate alloc;
 
 use crate::{
+    console_wait::ConsoleWaitTable,
     error::{
         build_error,
         fat32_to_error_code,
@@ -450,19 +451,21 @@ pub(crate) fn handle_read_with_hostfs(
     source_tid: ThreadIdentifier,
     msg: SystemCallMessage,
     pending: &mut PendingQueue,
+    console_wait: &mut ConsoleWaitTable,
     pipe_wait: &mut PipeWaitTable,
 ) -> Option<Message> {
     let req: ReadRequest = ReadRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
 
     if let Ok(stream) = ::vfs::fd::vfs_console_stream(fd) {
-        return Some(super::readwrite::handle_console_read(
+        return super::readwrite::handle_console_read(
             source_pid,
             source_tid,
             fd,
             stream,
             req.count as usize,
-        ));
+            console_wait,
+        );
     }
 
     // Pipe read end: served by the pipe handler (which may park the caller).

--- a/src/daemons/vfsd/src/handler/mod.rs
+++ b/src/daemons/vfsd/src/handler/mod.rs
@@ -9,6 +9,7 @@ mod hostfs_handlers;
 mod long;
 mod mount_handler;
 pub(crate) mod pipe;
+mod poll;
 mod readwrite;
 mod short;
 
@@ -19,5 +20,6 @@ mod short;
 pub(crate) use hostfs_handlers::*;
 pub(crate) use long::*;
 pub(crate) use mount_handler::*;
+pub(crate) use poll::*;
 pub(crate) use readwrite::*;
 pub(crate) use short::*;

--- a/src/daemons/vfsd/src/handler/poll.rs
+++ b/src/daemons/vfsd/src/handler/poll.rs
@@ -1,0 +1,122 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    console_wait::ConsoleWaitTable,
+    error::{
+        build_error,
+        fat32_to_error_code,
+    },
+};
+use ::alloc::{
+    vec,
+    vec::Vec,
+};
+use ::sys::{
+    error::ErrorCode,
+    ipc::{
+        Message,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::poll::{
+    poll_errors::POLLNVAL,
+    poll_flags::{
+        POLLIN,
+        POLLRDNORM,
+    },
+};
+use ::syscall::{
+    message::MessagePartitioner,
+    poll::message::{
+        PollRequest,
+        PollResponse,
+    },
+};
+use ::vfs::{
+    fd::ConsoleStream,
+    Fat32Error,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+pub(crate) fn handle_poll(
+    source_pid: ProcessIdentifier,
+    source: ThreadIdentifier,
+    request: PollRequest,
+    console_wait: &mut ConsoleWaitTable,
+) -> Vec<Message> {
+    if let Some((fd, _events)) = console_probe(&request) {
+        if let Err(error) = super::try_feed_console_input(fd) {
+            return vec![build_error(source, error)];
+        }
+        super::service_console_readers(console_wait);
+        ::vfs::fd::set_current_process(source_pid);
+    }
+
+    let revents: Vec<i16> = match collect_ready(&request) {
+        Ok(ready) => ready,
+        Err(error) => return vec![build_error(source, error)],
+    };
+
+    let response: PollResponse = match PollResponse::new(&revents) {
+        Ok(response) => response,
+        Err(error) => return vec![build_error(source, error.code)],
+    };
+    match response.into_parts(source, ProcessIdentifier::VFSD, MessageType::Ipc) {
+        Ok(parts) => parts,
+        Err(error) => vec![build_error(source, error.code)],
+    }
+}
+
+fn collect_ready(request: &PollRequest) -> Result<Vec<i16>, ErrorCode> {
+    let mut revents: Vec<i16> = Vec::with_capacity(request.fds.len());
+
+    for (&fd, &events) in request.fds.iter().zip(&request.events) {
+        if fd < 0 {
+            revents.push(0);
+            continue;
+        }
+
+        let events: i16 = match ::vfs::fd::vfs_poll(fd, events) {
+            Ok(events) => events,
+            Err(Fat32Error::InvalidFd) => POLLNVAL,
+            Err(error) => return Err(fat32_to_error_code(&error)),
+        };
+        revents.push(events);
+    }
+
+    Ok(revents)
+}
+
+fn console_probe(request: &PollRequest) -> Option<(i32, i16)> {
+    const READ_EVENTS: i16 = POLLIN | POLLRDNORM;
+
+    request
+        .fds
+        .iter()
+        .copied()
+        .zip(request.events.iter().copied())
+        .find_map(|(fd, events)| {
+            if events & READ_EVENTS == 0 {
+                return None;
+            }
+            if !matches!(::vfs::fd::vfs_console_stream(fd), Ok(ConsoleStream::Stdin)) {
+                return None;
+            }
+            match ::vfs::fd::vfs_poll(fd, events) {
+                Ok(revents) if revents & READ_EVENTS == 0 => Some((fd, events)),
+                _ => None,
+            }
+        })
+}

--- a/src/daemons/vfsd/src/handler/readwrite.rs
+++ b/src/daemons/vfsd/src/handler/readwrite.rs
@@ -5,12 +5,23 @@
 // Imports
 //==================================================================================================
 
-use crate::error::{
-    build_error,
-    fat32_to_error_code,
+use crate::{
+    console_wait::{
+        BlockedConsoleReader,
+        ConsoleWaitTable,
+    },
+    error::{
+        build_error,
+        fat32_to_error_code,
+        send_response,
+    },
 };
-use ::alloc::vec::Vec;
+use ::alloc::{
+    boxed::Box,
+    vec::Vec,
+};
 use ::arch::mem::PAGE_SIZE;
+use ::core::time::Duration;
 use ::sys::{
     error::{
         Error,
@@ -39,12 +50,13 @@ use ::sysapi::{
     },
     sys_types::c_size_t,
     termios::Termios,
-    unistd::{
-        STDIN_FILENO,
-        STDOUT_FILENO,
-    },
+    unistd::STDOUT_FILENO,
 };
 use ::syscall::{
+    poll::input_message::{
+        ConsoleReadRetry,
+        PollInputRequest,
+    },
     sys::ioctl::message::{
         TtyControlRequest,
         TtyControlResponse,
@@ -93,6 +105,13 @@ static mut BULK_BUFFER: [u8; MAX_BULK_TRANSFER_SIZE] = [0u8; MAX_BULK_TRANSFER_S
 /// keystroke as it is typed. Over-reading is safe: surplus bytes are buffered by the line
 /// discipline and served to later reads.
 const CONSOLE_RAW_READ_SIZE: usize = 256;
+
+/// Immediate host-console input snapshot.
+enum ConsoleInputSnapshot {
+    Empty,
+    Eof,
+    Data(Box<[u8]>),
+}
 
 //==================================================================================================
 // Read/Write Handlers (with push/pull bulk data transfer)
@@ -148,28 +167,28 @@ pub(crate) fn handle_read(
 
 /// Handles a `read()` on a console descriptor.
 ///
-/// Cooked input already buffered in the line discipline is served without blocking. When none is
-/// available and the descriptor is blocking, this fetches raw input from the host console and feeds
-/// it through the line discipline until a readable unit (a canonical line, a raw byte, or EOF)
-/// becomes available.
-///
-/// The host console protocol is synchronous and demand-driven — the host blocks until input arrives
-/// and delivers it only in response to an explicit request — and vfsd is single-threaded, so this
-/// fetch necessarily blocks the event loop while waiting for the user. Requests from other clients
-/// that arrive meanwhile are queued (never lost) and are serviced as soon as the read completes.
-/// Crucially, the raw fetch does not consume the kernel's acknowledgement with a nested
-/// `__kcall_recv()` (which could dequeue an unrelated request from the shared mailbox); those
-/// acknowledgements are drained by the main event loop instead.
+/// Cooked input already buffered in the line discipline is served without blocking. A blocking read
+/// with no cooked input is parked in `console_wait` and revived by an input-availability
+/// notification; VFSD therefore never blocks its event loop waiting for a host keystroke.
 pub(crate) fn handle_console_read(
     source_pid: ProcessIdentifier,
     source_tid: ThreadIdentifier,
     fd: i32,
     stream: ConsoleStream,
     count: usize,
-) -> Message {
+    console_wait: &mut ConsoleWaitTable,
+) -> Option<Message> {
     if stream != ConsoleStream::Stdin {
-        let _ = push_to_reader(source_pid, source_tid, &[], "console read");
-        return build_error(source_tid, ErrorCode::BadFile);
+        console_wait.park(BlockedConsoleReader {
+            source_pid,
+            source_tid,
+            fd,
+            count,
+            error: Some(ErrorCode::BadFile),
+        });
+        wake_console_readers(console_wait);
+        service_pending_console_input(console_wait);
+        return None;
     }
 
     if count > 0 {
@@ -180,51 +199,17 @@ pub(crate) fn handle_console_read(
         notify_terminal_access(source_pid, false);
     }
 
-    let buf_size: usize = count.min(MAX_BULK_TRANSFER_SIZE);
-    // Safety: vfsd is single-threaded; no concurrent access to BULK_BUFFER.
-    let buf: &mut [u8] = unsafe { &mut BULK_BUFFER[..buf_size] };
-
-    loop {
-        match ::vfs::fd::vfs_console_read(fd, buf) {
-            Ok(ConsoleReadOutcome::Read(n)) => {
-                if let Err(code) = push_to_reader(source_pid, source_tid, &buf[..n], "console read")
-                {
-                    return build_error(source_tid, code);
-                }
-                return ReadResponse::build(
-                    source_tid,
-                    n as i32,
-                    [0u8; ReadResponse::BUFFER_SIZE],
-                    ProcessIdentifier::VFSD,
-                    MessageType::Ipc,
-                );
-            },
-            Ok(ConsoleReadOutcome::Eof) => {
-                let _ = push_to_reader(source_pid, source_tid, &[], "console read");
-                return ReadResponse::build(
-                    source_tid,
-                    0,
-                    [0u8; ReadResponse::BUFFER_SIZE],
-                    ProcessIdentifier::VFSD,
-                    MessageType::Ipc,
-                );
-            },
-            Ok(ConsoleReadOutcome::WouldBlock) => {
-                if is_nonblocking(fd) {
-                    let _ = push_to_reader(source_pid, source_tid, &[], "console read");
-                    return build_error(source_tid, ErrorCode::TryAgain);
-                }
-                if let Err(code) = feed_console_input(fd) {
-                    let _ = push_to_reader(source_pid, source_tid, &[], "console read");
-                    return build_error(source_tid, code);
-                }
-            },
-            Err(error) => {
-                let _ = push_to_reader(source_pid, source_tid, &[], "console read");
-                return build_error(source_tid, tty_error_code(error));
-            },
-        }
+    console_wait.park(BlockedConsoleReader {
+        source_pid,
+        source_tid,
+        fd,
+        count,
+        error: None,
+    });
+    if !service_pending_console_input(console_wait) {
+        wake_console_readers(console_wait);
     }
+    None
 }
 
 pub(crate) fn handle_write(
@@ -272,33 +257,254 @@ fn is_nonblocking(fd: i32) -> bool {
     ::vfs::fd::vfs_get_status_flags(fd) & file_status_flags::O_NONBLOCK != 0
 }
 
-/// Pushes data to a reader blocked in `__kcall_pull`.
-fn push_to_reader(
-    pid: ProcessIdentifier,
-    tid: ThreadIdentifier,
-    data: &[u8],
-    context: &'static str,
-) -> Result<(), ErrorCode> {
-    if let Err(error) = ::sys::kcall::ipc::__kcall_push(pid, tid, data) {
-        ::syslog::error!("{context}: push failed (error={:?})", error);
-        return Err(ErrorCode::IoErr);
+/// Tries to feed currently buffered host-console input without waiting for a keystroke.
+pub(crate) fn try_feed_console_input(fd: i32) -> Result<bool, ErrorCode> {
+    match console_input_snapshot()? {
+        ConsoleInputSnapshot::Empty => Ok(false),
+        ConsoleInputSnapshot::Eof => {
+            ::vfs::fd::vfs_console_push_eof(fd).map_err(tty_error_code)?;
+            Ok(false)
+        },
+        ConsoleInputSnapshot::Data(raw) => {
+            process_console_input(fd, &raw)?;
+            Ok(true)
+        },
     }
-    Ok(())
 }
 
-/// Feeds a chunk of raw host-console input through the line discipline.
-///
-/// Fetches up to [`CONSOLE_RAW_READ_SIZE`] raw bytes from the kernel console, cooks them through the
-/// line discipline, and writes back any bytes the discipline wants echoed. A zero-length fetch means
-/// end-of-file, which is signalled to the discipline. Echo failures are non-fatal and only logged.
-fn feed_console_input(fd: i32) -> Result<(), ErrorCode> {
-    let mut raw: [u8; CONSOLE_RAW_READ_SIZE] = [0u8; CONSOLE_RAW_READ_SIZE];
-    let n: usize = kernel_read_stdin(&mut raw).map_err(|error| error.code)?;
+/// Fetches one immediate host-console input snapshot.
+fn console_input_snapshot() -> Result<ConsoleInputSnapshot, ErrorCode> {
+    let mut response: [u8; CONSOLE_RAW_READ_SIZE + 1] = [0u8; CONSOLE_RAW_READ_SIZE + 1];
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid().map_err(|error| error.code)?;
+    let request: Message = PollInputRequest::build(tid, CONSOLE_RAW_READ_SIZE as u32);
+    ::sys::kcall::ipc::__kcall_send(&request).map_err(|error| error.code)?;
+    let n: usize = ::sys::kcall::ipc::__kcall_pull(
+        ProcessIdentifier::KERNEL,
+        ThreadIdentifier::KERNEL,
+        &mut response,
+    )
+    .map_err(|error| error.code)?;
     if n == 0 {
-        return ::vfs::fd::vfs_console_push_eof(fd).map_err(tty_error_code);
+        return Err(ErrorCode::InvalidMessage);
     }
 
-    let echo: Vec<u8> = ::vfs::fd::vfs_console_push_input(fd, &raw[..n]).map_err(tty_error_code)?;
+    match response[0] {
+        PollInputRequest::STATUS_EMPTY => Ok(ConsoleInputSnapshot::Empty),
+        PollInputRequest::STATUS_EOF => Ok(ConsoleInputSnapshot::Eof),
+        PollInputRequest::STATUS_DATA if n > 1 => {
+            let raw: Box<[u8]> = Box::from(&response[1..n]);
+            Ok(ConsoleInputSnapshot::Data(raw))
+        },
+        _ => Err(ErrorCode::InvalidMessage),
+    }
+}
+
+/// Retains one host-input availability token and services it when a reader needs input.
+pub(crate) fn handle_console_input_available(console_wait: &mut ConsoleWaitTable) {
+    console_wait.mark_input_available();
+    service_pending_console_input(console_wait);
+}
+
+/// Fetches one retained host-input snapshot for the front reader.
+pub(crate) fn service_pending_console_input(console_wait: &mut ConsoleWaitTable) -> bool {
+    if !console_wait.front_needs_input() || !console_wait.take_input_available() {
+        return false;
+    }
+
+    match console_input_snapshot() {
+        Ok(ConsoleInputSnapshot::Data(raw)) => process_console_device_input(&raw),
+        Ok(ConsoleInputSnapshot::Eof) => {
+            ::vfs::fd::vfs_console_device_push_eof();
+        },
+        Ok(ConsoleInputSnapshot::Empty) => {},
+        Err(error) => {
+            ::syslog::warn!("console input notification failed (error={:?})", error);
+        },
+    }
+    wake_console_readers(console_wait);
+    true
+}
+
+/// Revives queued console readers in FIFO order while cooked data or EOF is available.
+fn wake_console_readers(console_wait: &mut ConsoleWaitTable) {
+    while let Some((source_pid, source_tid, fd, count, queued_error)) = console_wait.front() {
+        if let Some(error) = queued_error {
+            match ::sys::kcall::ipc::__kcall_push_timed(
+                source_pid,
+                source_tid,
+                &[],
+                Some(Duration::ZERO),
+            ) {
+                Ok(()) => {
+                    console_wait.pop();
+                    send_response(&build_error(source_tid, error));
+                    continue;
+                },
+                Err(push_error) if push_error.code == ErrorCode::OperationTimedOut => {
+                    schedule_console_read_retry(console_wait);
+                    break;
+                },
+                Err(_) => {
+                    console_wait.pop();
+                    continue;
+                },
+            }
+        }
+
+        ::vfs::fd::set_current_process(source_pid);
+        let buf_size: usize = count.min(MAX_BULK_TRANSFER_SIZE);
+        // Safety: VFSD is single-threaded and releases this borrow before processing another IPC.
+        let buf: &mut [u8] = unsafe { &mut BULK_BUFFER[..buf_size] };
+        match ::vfs::fd::vfs_console_peek(fd, buf) {
+            Ok(ConsoleReadOutcome::Read(n)) => {
+                match ::sys::kcall::ipc::__kcall_push_timed(
+                    source_pid,
+                    source_tid,
+                    &buf[..n],
+                    Some(Duration::ZERO),
+                ) {
+                    Ok(()) => {},
+                    Err(error) if error.code == ErrorCode::OperationTimedOut => {
+                        schedule_console_read_retry(console_wait);
+                        break;
+                    },
+                    Err(_) => {
+                        console_wait.pop();
+                        continue;
+                    },
+                }
+
+                let consumed: Result<ConsoleReadOutcome, TtyError> =
+                    ::vfs::fd::vfs_console_read(fd, buf);
+                console_wait.pop();
+                match consumed {
+                    Ok(ConsoleReadOutcome::Read(consumed)) if consumed == n => {
+                        send_response(&ReadResponse::build(
+                            source_tid,
+                            n as i32,
+                            [0u8; ReadResponse::BUFFER_SIZE],
+                            ProcessIdentifier::VFSD,
+                            MessageType::Ipc,
+                        ));
+                    },
+                    _ => send_response(&build_error(source_tid, ErrorCode::InvalidMessage)),
+                }
+            },
+            Ok(ConsoleReadOutcome::Eof) => {
+                match ::sys::kcall::ipc::__kcall_push_timed(
+                    source_pid,
+                    source_tid,
+                    &[],
+                    Some(Duration::ZERO),
+                ) {
+                    Ok(()) => {},
+                    Err(error) if error.code == ErrorCode::OperationTimedOut => {
+                        schedule_console_read_retry(console_wait);
+                        break;
+                    },
+                    Err(_) => {
+                        console_wait.pop();
+                        continue;
+                    },
+                }
+
+                let consumed: Result<ConsoleReadOutcome, TtyError> =
+                    ::vfs::fd::vfs_console_read(fd, buf);
+                console_wait.pop();
+                match consumed {
+                    Ok(ConsoleReadOutcome::Eof) => send_response(&ReadResponse::build(
+                        source_tid,
+                        0,
+                        [0u8; ReadResponse::BUFFER_SIZE],
+                        ProcessIdentifier::VFSD,
+                        MessageType::Ipc,
+                    )),
+                    _ => send_response(&build_error(source_tid, ErrorCode::InvalidMessage)),
+                }
+            },
+            Ok(ConsoleReadOutcome::WouldBlock) if is_nonblocking(fd) => {
+                match ::sys::kcall::ipc::__kcall_push_timed(
+                    source_pid,
+                    source_tid,
+                    &[],
+                    Some(Duration::ZERO),
+                ) {
+                    Ok(()) => {
+                        console_wait.pop();
+                        send_response(&build_error(source_tid, ErrorCode::TryAgain));
+                    },
+                    Err(error) if error.code == ErrorCode::OperationTimedOut => {
+                        schedule_console_read_retry(console_wait);
+                        break;
+                    },
+                    Err(_) => {
+                        console_wait.pop();
+                    },
+                }
+            },
+            Ok(ConsoleReadOutcome::WouldBlock) => break,
+            Err(error) => {
+                match ::sys::kcall::ipc::__kcall_push_timed(
+                    source_pid,
+                    source_tid,
+                    &[],
+                    Some(Duration::ZERO),
+                ) {
+                    Ok(()) => {
+                        console_wait.pop();
+                        send_response(&build_error(source_tid, tty_error_code(error)));
+                    },
+                    Err(push_error) if push_error.code == ErrorCode::OperationTimedOut => {
+                        schedule_console_read_retry(console_wait);
+                        break;
+                    },
+                    Err(_) => {
+                        console_wait.pop();
+                    },
+                }
+            },
+        }
+    }
+}
+
+/// Attempts delivery to parked console readers without consuming a queued retry marker.
+pub(crate) fn service_console_readers(console_wait: &mut ConsoleWaitTable) {
+    wake_console_readers(console_wait);
+}
+
+/// Yields to let the reader register its pull, then retries through VFSD's event loop.
+fn schedule_console_read_retry(console_wait: &mut ConsoleWaitTable) {
+    if !console_wait.schedule_read_retry() {
+        return;
+    }
+    if let Err(error) = ::sys::kcall::sched::__kcall_sched_yield() {
+        ::syslog::warn!("console read: failed to yield before retry (error={:?})", error);
+    }
+    let tid: ThreadIdentifier = match ::sys::kcall::pm::__kcall_gettid() {
+        Ok(tid) => tid,
+        Err(error) => {
+            console_wait.consume_read_retry();
+            ::syslog::error!("console read: failed to get VFSD tid (error={:?})", error);
+            return;
+        },
+    };
+    let retry: Message = ConsoleReadRetry::build(tid);
+    if let Err(error) = ::sys::kcall::ipc::__kcall_send(&retry) {
+        console_wait.consume_read_retry();
+        ::syslog::error!("console read: failed to schedule retry (error={:?})", error);
+    }
+}
+
+/// Retries delivery to parked console readers after they had time to register their pulls.
+pub(crate) fn retry_console_readers(console_wait: &mut ConsoleWaitTable) {
+    console_wait.consume_read_retry();
+    service_console_readers(console_wait);
+    service_pending_console_input(console_wait);
+}
+
+/// Cooks raw console bytes and handles echo and terminal-generated signals.
+fn process_console_input(fd: i32, raw: &[u8]) -> Result<(), ErrorCode> {
+    let echo: Vec<u8> = ::vfs::fd::vfs_console_push_input(fd, raw).map_err(tty_error_code)?;
     if !echo.is_empty() {
         if let Err(error) = kernel_write_console(STDOUT_FILENO, &echo) {
             ::syslog::warn!("console read: failed to echo input (error={:?})", error);
@@ -310,6 +516,17 @@ fn feed_console_input(fd: i32) -> Result<(), ErrorCode> {
     forward_console_signals(fd);
 
     Ok(())
+}
+
+/// Cooks raw bytes through the persistent console device and forwards echo and signals.
+fn process_console_device_input(raw: &[u8]) {
+    let echo: Vec<u8> = ::vfs::fd::vfs_console_device_push_input(raw);
+    if !echo.is_empty() {
+        if let Err(error) = kernel_write_console(STDOUT_FILENO, &echo) {
+            ::syslog::warn!("console input: failed to echo input (error={:?})", error);
+        }
+    }
+    forward_console_device_signals();
 }
 
 /// Notifies the process manager daemon that `pid` accessed the console, so it can raise `SIGTTIN`
@@ -380,33 +597,39 @@ fn forward_console_signals(fd: i32) {
     }
 }
 
-/// Reads raw input from the kernel console stdin stream.
-///
-/// Sends a `ReadRequest` to the kernel console and pulls the delivered bytes. The pulled byte count
-/// is authoritative: the host always completes the pull (with `0` bytes on end-of-file). The
-/// kernel's matching `ReadResponse` acknowledgement is intentionally left in vfsd's mailbox for the
-/// main event loop to discard, rather than consumed here with a nested `__kcall_recv()` that could
-/// instead dequeue an unrelated guest request (the mailbox is shared by the whole process).
-fn kernel_read_stdin(buf: &mut [u8]) -> Result<usize, Error> {
-    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
-    let request: Message = ReadRequest::build(
-        tid,
-        STDIN_FILENO,
-        buf.len() as c_size_t,
-        ProcessIdentifier::KERNEL,
-        MessageType::Ikc,
-    );
-    ::sys::kcall::ipc::__kcall_send(&request)?;
-    let bytes_pulled: usize =
-        ::sys::kcall::ipc::__kcall_pull(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buf)?;
-    Ok(bytes_pulled)
+/// Forwards terminal-generated signals drained directly from the shared console device.
+fn forward_console_device_signals() {
+    for signal in ::vfs::fd::vfs_console_device_take_signals() {
+        let signum: i32 = match signal {
+            TerminalSignal::Interrupt => SIGINT as i32,
+            TerminalSignal::Quit => SIGQUIT as i32,
+            TerminalSignal::Suspend => SIGTSTP as i32,
+        };
+        match ::proc::terminal_signal_request(ProcessIdentifier::VFSD, signum) {
+            Ok(message) => {
+                if let Err(error) = ::sys::kcall::ipc::__kcall_send(&message) {
+                    ::syslog::warn!(
+                        "console input: failed to forward terminal signal (signum={}, error={:?})",
+                        signum,
+                        error
+                    );
+                }
+            },
+            Err(error) => {
+                ::syslog::warn!(
+                    "console input: failed to build terminal-signal notification (error={:?})",
+                    error
+                );
+            },
+        }
+    }
 }
 
 /// Writes bytes to the kernel console output stream (used to echo cooked input).
 ///
-/// Like [`kernel_read_stdin`], the kernel's `WriteResponse` acknowledgement is left in vfsd's
-/// mailbox for the main event loop to discard rather than consumed with a nested `__kcall_recv()`,
-/// which could otherwise dequeue an unrelated guest request from the shared mailbox.
+/// The kernel's `WriteResponse` acknowledgement is left in VFSD's mailbox for the main event loop
+/// to discard rather than consumed with a nested `__kcall_recv()`, which could otherwise dequeue an
+/// unrelated guest request from the shared mailbox.
 fn kernel_write_console(fd: i32, buf: &[u8]) -> Result<(), Error> {
     if buf.is_empty() {
         return Ok(());
@@ -504,6 +727,7 @@ pub(crate) fn handle_tty_control(
     source_pid: ProcessIdentifier,
     source_tid: ThreadIdentifier,
     msg: SystemCallMessage,
+    console_wait: &mut ConsoleWaitTable,
 ) -> Message {
     let req: TtyControlRequest = TtyControlRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
@@ -526,12 +750,17 @@ pub(crate) fn handle_tty_control(
                         ::vfs::fd::vfs_tty_set_winsize(fd, winsize).map_err(tty_error_code)
                     };
                     match outcome {
-                        Ok(()) => TtyControlResponse::build(
-                            source_tid,
-                            0,
-                            ProcessIdentifier::VFSD,
-                            MessageType::Ipc,
-                        ),
+                        Ok(()) => {
+                            if request == TCSETS {
+                                wake_console_readers(console_wait);
+                            }
+                            TtyControlResponse::build(
+                                source_tid,
+                                0,
+                                ProcessIdentifier::VFSD,
+                                MessageType::Ipc,
+                            )
+                        },
                         Err(code) => build_error(source_tid, code),
                     }
                 },

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -10,6 +10,7 @@ use crate::{
         assemble_and_dispatch,
         AssemblerEntry,
     },
+    console_wait::ConsoleWaitTable,
     error::{
         build_error,
         send_response,
@@ -49,6 +50,7 @@ use ::sys::{
 };
 use ::syscall::{
     message::SystemCallMessagePart,
+    poll::input_message::ConsoleReadCancel,
     SystemCallMessage,
     SystemCallMessageHeader,
 };
@@ -95,7 +97,11 @@ fn caller_pid(message: &Message) -> ProcessIdentifier {
 // SystemMessage Handler (procd shutdown)
 //==================================================================================================
 
-fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Result<bool, Error> {
+fn handle_system_message(
+    message: Message,
+    console_wait: &mut ConsoleWaitTable,
+    pipe_wait: &mut PipeWaitTable,
+) -> Result<bool, Error> {
     // State-mutating process-management messages are privileged: only procd may direct them. The
     // caller (handle_ipc_message) routes here only when the kernel-attested `message.source.pid` is
     // PROCD, so a sender cannot reach this path by forging `message.source`. The debug assert below
@@ -184,6 +190,7 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                     let reclaim: ::vfs::fd::ProcessExitReclaim = ::vfs::fd::vfs_process_exit(pid);
                     // First discard any requests this process had parked: there is no longer a
                     // client to answer, so they must not be revived by the wakeups below.
+                    console_wait.purge_pid(pid);
                     pipe_wait.purge_pid(pid);
                     for closure in reclaim.pipe_closures {
                         if closure.was_write {
@@ -231,6 +238,9 @@ fn handle_system_message(message: Message, pipe_wait: &mut PipeWaitTable) -> Res
                 ProcessManagementMessageHeader::Exec => {
                     let exec: ExecMessage = ExecMessage::from_bytes(pm_msg.payload);
                     let pid: ProcessIdentifier = exec.pid;
+                    // Exec destroys every thread except the caller, so no console read issued by
+                    // the old image may survive into the replacement image.
+                    console_wait.purge_pid(pid);
                     // Bind the VFS to the exec'ing process and seed the root console if this is the
                     // root's first VFS-visible event, mirroring the fork-clone and syscall paths so
                     // close-on-exec is applied against a consistent table. The seed helper is
@@ -325,6 +335,7 @@ pub(crate) fn handle_ipc_message(
     message: Message,
     assemblers: &mut BTreeMap<(i32, u16), AssemblerEntry>,
     pending: &mut PendingQueue,
+    console_wait: &mut ConsoleWaitTable,
     pipe_wait: &mut PipeWaitTable,
 ) -> Result<bool, Error> {
     let source_tid: ThreadIdentifier = caller_tid(&message);
@@ -332,7 +343,7 @@ pub(crate) fn handle_ipc_message(
 
     // Route messages from the process manager daemon (PROCD).
     if source_pid == ProcessIdentifier::PROCD {
-        return handle_system_message(message, pipe_wait);
+        return handle_system_message(message, console_wait, pipe_wait);
     }
 
     // Bind the VFS to the requesting process so that descriptor and working-directory operations
@@ -375,6 +386,18 @@ pub(crate) fn handle_ipc_message(
         SystemCallMessageHeader::ResolveFdRequest => {
             let response: Message = handler::handle_resolve_fd(source_tid, syscall_msg);
             send_response(&response);
+        },
+        SystemCallMessageHeader::ConsoleReadCancelRequest => {
+            console_wait.cancel(source_pid, source_tid);
+            let _ = handler::service_pending_console_input(console_wait);
+            send_response(&ConsoleReadCancel::build_response(source_tid));
+        },
+        SystemCallMessageHeader::ConsoleReadRetry => {
+            if source_pid == ProcessIdentifier::VFSD {
+                handler::retry_console_readers(console_wait);
+            } else {
+                send_response(&build_error(source_tid, ErrorCode::PermissionDenied));
+            }
         },
         SystemCallMessageHeader::RegisterSocketRequest => {
             let response: Message = handler::handle_register_socket(source_tid, syscall_msg);
@@ -459,6 +482,7 @@ pub(crate) fn handle_ipc_message(
                 source_tid,
                 syscall_msg,
                 pending,
+                console_wait,
                 pipe_wait,
             ) {
                 send_response(&response);
@@ -481,7 +505,7 @@ pub(crate) fn handle_ipc_message(
         //==========================================================================================
         SystemCallMessageHeader::TtyControlRequest => {
             let response: Message =
-                handler::handle_tty_control(source_pid, source_tid, syscall_msg);
+                handler::handle_tty_control(source_pid, source_tid, syscall_msg, console_wait);
             send_response(&response);
         },
 
@@ -542,7 +566,8 @@ pub(crate) fn handle_ipc_message(
         | SystemCallMessageHeader::FileChownAtRequestPart
         | SystemCallMessageHeader::FileChmodAtRequestPart
         | SystemCallMessageHeader::HostMountRequestPart
-        | SystemCallMessageHeader::HostUmountRequestPart => {
+        | SystemCallMessageHeader::HostUmountRequestPart
+        | SystemCallMessageHeader::PollRequestPart => {
             let part: SystemCallMessagePart =
                 SystemCallMessagePart::from_bytes(syscall_msg.payload);
             if let Some(responses) = assemble_and_dispatch(
@@ -552,6 +577,7 @@ pub(crate) fn handle_ipc_message(
                 part,
                 assemblers,
                 pending,
+                console_wait,
             ) {
                 for response in responses {
                     send_response(&response);

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -13,6 +13,7 @@
 //==================================================================================================
 
 mod assembler;
+mod console_wait;
 mod error;
 mod handler;
 mod hostfs;
@@ -116,6 +117,13 @@ pub fn main() {
         }
     }
 
+    let tid: ::sys::pm::ThreadIdentifier =
+        ::sys::kcall::pm::__kcall_gettid().expect("failed to get vfsd thread id");
+    let subscription: Message =
+        ::syscall::poll::input_message::PollInputRequest::build_subscription(tid);
+    ::sys::kcall::ipc::__kcall_send(&subscription)
+        .expect("failed to subscribe to console input notifications");
+
     // Multi-part request assembler map keyed by (tid_value, header_discriminant).
     // TODO: add eviction/timeout for incomplete entries to prevent memory leaks from crashed clients.
     let mut assemblers: BTreeMap<(i32, u16), assembler::AssemblerEntry> = BTreeMap::new();
@@ -125,6 +133,9 @@ pub fn main() {
 
     // Suspended pipe readers/writers awaiting their complementary operation.
     let mut pipe_wait: pipe_wait::PipeWaitTable = pipe_wait::PipeWaitTable::new();
+
+    // Suspended console readers awaiting cooked input or end-of-file.
+    let mut console_wait: console_wait::ConsoleWaitTable = console_wait::ConsoleWaitTable::new();
 
     // In-flight multi-part hostfs *response* assembler, paired with the op_id
     // extracted eagerly from part 0 so a discarded stream can be cancelled (the
@@ -157,7 +168,13 @@ pub fn main() {
 
     // Process any messages that were buffered during the signup phase.
     while let Some(message) = buffered_messages.pop_front() {
-        match ipc::handle_ipc_message(message, &mut assemblers, &mut pending, &mut pipe_wait) {
+        match ipc::handle_ipc_message(
+            message,
+            &mut assemblers,
+            &mut pending,
+            &mut console_wait,
+            &mut pipe_wait,
+        ) {
             Ok(true) => {
                 let e = ::sys::kcall::pm::__kcall_exit(0);
                 ::syslog::error!("failed to shutdown vfsd (error={:?})", e);
@@ -180,6 +197,7 @@ pub fn main() {
                         message,
                         &mut assemblers,
                         &mut pending,
+                        &mut console_wait,
                         &mut pipe_wait,
                     ) {
                         Ok(true) => break,
@@ -195,21 +213,28 @@ pub fn main() {
                         ::syscall::SystemCallMessage::try_from_bytes(message.payload)
                     {
                         let header: SystemCallMessageHeader = syscall_msg.header;
+                        if header == SystemCallMessageHeader::ConsoleInputAvailable {
+                            let source: ::sys::ipc::MessageSender = message.source;
+                            if source != ::sys::ipc::MessageSender::KERNEL {
+                                ::syslog::warn!(
+                                    "ignored console input notification from {:?}",
+                                    source
+                                );
+                                continue;
+                            }
+                            handler::handle_console_input_available(&mut console_wait);
+                            continue;
+                        }
                         // networkd acknowledges a forwarded socket-endpoint close with an IKC
                         // `CloseResponse`. That close is fire-and-forget — vfsd does not wait on it
                         // — so the acknowledgement is expected and silently discarded.
                         if header == SystemCallMessageHeader::CloseResponse {
                             continue;
                         }
-                        // The console line-discipline backend fetches raw input and echoes output
-                        // through synchronous kernel-console exchanges (see vfsd's
-                        // `handle_console_read`). It deliberately does not consume the kernel's
-                        // `ReadResponse`/`WriteResponse` acknowledgement inline — a nested
-                        // `__kcall_recv()` there could dequeue an unrelated guest request from the
-                        // shared mailbox — so those acknowledgements surface here and are discarded.
-                        if header == SystemCallMessageHeader::ReadResponse
-                            || header == SystemCallMessageHeader::WriteResponse
-                        {
+                        // Console echo writes deliberately leave their `WriteResponse`
+                        // acknowledgement for this event loop; consuming it in the helper with a
+                        // nested receive could dequeue an unrelated guest request.
+                        if header == SystemCallMessageHeader::WriteResponse {
                             continue;
                         }
                         // Multi-part response stream: assemble parts before dispatch.

--- a/src/libs/net-backend/src/platform/unix.rs
+++ b/src/libs/net-backend/src/platform/unix.rs
@@ -33,6 +33,21 @@ pub(crate) const IPPROTO_UDP: libc::c_int = libc::IPPROTO_UDP;
 pub(crate) const INVALID_SOCKET: RawSocket = -1;
 
 //==================================================================================================
+// Poll Constants
+//==================================================================================================
+
+pub(crate) const PLATFORM_POLLIN: libc::c_short = libc::POLLIN;
+pub(crate) const PLATFORM_POLLPRI: libc::c_short = libc::POLLPRI;
+pub(crate) const PLATFORM_POLLOUT: libc::c_short = libc::POLLOUT;
+pub(crate) const PLATFORM_POLLERR: libc::c_short = libc::POLLERR;
+pub(crate) const PLATFORM_POLLHUP: libc::c_short = libc::POLLHUP;
+pub(crate) const PLATFORM_POLLNVAL: libc::c_short = libc::POLLNVAL;
+pub(crate) const PLATFORM_POLLRDNORM: libc::c_short = libc::POLLRDNORM;
+pub(crate) const PLATFORM_POLLRDBAND: libc::c_short = libc::POLLRDBAND;
+pub(crate) const PLATFORM_POLLWRNORM: libc::c_short = libc::POLLWRNORM;
+pub(crate) const PLATFORM_POLLWRBAND: Option<libc::c_short> = Some(libc::POLLWRBAND);
+
+//==================================================================================================
 // Shutdown Constants
 //==================================================================================================
 
@@ -93,6 +108,22 @@ pub(crate) fn socket_failed(result: RawSocket) -> bool {
 #[inline]
 pub(crate) unsafe fn close_socket(fd: RawSocket) -> libc::c_int {
     libc::close(fd)
+}
+
+/// Performs a non-blocking readiness query for one socket.
+pub(crate) unsafe fn raw_poll(
+    fd: RawSocket,
+    events: libc::c_short,
+    revents: &mut libc::c_short,
+) -> libc::c_int {
+    let mut pollfd: libc::pollfd = libc::pollfd {
+        fd,
+        events,
+        revents: 0,
+    };
+    let result: libc::c_int = libc::poll(&mut pollfd, 1, 0);
+    *revents = pollfd.revents;
+    result
 }
 
 //==================================================================================================

--- a/src/libs/net-backend/src/platform/windows.rs
+++ b/src/libs/net-backend/src/platform/windows.rs
@@ -33,6 +33,24 @@ pub(crate) const IPPROTO_UDP: libc::c_int = 17;
 pub(crate) const INVALID_SOCKET: RawSocket = !0usize;
 
 //==================================================================================================
+// Poll Constants
+//==================================================================================================
+
+// Guest POLLIN means normal data, whereas Winsock's aggregate POLLIN also includes POLLRDBAND.
+pub(crate) const PLATFORM_POLLIN: libc::c_short = 0x0100;
+// The Microsoft Winsock provider rejects POLLPRI but reports urgent data as POLLRDBAND.
+pub(crate) const PLATFORM_POLLPRI: libc::c_short = 0x0200;
+pub(crate) const PLATFORM_POLLOUT: libc::c_short = 0x0010;
+pub(crate) const PLATFORM_POLLERR: libc::c_short = 0x0001;
+pub(crate) const PLATFORM_POLLHUP: libc::c_short = 0x0002;
+pub(crate) const PLATFORM_POLLNVAL: libc::c_short = 0x0004;
+pub(crate) const PLATFORM_POLLRDNORM: libc::c_short = 0x0100;
+pub(crate) const PLATFORM_POLLRDBAND: libc::c_short = 0x0200;
+pub(crate) const PLATFORM_POLLWRNORM: libc::c_short = 0x0010;
+// The Microsoft Winsock provider rejects this request bit with WSAEINVAL.
+pub(crate) const PLATFORM_POLLWRBAND: Option<libc::c_short> = None;
+
+//==================================================================================================
 // Shutdown Constants
 //==================================================================================================
 
@@ -100,6 +118,22 @@ pub(crate) fn socket_failed(result: RawSocket) -> bool {
 #[inline]
 pub(crate) unsafe fn close_socket(fd: RawSocket) -> libc::c_int {
     winsock::closesocket(fd)
+}
+
+/// Performs a non-blocking readiness query for one socket.
+pub(crate) unsafe fn raw_poll(
+    fd: RawSocket,
+    events: libc::c_short,
+    revents: &mut libc::c_short,
+) -> libc::c_int {
+    let mut pollfd: winsock::WSAPOLLFD = winsock::WSAPOLLFD {
+        fd,
+        events,
+        revents: 0,
+    };
+    let result: libc::c_int = winsock::WSAPoll(&mut pollfd, 1, 0);
+    *revents = pollfd.revents;
+    result
 }
 
 //==================================================================================================
@@ -327,6 +361,15 @@ pub(crate) mod winsock {
     // ioctlsocket command to enable/disable non-blocking mode (FIONBIO).
     pub const FIONBIO: c_long = 0x8004667Eu32 as c_long;
 
+    /// Socket descriptor used by `WSAPoll()`.
+    #[repr(C)]
+    #[allow(clippy::upper_case_acronyms)]
+    pub struct WSAPOLLFD {
+        pub fd: SOCKET,
+        pub events: libc::c_short,
+        pub revents: libc::c_short,
+    }
+
     /// WSADATA structure for WSAStartup.
     #[repr(C)]
     #[allow(clippy::upper_case_acronyms)]
@@ -363,6 +406,7 @@ pub(crate) mod winsock {
         pub fn WSAGetLastError() -> c_int;
         pub fn closesocket(s: SOCKET) -> c_int;
         pub fn ioctlsocket(s: SOCKET, cmd: c_long, argp: *mut c_ulong) -> c_int;
+        pub fn WSAPoll(fdArray: *mut WSAPOLLFD, fds: c_ulong, timeout: c_int) -> c_int;
         pub fn shutdown(s: SOCKET, how: c_int) -> c_int;
         pub fn send(s: SOCKET, buf: *const c_char, len: c_int, flags: c_int) -> c_int;
         pub fn recv(s: SOCKET, buf: *mut c_char, len: c_int, flags: c_int) -> c_int;

--- a/src/libs/net-backend/src/socket.rs
+++ b/src/libs/net-backend/src/socket.rs
@@ -12,6 +12,7 @@ use crate::{
         i32_to_raw,
         is_interrupted,
         last_socket_error,
+        raw_poll,
         raw_set_nonblocking,
         raw_shutdown,
         raw_socketpair,
@@ -19,6 +20,16 @@ use crate::{
         sa_data_to_u8,
         socket_failed,
         SocklenT,
+        PLATFORM_POLLERR,
+        PLATFORM_POLLHUP,
+        PLATFORM_POLLIN,
+        PLATFORM_POLLNVAL,
+        PLATFORM_POLLOUT,
+        PLATFORM_POLLPRI,
+        PLATFORM_POLLRDBAND,
+        PLATFORM_POLLRDNORM,
+        PLATFORM_POLLWRBAND,
+        PLATFORM_POLLWRNORM,
         SOCKETPAIR_SUPPORTED,
     },
     types::{
@@ -40,9 +51,28 @@ use ::sys::error::{
     errno_to_error_code,
     ErrorCode,
 };
-use ::sysapi::sys_socket::{
-    sockaddr,
-    socklen_t,
+use ::sysapi::{
+    ffi::c_short,
+    poll::{
+        poll_errors::{
+            POLLERR,
+            POLLHUP,
+            POLLNVAL,
+        },
+        poll_flags::{
+            POLLIN,
+            POLLOUT,
+            POLLPRI,
+            POLLRDBAND,
+            POLLRDNORM,
+            POLLWRBAND,
+            POLLWRNORM,
+        },
+    },
+    sys_socket::{
+        sockaddr,
+        socklen_t,
+    },
 };
 use ::syscall::{
     netinet::in_::Protocol,
@@ -58,6 +88,78 @@ use ::syscall::{
 //==================================================================================================
 
 impl NetBackend {
+    /// Returns the events that can complete immediately on `sockfd`.
+    pub fn poll_socket(&self, sockfd: i32, events: c_short) -> Result<c_short, NetError> {
+        let mut platform_events: c_short = 0;
+        if events & POLLIN != 0 {
+            platform_events |= PLATFORM_POLLIN;
+        }
+        if events & POLLRDNORM != 0 {
+            platform_events |= PLATFORM_POLLRDNORM;
+        }
+        if events & POLLRDBAND != 0 {
+            platform_events |= PLATFORM_POLLRDBAND;
+        }
+        if events & POLLPRI != 0 {
+            platform_events |= PLATFORM_POLLPRI;
+        }
+        if events & POLLOUT != 0 {
+            platform_events |= PLATFORM_POLLOUT;
+        }
+        if events & POLLWRNORM != 0 {
+            platform_events |= PLATFORM_POLLWRNORM;
+        }
+        if let Some(platform_pollwrband) = PLATFORM_POLLWRBAND {
+            if events & POLLWRBAND != 0 {
+                platform_events |= platform_pollwrband;
+            }
+        }
+
+        let mut platform_revents: c_short = 0;
+        let result: libc::c_int = loop {
+            let result: libc::c_int =
+                unsafe { raw_poll(i32_to_raw(sockfd), platform_events, &mut platform_revents) };
+            if result < 0 && is_interrupted(last_socket_error()) {
+                continue;
+            }
+            break result;
+        };
+        if result < 0 {
+            let errno: i32 = last_socket_error();
+            return Err(NetError::Errno(errno_to_error_code(errno)));
+        }
+
+        let mut revents: c_short = 0;
+        if platform_revents & (PLATFORM_POLLIN | PLATFORM_POLLRDNORM) != 0 {
+            revents |= events & (POLLIN | POLLRDNORM);
+        }
+        if platform_revents & PLATFORM_POLLRDBAND != 0 {
+            revents |= events & POLLRDBAND;
+        }
+        if platform_revents & PLATFORM_POLLPRI != 0 {
+            revents |= events & POLLPRI;
+        }
+        if platform_revents & (PLATFORM_POLLOUT | PLATFORM_POLLWRNORM) != 0 {
+            revents |= events & (POLLOUT | POLLWRNORM);
+        }
+        if let Some(platform_pollwrband) = PLATFORM_POLLWRBAND {
+            if platform_revents & platform_pollwrband != 0 {
+                revents |= events & POLLWRBAND;
+            }
+        }
+        if platform_revents & PLATFORM_POLLERR != 0 {
+            revents |= POLLERR;
+        }
+        if platform_revents & PLATFORM_POLLHUP != 0 {
+            revents |= POLLHUP;
+            revents &= !(POLLOUT | POLLWRNORM);
+        }
+        if platform_revents & PLATFORM_POLLNVAL != 0 {
+            revents |= POLLNVAL;
+        }
+        Ok(revents)
+    }
+
     /// Creates a new socket.
     pub fn socket(
         &self,
@@ -340,6 +442,64 @@ impl NetBackend {
 mod test {
     use super::*;
     use crate::error::NetError;
+
+    /// Tests non-blocking socket readiness before and after data arrives.
+    #[cfg(unix)]
+    #[test]
+    fn poll_socket_tracks_read_and_write_readiness() {
+        let backend: NetBackend =
+            NetBackend::new().expect("platform initialization should succeed");
+        let (left, right): (i32, i32) = backend
+            .socketpair(AddressFamily::Unix, SocketType::Stream, Protocol::Ip)
+            .expect("socketpair should succeed");
+
+        assert_eq!(
+            backend
+                .poll_socket(left, POLLIN)
+                .expect("poll read interest"),
+            0,
+            "an empty stream socket should not be readable"
+        );
+        assert_eq!(
+            backend
+                .poll_socket(left, POLLOUT)
+                .expect("poll write interest"),
+            POLLOUT,
+            "a connected stream socket should be writable"
+        );
+
+        assert_eq!(backend.send(right, &[1], 1, 0).expect("send one byte"), 1);
+        assert_eq!(
+            backend
+                .poll_socket(left, POLLIN)
+                .expect("poll readable socket"),
+            POLLIN,
+            "queued data should make the socket readable"
+        );
+
+        backend.close(left).expect("close left socket");
+        backend.close(right).expect("close right socket");
+    }
+
+    /// Tests that a stream hangup suppresses write readiness as required by POSIX.
+    #[cfg(unix)]
+    #[test]
+    fn poll_socket_hangup_is_not_writable() {
+        let backend: NetBackend =
+            NetBackend::new().expect("platform initialization should succeed");
+        let (left, right): (i32, i32) = backend
+            .socketpair(AddressFamily::Unix, SocketType::Stream, Protocol::Ip)
+            .expect("socketpair should succeed");
+        backend.close(right).expect("close peer socket");
+
+        let revents: c_short = backend
+            .poll_socket(left, POLLIN | POLLOUT)
+            .expect("poll hung-up socket");
+        assert_ne!(revents & POLLHUP, 0, "peer closure should report hangup");
+        assert_eq!(revents & POLLOUT, 0, "hangup and write readiness are mutually exclusive");
+
+        backend.close(left).expect("close local socket");
+    }
 
     /// Tests that `connect()` rejects a socklen larger than `size_of::<sockaddr>()`.
     #[test]

--- a/src/libs/sys/src/sys/time/mod.rs
+++ b/src/libs/sys/src/sys/time/mod.rs
@@ -124,7 +124,7 @@ impl SystemTime {
     ///
     pub fn checked_sub(&self, earlier: &SystemTime) -> Result<Duration, Duration> {
         // Check if `self` happened after `earlier`.
-        if self.seconds >= earlier.seconds {
+        if self >= earlier {
             // Compute the difference in seconds using checked subtraction.
             let seconds: u64 = self.seconds - earlier.seconds;
 

--- a/src/libs/sys/src/sys/time/tests.rs
+++ b/src/libs/sys/src/sys/time/tests.rs
@@ -85,3 +85,11 @@ fn test_checked_sub_time_no_underflow() {
     assert_eq!(result.as_secs(), 5);
     assert_eq!(result.subsec_nanos(), 300_000_000);
 }
+
+#[test]
+fn test_checked_sub_time_same_second_returns_negative_duration() {
+    let earlier = SystemTime::new(10, 100_000_000).unwrap();
+    let later = SystemTime::new(10, 900_000_000).unwrap();
+    let result = earlier.checked_sub(&later);
+    assert_eq!(result, Err(Duration::from_millis(800)));
+}

--- a/src/libs/sysapi/headers/poll.toml
+++ b/src/libs/sysapi/headers/poll.toml
@@ -58,7 +58,15 @@ path = "poll::poll_flags::POLLRDNORM"
 emit = false
 
 [[rust_constants]]
+path = "poll::poll_flags::POLLRDBAND"
+emit = false
+
+[[rust_constants]]
 path = "poll::poll_flags::POLLWRNORM"
+emit = false
+
+[[rust_constants]]
+path = "poll::poll_flags::POLLWRBAND"
 emit = false
 
 [[raw_sections]]
@@ -71,7 +79,9 @@ text = '''
 #define POLLHUP 0x0010
 #define POLLNVAL 0x0020
 #define POLLRDNORM POLLIN
-#define POLLWRNORM POLLOUT'''
+#define POLLRDBAND 0x0080
+#define POLLWRNORM POLLOUT
+#define POLLWRBAND 0x0100'''
 
 [[sections]]
 title = "Functions"

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -159,46 +159,60 @@ fn is_coherent(entry_epoch: u64) -> bool {
 /// ([`resolve_via_vfsd`]).
 /// A cache hit on a coherent entry holds the lock only across a single map probe and never
 /// round-trips, so tight `read`/`write` loops stay local.
-pub(crate) fn resolve(fd: i32) -> Option<Resolution> {
+pub(crate) fn resolve_result(fd: i32) -> Result<Option<Resolution>, Error> {
+    Ok(resolve_for_poll(fd)?.map(|(resolution, _via_vfsd)| resolution))
+}
+
+/// Resolves a descriptor in unit tests, whose modeled authority cannot fail.
+#[cfg(test)]
+fn resolve(fd: i32) -> Option<Resolution> {
+    resolve_result(fd).expect("mock descriptor resolution should succeed")
+}
+
+/// Resolves a descriptor for `poll()`, preserving errors and direct-console fallback routing.
+pub(crate) fn resolve_for_poll(fd: i32) -> Result<Option<(Resolution, bool)>, Error> {
     {
         let cache: ::spin::MutexGuard<'_, BTreeMap<i32, CacheEntry>> = CACHE.lock();
         if let Some(entry) = cache.get(&fd) {
             if is_coherent(entry.epoch) {
-                return Some(Resolution {
-                    route: entry.route,
-                    backend_fd: entry.backend_fd,
-                });
+                return Ok(Some((
+                    Resolution {
+                        route: entry.route,
+                        backend_fd: entry.backend_fd,
+                    },
+                    true,
+                )));
             }
         }
     }
     // The cache missed or went stale; the authority decides, falling back to the console by number
     // only when no guest `vfsd` is available to answer.
-    match resolve_via_vfsd(fd) {
-        VfsdResolution::Hit(resolution) => Some(resolution),
-        VfsdResolution::BadFile => None,
-        VfsdResolution::Unavailable => derive_console(fd),
+    match resolve_via_vfsd(fd)? {
+        VfsdResolution::Hit(resolution) => Ok(Some((resolution, true))),
+        VfsdResolution::BadFile => Ok(None),
+        VfsdResolution::Unavailable => Ok(derive_console(fd).map(|resolution| (resolution, false))),
     }
 }
 
 /// Resolves `fd` for console I/O and reports whether vfsd owns the descriptor slot.
-pub(crate) fn resolve_console(fd: i32) -> ConsoleLookup {
+pub(crate) fn resolve_console(fd: i32) -> Result<ConsoleLookup, Error> {
     {
         let cache: ::spin::MutexGuard<'_, BTreeMap<i32, CacheEntry>> = CACHE.lock();
         if let Some(entry) = cache.get(&fd) {
             if is_coherent(entry.epoch) {
-                return if entry.route == Route::Console {
+                return Ok(if entry.route == Route::Console {
                     ConsoleLookup::Console {
                         backend_fd: entry.backend_fd,
                         via_vfsd: true,
                     }
                 } else {
                     ConsoleLookup::Other
-                };
+                });
             }
         }
     }
 
-    match resolve_via_vfsd(fd) {
+    Ok(match resolve_via_vfsd(fd)? {
         VfsdResolution::Hit(resolution) if resolution.route == Route::Console => {
             ConsoleLookup::Console {
                 backend_fd: resolution.backend_fd,
@@ -214,7 +228,7 @@ pub(crate) fn resolve_console(fd: i32) -> ConsoleLookup {
             },
             None => ConsoleLookup::BadFile,
         },
-    }
+    })
 }
 
 /// Resolves `fd` and returns the descriptor expected by `vfsd`.
@@ -224,7 +238,7 @@ pub(crate) fn resolve_console(fd: i32) -> ConsoleLookup {
 pub(crate) fn resolve_vfs(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
-    match resolve(fd) {
+    match resolve_result(fd)? {
         Some(resolution) if resolution.route == Route::Vfs => Ok(resolution.backend_fd),
         _ => {
             ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
@@ -242,7 +256,7 @@ pub(crate) fn resolve_vfs(fd: i32, syscall_name: &str) -> Result<i32, Error> {
 pub(crate) fn resolve_socket(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
-    match resolve(fd) {
+    match resolve_result(fd)? {
         Some(resolution) if resolution.route == Route::Socket => Ok(resolution.backend_fd),
         _ => {
             ::syslog::warn!("{syscall_name}(): not a socket fd={fd}");
@@ -264,7 +278,7 @@ pub(crate) fn resolve_socket(fd: i32, syscall_name: &str) -> Result<i32, Error> 
 pub(crate) fn resolve_table_op(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
-    match resolve(fd) {
+    match resolve_result(fd)? {
         Some(resolution) if matches!(resolution.route, Route::Vfs | Route::Console) => Ok(fd),
         _ => {
             ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
@@ -284,7 +298,7 @@ pub(crate) fn resolve_table_op(fd: i32, syscall_name: &str) -> Result<i32, Error
 pub(crate) fn resolve_tty(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
-    match resolve(fd) {
+    match resolve_result(fd)? {
         Some(resolution) if resolution.route == Route::Console => Ok(fd),
         Some(_) => {
             ::syslog::warn!("{syscall_name}(): fd is not a terminal fd={fd}");
@@ -323,7 +337,7 @@ pub(crate) fn record(fd: i32, route: Route, backend_fd: i32, epoch: u64) {
 /// so subsequent uses hit the cache. Returns `None` if `vfsd` reports no slot for `fd` (an invalid
 /// descriptor).
 #[cfg(not(test))]
-fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
+fn resolve_via_vfsd(fd: i32) -> Result<VfsdResolution, Error> {
     use crate::{
         unistd::message::{
             ResolveFdRequest,
@@ -339,37 +353,46 @@ fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
 
     let tid: ThreadIdentifier = match ::sys::kcall::pm::__kcall_gettid() {
         Ok(tid) => tid,
-        Err(_) => return VfsdResolution::Unavailable,
+        Err(_) => return Ok(VfsdResolution::Unavailable),
     };
     let pid: ::sys::pm::ProcessIdentifier = match ::sys::kcall::pm::getpid() {
         Ok(pid) => pid,
-        Err(_) => return VfsdResolution::Unavailable,
+        Err(_) => return Ok(VfsdResolution::Unavailable),
     };
     // A no-vfs image may assign the reserved vfsd pid to its workload. In that case a resolution
     // request would loop back to the caller instead of reaching a descriptor authority.
     if pid == crate::VFS_DESTINATION {
-        return VfsdResolution::Unavailable;
+        return Ok(VfsdResolution::Unavailable);
     }
 
     // Send the resolution query to vfsd and await its authoritative answer.
     let request: Message =
         ResolveFdRequest::build(tid, pid, fd, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
     if ::sys::kcall::ipc::__kcall_send(&request).is_err() {
-        return VfsdResolution::Unavailable;
+        return Ok(VfsdResolution::Unavailable);
     }
-    let response: Message = match ::sys::kcall::ipc::__kcall_recv() {
-        Ok(response) => response,
-        Err(_) => return VfsdResolution::Unavailable,
+    let mut interrupted: Option<Error> = None;
+    let response: Message = loop {
+        match ::sys::kcall::ipc::__kcall_recv() {
+            Ok(response) => break response,
+            Err(error) if error.code == ::sys::error::ErrorCode::Interrupted => {
+                interrupted.get_or_insert(error);
+            },
+            Err(_) => return Ok(VfsdResolution::Unavailable),
+        }
     };
+    if let Some(error) = interrupted {
+        return Err(error);
+    }
 
     // A non-zero status means vfsd holds no slot for this descriptor: it is unroutable.
     if response.status != 0 {
-        return VfsdResolution::BadFile;
+        return Ok(VfsdResolution::BadFile);
     }
 
     let message: SystemCallMessage = match SystemCallMessage::try_from_bytes(response.payload) {
         Ok(message) => message,
-        Err(_) => return VfsdResolution::BadFile,
+        Err(_) => return Ok(VfsdResolution::BadFile),
     };
     let resolved: ResolveFdResponse = match message.header {
         SystemCallMessageHeader::ResolveFdResponse => {
@@ -377,7 +400,7 @@ fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
         },
         _ => {
             ::syslog::warn!("resolve_via_vfsd(): unexpected response header (fd={fd})");
-            return VfsdResolution::BadFile;
+            return Ok(VfsdResolution::BadFile);
         },
     };
     // `ResolveFdResponse` is `#[repr(C, packed)]`, so read each field through a raw pointer to avoid
@@ -391,11 +414,11 @@ fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
         ResolveFdResponse::ROUTE_SOCKET => Route::Socket,
         other => {
             ::syslog::warn!("resolve_via_vfsd(): unknown route tag {other} (fd={fd})");
-            return VfsdResolution::BadFile;
+            return Ok(VfsdResolution::BadFile);
         },
     };
     record(fd, route, backend_fd, epoch);
-    VfsdResolution::Hit(Resolution { route, backend_fd })
+    Ok(VfsdResolution::Hit(Resolution { route, backend_fd }))
 }
 
 /// Test stand-in for the `vfsd` resolution query.
@@ -404,15 +427,21 @@ fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
 /// from [`MOCK_VFSD`], which a test populates to model `vfsd`'s table, and records it exactly as
 /// the production path would.
 #[cfg(test)]
-fn resolve_via_vfsd(fd: i32) -> VfsdResolution {
+fn resolve_via_vfsd(fd: i32) -> Result<VfsdResolution, Error> {
+    if MOCK_VFSD_INTERRUPTED.load(Ordering::Relaxed) {
+        return Err(Error::new(
+            ::sys::error::ErrorCode::Interrupted,
+            "mock descriptor resolution interrupted",
+        ));
+    }
     if MOCK_VFSD_UNAVAILABLE.load(Ordering::Relaxed) {
-        return VfsdResolution::Unavailable;
+        return Ok(VfsdResolution::Unavailable);
     }
     let Some((route, backend_fd, epoch)) = MOCK_VFSD.lock().get(&fd).copied() else {
-        return VfsdResolution::BadFile;
+        return Ok(VfsdResolution::BadFile);
     };
     record(fd, route, backend_fd, epoch);
-    VfsdResolution::Hit(Resolution { route, backend_fd })
+    Ok(VfsdResolution::Hit(Resolution { route, backend_fd }))
 }
 
 /// Test model of `vfsd`'s authoritative slot table, consulted by the test [`resolve_via_vfsd`].
@@ -422,6 +451,10 @@ static MOCK_VFSD: Mutex<BTreeMap<i32, (Route, i32, u64)>> = Mutex::new(BTreeMap:
 /// Test switch that models an unavailable guest `vfsd`.
 #[cfg(test)]
 static MOCK_VFSD_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// Test switch that makes the modeled `vfsd` lookup return `EINTR`.
+#[cfg(test)]
+static MOCK_VFSD_INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
 /// Drops any cached resolution for `fd`.
 ///
@@ -441,6 +474,7 @@ fn clear() {
     EXPECTED_EPOCH.store(0, Ordering::Relaxed);
     MOCK_VFSD.lock().clear();
     MOCK_VFSD_UNAVAILABLE.store(false, Ordering::Relaxed);
+    MOCK_VFSD_INTERRUPTED.store(false, Ordering::Relaxed);
 }
 
 //==================================================================================================
@@ -708,6 +742,25 @@ mod tests {
             Some(Route::Vfs),
             "a coherent entry must be served from the cache without a vfsd round-trip"
         );
+
+        clear();
+    }
+
+    /// Tests that an interrupted authoritative lookup is not converted into a descriptor error.
+    #[test]
+    fn interrupted_lookup_is_preserved() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        MOCK_VFSD_INTERRUPTED.store(true, Ordering::Relaxed);
+        let error: Error = resolve_result(4).expect_err("resolution should report interruption");
+        assert_eq!(error.code, ::sys::error::ErrorCode::Interrupted);
+
+        let error: Error = match resolve_console(STDIN_FILENO) {
+            Err(error) => error,
+            Ok(_) => panic!("console resolution should report interruption"),
+        };
+        assert_eq!(error.code, ::sys::error::ErrorCode::Interrupted);
 
         clear();
     }

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -333,6 +333,15 @@ pub enum SystemCallMessageHeader {
     ReceiveFromSocketResponse,
     FileCreationMaskRequest,
     FileCreationMaskResponse,
+    PollSocketRequest,
+    PollSocketResponse,
+    PollInputRequest,
+    ConsoleInputAvailable,
+    ConsoleInputSubscribe,
+    ConsoleReadCancelRequest,
+    ConsoleReadCancelResponse,
+    PollInputResponse,
+    ConsoleReadRetry,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -510,6 +519,15 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == ReceiveFromSocketResponse as u16 => Ok(ReceiveFromSocketResponse),
             x if x == FileCreationMaskRequest as u16 => Ok(FileCreationMaskRequest),
             x if x == FileCreationMaskResponse as u16 => Ok(FileCreationMaskResponse),
+            x if x == PollSocketRequest as u16 => Ok(PollSocketRequest),
+            x if x == PollSocketResponse as u16 => Ok(PollSocketResponse),
+            x if x == PollInputRequest as u16 => Ok(PollInputRequest),
+            x if x == ConsoleInputAvailable as u16 => Ok(ConsoleInputAvailable),
+            x if x == ConsoleInputSubscribe as u16 => Ok(ConsoleInputSubscribe),
+            x if x == ConsoleReadCancelRequest as u16 => Ok(ConsoleReadCancelRequest),
+            x if x == ConsoleReadCancelResponse as u16 => Ok(ConsoleReadCancelResponse),
+            x if x == PollInputResponse as u16 => Ok(PollInputResponse),
+            x if x == ConsoleReadRetry as u16 => Ok(ConsoleReadRetry),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/poll/bindings.rs
+++ b/src/libs/syscall/src/poll/bindings.rs
@@ -15,8 +15,10 @@ use crate::{
     },
 };
 use ::alloc::vec::Vec;
+use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
+    limits::OPEN_MAX,
     poll::{
         nfds_t,
         pollfd,
@@ -55,11 +57,21 @@ use ::syslog::trace_syscall;
 #[unsafe(no_mangle)]
 #[trace_syscall]
 pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) -> c_int {
+    if nfds as usize > OPEN_MAX {
+        unsafe {
+            *__errno_location() = ErrorCode::InvalidArgument.get();
+        }
+        return -1;
+    }
+
     let fds: &mut [pollfd] = if nfds == 0 {
         &mut []
     } else {
         core::slice::from_raw_parts_mut(fds, nfds as usize)
     };
+    for fd in fds.iter_mut() {
+        fd.revents = 0;
+    }
     let poll_fds: Vec<PollFd> = fds
         .iter()
         .map(|fd| {
@@ -71,13 +83,14 @@ pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) ->
 
     match syscall::poll(&poll_fds, timeout) {
         Ok(ready) => {
-            for (fd, revent) in &ready {
-                if let Some(i) = fds.iter().position(|poll_fd| poll_fd.fd == *fd) {
-                    fds[i].revents = revent.into();
+            let mut nready: c_int = 0;
+            for (fd, revent) in fds.iter_mut().zip(&ready) {
+                fd.revents = revent.into();
+                if fd.revents != 0 {
+                    nready += 1;
                 }
             }
-
-            ready.len() as c_int
+            nready
         },
         Err(error) => unsafe {
             ::syslog::warn!("poll(): failed (error={:?})", error);

--- a/src/libs/syscall/src/poll/input_message.rs
+++ b/src/libs/syscall/src/poll/input_message.rs
@@ -1,0 +1,245 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::mem;
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Request for an immediate host-console input snapshot.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PollInputRequest {
+    count: u32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PollInputRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PollInputRequest {
+    const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<u32>();
+
+    /// No raw input is currently available.
+    pub const STATUS_EMPTY: u8 = 0;
+    /// The host input stream has reached end-of-file.
+    pub const STATUS_EOF: u8 = 1;
+    /// Raw input bytes follow the status byte.
+    pub const STATUS_DATA: u8 = 2;
+
+    /// Creates a console input poll request.
+    pub fn new(count: u32) -> Self {
+        Self {
+            count,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a console input poll request.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the maximum number of raw input bytes requested.
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a console input poll request message.
+    pub fn build(tid: ThreadIdentifier, count: u32) -> Message {
+        let request: Self = Self::new(count);
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::PollInputRequest, request.into_bytes());
+        Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(ProcessIdentifier::KERNEL, ThreadIdentifier::NONE),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+
+    /// Builds a VFSD subscription request for console-input availability notifications.
+    pub fn build_subscription(tid: ThreadIdentifier) -> Message {
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConsoleInputSubscribe,
+            [0u8; SystemCallMessage::PAYLOAD_SIZE],
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::VFSD, tid),
+            MessageReceiver::new(ProcessIdentifier::KERNEL, ThreadIdentifier::NONE),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+
+    /// Builds a host-to-VFSD notification that console input or EOF is available.
+    pub fn build_available_notification() -> Message {
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConsoleInputAvailable,
+            [0u8; SystemCallMessage::PAYLOAD_SIZE],
+        );
+        Message::new(
+            MessageSender::KERNEL,
+            MessageReceiver::VFSD,
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+/// Response to an immediate host-console readiness snapshot.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PollInputResponse {
+    status: u8,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PollInputResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PollInputResponse {
+    const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<u8>();
+
+    /// Creates a console input poll response.
+    pub fn new(status: u8) -> Self {
+        Self {
+            status,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a console input poll response.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the input status.
+    pub fn status(&self) -> u8 {
+        self.status
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a console input poll response message.
+    pub fn build(tid: ThreadIdentifier, status: u8) -> Message {
+        let response: Self = Self::new(status);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PollInputResponse,
+            response.into_bytes(),
+        );
+        Message::new(
+            MessageSender::KERNEL,
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+/// Builds VFSD's private console-read retry event.
+pub struct ConsoleReadRetry;
+
+impl ConsoleReadRetry {
+    /// Builds a retry event addressed to VFSD's process mailbox.
+    pub fn build(tid: ThreadIdentifier) -> Message {
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConsoleReadRetry,
+            [0u8; SystemCallMessage::PAYLOAD_SIZE],
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::VFSD, tid),
+            MessageReceiver::VFSD,
+            MessageType::Ipc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+/// Builds console-read cancellation protocol messages.
+pub struct ConsoleReadCancel;
+
+impl ConsoleReadCancel {
+    /// Builds a request that cancels the caller thread's parked console read.
+    pub fn build_request(tid: ThreadIdentifier) -> Message {
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConsoleReadCancelRequest,
+            [0u8; SystemCallMessage::PAYLOAD_SIZE],
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::VFS_DESTINATION, ThreadIdentifier::NONE),
+            crate::VFS_MESSAGE_TYPE,
+            None,
+            message.into_bytes(),
+        )
+    }
+
+    /// Builds an acknowledgement for a console-read cancellation request.
+    pub fn build_response(tid: ThreadIdentifier) -> Message {
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::ConsoleReadCancelResponse,
+            [0u8; SystemCallMessage::PAYLOAD_SIZE],
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ipc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests request field preservation through serialization.
+    #[test]
+    fn request_round_trip() {
+        let request: PollInputRequest = PollInputRequest::new(256);
+        let decoded: PollInputRequest = PollInputRequest::from_bytes(request.into_bytes());
+        assert_eq!(decoded.count(), 256);
+    }
+
+    /// Tests response field preservation through serialization.
+    #[test]
+    fn response_round_trip() {
+        let response: PollInputResponse = PollInputResponse::new(PollInputRequest::STATUS_DATA);
+        let decoded: PollInputResponse = PollInputResponse::from_bytes(response.into_bytes());
+        assert_eq!(decoded.status(), PollInputRequest::STATUS_DATA);
+    }
+}

--- a/src/libs/syscall/src/poll/message.rs
+++ b/src/libs/syscall/src/poll/message.rs
@@ -191,11 +191,11 @@ impl MessageDeserializer for PollRequest {
                 .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid timeout"))?,
         );
 
-        // Check if the buffer is too short to hold all fds and events.
+        // Check if the buffer has exactly enough bytes to hold all fds and events.
         let fds_size: usize = nfds as usize * mem::size_of::<i32>();
         let events_size: usize = nfds as usize * mem::size_of::<i16>();
-        if bytes.len() < Self::OFFSET_OF_FDS + fds_size + events_size {
-            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        if bytes.len() != Self::OFFSET_OF_FDS + fds_size + events_size {
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid message size"));
         }
 
         // Deserialize `fds` array.
@@ -258,23 +258,20 @@ impl MessagePartitioner for PollRequest {
 
 #[derive(Debug)]
 pub struct PollResponse {
-    /// Number of file descriptors with ready events.
-    pub nready: u8,
-    /// File descriptors that are ready.
-    pub fds: Vec<i32>,
-    /// Events that occurred on each ready file descriptor.
+    /// Number of entries in `revents`.
+    pub nfds: u8,
+    /// Events that occurred on each requested file descriptor, in request order.
     pub revents: Vec<i16>,
 }
 
 impl PollResponse {
-    /// Offset of `nready`.
-    pub const OFFSET_OF_NREADY: usize = 0;
-    /// Offset of first array (fds) after nready.
-    pub const OFFSET_OF_FDS: usize = Self::OFFSET_OF_NREADY + mem::size_of::<u8>();
+    /// Offset of `nfds`.
+    pub const OFFSET_OF_NFDS: usize = 0;
+    /// Offset of the `revents` array.
+    pub const OFFSET_OF_REVENTS: usize = Self::OFFSET_OF_NFDS + mem::size_of::<u8>();
 
     /// Maximum size of the message.
-    pub const MAX_SIZE: usize = Self::OFFSET_OF_FDS
-        + OPEN_MAX * (core::mem::size_of::<i32>() + core::mem::size_of::<i16>());
+    pub const MAX_SIZE: usize = Self::OFFSET_OF_REVENTS + OPEN_MAX * mem::size_of::<i16>();
 
     ///
     /// # Description
@@ -283,23 +280,14 @@ impl PollResponse {
     ///
     /// # Parameters
     ///
-    /// - `fds`: File descriptors that are ready.
-    /// - `revents`: Events that occurred on each ready file descriptor.
+    /// - `revents`: Events that occurred on each requested file descriptor, in request order.
     ///
     /// # Return Value
     ///
     /// On success, this function returns the newly created response message for the `poll()` system
     /// call. Otherwise, it returns an error object that describes the failure.
     ///
-    pub fn new(fds: &[i32], revents: &[i16]) -> Result<Self, Error> {
-        // Check if array of file descriptors is too large.
-        if fds.len() > OPEN_MAX {
-            return Err(Error::new(
-                ErrorCode::InvalidArgument,
-                "number of file descriptors exceeds maximum supported",
-            ));
-        }
-
+    pub fn new(revents: &[i16]) -> Result<Self, Error> {
         // Check if array of events is too large.
         if revents.len() > OPEN_MAX {
             return Err(Error::new(
@@ -308,28 +296,19 @@ impl PollResponse {
             ));
         }
 
-        // Check if the number of events does not match the number of file descriptors.
-        if fds.len() != revents.len() {
-            return Err(Error::new(
-                ErrorCode::InvalidArgument,
-                "fds and revents must have the same length",
-            ));
-        }
-
-        // Attempt to convert `fds.len()` as a `u8`.
-        let nready: u8 = match fds.len().try_into() {
-            Ok(nready) => nready,
+        // Attempt to convert `revents.len()` as a `u8`.
+        let nfds: u8 = match revents.len().try_into() {
+            Ok(nfds) => nfds,
             Err(_error) => {
                 return Err(Error::new(
                     ErrorCode::ValueOutOfRange,
-                    "cannot encode number of ready file descriptors",
+                    "cannot encode number of file descriptors",
                 ));
             },
         };
 
         Ok(Self {
-            nready,
-            fds: fds.to_vec(),
+            nfds,
             revents: revents.to_vec(),
         })
     }
@@ -339,10 +318,7 @@ impl MessageSerializer for PollResponse {
     /// Serializes a response message for the `poll()` system call.
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
-        buffer.push(self.nready);
-        for fd in &self.fds {
-            buffer.extend_from_slice(&fd.to_le_bytes());
-        }
+        buffer.push(self.nfds);
         for ev in &self.revents {
             buffer.extend_from_slice(&ev.to_le_bytes());
         }
@@ -354,8 +330,7 @@ impl MessageDeserializer for PollResponse {
     /// Deserializes a response message for the `poll()` system call.
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         // Check if the buffer is too short.
-        if bytes.len() < Self::OFFSET_OF_FDS {
-            // need at least nready
+        if bytes.len() < Self::OFFSET_OF_REVENTS {
             return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
         }
 
@@ -364,37 +339,20 @@ impl MessageDeserializer for PollResponse {
             return Err(Error::new(ErrorCode::InvalidMessage, "message is too long"));
         }
 
-        // Deserialize `nready` field.
-        let nready: u8 = bytes[Self::OFFSET_OF_NREADY];
-        if nready as usize > OPEN_MAX {
-            return Err(Error::new(ErrorCode::InvalidMessage, "invalid nready"));
+        // Deserialize `nfds` field.
+        let nfds: u8 = bytes[Self::OFFSET_OF_NFDS];
+        if nfds as usize > OPEN_MAX {
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid nfds"));
         }
 
-        // Check if the buffer is too short to hold all fds and events.
-        let fds_size: usize = nready as usize * mem::size_of::<i32>();
-        let events_size: usize = nready as usize * mem::size_of::<i16>();
-        if bytes.len() < Self::OFFSET_OF_FDS + fds_size + events_size {
-            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        let expected_size: usize = Self::OFFSET_OF_REVENTS + nfds as usize * mem::size_of::<i16>();
+        if bytes.len() != expected_size {
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid message size"));
         }
 
-        // Deserialize `fds` array.
-        let mut fds: Vec<i32> = Vec::with_capacity(nready as usize);
-        let mut revents: Vec<i16> = Vec::with_capacity(nready as usize);
-        let fds_offset: usize = Self::OFFSET_OF_FDS;
-        for i in 0..nready as usize {
-            let base: usize = fds_offset + i * mem::size_of::<i32>();
-            let fd: i32 = i32::from_le_bytes(
-                bytes[base..base + mem::size_of::<i32>()]
-                    .try_into()
-                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid fd"))?,
-            );
-            fds.push(fd);
-        }
-
-        // Deserialize `revents` array.
-        let events_offset: usize = fds_offset + fds_size;
-        for i in 0..nready as usize {
-            let base: usize = events_offset + i * mem::size_of::<i16>();
+        let mut revents: Vec<i16> = Vec::with_capacity(nfds as usize);
+        for i in 0..nfds as usize {
+            let base: usize = Self::OFFSET_OF_REVENTS + i * mem::size_of::<i16>();
             let ev: i16 = i16::from_le_bytes(
                 bytes[base..base + mem::size_of::<i16>()]
                     .try_into()
@@ -403,7 +361,7 @@ impl MessageDeserializer for PollResponse {
             revents.push(ev);
         }
 
-        PollResponse::new(&fds, &revents)
+        PollResponse::new(&revents)
     }
 }
 

--- a/src/libs/syscall/src/poll/mod.rs
+++ b/src/libs/syscall/src/poll/mod.rs
@@ -5,7 +5,9 @@
 // Modules
 //==================================================================================================
 
+pub mod input_message;
 pub mod message;
+pub mod socket_message;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {

--- a/src/libs/syscall/src/poll/socket_message.rs
+++ b/src/libs/syscall/src/poll/socket_message.rs
@@ -1,0 +1,165 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::core::mem;
+use ::sys::{
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+use ::sysapi::ffi::c_short;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Request for a non-blocking socket readiness snapshot.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PollSocketRequest {
+    sockfd: i32,
+    events: c_short,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PollSocketRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PollSocketRequest {
+    const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<c_short>();
+
+    /// Creates a socket poll request.
+    pub fn new(sockfd: i32, events: c_short) -> Self {
+        Self {
+            sockfd,
+            events,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a socket poll request.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the networkd socket descriptor.
+    pub fn sockfd(&self) -> i32 {
+        self.sockfd
+    }
+
+    /// Returns the requested events.
+    pub fn events(&self) -> c_short {
+        self.events
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a socket poll request message.
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, events: c_short) -> Message {
+        let request: Self = Self::new(sockfd, events);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PollSocketRequest,
+            request.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::NETWORK_DESTINATION, ThreadIdentifier::NONE),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+/// Response to a non-blocking socket readiness snapshot.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PollSocketResponse {
+    revents: c_short,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PollSocketResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PollSocketResponse {
+    const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<c_short>();
+
+    /// Creates a socket poll response.
+    pub fn new(revents: c_short) -> Self {
+        Self {
+            revents,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a socket poll response.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the reported events.
+    pub fn revents(&self) -> c_short {
+        self.revents
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a socket poll response message.
+    pub fn build(tid: ThreadIdentifier, revents: c_short) -> Message {
+        let response: Self = Self::new(revents);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PollSocketResponse,
+            response.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(crate::NETWORK_SOURCE, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests request field preservation through serialization.
+    #[test]
+    fn request_round_trip() {
+        let request: PollSocketRequest = PollSocketRequest::new(7, 0x123);
+        let decoded: PollSocketRequest = PollSocketRequest::from_bytes(request.into_bytes());
+        assert_eq!(decoded.sockfd(), 7);
+        assert_eq!(decoded.events(), 0x123);
+    }
+
+    /// Tests response field preservation through serialization.
+    #[test]
+    fn response_round_trip() {
+        let response: PollSocketResponse = PollSocketResponse::new(0x45);
+        let decoded: PollSocketResponse = PollSocketResponse::from_bytes(response.into_bytes());
+        assert_eq!(decoded.revents(), 0x45);
+    }
+}

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -5,16 +5,78 @@
 // Imports
 //==================================================================================================
 
-use crate::safe::RawFileDescriptor;
+use crate::{
+    fdtable::{
+        resolve_for_poll,
+        Route,
+    },
+    message::{
+        MessagePartitioner,
+        SystemCallLongMessage,
+        SystemCallMessagePart,
+    },
+    poll::{
+        input_message::{
+            PollInputRequest,
+            PollInputResponse,
+        },
+        message::{
+            PollRequest,
+            PollResponse,
+        },
+        socket_message::{
+            PollSocketRequest,
+            PollSocketResponse,
+        },
+    },
+    safe::RawFileDescriptor,
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
 use ::alloc::vec::Vec;
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use ::core::{
+    cmp,
+    time::Duration,
 };
-use ::sysapi::ffi::{
-    c_int,
-    c_short,
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::Message,
+    pm::ThreadIdentifier,
+    time::SystemTime,
 };
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_short,
+    },
+    poll::{
+        poll_errors::POLLNVAL,
+        poll_flags::{
+            POLLIN,
+            POLLOUT,
+            POLLRDNORM,
+            POLLWRNORM,
+        },
+    },
+    unistd::{
+        STDERR_FILENO,
+        STDIN_FILENO,
+        STDOUT_FILENO,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Initial delay between readiness probes.
+const INITIAL_PROBE_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Maximum delay between readiness probes.
+const MAX_PROBE_INTERVAL: Duration = Duration::from_millis(32);
 
 //==================================================================================================
 // Structures
@@ -44,6 +106,13 @@ impl From<&c_short> for PollEvents {
 impl From<&PollEvents> for c_short {
     fn from(value: &PollEvents) -> Self {
         value.0
+    }
+}
+
+impl PollEvents {
+    /// Returns whether no events were reported.
+    fn is_empty(&self) -> bool {
+        self.0 == 0
     }
 }
 
@@ -107,19 +176,304 @@ impl PollFd {
 /// returned, the timeout expired without any file descriptor becoming ready. On failure, this
 /// function returns an error.
 ///
-/// # Safety
-///
-/// This function is unsafe because it may dereference raw pointers.
-///
-/// It is safe to call this function if the following conditions are met:
-/// - `fds` points to a valid array of pollfd structures of length `nfds`.
-///
-pub fn poll(
-    fds: &[PollFd],
-    timeout: PollTimeout,
-) -> Result<Vec<(RawFileDescriptor, PollEvents)>, Error> {
+pub fn poll(fds: &[PollFd], timeout: PollTimeout) -> Result<Vec<PollEvents>, Error> {
     ::syslog::trace!("poll(): fds={fds:?}, timeout={timeout:?}");
-    let reason: &str = "poll() is not available";
-    ::syslog::warn!("poll(): {reason} (fds={fds:?}, timeout={timeout:?})");
-    Err(Error::new(ErrorCode::OperationNotSupported, reason))
+
+    let timeout: c_int = timeout.into();
+
+    if fds.is_empty() || fds.iter().all(|fd| fd.fd() < 0) {
+        if timeout < 0 {
+            const MAX_SLEEP: Duration = Duration::from_secs(u32::MAX as u64);
+            loop {
+                ::sys::kcall::pm::__kcall_sleep(MAX_SLEEP)?;
+            }
+        }
+        if timeout > 0 {
+            ::sys::kcall::pm::__kcall_sleep(Duration::from_millis(timeout as u64))?;
+        }
+        return Ok(fds.iter().map(|_| PollEvents(0)).collect());
+    }
+
+    let deadline: Option<SystemTime> = if timeout > 0 {
+        let mut now: SystemTime = SystemTime::default();
+        ::sys::kcall::pm::__kcall_gettime(&mut now)?;
+        Some(
+            now.checked_add_duration(&Duration::from_millis(timeout as u64))
+                .ok_or_else(|| Error::new(ErrorCode::ValueOutOfRange, "poll timeout overflow"))?,
+        )
+    } else {
+        None
+    };
+
+    let mut probe_interval: Duration = INITIAL_PROBE_INTERVAL;
+    loop {
+        let ready: Vec<PollEvents> = poll_once(fds)?;
+        if ready.iter().any(|events| !events.is_empty()) || timeout == 0 {
+            return Ok(ready);
+        }
+
+        let sleep: Duration = match deadline {
+            Some(deadline) => {
+                let mut now: SystemTime = SystemTime::default();
+                ::sys::kcall::pm::__kcall_gettime(&mut now)?;
+                let remaining: Duration = match deadline.checked_sub(&now) {
+                    Ok(remaining) if !remaining.is_zero() => remaining,
+                    _ => return Ok(ready),
+                };
+                cmp::min(probe_interval, remaining)
+            },
+            None => probe_interval,
+        };
+        ::sys::kcall::pm::__kcall_sleep(sleep)?;
+        probe_interval = next_probe_interval(probe_interval);
+    }
+}
+
+/// Returns the next delay in the readiness-probe backoff sequence.
+fn next_probe_interval(current: Duration) -> Duration {
+    match current.checked_add(current) {
+        Some(next) => cmp::min(next, MAX_PROBE_INTERVAL),
+        None => MAX_PROBE_INTERVAL,
+    }
+}
+
+/// Queries each descriptor's resolved backend once without waiting for readiness.
+///
+/// The routing vectors retain one slot per input entry. Non-VFSD entries are represented by
+/// negative placeholders in the VFSD request, then invalid, socket, and direct-console results
+/// replace their corresponding slots. The returned vector therefore preserves input order and
+/// keeps duplicate descriptors distinct. Backend probes run sequentially, so the result is not an
+/// atomic readiness snapshot across all descriptors.
+fn poll_once(fds: &[PollFd]) -> Result<Vec<PollEvents>, Error> {
+    let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
+    let mut poll_fds: Vec<RawFileDescriptor> = Vec::with_capacity(fds.len());
+    let mut sockets: Vec<Option<RawFileDescriptor>> = Vec::with_capacity(fds.len());
+    let mut direct_consoles: Vec<Option<RawFileDescriptor>> = Vec::with_capacity(fds.len());
+    let mut invalid: Vec<bool> = Vec::with_capacity(fds.len());
+    for fd in fds {
+        if fd.fd() < 0 {
+            poll_fds.push(fd.fd());
+            sockets.push(None);
+            direct_consoles.push(None);
+            invalid.push(false);
+            continue;
+        }
+
+        match resolve_for_poll(fd.fd())? {
+            Some((resolution, _)) if resolution.route == Route::Socket => {
+                poll_fds.push(-1);
+                sockets.push(Some(resolution.backend_fd));
+                direct_consoles.push(None);
+                invalid.push(false);
+            },
+            Some((resolution, false)) if resolution.route == Route::Console => {
+                poll_fds.push(-1);
+                sockets.push(None);
+                direct_consoles.push(Some(resolution.backend_fd));
+                invalid.push(false);
+            },
+            Some(_) => {
+                poll_fds.push(fd.fd());
+                sockets.push(None);
+                direct_consoles.push(None);
+                invalid.push(false);
+            },
+            None => {
+                poll_fds.push(-1);
+                sockets.push(None);
+                direct_consoles.push(None);
+                invalid.push(true);
+            },
+        }
+    }
+    let events: Vec<c_short> = fds.iter().map(|fd| fd.events.0).collect();
+    let mut ready: Vec<PollEvents> = if poll_fds.iter().any(|fd| *fd >= 0) {
+        poll_vfs_once(tid, fds, &poll_fds, &events)?
+    } else {
+        fds.iter().map(|_| PollEvents(0)).collect()
+    };
+    for (index, is_invalid) in invalid.iter().enumerate() {
+        if *is_invalid {
+            ready[index] = PollEvents(POLLNVAL);
+        }
+    }
+    for (index, socket) in sockets.iter().enumerate() {
+        if let Some(sockfd) = socket {
+            ready[index] = poll_socket_once(tid, *sockfd, events[index])?;
+        }
+    }
+    for (index, console) in direct_consoles.iter().enumerate() {
+        if let Some(stream) = console {
+            ready[index] = poll_direct_console_once(tid, *stream, events[index])?;
+        }
+    }
+    Ok(ready)
+}
+
+/// Queries VFSD once for its subset of poll entries.
+fn poll_vfs_once(
+    tid: ThreadIdentifier,
+    fds: &[PollFd],
+    poll_fds: &[RawFileDescriptor],
+    events: &[c_short],
+) -> Result<Vec<PollEvents>, Error> {
+    let request: PollRequest = PollRequest::new(poll_fds, events, 0)?;
+    let requests: Vec<Message> =
+        request.into_parts(tid, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE)?;
+    for request in &requests {
+        ::sys::kcall::ipc::__kcall_send(request)?;
+    }
+
+    let capacity: usize = PollResponse::MAX_SIZE.div_ceil(SystemCallMessagePart::PAYLOAD_SIZE);
+    let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
+    let mut interrupted: Option<Error> = None;
+
+    loop {
+        let response: Message = receive_pending_response(&mut interrupted)?;
+        if response.status != 0 {
+            if let Some(error) = interrupted {
+                return Err(error);
+            }
+            let error_code: ErrorCode = ErrorCode::try_from(response.status).map_err(|error| {
+                ::syslog::warn!(
+                    "poll(): failed to parse error code (fds={fds:?}, error={error:?})"
+                );
+                Error::new(ErrorCode::InvalidMessage, "poll() returned an invalid error code")
+            })?;
+            return Err(Error::new(error_code, "poll() failed"));
+        }
+
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+        match message.header {
+            SystemCallMessageHeader::PollResponsePart => {},
+            _ => {
+                return Err(Error::new(
+                    ErrorCode::InvalidMessage,
+                    "poll() received an unexpected response",
+                ));
+            },
+        }
+
+        let part: SystemCallMessagePart = SystemCallMessagePart::from_bytes(message.payload);
+        assembler.add_part(part)?;
+        if !assembler.is_complete() {
+            continue;
+        }
+
+        if let Some(error) = interrupted {
+            return Err(error);
+        }
+
+        let response: PollResponse = PollResponse::from_parts(&assembler.take_parts())?;
+        if response.revents.len() != fds.len() {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "poll() response length does not match request",
+            ));
+        }
+        return Ok(response.revents.into_iter().map(PollEvents).collect());
+    }
+}
+
+/// Queries a direct-ELF console stream without consuming host input.
+fn poll_direct_console_once(
+    tid: ThreadIdentifier,
+    stream: RawFileDescriptor,
+    events: c_short,
+) -> Result<PollEvents, Error> {
+    const READ_EVENTS: c_short = POLLIN | POLLRDNORM;
+    const WRITE_EVENTS: c_short = POLLOUT | POLLWRNORM;
+
+    if matches!(stream, STDOUT_FILENO | STDERR_FILENO) {
+        return Ok(PollEvents(events & WRITE_EVENTS));
+    }
+    if stream != STDIN_FILENO || events & READ_EVENTS == 0 {
+        return Ok(PollEvents(0));
+    }
+
+    let request: Message = PollInputRequest::build(tid, 0);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+    let mut interrupted: Option<Error> = None;
+    let response: Message = receive_pending_response(&mut interrupted)?;
+    if let Some(error) = interrupted {
+        return Err(error);
+    }
+
+    let source: ::sys::ipc::MessageSender = response.source;
+    if source != ::sys::ipc::MessageSender::KERNEL {
+        return Err(Error::new(
+            ErrorCode::InvalidMessage,
+            "direct console poll returned an invalid sender",
+        ));
+    }
+    if response.status != 0 {
+        return Err(Error::new(
+            ErrorCode::try_from(response.status)?,
+            "direct console poll failed",
+        ));
+    }
+
+    let response: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+    let header: SystemCallMessageHeader = response.header;
+    if header != SystemCallMessageHeader::PollInputResponse {
+        return Err(Error::new(
+            ErrorCode::InvalidMessage,
+            "direct console poll returned an unexpected response",
+        ));
+    }
+    let response: PollInputResponse = PollInputResponse::from_bytes(response.payload);
+    match response.status() {
+        PollInputRequest::STATUS_DATA | PollInputRequest::STATUS_EOF => {
+            Ok(PollEvents(events & READ_EVENTS))
+        },
+        PollInputRequest::STATUS_EMPTY => Ok(PollEvents(0)),
+        _ => Err(Error::new(
+            ErrorCode::InvalidMessage,
+            "direct console poll returned an invalid status",
+        )),
+    }
+}
+
+/// Queries networkd once for a socket readiness snapshot.
+fn poll_socket_once(
+    tid: ThreadIdentifier,
+    sockfd: RawFileDescriptor,
+    events: c_short,
+) -> Result<PollEvents, Error> {
+    let request: Message = PollSocketRequest::build(tid, sockfd, events);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    let mut interrupted: Option<Error> = None;
+    let response: Message = receive_pending_response(&mut interrupted)?;
+    if let Some(error) = interrupted {
+        return Err(error);
+    }
+    if response.status != 0 {
+        let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
+        return Err(Error::new(error_code, "socket poll failed"));
+    }
+
+    let response: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+    let header: SystemCallMessageHeader = response.header;
+    if header != SystemCallMessageHeader::PollSocketResponse {
+        return Err(Error::new(
+            ErrorCode::InvalidMessage,
+            "socket poll returned an unexpected response",
+        ));
+    }
+    let response: PollSocketResponse = PollSocketResponse::from_bytes(response.payload);
+    Ok(PollEvents(response.revents()))
+}
+
+/// Receives a response while remembering signal interruption and keeping the mailbox synchronized.
+fn receive_pending_response(interrupted: &mut Option<Error>) -> Result<Message, Error> {
+    loop {
+        match ::sys::kcall::ipc::__kcall_recv() {
+            Ok(response) => return Ok(response),
+            Err(error) if error.code == ErrorCode::Interrupted => {
+                interrupted.get_or_insert(error);
+            },
+            Err(error) => return Err(error),
+        }
+    }
 }

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -45,10 +45,10 @@ pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
     // Only VFS-backed descriptors are routable here.
     let backend_fd: RawFileDescriptor = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             _ => {
                 ::syslog::warn!("fchmod(): bad file descriptor fd={fd}");

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -43,10 +43,10 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
     // character device with a stable, dup-shared identity synthesized by vfsd.
     let backend_fd: i32 = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             // A vfsd-served object or a console descriptor: vfsd answers `fstat` from the slot
             // it owns, addressed by the caller-facing flat descriptor. For a console this is the
             // slot number, not the stream number used to route I/O — the slot is the operand,

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -38,9 +38,9 @@ pub fn close(fd: i32) -> Result<(), Error> {
             close_target,
             CloseTarget,
         },
-        fdtable::resolve,
+        fdtable::resolve_result,
     };
-    let result: Result<(), Error> = match resolve(fd) {
+    let result: Result<(), Error> = match resolve_result(fd)? {
         Some(res) => {
             let target: CloseTarget = close_target(fd, res);
             close_ipc(

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -49,10 +49,10 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
     // Only VFS-backed descriptors are routable here.
     let backend_fd: RawFileDescriptor = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             _ => {
                 ::syslog::warn!("fchown(): bad file descriptor fd={fd}");

--- a/src/libs/syscall/src/unistd/syscall/isatty.rs
+++ b/src/libs/syscall/src/unistd/syscall/isatty.rs
@@ -37,10 +37,10 @@ pub fn isatty(fd: RawFileDescriptor) -> Result<bool, Error> {
     // answers correctly rather than being judged by its number. An unresolvable descriptor is
     // rejected with `EBADF`.
     use crate::fdtable::{
-        resolve,
+        resolve_result,
         Route,
     };
-    match resolve(fd) {
+    match resolve_result(fd)? {
         Some(resolution) if resolution.route == Route::Console => Ok(true),
         Some(_) => {
             ::syslog::trace!("isatty(): file descriptor is not a terminal (fd={})", fd);

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -37,10 +37,10 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
     // POSIX requires lseek on a pipe/FIFO/socket/stdio fd to return ESPIPE.
     let backend_fd: RawFileDescriptor = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             // VFS-backed descriptors fall through to the vfsd seek path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // Seeking the console (stdin/stdout/stderr) is an illegal seek.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -54,10 +54,10 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
     // POSIX requires pread on a non-seekable fd (pipe/stdio) to return ESPIPE.
     let backend_fd: RawFileDescriptor = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             // VFS-backed descriptors fall through to the vfsd read path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // The console (stdin/stdout/stderr) is not seekable.

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -54,10 +54,10 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
     // POSIX requires pwrite on a non-seekable fd (pipe/stdio) to return ESPIPE.
     let backend_fd: RawFileDescriptor = {
         use crate::fdtable::{
-            resolve,
+            resolve_result,
             Route,
         };
-        match resolve(fd) {
+        match resolve_result(fd)? {
             // VFS-backed descriptors fall through to the vfsd write path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // The console (stdin/stdout/stderr) is not seekable.

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -7,6 +7,7 @@
 
 use super::util::page_chunk_size;
 use crate::{
+    poll::input_message::ConsoleReadCancel,
     safe::RawFileDescriptor,
     unistd::message::{
         ReadRequest,
@@ -38,6 +39,16 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
+/// Backend routing and interruption policy for one read operation.
+#[derive(Clone, Copy)]
+struct ReadBackend {
+    destination: ProcessIdentifier,
+    message_type: MessageType,
+    pull_pid: ProcessIdentifier,
+    pull_tid: ThreadIdentifier,
+    cancel_console_on_interrupt: bool,
+}
+
 ///
 /// # Description
 ///
@@ -59,24 +70,49 @@ fn read_chunk(
     tid: ThreadIdentifier,
     fd: RawFileDescriptor,
     chunk: &mut [u8],
-    destination: ProcessIdentifier,
-    message_type: MessageType,
-    pull_pid: ProcessIdentifier,
-    pull_tid: ThreadIdentifier,
+    backend: ReadBackend,
 ) -> Result<c_size_t, Error> {
     // Send metadata-only ReadRequest via IPC message.
-    let request: Message =
-        ReadRequest::build(tid, fd, chunk.len() as c_size_t, destination, message_type);
+    let request: Message = ReadRequest::build(
+        tid,
+        fd,
+        chunk.len() as c_size_t,
+        backend.destination,
+        backend.message_type,
+    );
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Pull data via data chunk transfer.
-    let bytes_pulled: usize = ::sys::kcall::ipc::__kcall_pull(pull_pid, pull_tid, chunk)?;
+    let bytes_pulled: usize =
+        match ::sys::kcall::ipc::__kcall_pull(backend.pull_pid, backend.pull_tid, chunk) {
+            Ok(bytes_pulled) => bytes_pulled,
+            Err(error)
+                if error.code == ErrorCode::Interrupted && backend.cancel_console_on_interrupt =>
+            {
+                cancel_console_read(tid)?;
+                return Err(error);
+            },
+            Err(error) => return Err(error),
+        };
 
-    // Receive response metadata (count, status). The bulk data is already in the buffer.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    // Receive response metadata (count, status). Once the bulk transfer completed, always drain the
+    // matching response so a caught signal cannot leave stale metadata in this thread's mailbox.
+    let mut interrupted: Option<Error> = None;
+    let response: Message = loop {
+        match ::sys::kcall::ipc::__kcall_recv() {
+            Ok(response) => break response,
+            Err(error) if error.code == ErrorCode::Interrupted => {
+                interrupted.get_or_insert(error);
+            },
+            Err(error) => return Err(error),
+        }
+    };
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
+        if let Some(error) = interrupted {
+            return Err(error);
+        }
         ::syslog::warn!(
             "read_chunk(): failed (fd={:?}, chunk.len={:?}, error_code={:?})",
             fd,
@@ -132,6 +168,12 @@ fn read_chunk(
                 ));
             }
 
+            if count == 0 {
+                if let Some(error) = interrupted {
+                    return Err(error);
+                }
+            }
+
             Ok(count as c_size_t)
         },
         header => {
@@ -143,6 +185,42 @@ fn read_chunk(
             );
             Err(Error::new(ErrorCode::InvalidMessage, "read() failed"))
         },
+    }
+}
+
+/// Cancels this thread's parked VFSD console read and drains the acknowledgement.
+fn cancel_console_read(tid: ThreadIdentifier) -> Result<(), Error> {
+    let request: Message = ConsoleReadCancel::build_request(tid);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    loop {
+        let response: Message = match ::sys::kcall::ipc::__kcall_recv() {
+            Ok(response) => response,
+            Err(error) if error.code == ErrorCode::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        let source: ::sys::ipc::MessageSender = response.source;
+        if source.pid != ProcessIdentifier::VFSD {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "console read cancellation returned an invalid sender",
+            ));
+        }
+        if response.status != 0 {
+            return Err(Error::new(
+                ErrorCode::try_from(response.status)?,
+                "console read cancellation failed",
+            ));
+        }
+        let response: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+        let header: SystemCallMessageHeader = response.header;
+        if header != SystemCallMessageHeader::ConsoleReadCancelResponse {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "unexpected console read cancellation response",
+            ));
+        }
+        return Ok(());
     }
 }
 
@@ -170,12 +248,12 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
     // Route by the descriptor's resolved backend so flat descriptors are dispatched through vfsd's
     // authoritative table.
     use crate::fdtable::{
-        resolve,
         resolve_console,
+        resolve_result,
         ConsoleLookup,
         Route,
     };
-    match resolve_console(fd) {
+    match resolve_console(fd)? {
         // When vfsd owns the console slot, use the flat descriptor so vfsd can apply the shared
         // terminal line discipline. In direct-ELF runs without vfsd, keep the historical direct
         // kernel-console path.
@@ -187,19 +265,25 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
                 read_ipc(
                     fd,
                     buffer,
-                    crate::VFS_DESTINATION,
-                    crate::VFS_MESSAGE_TYPE,
-                    crate::VFS_PUSH_PULL_PID,
-                    crate::VFS_PUSH_PULL_TID,
+                    ReadBackend {
+                        destination: crate::VFS_DESTINATION,
+                        message_type: crate::VFS_MESSAGE_TYPE,
+                        pull_pid: crate::VFS_PUSH_PULL_PID,
+                        pull_tid: crate::VFS_PUSH_PULL_TID,
+                        cancel_console_on_interrupt: true,
+                    },
                 )
             } else {
                 read_ipc(
                     STDIN_FILENO,
                     buffer,
-                    crate::HOST_IO,
-                    MessageType::Ikc,
-                    ProcessIdentifier::KERNEL,
-                    ThreadIdentifier::KERNEL,
+                    ReadBackend {
+                        destination: crate::HOST_IO,
+                        message_type: MessageType::Ikc,
+                        pull_pid: ProcessIdentifier::KERNEL,
+                        pull_tid: ThreadIdentifier::KERNEL,
+                        cancel_console_on_interrupt: false,
+                    },
                 )
             }
         },
@@ -207,15 +291,18 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
             ::syslog::warn!("read(): bad file descriptor fd={fd}");
             Err(Error::new(ErrorCode::BadFile, "read: bad file descriptor"))
         },
-        ConsoleLookup::Other => match resolve(fd) {
+        ConsoleLookup::Other => match resolve_result(fd)? {
             // VFS-backed descriptors go to vfsd.
             Some(res) if res.route == Route::Vfs => read_ipc(
                 res.backend_fd,
                 buffer,
-                crate::VFS_DESTINATION,
-                crate::VFS_MESSAGE_TYPE,
-                crate::VFS_PUSH_PULL_PID,
-                crate::VFS_PUSH_PULL_TID,
+                ReadBackend {
+                    destination: crate::VFS_DESTINATION,
+                    message_type: crate::VFS_MESSAGE_TYPE,
+                    pull_pid: crate::VFS_PUSH_PULL_PID,
+                    pull_tid: crate::VFS_PUSH_PULL_TID,
+                    cancel_console_on_interrupt: false,
+                },
             ),
             // stdout/stderr, sockets, and unroutable descriptors are not readable here.
             _ => {
@@ -230,10 +317,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
 fn read_ipc(
     fd: RawFileDescriptor,
     buffer: &mut [u8],
-    destination: ProcessIdentifier,
-    message_type: MessageType,
-    pull_pid: ProcessIdentifier,
-    pull_tid: ThreadIdentifier,
+    backend: ReadBackend,
 ) -> Result<c_size_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
@@ -245,8 +329,7 @@ fn read_ipc(
             page_chunk_size(buffer[offset..].as_ptr() as usize, buffer.len() - offset);
         let chunk: &mut [u8] = &mut buffer[offset..offset + chunk_size];
 
-        let count: c_size_t =
-            read_chunk(tid, fd, chunk, destination, message_type, pull_pid, pull_tid)?;
+        let count: c_size_t = read_chunk(tid, fd, chunk, backend)?;
 
         // EOF or zero-length read.
         if count == 0 {

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -168,10 +168,10 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
     // Route by the descriptor's resolved backend so flat descriptors are dispatched through vfsd's
     // authoritative table.
     use crate::fdtable::{
-        resolve,
+        resolve_result,
         Route,
     };
-    match resolve(fd) {
+    match resolve_result(fd)? {
         // stdout/stderr writes flow directly to the kernel over IKC.
         Some(res)
             if res.route == Route::Console

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -67,7 +67,16 @@ use ::sysapi::{
         file_creation_flags,
         file_status_flags,
     },
-    ffi::c_int,
+    ffi::{
+        c_int,
+        c_short,
+    },
+    poll::poll_flags::{
+        POLLIN,
+        POLLOUT,
+        POLLRDNORM,
+        POLLWRNORM,
+    },
     sys_ioctl::Winsize,
     sys_stat::{
         file_mode,
@@ -105,6 +114,22 @@ const DEFAULT_FILE_CREATION_MASK: mode_t = 0;
 
 /// File permission bits affected by the file mode creation mask.
 const FILE_PERMISSION_BITS: mode_t = file_mode::S_IRWXU | file_mode::S_IRWXG | file_mode::S_IRWXO;
+
+//==================================================================================================
+// Global State
+//==================================================================================================
+
+/// Shared console device retained independently of process descriptor tables.
+static CONSOLE_TERMINAL: Mutex<Option<Arc<Mutex<LineDiscipline>>>> = Mutex::new(None);
+
+/// Returns the process-global console terminal, creating it on first use.
+fn console_device() -> Arc<Mutex<LineDiscipline>> {
+    let mut terminal: spin::MutexGuard<'_, Option<Arc<Mutex<LineDiscipline>>>> =
+        CONSOLE_TERMINAL.lock();
+    terminal
+        .get_or_insert_with(|| Arc::new(Mutex::new(LineDiscipline::default())))
+        .clone()
+}
 
 //==================================================================================================
 // Public Re-Exports
@@ -330,7 +355,7 @@ pub fn vfs_seed_root_console(pid: ProcessIdentifier) {
     // The three standard streams share one terminal device, so they reference a single shared
     // terminal-state object. A `tcsetattr` through any of them is therefore visible through the
     // others, and the shared object flows down every `fork`/`dup` with the descriptor slots.
-    let terminal: Arc<Mutex<LineDiscipline>> = Arc::new(Mutex::new(LineDiscipline::default()));
+    let terminal: Arc<Mutex<LineDiscipline>> = console_device();
     for (fd, stream) in [
         (STDIN_FILENO, ConsoleStream::Stdin),
         (STDOUT_FILENO, ConsoleStream::Stdout),
@@ -879,6 +904,36 @@ pub fn vfs_resolve(fd: c_int) -> Option<(VfsRoute, c_int)> {
         | VfsFileHandle::Pipe(_) => (VfsRoute::Vfs, fd),
     };
     Some(resolution)
+}
+
+/// Returns the events that can complete immediately on `fd` without performing I/O.
+pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
+    const READ_EVENTS: c_short = POLLIN | POLLRDNORM;
+    const WRITE_EVENTS: c_short = POLLOUT | POLLWRNORM;
+
+    let file: OpenFile = entry_arc(fd)?;
+    let (stream, terminal): (ConsoleStream, Arc<Mutex<LineDiscipline>>) = {
+        let guard = file.lock();
+        match &guard.handle {
+            VfsFileHandle::Console(handle) => (handle.stream(), handle.terminal().clone()),
+            VfsFileHandle::Fat32(_) | VfsFileHandle::DirectRead(_) | VfsFileHandle::HostFs(_) => {
+                return Ok(events & (READ_EVENTS | WRITE_EVENTS))
+            },
+            VfsFileHandle::Directory(_) => return Ok(events & READ_EVENTS),
+            VfsFileHandle::Pipe(end) => return Ok(end.poll(events)),
+            VfsFileHandle::Socket(_) => return Err(Fat32Error::NotSupported),
+        }
+    };
+
+    let mut revents: c_short = 0;
+    if stream == ConsoleStream::Stdin && events & READ_EVENTS != 0 && terminal.lock().is_readable()
+    {
+        revents |= events & READ_EVENTS;
+    }
+    if matches!(stream, ConsoleStream::Stdout | ConsoleStream::Stderr) {
+        revents |= events & WRITE_EVENTS;
+    }
+    Ok(revents)
 }
 
 /// Resolves a `dirfd` + `path` pair into an absolute VFS path.
@@ -1647,6 +1702,11 @@ pub fn vfs_console_push_input(fd: c_int, input: &[u8]) -> Result<Vec<u8>, TtyErr
     Ok(echo)
 }
 
+/// Feeds raw bytes directly into the shared console device.
+pub fn vfs_console_device_push_input(input: &[u8]) -> Vec<u8> {
+    console_device().lock().push_input(input)
+}
+
 /// Drains the terminal-generated signals (`^C`/`^\`/`^Z`) recognized by the console line discipline
 /// since the last drain.
 ///
@@ -1659,6 +1719,11 @@ pub fn vfs_console_take_signals(fd: c_int) -> Result<Vec<TerminalSignal>, TtyErr
     Ok(signals)
 }
 
+/// Drains terminal-generated signals directly from the shared console device.
+pub fn vfs_console_device_take_signals() -> Vec<TerminalSignal> {
+    console_device().lock().take_signals()
+}
+
 /// Signals end-of-input on the raw console stream.
 pub fn vfs_console_push_eof(fd: c_int) -> Result<(), TtyError> {
     let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
@@ -1666,10 +1731,22 @@ pub fn vfs_console_push_eof(fd: c_int) -> Result<(), TtyError> {
     Ok(())
 }
 
+/// Signals hard end-of-input directly on the shared console device.
+pub fn vfs_console_device_push_eof() {
+    console_device().lock().push_eof();
+}
+
 /// Attempts a non-blocking read from the console line discipline.
 pub fn vfs_console_read(fd: c_int, buf: &mut [u8]) -> Result<ConsoleReadOutcome, TtyError> {
     let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
     let outcome: ConsoleReadOutcome = terminal.lock().read(buf);
+    Ok(outcome)
+}
+
+/// Peeks at an immediate console read without consuming line-discipline state.
+pub fn vfs_console_peek(fd: c_int, buf: &mut [u8]) -> Result<ConsoleReadOutcome, TtyError> {
+    let terminal: Arc<Mutex<LineDiscipline>> = console_terminal(fd)?;
+    let outcome: ConsoleReadOutcome = terminal.lock().peek(buf);
     Ok(outcome)
 }
 
@@ -2403,6 +2480,7 @@ mod tests {
         CURRENT_PID.store(0, Ordering::Relaxed);
         // Clear the one-shot root-seeding latch so a later test starts from a pristine state.
         ROOT_CONSOLE_SEEDED.store(false, Ordering::Relaxed);
+        *CONSOLE_TERMINAL.lock() = None;
     }
 
     /// Tests file creation mask normalization, fork inheritance, and exec preservation.
@@ -3031,6 +3109,27 @@ mod tests {
         assert_eq!(&buf[..3], b"ab\n");
 
         forget_processes(&[root]);
+    }
+
+    /// Tests that the console device remains usable after init closes its stdin descriptor.
+    #[test]
+    fn console_device_outlives_init_stdin() {
+        let _guard = FORK_TEST_GUARD.lock();
+        let root: ProcessIdentifier = root_process_identifier();
+        let child: ProcessIdentifier = ProcessIdentifier::from(ProcessIdentifier::VFSD_RAW + 2);
+        vfs_seed_root_console(root);
+        vfs_fork_clone(root, child).expect("fork clone should succeed");
+
+        set_current_process(root);
+        vfs_close(STDIN_FILENO).expect("init stdin close should succeed");
+        assert_eq!(vfs_console_device_push_input(b"child\n"), b"child\r\n");
+
+        set_current_process(child);
+        let mut buf: [u8; 8] = [0; 8];
+        assert_eq!(vfs_console_read(STDIN_FILENO, &mut buf), Ok(ConsoleReadOutcome::Read(6)));
+        assert_eq!(&buf[..6], b"child\n");
+
+        forget_processes(&[root, child]);
     }
 
     /// Tests that a forked child observes the parent's terminal attributes, because the shared

--- a/src/libs/vfs/src/line_discipline/discipline.rs
+++ b/src/libs/vfs/src/line_discipline/discipline.rs
@@ -129,6 +129,8 @@ pub struct LineDiscipline {
     /// and drained by [`LineDiscipline::take_signals`] so the daemon can forward them to the
     /// foreground process group. The discipline itself never delivers signals.
     signals: Vec<TerminalSignal>,
+    /// Whether the underlying host input stream has closed permanently.
+    input_closed: bool,
 }
 
 impl Default for LineDiscipline {
@@ -140,6 +142,7 @@ impl Default for LineDiscipline {
             ready: VecDeque::new(),
             raw_run_open: false,
             signals: Vec::new(),
+            input_closed: false,
         }
     }
 }
@@ -170,6 +173,11 @@ impl LineDiscipline {
         self.termios.c_lflag & termios::ISIG != 0
     }
 
+    /// Returns `true` when terminal-generated signals should preserve queued input.
+    fn no_flush(&self) -> bool {
+        self.termios.c_lflag & termios::NOFLSH != 0
+    }
+
     /// Returns `true` when carriage returns are mapped to newlines on input (`ICRNL`).
     fn map_cr_to_nl(&self) -> bool {
         self.termios.c_iflag & termios::ICRNL != 0
@@ -196,6 +204,7 @@ impl LineDiscipline {
         let canonical: bool = self.canonical();
         let echo_on: bool = self.echo_enabled();
         let signals_on: bool = self.signals_enabled();
+        let no_flush: bool = self.no_flush();
         let map_cr_to_nl: bool = self.map_cr_to_nl();
         let erase: Option<u8> = self.control_char(termios::VERASE);
         let kill: Option<u8> = self.control_char(termios::VKILL);
@@ -230,7 +239,9 @@ impl LineDiscipline {
                     if echo_on {
                         echo.extend_from_slice(&Self::caret(byte));
                     }
-                    self.flush_input();
+                    if !no_flush {
+                        self.flush_input();
+                    }
                     self.signals.push(signal);
                     continue;
                 }
@@ -289,7 +300,7 @@ impl LineDiscipline {
         if !self.pending.is_empty() {
             self.commit_pending_line();
         }
-        self.ready.push_back(Segment::Eof);
+        self.input_closed = true;
         self.raw_run_open = false;
     }
 
@@ -322,6 +333,41 @@ impl LineDiscipline {
         [b'^', byte ^ 0x40]
     }
 
+    /// Returns whether a read can complete without waiting for more input.
+    pub fn is_readable(&self) -> bool {
+        !self.ready.is_empty()
+            || self.input_closed
+            || (!self.canonical()
+                && self.termios.c_cc[termios::VMIN] == 0
+                && self.termios.c_cc[termios::VTIME] == 0)
+    }
+
+    /// Copies the bytes an immediate read would return without consuming terminal state.
+    pub fn peek(&self, buf: &mut [u8]) -> ConsoleReadOutcome {
+        if buf.is_empty() {
+            return ConsoleReadOutcome::Read(0);
+        }
+
+        match self.ready.front() {
+            Some(Segment::Eof) => ConsoleReadOutcome::Eof,
+            Some(Segment::Data(data)) => {
+                let n: usize = buf.len().min(data.len());
+                for (dst, src) in buf.iter_mut().zip(data.iter().take(n)) {
+                    *dst = *src;
+                }
+                ConsoleReadOutcome::Read(n)
+            },
+            None if self.input_closed => ConsoleReadOutcome::Eof,
+            None if !self.canonical()
+                && self.termios.c_cc[termios::VMIN] == 0
+                && self.termios.c_cc[termios::VTIME] == 0 =>
+            {
+                ConsoleReadOutcome::Read(0)
+            },
+            None => ConsoleReadOutcome::WouldBlock,
+        }
+    }
+
     /// Reads cooked bytes into `buf`, returning the outcome of the attempt.
     ///
     /// In canonical mode a read returns at most one line and never crosses a line boundary; a line
@@ -333,10 +379,18 @@ impl LineDiscipline {
         if buf.is_empty() {
             return ConsoleReadOutcome::Read(0);
         }
+        if self.ready.is_empty()
+            && !self.canonical()
+            && self.termios.c_cc[termios::VMIN] == 0
+            && self.termios.c_cc[termios::VTIME] == 0
+        {
+            return ConsoleReadOutcome::Read(0);
+        }
 
         loop {
             match self.ready.front_mut() {
                 // No cooked input is available.
+                None if self.input_closed => return ConsoleReadOutcome::Eof,
                 None => return ConsoleReadOutcome::WouldBlock,
                 // An end-of-file marker: consume it and report EOF.
                 Some(Segment::Eof) => {
@@ -441,6 +495,30 @@ mod tests {
         assert_eq!(read_bytes(&mut ld, 16), b"hello\n");
         // After the line is consumed there is nothing left to read.
         assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that readiness follows queued input without consuming it.
+    #[test]
+    fn readability_tracks_queued_input() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        assert!(!ld.is_readable(), "an empty terminal is not readable");
+
+        clear_lflag(&mut ld, ICANON | ECHO);
+        ld.push_input(b"x");
+        assert!(ld.is_readable(), "raw input is immediately readable");
+        assert!(ld.is_readable(), "checking readiness does not consume input");
+
+        let mut peeked: [u8; 1] = [0];
+        assert_eq!(ld.peek(&mut peeked), ConsoleReadOutcome::Read(1));
+        assert_eq!(peeked, *b"x");
+
+        assert_eq!(read_bytes(&mut ld, 1), b"x");
+        assert!(!ld.is_readable(), "draining input clears readiness");
+
+        ld.push_eof();
+        assert!(ld.is_readable(), "queued EOF makes a read complete immediately");
+        assert_eq!(ld.read(&mut [0u8; 1]), ConsoleReadOutcome::Eof);
+        assert_eq!(ld.read(&mut [0u8; 1]), ConsoleReadOutcome::Eof);
     }
 
     /// Tests that echo is suppressed when the `ECHO` flag is cleared.
@@ -602,7 +680,7 @@ mod tests {
 
         assert_eq!(read_bytes(&mut ld, 16), b"abc");
         assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::Eof);
-        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+        assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::Eof);
     }
 
     /// Tests that raw bytes do not merge into an unread, already-committed canonical line.
@@ -659,6 +737,32 @@ mod tests {
 
         // The pending line was flushed: nothing is readable.
         assert_eq!(ld.read(&mut [0u8; 16]), ConsoleReadOutcome::WouldBlock);
+    }
+
+    /// Tests that `NOFLSH` preserves queued input when a terminal signal is recognized.
+    #[test]
+    fn noflsh_preserves_input_on_signal() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        ld.termios.c_lflag |= termios::NOFLSH;
+        ld.push_input(b"ready\npartial");
+        ld.push_input(&[ld.termios.c_cc[termios::VINTR]]);
+
+        assert_eq!(ld.take_signals(), alloc::vec![TerminalSignal::Interrupt]);
+        assert_eq!(read_bytes(&mut ld, 16), b"ready\n");
+        ld.push_input(b"\n");
+        assert_eq!(read_bytes(&mut ld, 16), b"partial\n");
+    }
+
+    /// Tests that noncanonical `VMIN=0,VTIME=0` reads complete immediately when empty.
+    #[test]
+    fn raw_zero_min_zero_time_is_immediately_readable() {
+        let mut ld: LineDiscipline = LineDiscipline::default();
+        clear_lflag(&mut ld, ICANON | ECHO);
+        ld.termios.c_cc[termios::VMIN] = 0;
+        ld.termios.c_cc[termios::VTIME] = 0;
+
+        assert!(ld.is_readable());
+        assert_eq!(ld.read(&mut [0u8; 1]), ConsoleReadOutcome::Read(0));
     }
 
     /// Tests that `^\` and `^Z` map to the quit and suspend signals respectively.

--- a/src/libs/vfs/src/pipe/pipe_end.rs
+++ b/src/libs/vfs/src/pipe/pipe_end.rs
@@ -39,6 +39,21 @@ use ::core::sync::atomic::{
     Ordering,
 };
 use ::spin::Mutex;
+use ::sysapi::{
+    ffi::c_short,
+    poll::{
+        poll_errors::{
+            POLLERR,
+            POLLHUP,
+        },
+        poll_flags::{
+            POLLIN,
+            POLLOUT,
+            POLLRDNORM,
+            POLLWRNORM,
+        },
+    },
+};
 
 //==================================================================================================
 // Constants
@@ -204,6 +219,33 @@ impl PipeEnd {
     /// Returns `true` if this is the write end, `false` if it is the read end.
     pub fn is_write(&self) -> bool {
         self.is_write
+    }
+
+    /// Returns the events that can complete immediately on this pipe end.
+    pub fn poll(&self, events: c_short) -> c_short {
+        const READ_EVENTS: c_short = POLLIN | POLLRDNORM;
+        const WRITE_EVENTS: c_short = POLLOUT | POLLWRNORM;
+
+        let inner: spin::MutexGuard<'_, PipeInner> = self.inner.lock();
+        if self.is_write {
+            let mut revents: c_short = 0;
+            if inner.readers == 0 {
+                revents |= POLLERR;
+            }
+            if inner.readers == 0 || inner.buf.len() < PIPE_CAPACITY {
+                revents |= events & WRITE_EVENTS;
+            }
+            revents
+        } else {
+            let mut revents: c_short = 0;
+            if !inner.buf.is_empty() || inner.writers == 0 {
+                revents |= events & READ_EVENTS;
+            }
+            if inner.writers == 0 {
+                revents |= POLLHUP;
+            }
+            revents
+        }
     }
 
     /// Attempts a non-blocking read from the pipe.
@@ -426,5 +468,50 @@ mod tests {
             matches!(r.read(&mut []).expect("read end"), PipeReadOutcome::Read(0)),
             "a zero-length read on an empty pipe with no writers must return Read(0)"
         );
+    }
+
+    /// Tests read-end readiness for empty, populated, and hung-up pipes.
+    #[test]
+    fn poll_read_end_tracks_data_and_writer_close() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(r.poll(POLLIN), 0, "an empty pipe with a writer is not readable");
+
+        w.write(&[1]).expect("write end");
+        assert_eq!(r.poll(POLLIN), POLLIN, "buffered data makes the read end readable");
+
+        drop(w);
+        assert_eq!(
+            r.poll(POLLIN),
+            POLLIN | POLLHUP,
+            "buffered data remains readable and writer closure reports hangup"
+        );
+        assert_eq!(read_all(&r, 1), alloc::vec![1]);
+        assert_eq!(
+            r.poll(POLLIN),
+            POLLIN | POLLHUP,
+            "EOF is readable and the hangup state persists"
+        );
+    }
+
+    /// Tests write-end readiness for available capacity, a full buffer, and reader closure.
+    #[test]
+    fn poll_write_end_tracks_capacity_and_reader_close() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        assert_eq!(w.poll(POLLOUT), POLLOUT, "an empty pipe is writable");
+
+        let data: alloc::vec::Vec<u8> = alloc::vec![0; PIPE_CAPACITY];
+        assert!(
+            matches!(w.write(&data).expect("write end"), PipeWriteOutcome::Wrote(PIPE_CAPACITY)),
+            "the write should fill the pipe"
+        );
+        assert_eq!(w.poll(POLLOUT), 0, "a full pipe is not writable");
+
+        drop(r);
+        assert_eq!(
+            w.poll(POLLOUT),
+            POLLOUT | POLLERR,
+            "a closed read end reports the write error without suppressing writability"
+        );
+        assert_eq!(w.poll(0), POLLERR, "pipe errors are reported without being requested");
     }
 }

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -150,6 +150,9 @@ extern void test_writev(void);
 // Tests whether we can poll a file descriptor for read/write readiness.
 extern void test_poll(void);
 
+// Tests whether we can poll a hostfsd-backed file descriptor for read/write readiness.
+extern void test_poll_hostfs(void);
+
 // Tests whether we can use select() to check read/write readiness on a file descriptor.
 extern void test_select(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -97,11 +97,11 @@ int main(int argc, const char *argv[])
     test_open_close();
     test_create_unlink(); // tests open() and unlink().
     test_write_read();    // tests open(), close() and unlink.
+    test_poll();          // tests open(), close(), write(), read(), poll() and unlink().
 #ifndef __NANVIX_STANDALONE__
-    // poll() and select() have no VFS implementation.
-    test_poll();            // tests open(), close(), write(), read(), poll() and unlink().
-    test_select();          // tests open(), close(), write(), read(), select() and unlink().
-#endif                      // __NANVIX_STANDALONE__
+    // select() has no VFS implementation.
+    test_select(); // tests open(), close(), write(), read(), select() and unlink().
+#endif             // __NANVIX_STANDALONE__
     test_posix_fadvise();   // requires open(), close() and unlink().
     test_lseek();           // requires open(), close(), read(), write() and unlink().
     test_posix_fallocate(); // requires open(), close(), lseek and unlink().
@@ -131,6 +131,7 @@ int main(int argc, const char *argv[])
     test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
     test_umask_ramfs(); // tests umask(), open(), close(), stat(), and unlink() on RAMFS.
     test_umask();      // tests umask(), open(), stat(), mkdir(), and unlinkat().
+    test_poll_hostfs(); // requires test_umask() to mount hostfs.
     test_dirent();
     test_getcwd();
     test_chdir(); // requires getcwd().

--- a/src/tests/integration/test-c-file/poll.c
+++ b/src/tests/integration/test-c-file/poll.c
@@ -12,9 +12,14 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <poll.h>
+#include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 //==================================================================================================
@@ -27,6 +32,339 @@
 // Timeout for poll() system call.
 #define POLL_TIMEOUT 1000
 
+// Short timeout used for timeout behavior checks.
+#define POLL_SHORT_TIMEOUT 20
+
+// Delay before a worker changes pipe state.
+#define POLL_WORKER_DELAY 25
+
+// Generous upper bound for a short timeout under the VM test scheduler.
+#define POLL_SHORT_TIMEOUT_UPPER 500
+
+// Event at POLL_WORKER_DELAY must wake comfortably before the one-second deadline.
+#define POLL_EARLY_WAKE_LIMIT 750
+
+// Pipe worker actions.
+#define POLL_ACTION_WRITE 0
+#define POLL_ACTION_CLOSE 1
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+struct poll_pipe_action {
+    int fd;
+    int action;
+};
+
+struct poll_signal_worker {
+    pid_t child;
+    int stop_fd;
+};
+
+// Set by the SIGUSR1 handler used to interrupt poll().
+static volatile sig_atomic_t poll_signal_caught;
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+// Returns elapsed milliseconds between two monotonic timestamps.
+static long elapsed_milliseconds(const struct timespec *start, const struct timespec *end)
+{
+    long seconds = (long)(end->tv_sec - start->tv_sec);
+    long nanoseconds = end->tv_nsec - start->tv_nsec;
+    return seconds * 1000 + nanoseconds / 1000000;
+}
+
+// Changes pipe state after a short delay.
+static void *run_pipe_action(void *arg)
+{
+    struct poll_pipe_action *action = (struct poll_pipe_action *)arg;
+
+    const struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = POLL_WORKER_DELAY * 1000000,
+    };
+    assert(nanosleep(&delay, NULL) == 0);
+
+    if (action->action == POLL_ACTION_WRITE) {
+        const char byte = 'x';
+        assert(write(action->fd, &byte, 1) == 1);
+    } else {
+        assert(action->action == POLL_ACTION_CLOSE);
+        assert(close(action->fd) == 0);
+    }
+    return NULL;
+}
+
+// Records delivery of the signal used to interrupt poll().
+static void handle_poll_signal(int signum)
+{
+    if (signum == SIGUSR1) {
+        poll_signal_caught = 1;
+    }
+}
+
+// Starts a child that repeatedly signals its parent until stopped.
+static struct poll_signal_worker start_signal_worker(void)
+{
+    int stopfds[2];
+    assert(pipe(stopfds) == 0);
+    pid_t parent = getpid();
+    pid_t child = fork();
+    assert(child != -1);
+    if (child == 0) {
+        assert(close(stopfds[1]) == 0);
+        int flags = fcntl(stopfds[0], F_GETFL);
+        assert(flags != -1);
+        assert(fcntl(stopfds[0], F_SETFL, flags | O_NONBLOCK) == 0);
+        const struct timespec delay = {
+            .tv_sec = 0,
+            .tv_nsec = POLL_WORKER_DELAY * 1000000,
+        };
+        for (;;) {
+            assert(nanosleep(&delay, NULL) == 0);
+            char stop;
+            ssize_t count = read(stopfds[0], &stop, 1);
+            if (count == 1) {
+                break;
+            }
+            assert(count == -1);
+            assert(errno == EAGAIN);
+            assert(kill(parent, SIGUSR1) == 0);
+        }
+        assert(close(stopfds[0]) == 0);
+        _exit(0);
+    }
+
+    assert(close(stopfds[0]) == 0);
+    return (struct poll_signal_worker){.child = child, .stop_fd = stopfds[1]};
+}
+
+// Stops and reaps a signal worker.
+static void stop_signal_worker(struct poll_signal_worker worker)
+{
+    const char stop = 'x';
+    ssize_t count;
+    do {
+        count = write(worker.stop_fd, &stop, 1);
+    } while (count == -1 && errno == EINTR);
+    assert(count == 1);
+    assert(close(worker.stop_fd) == 0);
+
+    int status;
+    while (waitpid(worker.child, &status, 0) == -1) {
+        assert(errno == EINTR);
+    }
+    assert(WIFEXITED(status));
+    assert(WEXITSTATUS(status) == 0);
+}
+
+// Tests signal interruption and verifies that the following poll receives its own response.
+static void test_poll_interruption(void)
+{
+    struct sigaction action;
+    struct sigaction old_action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = handle_poll_signal;
+    assert(sigemptyset(&action.sa_mask) == 0);
+    assert(sigaction(SIGUSR1, &action, &old_action) == 0);
+
+    int pipefds[2];
+    assert(pipe(pipefds) == 0);
+    struct poll_signal_worker worker = start_signal_worker();
+
+    struct pollfd read_end = {
+        .fd = pipefds[0],
+        .events = POLLIN,
+        .revents = 0,
+    };
+    poll_signal_caught = 0;
+    errno = 0;
+    assert(poll(&read_end, 1, POLL_TIMEOUT) == -1);
+    assert(errno == EINTR);
+    assert(poll_signal_caught == 1);
+    stop_signal_worker(worker);
+
+    const char ready_byte = 'y';
+    assert(write(pipefds[1], &ready_byte, 1) == 1);
+    read_end.revents = 0;
+    assert(poll(&read_end, 1, 0) == 1);
+    assert(read_end.revents == POLLIN);
+
+    assert(close(pipefds[0]) == 0);
+    assert(close(pipefds[1]) == 0);
+    assert(sigaction(SIGUSR1, &old_action, NULL) == 0);
+}
+
+// Tests empty sets, timeout behavior, ignored descriptors, and invalid descriptors.
+static void test_poll_arguments(void)
+{
+    assert(poll(NULL, 0, 0) == 0);
+
+    struct timespec start;
+    struct timespec end;
+    assert(clock_gettime(CLOCK_MONOTONIC, &start) == 0);
+    assert(poll(NULL, 0, POLL_SHORT_TIMEOUT) == 0);
+    assert(clock_gettime(CLOCK_MONOTONIC, &end) == 0);
+    assert(elapsed_milliseconds(&start, &end) >= POLL_SHORT_TIMEOUT);
+    assert(elapsed_milliseconds(&start, &end) < POLL_SHORT_TIMEOUT_UPPER);
+
+    errno = 0;
+    assert(poll(NULL, OPEN_MAX + 1, 0) == -1);
+    assert(errno == EINVAL);
+
+    struct pollfd ignored = {
+        .fd = -1,
+        .events = POLLIN,
+        .revents = (short)-1,
+    };
+    assert(poll(&ignored, 1, 0) == 0);
+    assert(ignored.fd == -1);
+    assert(ignored.events == POLLIN);
+    assert(ignored.revents == 0);
+
+    struct pollfd invalid = {
+        .fd = OPEN_MAX,
+        .events = 0,
+        .revents = (short)-1,
+    };
+    assert(poll(&invalid, 1, 0) == 1);
+    assert(invalid.events == 0);
+    assert(invalid.revents == POLLNVAL);
+}
+
+// Tests regular-file readiness, duplicate entries, EOF, and O_NONBLOCK independence.
+static void test_poll_regular_file(const char *filename)
+{
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    char buffer[POLL_TEST_DATA_MAX + 1];
+
+    assert(strlen(filename) <= NAME_MAX);
+    assert(data_len <= POLL_TEST_DATA_MAX);
+
+    int fd = open(filename, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    struct pollfd pfd = {
+        .fd = fd,
+        .events = POLLIN | POLLOUT | POLLRDBAND | POLLWRBAND,
+        .revents = 0,
+    };
+    assert(poll(&pfd, 1, POLL_TIMEOUT) == 1);
+    assert((pfd.revents & (POLLIN | POLLOUT)) == (POLLIN | POLLOUT));
+
+    assert(write(fd, data, data_len) == (ssize_t)data_len);
+    assert(lseek(fd, 0, SEEK_SET) == 0);
+    assert(read(fd, buffer, data_len) == (ssize_t)data_len);
+    buffer[data_len] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    assert(lseek(fd, 0, SEEK_END) != -1);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    assert(poll(&pfd, 1, POLL_TIMEOUT) == 1);
+    assert(pfd.revents == POLLIN);
+
+    struct pollfd duplicates[2] = {
+        {.fd = fd, .events = 0, .revents = (short)-1},
+        {.fd = fd, .events = POLLIN, .revents = (short)-1},
+    };
+    assert(poll(duplicates, 2, 0) == 1);
+    assert(duplicates[0].revents == 0);
+    assert(duplicates[1].revents == POLLIN);
+
+    int flags = fcntl(fd, F_GETFL);
+    assert(flags != -1);
+    assert(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+    pfd.revents = 0;
+    assert(poll(&pfd, 1, 0) == 1);
+    assert(pfd.revents == POLLIN);
+
+    pfd.events = POLLERR | POLLHUP | POLLNVAL;
+    pfd.revents = (short)-1;
+    assert(poll(&pfd, 1, 0) == 0);
+    assert(pfd.revents == 0);
+
+    assert(close(fd) == 0);
+    assert(unlink(filename) == 0);
+}
+
+// Tests pipe readiness, early wakeup, hangup, errors, and an infinite wait.
+static void test_poll_pipe(void)
+{
+    int pipefds[2];
+    assert(pipe(pipefds) == 0);
+
+    struct pollfd read_end = {
+        .fd = pipefds[0],
+        .events = POLLIN,
+        .revents = (short)-1,
+    };
+    assert(poll(&read_end, 1, POLL_SHORT_TIMEOUT) == 0);
+    assert(read_end.revents == 0);
+
+    struct pollfd write_end = {
+        .fd = pipefds[1],
+        .events = POLLOUT,
+        .revents = 0,
+    };
+    assert(poll(&write_end, 1, 0) == 1);
+    assert(write_end.revents == POLLOUT);
+
+    struct poll_pipe_action write_action = {
+        .fd = pipefds[1],
+        .action = POLL_ACTION_WRITE,
+    };
+    pthread_t writer;
+    assert(pthread_create(&writer, NULL, run_pipe_action, &write_action) == 0);
+
+    struct timespec start;
+    struct timespec end;
+    assert(clock_gettime(CLOCK_MONOTONIC, &start) == 0);
+    assert(poll(&read_end, 1, POLL_TIMEOUT) == 1);
+    assert(clock_gettime(CLOCK_MONOTONIC, &end) == 0);
+    assert(read_end.revents == POLLIN);
+    assert(elapsed_milliseconds(&start, &end) < POLL_EARLY_WAKE_LIMIT);
+    assert(pthread_join(writer, NULL) == 0);
+
+    char byte;
+    assert(read(pipefds[0], &byte, 1) == 1);
+    assert(byte == 'x');
+    assert(close(pipefds[1]) == 0);
+
+    read_end.revents = 0;
+    assert(poll(&read_end, 1, 0) == 1);
+    assert((read_end.revents & (POLLIN | POLLHUP)) == (POLLIN | POLLHUP));
+    assert(close(pipefds[0]) == 0);
+
+    assert(pipe(pipefds) == 0);
+    assert(close(pipefds[0]) == 0);
+    write_end.fd = pipefds[1];
+    write_end.events = 0;
+    write_end.revents = 0;
+    assert(poll(&write_end, 1, 0) == 1);
+    assert(write_end.revents == POLLERR);
+    assert(close(pipefds[1]) == 0);
+
+    assert(pipe(pipefds) == 0);
+    struct poll_pipe_action close_action = {
+        .fd = pipefds[1],
+        .action = POLL_ACTION_CLOSE,
+    };
+    pthread_t closer;
+    assert(pthread_create(&closer, NULL, run_pipe_action, &close_action) == 0);
+    read_end.fd = pipefds[0];
+    read_end.events = 0;
+    read_end.revents = 0;
+    assert(poll(&read_end, 1, -1) == 1);
+    assert(read_end.revents == POLLHUP);
+    assert(pthread_join(closer, NULL) == 0);
+    assert(close(pipefds[0]) == 0);
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -36,73 +374,24 @@ void test_poll(void)
 {
     fprintf(stderr, "testing poll() ... ");
 
-    const char *filename = "poll_testfile.tmp";
-    assert(strlen(filename) <= NAME_MAX);
+    test_poll_arguments();
+    test_poll_regular_file("poll_testfile.tmp");
+    test_poll_pipe();
+    test_poll_interruption();
 
-    const char *data = "Hello Nanvix!";
-    size_t data_len = strlen(data);
-    assert(data_len <= POLL_TEST_DATA_MAX);
-    char buffer[POLL_TEST_DATA_MAX + 1];
+    fprintf(stderr, "passed\n");
+}
 
-    // Open file with O_NONBLOCK so that readiness semantics are exercised.
-    int fd = open(filename, O_CREAT | O_EXCL | O_RDWR | O_NONBLOCK, S_IRUSR | S_IWUSR);
-    assert(fd != -1);
+// Tests whether we can poll a hostfsd-backed regular file.
+void test_poll_hostfs(void)
+{
+    if (getenv("NANVIX_TEST_HOSTFS") == NULL) {
+        return;
+    }
 
-    // Prepare pollfd for write readiness (POLLOUT).
-    struct pollfd pfd;
-    pfd.fd = fd;
-    pfd.events = POLLOUT;
-    pfd.revents = 0;
+    fprintf(stderr, "testing poll() with hostfs ... ");
 
-    // Poll for write readiness. Should be ready immediately.
-    int ret = poll(&pfd, 1, POLL_TIMEOUT);
-    assert(ret == 1);
-    assert((pfd.revents & POLLOUT) != 0);
-
-    // Write data.
-    ssize_t bytes_written = write(fd, data, data_len);
-    assert(bytes_written == (ssize_t)data_len);
-
-    // Rewind to begin of the file.
-    assert(lseek(fd, 0, SEEK_SET) == 0);
-
-    // Reset pollfd for read readiness.
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-
-    // Poll for read readiness. Should be ready immediately.
-    ret = poll(&pfd, 1, POLL_TIMEOUT);
-    assert(ret == 1);
-    assert((pfd.revents & POLLIN) != 0);
-
-    // Read data and sanity check.
-    ssize_t bytes_read = read(fd, buffer, (size_t)bytes_written);
-    assert(bytes_read == bytes_written);
-    buffer[bytes_read] = '\0';
-    assert(strcmp(buffer, data) == 0);
-
-    // Close file descriptor.
-    assert(close(fd) == 0);
-
-    // Re-open read-only non-blocking and poll for read.
-    fd = open(filename, O_RDONLY | O_NONBLOCK);
-    assert(fd != -1);
-
-    // Seek to end so that no data is available.
-    assert(lseek(fd, 0, SEEK_END) != -1);
-    pfd.fd = fd;
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-
-    // Poll for read readiness. It should either timeout, or return readiness with POLLHUP.
-    ret = poll(&pfd, 1, POLL_TIMEOUT);
-    assert(ret == 0 || ((ret == 1) && ((pfd.revents & (POLLIN | POLLHUP)) != 0)));
-
-    // Close file descriptor.
-    assert(close(fd) == 0);
-
-    // Remove test file.
-    assert(unlink(filename) == 0);
+    test_poll_regular_file("/mnt/poll_testfile.tmp");
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-file/umask.c
+++ b/src/tests/integration/test-c-file/umask.c
@@ -42,7 +42,7 @@ void test_umask(void)
     assert(umask(mask | ~permissions) == mask);
     assert(umask(mask) == mask);
 
-    if (getenv("NANVIX_TEST_HOSTFS_PERMISSIONS") != NULL) {
+    if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
         const mode_t expected_mode = permissions & ~mask;
         const char *filename = "/mnt/umask-file";
         const char *dirname = "/mnt/umask-dir";

--- a/src/tests/integration/test-c-network/common.h
+++ b/src/tests/integration/test-c-network/common.h
@@ -54,4 +54,7 @@ extern void test_get_sockname(int domain,
 extern void test_unix_sockets(char sun_path[]);
 extern void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr);
 
+// Tests poll() routing through hostfsd, networkd, VFSD, and all three services together.
+extern void test_poll_services(struct in_addr sin_addr);
+
 #endif

--- a/src/tests/integration/test-c-network/inet.c
+++ b/src/tests/integration/test-c-network/inet.c
@@ -12,15 +12,43 @@
 #include <assert.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <poll.h>
+#include <pthread.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <time.h>
 #include <unistd.h>
 
 //==================================================================================================
 // Private Functions
 //==================================================================================================
+
+struct delayed_datagram {
+    int fd;
+    struct sockaddr_in destination;
+};
+
+// Sends one datagram after poll() has begun waiting.
+static void *send_delayed_datagram(void *arg)
+{
+    struct delayed_datagram *request = (struct delayed_datagram *)arg;
+    const struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = 25 * 1000000,
+    };
+    assert(nanosleep(&delay, NULL) == 0);
+
+    const char byte = 'x';
+    assert(sendto(request->fd,
+                  &byte,
+                  1,
+                  0,
+                  (const struct sockaddr *)&request->destination,
+                  sizeof(request->destination)) == 1);
+    return NULL;
+}
 
 // Creates a datagram socket bound to an ephemeral port on the supplied address and reports the
 // address that the system assigned to it.
@@ -46,6 +74,40 @@ static int new_bound_dgram_socket(struct in_addr addr, struct sockaddr_in *assig
     assert(assigned->sin_family == AF_INET);
 
     return sockfd;
+}
+
+// Tests socket read/write readiness around a loopback datagram.
+static void test_inet_dgram_poll(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+    struct pollfd pfd = {
+        .fd = sockfd,
+        .events = POLLIN | POLLOUT,
+        .revents = 0,
+    };
+
+    assert(poll(&pfd, 1, 0) == 1);
+    assert((pfd.revents & POLLOUT) != 0);
+    assert((pfd.revents & POLLIN) == 0);
+
+    struct delayed_datagram request = {
+        .fd = sockfd,
+        .destination = self,
+    };
+    pthread_t sender;
+    assert(pthread_create(&sender, NULL, send_delayed_datagram, &request) == 0);
+
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    assert(poll(&pfd, 1, 1000) == 1);
+    assert(pfd.revents == POLLIN);
+    assert(pthread_join(sender, NULL) == 0);
+
+    char received;
+    assert(recvfrom(sockfd, &received, 1, 0, NULL, NULL) == 1);
+    assert(received == 'x');
+    assert(close(sockfd) == 0);
 }
 
 // Tests datagram `sendto()`/`recvfrom()` with an explicit destination address. A datagram is sent
@@ -353,6 +415,8 @@ void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr)
     test_listen_socket(
         domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
     test_get_sockname(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    test_inet_dgram_poll(sin_addr);
 
     // Exercise datagram sendto()/recvfrom() over loopback.
     test_inet_dgram_sendto_recvfrom(sin_addr);

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -139,6 +139,7 @@ int main(int argc, const char *argv[])
     struct in_addr sin_addr = {.s_addr = htonl(0x7f000001)};
 
     test_inet_sockets(sin_port, sin_addr);
+    test_poll_services(sin_addr);
 
     // The network service supports only AF_INET sockets.
 #ifndef __NANVIX_STANDALONE__

--- a/src/tests/integration/test-c-network/poll.c
+++ b/src/tests/integration/test-c-network/poll.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Timeout for poll() system calls that wait for readiness.
+#define POLL_TIMEOUT 1000
+
+// File used to exercise hostfsd-backed descriptors.
+#define POLL_HOSTFS_FILE "/mnt/poll-network-file.tmp"
+
+//==================================================================================================
+// Imported Symbols
+//==================================================================================================
+
+extern int mount(
+    const char *source,
+    const char *target,
+    const char *filesystemtype,
+    unsigned long mountflags);
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+// Creates a datagram socket bound to an ephemeral port on the supplied address.
+static int new_bound_dgram_socket(struct in_addr addr, struct sockaddr_in *assigned)
+{
+    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    assert(sockfd >= 0);
+
+    struct sockaddr_in bindaddr = {
+        .sin_len = sizeof(bindaddr),
+        .sin_family = AF_INET,
+        .sin_port = htons(0),
+        .sin_addr = addr,
+    };
+    assert(bind(sockfd, (const struct sockaddr *)&bindaddr, sizeof(bindaddr)) == 0);
+
+    socklen_t assigned_len = sizeof(*assigned);
+    assert(getsockname(sockfd, (struct sockaddr *)assigned, &assigned_len) == 0);
+    assert(assigned_len == sizeof(*assigned));
+    assert(assigned->sin_family == AF_INET);
+
+    return sockfd;
+}
+
+// Sends one byte to a datagram socket's own address.
+static void make_socket_readable(int sockfd, const struct sockaddr_in *self)
+{
+    const char byte = 's';
+    assert(sendto(sockfd,
+                  &byte,
+                  sizeof(byte),
+                  0,
+                  (const struct sockaddr *)self,
+                  sizeof(*self)) == sizeof(byte));
+}
+
+// Tests poll() readiness for a hostfsd-backed regular file.
+static void test_poll_hostfsd(void)
+{
+    int fd = open(POLL_HOSTFS_FILE, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+
+    struct pollfd pfd = {
+        .fd = fd,
+        .events = POLLIN | POLLOUT,
+        .revents = 0,
+    };
+    assert(poll(&pfd, 1, 0) == 1);
+    assert(pfd.revents == (POLLIN | POLLOUT));
+
+    assert(close(fd) == 0);
+    assert(unlink(POLL_HOSTFS_FILE) == 0);
+}
+
+// Tests poll() readiness for a networkd-backed datagram socket.
+static void test_poll_networkd(struct in_addr sin_addr)
+{
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+    struct pollfd pfd = {
+        .fd = sockfd,
+        .events = POLLIN | POLLOUT,
+        .revents = 0,
+    };
+
+    assert(poll(&pfd, 1, 0) == 1);
+    assert((pfd.revents & POLLOUT) != 0);
+    assert((pfd.revents & POLLIN) == 0);
+
+    make_socket_readable(sockfd, &self);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    assert(poll(&pfd, 1, POLL_TIMEOUT) == 1);
+    assert(pfd.revents == POLLIN);
+
+    char byte;
+    assert(recvfrom(sockfd, &byte, sizeof(byte), 0, NULL, NULL) == sizeof(byte));
+    assert(byte == 's');
+    assert(close(sockfd) == 0);
+}
+
+// Tests poll() readiness for a VFSD-backed pipe.
+static void test_poll_vfsd(void)
+{
+    int pipefds[2];
+    assert(pipe(pipefds) == 0);
+
+    struct pollfd pfds[2] = {
+        {.fd = pipefds[0], .events = POLLIN, .revents = (short)-1},
+        {.fd = pipefds[1], .events = POLLOUT, .revents = (short)-1},
+    };
+    assert(poll(pfds, 2, 0) == 1);
+    assert(pfds[0].revents == 0);
+    assert(pfds[1].revents == POLLOUT);
+
+    const char byte = 'p';
+    assert(write(pipefds[1], &byte, sizeof(byte)) == sizeof(byte));
+    pfds[0].revents = 0;
+    pfds[1].events = 0;
+    pfds[1].revents = 0;
+    assert(poll(pfds, 2, POLL_TIMEOUT) == 1);
+    assert(pfds[0].revents == POLLIN);
+    assert(pfds[1].revents == 0);
+
+    char received;
+    assert(read(pipefds[0], &received, sizeof(received)) == sizeof(received));
+    assert(received == byte);
+    assert(close(pipefds[0]) == 0);
+    assert(close(pipefds[1]) == 0);
+}
+
+// Tests one poll() request containing hostfsd-, networkd-, and VFSD-backed descriptors.
+static void test_poll_mixed(struct in_addr sin_addr)
+{
+    int hostfd = open(POLL_HOSTFS_FILE, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(hostfd >= 0);
+
+    struct sockaddr_in self;
+    int sockfd = new_bound_dgram_socket(sin_addr, &self);
+
+    int pipefds[2];
+    assert(pipe(pipefds) == 0);
+
+    struct pollfd pfds[3] = {
+        {.fd = hostfd, .events = POLLIN | POLLOUT, .revents = (short)-1},
+        {.fd = sockfd, .events = POLLIN, .revents = (short)-1},
+        {.fd = pipefds[0], .events = POLLIN, .revents = (short)-1},
+    };
+    assert(poll(pfds, 3, 0) == 1);
+    assert(pfds[0].revents == (POLLIN | POLLOUT));
+    assert(pfds[1].revents == 0);
+    assert(pfds[2].revents == 0);
+
+    make_socket_readable(sockfd, &self);
+    const char pipe_byte = 'p';
+    assert(write(pipefds[1], &pipe_byte, sizeof(pipe_byte)) == sizeof(pipe_byte));
+
+    for (size_t i = 0; i < 3; i++) {
+        pfds[i].revents = 0;
+    }
+    assert(poll(pfds, 3, POLL_TIMEOUT) == 3);
+    assert(pfds[0].revents == (POLLIN | POLLOUT));
+    assert(pfds[1].revents == POLLIN);
+    assert(pfds[2].revents == POLLIN);
+
+    char socket_byte;
+    assert(recvfrom(sockfd, &socket_byte, sizeof(socket_byte), 0, NULL, NULL) ==
+           sizeof(socket_byte));
+    assert(socket_byte == 's');
+    char received_pipe_byte;
+    assert(read(pipefds[0], &received_pipe_byte, sizeof(received_pipe_byte)) ==
+           sizeof(received_pipe_byte));
+    assert(received_pipe_byte == pipe_byte);
+
+    assert(close(hostfd) == 0);
+    assert(unlink(POLL_HOSTFS_FILE) == 0);
+    assert(close(sockfd) == 0);
+    assert(close(pipefds[0]) == 0);
+    assert(close(pipefds[1]) == 0);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests poll() routing through hostfsd, networkd, VFSD, and all three services together.
+void test_poll_services(struct in_addr sin_addr)
+{
+    fprintf(stderr, "testing poll() with networkd ... ");
+    test_poll_networkd(sin_addr);
+    fprintf(stderr, "passed\n");
+
+    fprintf(stderr, "testing poll() with vfsd ... ");
+    test_poll_vfsd();
+    fprintf(stderr, "passed\n");
+
+    if (getenv("NANVIX_TEST_HOSTFS") == NULL) {
+        return;
+    }
+
+    assert(mount("", "/mnt", "hostfs", 0) == 0);
+
+    fprintf(stderr, "testing poll() with hostfsd ... ");
+    test_poll_hostfsd();
+    fprintf(stderr, "passed\n");
+
+    fprintf(stderr, "testing poll() with mixed services ... ");
+    test_poll_mixed(sin_addr);
+    fprintf(stderr, "passed\n");
+}

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -61,6 +61,10 @@ use ::syscall::{
     SystemCallMessage,
     SystemCallMessageHeader,
     message::SystemCallMessagePart,
+    poll::input_message::{
+        PollInputRequest,
+        PollInputResponse,
+    },
     unistd::message::{
         ReadRequest,
         ReadResponse,
@@ -91,6 +95,31 @@ use crate::perf::PerfTimings;
 /// Payload sent to the hostfsd worker thread: the IKC message, a channel for the
 /// response, and the shared message counters.
 type HostFsRequest = (Message, mpsc::Sender<IkcFrame>, MessageCounters);
+
+/// Request handled by the asynchronous host-console input broker.
+enum ConsoleInputRequest {
+    /// Stops the broker and releases its VM input sender.
+    Shutdown,
+    /// Enables unsolicited input-availability notifications to VFSD.
+    Subscribe,
+    /// A blocking console read, completed when input or EOF becomes available.
+    Read {
+        tid: ThreadIdentifier,
+        pull_header: DataChunkHeader,
+        max_bytes: usize,
+    },
+    /// An immediate console readiness snapshot.
+    Poll {
+        source_pid: ProcessIdentifier,
+        pull_header: DataChunkHeader,
+        max_bytes: usize,
+    },
+    /// An immediate readiness snapshot returned inline without a bulk transfer.
+    PollStatus {
+        source_pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+    },
+}
 
 //==================================================================================================
 // Constants
@@ -419,14 +448,14 @@ async fn standalone_io_handler(
     mut vm_stdout_rx: mpsc::Receiver<IkcFrame>,
     vm_stdin_tx: mpsc::Sender<IkcFrame>,
     output_tx: mpsc::Sender<Vec<u8>>,
-    mut input_rx: mpsc::Receiver<Vec<u8>>,
+    input_rx: mpsc::Receiver<Vec<u8>>,
     counters: MessageCounters,
     networking_mode: NetworkingMode,
     host_filter: HostFilter,
     mount_directory: Option<String>,
 ) {
-    let mut input_buffer: VecDeque<u8> = VecDeque::new();
-    let mut input_closed: bool = false;
+    let console_input_tx: mpsc::Sender<ConsoleInputRequest> =
+        spawn_console_input_broker(input_rx, vm_stdin_tx.downgrade(), counters.clone());
 
     // Tracks the logical op_id of the long-request multi-part stream currently
     // being forwarded to the hostfsd worker. Captured on part 0 and cleared once
@@ -606,14 +635,43 @@ async fn standalone_io_handler(
                         handle_read_request(
                             &mut vm_stdout_rx,
                             &vm_stdin_tx,
-                            &mut input_rx,
-                            &mut input_buffer,
-                            &mut input_closed,
+                            &console_input_tx,
                             tid,
                             &req,
                             &counters,
                         )
                         .await;
+                    },
+                    SystemCallMessageHeader::PollInputRequest => {
+                        let source: MessageSender = msg.source;
+                        let tid: ThreadIdentifier = extract_tid(source);
+                        let request: PollInputRequest =
+                            PollInputRequest::from_bytes(syscall_msg.payload);
+                        handle_poll_input_request(
+                            &mut vm_stdout_rx,
+                            &console_input_tx,
+                            source.pid,
+                            tid,
+                            &request,
+                        )
+                        .await;
+                    },
+                    SystemCallMessageHeader::ConsoleInputSubscribe => {
+                        let source: MessageSender = msg.source;
+                        if source.pid != ProcessIdentifier::VFSD {
+                            warn!(
+                                "standalone io_handler: rejecting console subscription from {:?}",
+                                source.pid
+                            );
+                            continue;
+                        }
+                        if console_input_tx
+                            .send(ConsoleInputRequest::Subscribe)
+                            .await
+                            .is_err()
+                        {
+                            error!("standalone io_handler: console input broker is unavailable");
+                        }
                     },
                     SystemCallMessageHeader::SendSocketRequest => {
                         handle_send_request(
@@ -790,6 +848,7 @@ async fn standalone_io_handler(
         }
     }
 
+    let _ = console_input_tx.send(ConsoleInputRequest::Shutdown).await;
     debug!("standalone: I/O handler exiting (VM stdout channel closed)");
 }
 
@@ -1111,9 +1170,7 @@ async fn handle_write_request(
 async fn handle_read_request(
     vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
     vm_stdin_tx: &mpsc::Sender<IkcFrame>,
-    input_rx: &mut mpsc::Receiver<Vec<u8>>,
-    input_buffer: &mut VecDeque<u8>,
-    input_closed: &mut bool,
+    console_input_tx: &mpsc::Sender<ConsoleInputRequest>,
     tid: ThreadIdentifier,
     request: &ReadRequest,
     counters: &MessageCounters,
@@ -1172,45 +1229,284 @@ async fn handle_read_request(
     }
 
     let max_bytes: usize = core::cmp::min(request.count as usize, pull_header.data_len() as usize);
+    if console_input_tx
+        .send(ConsoleInputRequest::Read {
+            tid,
+            pull_header,
+            max_bytes,
+        })
+        .await
+        .is_err()
+    {
+        error!("standalone io_handler: console input broker is unavailable");
+        send_empty_pull_response(vm_stdin_tx, &pull_header, counters).await;
+    }
+}
 
-    // If the internal buffer is empty and the input channel is still open, wait for data.
-    if input_buffer.is_empty() && !*input_closed {
-        match input_rx.recv().await {
-            Some(data) => input_buffer.extend(data),
-            None => {
-                *input_closed = true;
-            },
+/// Handles an immediate, non-blocking host-console input snapshot.
+async fn handle_poll_input_request(
+    vm_stdout_rx: &mut mpsc::Receiver<IkcFrame>,
+    console_input_tx: &mpsc::Sender<ConsoleInputRequest>,
+    source_pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
+    request: &PollInputRequest,
+) {
+    if request.count() == 0 {
+        if console_input_tx
+            .send(ConsoleInputRequest::PollStatus { source_pid, tid })
+            .await
+            .is_err()
+        {
+            error!("standalone io_handler: console input broker is unavailable");
         }
+        return;
     }
 
-    // Take up to max_bytes from the buffer.
-    let available: usize = core::cmp::min(input_buffer.len(), max_bytes);
-    let data: Vec<u8> = input_buffer.drain(..available).collect();
-    let actual_len: u32 = match u32::try_from(data.len()) {
-        Ok(n) => n,
-        Err(_) => {
-            error!("standalone io_handler: read size overflows u32 (len={})", data.len());
-            let empty_buf: [u8; ReadResponse::BUFFER_SIZE] = [0u8; ReadResponse::BUFFER_SIZE];
-            let response: Message = ReadResponse::build(
-                tid,
-                -1,
-                empty_buf,
-                ProcessIdentifier::KERNEL,
-                MessageType::Ikc,
+    let pull_header: DataChunkHeader = match vm_stdout_rx.recv().await {
+        Some(IkcFrame::Bulk(bulk)) => *bulk.header(),
+        other => {
+            error!(
+                "standalone io_handler: expected bulk frame after PollInputRequest, got {:?}",
+                other.as_ref().map(|frame| frame.frame_type_byte())
             );
-            counters.increment_io_handler_messages_sent();
-            if vm_stdin_tx.send(IkcFrame::Message(response)).await.is_err() {
-                error!(
-                    "standalone io_handler: failed to send ReadResponse (VM input channel closed)"
-                );
-            }
             return;
         },
     };
 
-    // Construct bulk response with the read data and send it to the guest. The input_fn will
-    // write this data to guest memory at the pull_header's data_addr and construct a
-    // PullResponse notification to wake the sleeping pull thread.
+    let max_response: usize = pull_header.data_len() as usize;
+    let max_data: usize = core::cmp::min(request.count() as usize, max_response.saturating_sub(1));
+    if console_input_tx
+        .send(ConsoleInputRequest::Poll {
+            source_pid,
+            pull_header,
+            max_bytes: max_data,
+        })
+        .await
+        .is_err()
+    {
+        error!("standalone io_handler: console input broker is unavailable");
+    }
+}
+
+/// Starts the task that owns host-console input and completes reads without blocking the I/O loop.
+fn spawn_console_input_broker(
+    mut input_rx: mpsc::Receiver<Vec<u8>>,
+    vm_stdin_tx: mpsc::WeakSender<IkcFrame>,
+    counters: MessageCounters,
+) -> mpsc::Sender<ConsoleInputRequest> {
+    let (request_tx, mut request_rx): (
+        mpsc::Sender<ConsoleInputRequest>,
+        mpsc::Receiver<ConsoleInputRequest>,
+    ) = mpsc::channel(CHANNEL_CAPACITY);
+
+    tokio::spawn(async move {
+        let mut input_buffer: VecDeque<u8> = VecDeque::new();
+        let mut input_closed: bool = false;
+        let mut notifications_enabled: bool = false;
+        let mut notification_pending: bool = false;
+        let mut pending_reads: VecDeque<(ThreadIdentifier, DataChunkHeader, usize)> =
+            VecDeque::new();
+
+        loop {
+            while !pending_reads.is_empty()
+                && (!input_buffer.is_empty()
+                    || input_closed
+                    || pending_reads
+                        .front()
+                        .map(|read| read.2 == 0)
+                        .unwrap_or(false))
+            {
+                let Some((tid, pull_header, max_bytes)) = pending_reads.pop_front() else {
+                    break;
+                };
+                let available: usize = core::cmp::min(input_buffer.len(), max_bytes);
+                let data: Vec<u8> = input_buffer.drain(..available).collect();
+                let Some(sender) = vm_stdin_tx.upgrade() else {
+                    return;
+                };
+                send_console_read_response(&sender, tid, pull_header, data, &counters).await;
+            }
+
+            tokio::select! {
+                data = input_rx.recv(), if !input_closed
+                    && (!pending_reads.is_empty()
+                        || (notifications_enabled && input_buffer.is_empty())) => {
+                    match data {
+                        Some(data) => {
+                            input_buffer.extend(data);
+                            if notifications_enabled && !notification_pending {
+                                let Some(sender) = vm_stdin_tx.upgrade() else {
+                                    break;
+                                };
+                                if !notify_console_input_available(&sender, &counters).await {
+                                    break;
+                                }
+                                notification_pending = true;
+                            }
+                        },
+                        None => {
+                            input_closed = true;
+                            if notifications_enabled && !notification_pending {
+                                let Some(sender) = vm_stdin_tx.upgrade() else {
+                                    break;
+                                };
+                                if !notify_console_input_available(&sender, &counters).await {
+                                    break;
+                                }
+                                notification_pending = true;
+                            }
+                        },
+                    }
+                },
+                request = request_rx.recv() => {
+                    let Some(request) = request else {
+                        break;
+                    };
+
+                    let direct_input_request: bool = !notifications_enabled
+                        && matches!(
+                            &request,
+                            ConsoleInputRequest::Read { .. }
+                                | ConsoleInputRequest::Poll { .. }
+                                | ConsoleInputRequest::PollStatus { .. }
+                        );
+                    if direct_input_request
+                        && input_buffer.is_empty()
+                        && let Ok(data) = input_rx.try_recv()
+                    {
+                        input_buffer.extend(data);
+                    }
+                    if direct_input_request && input_rx.is_closed() && input_rx.is_empty() {
+                        input_closed = true;
+                    }
+
+                    match request {
+                        ConsoleInputRequest::Shutdown => break,
+                        ConsoleInputRequest::Subscribe => {
+                            notifications_enabled = true;
+                            if (!input_buffer.is_empty() || input_closed)
+                                && !notification_pending {
+                                let Some(sender) = vm_stdin_tx.upgrade() else {
+                                    break;
+                                };
+                                if !notify_console_input_available(&sender, &counters).await {
+                                    break;
+                                }
+                                notification_pending = true;
+                            }
+                        },
+                        ConsoleInputRequest::Read { tid, pull_header, max_bytes } => {
+                            pending_reads.push_back((tid, pull_header, max_bytes));
+                        },
+                        ConsoleInputRequest::Poll {
+                            source_pid,
+                            pull_header,
+                            max_bytes,
+                        } => {
+                            let from_vfsd: bool = source_pid == ProcessIdentifier::VFSD;
+                            let authorized: bool = !notifications_enabled || from_vfsd;
+                            let acknowledge_notification: bool = from_vfsd && notification_pending;
+                            if acknowledge_notification {
+                                notification_pending = false;
+                            }
+                            let mut data: Vec<u8> = Vec::with_capacity(max_bytes + 1);
+                            if !authorized {
+                                data.push(PollInputRequest::STATUS_EMPTY);
+                            } else if input_buffer.is_empty() {
+                                data.push(if input_closed {
+                                    PollInputRequest::STATUS_EOF
+                                } else {
+                                    PollInputRequest::STATUS_EMPTY
+                                });
+                            } else {
+                                data.push(PollInputRequest::STATUS_DATA);
+                                let available: usize =
+                                    core::cmp::min(input_buffer.len(), max_bytes);
+                                data.extend(input_buffer.drain(..available));
+                            }
+                            let Some(sender) = vm_stdin_tx.upgrade() else {
+                                break;
+                            };
+                            send_console_poll_response(
+                                &sender,
+                                pull_header,
+                                data,
+                                &counters,
+                            )
+                            .await;
+                            if acknowledge_notification
+                                && notifications_enabled
+                                && !input_buffer.is_empty()
+                                && !notification_pending
+                            {
+                                if !notify_console_input_available(&sender, &counters).await {
+                                    break;
+                                }
+                                notification_pending = true;
+                            }
+                        },
+                        ConsoleInputRequest::PollStatus { source_pid, tid } => {
+                            let authorized: bool = !notifications_enabled
+                                || source_pid == ProcessIdentifier::VFSD;
+                            let status: u8 = if !authorized {
+                                PollInputRequest::STATUS_EMPTY
+                            } else if input_buffer.is_empty() {
+                                if input_closed {
+                                    PollInputRequest::STATUS_EOF
+                                } else {
+                                    PollInputRequest::STATUS_EMPTY
+                                }
+                            } else {
+                                PollInputRequest::STATUS_DATA
+                            };
+                            let Some(sender) = vm_stdin_tx.upgrade() else {
+                                break;
+                            };
+                            send_console_poll_status(&sender, tid, status, &counters).await;
+                        },
+                    }
+                },
+            }
+        }
+    });
+
+    request_tx
+}
+
+/// Notifies VFSD that an immediate console-input snapshot can make progress.
+async fn notify_console_input_available(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    counters: &MessageCounters,
+) -> bool {
+    counters.increment_io_handler_messages_sent();
+    let notification: Message = PollInputRequest::build_available_notification();
+    if vm_stdin_tx
+        .send(IkcFrame::Message(notification))
+        .await
+        .is_err()
+    {
+        error!("standalone io_handler: failed to notify VFSD of console input");
+        false
+    } else {
+        true
+    }
+}
+
+/// Sends the bulk payload and acknowledgement for a completed console read.
+async fn send_console_read_response(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    tid: ThreadIdentifier,
+    pull_header: DataChunkHeader,
+    data: Vec<u8>,
+    counters: &MessageCounters,
+) {
+    let actual_len: u32 = match u32::try_from(data.len()) {
+        Ok(actual_len) => actual_len,
+        Err(_) => {
+            error!("standalone io_handler: console read length overflows u32");
+            return;
+        },
+    };
     let response_header: DataChunkHeader = DataChunkHeader::new(
         pull_header.source_pid(),
         pull_header.source_tid(),
@@ -1219,32 +1515,72 @@ async fn handle_read_request(
         pull_header.data_addr(),
         actual_len,
     );
-    let response_bulk: DataChunk = DataChunk::new(response_header, data);
-
-    // Increment once for the bulk frame and once for the message response that follow.
     counters.increment_io_handler_messages_sent();
     counters.increment_io_handler_messages_sent();
     if vm_stdin_tx
-        .send(IkcFrame::Bulk(response_bulk))
+        .send(IkcFrame::Bulk(DataChunk::new(response_header, data)))
         .await
         .is_err()
     {
-        error!("standalone io_handler: failed to send bulk response (VM input channel closed)");
+        error!("standalone io_handler: failed to send console read bulk response");
         return;
     }
 
-    // Send ReadResponse to guest. The empty buffer is expected — actual data was already
-    // transferred via the bulk frame above.
-    let empty_buf: [u8; ReadResponse::BUFFER_SIZE] = [0u8; ReadResponse::BUFFER_SIZE];
     let response: Message = ReadResponse::build(
         tid,
         actual_len.cast_signed(),
-        empty_buf,
+        [0u8; ReadResponse::BUFFER_SIZE],
         ProcessIdentifier::KERNEL,
         MessageType::Ikc,
     );
     if vm_stdin_tx.send(IkcFrame::Message(response)).await.is_err() {
-        error!("standalone io_handler: failed to send ReadResponse (VM input channel closed)");
+        error!("standalone io_handler: failed to send console read response");
+    }
+}
+
+/// Sends an immediate console input snapshot through the pending pull.
+async fn send_console_poll_response(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    pull_header: DataChunkHeader,
+    data: Vec<u8>,
+    counters: &MessageCounters,
+) {
+    let data_len: u32 = match u32::try_from(data.len()) {
+        Ok(data_len) => data_len,
+        Err(_) => {
+            error!("standalone io_handler: poll-input response length overflows u32");
+            return;
+        },
+    };
+    let response_header: DataChunkHeader = DataChunkHeader::new(
+        pull_header.source_pid(),
+        pull_header.source_tid(),
+        pull_header.destination_pid(),
+        pull_header.destination_tid(),
+        pull_header.data_addr(),
+        data_len,
+    );
+    counters.increment_io_handler_messages_sent();
+    if vm_stdin_tx
+        .send(IkcFrame::Bulk(DataChunk::new(response_header, data)))
+        .await
+        .is_err()
+    {
+        error!("standalone io_handler: failed to send poll-input bulk response");
+    }
+}
+
+/// Sends an immediate console readiness status without a bulk transfer.
+async fn send_console_poll_status(
+    vm_stdin_tx: &mpsc::Sender<IkcFrame>,
+    tid: ThreadIdentifier,
+    status: u8,
+    counters: &MessageCounters,
+) {
+    counters.increment_io_handler_messages_sent();
+    let response: Message = PollInputResponse::build(tid, status);
+    if vm_stdin_tx.send(IkcFrame::Message(response)).await.is_err() {
+        error!("standalone io_handler: failed to send poll-input status response");
     }
 }
 

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -340,7 +340,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-network"
 program = "./bin/test-c-network.initrd"
-extra_nanvixd_args = "-allow-host-networking"
+extra_nanvixd_args = "-allow-host-networking -mount ./bin/posix-tests-ramfs-seed"
 expected_exit_code = 0
 
 [[tests]]


### PR DESCRIPTION
## Summary

Add end-to-end `poll()` support so guests can wait on the readiness of
console, pipe, and socket descriptors, with per-fd `revents` reported by
the owning daemon. Console reads now park in VFSD and resume when cooked
input or EOF becomes available instead of blocking the UserVM I/O handler.

## What changed

**Syscall / libraries**
- New `syscall::poll` message types (input, socket, request/response) and
  poll syscall plumbing; `fdtable` poll routing; reworked `read` syscall.
- `net-backend` gains `poll_socket()` with unix and windows backends.
- `vfs` fd, line discipline, and pipe end extended with readiness support.
- Define `POLLRDBAND`/`POLLWRBAND` and update poll header bindings.

**Daemons**
- VFSD: new `console_wait` table for parked console readers plus a poll
  handler that probes console/pipe readiness.
- networkd: dispatch `PollSocketRequest` to the socket backend.

**UserVM**
- Replace inline stdin buffering with an asynchronous console input
  broker handling blocking reads, poll snapshots, and subscriptions.

**Supporting fix**
- Fix `SystemTime` `checked_sub` comparison in `sys`.

## Tests

Expanded the C poll() integration coverage:
- `test-c-file`: focused cases for argument validation/timeout, regular
  files, pipes (early wakeup, hangup, errors), and signal interruption;
  enabled poll sub-tests under the standalone VFS and added a
  hostfs-backed poll test.
- `test-c-network`: new `poll.c` for socket readiness plus extended
  `inet.c`.
- Build harness gated behind a new `NANVIX_TEST_HOSTFS` flag.