### PR TITLE
[ci] Publish x86_64 Standalone Release Archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1594,7 +1594,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: [ x86 ]
+        target-arch: [ x86, x86_64 ]
         machine-type: [ microvm ]
         memory-size: [ 256 ]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Extend the Linux `release-archive` job matrix to build both `x86` and
`x86_64` standalone archives so releases ship an `x86_64` libc/sysroot
bundle the Nanvix SDK can package from released inputs.

The build and publish paths were already target-aware — `ci-build`
produces `ci-build-release-x86_64-*` artifacts, `release-package`
derives the archive name from `target-arch`, and `publish-release`
uploads every `*.tar.bz2` it finds. Only the `release-archive` matrix
still pinned `x86`.

## Changes

- Add `x86_64` to the `release-archive` target-arch matrix.
- Preserve existing `x86` archive naming and Windows x86-only publication.

## Validation

- Built the x86_64 release archive locally; `lib/crt0.o` is ELF64
  (`Advanced Micro Devices X86-64`), and the archive includes headers,
  `libc.a`, `libm.a`, startup objects, compatibility archives, shared
  `libc.so`/`libm.so`, and `user.ld`.
- `./z build -- format-check` passes.

closes #3025