### PR TITLE
[vfsd] Cancel Parked Pipe Ops on Signal

### DIFF
--- a/build/make/lists/guest-posix-tests.mk
+++ b/build/make/lists/guest-posix-tests.mk
@@ -61,6 +61,7 @@ ALL_POSIX_TESTS := \
 	test-c-regex \
 	test-c-send \
 	test-c-setjmp \
+	test-c-signal-rpc \
 	test-c-sigmask \
 	test-c-stdio \
 	test-c-termios \

--- a/src/daemons/vfsd/src/handler/pipe.rs
+++ b/src/daemons/vfsd/src/handler/pipe.rs
@@ -24,8 +24,12 @@ use crate::{
     },
 };
 use ::arch::mem::PAGE_SIZE;
+use ::core::time::Duration;
 use ::sys::{
-    error::ErrorCode,
+    error::{
+        Error,
+        ErrorCode,
+    },
     ipc::{
         Message,
         MessageType,
@@ -35,19 +39,27 @@ use ::sys::{
         ThreadIdentifier,
     },
 };
-use ::syscall::unistd::message::{
-    PipeResponse,
-    ReadResponse,
-    WriteResponse,
+use ::syscall::{
+    poll::input_message::PipeReadRetry,
+    unistd::message::{
+        PipeResponse,
+        ReadResponse,
+        WriteResponse,
+    },
 };
-use ::vfs::fd::{
-    set_current_process,
-    vfs_get_status_flags,
-    vfs_pipe,
-    vfs_pipe_read,
-    vfs_pipe_write,
-    PipeReadOutcome,
-    PipeWriteOutcome,
+use ::vfs::{
+    fd::{
+        set_current_process,
+        vfs_get_status_flags,
+        vfs_pipe,
+        vfs_pipe_consume,
+        vfs_pipe_peek,
+        vfs_pipe_read,
+        vfs_pipe_write,
+        PipeReadOutcome,
+        PipeWriteOutcome,
+    },
+    Fat32Error,
 };
 
 //==================================================================================================
@@ -59,6 +71,9 @@ use ::vfs::fd::{
 /// Matches the page-aligned chunk size the syscall layer uses, so a single request never exceeds
 /// this. It must stay within `PIPE_BUF` so that each request is performed atomically.
 const PIPE_BULK_SIZE: usize = PAGE_SIZE;
+
+/// Revive pushes are non-blocking probes; callers without a registered pull stay queued for retry.
+const PIPE_REVIVE_PUSH_TIMEOUT: Duration = Duration::ZERO;
 
 /// Compile-time guarantee that a single pipe request is always atomic.
 ///
@@ -84,10 +99,35 @@ fn is_nonblocking(fd: i32) -> bool {
     vfs_get_status_flags(fd) & ::sysapi::fcntl::file_status_flags::O_NONBLOCK != 0
 }
 
+/// Outcome of pushing data to a parked reader.
+enum PushOutcome {
+    /// The caller received the data.
+    Delivered,
+    /// The caller has not registered its pull yet and must remain queued.
+    Retry,
+    /// The caller cannot be reached and should be dropped.
+    Failed,
+}
+
 /// Pushes an empty buffer to `(pid, tid)` to release a caller blocked in `__kcall_pull`.
-fn push_empty(pid: ProcessIdentifier, tid: ThreadIdentifier) {
-    if let Err(e) = ::sys::kcall::ipc::__kcall_push(pid, tid, &[]) {
-        ::syslog::error!("pipe: unblock push failed (error={:?})", e);
+fn push_empty(pid: ProcessIdentifier, tid: ThreadIdentifier, reviving: bool) -> PushOutcome {
+    let result: Result<(), Error> = if reviving {
+        ::sys::kcall::ipc::__kcall_push_timed(pid, tid, &[], Some(PIPE_REVIVE_PUSH_TIMEOUT))
+    } else {
+        ::sys::kcall::ipc::__kcall_push(pid, tid, &[])
+    };
+    match result {
+        Ok(()) => PushOutcome::Delivered,
+        Err(error) if reviving && error.code == ErrorCode::OperationTimedOut => PushOutcome::Retry,
+        Err(error) => {
+            ::syslog::error!(
+                "pipe: unblock push failed (pid={:?}, tid={:?}, error={:?})",
+                pid,
+                tid,
+                error
+            );
+            PushOutcome::Failed
+        },
     }
 }
 
@@ -111,7 +151,8 @@ fn write_response(tid: ThreadIdentifier, n: usize) -> Message {
 ///
 /// The data push to the caller (for [`Served`](ServeOutcome::Served), [`Eof`](ServeOutcome::Eof),
 /// and [`Error`](ServeOutcome::Error)) is performed inside [`try_serve_reader`]; only
-/// [`WouldBlock`](ServeOutcome::WouldBlock) leaves the caller blocked in `__kcall_pull`.
+/// [`WouldBlock`](ServeOutcome::WouldBlock) and [`Retry`](ServeOutcome::Retry) leave the caller
+/// blocked in `__kcall_pull`.
 enum ServeOutcome {
     /// Pushed `N` bytes to the caller (`N > 0`).
     Served(usize),
@@ -121,6 +162,10 @@ enum ServeOutcome {
     WouldBlock,
     /// The descriptor was not a readable pipe end; pushed an empty buffer.
     Error,
+    /// The parked caller has not registered its pull yet and must remain queued.
+    Retry,
+    /// The parked caller cannot be reached and was dropped.
+    Abandoned,
 }
 
 /// Attempts a non-blocking read of `fd` into the shared buffer and, on success, pushes the bytes to
@@ -130,27 +175,82 @@ fn try_serve_reader(
     tid: ThreadIdentifier,
     fd: i32,
     count: usize,
+    reviving: bool,
 ) -> ServeOutcome {
     let cap: usize = count.min(PIPE_BULK_SIZE);
     // SAFETY: single-threaded; the borrow is released when this function returns, and the only
     // callee touched while it is held (`__kcall_push`) does not access the buffer itself.
     let buf: &mut [u8] = unsafe { &mut PIPE_BULK_BUFFER[..cap] };
-    match vfs_pipe_read(fd, buf) {
+    // A revive must not consume the bytes before they are known to have reached the caller: the
+    // push may time out on a caller that a signal pulled out of its `__kcall_pull`.
+    let read: Result<PipeReadOutcome, Fat32Error> = if reviving {
+        vfs_pipe_peek(fd, buf)
+    } else {
+        vfs_pipe_read(fd, buf)
+    };
+    match read {
         Ok(PipeReadOutcome::Read(n)) => {
-            if let Err(e) = ::sys::kcall::ipc::__kcall_push(pid, tid, &buf[..n]) {
-                ::syslog::error!("pipe read: push failed (error={:?})", e);
-                return ServeOutcome::Error;
+            let push: Result<(), Error> = if reviving {
+                ::sys::kcall::ipc::__kcall_push_timed(
+                    pid,
+                    tid,
+                    &buf[..n],
+                    Some(PIPE_REVIVE_PUSH_TIMEOUT),
+                )
+            } else {
+                ::sys::kcall::ipc::__kcall_push(pid, tid, &buf[..n])
+            };
+            match push {
+                Ok(()) => {},
+                Err(error) if reviving && error.code == ErrorCode::OperationTimedOut => {
+                    return ServeOutcome::Retry;
+                },
+                Err(error) => {
+                    ::syslog::error!(
+                        "pipe read: push failed (pid={:?}, tid={:?}, fd={}, error={:?})",
+                        pid,
+                        tid,
+                        fd,
+                        error
+                    );
+                    return if reviving {
+                        ServeOutcome::Abandoned
+                    } else {
+                        ServeOutcome::Error
+                    };
+                },
+            }
+            if reviving {
+                match vfs_pipe_consume(fd, n) {
+                    Ok(consumed) if consumed == n => {},
+                    Ok(consumed) => ::syslog::error!(
+                        "pipe read: consume count mismatch (fd={}, expected={}, consumed={})",
+                        fd,
+                        n,
+                        consumed
+                    ),
+                    Err(error) => ::syslog::error!(
+                        "pipe read: consume failed (fd={}, count={}, error={:?})",
+                        fd,
+                        n,
+                        error
+                    ),
+                }
             }
             ServeOutcome::Served(n)
         },
-        Ok(PipeReadOutcome::Eof) => {
-            push_empty(pid, tid);
-            ServeOutcome::Eof
+        Ok(PipeReadOutcome::Eof) => match push_empty(pid, tid, reviving) {
+            PushOutcome::Delivered => ServeOutcome::Eof,
+            PushOutcome::Retry => ServeOutcome::Retry,
+            PushOutcome::Failed if reviving => ServeOutcome::Abandoned,
+            PushOutcome::Failed => ServeOutcome::Eof,
         },
         Ok(PipeReadOutcome::WouldBlock) => ServeOutcome::WouldBlock,
-        Err(_) => {
-            push_empty(pid, tid);
-            ServeOutcome::Error
+        Err(_) => match push_empty(pid, tid, reviving) {
+            PushOutcome::Delivered => ServeOutcome::Error,
+            PushOutcome::Retry => ServeOutcome::Retry,
+            PushOutcome::Failed if reviving => ServeOutcome::Abandoned,
+            PushOutcome::Failed => ServeOutcome::Error,
         },
     }
 }
@@ -204,17 +304,17 @@ pub(crate) fn handle_pipe_read(
     // Reading the write end is rejected with `EBADF`, regardless of `count`. The caller is blocked
     // in `__kcall_pull`, so release it before sending the error response.
     if is_write {
-        push_empty(source_pid, source_tid);
+        push_empty(source_pid, source_tid, false);
         return Some(build_error(source_tid, ErrorCode::BadFile));
     }
 
     // A zero-length read returns immediately without blocking.
     if count == 0 {
-        push_empty(source_pid, source_tid);
+        push_empty(source_pid, source_tid, false);
         return Some(read_response(source_tid, 0));
     }
 
-    match try_serve_reader(source_pid, source_tid, fd, count) {
+    match try_serve_reader(source_pid, source_tid, fd, count, false) {
         ServeOutcome::Served(n) => {
             // Freed buffer space: a suspended writer may now make progress.
             rebalance(pipe_id, pipe_wait);
@@ -224,7 +324,7 @@ pub(crate) fn handle_pipe_read(
         ServeOutcome::WouldBlock => {
             if is_nonblocking(fd) {
                 // The caller is blocked in `__kcall_pull`; release it before the error response.
-                push_empty(source_pid, source_tid);
+                push_empty(source_pid, source_tid, false);
                 Some(build_error(source_tid, ErrorCode::TryAgain))
             } else {
                 pipe_wait.park_reader(
@@ -240,6 +340,8 @@ pub(crate) fn handle_pipe_read(
             }
         },
         ServeOutcome::Error => Some(build_error(source_tid, ErrorCode::BadFile)),
+        // Unreachable: only a revive push can be retried or abandoned, and this path never revives.
+        ServeOutcome::Retry | ServeOutcome::Abandoned => None,
     }
 }
 
@@ -360,7 +462,7 @@ fn wake_readers(pipe_id: u64, pipe_wait: &mut PipeWaitTable) -> bool {
     let mut progress: bool = false;
     while let Some((pid, tid, fd, count)) = pipe_wait.front_reader(pipe_id) {
         set_current_process(pid);
-        match try_serve_reader(pid, tid, fd, count) {
+        match try_serve_reader(pid, tid, fd, count, true) {
             ServeOutcome::Served(n) => {
                 pipe_wait.pop_reader(pipe_id);
                 send_response(&read_response(tid, n));
@@ -377,9 +479,46 @@ fn wake_readers(pipe_id: u64, pipe_wait: &mut PipeWaitTable) -> bool {
                 send_response(&build_error(tid, ErrorCode::BadFile));
                 progress = true;
             },
+            ServeOutcome::Retry => {
+                schedule_pipe_read_retry(pipe_id, pipe_wait);
+                break;
+            },
+            ServeOutcome::Abandoned => {
+                pipe_wait.pop_reader(pipe_id);
+                progress = true;
+            },
         }
     }
     progress
+}
+
+/// Yields to let a parked reader register its pull, then retries through VFSD's event loop.
+fn schedule_pipe_read_retry(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
+    if !pipe_wait.schedule_read_retry(pipe_id) {
+        return;
+    }
+    if let Err(error) = ::sys::kcall::sched::__kcall_sched_yield() {
+        ::syslog::warn!("pipe read: failed to yield before retry (error={:?})", error);
+    }
+    let tid: ThreadIdentifier = match ::sys::kcall::pm::__kcall_gettid() {
+        Ok(tid) => tid,
+        Err(error) => {
+            pipe_wait.consume_read_retry(pipe_id);
+            ::syslog::error!("pipe read: failed to get VFSD tid (error={:?})", error);
+            return;
+        },
+    };
+    let retry: Message = PipeReadRetry::build(tid, pipe_id);
+    if let Err(error) = ::sys::kcall::ipc::__kcall_send(&retry) {
+        pipe_wait.consume_read_retry(pipe_id);
+        ::syslog::error!("pipe read: failed to schedule retry (error={:?})", error);
+    }
+}
+
+/// Retries delivery to parked pipe readers after they had time to register their pulls.
+pub(crate) fn retry_readers(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
+    pipe_wait.consume_read_retry(pipe_id);
+    rebalance(pipe_id, pipe_wait);
 }
 
 /// Advances as many suspended writers as the buffer allows, completing or re-parking each.
@@ -458,15 +597,11 @@ fn rebalance(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
     }
 }
 
-/// Wakes all readers suspended on `pipe_id` with end-of-file.
+/// Wakes all readers suspended on `pipe_id` after the last writer closes.
 ///
-/// Invoked when the last write end closes (or its owner exits): every parked reader is answered
-/// with a zero-length read.
+/// Buffered data is delivered first; remaining readers are answered with a zero-length read.
 pub(crate) fn wake_all_readers_eof(pipe_id: u64, pipe_wait: &mut PipeWaitTable) {
-    for reader in pipe_wait.drain_readers(pipe_id) {
-        push_empty(reader.source_pid, reader.source_tid);
-        send_response(&read_response(reader.source_tid, 0));
-    }
+    let _ = wake_readers(pipe_id, pipe_wait);
 }
 
 /// Fails all writers suspended on `pipe_id` with `EPIPE`.

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -50,7 +50,12 @@ use ::sys::{
 };
 use ::syscall::{
     message::SystemCallMessagePart,
-    poll::input_message::ConsoleReadCancel,
+    poll::input_message::{
+        ConsoleReadCancel,
+        PipeOpCancelRequest,
+        PipeOpCancelResponse,
+        PipeReadRetry,
+    },
     SystemCallMessage,
     SystemCallMessageHeader,
 };
@@ -392,9 +397,34 @@ pub(crate) fn handle_ipc_message(
             let _ = handler::service_pending_console_input(console_wait);
             send_response(&ConsoleReadCancel::build_response(source_tid));
         },
+        SystemCallMessageHeader::PipeOpCancelRequest => {
+            let request: PipeOpCancelRequest = PipeOpCancelRequest::from_bytes(syscall_msg.payload);
+            // The parked request is keyed by the caller's identity, so `fd` and the operation kind
+            // are diagnostic only. Always acknowledge: the client blocks until it drains this
+            // response, so an error reply would wedge it instead.
+            let transferred: usize = pipe_wait.cancel(source_pid, source_tid).unwrap_or(0);
+            ::syslog::trace!(
+                "cancelled pipe operation (pid={:?}, tid={:?}, fd={}, operation={:?}, \
+                 transferred={})",
+                source_pid,
+                source_tid,
+                request.fd(),
+                request.operation(),
+                transferred
+            );
+            send_response(&PipeOpCancelResponse::build(source_tid, transferred as u32));
+        },
         SystemCallMessageHeader::ConsoleReadRetry => {
             if source_pid == ProcessIdentifier::VFSD {
                 handler::retry_console_readers(console_wait);
+            } else {
+                send_response(&build_error(source_tid, ErrorCode::PermissionDenied));
+            }
+        },
+        SystemCallMessageHeader::PipeReadRetry => {
+            if source_pid == ProcessIdentifier::VFSD {
+                let retry: PipeReadRetry = PipeReadRetry::from_bytes(syscall_msg.payload);
+                handler::pipe::retry_readers(retry.pipe_id(), pipe_wait);
             } else {
                 send_response(&build_error(source_tid, ErrorCode::PermissionDenied));
             }

--- a/src/daemons/vfsd/src/pipe_wait.rs
+++ b/src/daemons/vfsd/src/pipe_wait.rs
@@ -18,6 +18,7 @@ extern crate alloc;
 use ::alloc::{
     collections::{
         BTreeMap,
+        BTreeSet,
         VecDeque,
     },
     vec::Vec,
@@ -67,6 +68,7 @@ pub(crate) struct BlockedWriter {
 pub(crate) struct PipeWaitTable {
     readers: BTreeMap<u64, VecDeque<BlockedReader>>,
     writers: BTreeMap<u64, VecDeque<BlockedWriter>>,
+    read_retries: BTreeSet<u64>,
 }
 
 impl PipeWaitTable {
@@ -75,6 +77,7 @@ impl PipeWaitTable {
         Self {
             readers: BTreeMap::new(),
             writers: BTreeMap::new(),
+            read_retries: BTreeSet::new(),
         }
     }
 
@@ -139,14 +142,54 @@ impl PipeWaitTable {
         writer
     }
 
-    /// Removes and returns all readers suspended on `pipe_id` (used for EOF wakeups).
-    pub fn drain_readers(&mut self, pipe_id: u64) -> VecDeque<BlockedReader> {
-        self.readers.remove(&pipe_id).unwrap_or_default()
-    }
-
     /// Removes and returns all writers suspended on `pipe_id` (used for `EPIPE` wakeups).
     pub fn drain_writers(&mut self, pipe_id: u64) -> VecDeque<BlockedWriter> {
         self.writers.remove(&pipe_id).unwrap_or_default()
+    }
+
+    /// Marks a pipe-read retry as pending.
+    ///
+    /// Returns `true` when the caller should enqueue a retry event, or `false` if one is already
+    /// pending for `pipe_id`.
+    pub fn schedule_read_retry(&mut self, pipe_id: u64) -> bool {
+        self.read_retries.insert(pipe_id)
+    }
+
+    /// Consumes the pending pipe-read retry marker for `pipe_id`.
+    pub fn consume_read_retry(&mut self, pipe_id: u64) {
+        self.read_retries.remove(&pipe_id);
+    }
+
+    /// Cancels every suspended request issued by one thread.
+    ///
+    /// Returns the number of bytes already accepted for a cancelled writer, or zero for a
+    /// cancelled reader. If the thread has no suspended pipe request, returns `None`.
+    pub fn cancel(&mut self, pid: ProcessIdentifier, tid: ThreadIdentifier) -> Option<usize> {
+        let mut transferred: Option<usize> = None;
+
+        self.readers.retain(|_, queue| {
+            queue.retain(|reader| {
+                let matches: bool = reader.source_pid == pid && reader.source_tid == tid;
+                if matches {
+                    transferred = Some(0);
+                }
+                !matches
+            });
+            !queue.is_empty()
+        });
+
+        self.writers.retain(|_, queue| {
+            queue.retain(|writer| {
+                let matches: bool = writer.source_pid == pid && writer.source_tid == tid;
+                if matches {
+                    transferred = Some(writer.written);
+                }
+                !matches
+            });
+            !queue.is_empty()
+        });
+
+        transferred
     }
 
     /// Drops every suspended request issued by `pid`.

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -342,6 +342,9 @@ pub enum SystemCallMessageHeader {
     ConsoleReadCancelResponse,
     PollInputResponse,
     ConsoleReadRetry,
+    PipeOpCancelRequest,
+    PipeOpCancelResponse,
+    PipeReadRetry,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageHeader
 impl TryFrom<u16> for SystemCallMessageHeader {
@@ -528,6 +531,9 @@ impl TryFrom<u16> for SystemCallMessageHeader {
             x if x == ConsoleReadCancelResponse as u16 => Ok(ConsoleReadCancelResponse),
             x if x == PollInputResponse as u16 => Ok(PollInputResponse),
             x if x == ConsoleReadRetry as u16 => Ok(ConsoleReadRetry),
+            x if x == PipeOpCancelRequest as u16 => Ok(PipeOpCancelRequest),
+            x if x == PipeOpCancelResponse as u16 => Ok(PipeOpCancelResponse),
+            x if x == PipeReadRetry as u16 => Ok(PipeReadRetry),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/poll/input_message.rs
+++ b/src/libs/syscall/src/poll/input_message.rs
@@ -184,6 +184,50 @@ impl ConsoleReadRetry {
     }
 }
 
+/// VFSD's private pipe-read retry event.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PipeReadRetry {
+    pipe_id: u64,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PipeReadRetry, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PipeReadRetry {
+    const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<u64>();
+
+    /// Deserializes a pipe-read retry event.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the stable identity of the pipe whose readers should be retried.
+    pub fn pipe_id(&self) -> u64 {
+        self.pipe_id
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a retry event addressed to VFSD's process mailbox.
+    pub fn build(tid: ThreadIdentifier, pipe_id: u64) -> Message {
+        let retry: Self = Self {
+            pipe_id,
+            _padding: [0; Self::PADDING_SIZE],
+        };
+        let message: SystemCallMessage =
+            SystemCallMessage::new(SystemCallMessageHeader::PipeReadRetry, retry.into_bytes());
+        Message::new(
+            MessageSender::new(ProcessIdentifier::VFSD, tid),
+            MessageReceiver::VFSD,
+            MessageType::Ipc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
 /// Builds console-read cancellation protocol messages.
 pub struct ConsoleReadCancel;
 
@@ -219,6 +263,138 @@ impl ConsoleReadCancel {
     }
 }
 
+/// Kind of pipe operation to cancel.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum PipeOperation {
+    /// A pipe read.
+    Read,
+    /// A pipe write.
+    Write,
+}
+
+impl TryFrom<u8> for PipeOperation {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            value if value == Self::Read as u8 => Ok(Self::Read),
+            value if value == Self::Write as u8 => Ok(Self::Write),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Request to cancel a parked pipe operation.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PipeOpCancelRequest {
+    fd: i32,
+    operation: u8,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PipeOpCancelRequest, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PipeOpCancelRequest {
+    const PADDING_SIZE: usize =
+        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u8>();
+
+    /// Creates a pipe-operation cancellation request.
+    pub fn new(fd: i32, operation: PipeOperation) -> Self {
+        Self {
+            fd,
+            operation: operation as u8,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a pipe-operation cancellation request.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the file descriptor for the cancelled operation.
+    pub fn fd(&self) -> i32 {
+        self.fd
+    }
+
+    /// Returns the kind of operation to cancel, or `None` if the encoded value is invalid.
+    pub fn operation(&self) -> Option<PipeOperation> {
+        PipeOperation::try_from(self.operation).ok()
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a pipe-operation cancellation request.
+    pub fn build(tid: ThreadIdentifier, fd: i32, operation: PipeOperation) -> Message {
+        let request: Self = Self::new(fd, operation);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PipeOpCancelRequest,
+            request.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageReceiver::new(crate::VFS_DESTINATION, ThreadIdentifier::NONE),
+            crate::VFS_MESSAGE_TYPE,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
+/// Response to a pipe-operation cancellation request.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct PipeOpCancelResponse {
+    transferred: u32,
+    _padding: [u8; Self::PADDING_SIZE],
+}
+::static_assert::assert_eq_size!(PipeOpCancelResponse, SystemCallMessage::PAYLOAD_SIZE);
+
+impl PipeOpCancelResponse {
+    const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<u32>();
+
+    /// Creates a pipe-operation cancellation response.
+    pub fn new(transferred: u32) -> Self {
+        Self {
+            transferred,
+            _padding: [0; Self::PADDING_SIZE],
+        }
+    }
+
+    /// Deserializes a pipe-operation cancellation response.
+    pub fn from_bytes(bytes: [u8; SystemCallMessage::PAYLOAD_SIZE]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+
+    /// Returns the number of bytes transferred before cancellation.
+    pub fn transferred(&self) -> u32 {
+        self.transferred
+    }
+
+    fn into_bytes(self) -> [u8; SystemCallMessage::PAYLOAD_SIZE] {
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Builds a pipe-operation cancellation response.
+    pub fn build(tid: ThreadIdentifier, transferred: u32) -> Message {
+        let response: Self = Self::new(transferred);
+        let message: SystemCallMessage = SystemCallMessage::new(
+            SystemCallMessageHeader::PipeOpCancelResponse,
+            response.into_bytes(),
+        );
+        Message::new(
+            MessageSender::new(ProcessIdentifier::VFSD, ThreadIdentifier::NONE),
+            MessageReceiver::new(ProcessIdentifier::from(i32::from(tid)), tid),
+            MessageType::Ipc,
+            None,
+            message.into_bytes(),
+        )
+    }
+}
+
 //==================================================================================================
 // Tests
 //==================================================================================================
@@ -241,5 +417,22 @@ mod tests {
         let response: PollInputResponse = PollInputResponse::new(PollInputRequest::STATUS_DATA);
         let decoded: PollInputResponse = PollInputResponse::from_bytes(response.into_bytes());
         assert_eq!(decoded.status(), PollInputRequest::STATUS_DATA);
+    }
+
+    /// Tests pipe cancellation request field preservation through serialization.
+    #[test]
+    fn pipe_cancel_request_round_trip() {
+        let request: PipeOpCancelRequest = PipeOpCancelRequest::new(7, PipeOperation::Write);
+        let decoded: PipeOpCancelRequest = PipeOpCancelRequest::from_bytes(request.into_bytes());
+        assert_eq!(decoded.fd(), 7);
+        assert_eq!(decoded.operation(), Some(PipeOperation::Write));
+    }
+
+    /// Tests pipe cancellation response field preservation through serialization.
+    #[test]
+    fn pipe_cancel_response_round_trip() {
+        let response: PipeOpCancelResponse = PipeOpCancelResponse::new(123);
+        let decoded: PipeOpCancelResponse = PipeOpCancelResponse::from_bytes(response.into_bytes());
+        assert_eq!(decoded.transferred(), 123);
     }
 }

--- a/src/libs/syscall/src/unistd/syscall/cancel.rs
+++ b/src/libs/syscall/src/unistd/syscall/cancel.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use crate::{
+    poll::input_message::{
+        PipeOpCancelRequest,
+        PipeOpCancelResponse,
+        PipeOperation,
+    },
+    SystemCallMessage,
+    SystemCallMessageHeader,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        Message,
+        MessageSender,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+/// Cancels this thread's parked pipe operation and drains the acknowledgement.
+pub(super) fn cancel_pipe_operation(
+    tid: ThreadIdentifier,
+    fd: i32,
+    operation: PipeOperation,
+) -> Result<u32, Error> {
+    let request: Message = PipeOpCancelRequest::build(tid, fd, operation);
+    ::sys::kcall::ipc::__kcall_send(&request)?;
+
+    loop {
+        let response: Message = match ::sys::kcall::ipc::__kcall_recv() {
+            Ok(response) => response,
+            Err(error) if error.code == ErrorCode::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        let source: MessageSender = response.source;
+        if source.pid != ProcessIdentifier::VFSD {
+            return Err(Error::new(
+                ErrorCode::InvalidMessage,
+                "pipe operation cancellation returned an invalid sender",
+            ));
+        }
+
+        // A response for the interrupted operation may have won the race with the cancellation.
+        // Drain it and continue until the cancellation acknowledgement arrives.
+        if response.status != 0 {
+            continue;
+        }
+        let message: SystemCallMessage = SystemCallMessage::try_from_bytes(response.payload)?;
+        match message.header {
+            SystemCallMessageHeader::PipeOpCancelResponse => {
+                let response: PipeOpCancelResponse =
+                    PipeOpCancelResponse::from_bytes(message.payload);
+                return Ok(response.transferred());
+            },
+            SystemCallMessageHeader::ReadResponse if operation == PipeOperation::Read => continue,
+            SystemCallMessageHeader::WriteResponse if operation == PipeOperation::Write => continue,
+            _ => {
+                return Err(Error::new(
+                    ErrorCode::InvalidMessage,
+                    "unexpected pipe operation cancellation response",
+                ));
+            },
+        }
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/mod.rs
+++ b/src/libs/syscall/src/unistd/syscall/mod.rs
@@ -20,6 +20,7 @@ mod util;
 cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {
         mod _exit;
+        mod cancel;
         mod chdir;
         mod close;
         mod dup;

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -5,9 +5,15 @@
 // Imports
 //==================================================================================================
 
-use super::util::page_chunk_size;
+use super::{
+    cancel::cancel_pipe_operation,
+    util::page_chunk_size,
+};
 use crate::{
-    poll::input_message::ConsoleReadCancel,
+    poll::input_message::{
+        ConsoleReadCancel,
+        PipeOperation,
+    },
     safe::RawFileDescriptor,
     unistd::message::{
         ReadRequest,
@@ -46,7 +52,15 @@ struct ReadBackend {
     message_type: MessageType,
     pull_pid: ProcessIdentifier,
     pull_tid: ThreadIdentifier,
-    cancel_console_on_interrupt: bool,
+    cancellation: ReadCancellation,
+}
+
+/// Cancellation protocol to run when a read's bulk pull is interrupted.
+#[derive(Clone, Copy)]
+enum ReadCancellation {
+    None,
+    Console,
+    Pipe,
 }
 
 ///
@@ -86,10 +100,15 @@ fn read_chunk(
     let bytes_pulled: usize =
         match ::sys::kcall::ipc::__kcall_pull(backend.pull_pid, backend.pull_tid, chunk) {
             Ok(bytes_pulled) => bytes_pulled,
-            Err(error)
-                if error.code == ErrorCode::Interrupted && backend.cancel_console_on_interrupt =>
-            {
-                cancel_console_read(tid)?;
+            Err(error) if error.code == ErrorCode::Interrupted => {
+                match backend.cancellation {
+                    ReadCancellation::None => {},
+                    ReadCancellation::Console => cancel_console_read(tid)?,
+                    ReadCancellation::Pipe => {
+                        let _transferred: u32 =
+                            cancel_pipe_operation(tid, fd, PipeOperation::Read)?;
+                    },
+                }
                 return Err(error);
             },
             Err(error) => return Err(error),
@@ -270,7 +289,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
                         message_type: crate::VFS_MESSAGE_TYPE,
                         pull_pid: crate::VFS_PUSH_PULL_PID,
                         pull_tid: crate::VFS_PUSH_PULL_TID,
-                        cancel_console_on_interrupt: true,
+                        cancellation: ReadCancellation::Console,
                     },
                 )
             } else {
@@ -282,7 +301,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
                         message_type: MessageType::Ikc,
                         pull_pid: ProcessIdentifier::KERNEL,
                         pull_tid: ThreadIdentifier::KERNEL,
-                        cancel_console_on_interrupt: false,
+                        cancellation: ReadCancellation::None,
                     },
                 )
             }
@@ -301,7 +320,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
                     message_type: crate::VFS_MESSAGE_TYPE,
                     pull_pid: crate::VFS_PUSH_PULL_PID,
                     pull_tid: crate::VFS_PUSH_PULL_TID,
-                    cancel_console_on_interrupt: false,
+                    cancellation: ReadCancellation::Pipe,
                 },
             ),
             // stdout/stderr, sockets, and unroutable descriptors are not readable here.

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -5,8 +5,12 @@
 // Imports
 //==================================================================================================
 
-use super::util::sg_chunk_size;
+use super::{
+    cancel::cancel_pipe_operation,
+    util::sg_chunk_size,
+};
 use crate::{
+    poll::input_message::PipeOperation,
     safe::RawFileDescriptor,
     unistd::message::{
         WriteRequest,
@@ -41,6 +45,16 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
+/// Backend routing and interruption policy for one write operation.
+#[derive(Clone, Copy)]
+struct WriteBackend {
+    destination: ProcessIdentifier,
+    message_type: MessageType,
+    push_pid: ProcessIdentifier,
+    push_tid: ThreadIdentifier,
+    cancel_pipe_on_interrupt: bool,
+}
+
 ///
 /// # Description
 ///
@@ -62,22 +76,32 @@ fn write_chunk(
     tid: ThreadIdentifier,
     fd: RawFileDescriptor,
     chunk: &[u8],
-    destination: ProcessIdentifier,
-    message_type: MessageType,
-    push_pid: ProcessIdentifier,
-    push_tid: ThreadIdentifier,
+    backend: WriteBackend,
 ) -> Result<c_size_t, Error> {
     // Build metadata-only request and send it via IPC message.
     let empty_buf: [u8; WriteRequest::BUFFER_SIZE] = [0u8; WriteRequest::BUFFER_SIZE];
-    let request: Message =
-        WriteRequest::build(tid, fd, chunk.len() as c_size_t, empty_buf, destination, message_type);
+    let request: Message = WriteRequest::build(
+        tid,
+        fd,
+        chunk.len() as c_size_t,
+        empty_buf,
+        backend.destination,
+        backend.message_type,
+    );
     ::sys::kcall::ipc::__kcall_send(&request)?;
 
     // Push actual data via data chunk transfer.
-    ::sys::kcall::ipc::__kcall_push(push_pid, push_tid, chunk)?;
+    ::sys::kcall::ipc::__kcall_push(backend.push_pid, backend.push_tid, chunk)?;
 
     // Receive response.
-    let response: Message = ::sys::kcall::ipc::__kcall_recv()?;
+    let response: Message = match ::sys::kcall::ipc::__kcall_recv() {
+        Ok(response) => response,
+        Err(error) if error.code == ErrorCode::Interrupted && backend.cancel_pipe_on_interrupt => {
+            let _transferred: u32 = cancel_pipe_operation(tid, fd, PipeOperation::Write)?;
+            return Err(error);
+        },
+        Err(error) => return Err(error),
+    };
 
     // Check whether system call succeeded or not.
     if response.status != 0 {
@@ -183,20 +207,26 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
             write_ipc(
                 res.backend_fd,
                 buffer,
-                crate::HOST_IO,
-                MessageType::Ikc,
-                ProcessIdentifier::KERNEL,
-                ThreadIdentifier::KERNEL,
+                WriteBackend {
+                    destination: crate::HOST_IO,
+                    message_type: MessageType::Ikc,
+                    push_pid: ProcessIdentifier::KERNEL,
+                    push_tid: ThreadIdentifier::KERNEL,
+                    cancel_pipe_on_interrupt: false,
+                },
             )
         },
         // VFS-backed descriptors go to vfsd.
         Some(res) if res.route == Route::Vfs => write_ipc(
             res.backend_fd,
             buffer,
-            crate::VFS_DESTINATION,
-            crate::VFS_MESSAGE_TYPE,
-            crate::VFS_PUSH_PULL_PID,
-            crate::VFS_PUSH_PULL_TID,
+            WriteBackend {
+                destination: crate::VFS_DESTINATION,
+                message_type: crate::VFS_MESSAGE_TYPE,
+                push_pid: crate::VFS_PUSH_PULL_PID,
+                push_tid: crate::VFS_PUSH_PULL_TID,
+                cancel_pipe_on_interrupt: true,
+            },
         ),
         // stdin, sockets, and unroutable descriptors are not writable here.
         _ => {
@@ -252,10 +282,7 @@ fn notify_terminal_write() {
 fn write_ipc(
     fd: RawFileDescriptor,
     buffer: &[u8],
-    destination: ProcessIdentifier,
-    message_type: MessageType,
-    push_pid: ProcessIdentifier,
-    push_tid: ThreadIdentifier,
+    backend: WriteBackend,
 ) -> Result<c_size_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::__kcall_gettid()?;
 
@@ -267,8 +294,7 @@ fn write_ipc(
             sg_chunk_size(buffer[offset..].as_ptr() as usize, buffer.len() - offset);
         let chunk: &[u8] = &buffer[offset..offset + chunk_size];
 
-        let written: c_size_t =
-            write_chunk(tid, fd, chunk, destination, message_type, push_pid, push_tid)?;
+        let written: c_size_t = write_chunk(tid, fd, chunk, backend)?;
         total_written += written;
         offset += written as usize;
 

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -780,6 +780,30 @@ pub fn vfs_pipe_read(fd: c_int, buf: &mut [u8]) -> Result<PipeReadOutcome, Fat32
     end.read(buf).map_err(|_| Fat32Error::InvalidFd)
 }
 
+/// Non-destructively copies bytes from a pipe read end into `buf`.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the write end.
+pub fn vfs_pipe_peek(fd: c_int, buf: &mut [u8]) -> Result<PipeReadOutcome, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.peek(buf).map_err(|_| Fat32Error::InvalidFd)
+}
+
+/// Removes up to `count` bytes from the front of a pipe read end.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidFd`] if `fd` is not a pipe or if it is the write end.
+pub fn vfs_pipe_consume(fd: c_int, count: usize) -> Result<usize, Fat32Error> {
+    let file: OpenFile = entry_arc(fd)?;
+    let guard = file.lock();
+    let end: &crate::pipe::PipeEnd = guard.handle.pipe_end().ok_or(Fat32Error::InvalidFd)?;
+    end.consume(count).map_err(|_| Fat32Error::InvalidFd)
+}
+
 /// Attempts a non-blocking write to a pipe write end, honoring `PIPE_BUF` atomicity.
 ///
 /// On [`PipeWriteOutcome::Wrote(n)`](PipeWriteOutcome::Wrote), `n` bytes became available, so vfsd

--- a/src/libs/vfs/src/pipe/pipe_end.rs
+++ b/src/libs/vfs/src/pipe/pipe_end.rs
@@ -31,7 +31,10 @@ use super::{
     PipeWriteOutcome,
 };
 use ::alloc::{
-    collections::VecDeque,
+    collections::{
+        vec_deque::Drain,
+        VecDeque,
+    },
     sync::Arc,
 };
 use ::core::sync::atomic::{
@@ -108,14 +111,8 @@ struct PipeInner {
 }
 
 impl PipeInner {
-    /// Non-blocking read from the buffer.
-    ///
-    /// Copies as many bytes as are available into `buf` (up to `buf.len()`). Returns
-    /// [`PipeReadOutcome::WouldBlock`] when the buffer is empty but at least one writer is still
-    /// open, and [`PipeReadOutcome::Eof`] when the buffer is empty and no writers remain. A
-    /// zero-length read transfers no data and never blocks — POSIX `read(2)` with `count == 0`
-    /// returns `0` immediately.
-    fn read(&mut self, buf: &mut [u8]) -> PipeReadOutcome {
+    /// Non-destructively copies bytes from the front of the buffer.
+    fn peek(&self, buf: &mut [u8]) -> PipeReadOutcome {
         // A zero-length read must succeed immediately and never block, even on an empty pipe.
         if buf.is_empty() {
             return PipeReadOutcome::Read(0);
@@ -128,11 +125,33 @@ impl PipeInner {
             return PipeReadOutcome::WouldBlock;
         }
         let n: usize = available.min(buf.len());
-        // `n <= self.buf.len()`, so the drain yields exactly `n` bytes in front-to-back order.
-        for (dst, src) in buf.iter_mut().zip(self.buf.drain(..n)) {
-            *dst = src;
+        for (dst, src) in buf.iter_mut().zip(self.buf.iter().take(n)) {
+            *dst = *src;
         }
         PipeReadOutcome::Read(n)
+    }
+
+    /// Removes up to `count` bytes from the front of the buffer.
+    fn consume(&mut self, count: usize) -> usize {
+        let consumed: usize = count.min(self.buf.len());
+        let _dropped: Drain<'_, u8> = self.buf.drain(..consumed);
+        consumed
+    }
+
+    /// Non-blocking read from the buffer.
+    ///
+    /// Copies as many bytes as are available into `buf` (up to `buf.len()`). Returns
+    /// [`PipeReadOutcome::WouldBlock`] when the buffer is empty but at least one writer is still
+    /// open, and [`PipeReadOutcome::Eof`] when the buffer is empty and no writers remain. A
+    /// zero-length read transfers no data and never blocks — POSIX `read(2)` with `count == 0`
+    /// returns `0` immediately.
+    fn read(&mut self, buf: &mut [u8]) -> PipeReadOutcome {
+        let outcome: PipeReadOutcome = self.peek(buf);
+        if let PipeReadOutcome::Read(n) = outcome {
+            let consumed: usize = self.consume(n);
+            debug_assert_eq!(consumed, n);
+        }
+        outcome
     }
 
     /// Non-blocking write into the buffer, honoring [`PIPE_BUF`] atomicity.
@@ -258,6 +277,26 @@ impl PipeEnd {
         Ok(self.inner.lock().read(buf))
     }
 
+    /// Non-destructively copies bytes from the pipe into `buf`.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the write end.
+    pub fn peek(&self, buf: &mut [u8]) -> Result<PipeReadOutcome, PipeEndError> {
+        if self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().peek(buf))
+    }
+
+    /// Removes up to `count` bytes from the front of the pipe buffer.
+    ///
+    /// Returns [`PipeEndError::WrongDirection`] when invoked on the write end.
+    pub fn consume(&self, count: usize) -> Result<usize, PipeEndError> {
+        if self.is_write {
+            return Err(PipeEndError::WrongDirection);
+        }
+        Ok(self.inner.lock().consume(count))
+    }
+
     /// Attempts a non-blocking write to the pipe.
     ///
     /// Returns [`PipeEndError::WrongDirection`] when invoked on the read end.
@@ -315,6 +354,22 @@ mod tests {
             _ => panic!("write should succeed"),
         }
         assert_eq!(read_all(&r, 16), data, "read bytes should match written bytes");
+    }
+
+    /// Tests that peeking preserves bytes until the caller explicitly consumes them.
+    #[test]
+    fn peek_then_consume_commits_prefix() {
+        let (r, w): (PipeEnd, PipeEnd) = PipeEnd::new_pair();
+        w.write(&[1, 2, 3, 4]).expect("write end");
+        let mut buf: [u8; 3] = [0; 3];
+
+        assert!(
+            matches!(r.peek(&mut buf).expect("read end"), PipeReadOutcome::Read(3)),
+            "peek should copy the requested prefix"
+        );
+        assert_eq!(buf, [1, 2, 3], "peeked bytes should preserve order");
+        assert_eq!(r.consume(2).expect("read end"), 2, "consume should remove two bytes");
+        assert_eq!(read_all(&r, 4), [3, 4], "only the committed prefix should be removed");
     }
 
     /// Tests that the two ends report the same, unique pipe identity.

--- a/src/tests/integration/test-c-signal-rpc/main.c
+++ b/src/tests/integration/test-c-signal-rpc/main.c
@@ -1,0 +1,383 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Regression test for cancelling pipe operations parked in vfsd when SIGCHLD interrupts the
+ * caller. The read scenario detects a stale reader stealing the next pull. The write scenario
+ * releases buffer space only after cancellation returns, then checks that the cancelled byte was
+ * not written. The final fork detects a response left in the caller's mailbox.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define PIPE_FILL_CHUNK_SIZE 4096
+#define PIPE_FILL_BYTE 0x31
+#define CANCELLED_WRITE_BYTE 0xa7
+#define COMMITTED_WRITE_BYTE 0xb8
+
+#define CHECK(step, condition) \
+    do {                       \
+        if (!(condition)) {    \
+            return (step);     \
+        }                      \
+    } while (0)
+
+static volatile sig_atomic_t sigchld_count;
+
+static void handle_sigchld(int signum)
+{
+    (void)signum;
+    sigchld_count++;
+}
+
+static int delay_ms(long milliseconds)
+{
+    struct timespec delay = {
+        .tv_sec = milliseconds / 1000,
+        .tv_nsec = (milliseconds % 1000) * 1000000L,
+    };
+
+    while (nanosleep(&delay, &delay) != 0) {
+        if (errno != EINTR) {
+            return (-1);
+        }
+    }
+    return (0);
+}
+
+static int wait_success(pid_t pid)
+{
+    int status = 0;
+    pid_t result;
+
+    do {
+        result = waitpid(pid, &status, 0);
+    } while (result < 0 && errno == EINTR);
+
+    return (result == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+
+static ssize_t read_retry(int fd, void *buffer, size_t count, int *interrupted)
+{
+    for (;;) {
+        ssize_t result = read(fd, buffer, count);
+        if (result >= 0 || errno != EINTR) {
+            return (result);
+        }
+        if (interrupted != NULL) {
+            *interrupted = 1;
+        }
+    }
+}
+
+static int fill_pipe(int fd, size_t *filled)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+        return (-1);
+    }
+
+    unsigned char buffer[PIPE_FILL_CHUNK_SIZE];
+    memset(buffer, PIPE_FILL_BYTE, sizeof(buffer));
+    size_t chunk_size = sizeof(buffer);
+    *filled = 0;
+
+    for (;;) {
+        ssize_t count = write(fd, buffer, chunk_size);
+        if (count > 0) {
+            *filled += (size_t)count;
+            continue;
+        }
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count < 0 && errno == EAGAIN) {
+            if (chunk_size > 1) {
+                chunk_size = 1;
+                continue;
+            }
+            break;
+        }
+        (void)fcntl(fd, F_SETFL, flags);
+        return (-1);
+    }
+
+    return (fcntl(fd, F_SETFL, flags));
+}
+
+static int drain_blocked_write_pipe(int data_fd, int release_fd, int ready_fd, size_t filled)
+{
+    unsigned char value = 0;
+    if (read_retry(release_fd, &value, sizeof(value), NULL) != sizeof(value)) {
+        return (-1);
+    }
+    if (read_retry(data_fd, &value, sizeof(value), NULL) != sizeof(value) ||
+        value != PIPE_FILL_BYTE) {
+        return (-1);
+    }
+
+    const unsigned char ready = 0x5c;
+    if (write(ready_fd, &ready, sizeof(ready)) != sizeof(ready)) {
+        return (-1);
+    }
+
+    size_t filler_remaining = filled - 1;
+    int committed_seen = 0;
+    unsigned char buffer[PIPE_FILL_CHUNK_SIZE];
+    for (;;) {
+        ssize_t count = read_retry(data_fd, buffer, sizeof(buffer), NULL);
+        if (count < 0) {
+            return (-1);
+        }
+        if (count == 0) {
+            break;
+        }
+        for (ssize_t i = 0; i < count; i++) {
+            if (filler_remaining > 0) {
+                if (buffer[i] != PIPE_FILL_BYTE) {
+                    return (-1);
+                }
+                filler_remaining--;
+            } else if (!committed_seen) {
+                if (buffer[i] != COMMITTED_WRITE_BYTE) {
+                    return (-1);
+                }
+                committed_seen = 1;
+            } else {
+                return (-1);
+            }
+        }
+    }
+
+    return (filler_remaining == 0 && committed_seen ? 0 : -1);
+}
+
+static int test_blocked_write(void)
+{
+    int data_pipe[2];
+    int release_pipe[2];
+    int ready_pipe[2];
+    CHECK(40, pipe(data_pipe) == 0);
+    CHECK(41, pipe(release_pipe) == 0);
+    CHECK(42, pipe(ready_pipe) == 0);
+
+    size_t filled = 0;
+    CHECK(43, fill_pipe(data_pipe[1], &filled) == 0);
+    CHECK(44, filled > 0);
+
+    pid_t drainer = fork();
+    CHECK(45, drainer >= 0);
+    if (drainer == 0) {
+        (void)close(data_pipe[1]);
+        (void)close(release_pipe[1]);
+        (void)close(ready_pipe[0]);
+        int status = drain_blocked_write_pipe(data_pipe[0], release_pipe[0], ready_pipe[1], filled);
+        (void)close(data_pipe[0]);
+        (void)close(release_pipe[0]);
+        (void)close(ready_pipe[1]);
+        _exit(status == 0 ? 0 : 1);
+    }
+
+    pid_t interrupter = fork();
+    CHECK(46, interrupter >= 0);
+    if (interrupter == 0) {
+        (void)close(data_pipe[0]);
+        (void)close(data_pipe[1]);
+        (void)close(release_pipe[0]);
+        (void)close(release_pipe[1]);
+        (void)close(ready_pipe[0]);
+        (void)close(ready_pipe[1]);
+        _exit(delay_ms(10) == 0 ? 0 : 1);
+    }
+
+    CHECK(47, close(data_pipe[0]) == 0);
+    CHECK(48, close(release_pipe[0]) == 0);
+    CHECK(49, close(ready_pipe[1]) == 0);
+
+    sig_atomic_t signals_before = sigchld_count;
+    const unsigned char cancelled = CANCELLED_WRITE_BYTE;
+    errno = 0;
+    ssize_t count = write(data_pipe[1], &cancelled, sizeof(cancelled));
+    int write_errno = errno;
+    int failure = 0;
+    if (count != -1) {
+        failure = 50;
+    } else if (write_errno != EINTR) {
+        failure = 51;
+    } else if (sigchld_count <= signals_before) {
+        failure = 52;
+    }
+
+    const unsigned char release = 0x6d;
+    if (write(release_pipe[1], &release, sizeof(release)) != sizeof(release) && failure == 0) {
+        failure = 53;
+    }
+
+    unsigned char ready = 0;
+    count = read_retry(ready_pipe[0], &ready, sizeof(ready), NULL);
+    if (count != sizeof(ready) && failure == 0) {
+        failure = 54;
+    } else if (ready != 0x5c && failure == 0) {
+        failure = 55;
+    }
+
+    if (failure == 0) {
+        const unsigned char committed = COMMITTED_WRITE_BYTE;
+        if (write(data_pipe[1], &committed, sizeof(committed)) != sizeof(committed)) {
+            failure = 56;
+        }
+    }
+
+    (void)close(data_pipe[1]);
+    (void)close(release_pipe[1]);
+    (void)close(ready_pipe[0]);
+    int interrupter_succeeded = wait_success(interrupter);
+    int drainer_succeeded = wait_success(drainer);
+    if (failure != 0) {
+        return (failure);
+    }
+    CHECK(57, interrupter_succeeded);
+    CHECK(58, drainer_succeeded);
+    return (0);
+}
+
+int main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    struct sigaction action = {0};
+    action.sa_handler = handle_sigchld;
+    CHECK(1, sigemptyset(&action.sa_mask) == 0);
+    CHECK(2, sigaction(SIGCHLD, &action, NULL) == 0);
+
+    int data_pipe[2];
+    int control_pipe[2];
+    int ready_pipe[2];
+    CHECK(3, pipe(data_pipe) == 0);
+    CHECK(4, pipe(control_pipe) == 0);
+    CHECK(5, pipe(ready_pipe) == 0);
+
+    pid_t writer = fork();
+    CHECK(6, writer >= 0);
+    if (writer == 0) {
+        const unsigned char first_data = 0x5a;
+        const unsigned char second_data = 0x6b;
+        const unsigned char control = 0xc3;
+        unsigned char ready = 0;
+
+        (void)close(data_pipe[0]);
+        (void)close(control_pipe[0]);
+        (void)close(ready_pipe[1]);
+        int status = delay_ms(50);
+        if (status == 0 &&
+            write(data_pipe[1], &first_data, sizeof(first_data)) != sizeof(first_data)) {
+            status = -1;
+        }
+        if (status == 0 && read(ready_pipe[0], &ready, sizeof(ready)) != sizeof(ready)) {
+            status = -1;
+        }
+        if (status == 0 && delay_ms(50) != 0) {
+            status = -1;
+        }
+        if (status == 0 &&
+            write(data_pipe[1], &second_data, sizeof(second_data)) != sizeof(second_data)) {
+            status = -1;
+        }
+        if (status == 0 && write(control_pipe[1], &control, sizeof(control)) != sizeof(control)) {
+            status = -1;
+        }
+        (void)close(data_pipe[1]);
+        (void)close(control_pipe[1]);
+        (void)close(ready_pipe[0]);
+        _exit(status == 0 ? 0 : 1);
+    }
+
+    // Forked after the writer so that only the three closes below, and not a fork(), have to fit
+    // inside this child's 10 ms fuse for the signal to land while the parent is blocked in read().
+    pid_t interrupter = fork();
+    CHECK(7, interrupter >= 0);
+    if (interrupter == 0) {
+        (void)close(data_pipe[0]);
+        (void)close(data_pipe[1]);
+        (void)close(control_pipe[0]);
+        (void)close(control_pipe[1]);
+        (void)close(ready_pipe[0]);
+        (void)close(ready_pipe[1]);
+        _exit(delay_ms(10) == 0 ? 0 : 1);
+    }
+
+    CHECK(8, close(data_pipe[1]) == 0);
+    CHECK(9, close(control_pipe[1]) == 0);
+    CHECK(10, close(ready_pipe[0]) == 0);
+
+    unsigned char first_data = 0;
+    int interrupted = 0;
+    ssize_t count = read_retry(data_pipe[0], &first_data, sizeof(first_data), &interrupted);
+    CHECK(11, interrupted);
+    CHECK(12, sigchld_count > 0);
+    CHECK(13, count == sizeof(first_data));
+    CHECK(14, first_data == 0x5a);
+
+    const unsigned char ready = 0xa5;
+    CHECK(15, write(ready_pipe[1], &ready, sizeof(ready)) == sizeof(ready));
+
+    unsigned char control = 0;
+    count = read_retry(control_pipe[0], &control, sizeof(control), NULL);
+    int failure = 0;
+    if (count != sizeof(control)) {
+        failure = 16;
+    } else if (control != 0xc3) {
+        failure = 17;
+    }
+    if (failure != 0) {
+        sigset_t blocked;
+        (void)sigemptyset(&blocked);
+        (void)sigaddset(&blocked, SIGCHLD);
+        (void)sigprocmask(SIG_BLOCK, &blocked, NULL);
+        (void)wait_success(interrupter);
+        (void)wait_success(writer);
+        (void)close(data_pipe[0]);
+        (void)close(control_pipe[0]);
+        (void)close(ready_pipe[1]);
+        return (failure);
+    }
+
+    unsigned char second_data = 0;
+    count = read_retry(data_pipe[0], &second_data, sizeof(second_data), NULL);
+    CHECK(18, count == sizeof(second_data));
+    CHECK(19, second_data == 0x6b);
+
+    CHECK(20, wait_success(interrupter));
+    CHECK(21, wait_success(writer));
+    CHECK(22, close(data_pipe[0]) == 0);
+    CHECK(23, close(control_pipe[0]) == 0);
+    CHECK(24, close(ready_pipe[1]) == 0);
+
+    int write_test_status = test_blocked_write();
+    if (write_test_status != 0) {
+        return (write_test_status);
+    }
+
+    sigset_t blocked;
+    CHECK(25, sigemptyset(&blocked) == 0);
+    CHECK(26, sigaddset(&blocked, SIGCHLD) == 0);
+    CHECK(27, sigprocmask(SIG_BLOCK, &blocked, NULL) == 0);
+
+    pid_t probe = fork();
+    CHECK(28, probe >= 0);
+    if (probe == 0) {
+        _exit(0);
+    }
+
+    CHECK(29, wait_success(probe));
+    return (0);
+}

--- a/test/test-posix-windows.toml
+++ b/test/test-posix-windows.toml
@@ -375,6 +375,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-signal-rpc"
+program = "./bin/test-c-signal-rpc.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-sigmask"
 program = "./bin/test-c-sigmask.initrd"
 expected_exit_code = 0

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -375,6 +375,13 @@ expected_exit_code = 0
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
+name = "posix/test-c-signal-rpc"
+program = "./bin/test-c-signal-rpc.initrd"
+expected_exit_code = 0
+
+[[tests]]
+build_modes = ["debug", "release"]
+executor = "terminal"
 name = "posix/test-c-sigmask"
 program = "./bin/test-c-sigmask.initrd"
 expected_exit_code = 0


### PR DESCRIPTION
## Summary

vfsd parks pipe reads and writes that cannot complete immediately, but offered no way to cancel one. A client interrupted by a signal returned `EINTR` and left its entry in `PipeWaitTable` forever. When the complementary operation later revived that waiter, vfsd issued an infinite `__kcall_push` against a client that had no matching pull, either wedging vfsd's single-threaded event loop or desynchronizing the client mailbox with a stale response.

This adds per-request cancellation for parked pipe operations and hardens the revive path so a vanished client can never block the event loop.

Part of #3013. Implements step 1 (#3014).

## Changes

**Libraries:**
- `syscall`: add `PipeOpCancelRequest`/`PipeOpCancelResponse` wire headers and a `PipeOperation` kind, modeled on `ConsoleReadCancel`.
- `syscall`: add `cancel_pipe_operation()` and invoke it from the read and write chunk paths on `EINTR`, draining any operation response that races the cancellation acknowledgement.
- `vfs`: add non-destructive `vfs_pipe_peek()` and `vfs_pipe_consume()`, splitting `PipeInner::read()` into peek + commit.

**vfsd:**
- Add `PipeWaitTable::cancel(pid, tid)` to retain-filter both reader and writer queues, returning a cancelled writer's already-buffered byte count.
- Dispatch `PipeOpCancelRequest` and always acknowledge it.
- Harden the revive path: peek then push with a bounded timeout and consume only on successful delivery, adding a `ServeOutcome::Abandoned` arm so a client that vanished cannot wedge the loop.

**Tests:**
- Add `test-c-signal-rpc`, an exit-code C integration test covering interrupted pipe read and write cancellation, plus a final `fork()` that detects a response stranded in the caller's mailbox.
- Register it in `guest-posix-tests.mk` and both `test-posix.toml` and `test-posix-windows.toml`.

## Notes

- Changing what `read()`/`write()` *report* after cancelling is out of scope here (tracked by #3016).
- The interrupted pipe-write *data rendezvous* window, before a waiter is parked, is tracked separately by #3023.
