### PR TITLE
[syscall] B: Preserve RPC Responses Across EINTR

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -61,6 +61,7 @@ ALL_POSIX_TESTS := \
 	test-c-regex \
 	test-c-send \
 	test-c-setjmp \
+	test-c-signal-rpc \
 	test-c-sigmask \
 	test-c-stdio \
 	test-c-termios \

--- a/src/libs/proc/src/syscall/job_control.rs
+++ b/src/libs/proc/src/syscall/job_control.rs
@@ -67,7 +67,7 @@ fn job_control(
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait for the response from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Parse response.
     match message.message_type {

--- a/src/libs/proc/src/syscall/kill.rs
+++ b/src/libs/proc/src/syscall/kill.rs
@@ -53,7 +53,7 @@ pub fn kill(target: ProcessIdentifier, signum: i32) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait response from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Parse response.
     match message.message_type {

--- a/src/libs/proc/src/syscall/lookup.rs
+++ b/src/libs/proc/src/syscall/lookup.rs
@@ -52,7 +52,7 @@ pub fn lookup(name: &str) -> Result<ProcessIdentifier, Error> {
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait response from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Parse response.
     match message.message_type {

--- a/src/libs/proc/src/syscall/signup.rs
+++ b/src/libs/proc/src/syscall/signup.rs
@@ -49,7 +49,7 @@ pub fn signup(pid: &ProcessIdentifier, name: &str) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait unblock message from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Parse message.
     match message.message_type {

--- a/src/libs/proc/src/syscall/wait.rs
+++ b/src/libs/proc/src/syscall/wait.rs
@@ -76,7 +76,7 @@ pub fn wait(target: WaitTarget, options: i32) -> Result<WaitOutcome, Error> {
     ::sys::kcall::ipc::__kcall_send(&message)?;
 
     // Wait response from the process manager daemon.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Parse response.
     match message.message_type {

--- a/src/libs/sys/src/sys/kcall/ipc.rs
+++ b/src/libs/sys/src/sys/kcall/ipc.rs
@@ -58,6 +58,21 @@ pub fn __kcall_recv() -> Result<Message, Error> {
     }
 }
 
+/// Receives the response to an RPC request that has already been submitted.
+///
+/// Once the request is visible to the remote side, it may already have committed or may still
+/// complete after a signal interrupts the underlying receive. Abandoning the logical RPC on
+/// `EINTR` would leave its eventual response in the caller's mailbox, so resume waiting after the
+/// signal handler returns.
+pub fn __kcall_recv_response() -> Result<Message, Error> {
+    loop {
+        match __kcall_recv() {
+            Err(error) if error.code == ErrorCode::Interrupted => {},
+            result => return result,
+        }
+    }
+}
+
 //==================================================================================================
 // Rendezvous Push
 //==================================================================================================

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -95,7 +95,7 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
 
     loop {
         // Wait for response message.
-        let response: Message = ::sys::kcall::ipc::__kcall_recv().map_err(|error| {
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response().map_err(|error| {
             let reason: &str = "failed to receive message";
             warn!("posix_getdents(): {reason} (error={:?})", error);
             Error::new(error.code, reason)

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -71,7 +71,7 @@ pub fn posix_fadvise(
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -57,7 +57,7 @@ pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Resu
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -47,7 +47,7 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -49,7 +49,7 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -70,7 +70,7 @@ pub fn renameat(
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -58,7 +58,7 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -373,7 +373,7 @@ fn resolve_via_vfsd(fd: i32) -> Result<VfsdResolution, Error> {
     }
     let mut interrupted: Option<Error> = None;
     let response: Message = loop {
-        match ::sys::kcall::ipc::__kcall_recv() {
+        match ::sys::kcall::ipc::__kcall_recv_response() {
             Ok(response) => break response,
             Err(error) if error.code == ::sys::error::ErrorCode::Interrupted => {
                 interrupted.get_or_insert(error);

--- a/src/libs/syscall/src/sys/ioctl/control.rs
+++ b/src/libs/syscall/src/sys/ioctl/control.rs
@@ -172,7 +172,7 @@ fn tty_pull(fd: i32, request: c_int, out: *mut u8, len: usize) -> Result<c_int, 
     ::sys::kcall::ipc::__kcall_send(&req)?;
     let bytes_pulled: usize =
         ::sys::kcall::ipc::__kcall_pull(crate::VFS_PUSH_PULL_PID, crate::VFS_PUSH_PULL_TID, out)?;
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
     check_status(&response)?;
 
     // On success vfsd pushes the full payload; a short pull would leave `out` only partially
@@ -207,7 +207,7 @@ fn tty_push(fd: i32, request: c_int, data: &[u8]) -> Result<c_int, Error> {
     );
     ::sys::kcall::ipc::__kcall_send(&req)?;
     ::sys::kcall::ipc::__kcall_push(crate::VFS_PUSH_PULL_PID, crate::VFS_PUSH_PULL_TID, data)?;
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
     check_status(&response)?;
     Ok(0)
 }

--- a/src/libs/syscall/src/sys/mount/syscall/mount_impl.rs
+++ b/src/libs/syscall/src/sys/mount/syscall/mount_impl.rs
@@ -63,7 +63,7 @@ pub fn mount(source: &str, target: &str, fstype: &str, flags: u64) -> Result<(),
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/mount/syscall/umount_impl.rs
+++ b/src/libs/syscall/src/sys/mount/syscall/umount_impl.rs
@@ -53,7 +53,7 @@ pub fn umount(target: &str) -> Result<(), Error> {
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -42,7 +42,7 @@ pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -41,7 +41,7 @@ pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -61,7 +61,7 @@ pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -57,7 +57,7 @@ pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -57,7 +57,7 @@ pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -35,7 +35,7 @@ pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn register_socket_slot(
         close_networkd_endpoint(remote_fd);
         return Err(e);
     }
-    let response = match ::sys::kcall::ipc::__kcall_recv() {
+    let response = match ::sys::kcall::ipc::__kcall_recv_response() {
         Ok(response) => response,
         Err(e) => {
             close_networkd_endpoint(remote_fd);
@@ -135,6 +135,6 @@ fn close_networkd_endpoint(remote_fd: ::sysapi::ffi::c_int) {
     };
     let request = CloseRequest::build(tid, remote_fd, crate::NETWORK_DESTINATION, MessageType::Ikc);
     if ::sys::kcall::ipc::__kcall_send(&request).is_ok() {
-        let _ = ::sys::kcall::ipc::__kcall_recv();
+        let _ = ::sys::kcall::ipc::__kcall_recv_response();
     }
 }

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -58,7 +58,7 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
     )?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recvfrom.rs
@@ -81,7 +81,7 @@ pub fn recvfrom(
     )?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -77,7 +77,7 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
     )?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/sendto.rs
@@ -89,7 +89,7 @@ pub fn sendto(
     ::sys::kcall::ipc::__kcall_push(ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL, buffer)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -38,7 +38,7 @@ pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -40,7 +40,7 @@ pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Res
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -70,7 +70,7 @@ pub fn socketpair(
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -70,7 +70,7 @@ pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -59,7 +59,7 @@ pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(
         ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -55,7 +55,7 @@ pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Erro
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -64,7 +64,7 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mod.rs
@@ -79,7 +79,7 @@ fn fstatat_response() -> Result<sys_stat::stat, Error> {
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/sys/stat/syscall/umask.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/umask.rs
@@ -46,7 +46,7 @@ pub fn umask(mask: mode_t) -> Result<mode_t, Error> {
         FileCreationMaskRequest::build(tid, mask, crate::VFS_DESTINATION, crate::VFS_MESSAGE_TYPE);
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
     if response.status != 0 {
         let error_code: ErrorCode = ErrorCode::try_from(response.status)?;
         return Err(Error::new(error_code, "umask() failed"));

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -75,7 +75,7 @@ pub fn utimensat(
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/exec/mod.rs
+++ b/src/libs/syscall/src/unistd/exec/mod.rs
@@ -659,15 +659,16 @@ pub fn exec_startup_barrier() {
     // has applied close-on-exec, or with a failure status if the relay could not be dispatched — so
     // exactly one acknowledgement is expected, and it is the only message in flight before `main`.
     //
-    // The wait is therefore a single receive: validate the reply and proceed. The image has already
-    // been replaced and the exec cannot be undone, so a malformed, misdelivered, or failing reply
-    // is logged and tolerated rather than retried. A retry loop would be unsafe here, not just
-    // unhelpful: crt0 has no non-blocking or timed receive primitive, so a second receive after an
-    // unexpected first message would block with nothing left to deliver. The self-addressed case
-    // (this image is `PROCD`) is already excluded above, so a separate procd is guaranteed to be
-    // the sender; a genuinely silent procd is a daemon-crash scenario beyond what the barrier can
-    // recover, exactly as for the fork barrier this mirrors.
-    let message: Message = match ::sys::kcall::ipc::__kcall_recv() {
+    // The wait is therefore for one logical response: an interrupted receive resumes after the
+    // signal handler, but the first delivered reply is validated and consumed exactly once. The
+    // image has already been replaced and the exec cannot be undone, so a malformed, misdelivered,
+    // or failing reply is logged and tolerated rather than followed by another receive. Waiting for
+    // a second delivered message would be unsafe here, not just unhelpful: crt0 has no non-blocking
+    // or timed receive primitive, so it would block with nothing left to deliver. The self-addressed
+    // case (this image is `PROCD`) is already excluded above, so a separate procd is guaranteed to
+    // be the sender; a genuinely silent procd is a daemon-crash scenario beyond what the barrier
+    // can recover, exactly as for the fork barrier this mirrors.
+    let message: Message = match ::sys::kcall::ipc::__kcall_recv_response() {
         Ok(message) => message,
         Err(error) => {
             ::syslog::warn!("exec_startup_barrier(): failed to receive exec ack: {error:?}");

--- a/src/libs/syscall/src/unistd/fork/mod.rs
+++ b/src/libs/syscall/src/unistd/fork/mod.rs
@@ -113,7 +113,7 @@ fn sync_child_after_fork() -> Result<(), Error> {
     // message a process inside this window — a child is not yet known to any peer, and the parent
     // is blocked here rather than servicing requests. A stray message would be reported as an error
     // (below) and fail `fork()`, rather than being silently mistaken for the acknowledgement.
-    let message: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let message: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     match message.message_type {
         MessageType::Ipc => {

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -54,7 +54,7 @@ pub fn chdir(path: &str) -> Result<(), Error> {
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -99,7 +99,7 @@ fn close_ipc(
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/dup2.rs
+++ b/src/libs/syscall/src/unistd/syscall/dup2.rs
@@ -54,7 +54,7 @@ fn dup2_via_vfsd(oldfd: c_int, newfd: c_int) -> Result<c_int, Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether the system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -63,7 +63,7 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
         ::sys::kcall::ipc::__kcall_send(&request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -45,7 +45,7 @@ pub fn fchdir(fd: c_int) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -75,7 +75,7 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -77,7 +77,7 @@ pub fn fchownat(
         ::sys::kcall::ipc::__kcall_send(request)?;
     }
 
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -52,7 +52,7 @@ pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -48,7 +48,7 @@ pub fn fsync(fd: c_int) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -57,7 +57,7 @@ pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -68,7 +68,7 @@ fn getcwd_response() -> Result<String, Error> {
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
         // Check whether the system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -79,7 +79,7 @@ pub fn linkat(
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -72,7 +72,7 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -44,7 +44,7 @@ fn pipe_vfsd() -> Result<[i32; 2], Error> {
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
     parse_pipe_response(response)
 }
 

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -96,7 +96,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -101,7 +101,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         ::sys::kcall::ipc::__kcall_send(&request)?;
 
         // Receive response.
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
         // Check whether the system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -73,7 +73,7 @@ pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, E
     let mut assembler: SystemCallLongMessage = SystemCallLongMessage::new(capacity)?;
 
     loop {
-        let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+        let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
         // Check whether system call succeeded or not.
         if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -67,7 +67,7 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
     }
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -77,7 +77,7 @@ fn write_chunk(
     ::sys::kcall::ipc::__kcall_push(push_pid, push_tid, chunk)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = ::sys::kcall::ipc::__kcall_recv_response()?;
 
     // Check whether system call succeeded or not.
     if response.status != 0 {

--- a/src/tests/integration/test-c-signal-rpc/main.c
+++ b/src/tests/integration/test-c-signal-rpc/main.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Regression test for signal interruption after an RPC request is committed.
+ *
+ * The parent fills a pipe and blocks while writing one more byte. One child
+ * exits to deliver SIGCHLD without SA_RESTART; another child drains one byte
+ * later so vfsd can complete the already-submitted write. The write must resume
+ * waiting for that response instead of returning EINTR and stranding it in the
+ * parent mailbox. A final fork verifies that the mailbox remains empty.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define CHECK(step, condition)                                                 \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      return (step);                                                           \
+    }                                                                          \
+  } while (0)
+
+static volatile sig_atomic_t signal_count;
+
+static void handle_signal(int signum) {
+  if (signum == SIGCHLD) {
+    signal_count++;
+  }
+}
+
+static int wait_for_child(pid_t child) {
+  int status = 0;
+  pid_t result;
+  do {
+    result = waitpid(child, &status, 0);
+  } while (result == -1 && errno == EINTR);
+
+  return result == child && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  struct sigaction action;
+  struct sigaction old_action;
+  memset(&action, 0, sizeof(action));
+  action.sa_handler = handle_signal;
+  CHECK(1, sigemptyset(&action.sa_mask) == 0);
+  CHECK(2, sigaction(SIGCHLD, &action, &old_action) == 0);
+
+  int pipefds[2];
+  CHECK(3, pipe(pipefds) == 0);
+
+  int startfds[2];
+  CHECK(4, pipe(startfds) == 0);
+
+  int flags = fcntl(pipefds[1], F_GETFL);
+  CHECK(5, flags != -1);
+  CHECK(6, fcntl(pipefds[1], F_SETFL, flags | O_NONBLOCK) == 0);
+
+  static const char fill[4096];
+  for (;;) {
+    ssize_t written = write(pipefds[1], fill, sizeof(fill));
+    if (written == -1) {
+      CHECK(7, errno == EAGAIN);
+      break;
+    }
+    CHECK(8, written == (ssize_t)sizeof(fill));
+  }
+  CHECK(9, fcntl(pipefds[1], F_SETFL, flags & ~O_NONBLOCK) == 0);
+
+  pid_t signal_child = fork();
+  CHECK(10, signal_child != -1);
+  if (signal_child == 0) {
+    const struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = 10000000,
+    };
+    char start;
+    if (close(startfds[1]) != 0 || close(pipefds[0]) != 0 ||
+        close(pipefds[1]) != 0 || read(startfds[0], &start, 1) != 1 ||
+        close(startfds[0]) != 0 || nanosleep(&delay, NULL) != 0) {
+      _exit(1);
+    }
+
+    _exit(0);
+  }
+
+  pid_t drain_child = fork();
+  CHECK(11, drain_child != -1);
+  if (drain_child == 0) {
+    const struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = 50000000,
+    };
+    char start;
+    char byte;
+    if (close(startfds[1]) != 0 || close(pipefds[1]) != 0 ||
+        read(startfds[0], &start, 1) != 1 || close(startfds[0]) != 0 ||
+        nanosleep(&delay, NULL) != 0 || read(pipefds[0], &byte, 1) != 1 ||
+        close(pipefds[0]) != 0) {
+      _exit(2);
+    }
+    _exit(0);
+  }
+
+  CHECK(12, close(startfds[0]) == 0);
+  signal_count = 0;
+  const char start[2] = {'s', 'd'};
+  CHECK(13, write(startfds[1], start, sizeof(start)) == (ssize_t)sizeof(start));
+  CHECK(14, close(startfds[1]) == 0);
+
+  const char byte = 'x';
+  errno = 0;
+  CHECK(15, write(pipefds[1], &byte, 1) == 1);
+  CHECK(16, signal_count > 0);
+  CHECK(17, wait_for_child(signal_child));
+  CHECK(18, wait_for_child(drain_child));
+  CHECK(19, close(pipefds[0]) == 0);
+  CHECK(20, close(pipefds[1]) == 0);
+
+  pid_t child = fork();
+  CHECK(21, child != -1);
+  if (child == 0) {
+    _exit(0);
+  }
+  CHECK(22, wait_for_child(child));
+  CHECK(23, sigaction(SIGCHLD, &old_action, NULL) == 0);
+
+  return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -375,6 +375,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-signal-rpc"
+program = "./bin/test-c-signal-rpc.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-sigmask"
 program = "./bin/test-c-sigmask.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -375,6 +375,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-signal-rpc"
+program = "./bin/test-c-signal-rpc.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-sigmask"
 program = "./bin/test-c-sigmask.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

- add a committed-RPC response helper that resumes `recv()` after signal interruption
- migrate direct syscall/process RPC response waits while preserving custom `read()` and `poll()` interruption handling
- add a Linux/Windows C regression that overlaps `SIGCHLD` with a committed pipe write and verifies the parent mailbox remains clean

## Root cause

A caught signal can interrupt the final `recv()` of a userspace RPC after its request has already reached the backend. Returning `EINTR` abandons the eventual response; callers that retry the outer operation can then consume mismatched responses or leave the mailbox nonempty, producing the BusyBox `/dev/null` and `fork()` failures.

## Validation

- repository pre-commit checks passed
- `test-c-signal-rpc` passes 20/20 locally; reverting only the write response helper fails deterministically at step 15
- focused POSIX suites pass: file, fork-pid, fork-pthread, sigmask, signal-rpc
- guest `cargo check` and Clippy with `-D warnings` pass for `sys`, `proc`, and `syscall`
- 31 host-supported `sys`/`proc` unit tests pass
- Linux and Windows POSIX manifests each select the new test exactly once

Closes #3008
Related to #3007