### PR TITLE
[ci] Fix Windows Release Artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1672,8 +1672,7 @@ jobs:
       - name: "Download Windows Build Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-build-${{ matrix.machine-type }}-release-${{ matrix.memory-size
-            }}mb
+          name: windows-build-${{ matrix.target-arch }}-${{matrix.machine-type }}-release-${{ matrix.memory-size }}mb
           path: windows-bin
 
       - name: "Package Windows Release Archive"


### PR DESCRIPTION
## Summary

- include the target architecture in the Windows release artifact lookup
- match the artifact name produced by `windows-ci-build`
- fix the failure observed in scheduled workflow run https://github.com/nanvix/nanvix/actions/runs/30509291456

## Testing

- `./z build -- format-check`
- parsed `.github/workflows/ci.yml` with PyYAML
- verified the producer and consumer artifact-name templates match