### PR TITLE
[libs] F: Implement pthread cleanup handlers

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -96,6 +96,8 @@ typedef struct {
  * Threads
  *==================================================================================================*/
 
+extern void _pthread_cleanup_pop(int execute);
+extern void _pthread_cleanup_push(void (*routine)(void *), void *arg);
 extern int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
 extern int pthread_join(pthread_t thread, void **retval_ptr);
 extern int pthread_detach(pthread_t thread);

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -111,6 +111,8 @@ text = '''
 [[sections]]
 title = "Threads"
 functions = [
+    "_pthread_cleanup_pop",
+    "_pthread_cleanup_push",
     "pthread_create",
     "pthread_join",
     "pthread_detach",

--- a/src/libs/syscall/src/pthread/bindings/_pthread_cleanup_pop.rs
+++ b/src/libs/syscall/src/pthread/bindings/_pthread_cleanup_pop.rs
@@ -1,0 +1,28 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Pops the top cancellation cleanup handler from the calling thread's cleanup stack.
+///
+/// # Parameters
+///
+/// - `execute`: Whether to invoke the cleanup handler.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub extern "C" fn _pthread_cleanup_pop(execute: c_int) {
+    crate::pthread::pthread_cleanup_pop(execute != 0);
+}

--- a/src/libs/syscall/src/pthread/bindings/_pthread_cleanup_push.rs
+++ b/src/libs/syscall/src/pthread/bindings/_pthread_cleanup_push.rs
@@ -1,0 +1,37 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::c_void;
+use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Pushes a cancellation cleanup handler onto the calling thread's cleanup stack.
+///
+/// # Parameters
+///
+/// - `routine`: Cleanup routine.
+/// - `arg`: Argument to pass to the cleanup routine.
+///
+#[unsafe(no_mangle)]
+#[trace_libcall]
+pub extern "C" fn _pthread_cleanup_push(
+    routine: Option<extern "C" fn(*mut c_void)>,
+    arg: *mut c_void,
+) {
+    if routine.is_none() {
+        ::syslog::warn!("_pthread_cleanup_push(): invalid cleanup routine");
+    }
+
+    // A null routine is still pushed, so that the cleanup stack stays balanced with pops.
+    crate::pthread::pthread_cleanup_push(routine, arg);
+}

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -5,6 +5,8 @@
 // Modules
 //==================================================================================================
 
+pub mod _pthread_cleanup_pop;
+pub mod _pthread_cleanup_push;
 pub mod pthread_atfork;
 pub mod pthread_attr_destroy;
 pub mod pthread_attr_getstack;

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -11,6 +11,8 @@ cfg_if::cfg_if! {
         pub use syscall::Pointer;
         pub use syscall::pthread_attr_destroy;
         pub use syscall::pthread_attr_init;
+        pub use syscall::pthread_cleanup_pop;
+        pub use syscall::pthread_cleanup_push;
         pub use syscall::pthread_create;
         pub use syscall::pthread_exit;
         pub use syscall::pthread_getattr_np;

--- a/src/libs/syscall/src/pthread/syscall/cleanup.rs
+++ b/src/libs/syscall/src/pthread/syscall/cleanup.rs
@@ -1,0 +1,131 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::tda::Pointer;
+use ::alloc::{
+    collections::btree_map::BTreeMap,
+    vec::Vec,
+};
+use ::spin::{
+    Lazy,
+    Mutex,
+};
+use ::sysapi::{
+    ffi::c_void,
+    sys_types::pthread_t,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// A cancellation cleanup handler.
+struct CleanupHandler {
+    /// Routine to invoke.
+    routine: Option<extern "C" fn(*mut c_void)>,
+    /// Argument to pass to the routine.
+    arg: Pointer,
+}
+
+impl CleanupHandler {
+    /// Invokes this cleanup handler.
+    fn call(self) {
+        if let Some(routine) = self.routine {
+            let arg: *mut c_void = self.arg.into();
+            routine(arg);
+        }
+    }
+}
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Cancellation cleanup handlers, indexed by thread identifier.
+static CLEANUP_HANDLERS: Lazy<Mutex<BTreeMap<pthread_t, Vec<CleanupHandler>>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Returns the identifier of the calling thread.
+fn current_thread(operation: &str) -> Option<pthread_t> {
+    match super::try_pthread_self() {
+        Ok(tid) => Some(tid),
+        Err(error) => {
+            ::syslog::warn!("{operation}(): failed to get thread identifier ({error:?})");
+            None
+        },
+    }
+}
+
+/// Removes and returns the top cleanup handler for `tid`.
+fn pop_handler(tid: pthread_t) -> Option<CleanupHandler> {
+    let mut handlers = CLEANUP_HANDLERS.lock();
+    let (handler, is_empty): (Option<CleanupHandler>, bool) = {
+        let stack: &mut Vec<CleanupHandler> = handlers.get_mut(&tid)?;
+        let handler: Option<CleanupHandler> = stack.pop();
+        (handler, stack.is_empty())
+    };
+
+    if is_empty {
+        handlers.remove(&tid);
+    }
+
+    handler
+}
+
+/// Pushes a cancellation cleanup handler for the calling thread.
+pub fn pthread_cleanup_push(routine: Option<extern "C" fn(*mut c_void)>, arg: *mut c_void) {
+    let Some(tid): Option<pthread_t> = current_thread("_pthread_cleanup_push") else {
+        return;
+    };
+    let handler: CleanupHandler = CleanupHandler {
+        routine,
+        arg: Pointer::from(arg),
+    };
+
+    CLEANUP_HANDLERS
+        .lock()
+        .entry(tid)
+        .or_default()
+        .push(handler);
+}
+
+/// Pops the top cancellation cleanup handler for the calling thread and optionally invokes it.
+pub fn pthread_cleanup_pop(execute: bool) {
+    let Some(tid): Option<pthread_t> = current_thread("_pthread_cleanup_pop") else {
+        return;
+    };
+
+    if let Some(handler) = pop_handler(tid) {
+        if execute {
+            handler.call();
+        }
+    }
+}
+
+/// Invokes and removes all cancellation cleanup handlers for the calling thread.
+pub(super) fn run() {
+    let Some(tid): Option<pthread_t> = current_thread("pthread_exit") else {
+        return;
+    };
+
+    while let Some(handler) = pop_handler(tid) {
+        handler.call();
+    }
+}
+
+/// Removes all cancellation cleanup handlers for the calling thread without invoking them.
+pub(super) fn discard() {
+    let Some(tid): Option<pthread_t> = current_thread("pthread_start") else {
+        return;
+    };
+
+    CLEANUP_HANDLERS.lock().remove(&tid);
+}

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -5,6 +5,9 @@
 // Modules
 //==================================================================================================
 
+/// Cancellation cleanup handlers.
+mod cleanup;
+
 /// Condition variables.
 mod cond;
 
@@ -76,6 +79,10 @@ use ::sysapi::sys_types::pthread_t;
 // Exports
 //==================================================================================================
 
+pub use cleanup::{
+    pthread_cleanup_pop,
+    pthread_cleanup_push,
+};
 pub use cond::*;
 pub use mutex::*;
 pub use pthread_attr_destroy::*;
@@ -106,6 +113,10 @@ struct ThreadStartArgs {
 extern "C" fn pthread_start(arg: usize) -> usize {
     let start_args: Box<ThreadStartArgs> = unsafe { Box::from_raw(arg as *mut ThreadStartArgs) };
     let retval: usize = (start_args.func)(start_args.arg);
+
+    // Handlers left pending on a normal return are discarded rather than run, because their
+    // arguments commonly point into the start routine's stack frame, which is already gone.
+    cleanup::discard();
 
     if let Err(error) = ::sysalloc::tda::cleanup() {
         ::syslog::warn!("pthread_start(): failed to cleanup thread data area ({error:?})");
@@ -256,6 +267,8 @@ pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
 ///
 pub fn pthread_exit(retval: usize) -> Result<!, Error> {
     ::syslog::trace!("pthread_exit(): retval={:?}", retval);
+
+    cleanup::run();
 
     // Attempt to clean up thread data area and check for errors.
     if let Err(error) = ::sysalloc::tda::cleanup() {

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -269,19 +269,14 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
 ///
 /// # Description
 ///
-/// Returns the identifier of the calling thread.
+/// Resolves the identifier of the calling thread, preferring the TDA cache over a kernel call.
 ///
 /// # Return Value
 ///
-/// The identifier of the calling thread.
+/// On successful completion, the identifier of the calling thread is returned. On failure, an error
+/// that contains the reason for the failure is returned instead.
 ///
-/// # Safety Notes
-///
-/// This function panics if:
-/// - The thread is unable to retrieve its own identifier.
-/// - The thread identifier returned by the kernel is not valid.
-///
-pub fn pthread_self() -> pthread_t {
+fn try_pthread_self() -> Result<pthread_t, Error> {
     // Fast path: read the cached thread ID from the TDA via segment register.
     //
     // Safety: `is_initialized()` indicates that TDA support was initialized for the process, and
@@ -293,27 +288,39 @@ pub fn pthread_self() -> pthread_t {
 
         // Check if the TDA slot contains a valid thread ID.
         if tid != TDA_TID_UNSET {
-            return tid as pthread_t;
+            return Ok(tid as pthread_t);
         }
 
         // Cache miss: the TDA slot still holds the TDA_TID_UNSET sentinel because tda::alloc()
         // cannot know the child's TID at allocation time. Resolve via kcall and cache for future
         // calls.
-        let real_tid: pthread_t = __kcall_gettid()
-            .expect("pthread_self(): gettid kcall failed (TDA cache-miss path)")
-            .try_into()
-            .expect("pthread_self(): invalid thread identifier from kernel (TDA cache-miss path)");
+        let real_tid: pthread_t = __kcall_gettid()?.try_into()?;
 
         unsafe {
             arch::write_tda_u32(TDA_TID_OFFSET as u32, real_tid);
         }
 
-        return real_tid;
+        return Ok(real_tid);
     }
 
     // Fallback: TDA not yet initialized (early startup).
-    __kcall_gettid()
-        .expect("pthread_self(): gettid kcall failed (early-startup path)")
-        .try_into()
-        .expect("pthread_self(): invalid thread identifier from kernel (early-startup path)")
+    __kcall_gettid()?.try_into()
+}
+
+///
+/// # Description
+///
+/// Returns the identifier of the calling thread.
+///
+/// # Return Value
+///
+/// The identifier of the calling thread.
+///
+/// # Safety Notes
+///
+/// This function panics if the calling thread is unable to resolve its own identifier. POSIX
+/// reserves no return value to report such a failure.
+///
+pub fn pthread_self() -> pthread_t {
+    try_pthread_self().expect("pthread_self(): failed to resolve thread identifier")
 }

--- a/src/tests/integration/test-c-thread/cleanup.c
+++ b/src/tests/integration/test-c-thread/cleanup.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Cleanup event recorded by the main thread.
+#define MAIN_THREAD_EVENT 1
+
+// First cleanup event pushed by the worker thread.
+#define WORKER_FIRST_EVENT 2
+
+// Second cleanup event pushed by the worker thread.
+#define WORKER_SECOND_EVENT 3
+
+// Maximum number of cleanup events.
+#define CLEANUP_EVENTS_MAX 3
+
+// Expected worker thread exit status.
+#define EXPECTED_EXIT_STATUS ((void *)0xdeadbeef)
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+// Recorded cleanup events.
+struct cleanup_state {
+    int events[CLEANUP_EVENTS_MAX];
+    size_t count;
+};
+
+// Argument passed to a cleanup handler.
+struct cleanup_arg {
+    struct cleanup_state *state;
+    int event;
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Records a cleanup event.
+static void record_cleanup(void *arg)
+{
+    struct cleanup_arg *cleanup_arg = (struct cleanup_arg *)arg;
+    assert(cleanup_arg->state->count < CLEANUP_EVENTS_MAX);
+    cleanup_arg->state->events[cleanup_arg->state->count++] = cleanup_arg->event;
+}
+
+// Returns normally with a pending cleanup handler.
+static void *returning_worker(void *arg)
+{
+    struct cleanup_arg *cleanup_arg = (struct cleanup_arg *)arg;
+    _pthread_cleanup_push(record_cleanup, cleanup_arg);
+
+    return (EXPECTED_EXIT_STATUS);
+}
+
+// Exercises cleanup handlers in a worker thread.
+static void *cleanup_worker(void *arg)
+{
+    struct cleanup_state *state = (struct cleanup_state *)arg;
+    struct cleanup_arg first = {state, WORKER_FIRST_EVENT};
+    struct cleanup_arg second = {state, WORKER_SECOND_EVENT};
+
+    _pthread_cleanup_push(record_cleanup, &first);
+    _pthread_cleanup_push(record_cleanup, &second);
+    pthread_exit(EXPECTED_EXIT_STATUS);
+
+    return (NULL);
+}
+
+// Tests if cancellation cleanup handlers can be pushed and popped.
+void test_pthread_cleanup(void)
+{
+    fprintf(stderr, "testing _pthread_cleanup_push() and _pthread_cleanup_pop() ... ");
+
+    // Verify that popping a handler without executing it removes the handler.
+    struct cleanup_state pop_state = {{0}, 0};
+    struct cleanup_arg pop_arg = {&pop_state, MAIN_THREAD_EVENT};
+    _pthread_cleanup_push(record_cleanup, &pop_arg);
+    _pthread_cleanup_pop(0);
+    assert(pop_state.count == 0);
+
+    // Verify that popping a handler with a non-zero argument executes the handler.
+    _pthread_cleanup_push(record_cleanup, &pop_arg);
+    _pthread_cleanup_pop(1);
+    assert(pop_state.count == 1);
+    assert(pop_state.events[0] == MAIN_THREAD_EVENT);
+
+    // Verify that a NULL routine is a balanced no-op.
+    _pthread_cleanup_push(NULL, NULL);
+    _pthread_cleanup_pop(1);
+
+    // Verify that returning normally does not execute or retain a pending handler.
+    struct cleanup_state return_state = {{0}, 0};
+    struct cleanup_arg return_arg = {&return_state, MAIN_THREAD_EVENT};
+    pthread_t returning_worker_tid = PTHREAD_NULL;
+    int ret = pthread_create(&returning_worker_tid, NULL, returning_worker, &return_arg);
+    assert(ret == 0);
+
+    void *retval = NULL;
+    ret = pthread_join(returning_worker_tid, &retval);
+    assert(ret == 0);
+    assert(retval == EXPECTED_EXIT_STATUS);
+    assert(return_state.count == 0);
+
+    // Keep a handler pending in the main thread while a worker exits with two pending handlers.
+    struct cleanup_state exit_state = {{0}, 0};
+    struct cleanup_arg main_arg = {&exit_state, MAIN_THREAD_EVENT};
+    _pthread_cleanup_push(record_cleanup, &main_arg);
+
+    pthread_t worker = PTHREAD_NULL;
+    ret = pthread_create(&worker, NULL, cleanup_worker, &exit_state);
+    assert(ret == 0);
+
+    retval = NULL;
+    ret = pthread_join(worker, &retval);
+    assert(ret == 0);
+    assert(retval == EXPECTED_EXIT_STATUS);
+
+    // Worker handlers run in reverse push order without consuming the main thread's handler.
+    assert(exit_state.count == 2);
+    assert(exit_state.events[0] == WORKER_SECOND_EVENT);
+    assert(exit_state.events[1] == WORKER_FIRST_EVENT);
+    assert(return_state.count == 0);
+
+    _pthread_cleanup_pop(1);
+    assert(exit_state.count == 3);
+    assert(exit_state.events[2] == MAIN_THREAD_EVENT);
+
+    // Verify that fork preserves the calling thread's cleanup stack in both processes.
+    struct cleanup_state fork_state = {{0}, 0};
+    struct cleanup_arg fork_arg = {&fork_state, MAIN_THREAD_EVENT};
+    _pthread_cleanup_push(record_cleanup, &fork_arg);
+
+    pid_t child = fork();
+    assert(child >= 0);
+    if (child == 0) {
+        _pthread_cleanup_pop(1);
+        _exit(fork_state.count == 1 && fork_state.events[0] == MAIN_THREAD_EVENT ? 0 : 1);
+    }
+
+    int status = 0;
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status));
+    assert(WEXITSTATUS(status) == 0);
+    assert(fork_state.count == 0);
+
+    _pthread_cleanup_pop(1);
+    assert(fork_state.count == 1);
+    assert(fork_state.events[0] == MAIN_THREAD_EVENT);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/integration/test-c-thread/common.h
+++ b/src/tests/integration/test-c-thread/common.h
@@ -15,6 +15,9 @@ extern void test_pthread_testcancel(void);
 // Tests if the cancellation state of the calling thread can be changed.
 extern void test_pthread_setcancelstate(void);
 
+// Tests if cancellation cleanup handlers can be pushed and popped.
+extern void test_pthread_cleanup(void);
+
 // Tests if `pthread_mutex_cond_timedwait()` can be used for synchronization.
 extern void test_pthread_cond_timedwait(void);
 

--- a/src/tests/integration/test-c-thread/main.c
+++ b/src/tests/integration/test-c-thread/main.c
@@ -135,6 +135,7 @@ int main(int argc, const char *argv[])
     test_pthread_self();
     test_pthread_setcancelstate();
     test_pthread_testcancel();
+    test_pthread_cleanup();
     test_pthread_attr_init_destroy();
     test_pthread_attr_setdetachstate();
     test_pthread_attr_getguardsize();

--- a/src/tests/integration/test-rust-c-bindings/src/main.rs
+++ b/src/tests/integration/test-rust-c-bindings/src/main.rs
@@ -151,6 +151,8 @@ unsafe extern "C" {
     static __nanvix_sys_cached_pid: u8;
     static __errno_location: u8;
     static _exit: u8;
+    static _pthread_cleanup_pop: u8;
+    static _pthread_cleanup_push: u8;
     static accept: u8;
     static access: u8;
     static bind: u8;
@@ -294,10 +296,12 @@ unsafe impl Sync for SymAddr {}
 
 /// Force the linker to retain all syscall symbols by referencing their addresses.
 #[used]
-static SYSCALL_SYMBOLS: [SymAddr; 135] = [
+static SYSCALL_SYMBOLS: [SymAddr; 137] = [
     SymAddr(&raw const __nanvix_sys_cached_pid),
     SymAddr(&raw const __errno_location),
     SymAddr(&raw const _exit),
+    SymAddr(&raw const _pthread_cleanup_pop),
+    SymAddr(&raw const _pthread_cleanup_push),
     SymAddr(&raw const accept),
     SymAddr(&raw const access),
     SymAddr(&raw const bind),


### PR DESCRIPTION
## Summary

Implements the POSIX cancellation cleanup handlers `_pthread_cleanup_push()` and `_pthread_cleanup_pop()`, backed by a per-thread stack of handlers. Handlers run in reverse push order when a thread calls `pthread_exit()`, and are discarded on a normal return from the start routine (their arguments typically point into the already-unwound stack frame).

## What changed

**Libraries (`syscall`):**
- New `cleanup` module holding a `BTreeMap<pthread_t, Vec<CleanupHandler>>` with `push`/`pop` plus internal `run()`/`discard()` helpers. Routines are `Option<extern "C" fn(*mut c_void)>` so a NULL routine from C is sound and still balances the stack.
- Wired `cleanup::run()` into `pthread_exit()` and `cleanup::discard()` into `pthread_start()`; re-exported the two entry points and added the C bindings.
- Extracted the calling-thread lookup into a fallible `try_pthread_self()` backend (TDA-cached fast path with kcall fallback) so cleanup resolves the caller without an extra kernel call; `pthread_self()` keeps its POSIX panic contract as a thin wrapper.

**Headers:**
- Declared both functions in `include/pthread.h` and `pthread.toml`.

**Tests:**
- Added `test_pthread_cleanup()` to the `test-c-thread` suite covering pop-without-execute, pop-with-execute, normal return (no run/retain), and `pthread_exit()` (reverse order, no cross-thread consumption).
- Retained the new symbols in `test-rust-c-bindings`.

## Validation

`check-guest-rlibs`, `format-check`, `lint-check`, `spellcheck`, `all`, `run-unit-tests`, `run-nanvix-tests`, and `run-posix-tests` all pass.

closes #481, closes #482