### PR TITLE
[vfs] chdir only on dir

### DIFF
--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -286,14 +286,12 @@ pub(crate) fn rename(cwd: &str, old_path: &str, new_path: &str) -> Result<(), Fa
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
 /// - [`Fat32Error::InvalidPath`] if the path is malformed.
 /// - [`Fat32Error::NotFound`] if no mount handles this path.
+/// - [`Fat32Error::NotADirectory`] if the path is not a directory.
 pub(crate) fn change_directory(cwd: &str, path: &str) -> Result<String, Fat32Error> {
-    let normalized: String = state::with_vfs_mut(|vfs| {
-        let normalized: String = vfs.normalize_path(path, cwd)?;
-        if !normalized.is_empty() && normalized != "/" {
-            let _ = vfs.resolve(&normalized, cwd)?;
-        }
-        Ok(normalized)
-    })?;
+    let normalized: String = normalize(cwd, path)?;
+    if !normalized.is_empty() && normalized != "/" && !stat(cwd, path)?.is_dir() {
+        return Err(Fat32Error::NotADirectory);
+    }
     Ok(normalized)
 }
 

--- a/src/tests/integration/test-c-file/chdir.c
+++ b/src/tests/integration/test-c-file/chdir.c
@@ -15,6 +15,7 @@
 //==================================================================================================
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
@@ -56,6 +57,19 @@ void test_chdir(void)
     // Verify the current working directory is restored.
     assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
     assert(strcmp(new_cwd, original_cwd) == 0);
+
+    // Regression: chdir() onto a regular file must fail with ENOTDIR and leave
+    // the cwd unchanged.
+    const char *filename = "testfile_chdir";
+    int fd = open(filename, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+    errno = 0;
+    assert(chdir(filename) != 0);
+    assert(errno == ENOTDIR);
+    assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
+    assert(strcmp(new_cwd, original_cwd) == 0);
+    assert(unlink(filename) == 0);
 
     // Clean up.
     assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);


### PR DESCRIPTION
Ensure that chdir errors when attempting to chdir onto a file. Also hooks up a regression test.