### PR TITLE
[ci] Publish Windows x86_64 Release Archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1659,7 +1659,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: [ x86 ]
+        target-arch: [ x86, x86_64 ]
         machine-type: [ microvm ]
         memory-size: [ 256 ]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Description

Add `x86_64` to the `windows-release-archive` target-arch matrix so releases ship a Windows x86_64 standalone `.zip` alongside the existing x86 archive.

## Why

The Windows build and integration-test jobs already cover both `x86` and `x86_64`, and the packaging and publish steps are target-aware. Only the `windows-release-archive` matrix still pinned `x86`, so the WHP x86_64 artifact was built and tested but never published. The latest release (`v0.23.11`) contained Linux x86, Linux x86_64, and Windows x86 archives, but no Windows x86_64 archive.

## Change

- Extend the `windows-release-archive` matrix from `[ x86 ]` to `[ x86, x86_64 ]`.
- Existing x86 archive naming and the generic package/publish paths are unchanged.
